### PR TITLE
dev: in IDE, show eslint as warnings, not errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,7 @@
   "editor.tabSize": 2,
   "editor.wordWrapColumn": 120,
   "eslint.workingDirectories": ["./src/RealtimeServer", "./src/SIL.XForge.Scripture/ClientApp"],
+  "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
   "jest.debugCodeLens.showWhenTestStateIn": ["fail"],
   "jest.rootPath": "src/RealtimeServer",
   "liveSassCompile.settings.includeItems": ["src/SIL.XForge.Scripture/wwwroot/scss/**.*"],


### PR DESCRIPTION
Before:
![eslint-error](https://github.com/sillsdev/web-xforge/assets/7265309/bb808ea9-fc64-416e-9588-03fed511c21d)

After:
![eslint-warning](https://github.com/sillsdev/web-xforge/assets/7265309/0cd01a9e-415f-4739-8147-cae253d3f229)

The different colour helps distinguish it from syntax and other compilation errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2108)
<!-- Reviewable:end -->
