### PR TITLE
SF-2278 Display book selection for draft training (UI only)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,6 +1,8 @@
-<mat-chip-list [multiple]="true" class="book-multi-select" [class.readonly]="readonly">
-  <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
-    <mat-icon *ngIf="book.selected && !readonly">check</mat-icon>
-    {{ book.name }}
-  </mat-chip>
-</mat-chip-list>
+<ng-container *transloco="let t">
+  <mat-chip-list [multiple]="true" class="book-multi-select" [class.readonly]="readonly">
+    <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
+      <mat-icon *ngIf="book.selected && !readonly">check</mat-icon>
+      {{ t("canon.book_names." + book.bookId) }}
+    </mat-chip>
+  </mat-chip-list>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,0 +1,5 @@
+<mat-chip-list [multiple]="true" class="book-multi-select">
+  <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
+    {{ book.name }}
+  </mat-chip>
+</mat-chip-list>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,4 +1,4 @@
-<mat-chip-list [multiple]="true" class="book-multi-select">
+<mat-chip-list [multiple]="true" class="book-multi-select" [class.readonly]="readonly">
   <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
     {{ book.name }}
   </mat-chip>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,5 +1,6 @@
 <mat-chip-list [multiple]="true" class="book-multi-select" [class.readonly]="readonly">
   <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
+    <mat-icon *ngIf="book.selected && !readonly">check</mat-icon>
     {{ book.name }}
   </mat-chip>
 </mat-chip-list>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -1,0 +1,7 @@
+@use 'src/variables' as vars;
+
+.mat-chip.mat-standard-chip {
+  &.mat-chip-selected {
+    background-color: #4a79c9;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -1,7 +1,23 @@
 @use 'src/variables' as vars;
 
-.mat-chip.mat-standard-chip {
-  &.mat-chip-selected {
+// TODO: Mat chips get significant changes in material 15+, so these styles need to be revisited after upgrade
+
+.mat-chip {
+  cursor: pointer;
+}
+
+.mat-chip-list {
+  .mat-chip-selected {
     background-color: #4a79c9;
+  }
+
+  &.readonly {
+    .mat-chip {
+      cursor: unset;
+    }
+
+    .mat-chip-selected {
+      background-color: #627186;
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -6,6 +6,13 @@
   cursor: pointer;
 }
 
+mat-icon {
+  width: auto;
+  height: auto;
+  font-size: 17px;
+  margin-inline-end: 10px;
+}
+
 .mat-chip-list {
   .mat-chip-selected {
     background-color: #4a79c9;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -28,3 +28,10 @@ mat-icon {
     }
   }
 }
+
+// .material-icons class has 'direction: ltr' even when ancestor is rtl
+:host-context([dir='rtl']) {
+  mat-icon {
+    direction: rtl;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -1,8 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatChipsModule } from '@angular/material/chips';
-import { I18nService } from 'xforge-common/i18n.service';
 
-import { mock, when } from 'ts-mockito';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { BookMultiSelectComponent, BookOption } from './book-multi-select.component';
 
@@ -10,14 +8,12 @@ describe('BookMultiSelectComponent', () => {
   let component: BookMultiSelectComponent;
   let fixture: ComponentFixture<BookMultiSelectComponent>;
 
-  const mockI18nService = mock(I18nService);
   const mockBooks: number[] = [1, 2, 3];
   const mockSelectedBooks: number[] = [1, 3];
 
   configureTestingModule(() => ({
     imports: [MatChipsModule],
-    declarations: [BookMultiSelectComponent],
-    providers: [{ provide: I18nService, useMock: mockI18nService }]
+    declarations: [BookMultiSelectComponent]
   }));
 
   beforeEach(() => {
@@ -30,16 +26,12 @@ describe('BookMultiSelectComponent', () => {
 
   it('should initialize book options on ngOnChanges', () => {
     const mockBookOptions: BookOption[] = [
-      { bookNum: 1, name: 'Book 1', selected: true },
-      { bookNum: 2, name: 'Book 2', selected: false },
-      { bookNum: 3, name: 'Book 3', selected: true }
+      { bookNum: 1, bookId: 'GEN', selected: true },
+      { bookNum: 2, bookId: 'EXO', selected: false },
+      { bookNum: 3, bookId: 'LEV', selected: true }
     ];
 
-    when(mockI18nService.localizeBook(1)).thenReturn('Book 1');
-    when(mockI18nService.localizeBook(2)).thenReturn('Book 2');
-    when(mockI18nService.localizeBook(3)).thenReturn('Book 3');
-
-    component.ngOnChanges();
+    component.ngOnChanges({});
 
     expect(component.bookOptions).toEqual(mockBookOptions);
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatChipsModule } from '@angular/material/chips';
+import { I18nService } from 'xforge-common/i18n.service';
+
+import { mock, when } from 'ts-mockito';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { BookMultiSelectComponent, BookOption } from './book-multi-select.component';
+
+describe('BookMultiSelectComponent', () => {
+  let component: BookMultiSelectComponent;
+  let fixture: ComponentFixture<BookMultiSelectComponent>;
+
+  const mockI18nService = mock(I18nService);
+  const mockBooks: number[] = [1, 2, 3];
+  const mockSelectedBooks: number[] = [1, 3];
+
+  configureTestingModule(() => ({
+    imports: [MatChipsModule],
+    declarations: [BookMultiSelectComponent],
+    providers: [{ provide: I18nService, useMock: mockI18nService }]
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BookMultiSelectComponent);
+    component = fixture.componentInstance;
+    component.availableBooks = mockBooks;
+    component.selectedBooks = mockSelectedBooks;
+    fixture.detectChanges();
+  });
+
+  it('should initialize book options on ngOnChanges', () => {
+    const mockBookOptions: BookOption[] = [
+      { bookNum: 1, name: 'Book 1', selected: true },
+      { bookNum: 2, name: 'Book 2', selected: false },
+      { bookNum: 3, name: 'Book 3', selected: true }
+    ];
+
+    when(mockI18nService.localizeBook(1)).thenReturn('Book 1');
+    when(mockI18nService.localizeBook(2)).thenReturn('Book 2');
+    when(mockI18nService.localizeBook(3)).thenReturn('Book 3');
+
+    component.ngOnChanges();
+
+    expect(component.bookOptions).toEqual(mockBookOptions);
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { I18nService } from 'xforge-common/i18n.service';
+
+export interface BookOption {
+  bookNum: number;
+  name: string;
+  selected: boolean;
+}
+
+@Component({
+  selector: 'app-book-multi-select',
+  templateUrl: './book-multi-select.component.html',
+  styleUrls: ['./book-multi-select.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BookMultiSelectComponent implements OnChanges {
+  @Input() availableBooks: number[] = [];
+  @Input() selectedBooks: number[] = [];
+  @Input() readonly: boolean = false;
+  @Output() bookSelect = new EventEmitter<number[]>();
+
+  bookOptions: BookOption[] = [];
+
+  constructor(private i18n: I18nService) {}
+
+  ngOnChanges(): void {
+    // Update book list
+    this.initBookOptions();
+  }
+
+  initBookOptions(): void {
+    this.bookOptions = this.availableBooks.map((bookNum: number) => ({
+      bookNum,
+      name: this.i18n.localizeBook(bookNum),
+      selected: this.selectedBooks?.includes(bookNum) ?? false
+    }));
+  }
+
+  toggleSelection(book: BookOption): void {
+    book.selected = !book.selected;
+    this.bookSelect.emit(
+      this.bookOptions.filter((opt: BookOption) => opt.selected).map((opt: BookOption) => opt.bookNum)
+    );
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -1,17 +1,16 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
-import { I18nService } from 'xforge-common/i18n.service';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Canon } from '@sillsdev/scripture';
 
 export interface BookOption {
   bookNum: number;
-  name: string;
+  bookId: string;
   selected: boolean;
 }
 
 @Component({
   selector: 'app-book-multi-select',
   templateUrl: './book-multi-select.component.html',
-  styleUrls: ['./book-multi-select.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  styleUrls: ['./book-multi-select.component.scss']
 })
 export class BookMultiSelectComponent implements OnChanges {
   @Input() availableBooks: number[] = [];
@@ -21,17 +20,17 @@ export class BookMultiSelectComponent implements OnChanges {
 
   bookOptions: BookOption[] = [];
 
-  constructor(private i18n: I18nService) {}
-
-  ngOnChanges(): void {
-    // Update book list
-    this.initBookOptions();
+  ngOnChanges(changes: SimpleChanges): void {
+    // Ignore the first change, which is array initialization to empty array
+    if (!changes.availableBooks?.firstChange) {
+      this.initBookOptions();
+    }
   }
 
   initBookOptions(): void {
     this.bookOptions = this.availableBooks.map((bookNum: number) => ({
       bookNum,
-      name: this.i18n.localizeBook(bookNum),
+      bookId: Canon.bookNumberToId(bookNum),
       selected: this.selectedBooks?.includes(bookNum) ?? false
     }));
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
@@ -6,6 +6,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { CheckingQuestionComponent } from '../checking/checking/checking-answers/checking-question/checking-question.component';
 import { SingleButtonAudioPlayerComponent } from '../checking/checking/single-button-audio-player/single-button-audio-player.component';
 import { BookChapterChooserComponent } from './book-chapter-chooser/book-chapter-chooser.component';
+import { BookMultiSelectComponent } from './book-multi-select/book-multi-select.component';
 import { ChapterNavComponent } from './chapter-nav/chapter-nav.component';
 import { InfoComponent } from './info/info.component';
 import { NoticeComponent } from './notice/notice.component';
@@ -26,7 +27,8 @@ const componentExports = [
   TextComponent,
   CheckingQuestionComponent,
   SingleButtonAudioPlayerComponent,
-  WorkingAnimatedIndicatorComponent
+  WorkingAnimatedIndicatorComponent,
+  BookMultiSelectComponent
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,38 +1,46 @@
-<mat-stepper orientation="vertical" [linear]="true">
-  <mat-step>
-    <ng-template matStepLabel>
-      Choose books for training
-      <mat-icon class="material-icons-outlined" [matMenuTriggerFor]="trainingInfo">info</mat-icon>
-    </ng-template>
-    <app-book-multi-select
-      [availableBooks]="(availableBooks$ | async) ?? []"
-      [selectedBooks]="selectedBooks"
-      (bookSelect)="onBookSelect($event)"
-    ></app-book-multi-select>
-    <div class="stepper-nav">
-      <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext color="primary">Next</button>
-    </div>
-  </mat-step>
+<ng-container *transloco="let t; read: 'draft_generation_steps'">
+  <mat-stepper orientation="vertical" [linear]="true">
+    <mat-step>
+      <ng-template matStepLabel>
+        {{ t("choose_books_for_training") }}
+        <mat-icon class="material-icons-outlined" [matMenuTriggerFor]="trainingInfo">info</mat-icon>
+      </ng-template>
+      <app-book-multi-select
+        [availableBooks]="(availableBooks$ | async) ?? []"
+        [selectedBooks]="selectedBooks"
+        (bookSelect)="onBookSelect($event)"
+      ></app-book-multi-select>
+      <div class="stepper-nav">
+        <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext color="primary">
+          {{ t("next") }}
+        </button>
+      </div>
+    </mat-step>
 
-  <mat-step>
-    <ng-template matStepLabel>Confirm books and generate</ng-template>
-    <app-book-multi-select
-      [availableBooks]="selectedBooks"
-      [selectedBooks]="selectedBooks"
-      [readonly]="true"
-    ></app-book-multi-select>
-    <p *ngIf="!selectedBooks.length">Click "Back" to select books.</p>
-    <div class="stepper-nav">
-      <button *ngIf="!selectedBooks.length" mat-flat-button matStepperPrevious color="primary">Back</button>
-      <button *ngIf="selectedBooks.length" mat-stroked-button matStepperPrevious>Back</button>
-      <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext (click)="onDone()" color="primary">
-        Generate draft
-      </button>
-    </div>
-  </mat-step>
-</mat-stepper>
+    <mat-step>
+      <ng-template matStepLabel>
+        {{ t("confirm_books_and_generate") }}
+      </ng-template>
+      <app-book-multi-select
+        [availableBooks]="selectedBooks"
+        [selectedBooks]="selectedBooks"
+        [readonly]="true"
+      ></app-book-multi-select>
+      <p *ngIf="!selectedBooks.length">{{ t("no_books_selected") }}</p>
+      <div class="stepper-nav">
+        <button *ngIf="!selectedBooks.length" mat-flat-button matStepperPrevious color="primary">
+          {{ t("back") }}
+        </button>
+        <button *ngIf="selectedBooks.length" mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
+        <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext (click)="onDone()" color="primary">
+          {{ t("generate_draft") }}
+        </button>
+      </div>
+    </mat-step>
+  </mat-stepper>
 
-<mat-menu #trainingInfo="matMenu" class="draft-generation-steps-info-menu">
-  <mat-icon class="material-icons-outlined">info</mat-icon>
-  Choose books with the most polished translations, as these will be used to train the model.
-</mat-menu>
+  <mat-menu #trainingInfo="matMenu" class="draft-generation-steps-info-menu">
+    <mat-icon class="material-icons-outlined">info</mat-icon>
+    {{ t("choose_books_for_training_info") }}
+  </mat-menu>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,0 +1,39 @@
+<mat-stepper orientation="vertical" [linear]="true">
+  <mat-step>
+    <ng-template matStepLabel>
+      Choose books for training
+      <mat-icon class="material-icons-outlined" [matMenuTriggerFor]="trainingInfo">info</mat-icon>
+    </ng-template>
+    <app-book-multi-select
+      [availableBooks]="(availableBooks$ | async) ?? []"
+      [selectedBooks]="selectedBooks"
+      (bookSelect)="onBookSelect($event)"
+    >
+    </app-book-multi-select>
+    <div class="stepper-nav">
+      <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext color="primary">Next</button>
+    </div>
+  </mat-step>
+
+  <mat-step>
+    <ng-template matStepLabel>Confirm books and generate</ng-template>
+    <app-book-multi-select
+      [availableBooks]="selectedBooks"
+      [selectedBooks]="selectedBooks"
+      (bookSelect)="onBookSelect($event)"
+    ></app-book-multi-select>
+    <p *ngIf="!selectedBooks.length">Click "Back" to select books.</p>
+    <div class="stepper-nav">
+      <button *ngIf="!selectedBooks.length" mat-flat-button matStepperPrevious color="primary">Back</button>
+      <button *ngIf="selectedBooks.length" mat-stroked-button matStepperPrevious>Back</button>
+      <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext (click)="onDone()" color="primary">
+        Generate draft
+      </button>
+    </div>
+  </mat-step>
+</mat-stepper>
+
+<mat-menu #trainingInfo="matMenu" class="draft-generation-steps-info-menu">
+  <mat-icon class="material-icons-outlined">info</mat-icon>
+  Choose books with the most polished translations, as these will be used to train the model.
+</mat-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -8,8 +8,7 @@
       [availableBooks]="(availableBooks$ | async) ?? []"
       [selectedBooks]="selectedBooks"
       (bookSelect)="onBookSelect($event)"
-    >
-    </app-book-multi-select>
+    ></app-book-multi-select>
     <div class="stepper-nav">
       <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext color="primary">Next</button>
     </div>
@@ -20,7 +19,7 @@
     <app-book-multi-select
       [availableBooks]="selectedBooks"
       [selectedBooks]="selectedBooks"
-      (bookSelect)="onBookSelect($event)"
+      [readonly]="true"
     ></app-book-multi-select>
     <p *ngIf="!selectedBooks.length">Click "Back" to select books.</p>
     <div class="stepper-nav">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -1,0 +1,46 @@
+@use 'src/xforge-common/media-breakpoints/breakpoints' as *;
+
+.stepper-nav {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+mat-stepper {
+  ::ng-deep {
+    // Space and vertically center the 'info' icon
+    .mat-step-text-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  }
+}
+
+// Menu exists in overlay, so ::ng-deep cannot be nested under :host
+::ng-deep {
+  .draft-generation-steps-info-menu {
+    .mat-menu-content {
+      padding: 16px;
+      background-color: #f7faff;
+      color: #002546;
+      font-style: italic;
+
+      mat-icon {
+        vertical-align: text-bottom;
+        margin-inline-end: 2px;
+      }
+    }
+
+    // Allow wider info popup on larger screens (default is 280px)
+    @include media-breakpoint('>', sm) {
+      max-width: 460px;
+    }
+  }
+}
+
+app-book-multi-select {
+  display: block;
+  margin-top: 4px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -4,10 +4,11 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
-import { mock, when } from 'ts-mockito';
+import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
 import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
 
 describe('DraftGenerationStepsComponent', () => {
@@ -15,16 +16,32 @@ describe('DraftGenerationStepsComponent', () => {
   let fixture: ComponentFixture<DraftGenerationStepsComponent>;
 
   const mockActivatedProjectService = mock(ActivatedProjectService);
-  const mockProjectDoc = { data: { texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }] } } as SFProjectProfileDoc;
+  const mockProjectService = mock(SFProjectService);
+  const mockTargetProjectDoc = {
+    data: {
+      translateConfig: {
+        source: { projectRef: 'test' }
+      }
+    }
+  } as SFProjectProfileDoc;
+  const mockSourceProjectDoc = {
+    data: {
+      texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }]
+    }
+  } as SFProjectProfileDoc;
 
   configureTestingModule(() => ({
     imports: [MatStepperModule, MatMenuModule, NoopAnimationsModule],
     declarations: [DraftGenerationStepsComponent],
-    providers: [{ provide: ActivatedProjectService, useMock: mockActivatedProjectService }]
+    providers: [
+      { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
+      { provide: SFProjectService, useMock: mockProjectService }
+    ]
   }));
 
   beforeEach(() => {
-    when(mockActivatedProjectService.projectDoc$).thenReturn(of(mockProjectDoc));
+    when(mockActivatedProjectService.projectDoc$).thenReturn(of(mockTargetProjectDoc));
+    when(mockProjectService.getProfile(anything())).thenResolve(mockSourceProjectDoc);
 
     fixture = TestBed.createComponent(DraftGenerationStepsComponent);
     component = fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -6,7 +6,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { configureTestingModule } from 'xforge-common/test-utils';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
@@ -31,7 +31,7 @@ describe('DraftGenerationStepsComponent', () => {
   } as SFProjectProfileDoc;
 
   configureTestingModule(() => ({
-    imports: [MatStepperModule, MatMenuModule, NoopAnimationsModule],
+    imports: [MatStepperModule, MatMenuModule, TestTranslocoModule, NoopAnimationsModule],
     declarations: [DraftGenerationStepsComponent],
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatStepperModule } from '@angular/material/stepper';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { mock, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
+
+describe('DraftGenerationStepsComponent', () => {
+  let component: DraftGenerationStepsComponent;
+  let fixture: ComponentFixture<DraftGenerationStepsComponent>;
+
+  const mockActivatedProjectService = mock(ActivatedProjectService);
+  const mockProjectDoc = { data: { texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }] } } as SFProjectProfileDoc;
+
+  configureTestingModule(() => ({
+    imports: [MatStepperModule, MatMenuModule, NoopAnimationsModule],
+    declarations: [DraftGenerationStepsComponent],
+    providers: [{ provide: ActivatedProjectService, useMock: mockActivatedProjectService }]
+  }));
+
+  beforeEach(() => {
+    when(mockActivatedProjectService.projectDoc$).thenReturn(of(mockProjectDoc));
+
+    fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should set availableBooks$ correctly', () => {
+    component.availableBooks$?.subscribe(books => {
+      expect(books).toEqual([1, 2, 3]);
+    });
+  });
+
+  it('should select all books initially', () => {
+    component.availableBooks$?.subscribe(() => {
+      expect(component.selectedBooks).toEqual([1, 2, 3]);
+    });
+  });
+
+  it('should emit the correct selected books when onDone is called', () => {
+    const mockSelectedBooks = [1, 2, 3];
+    component.selectedBooks = mockSelectedBooks;
+
+    spyOn(component.done, 'emit');
+
+    component.onDone();
+
+    expect(component.done.emit).toHaveBeenCalledWith({ books: mockSelectedBooks } as DraftGenerationStepsResult);
+  });
+
+  it('should emit the correct selected books when onBookSelect is called', () => {
+    const mockSelectedBooks = [1, 2, 3];
+
+    spyOn(component, 'onBookSelect');
+
+    const bookMultiSelect = fixture.debugElement.query(By.css('app-book-multi-select'));
+    bookMultiSelect.triggerEventHandler('bookSelect', mockSelectedBooks);
+
+    expect(component.onBookSelect).toHaveBeenCalledWith(mockSelectedBooks);
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,0 +1,40 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+
+export interface DraftGenerationStepsResult {
+  books: number[];
+}
+
+@Component({
+  selector: 'app-draft-generation-steps',
+  templateUrl: './draft-generation-steps.component.html',
+  styleUrls: ['./draft-generation-steps.component.scss']
+})
+export class DraftGenerationStepsComponent implements OnInit {
+  @Output() done = new EventEmitter<DraftGenerationStepsResult>();
+
+  availableBooks$?: Observable<number[]>;
+  selectedBooks: number[] = [];
+
+  constructor(private readonly activatedProject: ActivatedProjectService) {}
+
+  ngOnInit(): void {
+    this.availableBooks$ = this.activatedProject.projectDoc$.pipe(
+      map(doc => doc?.data?.texts.map(t => t.bookNum) ?? []),
+      tap((books: number[]) => {
+        // Initially select all books
+        this.selectedBooks = books;
+      })
+    );
+  }
+
+  onBookSelect(selectedBooks: number[]): void {
+    this.selectedBooks = selectedBooks;
+  }
+
+  onDone(): void {
+    this.done.emit({ books: this.selectedBooks });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -59,172 +59,188 @@
     </ul>
   </section>
 
+  <mat-divider inset></mat-divider>
+
   <ng-container *ngIf="!isOnline">
-    <mat-divider inset></mat-divider>
     <section>
       <!-- TODO: Update i18n -->
       <p class="offline-text">Draft generation is not available when offline.</p>
     </section>
   </ng-container>
 
-  <ng-container *ngIf="isOnline && isDraftJobFetched">
-    <mat-divider inset></mat-divider>
-
-    <section *ngIf="infoAlert === InfoAlert.NotBackTranslation">
-      <h3>Project type is not supported for draft generation</h3>
-      <p>In order to generate a draft translation, the project must be a back translation project.</p>
-    </section>
-
-    <section *ngIf="infoAlert === InfoAlert.NotSupportedLanguage">
-      <h3>Target language is not supported for draft generation</h3>
-      <p>
-        Your project language
-        <ng-container *ngIf="getTargetLanguageDisplayName()">
-          of <em>"{{ getTargetLanguageDisplayName() }}"</em>
-        </ng-container>
-        is not in the
-        <a
-          href="https://ai.facebook.com/research/no-language-left-behind/#200-languages-accordion"
-          target="_blank"
-          rel="noopener noreferrer"
-          >No Language Left Behind</a
-        >
-        set.
-      </p>
-    </section>
-
-    <section *ngIf="infoAlert === InfoAlert.NoSourceProjectSet">
-      <h3>Source text not selected</h3>
-      <p>
-        A source text has not been selected for this project. You can select a source text in
-        <a [routerLink]="projectSettingsUrl">project settings</a>.
-      </p>
-    </section>
-
-    <section *ngIf="infoAlert === InfoAlert.SourceAndTargetLanguageIdentical">
-      <h3>Same source and target language</h3>
-      <p>The language for your source text must be different than the target language.</p>
-    </section>
-
-    <ng-container *ngIf="isGenerationSupported">
-      <section *ngIf="draftJob == null; else jobExists">
-        <h3>Generate draft</h3>
-        <p>
-          Click <em>"Generate draft"</em> to start the process of generating a back translation draft. This will take at
-          least a few hours.
-        </p>
-
-        <button mat-flat-button color="primary" (click)="generateDraft()">
-          <mat-icon>model_training</mat-icon>
-          Generate draft
-        </button>
-      </section>
-
-      <ng-template #jobExists>
-        <ng-container *ngIf="isDraftFaulted(draftJob)">
-          <section>
-            <h3><mat-icon color="warn">warning</mat-icon>Last generation attempt failed</h3>
-            <p>Click <em>"Generate draft"</em> below to try again.</p>
+  <ng-container *ngIf="isOnline">
+    <mat-tab-group>
+      <mat-tab>
+        <div *ngIf="isDraftJobFetched">
+          <section *ngIf="infoAlert === InfoAlert.NotBackTranslation">
+            <h3>Project type is not supported for draft generation</h3>
+            <p>In order to generate a draft translation, the project must be a back translation project.</p>
           </section>
-          <mat-divider inset></mat-divider>
-        </ng-container>
 
-        <section *ngIf="!isDraftInProgress(draftJob)" class="view-or-create-options">
-          <ng-container *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
-            <div>
-              <ng-container *ngIf="isDraftComplete(draftJob)">
-                <h3>Draft generation complete</h3>
-                <p>
-                  Go to <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the generated draft to
-                  chapters of your choice.
-                </p>
-                <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-                  <mat-icon>edit_note</mat-icon>
-                  Preview draft
-                </a>
-              </ng-container>
-
-              <ng-container *ngIf="!isDraftComplete(draftJob)">
-                <h3>Preview last draft</h3>
-                <p>
-                  The last draft build did not complete, but you can go to
-                  <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the last generated draft to
-                  chapters of your choice.
-                </p>
-                <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-                  <mat-icon>edit_note</mat-icon>
-                  Preview last draft
-                </a>
-              </ng-container>
-            </div>
-
-            <mat-divider inset vertical data-text="or"></mat-divider>
-          </ng-container>
-
-          <div *ngIf="!isDraftInProgress(draftJob)">
-            <h3>Generate new draft</h3>
-            <!-- TODO: Update i18n -->
+          <section *ngIf="infoAlert === InfoAlert.NotSupportedLanguage">
+            <h3>Target language is not supported for draft generation</h3>
             <p>
-              Click <em>"Generate draft"</em> to start the process of generating a new back translation draft. This will
-              take at least a few hours and could take as long as 16 hours.
+              Your project language
+              <ng-container *ngIf="getTargetLanguageDisplayName()">
+                of <em>"{{ getTargetLanguageDisplayName() }}"</em>
+              </ng-container>
+              is not in the
+              <a
+                href="https://ai.facebook.com/research/no-language-left-behind/#200-languages-accordion"
+                target="_blank"
+                rel="noopener noreferrer"
+                >No Language Left Behind</a
+              >
+              set.
             </p>
+          </section>
 
-            <!-- TODO: (not needed yet) Add logic to not offer regeneration until some determined unit of work is complete -->
-            <!-- TODO: Update i18n -->
-            <p>A suggested workflow is to complete at least a chapter before regenerating a draft.</p>
-
-            <button mat-flat-button color="primary" (click)="generateDraft({ withConfirm: true })">
-              <mat-icon>model_training</mat-icon>
-              Generate new draft
-            </button>
-          </div>
-        </section>
-
-        <section *ngIf="isDraftQueued(draftJob)">
-          <h3>Draft queued</h3>
-
-          <p>The back translation draft has been queued. Please check back later.</p>
-          <p *ngIf="hasAnyCompletedBuild">
-            While the new draft generation is in progress, you can continue working with the previously generated draft.
-          </p>
-          <app-working-animated-indicator></app-working-animated-indicator>
-
-          <div class="button-strip">
-            <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-              <mat-icon>highlight_off</mat-icon>
-              Cancel generation
-            </button>
-            <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-              <mat-icon>edit_note</mat-icon>
-              Preview last draft
-            </a>
-          </div>
-        </section>
-
-        <section *ngIf="isDraftActive(draftJob)" class="progress-active">
-          <h3>Draft in progress</h3>
-
-          <div class="progress-text">
-            <p>Generating draft; this can take a few hours.</p>
-            <p *ngIf="hasAnyCompletedBuild">
-              While the new draft generation is in progress, you can continue working with the previously generated
-              draft.
+          <section *ngIf="infoAlert === InfoAlert.NoSourceProjectSet">
+            <h3>Source text not selected</h3>
+            <p>
+              A source text has not been selected for this project. You can select a source text in
+              <a [routerLink]="projectSettingsUrl">project settings</a>.
             </p>
-          </div>
-          <circle-progress [percent]="draftJob!.percentCompleted"></circle-progress>
+          </section>
 
-          <div class="button-strip">
-            <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-              <mat-icon>highlight_off</mat-icon>
-              Cancel generation
-            </button>
-            <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-              <mat-icon>edit_note</mat-icon>
-              Preview last draft
-            </a>
-          </div>
-        </section>
-      </ng-template>
-    </ng-container>
+          <section *ngIf="infoAlert === InfoAlert.SourceAndTargetLanguageIdentical">
+            <h3>Same source and target language</h3>
+            <p>The language for your source text must be different than the target language.</p>
+          </section>
+
+          <ng-container *ngIf="isGenerationSupported">
+            <section *ngIf="draftJob == null; else jobExists">
+              <h3>Generate draft</h3>
+              <p>
+                Click <em>"Generate draft"</em> to start the process of generating a back translation draft. This will
+                take at least a few hours.
+              </p>
+
+              <button mat-flat-button color="primary" (click)="generateDraft()">
+                <mat-icon>model_training</mat-icon>
+                Generate draft
+              </button>
+            </section>
+
+            <ng-template #jobExists>
+              <ng-container *ngIf="isDraftFaulted(draftJob)">
+                <section>
+                  <h3><mat-icon color="warn">warning</mat-icon>Last generation attempt failed</h3>
+                  <p>Click <em>"Generate draft"</em> below to try again.</p>
+                </section>
+                <mat-divider inset></mat-divider>
+              </ng-container>
+
+              <section *ngIf="!isDraftInProgress(draftJob)" class="view-or-create-options">
+                <ng-container *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
+                  <div>
+                    <ng-container *ngIf="isDraftComplete(draftJob)">
+                      <h3>Draft generation complete</h3>
+                      <p>
+                        Go to <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the generated draft
+                        to chapters of your choice.
+                      </p>
+                      <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                        <mat-icon>edit_note</mat-icon>
+                        Preview draft
+                      </a>
+                    </ng-container>
+
+                    <ng-container *ngIf="!isDraftComplete(draftJob)">
+                      <h3>Preview last draft</h3>
+                      <p>
+                        The last draft build did not complete, but you can go to
+                        <a [routerLink]="draftViewerUrl">draft viewer</a> to preview and apply the last generated draft
+                        to chapters of your choice.
+                      </p>
+                      <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                        <mat-icon>edit_note</mat-icon>
+                        Preview last draft
+                      </a>
+                    </ng-container>
+                  </div>
+
+                  <mat-divider inset vertical data-text="or"></mat-divider>
+                </ng-container>
+
+                <div *ngIf="!isDraftInProgress(draftJob)">
+                  <h3>Generate new draft</h3>
+                  <!-- TODO: Update i18n -->
+                  <p>
+                    Click <em>"Generate draft"</em> to start the process of generating a new back translation draft.
+                    This will take at least a few hours and could take as long as 16 hours.
+                  </p>
+
+                  <!-- TODO: (not needed yet) Add logic to not offer regeneration until some determined unit of work is complete -->
+                  <!-- TODO: Update i18n -->
+                  <p>A suggested workflow is to complete at least a chapter before regenerating a draft.</p>
+
+                  <button mat-flat-button color="primary" (click)="generateDraft({ withConfirm: true })">
+                    <mat-icon>model_training</mat-icon>
+                    Generate new draft
+                  </button>
+                </div>
+              </section>
+
+              <section *ngIf="isDraftQueued(draftJob)">
+                <h3>Draft queued</h3>
+
+                <p>The back translation draft has been queued. Please check back later.</p>
+                <p *ngIf="hasAnyCompletedBuild">
+                  While the new draft generation is in progress, you can continue working with the previously generated
+                  draft.
+                </p>
+                <app-working-animated-indicator></app-working-animated-indicator>
+
+                <div class="button-strip">
+                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+                    <mat-icon>highlight_off</mat-icon>
+                    Cancel generation
+                  </button>
+                  <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                    <mat-icon>edit_note</mat-icon>
+                    Preview last draft
+                  </a>
+                </div>
+              </section>
+
+              <section *ngIf="isDraftActive(draftJob)" class="progress-active">
+                <h3>Draft in progress</h3>
+
+                <div class="progress-text">
+                  <p>Generating draft; this can take a few hours.</p>
+                  <p *ngIf="hasAnyCompletedBuild">
+                    While the new draft generation is in progress, you can continue working with the previously
+                    generated draft.
+                  </p>
+                </div>
+                <circle-progress [percent]="draftJob!.percentCompleted"></circle-progress>
+
+                <div class="button-strip">
+                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+                    <mat-icon>highlight_off</mat-icon>
+                    Cancel generation
+                  </button>
+                  <a *ngIf="hasAnyCompletedBuild" mat-flat-button color="primary" [routerLink]="draftViewerUrl">
+                    <mat-icon>edit_note</mat-icon>
+                    Preview last draft
+                  </a>
+                </div>
+              </section>
+            </ng-template>
+          </ng-container>
+        </div>
+      </mat-tab>
+      <mat-tab>
+        <!-- Lazy load tab content -->
+        <ng-template matTabContent>
+          <button mat-stroked-button class="backout-button" (click)="navigateToTab('initial')">
+            <mat-icon class="mirror-rtl">navigate_before</mat-icon>
+            Back
+          </button>
+          <app-draft-generation-steps (done)="onPreGenerationStepsComplete($event)"></app-draft-generation-steps>
+        </ng-template>
+      </mat-tab>
+    </mat-tab-group>
   </ng-container>
 </mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -48,6 +48,13 @@ em {
   }
 }
 
+// Hide the tab headers
+mat-tab-group {
+  ::ng-deep .mat-tab-header {
+    display: none;
+  }
+}
+
 .view-or-create-options {
   display: grid;
   grid-template-columns: minmax(0, 500px) 1px minmax(0, 500px);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
+import { MatTabGroup } from '@angular/material/tabs';
 import { isEmpty } from 'lodash-es';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { of, Subscription } from 'rxjs';
@@ -15,6 +16,7 @@ import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { NllbLanguageService } from '../nllb-language.service';
 import { activeBuildStates } from './draft-generation';
+import { DraftGenerationStepsResult } from './draft-generation-steps/draft-generation-steps.component';
 import { DraftGenerationService } from './draft-generation.service';
 
 export enum InfoAlert {
@@ -31,6 +33,7 @@ export enum InfoAlert {
   styleUrls: ['./draft-generation.component.scss']
 })
 export class DraftGenerationComponent extends SubscriptionDisposable implements OnInit {
+  @ViewChild(MatTabGroup) tabGroup?: MatTabGroup;
   draftJob?: BuildDto;
 
   draftViewerUrl?: string;
@@ -144,7 +147,8 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
       }
     }
 
-    this.startBuild();
+    // Display pre-generation steps
+    this.navigateToTab('pre-generate-steps');
   }
 
   // TODO: update i18n
@@ -170,6 +174,28 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     }
 
     this.cancelBuild();
+  }
+
+  navigateToTab(tab: 'initial' | 'pre-generate-steps'): void {
+    if (this.tabGroup == null) {
+      return;
+    }
+
+    switch (tab) {
+      case 'initial':
+        this.tabGroup.selectedIndex = 0;
+        break;
+      case 'pre-generate-steps':
+        this.tabGroup.selectedIndex = 1;
+        break;
+    }
+  }
+
+  onPreGenerationStepsComplete(_result: DraftGenerationStepsResult): void {
+    this.navigateToTab('initial');
+
+    // TODO: Send selected books to the back-end
+    this.startBuild();
   }
 
   getTargetLanguageDisplayName(): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -251,7 +251,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     return job == null || this.isDraftInProgress(job);
   }
 
-  private startBuild(): void {
+  startBuild(): void {
     this.jobSubscription?.unsubscribe();
     this.jobSubscription = this.subscribe(
       this.draftGenerationService.startBuildOrGetActiveBuild(this.activatedProject.projectId!).pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -7,6 +7,7 @@ import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { SharedModule } from '../shared/shared.module';
 import { BiblicalTermDialogComponent } from './biblical-terms/biblical-term-dialog.component';
 import { BiblicalTermsComponent } from './biblical-terms/biblical-terms.component';
+import { DraftGenerationStepsComponent } from './draft-generation/draft-generation-steps/draft-generation-steps.component';
 import { DraftGenerationComponent } from './draft-generation/draft-generation.component';
 import { DraftViewerComponent } from './draft-generation/draft-viewer/draft-viewer.component';
 import { EditorComponent } from './editor/editor.component';
@@ -30,7 +31,8 @@ import { TranslateRoutingModule } from './translate-routing.module';
     TrainingProgressComponent,
     TranslateOverviewComponent,
     DraftGenerationComponent,
-    DraftViewerComponent
+    DraftViewerComponent,
+    DraftGenerationStepsComponent
   ],
   imports: [
     AngularSplitModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -116,6 +116,15 @@
     "please_type_project_name": "Please type in the name of the project to confirm.",
     "project_name": "Project Name"
   },
+  "draft_generation_steps": {
+    "back": "Back",
+    "choose_books_for_training": "Choose books for training",
+    "choose_books_for_training_info": "Choose books with the most polished translations, as these will be used to train the model.",
+    "confirm_books_and_generate": "Confirm books and generate",
+    "generate_draft": "Generate draft",
+    "next": "Next",
+    "no_books_selected": "Click \"Back\" to select books."
+  },
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -96,6 +96,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.button-theme($material-app-theme);
 @include mat.card-theme($material-app-theme);
 @include mat.checkbox-theme($material-app-theme);
+@include mat.chips-theme($material-app-theme);
 @include mat.dialog-theme($material-app-theme);
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);
@@ -113,6 +114,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.slide-toggle-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
 @include mat.snack-bar-theme($material-app-theme);
+@include mat.stepper-theme($material-app-theme);
 @include mat.table-theme($material-app-theme);
 @include mat.tabs-theme($material-app-theme);
 @include mat.toolbar-theme($material-app-theme);
@@ -121,11 +123,9 @@ $material-theme-accent-error: mat.define-light-theme(
 // Other components that appear to not be used at this time
 
 // @include mat.button-toggle-theme($material-app-theme);
-// @include mat.chips-theme($material-app-theme);
 // @include mat.grid-list-theme($material-app-theme);
 // @include mat.slide-toggle-theme($material-app-theme);
 // @include mat.sort-theme($material-app-theme);
-// @include mat.stepper-theme($material-app-theme);
 // @include mat.tree-theme($material-app-theme);
 
 .card-outline {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -27,6 +27,7 @@ import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatOptionModule } from '@angular/material/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
@@ -40,18 +41,19 @@ import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginato
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSliderModule } from '@angular/material/slider';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSortModule } from '@angular/material/sort';
+import { MatStepperModule } from '@angular/material/stepper';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoService } from '@ngneat/transloco';
 import { NgCircleProgressModule } from 'ng-circle-progress';
-import { MatSidenavModule } from '@angular/material/sidenav';
 import { AutofocusDirective } from './autofocus.directive';
 import { BlurOnClickDirective } from './blur-on-click.directive';
 import { DonutChartModule } from './donut-chart/donut-chart.module';
@@ -70,6 +72,7 @@ const modules = [
   MatButtonModule,
   MatCardModule,
   MatCheckboxModule,
+  MatChipsModule,
   MatDialogModule,
   MatDividerModule,
   MatFormFieldModule,
@@ -88,6 +91,7 @@ const modules = [
   MatSlideToggleModule,
   MatSnackBarModule,
   MatSortModule,
+  MatStepperModule,
   MatTableModule,
   MatTabsModule,
   MatToolbarModule,


### PR DESCRIPTION
When user selects to generate a draft, the user is now shown pre-generation steps in which he will select books for training.

This pull request just implements the initial UI concept.  The selected books are not currently sent to the API with the draft request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2120)
<!-- Reviewable:end -->
