### PR TITLE
Add dependabot updates for Serval.Client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "Serval.Client"


### PR DESCRIPTION
To ensure that we no longer miss out on updates to Serval.Client, this PR configures dependabot to create Pull Requests whenever an update to Serval.Client is published to NuGet.

The success or failure of the created PR's build will help determine whether this is a breaking change to the Serval API or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2115)
<!-- Reviewable:end -->
