### PR TITLE
SF-2307 SF-2308 Fix scripture audio play button and RTL skip buttons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -1,23 +1,25 @@
 <div class="scripture-audio-player" [dir]="i18n.direction" *transloco="let t; read: 'checking_audio_player'">
   <div class="audio-action-buttons">
-    <button mat-icon-button class="previous-ref-button" (click)="previousRef()" [disabled]="!isAudioAvailable">
-      <mat-icon class="mirror-rtl">skip_previous</mat-icon>
-    </button>
-    <button
-      mat-icon-button
-      class="play-pause-button"
-      (click)="isPlaying ? pause() : play()"
-      [disabled]="!isAudioAvailable"
-    >
-      <mat-icon>{{ isPlaying ? "pause" : "play_arrow" }}</mat-icon>
-    </button>
-    <button mat-icon-button class="next-ref-button" (click)="nextRef()" [disabled]="!isAudioAvailable">
-      <mat-icon class="mirror-rtl">skip_next</mat-icon>
+    <div class="playback-controls" dir="ltr">
+      <button mat-icon-button class="previous-ref-button" (click)="previousRef()" [disabled]="!isAudioAvailable">
+        <mat-icon>skip_previous</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        class="play-pause-button"
+        (click)="isPlaying ? pause() : play()"
+        [disabled]="!isAudioAvailable"
+      >
+        <mat-icon>{{ isPlaying ? "pause" : "play_arrow" }}</mat-icon>
+      </button>
+      <button mat-icon-button class="next-ref-button" (click)="nextRef()" [disabled]="!isAudioAvailable">
+        <mat-icon>skip_next</mat-icon>
+      </button>
+    </div>
+    <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
+      <mat-icon>close</mat-icon>
     </button>
   </div>
-  <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
-    <mat-icon>close</mat-icon>
-  </button>
   <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>
   <span class="verse-label">{{ verseLabel }}</span>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
@@ -4,8 +4,16 @@
 }
 
 .audio-action-buttons {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+
+  .playback-controls {
+    grid-column-start: 2;
+  }
+
+  .close-button {
+    justify-self: end;
+  }
 }
 
 .verse-label {
@@ -14,25 +22,13 @@
   font-size: 0.9em;
 }
 
-div[dir='ltr'] .close-button {
-  position: absolute;
-  right: 8px;
-}
-
-div[dir='rtl'] .close-button {
-  position: absolute;
-  left: 8px;
-}
-
 .previous-ref-button,
 .next-ref-button {
-  transform: scale(1.1);
+  mat-icon {
+    transform: scale(1.1);
+  }
 }
 
 .play-pause-button mat-icon {
   transform: scale(1.9);
-}
-
-app-audio-player {
-  margin: -10px 0;
 }


### PR DESCRIPTION
This PR fixes two bugs and makes one layout improvement.

- The buttom of the play/pause button was partially hidden underneath the slider, which was not visually apparent, but caused some clicks to go to the slider when the user would expect the audio to play/pause. See SF-2308.
- The skip forward/backward buttons were inverted in RTL mode (i.e., they did not match the direction of the slider). See SF-2307.
- The reference of the verse being played has been moved from below the slider, to above the slider. See screenshots.

Before | After
-------|------
![scripture_audio_player_before](https://github.com/sillsdev/web-xforge/assets/6140710/3ad186a1-0ac1-4e9f-8900-efbff9623f4b) | ![scripture_audio_player_after](https://github.com/sillsdev/web-xforge/assets/6140710/0cfbc9d5-f3d0-4c2b-a16d-d0c44c70634a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2153)
<!-- Reviewable:end -->
