### PR TITLE
FIX: Disable Remote Feature Flag Support

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
@@ -34,7 +34,7 @@ describe('FeatureFlagService', () => {
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
   }));
 
-  it('loads remote feature flags', fakeAsync(() => {
+  xit('loads remote feature flags', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
@@ -43,7 +43,7 @@ describe('FeatureFlagService', () => {
     verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
   }));
 
-  it('undefined remote feature flags default to false', fakeAsync(() => {
+  xit('undefined remote feature flags default to false', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
@@ -52,7 +52,7 @@ describe('FeatureFlagService', () => {
     verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
   }));
 
-  it('remote feature flags are read only', fakeAsync(() => {
+  xit('remote feature flags are read only', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.showNonPublishedLocalizations.enabled).toBeFalsy();
@@ -61,7 +61,7 @@ describe('FeatureFlagService', () => {
     verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
   }));
 
-  it('does not throw errors when retrieving remote feature flags', fakeAsync(() => {
+  xit('does not throw errors when retrieving remote feature flags', fakeAsync(() => {
     const env = new TestEnvironment(new CommandError(CommandErrorCode.InternalError, 'unknown error'));
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
@@ -70,7 +70,7 @@ describe('FeatureFlagService', () => {
     verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
   }));
 
-  it('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
+  xit('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
     const env = new TestEnvironment({});
     // The first call loads the remote feature flags
     expect(env.service.versionSuffix).toEqual('');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { CommandService } from 'xforge-common/command.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { PROJECTS_URL } from 'xforge-common/url-constants';
+// import { PROJECTS_URL } from 'xforge-common/url-constants';
 
 export interface FeatureFlag {
   readonly key: string;
@@ -93,6 +93,7 @@ export class FeatureFlagStore extends SubscriptionDisposable {
   }
 
   private retrieveFeatureFlagsIfMissing(): void {
+    /* Temporarily disabled
     if (this.remoteFlagCacheExpiry <= new Date() && this.onlineStatusService.isOnline) {
       // Set to the next remote flag cache expiry timestamp for 1 hour so that the null check above returns false
       this.remoteFlagCacheExpiry = new Date(new Date().getTime() + 3_600_000);
@@ -120,6 +121,7 @@ export class FeatureFlagStore extends SubscriptionDisposable {
           this.remoteFlagCacheExpiry = new Date(new Date().getTime() + recheckInMinutes * 60_000);
         });
     }
+    */
   }
 }
 


### PR DESCRIPTION
This PR temporarily disables remote feature flags, which due to an injection hierarchy issue on QA causes a blocking error.

A later PR will correctly fix this issue, however this PR will resolve the current impasse on QA.

Due to the nature of this bug, the only real effective test of it will be deployment and execution on the QA environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2128)
<!-- Reviewable:end -->
