### PR TITLE
SF-2260 Delete comments on deleted answers during synchronize

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -614,6 +614,11 @@ public class ParatextNotesMapperTests
                                 </content>
                                 <tagAdded>3</tagAdded>
                             </comment>
+                            <comment user=""PT User 3"" date=""2019-01-03T09:00:00.0000000+00:00"">
+                                <content>
+                                    <p>Test comment 4.</p>
+                                </content>
+                            </comment>
                         </thread>
                     </notes>";
         Dictionary<string, ParatextUserProfile> ptProjectUsers = env.PtProjectUsers.ToDictionary(u => u.Username);
@@ -672,6 +677,11 @@ public class ParatextNotesMapperTests
                                     <p>Test answer 3.</p>
                                 </content>
                                 <tagAdded>3</tagAdded>
+                            </comment>
+                            <comment user=""PT User 3"" date=""2019-01-03T09:00:00.0000000+00:00"" deleted=""true"">
+                                <content>
+                                    <p>Test comment 4.</p>
+                                </content>
                             </comment>
                         </thread>
                     </notes>";
@@ -1074,6 +1084,17 @@ public class ParatextNotesMapperTests
                                     VerseRef = new VerseRefData(40, 1, "2-3"),
                                     Status = AnswerStatus.Exportable,
                                     Deleted = true,
+                                    Comments =
+                                    {
+                                        new Comment
+                                        {
+                                            DataId = "comment04",
+                                            OwnerRef = "user03",
+                                            SyncUserRef = commentSyncUserId1,
+                                            DateCreated = new DateTime(2019, 1, 3, 9, 0, 0, DateTimeKind.Utc),
+                                            Text = "Test comment 4."
+                                        }
+                                    }
                                 },
                                 new Answer
                                 {


### PR DESCRIPTION
Up until now, comments on answers would not be deleted when an answer was deleted. This was because the deleted property was never set on the answer comments. It is not possible to set the deleted property on the front end because the user does not have permission to edit other users' comments.

This change determines whether to delete an answer comment should be deleted based on whether the answer or comment has been deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2105)
<!-- Reviewable:end -->
