### PR TITLE
Remove button mixin from training progress component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
@@ -1,5 +1,3 @@
-@use '@material/button/mixins' as button;
-
 @import 'src/variables';
 
 .training-progress {
@@ -22,9 +20,6 @@
     > div {
       color: white;
     }
-    > button {
-      @include button.ink-color(white);
-    }
     background-color: $sf_grey;
   }
 
@@ -37,4 +32,7 @@
 #training-progress-spinner {
   width: 24px;
   height: 24px;
+}
+#training-close-button mat-icon {
+  color: white;
 }


### PR DESCRIPTION
I think this is most easily tested by a developer, since making sure the old rule was doing what I think it was doing is more than 50% of the challenge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2101)
<!-- Reviewable:end -->
