### PR TITLE
Fix 'missing translation' error in checking component template

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -36,8 +36,9 @@
         </div>
         <button mat-button [matMenuTriggerFor]="questionFilterMenu" class="active-question-scope-button">
           <mat-icon [ngClass]="{ 'material-icons-outlined': !isQuestionFilterApplied }">filter_alt</mat-icon>
-          {{ t(questionScopes.get(activeQuestionScope ?? "all")!) }} <span class="divider">|</span
-          >{{ t(appliedQuestionFilterKey) }}
+          {{ t(questionScopes.get(activeQuestionScope ?? "all")!) }}
+          <span class="divider">|</span>
+          {{ t(appliedQuestionFilterKey ?? "question_filter_none") }}
         </button>
       </header>
       <div class="panel-content">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -184,7 +184,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   }
 
   get appliedQuestionFilterKey(): string | undefined {
-    return this.questionFilters.get(this.activeQuestionFilter)!;
+    return this.questionFilters.get(this.activeQuestionFilter);
   }
 
   get bookName(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -183,7 +183,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     return undefined;
   }
 
-  get appliedQuestionFilterKey(): string {
+  get appliedQuestionFilterKey(): string | undefined {
     return this.questionFilters.get(this.activeQuestionFilter)!;
   }
 


### PR DESCRIPTION
Minor fix to ensure filter translation key has a value, as the list of question filters might not have been populated yet when first accessed.  This fix just clears up a console error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2133)
<!-- Reviewable:end -->
