### PR TITLE
Fix Angular Test Execution Warnings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1780,6 +1780,7 @@ describe('CheckingComponent', () => {
       env.waitForQuestionTimersToComplete();
 
       verify(chapterAudio.pause()).once();
+      expect(env.component.showScriptureAudioPlayer).toBe(true);
     }));
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
@@ -58,6 +58,7 @@ describe('SingleButtonAudioPlayerComponent', () => {
 
     env.component.player.stop();
     verify(audioMock.stop()).once();
+    expect(env.component.player.audio).not.toBeNull();
   }));
 
   it('does not reset when playing finishes', fakeAsync(() => {
@@ -67,6 +68,7 @@ describe('SingleButtonAudioPlayerComponent', () => {
     env.component.player.hasFinishedPlayingOnce$.next(true);
 
     verify(audioMock.stop()).never();
+    expect(env.component.player.hasFinishedPlayingOnce$.value).toBe(true);
   }));
 
   it('reflects audio.isPlaying', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -11,6 +11,7 @@ import { AnonymousService } from 'xforge-common/anonymous.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -31,6 +32,7 @@ const mockedI18nService = mock(I18nService);
 const mockedLocationService = mock(LocationService);
 const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedRouter = mock(Router);
+const mockErrorReportingService = mock(ErrorReportingService);
 const mockedSFProjectService = mock(SFProjectService);
 
 describe('JoinComponent', () => {
@@ -52,6 +54,7 @@ describe('JoinComponent', () => {
       { provide: LocationService, useMock: mockedLocationService },
       { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
       { provide: Router, useMock: mockedRouter },
+      { provide: ErrorReportingService, useMock: mockErrorReportingService },
       { provide: SFProjectService, useMock: mockedSFProjectService }
     ]
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { EMPTY, of } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
@@ -111,7 +112,7 @@ describe('DraftGenerationComponent', () => {
     init(): void {
       TestBed.configureTestingModule({
         declarations: [DraftGenerationComponent],
-        imports: [UICommonModule, SharedModule],
+        imports: [UICommonModule, SharedModule, RouterTestingModule],
         providers: [
           { provide: FeatureFlagService, useValue: mockFeatureFlagService },
           { provide: DraftGenerationService, useValue: mockDraftGenerationService },
@@ -297,6 +298,7 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.generateDraft();
+      expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith('testProjectId');
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
     });
@@ -312,6 +314,7 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.generateDraft();
+      expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith('testProjectId');
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
     });
@@ -327,6 +330,7 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.generateDraft();
+      expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith('testProjectId');
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
@@ -15,7 +15,7 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule } from 'xforge-common/test-utils';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -113,6 +113,7 @@ describe('DraftViewerComponent', () => {
       SharedModule,
       RouterTestingModule,
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
+      TestTranslocoModule,
       NoopAnimationsModule
     ],
     providers: [
@@ -203,6 +204,7 @@ describe('DraftViewerComponent', () => {
     env.component.targetProjectId = '123';
     env.component.editChapter();
     verify(mockRouter.navigateByUrl('/projects/123/translate/GEN/2')).once();
+    expect(mockRouter.navigateByUrl('/projects/123/translate/GEN/2')).toBeTruthy();
   }));
 
   it('should navigate to the correct URL for the given book and chapter', fakeAsync(() => {
@@ -214,6 +216,7 @@ describe('DraftViewerComponent', () => {
     env.component.targetProjectId = '123';
     env.component.navigateBookChapter(book, chapter);
     verify(mockRouter.navigateByUrl('/projects/123/draft-preview/GEN/2')).once();
+    expect(mockRouter.navigateByUrl('/projects/123/draft-preview/GEN/2')).toBeTruthy();
   }));
 
   it('should navigate to the given chapter of the given book if chapter is in range', fakeAsync(() => {
@@ -243,6 +246,7 @@ describe('DraftViewerComponent', () => {
     });
 
     verify(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).once();
+    expect(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).toBeTruthy();
   }));
 
   it('should navigate to the first chapter of the new book when user changes book', fakeAsync(() => {
@@ -251,6 +255,7 @@ describe('DraftViewerComponent', () => {
     env.component.currentChapter = 2;
     env.component.onBookChange(1);
     verify(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).once();
+    expect(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).toBeTruthy();
   }));
 
   const projectProfileDoc = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -769,28 +769,29 @@ describe('EditorComponent', () => {
 
     it('change chapters', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
-      env.wait();
-      expect(env.component.chapter).toBe(1);
-      expect(env.component.target!.segmentRef).toBe('verse_1_1');
-      verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
+      env.ngZone.run(() => {
+        env.setProjectUserConfig({ selectedBookNum: 40, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
+        env.wait();
+        expect(env.component.chapter).toBe(1);
+        expect(env.component.target!.segmentRef).toBe('verse_1_1');
+        verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
 
-      resetCalls(env.mockedRemoteTranslationEngine);
-      env.component.chapter = 2;
-      env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
-      env.wait();
-      const verseText = env.component.target!.getSegmentText('verse_2_1');
-      expect(verseText).toBe('target: chapter 2, verse 1.');
-      expect(env.component.target!.segmentRef).toEqual('verse_1_1');
-      verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
+        resetCalls(env.mockedRemoteTranslationEngine);
+        env.component.chapter = 2;
+        env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
+        env.wait();
+        const verseText = env.component.target!.getSegmentText('verse_2_1');
+        expect(verseText).toBe('target: chapter 2, verse 1.');
+        expect(env.component.target!.segmentRef).toEqual('verse_1_1');
+        verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
 
-      resetCalls(env.mockedRemoteTranslationEngine);
-      env.component.chapter = 1;
-      env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
-      env.wait();
-      expect(env.component.target!.segmentRef).toBe('verse_1_1');
-      verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
-
+        resetCalls(env.mockedRemoteTranslationEngine);
+        env.component.chapter = 1;
+        env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+        expect(env.component.target!.segmentRef).toBe('verse_1_1');
+        verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).once();
+      });
       env.dispose();
     }));
 
@@ -2951,22 +2952,24 @@ describe('EditorComponent', () => {
 
     it('deselects a verse when bottom sheet is open and chapter changed', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.setProjectUserConfig();
-      when(mockedMediaObserver.isActive(anything())).thenReturn(true);
-      env.wait();
+      env.ngZone.run(() => {
+        env.setProjectUserConfig();
+        when(mockedMediaObserver.isActive(anything())).thenReturn(true);
+        env.wait();
 
-      const segmentRef = 'verse_1_1';
-      env.setSelectionAndInsertNote(segmentRef);
-      expect(env.mobileNoteTextArea).toBeTruthy();
-      env.component.chapter = 2;
-      env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
-      env.wait();
-      env.clickSegmentRef('verse_2_2');
-      env.wait();
-      const verse1Elem: HTMLElement = env.getSegmentElement('verse_2_1')!;
-      expect(verse1Elem.classList).not.toContain('commenter-selection');
-      const verse2Elem: HTMLElement = env.getSegmentElement('verse_2_2')!;
-      expect(verse2Elem.classList).toContain('commenter-selection');
+        const segmentRef = 'verse_1_1';
+        env.setSelectionAndInsertNote(segmentRef);
+        expect(env.mobileNoteTextArea).toBeTruthy();
+        env.component.chapter = 2;
+        env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
+        env.wait();
+        env.clickSegmentRef('verse_2_2');
+        env.wait();
+        const verse1Elem: HTMLElement = env.getSegmentElement('verse_2_1')!;
+        expect(verse1Elem.classList).not.toContain('commenter-selection');
+        const verse2Elem: HTMLElement = env.getSegmentElement('verse_2_2')!;
+        expect(verse2Elem.classList).toContain('commenter-selection');
+      });
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -355,6 +355,7 @@ describe('TranslateMetricsSession', () => {
     // No error, no throw.
     when(mockedSFProjectService.onlineAddTranslateMetrics('project01', anything())).thenResolve();
     env.keyPress('a');
+    expect(env.session.metrics.type).toBe('edit');
     tick(SEND_METRICS_INTERVAL);
     verify(mockedSFProjectService.onlineAddTranslateMetrics('project01', anything())).once();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.spec.ts
@@ -49,6 +49,7 @@ describe('TrainingProgressComponent', () => {
     env.wait();
 
     verify(env.mockedRemoteTranslationEngine.listenForTrainingStatus()).once();
+    expect(env.trainingProgress).toBeNull();
   }));
 
   it('should not setup the translation engine if no edit permission', fakeAsync(() => {
@@ -58,6 +59,7 @@ describe('TrainingProgressComponent', () => {
     env.wait();
 
     verify(env.mockedRemoteTranslationEngine.listenForTrainingStatus()).never();
+    expect(env.trainingProgress).toBeNull();
   }));
 
   it('should display', fakeAsync(() => {


### PR DESCRIPTION
This PR fixes many of the test execution warnings that were providing noise during test execution in Jasmine.

Not all are fixed, as some are caused by components that should not or cannot be mocked, but the net result of this PR is less noise in the test execution console output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2099)
<!-- Reviewable:end -->
