### PR TITLE
SF-2294 Fix remote feature flag retrieval

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/anonymous.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/anonymous.service.ts
@@ -20,6 +20,11 @@ export class AnonymousService {
     return response.body!;
   }
 
+  async featureFlags(): Promise<{ [key: string]: boolean } | null> {
+    const response = await this.get<{ [key: string]: boolean }>('featureFlags');
+    return response.body;
+  }
+
   async generateAccount(shareKey: string, displayName: string, language: string): Promise<boolean> {
     const body: GenerateAccountRequest = {
       shareKey,
@@ -28,6 +33,17 @@ export class AnonymousService {
     };
     const response = await this.post<boolean>('generateAccount', body);
     return response.body!;
+  }
+
+  private get<T>(endPoint: string): Promise<HttpResponse<T>> {
+    const url: string = `${ANONYMOUS_URL}/${endPoint}`;
+    return this.http
+      .get<T>(url, {
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        responseType: 'json',
+        observe: 'response'
+      })
+      .toPromise();
   }
 
   private post<T>(endPoint: string, body?: any): Promise<HttpResponse<T>> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
@@ -1,20 +1,19 @@
 import { fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { mock, verify, when } from 'ts-mockito';
-import { CommandError, CommandErrorCode, CommandService } from 'xforge-common/command.service';
+import { AnonymousService } from 'xforge-common/anonymous.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { PROJECTS_URL } from 'xforge-common/url-constants';
 import { FeatureFlagService } from './feature-flag.service';
 
-const mockedCommandService = mock(CommandService);
+const mockedAnonymousService = mock(AnonymousService);
 
 describe('FeatureFlagService', () => {
   configureTestingModule(() => ({
     imports: [TestOnlineStatusModule.forRoot()],
     providers: [
-      { provide: CommandService, useMock: mockedCommandService },
+      { provide: AnonymousService, useMock: mockedAnonymousService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
@@ -33,49 +32,49 @@ describe('FeatureFlagService', () => {
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
   }));
 
-  xit('loads remote feature flags', fakeAsync(() => {
+  it('loads remote feature flags', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
     flush();
     expect(env.service.preventOpSubmission.enabled).toBeTruthy();
-    verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
+    verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  xit('undefined remote feature flags default to false', fakeAsync(() => {
+  it('undefined remote feature flags default to false', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
     flush();
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
-    verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
+    verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  xit('remote feature flags are read only', fakeAsync(() => {
+  it('remote feature flags are read only', fakeAsync(() => {
     const env = new TestEnvironment();
     // The first call loads the remote feature flags
     expect(env.service.showNonPublishedLocalizations.enabled).toBeFalsy();
     flush();
     expect(env.service.showNonPublishedLocalizations.readonly).toBeTruthy();
-    verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
+    verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  xit('does not throw errors when retrieving remote feature flags', fakeAsync(() => {
-    const env = new TestEnvironment(new CommandError(CommandErrorCode.InternalError, 'unknown error'));
+  it('does not throw errors when retrieving remote feature flags', fakeAsync(() => {
+    const env = new TestEnvironment(new Error('error'));
     // The first call loads the remote feature flags
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
     flush();
     expect(env.service.preventOpAcknowledgement.enabled).toBeFalsy();
-    verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
+    verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  xit('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
+  it('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
     const env = new TestEnvironment({});
     // The first call loads the remote feature flags
     expect(env.service.versionSuffix).toEqual('');
     flush();
     expect(env.service.versionSuffix).toEqual('');
-    verify(mockedCommandService.onlineInvoke(PROJECTS_URL, 'featureFlags')).once();
+    verify(mockedAnonymousService.featureFlags()).once();
   }));
 
   it('getFeatureFlagVersion returns a string based on the order of feature flags', fakeAsync(() => {
@@ -170,13 +169,9 @@ class TestEnvironment {
     }
   ) {
     if (featureFlags instanceof Error) {
-      when(mockedCommandService.onlineInvoke<{ [key: string]: boolean }>(PROJECTS_URL, 'featureFlags')).thenReject(
-        featureFlags
-      );
+      when(mockedAnonymousService.featureFlags()).thenReject(featureFlags);
     } else {
-      when(mockedCommandService.onlineInvoke<{ [key: string]: boolean }>(PROJECTS_URL, 'featureFlags')).thenResolve(
-        featureFlags
-      );
+      when(mockedAnonymousService.featureFlags()).thenResolve(featureFlags);
     }
     this.service = TestBed.inject(FeatureFlagService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { CommandService } from 'xforge-common/command.service';
+import { AnonymousService } from 'xforge-common/anonymous.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-// import { PROJECTS_URL } from 'xforge-common/url-constants';
 
 export interface FeatureFlag {
   readonly key: string;
@@ -29,7 +28,7 @@ export class FeatureFlagStore extends SubscriptionDisposable {
   private remoteFlagCacheExpiry: Date = new Date();
 
   constructor(
-    private readonly commandService: CommandService,
+    private readonly anonymousService: AnonymousService,
     private readonly onlineStatusService: OnlineStatusService
   ) {
     super();
@@ -93,12 +92,11 @@ export class FeatureFlagStore extends SubscriptionDisposable {
   }
 
   private retrieveFeatureFlagsIfMissing(): void {
-    /* Temporarily disabled
     if (this.remoteFlagCacheExpiry <= new Date() && this.onlineStatusService.isOnline) {
       // Set to the next remote flag cache expiry timestamp for 1 hour so that the null check above returns false
       this.remoteFlagCacheExpiry = new Date(new Date().getTime() + 3_600_000);
-      this.commandService
-        .onlineInvoke<{ [key: string]: boolean }>(PROJECTS_URL, 'featureFlags')
+      this.anonymousService
+        .featureFlags()
         .then(flags => {
           this.remoteFlags = flags ?? {};
           // Set any feature flag values to local storage
@@ -121,7 +119,6 @@ export class FeatureFlagStore extends SubscriptionDisposable {
           this.remoteFlagCacheExpiry = new Date(new Date().getTime() + recheckInMinutes * 60_000);
         });
     }
-    */
   }
 }
 

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Router.Abstractions;
-using Microsoft.FeatureManagement;
 using SIL.XForge.Controllers;
 using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
@@ -23,19 +22,16 @@ public class SFProjectsRpcController : RpcControllerBase
     internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
 
     private readonly IExceptionHandler _exceptionHandler;
-    private readonly IFeatureManager _featureManager;
     private readonly ISFProjectService _projectService;
 
     public SFProjectsRpcController(
         IUserAccessor userAccessor,
         ISFProjectService projectService,
-        IFeatureManager featureManager,
         IExceptionHandler exceptionHandler
     )
         : base(userAccessor, exceptionHandler)
     {
         _exceptionHandler = exceptionHandler;
-        _featureManager = featureManager;
         _projectService = projectService;
     }
 
@@ -689,16 +685,5 @@ public class SFProjectsRpcController : RpcControllerBase
             );
             throw;
         }
-    }
-
-    public async Task<IRpcMethodResult> FeatureFlags()
-    {
-        Dictionary<string, bool> features = new Dictionary<string, bool>();
-        await foreach (string feature in _featureManager.GetFeatureNamesAsync())
-        {
-            features.Add(feature, await _featureManager.IsEnabledAsync(feature));
-        }
-
-        return Ok(features);
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -1,12 +1,7 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using EdjCase.JsonRpc.Common;
-using EdjCase.JsonRpc.Router.Abstractions;
 using EdjCase.JsonRpc.Router.Defaults;
-using Microsoft.FeatureManagement;
 using NSubstitute;
 using NUnit.Framework;
-using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
 
@@ -30,45 +25,19 @@ public class SFProjectsRpcControllerTests
         await env.Controller.UninviteUser("some-project-id", "some-email-address");
     }
 
-    [Test]
-    public async Task FeatureFlags_ReturnsFeatureFlags()
-    {
-        var env = new TestEnvironment();
-        env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(true));
-
-        // SUT
-        IRpcMethodResult result = await env.Controller.FeatureFlags();
-
-        // Verify result
-        Dictionary<string, bool> featureFlags = result.ToRpcResponse(new RpcId()).Result as Dictionary<string, bool>;
-        Assert.IsNotNull(featureFlags);
-        Assert.IsTrue(featureFlags[FeatureFlags.Serval]);
-        Assert.IsFalse(featureFlags[FeatureFlags.UseEchoForPreTranslation]);
-    }
-
     private class TestEnvironment
     {
         public TestEnvironment()
         {
             ExceptionHandler = Substitute.For<IExceptionHandler>();
-            FeatureManager = Substitute.For<IFeatureManager>();
-            FeatureManager.GetFeatureNamesAsync().Returns(GetFeatureFlags());
             SFProjectService = Substitute.For<ISFProjectService>();
             UserAccessor = Substitute.For<IUserAccessor>();
-            Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, FeatureManager, ExceptionHandler);
+            Controller = new SFProjectsRpcController(UserAccessor, SFProjectService, ExceptionHandler);
         }
 
         public IExceptionHandler ExceptionHandler { get; }
         public SFProjectsRpcController Controller { get; }
-        public IFeatureManager FeatureManager { get; }
         public ISFProjectService SFProjectService { get; }
         public IUserAccessor UserAccessor { get; }
-
-        private static async IAsyncEnumerable<string> GetFeatureFlags()
-        {
-            yield return FeatureFlags.Serval;
-            yield return FeatureFlags.UseEchoForPreTranslation;
-            await Task.CompletedTask;
-        }
     }
 }


### PR DESCRIPTION
Remote Feature Flag retrieval have been disabled on master due to a race condition discovered on QA.

This PR fixes the issue by retrieving the feature flags from an anonymous controller. This is required because the `AuthService` is dependent on services that use the `FeatureFlagService`, creating a circular reference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2131)
<!-- Reviewable:end -->
