### PR TITLE
Update Serval.Client to 0.5.4

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -34,7 +34,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.3.0.9" />
-    <PackageReference Include="Serval.Client" Version="0.5.2" />
+    <PackageReference Include="Serval.Client" Version="0.5.4" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -56,7 +56,7 @@ public class PreTranslationService : IPreTranslationService
         // Get the pre-translation data from Serval
         string textId = GetTextId(bookNum, chapterNum);
         foreach (
-            Pretranslation preTranslation in await _translationEnginesClient.GetAllPretranslations2Async(
+            Pretranslation preTranslation in await _translationEnginesClient.GetAllPretranslationsAsync(
                 translationEngineId,
                 corpusId,
                 textId,

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -53,7 +53,7 @@ public class PreTranslationServiceTests
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
         env.TranslationEnginesClient
-            .GetAllPretranslations2Async(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
             .Returns(Task.FromResult<IList<Pretranslation>>(new List<Pretranslation>()));
 
         // SUT
@@ -76,7 +76,7 @@ public class PreTranslationServiceTests
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
         env.TranslationEnginesClient
-            .GetAllPretranslations2Async(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
             .Returns(
                 Task.FromResult<IList<Pretranslation>>(
                     new List<Pretranslation>


### PR DESCRIPTION
The Serval API has changed the API endpoint where draft pre-translations are generated. Serval.Client 0.5.4 contains an update that allows use of this updated endpoint.

This PR updates SF to use the updated client, and modifies calls to affected methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2113)
<!-- Reviewable:end -->
