### PR TITLE
SF-2282 Wrap text when question filter text overflows

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -313,12 +313,12 @@ header {
   color: vars.$blueMedium;
   font-weight: 400;
   align-self: flex-start;
-  line-height: 1.5;
+  line-height: 1;
   display: flex;
   align-items: center;
-  margin-top: -5px;
   margin-inline-start: -($questionsHeaderInlineStartPadding - 2px);
   padding-inline: 5px 8px; // Reduce padding from mat-button defaults
+  white-space: pre-wrap;
 
   ::ng-deep .mat-button-wrapper {
     display: flex;


### PR DESCRIPTION
I think ideally this text would overflow with an ellipsis, but I was struggling to get that to work. However, I was able to get the text to wrap, which looks good to me.

Before
![Question filter before](https://github.com/sillsdev/web-xforge/assets/17931130/d6360f41-0075-45de-8bfb-aba321bc9f9c)

After
![Question filter after](https://github.com/sillsdev/web-xforge/assets/17931130/d2065406-6b42-4727-9e22-092deb15ec02)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2118)
<!-- Reviewable:end -->
