### PR TITLE
SF-2254 Hide Pre-Translation Draft UI When Offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
@@ -49,11 +49,11 @@
     <h2>
       {{ targetProject?.shortName }}
       <!-- TODO: Update i18n -->
-      <span *ngIf="hasDraft" class="draft-indicator" [ngClass]="{ applied: isDraftApplied }">
+      <span *ngIf="showDraft" class="draft-indicator" [ngClass]="{ applied: isDraftApplied }">
         DRAFT {{ isDraftApplied ? " APPLIED" : "" }}
         <mat-icon *ngIf="isDraftApplied" class="check-icon">check</mat-icon>
       </span>
-      <div *ngIf="!isDraftApplied && hasDraft" class="apply-draft-button-container">
+      <div *ngIf="!isDraftApplied && showDraft" class="apply-draft-button-container">
         <button mat-flat-button color="primary" (click)="applyDraft()">
           <mat-icon>auto_awesome</mat-icon>
           Apply to project

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
@@ -1,73 +1,81 @@
 <h1>Draft preview and apply</h1>
-<p>Select <em>"Apply to project"</em> for each chapter that you want to overwrite with the draft text.</p>
-<p>Select <em>"Edit"</em> to go to the editor page for this chapter.</p>
 
-<div class="draft-viewer-body">
-  <div class="controls">
-    <mat-card>
-      <app-book-chapter-chooser
-        [books]="books"
-        [book]="currentBook"
-        (bookChange)="onBookChange($event)"
-        [chapters]="chapters"
-        [chapter]="currentChapter"
-        (chapterChange)="onChapterChange($event)"
-      ></app-book-chapter-chooser>
+<section *ngIf="!isOnline">
+  <!-- TODO: Update i18n -->
+  <p class="offline-text">Draft preview is not available while offline.</p>
+</section>
 
-      <div class="draft-buttons">
-        <button mat-button (click)="editChapter()">
-          <mat-icon>edit</mat-icon>
-          Edit
-        </button>
-      </div>
-    </mat-card>
-  </div>
+<div [class.offline]="!isOnline">
+  <p>Select <em>"Apply to project"</em> for each chapter that you want to overwrite with the draft text.</p>
+  <p>Select <em>"Edit"</em> to go to the editor page for this chapter.</p>
 
-  <div class="source">
-    <h2>{{ sourceProject?.shortName }}</h2>
-    <app-text
-      #sourceText
-      [isReadOnly]="true"
-      [subscribeToUpdates]="false"
-      [placeholder]="'Loading..'"
-      [isRightToLeft]="!!sourceProject?.isRightToLeft"
-      [id]="sourceTextDocId"
-    ></app-text>
-  </div>
+  <div class="draft-viewer-body">
+    <div class="controls">
+      <mat-card>
+        <app-book-chapter-chooser
+          [books]="books"
+          [book]="currentBook"
+          (bookChange)="onBookChange($event)"
+          [chapters]="chapters"
+          [chapter]="currentChapter"
+          (chapterChange)="onChapterChange($event)"
+        ></app-book-chapter-chooser>
 
-  <div *ngIf="!sourceProjectId" class="source missing">
-    <h2>Source not set</h2>
-    <div>
-      <mat-icon>info</mat-icon>
-      <p>
-        A source text has not been selected for this project. You can select a source text in
-        <a [routerLink]="projectSettingsUrl">project settings</a>.
-      </p>
+        <div class="draft-buttons">
+          <button mat-button (click)="editChapter()">
+            <mat-icon>edit</mat-icon>
+            Edit
+          </button>
+        </div>
+      </mat-card>
     </div>
-  </div>
-  <div class="draft">
-    <h2>
-      {{ targetProject?.shortName }}
-      <!-- TODO: Update i18n -->
-      <span *ngIf="showDraft" class="draft-indicator" [ngClass]="{ applied: isDraftApplied }">
-        DRAFT {{ isDraftApplied ? " APPLIED" : "" }}
-        <mat-icon *ngIf="isDraftApplied" class="check-icon">check</mat-icon>
-      </span>
-      <div *ngIf="!isDraftApplied && showDraft" class="apply-draft-button-container">
-        <button mat-flat-button color="primary" (click)="applyDraft()">
-          <mat-icon>auto_awesome</mat-icon>
-          Apply to project
-        </button>
+
+    <div class="source">
+      <h2>{{ sourceProject?.shortName }}</h2>
+      <app-text
+        #sourceText
+        [isReadOnly]="true"
+        [subscribeToUpdates]="false"
+        [placeholder]="'Loading..'"
+        [isRightToLeft]="!!sourceProject?.isRightToLeft"
+        [id]="sourceTextDocId"
+      ></app-text>
+    </div>
+
+    <div *ngIf="!sourceProjectId" class="source missing">
+      <h2>Source not set</h2>
+      <div>
+        <mat-icon>info</mat-icon>
+        <p>
+          A source text has not been selected for this project. You can select a source text in
+          <a [routerLink]="projectSettingsUrl">project settings</a>.
+        </p>
       </div>
-    </h2>
-    <app-text
-      [ngClass]="{ applied: isDraftApplied }"
-      #targetText
-      [isReadOnly]="true"
-      [subscribeToUpdates]="false"
-      [placeholder]="'Loading..'"
-      [isRightToLeft]="!!targetProject?.isRightToLeft"
-      [id]="targetTextDocId"
-    ></app-text>
+    </div>
+    <div class="draft">
+      <h2>
+        {{ targetProject?.shortName }}
+        <!-- TODO: Update i18n -->
+        <span *ngIf="hasDraft" class="draft-indicator" [ngClass]="{ applied: isDraftApplied }">
+          DRAFT {{ isDraftApplied ? " APPLIED" : "" }}
+          <mat-icon *ngIf="isDraftApplied" class="check-icon">check</mat-icon>
+        </span>
+        <div *ngIf="!isDraftApplied && hasDraft" class="apply-draft-button-container">
+          <button mat-flat-button color="primary" (click)="applyDraft()">
+            <mat-icon>auto_awesome</mat-icon>
+            Apply to project
+          </button>
+        </div>
+      </h2>
+      <app-text
+        [ngClass]="{ applied: isDraftApplied }"
+        #targetText
+        [isReadOnly]="true"
+        [subscribeToUpdates]="false"
+        [placeholder]="'Loading..'"
+        [isRightToLeft]="!!targetProject?.isRightToLeft"
+        [id]="targetTextDocId"
+      ></app-text>
+    </div>
   </div>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
@@ -28,6 +28,10 @@ em {
   }
 }
 
+.offline {
+  display: none;
+}
+
 .draft-buttons {
   display: flex;
   margin-inline-start: 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
@@ -9,6 +9,7 @@ import { Delta, TextDocId } from 'src/app/core/models/text-doc';
 import { SFProjectService } from 'src/app/core/sf-project.service';
 import { TextComponent } from 'src/app/shared/text/text.component';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { DraftSegmentMap } from '../draft-generation';
 import { DraftGenerationService } from '../draft-generation.service';
 import { DraftViewerService } from './draft-viewer.service';
@@ -48,9 +49,14 @@ export class DraftViewerComponent implements OnInit {
     private readonly draftViewerService: DraftViewerService,
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly projectService: SFProjectService,
+    private readonly onlineStatusService: OnlineStatusService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly router: Router
   ) {}
+
+  get showDraft(): boolean {
+    return this.onlineStatusService.isOnline && this.hasDraft;
+  }
 
   async ngOnInit(): Promise<void> {
     this.targetProjectId = this.activatedProjectService.projectId!;
@@ -66,6 +72,7 @@ export class DraftViewerComponent implements OnInit {
     // Wait to populate draft until both editors are loaded with current chapter
     zip(this.sourceEditor?.loaded ?? of(null), this.targetEditor.loaded).subscribe(() => {
       // Both editors are now loaded (or just target is loaded if no source text set in project settings)
+      this.hasDraft = false;
       this.isDraftApplied = false;
       this.preDraftTargetDelta = this.targetEditor.editor?.getContents();
       this.populateDraftText();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
@@ -3,13 +3,13 @@ import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Canon } from '@sillsdev/scripture';
 import { DeltaOperation, DeltaStatic } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { of, zip } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { Delta, TextDocId } from 'src/app/core/models/text-doc';
 import { SFProjectService } from 'src/app/core/sf-project.service';
 import { TextComponent } from 'src/app/shared/text/text.component';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { DraftSegmentMap } from '../draft-generation';
 import { DraftGenerationService } from '../draft-generation.service';
 import { DraftViewerService } from './draft-viewer.service';
@@ -19,8 +19,7 @@ import { DraftViewerService } from './draft-viewer.service';
   templateUrl: './draft-viewer.component.html',
   styleUrls: ['./draft-viewer.component.scss']
 })
-export class DraftViewerComponent implements OnInit {
-  @ViewChild('sourceText') sourceEditor?: TextComponent; // Vernacular (source might not be set in project settings)
+export class DraftViewerComponent extends SubscriptionDisposable implements OnInit {
   @ViewChild('targetText') targetEditor!: TextComponent; // Already translated interleaved with draft
 
   books: number[] = [];
@@ -40,6 +39,8 @@ export class DraftViewerComponent implements OnInit {
 
   isDraftApplied = false;
   hasDraft = false;
+  draftPopulated = false;
+  isOnline = this.onlineStatusService.isOnline;
 
   projectSettingsUrl?: string;
   preDraftTargetDelta?: DeltaStatic;
@@ -52,10 +53,8 @@ export class DraftViewerComponent implements OnInit {
     private readonly onlineStatusService: OnlineStatusService,
     private readonly activatedRoute: ActivatedRoute,
     private readonly router: Router
-  ) {}
-
-  get showDraft(): boolean {
-    return this.onlineStatusService.isOnline && this.hasDraft;
+  ) {
+    super();
   }
 
   async ngOnInit(): Promise<void> {
@@ -69,17 +68,27 @@ export class DraftViewerComponent implements OnInit {
       this.sourceProject = (await this.projectService.getProfile(this.sourceProjectId)).data;
     }
 
-    // Wait to populate draft until both editors are loaded with current chapter
-    zip(this.sourceEditor?.loaded ?? of(null), this.targetEditor.loaded).subscribe(() => {
-      // Both editors are now loaded (or just target is loaded if no source text set in project settings)
-      this.hasDraft = false;
-      this.isDraftApplied = false;
-      this.preDraftTargetDelta = this.targetEditor.editor?.getContents();
-      this.populateDraftText();
-    });
+    // Wait to populate draft until target editor is loaded with current chapter
+    this.subscribe(
+      this.targetEditor.loaded.pipe(
+        tap(() => {
+          this.draftPopulated = false;
+        }),
+        // Listen for online status changes once the editor loads
+        switchMap(() => this.onlineStatusService.onlineStatus$)
+      ),
+      (online: boolean) => {
+        this.isOnline = online;
+
+        // Populate just once per editor load
+        if (online && !this.draftPopulated) {
+          this.populateDraftText();
+        }
+      }
+    );
 
     // Set book/chapter from route, or first book/chapter if not provided
-    this.activatedRoute.paramMap.subscribe((params: ParamMap) => {
+    this.subscribe(this.activatedRoute.paramMap, (params: ParamMap) => {
       const bookId: string | null = params.get('bookId');
       const book: number = bookId ? Canon.bookIdToNumber(bookId) : this.books[0];
 
@@ -116,12 +125,13 @@ export class DraftViewerComponent implements OnInit {
   }
 
   populateDraftText(): void {
-    if (this.currentBook == null || this.currentChapter == null) {
-      throw new Error(`'populateDraftText()' called when 'currentBook' or 'currentChapter' is not set`);
-    }
+    this.draftPopulated = true;
+    this.hasDraft = false;
+    this.isDraftApplied = false;
+    this.preDraftTargetDelta = this.targetEditor.editor?.getContents();
 
-    if (!this.preDraftTargetDelta?.ops) {
-      throw new Error(`'populateDraftText()' called when 'preDraftTargetDelta' is not set`);
+    if (this.currentBook == null || this.currentChapter == null || !this.preDraftTargetDelta?.ops) {
+      return;
     }
 
     this.draftGenerationService

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -32,7 +32,7 @@
           <div class="toolbar-separator">&nbsp;</div>
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
         </ng-container>
-        <ng-container *ngIf="featureFlags.showNmtDrafting.enabled && hasDraft">
+        <ng-container *ngIf="showPreviewDraft">
           <div class="toolbar-separator"></div>
           <button mat-stroked-button title="Preview draft" class="preview-draft-button" (click)="goToDraftPreview()">
             <mat-icon>edit_note</mat-icon>
@@ -107,7 +107,7 @@
                 #targetContainer
                 class="text-container"
                 [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'"
-                [ngClass]="{ 'has-draft': featureFlags.showNmtDrafting.enabled && hasDraft }"
+                [ngClass]="{ 'has-draft': showPreviewDraft }"
               >
                 <app-text
                   #target

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -487,6 +487,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.onlineStatusService.isOnline && this.multiCursorViewers.length > 0;
   }
 
+  get showPreviewDraft(): boolean {
+    return this.onlineStatusService.isOnline && this.featureFlags.showNmtDrafting.enabled && this.hasDraft;
+  }
+
   /**
    * Determines whether the comment adding UI should be shown
    * This will be true any time the user has the right to add notes

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 interface FeatureFlagStore {
   enabled: boolean;
@@ -34,6 +35,9 @@ class LocalStorageFlagStore implements FeatureFlagStore {
 }
 
 export class FeatureFlag {
+  private enabledSource$ = new BehaviorSubject<boolean>(this.storage.enabled);
+  enabled$ = this.enabledSource$.asObservable(); // This ensures 'next()' is only called here
+
   constructor(private readonly storage: FeatureFlagStore, readonly description: string) {}
 
   get enabled(): boolean {
@@ -42,6 +46,7 @@ export class FeatureFlag {
 
   set enabled(value: boolean) {
     this.storage.enabled = value;
+    this.enabledSource$.next(value);
   }
 }
 


### PR DESCRIPTION
When the user's Internet connection goes offline, the functionality to preview the pre-translation draft and apply the draft to the project remains visible.

This PR hides that functionality when the connection goes offline, as the pre-translation drafting functionality requires a live connection to Serval via SF's Machine API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2114)
<!-- Reviewable:end -->
