### PR TITLE
Fix checking UI for some screen widths

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -66,7 +66,7 @@
               [chapter]="chapter"
               [bookSelectDisabled]="activeQuestionScope === 'all'"
               [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
-              [prevNextHidden]="true"
+              [prevNextHidden]="activeQuestionScope !== 'chapter' || isScreenSmall"
               (bookChange)="onBookSelect($event)"
               (chapterChange)="onChapterSelect($event)"
             >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -66,7 +66,7 @@
               [chapter]="chapter"
               [bookSelectDisabled]="activeQuestionScope === 'all'"
               [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
-              [prevNextHidden]="activeQuestionScope !== 'chapter'"
+              [prevNextHidden]="true"
               (bookChange)="onBookSelect($event)"
               (chapterChange)="onChapterSelect($event)"
             >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -1,9 +1,8 @@
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 @use 'src/variables' as vars;
 
-// Width chosen based on material design suggestion for when main content area should span entire width of screen:
-// https://m3.material.io/components/navigation-drawer/guidelines#56b3fea0-ecc6-4ff0-bb0a-80ff48c74a58
-$questionsPanelBreakpoint: 600px;
+// Width chosen based on when the book/chapter chooser runs into the action icon buttons at the top of the text viewer
+$questionsPanelBreakpoint: 700px;
 
 $questionsHeaderInlineStartPadding: 8px;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -111,6 +111,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   showScriptureAudioPlayer: boolean = false;
   isCreatingNewQuestion: boolean = false;
   questionToBeCreated: PreCreationQuestionData | undefined;
+  isScreenSmall = false;
 
   /** The book/chapter from the route.  Stored question activation is constrained to this book/chapter. */
   routeBookChapter?: BookChapter;
@@ -160,7 +161,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     private readonly projectService: SFProjectService,
     private readonly checkingQuestionsService: CheckingQuestionsService,
     private readonly userService: UserService,
-    private readonly breakpointObserver: BreakpointObserver,
+    readonly breakpointObserver: BreakpointObserver,
     private readonly mediaBreakpointService: MediaBreakpointService,
     noticeService: NoticeService,
     private readonly router: Router,
@@ -722,11 +723,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   ngAfterViewInit(): void {
     // Allows scrolling to the active question in the question list once it becomes visible
     this.subscribe(
-      this.breakpointObserver.observe([
+      this.breakpointObserver.observe(
         this.mediaBreakpointService.width('>', Breakpoint.SM, this.questionsPanel?.nativeElement)
-      ]),
+      ),
       (state: BreakpointState) => {
         this.calculateScriptureSliderPosition();
+
         // `questionsPanel` is undefined until ngAfterViewInit, but setting `isQuestionListPermanent`
         // here causes `ExpressionChangedAfterItHasBeenCheckedError`, so wrap in setTimeout
         setTimeout(() => {
@@ -734,6 +736,15 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         });
       }
     );
+
+    // Allows hiding the prev/next chapter buttons for small screens
+    this.subscribe(
+      this.breakpointObserver.observe(this.mediaBreakpointService.width('<', Breakpoint.MD)),
+      (state: BreakpointState) => {
+        this.isScreenSmall = state.matches;
+      }
+    );
+
     this.subscribe(fromEvent(window, 'resize'), () => {
       if (this.hideChapterText) {
         this.scriptureAreaMaxSize = this.scriptureAudioPlayerHeightPercent;


### PR DESCRIPTION
This fix hides the next/previous chapter buttons and increases the breakpoint width for hiding the questions list to 700px (was 600px).

The next/previous chapter buttons were prevent the page from shrinking:
![image](https://github.com/sillsdev/web-xforge/assets/133386342/43a95fe7-0f25-4073-8a42-3e63842878fd)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2155)
<!-- Reviewable:end -->
