### PR TITLE
SF-2247 Fix pre-translation drafting permission error

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -856,6 +856,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.observeResize(this.target.editor);
           this.subscribeScroll(this.target.editor);
           this.targetEditorLoaded$.next();
+          this.checkForPreTranslations();
         }
         break;
     }
@@ -2176,6 +2177,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     // Ensure we have the target editor
     if (this.target?.editor == null) return;
 
+    // Check to see if the user has edit rights
+    if (!this.userHasGeneralEditRight) return;
+
+    // Check to see if chapter is complete
     const targetOps: DeltaOperation[] = this.target.editor.getContents().ops!;
     const isChapterComplete: boolean = targetOps.every(op => {
       // If segment is a verse, check if it has a translation


### PR DESCRIPTION
This PR resolves the "403" errors when viewing a chapter for a project when Pre-Translation drafting is enabled.

Please see the JIRA ticket for further details, and the steps to reproduce.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2111)
<!-- Reviewable:end -->
