### PR TITLE
SF-2249 Handle invalid url book in draft preview and editor pages

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
@@ -10,7 +10,7 @@ import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-
 import * as RichText from 'rich-text';
 import { of } from 'rxjs';
 import { SharedModule } from 'src/app/shared/shared.module';
-import { anything, mock, verify, when } from 'ts-mockito';
+import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -209,6 +209,29 @@ describe('DraftViewerComponent', () => {
     expect(mockRouter.navigateByUrl('/projects/123/translate/GEN/2')).toBeTruthy();
   }));
 
+  it('should navigate to first book in project if url book is not in project', fakeAsync(() => {
+    new TestEnvironment(() => {
+      when(mockActivatedRoute.paramMap).thenReturn(
+        of({
+          get: (p: string) => {
+            if (p === 'bookId') {
+              return 'LEV';
+            }
+            if (p === 'chapter') {
+              return '2';
+            }
+            return null;
+          }
+        } as ParamMap)
+      );
+    });
+
+    verify(
+      mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1', deepEqual({ replaceUrl: true }))
+    ).once();
+    expect(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).toBeTruthy();
+  }));
+
   it('should navigate to the correct URL for the given book and chapter', fakeAsync(() => {
     const env = new TestEnvironment();
     const book = 1;
@@ -217,7 +240,7 @@ describe('DraftViewerComponent', () => {
     env.component.currentChapter = 3;
     env.component.targetProjectId = '123';
     env.component.navigateBookChapter(book, chapter);
-    verify(mockRouter.navigateByUrl('/projects/123/draft-preview/GEN/2')).once();
+    verify(mockRouter.navigateByUrl('/projects/123/draft-preview/GEN/2', undefined)).once();
     expect(mockRouter.navigateByUrl('/projects/123/draft-preview/GEN/2')).toBeTruthy();
   }));
 
@@ -247,7 +270,9 @@ describe('DraftViewerComponent', () => {
       );
     });
 
-    verify(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).once();
+    verify(
+      mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1', deepEqual({ replaceUrl: true }))
+    ).once();
     expect(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).toBeTruthy();
   }));
 
@@ -256,7 +281,7 @@ describe('DraftViewerComponent', () => {
     env.component.currentBook = 2;
     env.component.currentChapter = 2;
     env.component.onBookChange(1);
-    verify(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).once();
+    verify(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1', undefined)).once();
     expect(mockRouter.navigateByUrl('/projects/targetProjectId/draft-preview/GEN/1')).toBeTruthy();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, NavigationBehaviorOptions, ParamMap, Router } from '@angular/router';
 import { Canon } from '@sillsdev/scripture';
 import { DeltaOperation, DeltaStatic } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -102,12 +102,18 @@ export class DraftViewerComponent extends SubscriptionDisposable implements OnIn
   }
 
   setBook(book: number, chapter?: number): void {
+    // If book is not in project, navigate to first book of project
+    if (!this.books.some(b => b === book)) {
+      this.navigateBookChapter(this.books[0], 1, { replaceUrl: true });
+      return;
+    }
+
     this.currentBook = book;
     this.chapters = this.targetProject?.texts?.find(t => t.bookNum === book)?.chapters.map(c => c.number) ?? [];
 
     // Navigate to first included chapter of book if specified chapter is not included in book
     if (chapter != null && !this.chapters.includes(chapter)) {
-      this.navigateBookChapter(book, this.chapters[0]);
+      this.navigateBookChapter(book, this.chapters[0], { replaceUrl: true });
       return;
     }
 
@@ -196,9 +202,10 @@ export class DraftViewerComponent extends SubscriptionDisposable implements OnIn
     );
   }
 
-  navigateBookChapter(book: number, chapter: number): void {
+  navigateBookChapter(book: number, chapter: number, options?: NavigationBehaviorOptions): void {
     this.router.navigateByUrl(
-      `/projects/${this.targetProjectId}/draft-preview/${Canon.bookNumberToId(book)}/${chapter}`
+      `/projects/${this.targetProjectId}/draft-preview/${Canon.bookNumberToId(book)}/${chapter}`,
+      options
     );
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -61,7 +61,7 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
 import { BehaviorSubject, defer, Observable, of, Subject } from 'rxjs';
-import { anything, capture, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
+import { anything, capture, deepEqual, instance, mock, resetCalls, spy, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { CONSOLE } from 'xforge-common/browser-globals';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
@@ -77,6 +77,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
 import { BiblicalTermDoc } from '../../core/models/biblical-term-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -3519,6 +3520,21 @@ describe('EditorComponent', () => {
 
       env.dispose();
     }));
+
+    it('should navigate to first book in project if url book is not in project', fakeAsync(() => {
+      const navigationParams: Params = { projectId: 'project01', bookId: 'GEN', chapter: '2' };
+      const env = new TestEnvironment();
+      const spyRouterNavigate = spyOn(env.router, 'navigateByUrl');
+      const spyActivatedProjectService = spy(env.activatedProjectService);
+
+      when(spyActivatedProjectService.projectId).thenReturn('testProjectId');
+
+      env.updateParams(navigationParams);
+      env.wait();
+
+      // First book in project
+      expect(spyRouterNavigate).toHaveBeenCalledWith('/projects/testProjectId/translate/MAT/1', jasmine.any(Object));
+    }));
   });
 });
 
@@ -3535,6 +3551,7 @@ class TestEnvironment {
   readonly component: EditorComponent;
   readonly fixture: ComponentFixture<EditorComponent>;
   readonly mockedRemoteTranslationEngine = mock(RemoteTranslationEngine);
+  readonly activatedProjectService: ActivatedProjectService;
   readonly router: Router;
   readonly location: Location;
   readonly mockNoteDialogRef;
@@ -3820,6 +3837,7 @@ class TestEnvironment {
     });
     when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(of({}));
 
+    this.activatedProjectService = TestBed.inject(ActivatedProjectService);
     this.router = TestBed.inject(Router);
     this.location = TestBed.inject(Location);
     this.ngZone = TestBed.inject(NgZone);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3521,7 +3521,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('should navigate to first book in project if url book is not in project', fakeAsync(() => {
+    it('should navigate to "projects" route if url book is not in project', fakeAsync(() => {
       const navigationParams: Params = { projectId: 'project01', bookId: 'GEN', chapter: '2' };
       const env = new TestEnvironment();
       const spyRouterNavigate = spyOn(env.router, 'navigateByUrl');
@@ -3532,8 +3532,7 @@ describe('EditorComponent', () => {
       env.updateParams(navigationParams);
       env.wait();
 
-      // First book in project
-      expect(spyRouterNavigate).toHaveBeenCalledWith('/projects/testProjectId/translate/MAT/1', jasmine.any(Object));
+      expect(spyRouterNavigate).toHaveBeenCalledWith('projects', jasmine.any(Object));
     }));
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -622,14 +622,31 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             this.loadProjectUserConfig()
           );
         }
-        if (this.projectDoc == null || this.projectDoc.data == null) {
+
+        if (this.projectDoc?.data == null) {
           return;
         }
+
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
+
+        // If book is not in project, navigate to first book of project
+        if (this.text == null) {
+          const firstText = this.projectDoc.data.texts[0];
+          const newBookId = Canon.bookNumberToId(firstText.bookNum);
+          const chapter = firstText.chapters[0].number;
+
+          this.router.navigateByUrl(
+            `/projects/${this.activatedProjectService.projectId}/translate/${newBookId}/${chapter}`,
+            { replaceUrl: true }
+          );
+          return;
+        }
+
         if (this.sourceProjectDoc?.data != null) {
           this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
         }
-        this.chapters = this.text == null ? [] : this.text.chapters.map(c => c.number);
+
+        this.chapters = this.text.chapters.map(c => c.number);
 
         this.updateVerseNumber();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -629,16 +629,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
 
-        // If book is not in project, navigate to first book of project
+        // If book is not in project, navigate to 'projects' route, which should send the user
+        // to the book stored in SFProjectUserConfig.
         if (this.text == null) {
-          const firstText = this.projectDoc.data.texts[0];
-          const newBookId = Canon.bookNumberToId(firstText.bookNum);
-          const chapter = firstText.chapters[0].number;
-
-          this.router.navigateByUrl(
-            `/projects/${this.activatedProjectService.projectId}/translate/${newBookId}/${chapter}`,
-            { replaceUrl: true }
-          );
+          this.router.navigateByUrl('projects', { replaceUrl: true });
           return;
         }
 


### PR DESCRIPTION
When the URL of either the Translate or Preview Draft screen is manually changed to a book that is not in the target project, the draft viewer component should now route to the first valid book/chapter of the project, and the editor component routes to the 'projects' route, which should send the user to the last selected book stored in SFProjectUserConfig.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2147)
<!-- Reviewable:end -->
