### PR TITLE
SF-2264 Convert navigation project selector to Material

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -108,25 +108,11 @@
       [opened]="isExpanded || isDrawerPermanent"
       (closed)="drawerCollapsed()"
     >
-      <mdc-select
-        *ngIf="projectDocs != null"
-        dir="auto"
-        class="project-select"
-        (valueChange)="projectChanged($event.value)"
-      >
-        <mdc-menu>
-          <mdc-list>
-            <mdc-list-item *ngFor="let projectDoc of projectDocs" [value]="projectDoc.id">{{
-              projectLabel(projectDoc.data)
-            }}</mdc-list-item>
-            <mdc-list-divider></mdc-list-divider>
-            <mdc-list-item [dir]="i18n.direction" value="*connect-project*" [class.list-item-disabled]="!isAppOnline">
-              <mdc-icon mdcListItemGraphic>add</mdc-icon>
-              {{ t("connect_project") }}
-            </mdc-list-item>
-          </mdc-list>
-        </mdc-menu>
-      </mdc-select>
+      <app-navigation-project-selector
+        [projectDocs]="projectDocs"
+        [selected]="selectedProjectDoc"
+        (changed)="projectChanged($event)"
+      ></app-navigation-project-selector>
       <mat-nav-list id="tools-menu-list">
         <a
           mat-list-item

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -24,22 +24,6 @@ $toolbar-height: 56px;
     z-index: 8;
   }
 
-  .project-select {
-    ::ng-deep .mdc-select__anchor {
-      width: 100%;
-    }
-
-    .mdc-list-item {
-      // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
-      // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
-      // overflows to the left in a menu that is layed out in LTR.
-      overflow-wrap: anywhere;
-
-      height: unset;
-      min-height: 48px;
-    }
-  }
-
   > header {
     position: absolute;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -45,6 +45,7 @@ import { SF_TYPE_REGISTRY } from './core/models/sf-type-registry';
 import { SFProjectService } from './core/sf-project.service';
 import { SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from './shared/project-router.guard';
 import { paratextUsersFromRoles } from './shared/test-utils';
+import { NavigationProjectSelectorComponent } from './navigation-project-selector/navigation-project-selector.component';
 
 const mockedAuthService = mock(AuthService);
 const mockedUserService = mock(UserService);
@@ -83,7 +84,7 @@ const ROUTES: Route[] = [
 
 describe('AppComponent', () => {
   configureTestingModule(() => ({
-    declarations: [AppComponent, MockComponent],
+    declarations: [AppComponent, NavigationProjectSelectorComponent, MockComponent],
     imports: [
       AvatarTestingModule,
       DialogTestModule,
@@ -765,7 +766,7 @@ class TestEnvironment {
   }
 
   get selectedProjectId(): string {
-    return this.component.projectSelect!.value;
+    return this.component.selectedProjectId!;
   }
 
   get menuLength(): number {
@@ -890,7 +891,7 @@ class TestEnvironment {
 
   selectProject(projectId: string): void {
     this.ngZone.run(() => {
-      this.component.projectSelect!.setSelectionByValue(projectId);
+      this.component.projectChanged(projectId);
     });
     this.wait();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { UsersModule } from './users/users.module';
 import { TextNoteDialogComponent } from './shared/text/text-note-dialog/text-note-dialog.component';
 import { JoinComponent } from './join/join.component';
 import { SharedModule } from './shared/shared.module';
+import { NavigationProjectSelectorComponent } from './navigation-project-selector/navigation-project-selector.component';
 
 @NgModule({
   declarations: [
@@ -52,7 +53,8 @@ import { SharedModule } from './shared/shared.module';
     ProjectSelectComponent,
     SyncProgressComponent,
     TextNoteDialogComponent,
-    JoinComponent
+    JoinComponent,
+    NavigationProjectSelectorComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.html
@@ -1,0 +1,14 @@
+<ng-container *transloco="let t; read: 'navigation-project_selector'">
+  <mat-form-field appearance="fill" *ngIf="hasProjects">
+    <mat-select dir="auto" [value]="selectedProjectId" (valueChange)="changed.emit($event)">
+      <mat-option class="project-option" *ngFor="let projectDoc of projectDocs" [value]="projectDoc.id">{{
+        projectLabel(projectDoc)
+      }}</mat-option>
+      <mat-divider></mat-divider>
+      <mat-option [dir]="i18n.direction" value="*connect-project*" [class.list-item-disabled]="!isOnline">
+        <mat-icon>add</mat-icon>
+        {{ t("connect_project") }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
@@ -1,0 +1,41 @@
+:host ::ng-deep mat-form-field {
+  .mat-form-field-flex {
+    padding-top: 0;
+    min-height: 48px;
+  }
+
+  .mat-form-field-wrapper {
+    padding-bottom: 0;
+  }
+
+  .mat-form-field-underline {
+    bottom: 0;
+  }
+
+  .mat-select-arrow-wrapper {
+    transform: unset;
+  }
+}
+
+mat-form-field {
+  width: 100%;
+  padding: 0;
+}
+
+// A lot of these styles can be removed once we upgrade to Material v15+
+.project-option {
+  height: unset !important;
+  ::ng-deep .mat-option-text {
+    // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
+    // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
+    // overflows to the left in a menu that is laid out in LTR.
+    overflow-wrap: anywhere;
+    min-height: 48px;
+    white-space: normal;
+    overflow: visible;
+    max-width: 255px;
+    line-height: 1.5rem;
+    display: flex;
+    align-items: center;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
@@ -19,7 +19,6 @@
 
 mat-form-field {
   width: 100%;
-  padding: 0;
 }
 
 // A lot of these styles can be removed once we upgrade to Material v15+

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
@@ -7,15 +7,20 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { By } from '@angular/platform-browser';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { mock, when } from 'ts-mockito';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { NavigationProjectSelectorComponent } from './navigation-project-selector.component';
 
 const mockOnlineStatusService = mock(OnlineStatusService);
+const mockFeatureFlagService = mock(FeatureFlagService);
 
 describe('NavigationProjectSelectorComponent', () => {
   configureTestingModule(() => ({
     declarations: [NavigationProjectSelectorComponent],
-    providers: [{ provide: OnlineStatusService, useMock: mockOnlineStatusService }],
+    providers: [
+      { provide: OnlineStatusService, useMock: mockOnlineStatusService },
+      { provide: FeatureFlagService, useMock: mockFeatureFlagService }
+    ],
     imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule]
   }));
 
@@ -26,6 +31,8 @@ describe('NavigationProjectSelectorComponent', () => {
     env.click(env.select);
     const options = env.options;
     expect(options.length).toEqual(3);
+    env.click(options[0]);
+    expect(env.component.changed).toEqual('project01');
     env.click(options[2]);
     expect(env.component.changed).toEqual('*connect-project*');
     env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
@@ -1,0 +1,91 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Component, DebugElement } from '@angular/core';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { By } from '@angular/platform-browser';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { mock, when } from 'ts-mockito';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { NavigationProjectSelectorComponent } from './navigation-project-selector.component';
+
+const mockOnlineStatusService = mock(OnlineStatusService);
+
+describe('NavigationProjectSelectorComponent', () => {
+  configureTestingModule(() => ({
+    declarations: [NavigationProjectSelectorComponent],
+    providers: [{ provide: OnlineStatusService, useMock: mockOnlineStatusService }],
+    imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule]
+  }));
+
+  it('emits event when project changes', fakeAsync(() => {
+    const template = `<app-navigation-project-selector [projectDocs]="projectDocs" (changed)="changed = $event"></app-navigation-project-selector>`;
+    const env = new TestEnvironment(template);
+
+    env.click(env.select);
+    const options = env.options;
+    expect(options.length).toEqual(3);
+    env.click(options[2]);
+    expect(env.component.changed).toEqual('*connect-project*');
+    env.wait();
+  }));
+});
+
+@Component({ selector: 'app-host', template: '' })
+class HostComponent {
+  changed?: string;
+  projectDocs: Partial<SFProjectProfileDoc>[] = [
+    {
+      id: 'project01',
+      data: createTestProjectProfile({
+        name: 'Project 01',
+        shortName: 'PR1',
+        paratextId: ''
+      })
+    },
+    {
+      id: 'project02',
+      data: createTestProjectProfile({
+        name: 'Project 02',
+        shortName: 'PR2',
+        paratextId: ''
+      })
+    }
+  ];
+}
+
+class TestEnvironment {
+  readonly component: HostComponent;
+  readonly fixture: ComponentFixture<HostComponent>;
+
+  constructor(template: string) {
+    when(mockOnlineStatusService.isOnline).thenReturn(true);
+    TestBed.configureTestingModule({
+      declarations: [NavigationProjectSelectorComponent, HostComponent],
+      imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule]
+    });
+    TestBed.overrideComponent(HostComponent, { set: { template: template } });
+    this.fixture = TestBed.createComponent(HostComponent);
+    this.component = this.fixture.componentInstance;
+    this.wait();
+  }
+
+  get select(): DebugElement {
+    return this.fixture.debugElement.query(By.css('mat-select'));
+  }
+
+  get options(): DebugElement[] {
+    return this.fixture.debugElement.queryAll(By.css('mat-option'));
+  }
+
+  click(element: DebugElement): void {
+    element.nativeElement.click();
+    this.fixture.detectChanges();
+  }
+
+  wait(): void {
+    tick();
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.ts
@@ -24,15 +24,15 @@ export class NavigationProjectSelectorComponent {
     return this.onlineStatusService.isOnline;
   }
 
+  get selectedProjectId(): string | undefined {
+    return this.selected?.id;
+  }
+
   projectLabel(doc: SFProjectProfileDoc): string {
     return projectLabel({
       name: doc.data?.name,
       shortName: doc.data?.shortName,
       paratextId: doc.data?.paratextId
     } as SelectableProject);
-  }
-
-  get selectedProjectId(): string | undefined {
-    return this.selected?.id;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.ts
@@ -1,0 +1,38 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { I18nService } from 'xforge-common/i18n.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { projectLabel } from '../shared/utils';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { SelectableProject } from '../core/paratext.service';
+
+@Component({
+  selector: 'app-navigation-project-selector',
+  templateUrl: './navigation-project-selector.component.html',
+  styleUrls: ['./navigation-project-selector.component.scss']
+})
+export class NavigationProjectSelectorComponent {
+  @Output() changed: EventEmitter<string> = new EventEmitter<string>();
+  @Input() projectDocs?: SFProjectProfileDoc[];
+  @Input() selected?: SFProjectProfileDoc;
+  constructor(readonly i18n: I18nService, private readonly onlineStatusService: OnlineStatusService) {}
+
+  get hasProjects(): boolean {
+    return this.projectDocs != null && this.projectDocs.length > 0;
+  }
+
+  get isOnline(): boolean {
+    return this.onlineStatusService.isOnline;
+  }
+
+  projectLabel(doc: SFProjectProfileDoc): string {
+    return projectLabel({
+      name: doc.data?.name,
+      shortName: doc.data?.shortName,
+      paratextId: doc.data?.paratextId
+    } as SelectableProject);
+  }
+
+  get selectedProjectId(): string | undefined {
+    return this.selected?.id;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -7,7 +7,6 @@
     "change_password": "Change password",
     "community_checking": "Community Checking",
     "community_support": "Community Support",
-    "connect_project": "Connect project",
     "help": "Help",
     "language": "Language",
     "log_out": "Log out",
@@ -339,6 +338,9 @@
   "dialog": {
     "cancel": "Cancel",
     "close": "Close"
+  },
+  "navigation-project_selector": {
+    "connect_project": "Connect project"
   },
   "scripture_chooser_dialog": {
     "choose_book": "Choose book",


### PR DESCRIPTION
* Moved navigation project select into its own component
* Convert from MDC to Material

The conversion to Material isn't as ideal as it currently looks on MDC. Once we upgrade to Material 15+ we'll be able to get it a lot closer to the current MDC look and feel.

**MDC**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/83838171-9e62-45e5-8b24-bad05e4d6257)

**Material 14**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/6b3b0740-5d02-4108-a626-81242bfc9f15)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2103)
<!-- Reviewable:end -->
