### PR TITLE
Fix broken gloss in Indonesian Biblical Terms

### DIFF
--- a/src/SIL.XForge.Scripture/Terms/Lists/BiblicalTermsId.xml
+++ b/src/SIL.XForge.Scripture/Terms/Lists/BiblicalTermsId.xml
@@ -6220,7 +6220,7 @@ putra Ahab, raja Israel
     <Localization Id="יוֹאָשׁ-3" Gloss="Yoas">
 putra Ahazia; raja Yehuda (835-796)
     </Localization>
-    <Localization Id="יוֹאָשׁ-4" Glosys="Yoas">
+    <Localization Id="יוֹאָשׁ-4" Gloss="Yoas">
 putra Yoahas; raja Israel (798-782/781); juga dikenal sebagai Yehoas
     </Localization>
     <Localization Id="יוֹאָשׁ-5" Gloss="Yoas">


### PR DESCRIPTION
This PR fixes a typo in the Indonesian Biblical Terms Localization file that causes a gloss to not be loaded correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2096)
<!-- Reviewable:end -->
