### PR TITLE
SF-2293 Remove redundant question filter icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -6,10 +6,7 @@
           <h2>
             {{ t("questions") }} <span>({{ totalVisibleQuestionsString }})</span>
           </h2>
-          <button mat-icon-button [matMenuTriggerFor]="questionFilterMenu">
-            <mat-icon [ngClass]="{ 'material-icons-outlined': !isQuestionFilterApplied }">filter_alt</mat-icon>
-          </button>
-          <mat-menu #questionFilterMenu xPosition="before">
+          <mat-menu #questionFilterMenu>
             <mat-selection-list [multiple]="true" class="menu-list">
               <h2 matSubheader>{{ t("questions_range") }}</h2>
               <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -317,6 +317,8 @@ header {
   display: flex;
   align-items: center;
   margin-inline-start: -($questionsHeaderInlineStartPadding - 2px);
+  padding-top: 4px;
+  padding-bottom: 4px;
   padding-inline: 5px 8px; // Reduce padding from mat-button defaults
   white-space: pre-wrap;
 


### PR DESCRIPTION
Removed the redundant large corner filter icon since the filter text is now an always-visible button, displays the icon, and triggers the filter menu.  Also added some top and bottom padding to the filter button.

Before:
![image](https://github.com/sillsdev/web-xforge/assets/133386342/beb0a13c-d973-48ec-9fe7-d51c6eaa1e2b)

After:
![image](https://github.com/sillsdev/web-xforge/assets/133386342/2f18099e-4d16-48d7-95de-de3b75012d0c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2126)
<!-- Reviewable:end -->
