### PR TITLE
SF-2287 Sort books canonically in dropdowns

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -93,7 +93,9 @@ export class ChapterAudioDialogComponent implements AfterViewInit {
   }
 
   get books(): number[] {
-    return Object.values(this.data.textsByBookId).map(t => t.bookNum);
+    return Object.values(this.data.textsByBookId)
+      .map(t => t.bookNum)
+      .sort((a, b) => a - b);
   }
 
   get chapter(): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -513,7 +513,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             }
 
             this.showOrHideScriptureText();
-            this.books = this.projectDoc.data.texts.map(t => t.bookNum) ?? [];
+            this.books = this.projectDoc.data.texts.map(t => t.bookNum).sort((a, b) => a - b);
             this.initQuestionFilters();
 
             this.projectUserConfigDoc = await this.projectService.getUserConfig(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
@@ -62,7 +62,7 @@ export class DraftViewerComponent extends SubscriptionDisposable implements OnIn
     this.targetProject = this.activatedProjectService.projectDoc?.data;
     this.sourceProjectId = this.targetProject?.translateConfig.source?.projectRef!;
     this.projectSettingsUrl = `/projects/${this.activatedProjectService.projectId}/settings`;
-    this.books = this.targetProject?.texts.map(t => t.bookNum) ?? [];
+    this.books = this.targetProject?.texts.map(t => t.bookNum).sort((a, b) => a - b) ?? [];
 
     if (this.sourceProjectId) {
       this.sourceProject = (await this.projectService.getProfile(this.sourceProjectId)).data;


### PR DESCRIPTION
The book dropdowns in the chapter audio, community checking, and draft preview screens are sorted by database order, not canonical order.

This PR fixes this by sorting the book number arrays in these three locations by the book number.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2123)
<!-- Reviewable:end -->
