### PR TITLE
Remove typography mixin from editor styles

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -1,5 +1,3 @@
-@use '@material/typography/mixins' as typography;
-
 @import 'src/variables';
 @import 'quill/dist/quill.snow.css';
 @import 'usx';
@@ -7,7 +5,7 @@
 quill-editor {
   height: 100%;
   > .ql-container {
-    @include typography.typography(body1);
+    letter-spacing: 0.03125em;
     > .ql-editor {
       font-family: Roboto, 'Noto Sans Kayah Li', sans-serif;
       line-height: 1.6;


### PR DESCRIPTION
I removed the typography mixin and added the declaration `letter-spacing: 0.03125em;`. As far as I could tell (in the project I was testing), it was the only declaration crated by the mixin that appeared to have any visual effect. However, I can't be certain it doesn't have an impact on any other project, but it's hard to write test steps ("make sure every project looks identical before and after this change" is hard to test without creating screenshots of every project and then switching between them).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2104)
<!-- Reviewable:end -->
