### PR TITLE
Fix broken Storybook Checking Audio Test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.storybook/main.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/.storybook/main.ts
@@ -10,6 +10,6 @@ module.exports = {
   },
   staticDirs: [
     { from: '../src/assets', to: '/assets' },
-    { from: '../src/app/checking/checking/checking-audio-player', to: '/assets/audio/' }
+    { from: '../src/app/checking/checking/test-audio', to: '/assets/audio/' }
   ]
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player-new.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player-new.stories.ts
@@ -8,6 +8,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
 import { AudioTimePipe } from '../../../shared/audio/audio-time-pipe';
+import { InfoComponent } from '../../../shared/info/info.component';
 import { CheckingAudioPlayerComponent } from './checking-audio-player.component';
 
 const mockedOnlineStatusService = mock(OnlineStatusService);
@@ -20,7 +21,7 @@ const meta: Meta<CheckingAudioPlayerComponent> = {
   decorators: [
     moduleMetadata({
       imports: [UICommonModule, CommonModule, I18nStoryModule],
-      declarations: [CheckingAudioPlayerComponent, AudioPlayerComponent, AudioTimePipe],
+      declarations: [CheckingAudioPlayerComponent, AudioPlayerComponent, AudioTimePipe, InfoComponent],
       providers: [{ provide: OnlineStatusService, useValue: instance(mockedOnlineStatusService) }]
     })
   ],


### PR DESCRIPTION
This PR fixes a broken storybook Checking Audio test.

The test was broken because the webm file the test played was moved, and a declaration for a new subcomponent was required.

**Testing Instructions**

***Prerequisite:** Scripture Forge is in the directory `~/src/web-xforge/`*

1. In a terminal run:

```sh
cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
npm run storybook
```
2. Once Storybook has started, run the following in a new Terminal:
```sh
cd ~/src/web-xforge/src/SIL.XForge.Scripture/ClientApp
npm run test-storybook
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2097)
<!-- Reviewable:end -->
