### PR TITLE
Fix warnings and messages in Angular unit tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2402,7 +2402,7 @@ class TestEnvironment {
     when(query.remoteChanges$).thenReturn(new BehaviorSubject<void>(undefined));
     const doc = mock(TextAudioDoc);
     const textAudio = mock<TextAudio>();
-    when(textAudio.audioUrl).thenReturn('something');
+    when(textAudio.audioUrl).thenReturn('test-audio-short.webm');
     when(textAudio.timings).thenReturn([]);
     when(doc.id).thenReturn('project01:43:1:target');
     when(doc.data).thenReturn(instance(textAudio));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.spec.ts
@@ -1,27 +1,28 @@
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { mock } from 'ts-mockito';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component, DebugElement } from '@angular/core';
-import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { By } from '@angular/platform-browser';
-import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { mock, when } from 'ts-mockito';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { NavigationProjectSelectorComponent } from './navigation-project-selector.component';
 
-const mockOnlineStatusService = mock(OnlineStatusService);
 const mockFeatureFlagService = mock(FeatureFlagService);
 
 describe('NavigationProjectSelectorComponent', () => {
   configureTestingModule(() => ({
     declarations: [NavigationProjectSelectorComponent],
     providers: [
-      { provide: OnlineStatusService, useMock: mockOnlineStatusService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: FeatureFlagService, useMock: mockFeatureFlagService }
     ],
-    imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule]
+    imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule, TestOnlineStatusModule.forRoot()]
   }));
 
   it('emits event when project changes', fakeAsync(() => {
@@ -67,7 +68,6 @@ class TestEnvironment {
   readonly fixture: ComponentFixture<HostComponent>;
 
   constructor(template: string) {
-    when(mockOnlineStatusService.isOnline).thenReturn(true);
     TestBed.configureTestingModule({
       declarations: [NavigationProjectSelectorComponent, HostComponent],
       imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -1,12 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatStepperModule } from '@angular/material/stepper';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
+import { BookMultiSelectComponent } from 'src/app/shared/book-multi-select/book-multi-select.component';
 import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
@@ -31,33 +31,38 @@ describe('DraftGenerationStepsComponent', () => {
   } as SFProjectProfileDoc;
 
   configureTestingModule(() => ({
-    imports: [MatStepperModule, MatMenuModule, TestTranslocoModule, NoopAnimationsModule],
-    declarations: [DraftGenerationStepsComponent],
+    imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule],
+    declarations: [DraftGenerationStepsComponent, BookMultiSelectComponent],
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: SFProjectService, useMock: mockProjectService }
     ]
   }));
 
-  beforeEach(() => {
+  beforeEach(fakeAsync(() => {
     when(mockActivatedProjectService.projectDoc$).thenReturn(of(mockTargetProjectDoc));
     when(mockProjectService.getProfile(anything())).thenResolve(mockSourceProjectDoc);
 
     fixture = TestBed.createComponent(DraftGenerationStepsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+    tick();
+  }));
 
   it('should set availableBooks$ correctly', () => {
     component.availableBooks$?.subscribe(books => {
       expect(books).toEqual([1, 2, 3]);
     });
+
+    expect(component.selectedBooks).toEqual([1, 2, 3]);
   });
 
   it('should select all books initially', () => {
     component.availableBooks$?.subscribe(() => {
       expect(component.selectedBooks).toEqual([1, 2, 3]);
     });
+
+    expect(component.selectedBooks).toEqual([1, 2, 3]);
   });
 
   it('should emit the correct selected books when onDone is called', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
+++ b/src/SIL.XForge.Scripture/ClientApp/src/karma.conf.js
@@ -55,7 +55,10 @@ module.exports = function (config) {
     ],
     proxies: {
       '/assets/audio/audio.mp3': '',
-      '/assets/audio/': '/base/app/checking/checking/test-audio/'
+      '/assets/audio/': '/base/app/checking/checking/test-audio/',
+      '/assets/icons/TagIcons/defaultIcon.png': '',
+      '/assets/icons/TagIcons/flag01.png': '',
+      '/assets/icons/TagIcons/flag05.png': ''
     },
     reporters: karmaReporters,
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -42,7 +42,7 @@ class MockConsole {
         'Original error',
         'Http failure response for (unknown url): 400 Bad Request',
         'Http failure response for http://localhost:5000/command-api/some-end-point: 504 Gateway Timeout',
-        'Http failure response for http://localhost:5000/machine-api/v2/translation/engines/some-end-point: 504 Gateway Timeout'
+        'Http failure response for http://localhost:5000/machine-api/v3/translation/engines/some-end-point: 504 Gateway Timeout'
       ].includes(val.message) &&
       !val.message?.startsWith('Unknown error')
     ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
@@ -11,6 +11,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { mock, when } from 'ts-mockito';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { NoticeComponent } from '../../app/shared/notice/notice.component';
 import { FeatureFlagService } from './feature-flag.service';
 import { FeatureFlagsDialogComponent } from './feature-flags-dialog.component';
 
@@ -68,7 +69,7 @@ describe('FeatureFlagsComponent', () => {
     NoopAnimationsModule,
     HttpClientTestingModule
   ],
-  declarations: [FeatureFlagsDialogComponent],
+  declarations: [FeatureFlagsDialogComponent, NoticeComponent],
   exports: [FeatureFlagsDialogComponent]
 })
 class DialogTestModule {}


### PR DESCRIPTION
This PR fixes the following warnings, messages, and items missed in some of the frontend unit tests:

 * **Updated:** The tests for `NavigationProjectSelectorComponent` to use the new `TestOnlineStatusService`
 * **Fixed:** The following expectations were not always triggered: 
    * `WARN: 'Spec 'DraftGenerationStepsComponent should set availableBooks$ correctly' has no expectations.', [[]]`
    * `WARN: 'Spec 'DraftGenerationStepsComponent should select all books initially' has no expectations.', [[]]`
 * **Fixed:** The following message in the test log: `ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, headers: Map{}}, status: 504, statusText: 'Gateway Timeout', url: 'http://localhost:5000/machine-api/v3/translation/engines/some-end-point', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:5000/machine-api/v3/translation/engines/some-end-point: 504 Gateway Timeout', error: null}, [[]]`
* **Fixed:** The following 404 errors in the console log:
   * `WARN [web-server]: 404: /_karma_webpack_/base/app/checking/checking/test-audio/something`
   * `WARN [web-server]: 404: /_karma_webpack_/assets/icons/TagIcons/defaultIcon.png`
   * `WARN [web-server]: 404: /_karma_webpack_/assets/icons/TagIcons/flag01.png`
   * `WARN [web-server]: 404: /_karma_webpack_/assets/icons/TagIcons/flag05.png`
 * **Fixed:** the following Angular binding errors in the console log:
   * `ERROR: 'NG0304: 'app-book-multi-select' is not a known element (used in the 'DraftGenerationStepsComponent' component template):`
   * `ERROR: 'NG0303: Can't bind to 'selectedBooks' since it isn't a known property of 'app-book-multi-select' (used in the 'DraftGenerationStepsComponent' component template).`
   * `ERROR: 'NG0303: Can't bind to 'availableBooks' since it isn't a known property of 'app-book-multi-select' (used in the 'DraftGenerationStepsComponent' component template).`
   * `ERROR: 'NG0303: Can't bind to 'outline' since it isn't a known property of 'app-notice' (used in the 'FeatureFlagsDialogComponent' component template)`

This PR should result in a further reduction in the noise in the test console log, especially when running locally.

As only spec files and Karma config are changed, a successful passing of the unit tests will be sufficient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2137)
<!-- Reviewable:end -->
