### PR TITLE
SF-2292 Disable Nepali locale

### DIFF
--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -82,11 +82,5 @@
     "englishName": "Western Kayah Li",
     "tags": ["kyu", "kyu-Kali"],
     "production": true
-  },
-  {
-    "localName": "नेपाली",
-    "englishName": "Nepali",
-    "tags": ["npi", "ne-NP"],
-    "production": false
   }
 ]


### PR DESCRIPTION
The Nepali locale is visible on the home page on development machines before any of the translations are ready. Disable it for the time until translations and auth0 configs are put in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2146)
<!-- Reviewable:end -->
