### PR TITLE
test: introduce TestOnlineStatusService

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -23,8 +23,9 @@ import {
   getAudioBlob
 } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { of } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { CheckingModule } from '../checking.module';
 import { AudioAttachment } from '../checking/checking-audio-recorder/checking-audio-recorder.component';
@@ -37,16 +38,15 @@ import {
 const mockedDialogService = mock(DialogService);
 const mockedCsvService = mock(CsvService);
 const mockedFileService = mock(FileService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 
 describe('ChapterAudioDialogComponent', () => {
   configureTestingModule(() => ({
-    imports: [DialogTestModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
+    imports: [DialogTestModule, TestOnlineStatusModule.forRoot(), TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
     providers: [
       { provide: DialogService, useMock: mockedDialogService },
       { provide: CsvService, useMock: mockedCsvService },
       { provide: FileService, useMock: mockedFileService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
@@ -366,8 +366,6 @@ class TestEnvironment {
       };
     }
 
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
-    when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
     when(mockedCsvService.parse(anything())).thenResolve([
       ['0.1', '0', 'v1'],
       ['1', '0', 'v2']

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
@@ -1,4 +1,3 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -6,10 +5,12 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { getTextAudioId, TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
@@ -22,7 +23,6 @@ import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-
 import { CheckingQuestionComponent } from './checking-question.component';
 
 const mockedSFProjectService = mock(SFProjectService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedQuestionDoc = mock(QuestionDoc);
 const mockedQuestion = mock<Question>();
 const mockedSFProjectUserConfig = mock<SFProjectUserConfig>();
@@ -59,11 +59,11 @@ class MockComponent {
 
 describe('CheckingQuestionComponent', () => {
   configureTestingModule(() => ({
-    imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule, HttpClientTestingModule],
+    imports: [UICommonModule, TestTranslocoModule, TestOnlineStatusModule.forRoot(), NoopAnimationsModule],
     declarations: [CheckingQuestionComponent, SingleButtonAudioPlayerComponent, MockComponent],
     providers: [
       { provide: SFProjectService, useMock: mockedSFProjectService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: QuestionDoc, useMock: mockedQuestionDoc },
       { provide: SFProjectUserConfigDoc, useMock: mockedSFProjectUserConfigDoc }
     ]
@@ -275,7 +275,6 @@ class TestEnvironment {
     when(this.query.remoteChanges$).thenReturn(this.queryChanged$);
     when(this.query.docs).thenReturn([instance(audio1), instance(audio2)]);
 
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
     when(mockedSFProjectService.onlineIsSourceProject('project01')).thenResolve(false);
     when(mockedSFProjectService.onlineDelete(anything())).thenResolve();
     when(mockedSFProjectService.onlineUpdateSettings('project01', anything())).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-combined/checking-audio-combined.component.spec.ts
@@ -2,7 +2,6 @@ import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ngfModule } from 'angular-file';
-import { of } from 'rxjs';
 import { mock, when } from 'ts-mockito';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -13,6 +12,8 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
 import { AudioTimePipe } from '../../../shared/audio/audio-time-pipe';
@@ -22,7 +23,6 @@ import { CheckingAudioCombinedComponent } from './checking-audio-combined.compon
 
 const mockedUserService = mock(UserService);
 const mockedNoticeService = mock(NoticeService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedI18nService = mock(I18nService);
 
 describe('CheckingAudioCombinedComponent', () => {
@@ -34,11 +34,17 @@ describe('CheckingAudioCombinedComponent', () => {
       AudioTimePipe,
       AudioPlayerComponent
     ],
-    imports: [UICommonModule, ngfModule, TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
+    imports: [
+      UICommonModule,
+      ngfModule,
+      TestTranslocoModule,
+      TestOnlineStatusModule.forRoot(),
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)
+    ],
     providers: [
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: I18nService, useMock: mockedI18nService }
     ]
   }));
@@ -109,8 +115,6 @@ class TestEnvironment {
     when(mockedUserService.getCurrentUser()).thenCall(() =>
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
-    when(mockedOnlineStatusService.isOnline).thenReturn(true);
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
     this.fixture.detectChanges();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -1,11 +1,11 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { of } from 'rxjs';
-import { instance, mock, when } from 'ts-mockito';
+import { instance, mock } from 'ts-mockito';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { AudioStatus } from '../../../shared/audio/audio-player';
@@ -159,7 +159,7 @@ class HostComponent {
 }
 
 class TestEnvironment {
-  readonly mockedOnlineStatusService = mock(OnlineStatusService);
+  readonly testOnlineStatusService: TestOnlineStatusService;
   readonly mockedI18nService = mock(I18nService);
   readonly ngZone: NgZone;
 
@@ -170,16 +170,16 @@ class TestEnvironment {
     TestBed.configureTestingModule({
       declarations: [HostComponent, CheckingAudioPlayerComponent, AudioPlayerComponent, AudioTimePipe, InfoComponent],
       providers: [
-        { provide: OnlineStatusService, useFactory: () => instance(this.mockedOnlineStatusService) },
+        { provide: OnlineStatusService, useClass: TestOnlineStatusService },
         { provide: I18nService, useFactory: () => instance(this.mockedI18nService) }
       ],
-      imports: [UICommonModule, TestTranslocoModule, HttpClientTestingModule]
+      imports: [UICommonModule, TestOnlineStatusModule.forRoot(), TestTranslocoModule]
     });
-    when(this.mockedOnlineStatusService.isOnline).thenCall(() => isOnline);
-    when(this.mockedOnlineStatusService.onlineStatus$).thenReturn(of(isOnline));
 
     TestBed.overrideComponent(HostComponent, { set: { template: template } });
     this.ngZone = TestBed.inject(NgZone);
+    this.testOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
+    this.testOnlineStatusService.setIsOnline(isOnline);
     this.fixture = TestBed.createComponent(HostComponent);
     this.component = this.fixture.componentInstance;
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -1,11 +1,11 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement, Input, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AudioTiming } from 'realtime-server/scriptureforge/models/audio-timing';
-import { BehaviorSubject, of } from 'rxjs';
-import { instance, mock, when } from 'ts-mockito';
+import { BehaviorSubject } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { TextDocId } from '../../../core/models/text-doc';
@@ -179,13 +179,14 @@ class HostComponent {
   template: '<p>Mock Audio Player</p>'
 })
 class AudioPlayerStubComponent {
-  static onlineStatusService = mock(OnlineStatusService);
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
   audio: AudioPlayerStub;
   isAudioAvailable$ = new BehaviorSubject(false);
 
   constructor() {
-    when(AudioPlayerStubComponent.onlineStatusService.onlineStatus$).thenReturn(new BehaviorSubject(false));
-    this.audio = new AudioPlayerStub(audioFile, instance(AudioPlayerStubComponent.onlineStatusService));
+    this.audio = new AudioPlayerStub(audioFile, this.testOnlineStatusService);
   }
 
   @Input() set source(source: string | undefined) {
@@ -194,7 +195,6 @@ class AudioPlayerStubComponent {
 }
 
 class TestEnvironment {
-  readonly mockOnlineStatusService = mock(OnlineStatusService);
   fixture: ComponentFixture<HostComponent>;
   component: HostComponent;
   ngZone: NgZone;
@@ -208,10 +208,9 @@ class TestEnvironment {
 
     TestBed.configureTestingModule({
       declarations: [HostComponent, CheckingScriptureAudioPlayerComponent, AudioPlayerStubComponent, AudioTimePipe],
-      providers: [{ provide: OnlineStatusService, useFactory: () => instance(this.mockOnlineStatusService) }],
-      imports: [UICommonModule, TestTranslocoModule, HttpClientTestingModule]
+      providers: [{ provide: OnlineStatusService, useClass: TestOnlineStatusService }],
+      imports: [UICommonModule, TestOnlineStatusModule.forRoot(), TestTranslocoModule]
     });
-    when(this.mockOnlineStatusService.onlineStatus$).thenReturn(of(true));
     TestBed.overrideComponent(HostComponent, { set: { template: template } });
     this.ngZone = TestBed.inject(NgZone);
     this.fixture = TestBed.createComponent(HostComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.spec.ts
@@ -2,24 +2,25 @@ import { Component, DebugElement, NgZone, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { AudioPlayer, AudioStatus } from '../../../shared/audio/audio-player';
 import { AudioSegmentPlayer } from '../../../shared/audio/audio-segment-player';
 import { SingleButtonAudioPlayerComponent } from './single-button-audio-player.component';
 
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const audioMock = mock(AudioPlayer);
 when(audioMock.status$).thenReturn(new BehaviorSubject<AudioStatus>(AudioStatus.Available));
 
 describe('SingleButtonAudioPlayerComponent', () => {
   configureTestingModule(() => ({
-    imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule],
+    imports: [UICommonModule, TestTranslocoModule, TestOnlineStatusModule.forRoot(), NoopAnimationsModule],
     declarations: [TestComponent, MockComponent],
-    providers: [{ provide: OnlineStatusService, useMock: mockedOnlineStatusService }]
+    providers: [{ provide: OnlineStatusService, useClass: TestOnlineStatusService }]
   }));
 
   let env: TestEnvironment;
@@ -137,8 +138,6 @@ class TestEnvironment {
   readonly ngZone: NgZone;
 
   constructor() {
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
-
     this.ngZone = TestBed.inject(NgZone);
     this.fixture = TestBed.createComponent(MockComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -1,5 +1,4 @@
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
@@ -24,6 +23,8 @@ import { createStorageFileData, FileType } from 'xforge-common/models/file-offli
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import {
@@ -49,25 +50,28 @@ const mockedAuthService = mock(AuthService);
 const mockedNoticeService = mock(NoticeService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
-const mockedHttpClient = mock(HttpClient);
 const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
 const mockedFileService = mock(FileService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 
 describe('QuestionDialogComponent', () => {
   configureTestingModule(() => ({
-    imports: [ReactiveFormsModule, FormsModule, DialogTestModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
+    imports: [
+      ReactiveFormsModule,
+      FormsModule,
+      DialogTestModule,
+      TestOnlineStatusModule.forRoot(),
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)
+    ],
     providers: [
       { provide: AuthService, useMock: mockedAuthService },
       { provide: UserService, useMock: mockedUserService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: HttpClient, useMock: mockedHttpClient },
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: CookieService, useMock: mockedCookieService },
       { provide: FileService, useMock: mockedFileService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
@@ -605,8 +609,6 @@ class TestEnvironment {
       id: 'user01',
       data: createTestUser()
     });
-
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
 
     this.dialogRef = TestBed.inject(MatDialog).open(QuestionDialogComponent, config);
     this.afterCloseCallback = jasmine.createSpy('afterClose callback');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.spec.ts
@@ -6,6 +6,8 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -19,17 +21,22 @@ import { ShareButtonComponent } from './share-button.component';
 const mockedProjectService = mock(SFProjectService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedUserService = mock(UserService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 
 describe('ShareButtonComponent', () => {
   configureTestingModule(() => ({
-    imports: [DialogTestModule, TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY), UICommonModule],
+    imports: [
+      DialogTestModule,
+      TestTranslocoModule,
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
+      TestOnlineStatusModule.forRoot(),
+      UICommonModule
+    ],
     declarations: [ShareButtonComponent],
     providers: [
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },
       { provide: UserService, useMock: mockedUserService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
@@ -56,7 +63,6 @@ class TestEnvironment {
   readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor() {
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockedProjectService.getProfile(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -21,6 +21,8 @@ import { DOCUMENT } from 'xforge-common/browser-globals';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -35,19 +37,23 @@ import { TextChooserDialogComponent, TextChooserDialogData, TextSelection } from
 
 const mockedDocument = mock(Document);
 const mockedBugsnagService = mock(BugsnagService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 
 describe('TextChooserDialogComponent', () => {
   configureTestingModule(() => ({
-    imports: [DialogTestModule, NoopAnimationsModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
+    imports: [
+      DialogTestModule,
+      NoopAnimationsModule,
+      TestOnlineStatusModule.forRoot(),
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)
+    ],
     providers: [
       { provide: AuthService, useMock: mock(AuthService) },
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: DOCUMENT, useMock: mockedDocument },
       { provide: CookieService, useMock: mock(CookieService) },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: UserService, useMock: mockedUserService }
     ]
@@ -456,8 +462,6 @@ class TestEnvironment {
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
     );
 
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
-
     const dialogRef = TestBed.inject(MatDialog).open(TextChooserDialogComponent, { data: config });
     this.component = dialogRef.componentInstance;
     this.resultPromise = dialogRef.afterClosed().toPromise();
@@ -467,7 +471,6 @@ class TestEnvironment {
     when(dialogSpy.openMatDialog(anything(), anything())).thenReturn(instance(this.mockedScriptureChooserMatDialogRef));
     const chooserDialogResult = new VerseRef('LUK', '1', '2');
     when(this.mockedScriptureChooserMatDialogRef.afterClosed()).thenReturn(of(chooserDialogResult));
-    when(mockedOnlineStatusService.isOnline).thenReturn(true);
 
     this.fixture.detectChanges();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
@@ -1,5 +1,4 @@
 import { CommonModule } from '@angular/common';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ParamMap, Router } from '@angular/router';
@@ -14,6 +13,8 @@ import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -31,7 +32,6 @@ import { DraftViewerComponent } from './draft-viewer.component';
 describe('DraftViewerComponent', () => {
   const mockDraftGenerationService = mock(DraftGenerationService);
   const mockProjectService = mock(SFProjectService);
-  const mockOnlineStatusService = mock(OnlineStatusService);
   const mockUserService = mock(UserService);
   const mockActivatedProjectService = mock(ActivatedProjectService);
   const mockActivatedRoute = mock(ActivatedRoute);
@@ -72,8 +72,6 @@ describe('DraftViewerComponent', () => {
       );
       when(mockProjectService.getProfile(anything())).thenResolve(cloneDeep(projectProfileDoc));
       when(mockProjectService.getProfile(anything())).thenResolve(cloneDeep(projectProfileDoc));
-      when(mockOnlineStatusService.isOnline).thenReturn(true);
-      when(mockOnlineStatusService.onlineStatus$).thenReturn(of(true));
       when(mockUserService.getCurrentUser()).thenCall(() =>
         this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')
       );
@@ -115,8 +113,8 @@ describe('DraftViewerComponent', () => {
       RouterTestingModule,
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
       TestTranslocoModule,
-      NoopAnimationsModule,
-      HttpClientTestingModule
+      TestOnlineStatusModule.forRoot(),
+      NoopAnimationsModule
     ],
     providers: [
       { provide: DraftGenerationService, useMock: mockDraftGenerationService },
@@ -124,7 +122,7 @@ describe('DraftViewerComponent', () => {
       { provide: SFProjectService, useMock: mockProjectService },
       { provide: ActivatedRoute, useMock: mockActivatedRoute },
       { provide: UserService, useMock: mockUserService },
-      { provide: OnlineStatusService, useMock: mockOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: Router, useMock: mockRouter }
     ]
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -66,6 +66,8 @@ import { GenericDialogComponent, GenericDialogOptions } from 'xforge-common/gene
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -100,7 +102,6 @@ const mockedNoticeService = mock(NoticeService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedTranslationEngineService = mock(TranslationEngineService);
 const mockedMatDialog = mock(MatDialog);
 const mockedFeatureFlagService = mock(FeatureFlagService);
@@ -138,6 +139,7 @@ describe('EditorComponent', () => {
       SharedModule,
       UICommonModule,
       TestTranslocoModule,
+      TestOnlineStatusModule.forRoot(),
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)
     ],
     providers: [
@@ -149,7 +151,7 @@ describe('EditorComponent', () => {
       { provide: CONSOLE, useValue: new MockConsole() },
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: CookieService, useMock: mockedCookieService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: TranslationEngineService, useMock: mockedTranslationEngineService },
       { provide: MatDialog, useMock: mockedMatDialog },
       { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
@@ -642,7 +644,6 @@ describe('EditorComponent', () => {
       const text = 'target: chapter 1, verse 5';
       expect(env.component.target!.segmentText).toBe(text);
       env.onlineStatus = false;
-      when(mockedOnlineStatusService.isOnline).thenReturn(false);
       const range = env.component.target!.getSegmentRange('verse_1_1');
       env.targetEditor.setSelection(range!.index, 0, 'user');
       env.wait();
@@ -3535,6 +3536,9 @@ class TestEnvironment {
   readonly mockNoteDialogRef;
   readonly mockedDialogRef = mock<MatDialogRef<GenericDialogComponent<any>, GenericDialogOptions<any>>>(MatDialogRef);
   readonly ngZone: NgZone;
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
 
   private userRolesOnProject = {
     user01: SFProjectRole.ParatextTranslator,
@@ -3788,9 +3792,6 @@ class TestEnvironment {
       })
     );
 
-    when(mockedOnlineStatusService.isOnline).thenReturn(true);
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
-
     this.fixture = TestBed.createComponent(EditorComponent);
     when(mockedMatDialog.openDialogs).thenCall(() => this.openNoteDialogs);
     this.mockNoteDialogRef = new MockNoteDialogRef(this.fixture.nativeElement);
@@ -3931,8 +3932,7 @@ class TestEnvironment {
   }
 
   set onlineStatus(value: boolean) {
-    when(mockedOnlineStatusService.isOnline).thenReturn(value);
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(value));
+    this.testOnlineStatusService.setIsOnline(value);
   }
 
   clickSegmentRef(segmentRef: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -16,7 +16,7 @@ import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-proj
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { BehaviorSubject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { anything, deepEqual, mock, resetCalls, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { AvatarTestingModule } from 'xforge-common/avatar/avatar-testing.module';
@@ -28,6 +28,8 @@ import { NONE_ROLE, ProjectRoleInfo } from 'xforge-common/models/project-role-in
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, emptyHammerLoader, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -50,7 +52,6 @@ const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 const mockedDialogService = mock(DialogService);
 
 describe('CollaboratorsComponent', () => {
@@ -63,6 +64,7 @@ describe('CollaboratorsComponent', () => {
       TestTranslocoModule,
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
       SharedModule,
+      TestOnlineStatusModule.forRoot(),
       HttpClientTestingModule
     ],
     providers: [
@@ -74,7 +76,7 @@ describe('CollaboratorsComponent', () => {
       { provide: UserService, useMock: mockedUserService },
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: CookieService, useMock: mockedCookieService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: DialogService, useMock: mockedDialogService },
       emptyHammerLoader
     ]
@@ -430,7 +432,9 @@ class TestEnvironment {
   readonly component: CollaboratorsComponent;
   readonly loader: HarnessLoader;
   readonly project01Id: string = 'project01';
-  private isOnline: BehaviorSubject<boolean>;
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
 
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
@@ -480,9 +484,7 @@ class TestEnvironment {
       }
     ]);
 
-    this.isOnline = new BehaviorSubject<boolean>(hasConnection);
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(this.isOnline.asObservable());
-    when(mockedOnlineStatusService.isOnline).thenReturn(this.isOnline.value);
+    this.testOnlineStatusService.setIsOnline(hasConnection);
     when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
     this.fixture = TestBed.createComponent(CollaboratorsComponent);
     this.component = this.fixture.componentInstance;
@@ -536,7 +538,7 @@ class TestEnvironment {
   }
 
   set onlineStatus(hasConnection: boolean) {
-    this.isOnline.next(hasConnection);
+    this.testOnlineStatusService.setIsOnline(hasConnection);
     tick();
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.spec.ts
@@ -1,11 +1,21 @@
-import { instance, mock } from 'ts-mockito';
+import { TestBed } from '@angular/core/testing';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
 import { AvatarComponent } from './avatar.component';
 
 describe('AvatarComponent', () => {
+  configureTestingModule(() => ({
+    imports: [TestOnlineStatusModule.forRoot()],
+    providers: [{ provide: OnlineStatusService, useClass: TestOnlineStatusService }]
+  }));
+
   it('should return values when user is undefined', () => {
-    const mockedOnlineStatusService = mock(OnlineStatusService);
-    const component = new AvatarComponent(instance(mockedOnlineStatusService));
+    const testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+      OnlineStatusService
+    ) as TestOnlineStatusService;
+    const component = new AvatarComponent(testOnlineStatusService);
     component.user = undefined;
     expect(component.avatarUrl).toBeDefined();
     expect(component.name).toBeDefined();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -3,24 +3,26 @@ import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject } from 'rxjs';
-import { mock, when } from 'ts-mockito';
+import { mock } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { EditNameDialogComponent, EditNameDialogResult } from './edit-name-dialog.component';
 
 const mockedI18nService = mock(I18nService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 
 describe('EditNameDialogComponent', () => {
   configureTestingModule(() => ({
+    imports: [TestOnlineStatusModule.forRoot()],
     providers: [
       DialogService,
       { provide: I18nService, useMock: mockedI18nService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
@@ -108,17 +110,16 @@ describe('EditNameDialogComponent', () => {
 });
 
 class TestEnvironment {
+  readonly testOnlineStatusService: TestOnlineStatusService;
   fixture: ComponentFixture<DialogOpenerComponent>;
   component: DialogOpenerComponent;
-
-  private onlineStatus$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
 
   constructor() {
     TestBed.configureTestingModule({
       declarations: [DialogOpenerComponent],
       imports: [DialogTestModule, UICommonModule]
     });
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(this.onlineStatus$.asObservable());
+    this.testOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
     this.fixture = TestBed.createComponent(DialogOpenerComponent);
     this.component = this.fixture.componentInstance;
   }
@@ -152,7 +153,7 @@ class TestEnvironment {
   }
 
   set isOnline(value: boolean) {
-    this.onlineStatus$.next(value);
+    this.testOnlineStatusService.setIsOnline(value);
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
@@ -1,22 +1,21 @@
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
 import { mock, verify, when } from 'ts-mockito';
 import { CommandError, CommandErrorCode, CommandService } from 'xforge-common/command.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { PROJECTS_URL } from 'xforge-common/url-constants';
 import { FeatureFlagService } from './feature-flag.service';
 
 const mockedCommandService = mock(CommandService);
-const mockedOnlineStatusService = mock(OnlineStatusService);
 
 describe('FeatureFlagService', () => {
   configureTestingModule(() => ({
-    imports: [HttpClientTestingModule],
+    imports: [TestOnlineStatusModule.forRoot()],
     providers: [
       { provide: CommandService, useMock: mockedCommandService },
-      { provide: OnlineStatusService, useMock: mockedOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
@@ -179,8 +178,6 @@ class TestEnvironment {
         featureFlags
       );
     }
-    when(mockedOnlineStatusService.isOnline).thenReturn(true);
-    when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(true));
     this.service = TestBed.inject(FeatureFlagService);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.spec.ts
@@ -1,9 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { fakeAsync, flush } from '@angular/core/testing';
-import { instance, mock } from 'ts-mockito';
+import { instance, mock, when } from 'ts-mockito';
 import { OnlineStatusService } from './online-status.service';
 
 const mockedHttpClient = mock(HttpClient);
+const mockedNavigator = mock(Navigator);
 
 describe('OnlineStatusService', () => {
   it('offline when navigator is set to offline', fakeAsync(() => {
@@ -87,9 +88,8 @@ class TestEnvironment {
   private navigatorOnline: boolean = true;
 
   constructor() {
-    this.onlineStatusService = new OnlineStatusService(instance(mockedHttpClient));
-
-    spyOnProperty(window.navigator, 'onLine').and.returnValue(this.navigatorOnline);
+    when(mockedNavigator.onLine).thenCall(() => this.navigatorOnline);
+    this.onlineStatusService = new OnlineStatusService(instance(mockedHttpClient), instance(mockedNavigator));
   }
 
   set onlineStatus(status: boolean) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.module.ts
@@ -1,0 +1,17 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { mock, when } from 'ts-mockito';
+
+@NgModule({
+  imports: [HttpClientTestingModule]
+})
+export class TestOnlineStatusModule {
+  static forRoot(): ModuleWithProviders<TestOnlineStatusModule> {
+    const mockedNavigator = mock(Navigator);
+    when(mockedNavigator.onLine).thenReturn(true);
+    return {
+      ngModule: TestOnlineStatusModule,
+      providers: [{ provide: Navigator, useValue: mockedNavigator }]
+    };
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { when, anything, instance, spy } from 'ts-mockito';
+import { of, throwError } from 'rxjs';
+import { OnlineStatusService } from './online-status.service';
+
+/** This class is a helper for tests. */
+@Injectable({
+  providedIn: 'root'
+})
+export class TestOnlineStatusService extends OnlineStatusService {
+  constructor(public readonly httpClient: HttpClient, public readonly mockedNavigator: Navigator) {
+    super(httpClient, instance(mockedNavigator));
+    this.setIsOnline(true);
+    this.setRealtimeServerSocketIsOnline(true);
+  }
+
+  /** Set that the browser is online or offline. */
+  public setIsOnline(value: boolean): void {
+    when(this.mockedNavigator.onLine).thenReturn(value);
+    const httpClientSpy = spy(this.httpClient);
+    if (value) {
+      when(httpClientSpy.get('ping', anything())).thenCall(() => of('ok'));
+    } else {
+      when(httpClientSpy.get('ping', anything())).thenReturn(throwError('error'));
+    }
+    window.dispatchEvent(new Event(value ? 'online' : 'offline'));
+  }
+
+  /** Set that the realtime server connection is online or offline. */
+  public setRealtimeServerSocketIsOnline(value: boolean): void {
+    this.webSocketResponse = value;
+  }
+}


### PR DESCRIPTION
OnlineStatusService exposes several API elements that code might
access during tests. It may often be enough only to mock isOnline and
onlineStatus$, but that leaves other parts of the API unprepared for
giving the right answer.

TestOnlineStatusService is a substitute for OnlineStatusService that
more comprehensively covers the API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2110)
<!-- Reviewable:end -->
