### PR TITLE
SF-2230 Display draft preview button while build running

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -114,7 +114,10 @@
           least a few hours.
         </p>
 
-        <button mat-flat-button color="primary" (click)="generateDraft()">Generate draft</button>
+        <button mat-flat-button color="primary" (click)="generateDraft()">
+          <mat-icon class="material-icons-outlined">padding</mat-icon>
+          Generate draft
+        </button>
       </section>
 
       <ng-template #jobExists>
@@ -126,30 +129,33 @@
           <mat-divider inset></mat-divider>
         </ng-container>
 
-        <section *ngIf="isDraftComplete(draftJob) || !isDraftInProgress(draftJob)" class="view-or-create-options">
-          <ng-container *ngIf="isDraftComplete(draftJob)">
+        <section *ngIf="!isDraftInProgress(draftJob)" class="view-or-create-options">
+          <ng-container *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
             <div>
-              <h3>Draft generation complete</h3>
-              <p>
-                Go to <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the generated draft to
-                chapters of your choice.
-              </p>
-              <a mat-flat-button color="primary" [routerLink]="draftViewerUrl"> Preview draft </a>
-            </div>
+              <ng-container *ngIf="isDraftComplete(draftJob)">
+                <h3>Draft generation complete</h3>
+                <p>
+                  Go to <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the generated draft to
+                  chapters of your choice.
+                </p>
+                <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                  <mat-icon>manage_search</mat-icon>
+                  Preview draft
+                </a>
+              </ng-container>
 
-            <mat-divider inset vertical data-text="or"></mat-divider>
-          </ng-container>
-
-          <!-- No draft in progress and latest build did not complete (maybe canceled) but a past completed build exists  -->
-          <ng-container *ngIf="!isDraftComplete(draftJob) && (hasAnyCompletedBuild$ | async)">
-            <div>
-              <h3>Preview last draft</h3>
-              <p>
-                No builds are in currently in progress, but you can go to
-                <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the last generated draft to
-                chapters of your choice.
-              </p>
-              <a mat-flat-button color="primary" [routerLink]="draftViewerUrl"> Preview draft </a>
+              <ng-container *ngIf="!isDraftComplete(draftJob)">
+                <h3>Preview last draft</h3>
+                <p>
+                  The last draft build did not complete, but you can go to
+                  <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the last generated draft to
+                  chapters of your choice.
+                </p>
+                <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                  <mat-icon>manage_search</mat-icon>
+                  Preview last draft
+                </a>
+              </ng-container>
             </div>
 
             <mat-divider inset vertical data-text="or"></mat-divider>
@@ -168,27 +174,55 @@
             <p>A suggested workflow is to complete at least a chapter before regenerating a draft.</p>
 
             <button mat-flat-button color="primary" (click)="generateDraft({ withConfirm: true })">
-              Generate draft
+              <mat-icon class="material-icons-outlined">padding</mat-icon>
+              Generate new draft
             </button>
           </div>
         </section>
 
         <section *ngIf="isDraftQueued(draftJob)">
           <h3>Draft queued</h3>
+
           <p>The back translation draft has been queued. Please check back later.</p>
+          <p *ngIf="hasAnyCompletedBuild">
+            While the new draft generation is in progress, you can continue working with the previously generated draft.
+          </p>
           <app-working-animated-indicator></app-working-animated-indicator>
-          <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-            Cancel generation
-          </button>
+
+          <div class="button-strip">
+            <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+              <mat-icon>highlight_off</mat-icon>
+              Cancel generation
+            </button>
+            <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+              <mat-icon>manage_search</mat-icon>
+              Preview last draft
+            </a>
+          </div>
         </section>
 
         <section *ngIf="isDraftActive(draftJob)" class="progress-active">
           <h3>Draft in progress</h3>
-          <p>Generating draft; this can take a few hours.</p>
+
+          <div class="progress-text">
+            <p>Generating draft; this can take a few hours.</p>
+            <p *ngIf="hasAnyCompletedBuild">
+              While the new draft generation is in progress, you can continue working with the previously generated
+              draft.
+            </p>
+          </div>
           <circle-progress [percent]="draftJob!.percentCompleted"></circle-progress>
-          <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-            Cancel generation
-          </button>
+
+          <div class="button-strip">
+            <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+              <mat-icon>highlight_off</mat-icon>
+              Cancel generation
+            </button>
+            <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+              <mat-icon>manage_search</mat-icon>
+              Preview last draft
+            </a>
+          </div>
         </section>
       </ng-template>
     </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -115,7 +115,7 @@
         </p>
 
         <button mat-flat-button color="primary" (click)="generateDraft()">
-          <mat-icon class="material-icons-outlined">padding</mat-icon>
+          <mat-icon>model_training</mat-icon>
           Generate draft
         </button>
       </section>
@@ -174,7 +174,7 @@
             <p>A suggested workflow is to complete at least a chapter before regenerating a draft.</p>
 
             <button mat-flat-button color="primary" (click)="generateDraft({ withConfirm: true })">
-              <mat-icon class="material-icons-outlined">padding</mat-icon>
+              <mat-icon>model_training</mat-icon>
               Generate new draft
             </button>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -139,7 +139,7 @@
                   chapters of your choice.
                 </p>
                 <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-                  <mat-icon>manage_search</mat-icon>
+                  <mat-icon>edit_note</mat-icon>
                   Preview draft
                 </a>
               </ng-container>
@@ -152,7 +152,7 @@
                   chapters of your choice.
                 </p>
                 <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-                  <mat-icon>manage_search</mat-icon>
+                  <mat-icon>edit_note</mat-icon>
                   Preview last draft
                 </a>
               </ng-container>
@@ -195,7 +195,7 @@
               Cancel generation
             </button>
             <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-              <mat-icon>manage_search</mat-icon>
+              <mat-icon>edit_note</mat-icon>
               Preview last draft
             </a>
           </div>
@@ -219,7 +219,7 @@
               Cancel generation
             </button>
             <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-              <mat-icon>manage_search</mat-icon>
+              <mat-icon>edit_note</mat-icon>
               Preview last draft
             </a>
           </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -1,4 +1,5 @@
 @use 'src/variables';
+@use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 
 app-working-animated-indicator {
   display: block;
@@ -56,6 +57,7 @@ em {
     position: relative;
     margin: 0;
 
+    // 'OR' text
     &::after {
       content: attr(data-text);
       position: absolute;
@@ -69,11 +71,59 @@ em {
       text-transform: uppercase;
     }
   }
+
+  // Stack the actions vertically with a horizontal divider on mobile
+  @include media-breakpoint('<', sm) {
+    display: block;
+
+    mat-divider {
+      margin: 20px 0;
+      border: 0;
+      text-align: center;
+
+      // Horizontal line
+      &::before {
+        content: '';
+        position: absolute;
+        background-color: #e0e0e0;
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 1px;
+      }
+
+      // 'OR' text
+      &::after {
+        top: 0;
+        left: 0;
+        position: relative;
+        z-index: 1;
+      }
+    }
+  }
+}
+
+.button-strip {
+  display: flex;
+  gap: 10px;
 }
 
 a[mat-flat-button],
 button {
   margin-top: 8px;
+
+  ::ng-deep .mat-button-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  // Hide the button icons to save space on mobile
+  @include media-breakpoint('<', sm) {
+    mat-icon {
+      display: none;
+    }
+  }
 }
 
 section {
@@ -86,22 +136,22 @@ section {
     'header progress'
     'text progress'
     'button progress';
-  grid-template-columns: minmax(220px, 320px) minmax(100px, 150px);
+  grid-template-columns: minmax(220px, 380px) minmax(100px, 150px);
   place-items: center start;
 
   h3 {
     grid-area: header;
-
-    + p {
-      margin-top: 0;
-    }
   }
 
-  p {
+  .progress-text {
     grid-area: text;
   }
 
-  button {
+  p:first-child {
+    margin-top: 0;
+  }
+
+  .button-strip {
     grid-area: button;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -1,9 +1,9 @@
 @use 'src/variables';
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 
+// Manually center over cancel button
 app-working-animated-indicator {
-  display: block;
-  margin: 10px 0;
+  margin-inline-start: 24px;
 }
 
 h3 {
@@ -105,11 +105,10 @@ em {
 
 .button-strip {
   display: flex;
-  gap: 10px;
+  gap: 20px;
 }
 
-a[mat-flat-button],
-button {
+.mat-button-base {
   margin-top: 8px;
 
   ::ng-deep .mat-button-wrapper {
@@ -117,12 +116,17 @@ button {
     align-items: center;
     gap: 6px;
   }
+}
 
+@include media-breakpoint('<', sm) {
   // Hide the button icons to save space on mobile
-  @include media-breakpoint('<', sm) {
-    mat-icon {
-      display: none;
-    }
+  .mat-button-base mat-icon {
+    display: none;
+  }
+
+  // Manually center over cancel button
+  app-working-animated-indicator {
+    margin-inline-start: 10px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -47,7 +47,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   infoAlert?: InfoAlert;
 
   jobSubscription?: Subscription;
-  isOnline: boolean = true;
+  isOnline = true;
 
   /**
    * Once true, UI can proceed with display according to status of fetched job.
@@ -61,7 +61,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
    * in which case a 'Preview draft' button can still be shown, as the pre-translations
    * from that build can still be retrieved.
    */
-  hasAnyCompletedBuild!: boolean;
+  hasAnyCompletedBuild = false;
 
   cancelDialogRef?: MatDialogRef<any>;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { isEmpty } from 'lodash-es';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { Observable, of, Subscription } from 'rxjs';
+import { of, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -61,7 +61,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
    * in which case a 'Preview draft' button can still be shown, as the pre-translations
    * from that build can still be retrieved.
    */
-  hasAnyCompletedBuild$!: Observable<boolean>;
+  hasAnyCompletedBuild!: boolean;
 
   cancelDialogRef?: MatDialogRef<any>;
 
@@ -101,11 +101,16 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
       this.infoAlert = this.getInfoAlert();
     });
 
-    this.hasAnyCompletedBuild$ = this.activatedProject.projectId$.pipe(
-      filterNullish(),
-      switchMap(projectId =>
-        this.draftGenerationService.getLastCompletedBuild(projectId).pipe(map(build => !isEmpty(build)))
-      )
+    this.subscribe(
+      this.activatedProject.projectId$.pipe(
+        filterNullish(),
+        switchMap(projectId =>
+          this.draftGenerationService.getLastCompletedBuild(projectId).pipe(map(build => !isEmpty(build)))
+        )
+      ),
+      (hasAnyCompletedBuild: boolean) => {
+        this.hasAnyCompletedBuild = hasAnyCompletedBuild;
+      }
     );
 
     this.subscribe(this.onlineStatusService.onlineStatus$, (isOnline: boolean) => {


### PR DESCRIPTION
Show button to preview draft while a build job is running if a previous draft exists.  Now UI should conform to flow chart:
![Pre-Translation Drafting UI States](https://github.com/sillsdev/web-xforge/assets/133386342/cd3bc7bf-ddf3-402b-b273-5d082f492789)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2112)
<!-- Reviewable:end -->
