### PR TITLE
SF-2266 Resize bug when audio-only

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -202,10 +202,11 @@ describe('CheckingComponent', () => {
       const testProject: SFProject = TestEnvironment.generateTestProject();
       testProject.checkingConfig.hideCommunityCheckingText = true;
       const env = new TestEnvironment({ user: CHECKER_USER, testProject });
-      const spySliderPosition = spyOn<any>(env.component, 'calculateScriptureSliderPosition').and.callThrough();
-      window.dispatchEvent(new Event('resize'));
       env.waitForSliderUpdate();
-      expect(spySliderPosition).toHaveBeenCalledTimes(1);
+      (env.component as any)._scriptureAreaMaxSize = 1;
+      expect(env.component.scriptureAreaMaxSize).toEqual(1);
+      window.dispatchEvent(new Event('resize'));
+      expect(env.component.scriptureAreaMaxSize).toBeGreaterThan(1);
       flush();
       discardPeriodicTasks();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -198,6 +198,18 @@ describe('CheckingComponent', () => {
       expect(nextQuestion).toEqual(1);
     }));
 
+    it('should re-calculate scripture slide position on resize', fakeAsync(() => {
+      const testProject: SFProject = TestEnvironment.generateTestProject();
+      testProject.checkingConfig.hideCommunityCheckingText = true;
+      const env = new TestEnvironment({ user: CHECKER_USER, testProject });
+      const spySliderPosition = spyOn<any>(env.component, 'calculateScriptureSliderPosition').and.callThrough();
+      window.dispatchEvent(new Event('resize'));
+      env.waitForSliderUpdate();
+      expect(spySliderPosition).toHaveBeenCalledTimes(1);
+      flush();
+      discardPeriodicTasks();
+    }));
+
     describe('Prev/Next question buttons', () => {
       it('prev/next disabled state based on existence of prev/next question', fakeAsync(() => {
         const env = new TestEnvironment({ user: ADMIN_USER, projectBookRoute: 'JHN', projectChapterRoute: 1 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -725,9 +725,11 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       }
     );
     this.subscribe(fromEvent(window, 'resize'), () => {
-      if (this.hideChapterText && this.contentPanelHeight > this.scriptureAudioPlayerAreaHeight) {
+      if (this.hideChapterText) {
         this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent;
-        this.calculateScriptureSliderPosition();
+        if (this.contentPanelHeight > this.scriptureAudioPlayerAreaHeight) {
+          this.calculateScriptureSliderPosition();
+        }
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -720,7 +720,10 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         });
       }
     );
-    this.subscribe(fromEvent(window, 'resize'), () => this.calculateScriptureSliderPosition());
+    this.subscribe(
+      fromEvent(window, 'resize'),
+      () => (this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent)
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -16,7 +16,7 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { getTextAudioId } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { VerseRefData, toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
-import { Subscription, combineLatest, merge } from 'rxjs';
+import { Subscription, combineLatest, fromEvent, merge } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, throttleTime } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
@@ -720,6 +720,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         });
       }
     );
+    this.subscribe(fromEvent(window, 'resize'), () => this.calculateScriptureSliderPosition());
   }
 
   ngOnDestroy(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -448,6 +448,10 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       : 0;
   }
 
+  private get contentPanelHeight(): number {
+    return this.scripturePanelContainerElement?.nativeElement.offsetHeight;
+  }
+
   private get scriptureAudioPlayerAreaHeight(): number {
     const scriptureAudioPlayerArea: Element | null = document.querySelector('.scripture-audio-player-wrapper');
     return scriptureAudioPlayerArea == null ? 0 : scriptureAudioPlayerArea.getBoundingClientRect().height;
@@ -720,10 +724,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         });
       }
     );
-    this.subscribe(
-      fromEvent(window, 'resize'),
-      () => (this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent)
-    );
+    this.subscribe(fromEvent(window, 'resize'), () => {
+      if (this.hideChapterText && this.contentPanelHeight > this.scriptureAudioPlayerAreaHeight) {
+        this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent;
+        this.calculateScriptureSliderPosition();
+      }
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
* Calculate scripture slider position on window resize

This fix relates to changing the split component size and then dynamically resizing the screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2124)
<!-- Reviewable:end -->
