### PR TITLE
Update the Serval audience

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -55,7 +55,7 @@
   },
   "Serval": {
     "ApiServer": "https://serval-api.org",
-    "Audience": "https://machine.sil.org",
+    "Audience": "https://serval-api.org/",
     "TokenUrl": "https://languagetechnology.auth0.com/oauth/token"
   },
   "FeatureManagement": {


### PR DESCRIPTION
The Serval Auth0 audience has changed from `https://machine.sil.org` to `https://serval-api.org/` across all environments.

All branches/PRs will need to be rebased to use this updated audience or Serval support will not work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2143)
<!-- Reviewable:end -->
