### PR TITLE
SF-2302 Improve Serval API Exception Error Handling

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -948,6 +948,11 @@ public class MachineApiService : IMachineApiService
     {
         switch (e)
         {
+            case ServalApiException
+                when doNotThrowIfInProcessEnabled
+                    && await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess):
+                _exceptionHandler.ReportException(e);
+                return;
             case ServalApiException { StatusCode: StatusCodes.Status204NoContent }:
                 throw new DataNotFoundException("Entity Deleted");
             case ServalApiException { StatusCode: StatusCodes.Status403Forbidden }:
@@ -961,9 +966,6 @@ public class MachineApiService : IMachineApiService
             case ServalApiException { StatusCode: StatusCodes.Status409Conflict }:
                 throw new DataNotFoundException("Entity Deleted");
             case BrokenCircuitException
-                when doNotThrowIfInProcessEnabled
-                    && await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess):
-            case ServalApiException
                 when doNotThrowIfInProcessEnabled
                     && await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess):
                 _exceptionHandler.ReportException(e);


### PR DESCRIPTION
When a Serval API Exception is reported by Serval when both Serval and the In-Process machine are enabled, this error incorrectly is returned to the frontend.

This PR instead reports the exception to bugsnag and calls the appropriate method in the in-process machine instance, returning the output of that method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2149)
<!-- Reviewable:end -->
