### PR TITLE
SF-2279 Fix Hide Scripture Text settings updates

### DIFF
--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -162,6 +162,9 @@ export class SFProjectService extends ProjectService<SFProject> {
           },
           noteTagId: {
             bsonType: 'int'
+          },
+          hideCommunityCheckingText: {
+            bsonType: 'bool'
           }
         },
         additionalProperties: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -316,7 +316,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     ) {
       this.updateSetting(newValue, 'checkingAnswerExport');
     }
-    if (newValue.hideCommunityCheckingText !== this.previousFormValues.hideCommunityCheckingText) {
+    if ((newValue.hideCommunityCheckingText ?? null) !== (this.previousFormValues.hideCommunityCheckingText ?? null)) {
       this.updateSetting(newValue, 'hideCommunityCheckingText');
     }
   }


### PR DESCRIPTION
This PR fixes a bug where the "Hide Scripture Text" setting would always tick as updated when viewing the Settings screen.

I have also taken the opportunity to add the `hideCommunityCheckingText` field this setting corresponds to into the `sf_project` validation schema.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2119)
<!-- Reviewable:end -->
