### PR TITLE
SF-2313 Ability to enable MT drafting in System Administration

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -158,6 +158,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.onlineInvoke('cancelSync', { projectId: id });
   }
 
+  onlineSetPreTranslate(projectId: string, preTranslate: boolean): Promise<void> {
+    return this.onlineInvoke<void>('setPreTranslate', { projectId, preTranslate });
+  }
+
   onlineUpdateSettings(id: string, settings: SFProjectSettings): Promise<void> {
     return this.onlineInvoke('updateSettings', { projectId: id, settings });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -41,8 +41,15 @@
           </mat-checkbox>
         </td>
       </ng-container>
+      <ng-container matColumnDef="preTranslate">
+        <td mat-cell *matCellDef="let row">
+          <mat-checkbox [checked]="row.preTranslate" (change)="onUpdatePreTranslate(row, $event.checked)">
+            NMT Drafting
+          </mat-checkbox>
+        </td>
+      </ng-container>
 
-      <tr mat-row *matRowDef="let row; columns: ['name', 'tasks', 'role', 'syncDisabled']"></tr>
+      <tr mat-row *matRowDef="let row; columns: ['name', 'tasks', 'role', 'syncDisabled', 'preTranslate']"></tr>
     </table>
 
     <mat-paginator

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -4,18 +4,18 @@ import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { BehaviorSubject } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
+import { SFProjectDoc } from '../../app/core/models/sf-project-doc';
+import { SFProjectService } from '../../app/core/sf-project.service';
 import { DataLoadingComponent } from '../data-loading-component';
-import { ProjectDoc } from '../models/project-doc';
 import { NONE_ROLE, ProjectRoleInfo } from '../models/project-role-info';
 import { NoticeService } from '../notice.service';
-import { ProjectService } from '../project.service';
 import { QueryParameters } from '../query-parameters';
 import { UserService } from '../user.service';
 
 class Row {
   isUpdatingRole: boolean = false;
 
-  constructor(public readonly projectDoc: ProjectDoc, public projectRole: ProjectRoleInfo) {}
+  constructor(public readonly projectDoc: SFProjectDoc, public projectRole: ProjectRoleInfo) {}
 
   get id(): string {
     return this.projectDoc.id;
@@ -39,6 +39,13 @@ class Row {
     }
     return this.projectDoc.data.syncDisabled;
   }
+
+  get preTranslate(): boolean {
+    if (this.projectDoc.data == null) {
+      return false;
+    }
+    return this.projectDoc.data.translateConfig.preTranslate;
+  }
 }
 
 @Component({
@@ -55,7 +62,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
   pageIndex: number = 0;
   pageSize: number = 50;
 
-  private projectDocs?: Readonly<ProjectDoc[]>;
+  private projectDocs?: Readonly<SFProjectDoc[]>;
 
   private readonly searchTerm$: BehaviorSubject<string>;
   private readonly queryParameters$: BehaviorSubject<QueryParameters>;
@@ -63,7 +70,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
   constructor(
     noticeService: NoticeService,
     readonly i18n: I18nService,
-    private readonly projectService: ProjectService,
+    private readonly projectService: SFProjectService,
     private readonly userService: UserService
   ) {
     super(noticeService);
@@ -123,6 +130,10 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
     }
     row.projectRole = projectRole;
     row.isUpdatingRole = false;
+  }
+
+  onUpdatePreTranslate(row: Row, newValue: boolean): Promise<void> {
+    return this.projectService.onlineSetPreTranslate(row.id, newValue);
   }
 
   onUpdateSyncDisabled(row: Row, newValue: boolean): Promise<void> {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -537,6 +537,35 @@ public class SFProjectsRpcController : RpcControllerBase
         }
     }
 
+    public async Task<IRpcMethodResult> SetPreTranslate(string projectId, bool preTranslate)
+    {
+        try
+        {
+            await _projectService.SetPreTranslateAsync(UserId, SystemRole, projectId, preTranslate);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "SetPreTranslate" },
+                    { "projectId", projectId },
+                    { "preTranslate", preTranslate.ToString() },
+                }
+            );
+            throw;
+        }
+    }
+
     public async Task<IRpcMethodResult> SetSyncDisabled(string projectId, bool isDisabled)
     {
         try

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -40,4 +40,5 @@ public interface ISFProjectService : IProjectService
         string audioUrl
     );
     Task DeleteAudioTimingData(string userId, string projectId, int book, int chapter);
+    Task SetPreTranslateAsync(string curUserId, string systemRole, string projectId, bool preTranslate);
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -948,6 +948,16 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         );
     }
 
+    public async Task SetPreTranslateAsync(string curUserId, string systemRole, string projectId, bool preTranslate)
+    {
+        if (systemRole != SystemRole.SystemAdmin)
+            throw new ForbiddenException();
+
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
+        await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.PreTranslate, preTranslate));
+    }
+
     protected override async Task AddUserToProjectAsync(
         IConnection conn,
         IDocument<SFProject> projectDoc,

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2943,6 +2943,40 @@ public class SFProjectServiceTests
         );
     }
 
+    [Test]
+    public void SetPreTranslate_RequiresSysAdmin()
+    {
+        var env = new TestEnvironment();
+        // SUT 1
+        Assert.ThrowsAsync<ForbiddenException>(
+            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.User, Project01, false)
+        );
+        // SUT 2
+        Assert.ThrowsAsync<ForbiddenException>(
+            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.None, Project01, false)
+        );
+        // SUT 3
+        Assert.DoesNotThrowAsync(
+            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.SystemAdmin, Project01, false)
+        );
+    }
+
+    [Test]
+    public async Task SetPreTranslate_Success()
+    {
+        var env = new TestEnvironment();
+
+        Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(false));
+        // SUT 1
+        await env.Service.SetPreTranslateAsync(User01, SystemRole.SystemAdmin, Project02, true);
+        Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(true));
+
+        Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(true));
+        // SUT 2
+        await env.Service.SetPreTranslateAsync(User01, SystemRole.SystemAdmin, Project01, false);
+        Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(false));
+    }
+
     private class TestEnvironment
     {
         public TestEnvironment()
@@ -3061,6 +3095,7 @@ public class SFProjectServiceTests
                             ShortName = "P01",
                             TranslateConfig = new TranslateConfig
                             {
+                                PreTranslate = true,
                                 TranslationSuggestionsEnabled = true,
                                 ShareEnabled = true,
                                 Source = new TranslateSource


### PR DESCRIPTION
This PR is the backend change to allow setting of the `preTranslate` flag via the system administration area of Scripture Forge.

This code does not yet change the frontend, but a separate PR (SF-2269) will address this.

Developer testing will be sufficient as this is a change that is only accessible by developers and it updates a database field (`sf_projects.translateConfig.preTranslate`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2156)
<!-- Reviewable:end -->
