### PR TITLE
Set audio component source intentionally - Proof of concept

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/checking-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/checking-config.ts
@@ -10,4 +10,5 @@ export interface CheckingConfig {
   shareEnabled: boolean;
   answerExportMethod: CheckingAnswerExport;
   noteTagId?: number;
+  hideCommunityCheckingText?: boolean;
 }

--- a/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
@@ -23,7 +23,8 @@ function testProjectProfile(ordinal: number): SFProjectProfile {
       checkingEnabled: true,
       usersSeeEachOthersResponses: true,
       shareEnabled: false,
-      answerExportMethod: CheckingAnswerExport.MarkedForExport
+      answerExportMethod: CheckingAnswerExport.MarkedForExport,
+      hideCommunityCheckingText: false
     },
     texts: [],
     sync: {

--- a/src/RealtimeServer/scriptureforge/models/text-audio-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/text-audio-test-data.ts
@@ -1,0 +1,18 @@
+import merge from 'lodash/merge';
+import { RecursivePartial } from '../../common/utils/type-utils';
+import { TextAudio } from './text-audio';
+
+function testTextAudio(ordinal: number): TextAudio {
+  return {
+    ownerRef: '',
+    projectRef: '',
+    dataId: '',
+    timings: [],
+    mimeType: 'audio/opus',
+    audioUrl: `https://example.com/file${ordinal}.opus`
+  };
+}
+
+export function createTestTextAudio(overrides?: RecursivePartial<TextAudio>, ordinal = 1): TextAudio {
+  return merge(testTextAudio(ordinal), overrides);
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -10,7 +10,7 @@
       <mat-icon class="mirror-rtl">skip_next</mat-icon>
     </button>
   </div>
-  <button mat-icon-button class="close-button" (click)="close()">
+  <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
     <mat-icon>close</mat-icon>
   </button>
   <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -13,6 +13,6 @@
   <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
     <mat-icon>close</mat-icon>
   </button>
-  <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>
+  <app-audio-player #audioPlayer></app-audio-player>
   <span class="verse-label">{{ verseLabel }}</span>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -188,7 +188,9 @@ class AudioPlayerStubComponent {
     this.audio = new AudioPlayerStub(audioFile, instance(AudioPlayerStubComponent.onlineStatusService));
   }
 
-  @Input() set source(source: string | undefined) {}
+  @Input() set source(source: string | undefined) {
+    if (source != null) this.isAudioAvailable$.next(true);
+  }
 }
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -34,13 +34,15 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
     this._timing = Object.values(value).sort((a, b) => a.from - b.from);
   }
 
-  @Input() set source(value: string | undefined) {
+  set source(value: string | undefined) {
     this.audioSource = value;
     this.doAudioSubscriptions();
+    if (this.audioPlayer == null) return;
+    this.audioPlayer.source = value;
   }
 
   verseLabel: string = this.emptyVerseLabel;
-  audioSource?: string;
+  private audioSource?: string;
 
   private _timing: AudioTiming[] = [];
   private _textDocId?: TextDocId;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -16,9 +16,13 @@ import { AudioHeadingRef, AudioTextRef, CheckingUtils } from '../../checking.uti
   styleUrls: ['./checking-scripture-audio-player.component.scss']
 })
 export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposable implements AfterViewInit {
+  @Input() canClose: boolean = true;
   @Output() currentVerseChanged = new EventEmitter<string>();
   @Output() closed: EventEmitter<void> = new EventEmitter<void>();
   @ViewChild('audioPlayer') audioPlayer?: AudioPlayerComponent;
+  /** Having some text in the verse label (rather than empty string or a space) helps containing components predict the
+   * likely height. */
+  private readonly emptyVerseLabel: string = ':';
 
   @Input() set textDocId(value: TextDocId | undefined) {
     this._textDocId = value;
@@ -35,7 +39,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
     this.doAudioSubscriptions();
   }
 
-  verseLabel: string = '';
+  verseLabel: string = this.emptyVerseLabel;
   audioSource?: string;
 
   private _timing: AudioTiming[] = [];
@@ -57,7 +61,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   }
 
   private get currentVerseLabel(): string {
-    if (this._textDocId == null) return '';
+    if (this._textDocId == null) return this.emptyVerseLabel;
     const currentTime: number = this.audioPlayer?.audio?.currentTime ?? 0;
     const currentVerseStr: string = this.getCurrentVerseStr(currentTime);
     const verseRef = new VerseRef(
@@ -182,7 +186,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   private subscribeToAudioFinished(audio: AudioPlayer): void {
     this.finishedSubscription?.unsubscribe();
     this.finishedSubscription = this.subscribe(audio.finishedPlaying$.pipe(first()), () => {
-      this.close();
+      if (this.canClose) this.close();
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -130,7 +130,6 @@
                     <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
                     <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">
                       <app-checking-scripture-audio-player
-                        [source]="chapterAudioSource"
                         [timing]="chapterTextAudioTiming"
                         [textDocId]="textDocId"
                         [canClose]="!hideChapterText"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -124,6 +124,7 @@
                 (dragEnd)="checkSliderPosition($event)"
                 [useTransition]="true"
               >
+                <!-- Splitter area sizes are controlled programmatically. -->
                 <as-split-area [size]="100">
                   <div class="panel-content" #scripturePanelContainer>
                     <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
@@ -132,6 +133,7 @@
                         [source]="chapterAudioSource"
                         [timing]="chapterTextAudioTiming"
                         [textDocId]="textDocId"
+                        [canClose]="!hideChapterText"
                         (currentVerseChanged)="handleAudioTextRefChanged($event)"
                         (closed)="hideChapterAudio()"
                       ></app-checking-scripture-audio-player>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -144,6 +144,7 @@
                       [questionVerses]="questionVerseRefs"
                       (questionVerseSelected)="verseRefClicked($event)"
                       [isRightToLeft]="isRightToLeft"
+                      [class.hidden]="hideChapterText"
                     ></app-checking-text>
                   </div>
                 </as-split-area>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -125,7 +125,7 @@
                 [useTransition]="true"
               >
                 <!-- Splitter area sizes are controlled programmatically. -->
-                <as-split-area [size]="100">
+                <as-split-area [size]="100" [maxSize]="scriptureAreaMaxSize">
                   <div class="panel-content" #scripturePanelContainer>
                     <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
                     <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -267,3 +267,7 @@ $questionsPanelBreakpoint: 600px;
   z-index: 1;
   padding: 0.25rem;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1667,7 +1667,7 @@ describe('CheckingComponent', () => {
       const env = new TestEnvironment({ user: CHECKER_USER });
       env.waitForAudioPlayer();
       const quillElementLang = env.quillEditorElement.getAttribute('lang');
-      expect(quillElementLang).toEqual(env.project01WritingSystemTag);
+      expect(quillElementLang).toEqual(TestEnvironment.project01WritingSystemTag);
     }));
 
     it('adds question count attribute to element', fakeAsync(() => {
@@ -1791,6 +1791,8 @@ interface UserInfo {
 }
 
 class TestEnvironment {
+  static project01WritingSystemTag = 'en';
+
   readonly component: CheckingComponent;
   readonly fixture: ComponentFixture<CheckingComponent>;
   readonly loader: HarnessLoader;
@@ -1801,7 +1803,6 @@ class TestEnvironment {
   readonly router: Router;
 
   questionReadTimer: number = 2000;
-  project01WritingSystemTag = 'en';
   isOnline: BehaviorSubject<boolean>;
   fileSyncComplete: Subject<void> = new Subject();
 
@@ -1874,61 +1875,23 @@ class TestEnvironment {
 
   private projectBookRoute: string = 'JHN';
 
-  private readonly testProject: SFProject = createTestProject({
-    writingSystem: {
-      tag: this.project01WritingSystemTag
-    },
-    translateConfig: {
-      translationSuggestionsEnabled: true,
-      source: {
-        paratextId: 'project02',
-        projectRef: 'project02',
-        name: 'Source',
-        shortName: 'SRC',
-        writingSystem: { tag: 'qaa' }
-      }
-    },
-    texts: [
-      {
-        bookNum: 43,
-        hasSource: false,
-        chapters: [
-          { number: 1, lastVerse: 18, isValid: true, permissions: {}, hasAudio: true },
-          { number: 2, lastVerse: 25, isValid: true, permissions: {}, hasAudio: true }
-        ],
-        permissions: {}
-      },
-      {
-        bookNum: 40,
-        hasSource: false,
-        chapters: [{ number: 1, lastVerse: 28, isValid: true, permissions: {} }],
-        permissions: {}
-      }
-    ],
-    userRoles: {
-      [ADMIN_USER.id]: ADMIN_USER.role,
-      [CHECKER_USER.id]: CHECKER_USER.role,
-      [CLEAN_CHECKER_USER.id]: CLEAN_CHECKER_USER.role,
-      [OBSERVER_USER.id]: OBSERVER_USER.role
-    },
-    paratextUsers: [
-      { sfUserId: ADMIN_USER.id, username: ADMIN_USER.user.name, opaqueUserId: `opaque${ADMIN_USER.id}` },
-      { sfUserId: OBSERVER_USER.id, username: OBSERVER_USER.user.name, opaqueUserId: `opaque${OBSERVER_USER.id}` }
-    ]
-  });
+  private readonly testProject: SFProject = TestEnvironment.generateTestProject();
 
   constructor({
     user,
     projectBookRoute = 'JHN',
     hasConnection = true,
-    scriptureAudio = false
+    scriptureAudio = false,
+    testProject = undefined
   }: {
     user: UserInfo;
     projectBookRoute?: string;
     hasConnection?: boolean;
     scriptureAudio?: boolean;
+    testProject?: SFProject;
   }) {
     reset(mockedFileService);
+    if (testProject != null) this.testProject = testProject;
     this.params$ = new BehaviorSubject<Params>({ projectId: 'project01', bookId: projectBookRoute });
     this.setBookId(projectBookRoute);
     this.setupDefaultProjectData(user);
@@ -2158,6 +2121,51 @@ class TestEnvironment {
 
   get unreadAnswersBannerCount(): number | null {
     return this.getFirstNumberFromElementText('#show-unread-answers-button');
+  }
+
+  static generateTestProject(): SFProject {
+    return createTestProject({
+      writingSystem: {
+        tag: TestEnvironment.project01WritingSystemTag
+      },
+      translateConfig: {
+        translationSuggestionsEnabled: true,
+        source: {
+          paratextId: 'project02',
+          projectRef: 'project02',
+          name: 'Source',
+          shortName: 'SRC',
+          writingSystem: { tag: 'qaa' }
+        }
+      },
+      texts: [
+        {
+          bookNum: 43,
+          hasSource: false,
+          chapters: [
+            { number: 1, lastVerse: 18, isValid: true, permissions: {}, hasAudio: true },
+            { number: 2, lastVerse: 25, isValid: true, permissions: {}, hasAudio: true }
+          ],
+          permissions: {}
+        },
+        {
+          bookNum: 40,
+          hasSource: false,
+          chapters: [{ number: 1, lastVerse: 28, isValid: true, permissions: {} }],
+          permissions: {}
+        }
+      ],
+      userRoles: {
+        [ADMIN_USER.id]: ADMIN_USER.role,
+        [CHECKER_USER.id]: CHECKER_USER.role,
+        [CLEAN_CHECKER_USER.id]: CLEAN_CHECKER_USER.role,
+        [OBSERVER_USER.id]: OBSERVER_USER.role
+      },
+      paratextUsers: [
+        { sfUserId: ADMIN_USER.id, username: ADMIN_USER.user.name, opaqueUserId: `opaque${ADMIN_USER.id}` },
+        { sfUserId: OBSERVER_USER.id, username: OBSERVER_USER.user.name, opaqueUserId: `opaque${OBSERVER_USER.id}` }
+      ]
+    });
   }
 
   activateQuestion(dataId: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1698,6 +1698,81 @@ describe('CheckingComponent', () => {
       expect(segment.classList.contains('question-segment')).toBe(true);
       expect(segment.classList.contains('highlight-segment')).toBe(true);
     }));
+
+    it('is not hidden when project setting did not specify to hide it', fakeAsync(() => {
+      const env = new TestEnvironment({ user: CHECKER_USER });
+      expect(env.component.projectDoc!.data!.checkingConfig.hideCommunityCheckingText).withContext('setup').toBe(false);
+
+      // SUT 1
+      expect(env.component.hideChapterText)
+        .withContext('component should specify in accordance with project setting')
+        .toBe(false);
+
+      // SUT 2
+      expect(env.appCheckingTextElement.classes.hidden ?? false)
+        .withContext('Scripture text should be shown since the project is set not to hide it')
+        .toBe(false);
+    }));
+
+    it('is hidden when project setting specified', fakeAsync(() => {
+      const testProject: SFProject = TestEnvironment.generateTestProject();
+      testProject.checkingConfig.hideCommunityCheckingText = true;
+      const env = new TestEnvironment({ user: CHECKER_USER, testProject });
+      expect(env.component.projectDoc!.data!.checkingConfig.hideCommunityCheckingText).withContext('setup').toBe(true);
+
+      // SUT 1
+      expect(env.component.hideChapterText)
+        .withContext('component should specify in accordance with project setting')
+        .toBe(true);
+
+      // SUT 2
+      expect(env.appCheckingTextElement.classes.hidden ?? false)
+        .withContext('Scripture text should be hidden when project setting')
+        .toBe(true);
+    }));
+
+    it('dynamically hides when project setting changes to specify hide text', fakeAsync(() => {
+      const env = new TestEnvironment({ user: CHECKER_USER });
+      // Starts off not hiding text.
+      expect(env.component.projectDoc!.data!.checkingConfig.hideCommunityCheckingText).withContext('setup').toBe(false);
+
+      // After the page was originally set up, now set project setting to hide community checking text
+      const changeOriginatesLocally: boolean = false;
+      env.component.projectDoc?.submitJson0Op(op => {
+        op.set(proj => proj.checkingConfig.hideCommunityCheckingText, true);
+      }, changeOriginatesLocally);
+      env.fixture.detectChanges();
+      expect(env.component.projectDoc!.data!.checkingConfig.hideCommunityCheckingText).withContext('setup').toBe(true);
+      env.waitForSliderUpdate();
+
+      // SUT 1
+      expect(env.component.hideChapterText)
+        .withContext('component should specify in accordance with project setting')
+        .toBe(true);
+
+      // SUT 2
+      expect(env.appCheckingTextElement.classes.hidden ?? false)
+        .withContext('Scripture text should be hidden when project setting')
+        .toBe(true);
+
+      // And now set project setting NOT to hide community checking text
+      env.component.projectDoc?.submitJson0Op(op => {
+        op.set(proj => proj.checkingConfig.hideCommunityCheckingText, false);
+      }, changeOriginatesLocally);
+      env.fixture.detectChanges();
+      expect(env.component.projectDoc!.data!.checkingConfig.hideCommunityCheckingText).withContext('setup').toBe(false);
+      env.waitForSliderUpdate();
+
+      // SUT 3
+      expect(env.component.hideChapterText)
+        .withContext('component should specify in accordance with project setting')
+        .toBe(false);
+
+      // SUT 4
+      expect(env.appCheckingTextElement.classes.hidden ?? false)
+        .withContext('Scripture text should not be hidden')
+        .toBe(false);
+    }));
   });
 
   describe('Chapter Audio', () => {
@@ -2123,6 +2198,10 @@ class TestEnvironment {
     return this.getFirstNumberFromElementText('#show-unread-answers-button');
   }
 
+  get appCheckingTextElement(): DebugElement {
+    return this.fixture.debugElement.query(By.css('app-checking-text'));
+  }
+
   static generateTestProject(): SFProject {
     return createTestProject({
       writingSystem: {
@@ -2395,6 +2474,7 @@ class TestEnvironment {
     this.waitForTimersToComplete();
   }
 
+  /** Wait for the code in calculateScriptureSliderPosition() to wait for the DOM to update. */
   waitForSliderUpdate(): void {
     this.waitForTimersToComplete(100);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -176,7 +176,7 @@ describe('CheckingComponent', () => {
 
   describe('Interface', () => {
     it('can navigate using next button', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(1);
       env.clickButton(env.nextButton);
       tick(env.questionReadTimer);
@@ -185,7 +185,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can navigate using previous button', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(2);
       env.clickButton(env.previousButton);
       tick(env.questionReadTimer);
@@ -194,7 +194,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('check navigate buttons disable at the end of the question list', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(1);
       const prev = env.previousButton;
       const next = env.nextButton;
@@ -207,19 +207,19 @@ describe('CheckingComponent', () => {
     }));
 
     it('should open question dialog', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.clickButton(env.addQuestionButton);
       verify(mockedQuestionDialogService.questionDialog(anything())).once();
       expect().nothing();
     }));
 
     it('hides add question button for community checker', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       expect(env.addQuestionButton).toBeNull();
     }));
 
     it('responds to remote removed from project', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(1);
       expect(env.component.questionDocs.length).toEqual(15);
       env.component.projectDoc!.submitJson0Op(op => op.unset<string>(p => p.userRoles[CHECKER_USER.id]), false);
@@ -230,7 +230,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('responds to remote community checking disabled when checker', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(1);
       const projectUserConfig = env.component.projectUserConfigDoc!.data!;
       expect(projectUserConfig.selectedTask).toEqual('checking');
@@ -244,7 +244,7 @@ describe('CheckingComponent', () => {
 
     it('responds to remote community checking disabled when observer', fakeAsync(() => {
       // User with access to translate app should get redirected there
-      const env = new TestEnvironment(OBSERVER_USER, 'ALL');
+      const env = new TestEnvironment({ user: OBSERVER_USER, projectBookRoute: 'ALL' });
       env.selectQuestion(1);
       env.setCheckingEnabled(false);
       expect(env.location.path()).toEqual('/projects/project01/translate/JHN');
@@ -256,7 +256,7 @@ describe('CheckingComponent', () => {
 
   describe('Questions', () => {
     it('questions are displaying and audio is cached', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       verify(mockedFileService.findOrUpdateCache(FileType.Audio, QuestionDoc.COLLECTION, anything(), anything())).times(
         31
       );
@@ -270,7 +270,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('questions are displaying for all books', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER, 'ALL');
+      const env = new TestEnvironment({ user: CHECKER_USER, projectBookRoute: 'ALL' });
       // Question 5 has been stored as the question to start at
       expect(env.component.questionsList!.activeQuestionDoc!.data!.dataId).toBe('q5Id');
       // A sixteenth question is archived
@@ -284,13 +284,13 @@ describe('CheckingComponent', () => {
     }));
 
     it('can select a question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const question = env.selectQuestion(1);
       expect(question.classes['selected']).toBe(true);
     }));
 
     it('question status change to read', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       let question = env.selectQuestion(2, false);
       expect(question.classes['question-read']).toBeUndefined();
       question = env.selectQuestion(3);
@@ -298,14 +298,14 @@ describe('CheckingComponent', () => {
     }));
 
     it('question status change to answered', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const question = env.selectQuestion(2);
       env.answerQuestion('Answer question 2');
       expect(question.classes['question-answered']).toBe(true);
     }));
 
     it('question shows answers icon and total', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const question = env.selectQuestion(6, false);
       expect(env.getUnread(question)).toEqual(1);
       tick(env.questionReadTimer);
@@ -315,7 +315,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('allows admin to archive a question', fakeAsync(async () => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(1);
       const question = env.component.answersPanel!.questionDoc!.data!;
       expect(question.isArchived).toBe(false);
@@ -331,7 +331,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('opens a dialog when edit question is clicked', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(15);
       when(mockedQuestionDialogService.questionDialog(anything())).thenResolve(
         env.component.questionsList!.activeQuestionDoc
@@ -351,7 +351,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('removes audio player when question audio deleted', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const questionId = 'q15Id';
       const questionDoc = cloneDeep(env.getQuestionDoc(questionId));
       questionDoc.submitJson0Op(op => {
@@ -372,7 +372,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('uploads audio then updates audio url', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, 'JHN', false);
+      const env = new TestEnvironment({ user: ADMIN_USER, projectBookRoute: 'JHN', hasConnection: false });
       env.selectQuestion(14);
       const questionId = 'q14Id';
       const questionDoc = cloneDeep(env.getQuestionDoc(questionId));
@@ -394,7 +394,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('user must confirm question answered dialog before question dialog appears', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
       // Edit a question with answers
       env.selectQuestion(6);
@@ -408,7 +408,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('should move highlight and question icon when question is edited to move verses', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(1);
       env.waitForSliderUpdate();
       expect(env.segmentHasQuestion(1, 1)).toBe(true);
@@ -434,14 +434,14 @@ describe('CheckingComponent', () => {
     }));
 
     it('unread answers badge is only visible when the setting is ON to see other answers', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.getUnread(env.questions[5])).toEqual(1);
       env.setSeeOtherUserResponses(false);
       expect(env.getUnread(env.questions[5])).toEqual(0);
     }));
 
     it('unread answers badge always hidden from community checkers', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       // One unread answer and three comments are hidden
       expect(env.getUnread(env.questions[6])).toEqual(0);
       env.setSeeOtherUserResponses(false);
@@ -449,7 +449,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('responds to remote question added', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       let question = env.selectQuestion(1);
       const questionId = env.component.questionsList!.activeQuestionDoc!.id;
       expect(env.questions.length).toEqual(15);
@@ -475,7 +475,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('question with audio and no text should display book/chapter as a reference', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const dateNow = new Date();
       const newQuestion: Question = {
         dataId: objectId(),
@@ -498,7 +498,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('respond to remote question audio added or removed', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(1);
       expect(env.audioPlayerOnQuestion).toBeNull();
       env.simulateRemoteEditQuestionAudio('filename.mp3');
@@ -519,7 +519,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('question added to another book changes the route to that book and activates the question', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const dateNow = new Date();
       const newQuestion: Question = {
         dataId: objectId(),
@@ -540,7 +540,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('admin can see appropriate filter options', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.component.questionFilters.has(QuestionFilter.None)).withContext('All').toEqual(true);
       expect(env.component.questionFilters.has(QuestionFilter.HasAnswers)).withContext('HasAnswers').toEqual(true);
       expect(env.component.questionFilters.has(QuestionFilter.NoAnswers)).withContext('NoAnswers').toEqual(true);
@@ -558,7 +558,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('non-admin can see appropriate filter options', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       expect(env.component.questionFilters.has(QuestionFilter.None)).withContext('All').toEqual(true);
       expect(env.component.questionFilters.has(QuestionFilter.HasAnswers)).withContext('HasAnswers').toEqual(false);
       expect(env.component.questionFilters.has(QuestionFilter.NoAnswers)).withContext('NoAnswers').toEqual(false);
@@ -576,7 +576,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can filter questions', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const totalQuestions = env.questions.length;
       const expectedQuestionCounts: { filter: QuestionFilter; total: number }[] = [
         { filter: QuestionFilter.None, total: 15 },
@@ -602,14 +602,14 @@ describe('CheckingComponent', () => {
     }));
 
     it('show applied filter label', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.questionFilterLabel).toBeUndefined();
       env.setQuestionFilter(QuestionFilter.HasAnswers);
       expect(env.questionFilterLabel).toEqual('Filter: Has answers');
     }));
 
     it('show no questions message for filter', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, 'MAT');
+      const env = new TestEnvironment({ user: ADMIN_USER, projectBookRoute: 'MAT' });
       expect(env.questions.length).toEqual(1);
       env.setQuestionFilter(QuestionFilter.StatusExport);
       expect(env.questions.length).toEqual(0);
@@ -617,7 +617,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('should update question summary when filtered', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.questions.length).toEqual(15);
       // Admin has already read 2 questions and the 3rd is read on load
       expect(env.component.summary.unread).toEqual(12);
@@ -628,7 +628,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('should reset filtering after a new question is added', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.questions.length).toEqual(15);
       env.setQuestionFilter(QuestionFilter.StatusResolved);
       expect(env.questions.length).toEqual(1);
@@ -644,7 +644,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('should reset filtering when changing books', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, 'ALL');
+      const env = new TestEnvironment({ user: ADMIN_USER, projectBookRoute: 'ALL' });
       env.setQuestionFilter(QuestionFilter.StatusResolved);
       expect(env.component.bookName).toEqual('John');
       expect(env.component.questionFilterSelected).toEqual(QuestionFilter.StatusResolved);
@@ -658,12 +658,12 @@ describe('CheckingComponent', () => {
 
   describe('Answers', () => {
     it('answer panel is initiated and shows the first question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       expect(env.answerPanel).not.toBeNull();
     }));
 
     it('can answer a question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       // Checker user already has an answer on question 6 and 9
       expect(env.component.summary.answered).toEqual(2);
@@ -674,7 +674,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('opens edit display name dialog if answering a question for the first time', fakeAsync(() => {
-      const env = new TestEnvironment(CLEAN_CHECKER_USER);
+      const env = new TestEnvironment({ user: CLEAN_CHECKER_USER });
       env.selectQuestion(2);
       env.answerQuestion('Answering question 2 should pop up a dialog');
       verify(mockedUserService.editDisplayName(true)).once();
@@ -683,7 +683,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('does not open edit display name dialog if offline', fakeAsync(() => {
-      const env = new TestEnvironment(CLEAN_CHECKER_USER, 'JHN', false);
+      const env = new TestEnvironment({ user: CLEAN_CHECKER_USER, projectBookRoute: 'JHN', hasConnection: false });
       env.selectQuestion(2);
       env.answerQuestion('Answering question 2 offline');
       verify(mockedUserService.editDisplayName(anything())).never();
@@ -692,7 +692,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('inserts newer answer above older answers', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       env.answerQuestion('Just added answer');
       expect(env.answers.length).toEqual(2);
@@ -701,7 +701,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('saves the location of the last visited question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const projectUserConfigDoc = env.component.projectUserConfigDoc!.data!;
       verify(mockedTranslationEngineService.trainSelectedSegment(anything(), anything())).once();
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q5Id');
@@ -717,7 +717,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('saves the last visited question in all question context', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER, 'ALL');
+      const env = new TestEnvironment({ user: CHECKER_USER, projectBookRoute: 'ALL' });
       const projectUserConfigDoc = env.component.projectUserConfigDoc!.data!;
       verify(mockedTranslationEngineService.trainSelectedSegment(anything(), anything())).once();
       expect(projectUserConfigDoc.selectedQuestionRef).toBe('project01:q5Id');
@@ -729,7 +729,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can cancel answering a question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       env.clickButton(env.addAnswerButton);
       env.waitForSliderUpdate();
@@ -741,7 +741,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('does not save the answer when storage quota exceeded', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       when(
         mockedFileService.uploadFile(
           FileType.Audio,
@@ -777,7 +777,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can change answering tabs', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       env.clickButton(env.addAnswerButton);
       env.waitForSliderUpdate();
@@ -787,7 +787,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('check answering validation', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       env.clickButton(env.addAnswerButton);
       env.clickButton(env.saveAnswerButton);
@@ -796,7 +796,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can edit a new answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       env.answerQuestion('Answer question 7');
       const myAnswerIndex = 0;
@@ -813,7 +813,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can edit an existing answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       // Open up question where user already has an answer
       env.selectQuestion(9);
       expect(env.answers.length).withContext('setup problem').toBeGreaterThan(1);
@@ -850,7 +850,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('highlights remotely edited answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(9);
       const otherAnswerIndex = 1;
       expect(env.getAnswer(otherAnswerIndex).classes['attention']).toBeUndefined();
@@ -862,7 +862,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('does not highlight upon sync', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(9);
       const answerIndex = 1;
       expect(env.getAnswer(answerIndex).classes['attention']).toBeUndefined();
@@ -874,7 +874,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('still shows answers as read after canceling an edit', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       env.answerQuestion('Answer question 7');
       const myAnswerIndex = 0;
@@ -891,7 +891,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('only my answer is highlighted after I add an answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       env.answerQuestion('My answer');
       expect(env.answers.length).withContext('setup problem').toBeGreaterThan(1);
@@ -902,7 +902,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can remove audio from answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const data: FileOfflineData = { id: 'a6Id', dataCollection: 'questions', blob: getAudioBlob() };
       when(mockedFileService.findOrUpdateCache(FileType.Audio, 'questions', 'a6Id', '/audio.mp3')).thenResolve(data);
       env.selectQuestion(6);
@@ -920,7 +920,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('saves audio answer offline and plays from cache', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER, 'JHN', false);
+      const env = new TestEnvironment({ user: CHECKER_USER, projectBookRoute: 'JHN', hasConnection: false });
       const resolveUpload$: Subject<void> = env.resolveFileUploadSubject('blob://audio');
       env.answerQuestion('An offline answer', 'audioFile.mp3');
       resolveUpload$.next();
@@ -945,7 +945,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('saves the answer to the correct question when active question changed', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const resolveUpload$: Subject<void> = env.resolveFileUploadSubject('uploadedFile.mp3');
       env.selectQuestion(1);
       env.answerQuestion('Answer with audio', 'audioFile.mp3');
@@ -960,7 +960,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can delete an answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(6);
       expect(env.answers.length).toEqual(1);
       env.clickButton(env.answerDeleteButton(0));
@@ -972,7 +972,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can delete correct answer after changing chapters', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       env.answerQuestion('Answer question 2');
       env.component.chapter!++;
@@ -982,7 +982,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('answers reset when changing questions', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(2);
       env.answerQuestion('Answer question 2');
       expect(env.answers.length).toEqual(1);
@@ -991,7 +991,7 @@ describe('CheckingComponent', () => {
     }));
 
     it("checker user can like and unlike another's answer", fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       env.answerQuestion('Answer question 7');
       expect(env.getAnswerText(1)).toBe('Answer 7 on question');
@@ -1007,7 +1007,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('cannot like your own answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(1);
       env.answerQuestion('Answer question to be liked');
       expect(env.getLikeTotal(0)).toBe(0);
@@ -1018,7 +1018,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('observer cannot like an answer', fakeAsync(() => {
-      const env = new TestEnvironment(OBSERVER_USER);
+      const env = new TestEnvironment({ user: OBSERVER_USER });
       env.selectQuestion(7);
       expect(env.getAnswerText(0)).toBe('Answer 7 on question');
       expect(env.getLikeTotal(0)).toBe(0);
@@ -1029,7 +1029,7 @@ describe('CheckingComponent', () => {
     }));
 
     it("admin user can like and unlike another's answer", fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(9);
       expect(env.getAnswerText(0)).toBe('Answer 0 on question');
       expect(env.getAnswerText(1)).toBe('Answer 1 on question');
@@ -1050,7 +1050,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('hides the like icon if see other users responses is disabled', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(6);
       expect(env.answers.length).toEqual(1);
       expect(env.likeButtons.length).toEqual(1);
@@ -1061,7 +1061,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('do not show answers until current user has submitted an answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       expect(env.getUnread(env.questions[6])).toEqual(0);
       env.selectQuestion(7);
       expect(env.answers.length).toBe(0);
@@ -1070,7 +1070,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('checker can only see their answers when the setting is OFF to see other answers', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.setSeeOtherUserResponses(false);
       env.selectQuestion(6);
       expect(env.answers.length).toBe(1);
@@ -1081,7 +1081,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can add scripture to an answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const selection: TextSelection = {
         verses: { bookNum: 43, chapterNum: 2, verseNum: 2, verse: '2-5' },
         text: 'The selected text',
@@ -1102,7 +1102,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can remove scripture from an answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(6);
       expect(env.getAnswerScriptureText(0)).toBe('Quoted scripture(John 1:1)');
       env.clickButton(env.getAnswerEditButton(0));
@@ -1114,13 +1114,13 @@ describe('CheckingComponent', () => {
     }));
 
     it('observer cannot answer a question', fakeAsync(() => {
-      const env = new TestEnvironment(OBSERVER_USER);
+      const env = new TestEnvironment({ user: OBSERVER_USER });
       env.selectQuestion(2);
       expect(env.addAnswerButton).toBeNull();
     }));
 
     it('project admins can only edit own answers', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(6);
       expect(env.answers.length).toEqual(1);
       expect(env.getAnswerEditButton(0)).toBeNull();
@@ -1129,7 +1129,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('error about "answer or recording required" goes away after add recording', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(1);
       env.clickButton(env.addAnswerButton);
       env.clickButton(env.saveAnswerButton);
@@ -1149,7 +1149,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('new remote answers from other users are not displayed until requested', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
 
       env.selectQuestion(7);
       expect(env.totalAnswersMessageCount).withContext('setup').toBeNull();
@@ -1187,7 +1187,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('new remote answers from other users are not displayed to proj admin until requested', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       // Select a question with at least one answer, but with no answers
       // authored by the project admin since that was hindering this test.
       env.selectQuestion(6);
@@ -1222,7 +1222,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('proj admin sees total answer count if >0 answers', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       // Select a question with at least one answer, but with no answers
       // authored by the project admin, in case that hinders this test.
       env.selectQuestion(6);
@@ -1244,7 +1244,7 @@ describe('CheckingComponent', () => {
     }));
 
     it("new remote answers and banner don't show, if user has not yet answered the question", fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       expect(env.answers.length).withContext('setup (no answers in DOM yet)').toEqual(0);
       expect(env.component.answersPanel!.answers.length).withContext('setup').toEqual(1);
@@ -1268,7 +1268,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('show-remote-answer banner disappears if user deletes their answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       // User answers a question
       env.answerQuestion('New answer from current user');
@@ -1315,7 +1315,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('show-remote-answer banner disappears if the un-shown remote answer is deleted', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       // User answers a question
       env.answerQuestion('New answer from current user');
@@ -1336,7 +1336,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('show-remote-answer banner not shown if user is editing their answer', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(7);
       // User answers a question
       env.answerQuestion('New answer from current user');
@@ -1362,7 +1362,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('show-remote-answer banner not shown to user if see-others-answers is disabled', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.setSeeOtherUserResponses(false);
       expect(env.component.projectDoc!.data!.checkingConfig.usersSeeEachOthersResponses)
         .withContext('setup')
@@ -1380,7 +1380,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('show-remote-answer banner still shown to proj admin if see-others-answers is disabled', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.setSeeOtherUserResponses(false);
       expect(env.component.projectDoc!.data!.checkingConfig.usersSeeEachOthersResponses)
         .withContext('setup')
@@ -1398,7 +1398,7 @@ describe('CheckingComponent', () => {
 
     describe('Comments', () => {
       it('can comment on an answer', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         env.selectQuestion(1);
         env.answerQuestion('Answer question to be commented on');
         env.commentOnAnswer(0, 'Response to answer');
@@ -1406,7 +1406,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('can edit comment on an answer', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         // Answer a question in a chapter where chapters previous also have comments
         env.selectQuestion(15);
         env.answerQuestion('Answer question to be commented on');
@@ -1423,7 +1423,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('can delete comment on an answer', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         env.selectQuestion(1);
         env.answerQuestion('Answer question to be commented on');
         env.commentOnAnswer(0, 'Response to answer');
@@ -1434,7 +1434,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('comments only appear on the relevant answer', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         env.selectQuestion(1);
         env.answerQuestion('Answer question to be commented on');
         env.commentOnAnswer(0, 'First comment');
@@ -1450,7 +1450,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('comments display show more button', fakeAsync(() => {
-        const env = new TestEnvironment(ADMIN_USER);
+        const env = new TestEnvironment({ user: ADMIN_USER });
         // Show maximum of 3 comments before displaying 'show all' button
         env.selectQuestion(7);
         expect(env.getAnswerComments(0).length).toBe(3);
@@ -1470,7 +1470,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('comments unread only mark as read when the show more button is clicked', fakeAsync(() => {
-        const env = new TestEnvironment(ADMIN_USER);
+        const env = new TestEnvironment({ user: ADMIN_USER });
         const question = env.selectQuestion(8, false);
         expect(env.getUnread(question)).toEqual(4);
         tick(env.questionReadTimer);
@@ -1482,7 +1482,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('displays comments in real-time', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         env.selectQuestion(1);
         env.answerQuestion('Admin will add a comment to this');
         expect(env.getAnswerComments(0).length).toEqual(0);
@@ -1498,7 +1498,7 @@ describe('CheckingComponent', () => {
       }));
 
       it('does not mark third comment read if fourth comment also added', fakeAsync(() => {
-        const env = new TestEnvironment(CHECKER_USER);
+        const env = new TestEnvironment({ user: CHECKER_USER });
         env.selectQuestion(1);
         env.answerQuestion('Admin will add four comments');
         env.commentOnAnswer(0, 'First comment');
@@ -1519,14 +1519,14 @@ describe('CheckingComponent', () => {
       }));
 
       it('observer cannot comment on an answer', fakeAsync(() => {
-        const env = new TestEnvironment(OBSERVER_USER);
+        const env = new TestEnvironment({ user: OBSERVER_USER });
         env.selectQuestion(6);
         expect(env.getAddCommentButton(0)).toBeNull();
         env.waitForAudioPlayer();
       }));
 
       it('project admins can only edit own comments', fakeAsync(() => {
-        const env = new TestEnvironment(ADMIN_USER);
+        const env = new TestEnvironment({ user: ADMIN_USER });
         env.selectQuestion(7);
         expect(env.getEditCommentButton(0, 0)).not.toBeNull();
         env.selectQuestion(8);
@@ -1536,7 +1536,7 @@ describe('CheckingComponent', () => {
     });
 
     it('update answer audio cache when activating a question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const questionDoc = spy(env.getQuestionDoc('q5Id'));
       verify(questionDoc!.updateAnswerFileCache()).never();
       env.selectQuestion(5);
@@ -1545,7 +1545,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('update answer audio cache after save', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const questionDoc = spy(env.getQuestionDoc('q6Id'));
       env.selectQuestion(6);
       env.clickButton(env.getAnswerEditButton(0));
@@ -1557,7 +1557,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('update answer audio cache on remote update to question', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       const questionDoc = spy(env.getQuestionDoc('q6Id'));
       env.selectQuestion(6);
       env.simulateRemoteEditAnswer(0, 'Question 6 edited answer');
@@ -1566,7 +1566,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('update answer audio cache on remote removal of an answer', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const questionDoc = spy(env.getQuestionDoc('q6Id'));
       env.selectQuestion(6);
       env.simulateRemoteDeleteAnswer('q6Id', 0);
@@ -1576,7 +1576,7 @@ describe('CheckingComponent', () => {
 
     it('only admins can change answer export status', fakeAsync(() => {
       [OBSERVER_USER, CHECKER_USER, ADMIN_USER].forEach(USER => {
-        const env = new TestEnvironment(USER);
+        const env = new TestEnvironment({ user: USER });
 
         env.selectQuestion(6);
         if (USER === ADMIN_USER) {
@@ -1591,7 +1591,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can mark answer ready for export', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(6);
       const buttonIndex = 0;
 
@@ -1603,7 +1603,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can mark answer as resolved', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(6);
       const buttonIndex = 0;
 
@@ -1615,7 +1615,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can change between different answer statuses', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.selectQuestion(6);
       const buttonIndex = 0;
 
@@ -1644,7 +1644,7 @@ describe('CheckingComponent', () => {
 
   describe('Text', () => {
     it('can increase and decrease font size', fakeAsync(async () => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const editor = env.quillEditor;
       expect(editor.style.fontSize).toBe('1rem');
       await (await env.getIncreaseFontSizeButton()).click();
@@ -1655,7 +1655,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can select a question from the text', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.getVerse(1, 3).dispatchEvent(new Event('click'));
       env.waitForSliderUpdate();
       tick(env.questionReadTimer);
@@ -1664,21 +1664,21 @@ describe('CheckingComponent', () => {
     }));
 
     it('quill editor element lang attribute is set from project language', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.waitForAudioPlayer();
       const quillElementLang = env.quillEditorElement.getAttribute('lang');
       expect(quillElementLang).toEqual(env.project01WritingSystemTag);
     }));
 
     it('adds question count attribute to element', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER);
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const segment = env.quillEditor.querySelector('usx-segment[data-segment=verse_1_1]')!;
       expect(segment.hasAttribute('data-question-count')).toBe(true);
       expect(segment.getAttribute('data-question-count')).toBe('13');
     }));
 
     it('updates question highlight when verse ref changes', fakeAsync(() => {
-      const env = new TestEnvironment(CHECKER_USER);
+      const env = new TestEnvironment({ user: CHECKER_USER });
       env.selectQuestion(4);
       expect(env.getVerse(1, 3)).not.toBeNull();
       let segment = env.getVerse(1, 3);
@@ -1702,7 +1702,7 @@ describe('CheckingComponent', () => {
 
   describe('Chapter Audio', () => {
     it('can open chapter audio', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, undefined, undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
       env.fixture.detectChanges();
 
       expect(env.component.showScriptureAudioPlayer).toBe(false);
@@ -1714,7 +1714,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can close chapter audio', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, undefined, undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -1727,7 +1727,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('pauses audio when changing chapter', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, undefined, undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -1741,7 +1741,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('hides chapter audio if chapter audio is absent', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, undefined, undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -1755,7 +1755,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('keeps chapter audio if chapter audio is present', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, undefined, undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -1769,7 +1769,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('pauses audio on reload (changing book)', fakeAsync(() => {
-      const env = new TestEnvironment(ADMIN_USER, 'ALL', undefined, true);
+      const env = new TestEnvironment({ user: ADMIN_USER, projectBookRoute: 'ALL', scriptureAudio: true });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -1917,12 +1917,17 @@ class TestEnvironment {
     ]
   });
 
-  constructor(
-    user: UserInfo,
-    projectBookRoute: string = 'JHN',
-    hasConnection: boolean = true,
-    scriptureAudio: boolean = false
-  ) {
+  constructor({
+    user,
+    projectBookRoute = 'JHN',
+    hasConnection = true,
+    scriptureAudio = false
+  }: {
+    user: UserInfo;
+    projectBookRoute?: string;
+    hasConnection?: boolean;
+    scriptureAudio?: boolean;
+  }) {
     reset(mockedFileService);
     this.params$ = new BehaviorSubject<Params>({ projectId: 'project01', bookId: projectBookRoute });
     this.setBookId(projectBookRoute);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -120,6 +120,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   userDoc?: UserDoc;
   visibleQuestions?: QuestionDoc[];
   showScriptureAudioPlayer: boolean = false;
+  hideChapterText: boolean = false;
 
   private _book?: number;
   private _isDrawerPermanent: boolean = true;
@@ -194,7 +195,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
           : undefined;
 
       this._scriptureAudioPlayer?.pause();
-      if (!this.chapterHasAudio) {
+      if (!this.chapterHasAudio && !this.hideChapterText) {
         this.hideChapterAudio();
       }
     }
@@ -444,6 +445,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       if (!this.projectDoc.isLoaded) {
         return;
       }
+      this.showOrHideScriptureText();
       const bookNum = bookId == null ? 0 : Canon.bookIdToNumber(bookId);
       this.projectUserConfigDoc = await this.projectService.getUserConfig(projectId, this.userService.currentUserId);
       if (prevProjectId !== this.projectDoc.id || this.book !== bookNum || (bookId !== 'ALL' && this.showAllBooks)) {
@@ -538,6 +540,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
               this.onRemovedFromProject();
             }
           }
+          this.showOrHideScriptureText();
         }
       });
       this.projectDeleteSub?.unsubscribe();
@@ -1213,6 +1216,11 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
   isAudioPlaying(): boolean {
     return this._scriptureAudioPlayer?.isPlaying ?? false;
+  }
+
+  private showOrHideScriptureText(): void {
+    this.hideChapterText = this.projectDoc?.data?.checkingConfig.hideCommunityCheckingText ?? false;
+    if (this.hideChapterText) this.showScriptureAudioPlayer = true;
   }
 
   hideChapterAudio(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -150,6 +150,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   private text?: TextInfo;
   private isProjectAdmin: boolean = false;
   private _scriptureAudioPlayer?: CheckingScriptureAudioPlayerComponent;
+  private _scriptureAreaMaxSize: number | null = null;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -445,6 +446,15 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   /** Percentage of the vertical space of the as-splitter, needed by just the Scripture audio player. */
   private get scriptureAudioPlayerHeightPercent(): number {
     return (this.scriptureAudioPlayerAreaHeight / this.splitContainerElementHeight) * 100;
+  }
+
+  /** maxSize for as-split-area for the Scripture+audio area. */
+  public get scriptureAreaMaxSize(): number | null {
+    return this._scriptureAreaMaxSize;
+  }
+
+  private set scriptureAreaMaxSize(value: number | null) {
+    this._scriptureAreaMaxSize = value;
   }
 
   ngOnInit(): void {
@@ -1131,6 +1141,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       if (this.hideChapterText) {
         const answerPanelHeight = 100 - this.scriptureAudioPlayerHeightPercent;
         this.splitComponent?.setVisibleAreaSizes([this.scriptureAudioPlayerHeightPercent, answerPanelHeight]);
+        this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent;
       } else {
         let answerPanelHeight: number;
         if (maximizeAnswerPanel) {
@@ -1143,6 +1154,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         const scripturePanelHeight = 100 - answerPanelHeight;
 
         this.splitComponent.setVisibleAreaSizes([scripturePanelHeight, answerPanelHeight]);
+        this.scriptureAreaMaxSize = null;
       }
     }, changeUpdateDelayMs);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -94,6 +94,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   ) {
     this._scriptureAudioPlayer = newValue;
     if (newValue !== undefined) {
+      // If we are automatically showing the Scripture audio player because hide-text is enabled, don't auto-play.
+      if (this.hideChapterText) return;
       Promise.resolve(null).then(() => this._scriptureAudioPlayer?.play());
     }
   }
@@ -433,6 +435,16 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     return this.splitContainerElement && this.splitComponent
       ? this.splitContainerElement.nativeElement.offsetHeight - this.splitComponent.gutterSize!
       : 0;
+  }
+
+  private get scriptureAudioPlayerAreaHeight(): number {
+    const scriptureAudioPlayerArea: Element | null = document.querySelector('.scripture-audio-player-wrapper');
+    return scriptureAudioPlayerArea == null ? 0 : scriptureAudioPlayerArea.getBoundingClientRect().height;
+  }
+
+  /** Percentage of the vertical space of the as-splitter, needed by just the Scripture audio player. */
+  private get scriptureAudioPlayerHeightPercent(): number {
+    return (this.scriptureAudioPlayerAreaHeight / this.splitContainerElementHeight) * 100;
   }
 
   ngOnInit(): void {
@@ -864,6 +876,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       currentChapter: this._chapter
     };
     await this.chapterAudioDialogService.openDialog(dialogConfig);
+    this.calculateScriptureSliderPosition();
   }
 
   handleAudioTextRefChanged(ref: string): void {
@@ -1106,25 +1119,32 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     this._activeQuestionVerseRef = questionDoc.data == null ? undefined : toVerseRef(questionDoc.data.verseRef);
   }
 
+  /** Adjust the position of the splitter between Scripture text and answers. */
   private calculateScriptureSliderPosition(maximizeAnswerPanel: boolean = false): void {
-    const waitMs: number = 100;
-    // Wait while Angular updates visible DOM elements before we can calculate the height correctly
-    setTimeout(() => {
+    // Wait while Angular updates visible DOM elements before we can calculate the height correctly.
+    // 100 ms is a speculative value for waiting for elements to be loaded and updated in the DOM.
+    const changeUpdateDelayMs: number = 100;
+    setTimeout(async () => {
       if (this.splitComponent == null) {
         return;
       }
-
-      let answerPanelHeight: number;
-      if (maximizeAnswerPanel) {
-        answerPanelHeight = this.fullyExpandedAnswerPanelPercent;
+      if (this.hideChapterText) {
+        const answerPanelHeight = 100 - this.scriptureAudioPlayerHeightPercent;
+        this.splitComponent?.setVisibleAreaSizes([this.scriptureAudioPlayerHeightPercent, answerPanelHeight]);
       } else {
-        answerPanelHeight = this.minAnswerPanelPercent;
-      }
+        let answerPanelHeight: number;
+        if (maximizeAnswerPanel) {
+          answerPanelHeight = this.fullyExpandedAnswerPanelPercent;
+        } else {
+          answerPanelHeight = this.minAnswerPanelPercent;
+        }
 
-      answerPanelHeight = Math.min(75, answerPanelHeight);
-      const scripturePanelHeight = 100 - answerPanelHeight;
-      this.splitComponent.setVisibleAreaSizes([scripturePanelHeight, answerPanelHeight]);
-    }, waitMs);
+        answerPanelHeight = Math.min(75, answerPanelHeight);
+        const scripturePanelHeight = 100 - answerPanelHeight;
+
+        this.splitComponent.setVisibleAreaSizes([scripturePanelHeight, answerPanelHeight]);
+      }
+    }, changeUpdateDelayMs);
   }
 
   // Unbind this component from the data when a user is removed from the project, otherwise console
@@ -1219,8 +1239,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   }
 
   private showOrHideScriptureText(): void {
-    this.hideChapterText = this.projectDoc?.data?.checkingConfig.hideCommunityCheckingText ?? false;
+    const oldValue = this.hideChapterText;
+    const newVal = this.projectDoc?.data?.checkingConfig.hideCommunityCheckingText ?? false;
+    this.hideChapterText = newVal;
     if (this.hideChapterText) this.showScriptureAudioPlayer = true;
+    // (Don't needlessly have setTimeout get called if the value hasn't changed.)
+    if (oldValue !== newVal) {
+      this.calculateScriptureSliderPosition();
+    }
   }
 
   hideChapterAudio(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -200,6 +200,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       this._scriptureAudioPlayer?.pause();
       if (!this.chapterHasAudio && !this.hideChapterText) {
         this.hideChapterAudio();
+      } else if (this._scriptureAudioPlayer != null) {
+        this._scriptureAudioPlayer.source = this.chapterAudioSource;
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
@@ -1,7 +1,7 @@
 <button type="button" [style.--audio-progress]="progressInDegrees" *transloco="let t; read: 'checking_audio_player'">
   <ng-content *ngIf="isAudioAvailable$ | async"></ng-content>
-  <mat-spinner *ngIf="audioStatus === 'audio_initialized'" [diameter]="20" color="primary"></mat-spinner>
-  <mat-icon *ngIf="!isAudioAvailable$.value && audioStatus !== 'audio_initialized'" [matTooltip]="t(audioStatus)">
+  <mat-spinner *ngIf="audioStatus === AudioStatus.Initializing" [diameter]="20" color="primary"></mat-spinner>
+  <mat-icon *ngIf="!isAudioAvailable$.value && audioStatus !== AudioStatus.Initializing" [matTooltip]="t(audioStatus)">
     play_disabled
   </mat-icon>
 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.ts
@@ -12,7 +12,8 @@ import { AudioSegmentPlayer } from '../../../shared/audio/audio-segment-player';
 })
 export class SingleButtonAudioPlayerComponent extends AudioPlayerBaseComponent implements OnChanges {
   private _source?: string;
-
+  // Expose enum to template.
+  readonly AudioStatus = AudioStatus;
   readonly hasFinishedPlayingOnce$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   @Input() start?: number;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
@@ -13,4 +13,5 @@ export interface SFProjectSettings {
   usersSeeEachOthersResponses?: boolean;
   checkingShareEnabled?: boolean;
   checkingAnswerExport?: CheckingAnswerExport;
+  hideCommunityCheckingText?: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -156,6 +156,21 @@
                   </mat-radio-group>
                 </div>
               </div>
+              <div class="tool-setting" *ngIf="featureFlags.scriptureAudio.enabled">
+                <div class="tool-setting-field checkbox-field">
+                  <mat-checkbox
+                    formControlName="hideCommunityCheckingText"
+                    id="checkbox-hide-community-checking-text"
+                    >{{ t("hide_community_checking_text") }}</mat-checkbox
+                  >
+                  <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
+                  <app-write-status
+                    [state]="getControlState('hideCommunityCheckingText')"
+                    [formGroup]="form"
+                    id="hide-community-checking-text-status"
+                  ></app-write-status>
+                </div>
+              </div>
             </ng-container>
           </mat-card-content>
           <mat-divider></mat-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -8,16 +8,21 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Route } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CookieService } from 'ngx-cookie-service';
+import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { CheckingConfig } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { createTestTextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio-test-data';
+import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { TranslateConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { BehaviorSubject, of } from 'rxjs';
 import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
+import { FeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { QueryParameters } from 'xforge-common/query-parameters';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -26,6 +31,7 @@ import { UserService } from 'xforge-common/user.service';
 import { WriteStatusComponent } from 'xforge-common/write-status/write-status.component';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
+import { TextAudioDoc } from '../core/models/text-audio-doc';
 import { ParatextService, SelectableProject } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { ProjectSelectComponent } from '../project-select/project-select.component';
@@ -43,6 +49,7 @@ const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
 const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedDialog = mock(MatDialog);
+const mockedFeatureFlagService = mock(FeatureFlagService);
 
 @Component({
   template: `<div>Mock</div>`
@@ -72,6 +79,7 @@ describe('SettingsComponent', () => {
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: CookieService, useMock: mockedCookieService },
       { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: FeatureFlagService, useValue: instance(mockedFeatureFlagService) },
       { provide: MatDialog, useMock: mockedDialog }
     ]
   }));
@@ -361,20 +369,24 @@ describe('SettingsComponent', () => {
     describe('Checking options', () => {
       it('should hide options when Checking is disabled', fakeAsync(() => {
         const env = new TestEnvironment();
+        env.makeProjectHaveTextAudio();
         env.setupProject();
         env.wait();
         expect(env.inputElement(env.translationSuggestionsCheckbox).checked).toBe(true);
         expect(env.inputElement(env.checkingCheckbox).checked).toBe(false);
         expect(env.seeOthersResponsesCheckbox).toBeNull();
         expect(env.checkingShareCheckbox).toBeNull();
+        expect(env.checkingHideCommunityCheckingTextCheckbox).toBeNull();
         env.clickElement(env.inputElement(env.checkingCheckbox));
         expect(env.inputElement(env.checkingCheckbox).checked).toBe(true);
         expect(env.seeOthersResponsesCheckbox).not.toBeNull();
         expect(env.checkingShareCheckbox).not.toBeNull();
+        expect(env.checkingHideCommunityCheckingTextCheckbox).not.toBeNull();
       }));
 
       it('changing state of checking option results in status icon', fakeAsync(() => {
         const env = new TestEnvironment();
+        env.makeProjectHaveTextAudio();
         env.setupProject();
         env.wait();
         env.clickElement(env.inputElement(env.checkingCheckbox));
@@ -397,6 +409,23 @@ describe('SettingsComponent', () => {
         tick();
         env.fixture.detectChanges();
         expect(env.statusDone(env.checkingExportStatus)).not.toBeNull();
+
+        expect(env.statusDone(env.checkingHideCommunityCheckingTextStatus)).toBeNull();
+        env.clickElement(env.inputElement(env.checkingHideCommunityCheckingTextCheckbox));
+        tick();
+        env.fixture.detectChanges();
+        expect(env.statusDone(env.checkingHideCommunityCheckingTextStatus)).not.toBeNull();
+      }));
+
+      it('has hide-text option', fakeAsync(async () => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        env.wait();
+        env.clickElement(env.inputElement(env.checkingCheckbox));
+        expect(env.inputElement(env.checkingCheckbox).checked).toBe(true);
+
+        // SUT
+        expect(env.checkingHideCommunityCheckingTextCheckbox).withContext('checkbox should be shown').not.toBeNull();
       }));
     });
 
@@ -485,7 +514,6 @@ class TestEnvironment {
   readonly component: SettingsComponent;
   readonly fixture: ComponentFixture<SettingsComponent>;
   readonly location: Location;
-
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
   private isOnline: BehaviorSubject<boolean>;
   private mockedDialogRef = mock<MatDialogRef<DeleteProjectDialogComponent>>(MatDialogRef);
@@ -529,6 +557,14 @@ class TestEnvironment {
       },
       { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895', shortName: 'RVA' }
     ]);
+    when(mockedFeatureFlagService.scriptureAudio).thenReturn({ enabled: true } as FeatureFlag);
+
+    when(mockedSFProjectService.queryAudioText(anything())).thenCall(sfProjectId => {
+      const queryParams: QueryParameters = {
+        [obj<TextAudio>().pathStr(t => t.projectRef)]: sfProjectId
+      };
+      return this.realtimeService.subscribeQuery(TextAudioDoc.COLLECTION, queryParams);
+    });
 
     this.fixture = TestBed.createComponent(SettingsComponent);
     this.component = this.fixture.componentInstance;
@@ -591,6 +627,14 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#checking-share-status'));
   }
 
+  get checkingHideCommunityCheckingTextCheckbox(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#checkbox-hide-community-checking-text'));
+  }
+
+  get checkingHideCommunityCheckingTextStatus(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#hide-community-checking-text-status'));
+  }
+
   get dangerZoneTitle(): HTMLElement {
     return this.fixture.nativeElement.querySelector('#danger-zone div');
   }
@@ -639,6 +683,13 @@ class TestEnvironment {
 
   get basedOnSelectProjectsResources(): SelectableProject[] {
     return (this.basedOnSelectComponent.projects || []).concat(this.basedOnSelectComponent.resources || []);
+  }
+
+  makeProjectHaveTextAudio(): void {
+    this.realtimeService.addSnapshot<TextAudio>(TextAudioDoc.COLLECTION, {
+      id: 'sAudio1',
+      data: createTestTextAudio({ projectRef: 'project01' })
+    });
   }
 
   setDialogResponse(confirm: boolean): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -35,6 +36,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   usersSeeEachOthersResponses = new UntypedFormControl(false);
   checkingShareEnabled = new UntypedFormControl(false);
   checkingAnswerExport = new UntypedFormControl(undefined);
+  hideCommunityCheckingText = new UntypedFormControl(false);
 
   CheckingAnswerExport = CheckingAnswerExport;
 
@@ -46,7 +48,8 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     checkingEnabled: this.checkingEnabled,
     usersSeeEachOthersResponses: this.usersSeeEachOthersResponses,
     checkingShareEnabled: this.checkingShareEnabled,
-    checkingAnswerExport: this.checkingAnswerExport
+    checkingAnswerExport: this.checkingAnswerExport,
+    hideCommunityCheckingText: this.hideCommunityCheckingText
   });
 
   isActiveSourceProject: boolean = false;
@@ -55,7 +58,6 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   nonSelectableProjects?: SelectableProject[];
   projectLoadingFailed = false;
   resourceLoadingFailed = false;
-
   mainSettingsLoaded = false;
 
   private static readonly projectSettingValueUnset = 'unset';
@@ -74,7 +76,8 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly dialogService: DialogService,
     private readonly router: Router,
     private readonly onlineStatusService: OnlineStatusService,
-    readonly i18n: I18nService
+    readonly i18n: I18nService,
+    readonly featureFlags: FeatureFlagService
   ) {
     super(noticeService);
     this.loading = true;
@@ -313,6 +316,9 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     ) {
       this.updateSetting(newValue, 'checkingAnswerExport');
     }
+    if (newValue.hideCommunityCheckingText !== this.previousFormValues.hideCommunityCheckingText) {
+      this.updateSetting(newValue, 'hideCommunityCheckingText');
+    }
   }
 
   private checkUpdateStatus(setting: Extract<keyof SFProjectSettings, string>, updatePromise: Promise<void>): void {
@@ -336,6 +342,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       checkingEnabled: this.projectDoc.data.checkingConfig.checkingEnabled,
       usersSeeEachOthersResponses: this.projectDoc.data.checkingConfig.usersSeeEachOthersResponses,
       checkingShareEnabled: this.projectDoc.data.checkingConfig.shareEnabled,
+      hideCommunityCheckingText: this.projectDoc.data.checkingConfig.hideCommunityCheckingText,
       checkingAnswerExport: this.projectDoc.data.checkingConfig.answerExportMethod ?? CheckingAnswerExport.All
     };
     this.form.reset(this.previousFormValues);
@@ -362,6 +369,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     this.controlStates.set('translateShareEnabled', ElementState.InSync);
     this.controlStates.set('checkingEnabled', ElementState.InSync);
     this.controlStates.set('usersSeeEachOthersResponses', ElementState.InSync);
+    this.controlStates.set('hideCommunityCheckingText', ElementState.InSync);
     this.controlStates.set('checkingShareEnabled', ElementState.InSync);
     this.controlStates.set('checkingAnswerExport', ElementState.InSync);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.spec.ts
@@ -42,16 +42,16 @@ describe('AudioPlayerBaseComponent', () => {
     env.component.baseComponent.fireStatusChange(AudioStatus.Available);
 
     expect(spy.calls.allArgs()).toEqual([[false], [true]]);
-    expect(env.component.baseComponent.isAudioInitComplete).toBe(true);
+    expect(env.component.baseComponent.hasProblem).toBe(false);
   }));
 
-  it('sets isAudioInitComplete when status changes from Init', fakeAsync(() => {
+  it('sets hasProblem when status changes from Init', fakeAsync(() => {
     env.component.baseComponent.setAudio(new AudioPlayerStub(audioFile, instance(env.mockOnlineStatusService)));
-    expect(env.component.baseComponent.isAudioInitComplete).toBe(false);
+    expect(env.component.baseComponent.hasProblem).toBe(false);
 
     env.component.baseComponent.fireStatusChange(AudioStatus.Unavailable);
 
-    expect(env.component.baseComponent.isAudioInitComplete).toBe(true);
+    expect(env.component.baseComponent.hasProblem).toBe(true);
   }));
 
   it('resets seek when audio becomes available', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
@@ -53,13 +53,14 @@ export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable im
     );
   }
 
-  @Input() set source(source: string | undefined) {
+  set source(source: string | undefined) {
     this.isAudioAvailable$.next(false);
     this.audio?.dispose();
     if (source != null && source !== '') {
       this.audio = new AudioPlayer(source, this.onlineStatusService);
     } else {
       this.audio = undefined;
+      this.hasProblem = true;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player-base/audio-player-base.component.ts
@@ -9,15 +9,22 @@ import { AudioPlayer, AudioStatus } from '../audio-player';
 })
 export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable implements OnDestroy {
   readonly isAudioAvailable$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  private _isAudioInitComplete: boolean = false;
+  private _hasProblem: boolean = false;
   private _audio: AudioPlayer | undefined;
 
   constructor(protected readonly onlineStatusService: OnlineStatusService) {
     super();
-
     this.subscribe(this.isAudioAvailable$, () => {
       this.audio?.setSeek(0);
     });
+  }
+
+  public get hasProblem(): boolean {
+    return this._hasProblem;
+  }
+
+  private set hasProblem(value: boolean) {
+    this._hasProblem = value;
   }
 
   get audio(): AudioPlayer | undefined {
@@ -29,10 +36,12 @@ export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable im
     if (this.audio !== undefined) {
       this.subscribe(this.audio.status$, newVal => {
         if (newVal === AudioStatus.Available) {
+          this.hasProblem = false;
           this.isAudioAvailable$.next(true);
         }
-        if (newVal !== AudioStatus.Init) {
-          this._isAudioInitComplete = true;
+        if (this._audio?.hasErrorState) {
+          this.hasProblem = true;
+          this.isAudioAvailable$.next(false);
         }
       });
     }
@@ -42,10 +51,6 @@ export abstract class AudioPlayerBaseComponent extends SubscriptionDisposable im
     return (
       this.audio?.status$.value ?? (this.onlineStatusService.isOnline ? AudioStatus.Unavailable : AudioStatus.Offline)
     );
-  }
-
-  get isAudioInitComplete(): boolean {
-    return this._isAudioInitComplete;
   }
 
   @Input() set source(source: string | undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
@@ -6,7 +6,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 
 export enum AudioStatus {
-  Init = 'audio_initialized',
+  Initializing = 'audio_initializing',
   Available = 'audio_available',
   Unavailable = 'audio_cannot_be_accessed',
   LocalNotAvailable = 'audio_cannot_be_previewed',
@@ -21,7 +21,7 @@ export class AudioPlayer extends SubscriptionDisposable {
   // See explanatory comment where this number is used
   protected static readonly ARBITRARILY_LARGE_NUMBER = 1e10;
 
-  readonly status$: BehaviorSubject<AudioStatus> = new BehaviorSubject<AudioStatus>(AudioStatus.Init);
+  readonly status$: BehaviorSubject<AudioStatus> = new BehaviorSubject<AudioStatus>(AudioStatus.Initializing);
   readonly finishedPlaying$: EventEmitter<void> = new EventEmitter<void>();
   readonly timeUpdated$: BehaviorSubject<void> = new BehaviorSubject<void>(undefined);
 
@@ -88,11 +88,11 @@ export class AudioPlayer extends SubscriptionDisposable {
     // know the duration once metadata has loaded.
     this.audio.currentTime = AudioPlayer.ARBITRARILY_LARGE_NUMBER;
     this.audio.src = formatFileSource(FileType.Audio, source);
-    this.status$.next(AudioStatus.Init);
+    this.status$.next(AudioStatus.Initializing);
   }
 
   get hasErrorState(): boolean {
-    return !(this.status$.value === AudioStatus.Init || this.status$.value === AudioStatus.Available);
+    return !(this.status$.value === AudioStatus.Initializing || this.status$.value === AudioStatus.Available);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
@@ -81,6 +81,7 @@ export class AudioPlayer extends SubscriptionDisposable {
       }
     };
 
+    this.status$.next(AudioStatus.Initializing);
     // In Chromium the duration of blobs isn't known even after metadata is loaded
     // By making it skip to the end the duration becomes available. To do this we have to skip to some point that we
     // assume is past the end. This number should be large, but numbers as small as 1e16 have been observed to cause
@@ -88,7 +89,6 @@ export class AudioPlayer extends SubscriptionDisposable {
     // know the duration once metadata has loaded.
     this.audio.currentTime = AudioPlayer.ARBITRARILY_LARGE_NUMBER;
     this.audio.src = formatFileSource(FileType.Audio, source);
-    this.status$.next(AudioStatus.Initializing);
   }
 
   get hasErrorState(): boolean {
@@ -127,6 +127,8 @@ export class AudioPlayer extends SubscriptionDisposable {
   }
 
   get currentTime(): number {
+    // Don't believe the HTMLAudioElement's inflated currentTime value until we are done initializing.
+    if (this.status$.value === AudioStatus.Initializing) return 0;
     return isNaN(this.audio.currentTime) || this.audio.currentTime === AudioPlayer.ARBITRARILY_LARGE_NUMBER
       ? 0
       : this.audio.currentTime;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -1,24 +1,22 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
-  <div *ngIf="isAudioInitComplete">
-    <div *ngIf="audio !== undefined && (isAudioAvailable$ | async)" class="content" dir="ltr">
-      <div class="current-time">{{ audio.currentTime | audioTime }}</div>
-      <mat-slider
-        class="slider"
-        [min]="0"
-        [max]="100"
-        [step]="1"
-        [value]="seek"
-        (input)="onSeek($event)"
-        [dir]="i18n.direction"
-      ></mat-slider>
-      <div class="duration">{{ duration | audioTime }}</div>
-    </div>
-    <div *ngIf="(isAudioAvailable$ | async) !== true" class="audio-not-available">
-      <mat-icon>volume_off</mat-icon>
-      <span>{{ t("audio_unavailable") }}</span>
-      <div *ngIf="audio?.hasErrorState">
-        <app-info id="error-load" [text]="t(audioStatus)"></app-info>
-      </div>
+  <div *ngIf="!hasProblem" class="content" dir="ltr">
+    <div class="current-time">{{ audio?.currentTime ?? 0 | audioTime }}</div>
+    <mat-slider
+      class="slider"
+      [min]="0"
+      [max]="100"
+      [step]="1"
+      [value]="seek"
+      (input)="onSeek($event)"
+      [dir]="i18n.direction"
+    ></mat-slider>
+    <div class="duration">{{ duration | audioTime }}</div>
+  </div>
+  <div *ngIf="hasProblem" class="audio-not-available">
+    <mat-icon>volume_off</mat-icon>
+    <span>{{ t("audio_unavailable") }}</span>
+    <div *ngIf="audio?.hasErrorState">
+      <app-info id="error-load" [text]="t(audioStatus)"></app-info>
     </div>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -287,6 +287,8 @@
     "translation_suggestions": "Enable Translation Suggestions",
     "translations_will_be_suggested": "Translations for words and phrases will be suggested as you edit Scripture based on the project or resource selected above.",
     "users_can_share_the_project": "Allow users to invite people outside Paratext to the project. They will receive the same role as the user who invited them.",
+    "hide_community_checking_text": "Hide Scripture text",
+    "checkers_listen_to_scripture_audio": "Checkers will need to listen to Scripture audio.",
     "will_not_delete_paratext_project": "This will {{ boldStart }}not{{ boldEnd }} delete your Paratext project, but it will delete any unsynchronized data stored in Scripture Forge. It is recommended to {{ templateTagBoundary }}Synchronize{{ templateTagBoundary }} first before deleting."
   },
   "suggestions_settings_dialog": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/json-realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/json-realtime-doc.ts
@@ -10,7 +10,8 @@ export abstract class JsonRealtimeDoc<T = any> extends RealtimeDoc<T, OtJson0Op[
    * that will be submitted to the document.
    *
    * @param {(op: Json0OpBuilder<T>) => void} build The function to build the operation.
-   * @param {*} [source] The source.
+   * @param {*} [source] The source. In practice, `true` (the default) specifies that the op should be
+   * to considered to have originated locally, rather than `false` to specify remotely.
    */
   async submitJson0Op(build: (op: Json0OpBuilder<T>) => void, source: any = true): Promise<boolean> {
     if (this.data == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -117,7 +117,8 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
    * realtime server. Data can only be updated using operations and should not be updated directly.
    *
    * @param {Ops} ops The operations to submit.
-   * @param {*} [source] The source.
+   * @param {*} [source] The source. In practice, `true` (the default) specifies that the op should be
+   * to considered to have originated locally, rather than `false` to specify remotely.
    * @returns {Promise<void>} Resolves when the operations have been successfully submitted.
    */
   async submit(ops: Ops, source?: any): Promise<void> {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -124,6 +124,7 @@ public class SFProjectsRpcController : RpcControllerBase
                     { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },
                     { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled?.ToString() },
                     { "UsersSeeEachOthersResponses", settings?.UsersSeeEachOthersResponses?.ToString() },
+                    { "HideCommunityCheckingText", settings?.HideCommunityCheckingText?.ToString() },
                 }
             );
             throw;

--- a/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/CheckingConfig.cs
@@ -7,4 +7,7 @@ public class CheckingConfig
     public bool ShareEnabled { get; set; } = false;
     public string AnswerExportMethod { get; set; } = CheckingAnswerExport.All;
     public int? NoteTagId { get; set; }
+
+    /// <summary>Do not show chapter text in community checking area (i.e. only audio should be shown)</summary>
+    public bool? HideCommunityCheckingText { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
@@ -18,4 +18,5 @@ public class SFProjectSettings
     public bool? DownloadAudioFiles { get; set; }
     public bool? CheckingShareEnabled { get; set; }
     public string CheckingAnswerExport { get; set; }
+    public bool? HideCommunityCheckingText { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -297,6 +297,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             UpdateSetting(op, p => p.CheckingConfig.UsersSeeEachOthersResponses, settings.UsersSeeEachOthersResponses);
             UpdateSetting(op, p => p.CheckingConfig.ShareEnabled, settings.CheckingShareEnabled);
             UpdateSetting(op, p => p.CheckingConfig.AnswerExportMethod, settings.CheckingAnswerExport);
+            UpdateSetting(op, p => p.CheckingConfig.HideCommunityCheckingText, settings.HideCommunityCheckingText);
         });
 
         bool suggestionsEnabledSet = settings.TranslationSuggestionsEnabled != null;


### PR DESCRIPTION
This proof of concept removes the audio source from being an `@Input` to the audio player. Instead of the source being set in the template, the source is passed to the audio player when the chapter changes. 

Because of this, we don't set an empty source at page-construction time. Therefore, the audio player can know that source setting instances are intentionally done by the parent/owner.

Here the audio player has the responsibility to say whether the audio is available or not.

This code isn't meant to be super well designed, but showing the idea.

Video showing behaviour:
[set-source-intentionally.webm](https://github.com/sillsdev/web-xforge/assets/7265309/4a63c4c0-6b3b-4037-a72c-8e835501d62e)

Note: This PR is targeting an unmerged commit so that the relevant changes are shown.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2094)
<!-- Reviewable:end -->
