### PR TITLE
SF-2272 Prevent corrupting text when user deletes all verse text offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -729,7 +729,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   onContentChanged(delta: DeltaStatic, source: string): void {
     const preDeltaSegmentCache: IterableIterator<[string, RangeStatic]> = this.viewModel.segmentsSnapshot;
     const preDeltaEmbedCache: Readonly<Map<string, number>> = this.viewModel.embeddedElementsSnapshot;
-    this.viewModel.update(delta, source as Sources);
+    this.viewModel.update(delta, source as Sources, this.onlineStatusService.isOnline);
     this.updatePlaceholderText();
     // skip updating when only formatting changes occurred
     if (delta.ops != null && delta.ops.some(op => op.insert != null || op.delete != null)) {


### PR DESCRIPTION
When editing a text doc offline, the ops for the edits are stored in IndexedDB and sent to the real-time server when coming back online. However, the way that our text component handles ops that include inserting a blank embed has a bug that incorrectly interprets the delta from that op. If only one user is editing a doc while offline, there is no issue. But when two users edit the same doc while offline, the merge event results in duplicated verses.

To prevent this issue from happening, I decided to skip the code that inserts blank embeds when text is deleted from a verse. The negative impact of this fix is that blanks do not get automatically inserted if a user removes all text from a verse, but I think this will have a minimal impact because:

- I don't expect users to be intentionally removing all text from a verse in large quantities
- The blank will automatically be restored when returning online

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2148)
<!-- Reviewable:end -->
