### PR TITLE
SF-2215 Reorganized Community Checking

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -49,9 +49,11 @@ $toolbar-height: 56px;
 
     > div {
       flex: 1;
-      padding: 14px 20px;
+      padding-block-start: 14px;
+      padding-inline: 20px;
       @include media-breakpoint-only(xs, variables.$grid-breakpoints) {
-        padding: 10px;
+        padding-block-start: 0px;
+        padding-inline: 10px;
       }
       display: flex;
       flex-direction: column;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -1,6 +1,10 @@
 @use 'src/variables';
 @use 'bootstrap/scss/mixins/breakpoints';
 
+:host {
+  padding-block: 10px;
+}
+
 .header {
   display: flex;
   flex-wrap: wrap;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -8,44 +8,19 @@
         (audioPlayed)="playAudio()"
       >
       </app-checking-question>
-      <div
-        class="answer-question"
-        [ngClass]="{
-          'question-read': hasUserRead,
-          'question-unread': !hasUserRead,
-          'question-answered': currentUserTotalAnswers
-        }"
-      >
-        <div class="question">
-          <ng-container *ngIf="!featureFlags.scriptureAudio.enabled">
-            <div class="question-text">{{ questionDoc?.data?.text }}</div>
-            <div *ngIf="questionDoc?.data?.audioUrl" class="question-audio">
-              <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
-              </app-checking-audio-player>
-            </div>
-          </ng-container>
-          <div class="question-footer" *ngIf="canEditQuestion">
-            <div class="actions">
-              <button mat-button type="button" (click)="questionDialog()" class="edit-question-button short-button">
-                {{ t("edit") }}
-              </button>
-              <button mat-button type="button" (click)="archiveQuestion()" class="archive-question-button short-button">
-                {{ t("archive") }}
-              </button>
-            </div>
+      <div class="question" *ngIf="!featureFlags.scriptureAudio.enabled">
+        <ng-container>
+          <div class="question-text">{{ questionDoc?.data?.text }}</div>
+          <div *ngIf="questionDoc?.data?.audioUrl" class="question-audio">
+            <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
+            </app-checking-audio-player>
           </div>
-        </div>
-        <div *ngIf="!answerFormVisible" class="actions">
-          <button
-            *ngIf="currentUserTotalAnswers === 0 && canAddAnswer"
-            mat-flat-button
-            color="primary"
-            (click)="showAnswerForm()"
-            id="add-answer"
-          >
-            {{ t("add_answer") }}
-          </button>
-        </div>
+        </ng-container>
+      </div>
+      <div *ngIf="!answerFormVisible && currentUserTotalAnswers === 0 && canAddAnswer" class="actions">
+        <button mat-flat-button color="primary" (click)="showAnswerForm()" id="add-answer">
+          {{ t("add_answer") }}
+        </button>
       </div>
       <div *ngIf="answerFormVisible">
         <form [formGroup]="answerForm" autocomplete="off" id="answer-form" appScrollIntoView>
@@ -138,7 +113,7 @@
           </div>
         </form>
       </div>
-      <div class="answers-container">
+      <div class="answers-container" *ngIf="totalAnswers > 0">
         <ng-container *ngIf="shouldShowAnswers">
           <h3 id="totalAnswersMessage">
             <div *ngIf="shouldSeeAnswersList; else noAnswerCountReport">
@@ -177,58 +152,56 @@
               <app-checking-audio-player *ngIf="answer.audioUrl" [source]="getFileSource(answer.audioUrl)">
               </app-checking-audio-player>
               <div class="answer-footer">
-                <app-owner
-                  [ownerRef]="answer.ownerRef"
-                  [includeAvatar]="true"
-                  [layoutStacked]="true"
-                  [dateTime]="answer.dateCreated"
-                ></app-owner>
                 <div class="actions">
                   <button
                     *ngIf="canChangeAnswerStatus(answer)"
                     mat-button
                     type="button"
                     (click)="markAnswerForExport(answer)"
-                    class="answer-status answer-export short-button"
+                    class="answer-status answer-export"
                     [class.status-exportable]="isMarkedForExport(answer)"
                     [matTooltip]="t('tooltip_status_export')"
                     matTooltipPosition="above"
                   >
-                    {{ t(isMarkedForExport(answer) ? "marked_for_export" : "mark_for_export") }}
+                    <mat-icon>sync</mat-icon>
                   </button>
                   <button
                     *ngIf="canChangeAnswerStatus(answer)"
                     mat-button
                     type="button"
                     (click)="markAnswerAsResolved(answer)"
-                    class="answer-status answer-resolve short-button"
+                    class="answer-status answer-resolve"
                     [class.status-resolved]="isAnswerResolved(answer)"
                     [matTooltip]="t('tooltip_status_resolve')"
                     matTooltipPosition="above"
                   >
-                    {{ t(isAnswerResolved(answer) ? "resolved" : "resolve") }}
+                    <mat-icon>check_box</mat-icon>
                   </button>
-
                   <button
                     *ngIf="canEditAnswer(answer)"
                     mat-button
                     type="button"
                     (click)="editAnswer(answer)"
-                    class="answer-edit short-button"
+                    class="answer-status answer-edit"
                   >
-                    {{ t("edit") }}
+                    <mat-icon>edit</mat-icon>
                   </button>
-                  <div *ngIf="canDeleteAnswer(answer)" class="delete-divider">|</div>
                   <button
                     *ngIf="canDeleteAnswer(answer)"
                     mat-button
                     type="button"
                     (click)="deleteAnswerClicked(answer)"
-                    class="answer-delete short-button"
+                    class="answer-status answer-delete"
                   >
-                    {{ t("delete") }}
+                    <mat-icon>delete</mat-icon>
                   </button>
                 </div>
+                <app-owner
+                  [ownerRef]="answer.ownerRef"
+                  [includeAvatar]="true"
+                  [layoutStacked]="true"
+                  [dateTime]="answer.dateCreated"
+                ></app-owner>
               </div>
               <app-checking-comments
                 [project]="project"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -10,49 +10,12 @@
 }
 
 .answers-component-scrollable-content {
+  padding-block: 12px;
   overflow-y: auto;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-.answer-question {
-  padding-inline-start: 15px;
-  position: relative;
-  &:before {
-    position: absolute;
-    content: '';
-    background-color: transparent;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 5px;
-  }
-  &.question-unread {
-    &:before {
-      background-color: checking-vars.$questionUnread;
-    }
-  }
-  &.question-answered {
-    &:before {
-      background-color: checking-vars.$questionAnswered;
-    }
-  }
-  .question {
-    > * {
-      margin-bottom: 10px;
-    }
-    .question-text {
-      font-weight: bold;
-    }
-    .question-footer {
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-      }
-    }
-  }
 }
 
 #answer-form {
@@ -165,13 +128,6 @@
       .actions {
         display: flex;
         flex: 1;
-        align-items: flex-end;
-
-        @include breakpoints.media-breakpoint-down(sm, checking-vars.$grid-breakpoints) {
-          align-items: flex-start;
-          flex-direction: column;
-          row-gap: 5px;
-        }
 
         button {
           &.answer-status {
@@ -184,9 +140,11 @@
               background: checking-vars.$answerResolved;
               color: #fff;
             }
-          }
-          &.answer-delete {
-            color: variables.$errorColor;
+
+            min-width: 32px;
+            height: 32px;
+            line-height: 32px;
+            padding: 0px;
           }
         }
         .delete-divider {
@@ -214,7 +172,7 @@
 
       .answer-footer {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         row-gap: 10px;
         border-bottom: 1px solid checking-vars.$borderColor;
         padding: 10px 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
@@ -18,7 +18,7 @@
           (click)="editComment(comment)"
           class="comment-edit"
         >
-          {{ t("edit") }}
+          <mat-icon>edit</mat-icon>
         </button>
         <button
           *ngIf="canDeleteComment(comment)"
@@ -27,7 +27,7 @@
           (click)="deleteCommentClicked(comment)"
           class="comment-delete"
         >
-          {{ t("delete") }}
+          <mat-icon>delete</mat-icon>
         </button>
       </div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.scss
@@ -35,8 +35,9 @@
     }
 
     .mat-button {
-      line-height: unset;
-      padding: 0 8px;
+      min-width: 32px;
+      line-height: 18px;
+      padding: 0px;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'checking_questions'">
-  <div>
+  <div class="two-rows">
     <div class="scripture-audio" [class]="focusedText" *ngIf="scriptureAudioUrl != null">
       <span class="spacer"></span>
       <app-single-button-audio-player

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.scss
@@ -4,6 +4,12 @@
   padding-inline: 12px;
 }
 
+.two-rows {
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+}
+
 .scripture-audio,
 .question-text {
   display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -1,18 +1,17 @@
 <div class="scripture-audio-player" [dir]="i18n.direction" *transloco="let t; read: 'checking_audio_player'">
+  <div class="header">
+    <span class="verse-label">{{ verseLabel }}</span>
+    <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
   <div class="audio-action-buttons">
     <button mat-icon-button class="previous-ref-button" (click)="previousRef()">
       <mat-icon class="mirror-rtl">skip_previous</mat-icon>
     </button>
-    <button mat-icon-button class="play-pause-button" (click)="isPlaying ? pause() : play()">
-      <mat-icon>{{ isPlaying ? "pause" : "play_arrow" }}</mat-icon>
-    </button>
+    <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>
     <button mat-icon-button class="next-ref-button" (click)="nextRef()">
       <mat-icon class="mirror-rtl">skip_next</mat-icon>
     </button>
   </div>
-  <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
-    <mat-icon>close</mat-icon>
-  </button>
-  <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>
-  <span class="verse-label">{{ verseLabel }}</span>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.scss
@@ -3,25 +3,34 @@
   flex-direction: column;
 }
 
-.audio-action-buttons {
+.header {
   display: flex;
   justify-content: center;
 }
 
+.audio-action-buttons {
+  display: flex;
+}
+
 .verse-label {
-  padding: 8px;
+  padding: 12px;
   font-weight: 500;
   font-size: 0.9em;
 }
 
-div[dir='ltr'] .close-button {
+.close-button {
   position: absolute;
-  right: 8px;
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+}
+
+div[dir='ltr'] .close-button {
+  right: 12px;
 }
 
 div[dir='rtl'] .close-button {
-  position: absolute;
-  left: 8px;
+  left: 12px;
 }
 
 .previous-ref-button,
@@ -34,5 +43,6 @@ div[dir='rtl'] .close-button {
 }
 
 app-audio-player {
-  margin: -10px 0;
+  margin: -2px 0;
+  width: 100%;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -1,6 +1,11 @@
 <ng-container *transloco="let t; read: 'checking'">
   <div id="checking-app-container">
-    <div id="questions-panel" #questionsPanel [ngClass]="{ 'overlay-visible': isQuestionsOverlayVisible }">
+    <div
+      id="questions-panel"
+      #questionsPanel
+      [class.invisible]="!isQuestionsOverlayVisible"
+      [ngClass]="{ 'overlay-visible': isQuestionsOverlayVisible }"
+    >
       <header [ngClass]="{ 'filter-applied': isQuestionFilterApplied }">
         <div class="header-main">
           <h2>
@@ -59,43 +64,27 @@
       <div id="scripture-panel">
         <header>
           <div class="panel-nav">
-            <app-book-chapter-chooser
-              [books]="books"
-              [book]="book"
-              [chapters]="chapters"
-              [chapter]="chapter"
-              [bookSelectDisabled]="activeQuestionScope === 'all'"
-              [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
-              [prevNextHidden]="activeQuestionScope !== 'chapter'"
-              (bookChange)="onBookSelect($event)"
-              (chapterChange)="onChapterSelect($event)"
-            >
-            </app-book-chapter-chooser>
-
-            <div class="action-icons">
-              <ng-container *ngIf="canCreateQuestions">
-                <button
-                  mat-icon-button
-                  type="button"
-                  title="{{ t('add_question') }}"
-                  (click)="questionDialog()"
-                  class="add-question-button"
-                >
-                  <mat-icon class="mirror-rtl">post_add</mat-icon>
-                </button>
-                <button mat-button type="button" (click)="questionDialog()" class="add-question-button">
-                  <mat-icon class="mirror-rtl">post_add</mat-icon>
-                  <span>{{ t("add_question") }}</span>
-                </button>
-                <button
-                  *ngIf="canCreateScriptureAudio && !chapterHasAudio"
-                  type="button"
-                  mat-icon-button
-                  (click)="addAudioTimingData()"
-                >
-                  <mat-icon>audiotrack</mat-icon>
-                </button>
-              </ng-container>
+            <div>
+              <app-book-chapter-chooser
+                [books]="books"
+                [book]="book"
+                [chapters]="chapters"
+                [chapter]="chapter"
+                [bookSelectDisabled]="activeQuestionScope === 'all'"
+                [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
+                [prevNextHidden]="activeQuestionScope !== 'chapter'"
+                (bookChange)="onBookSelect($event)"
+                (chapterChange)="onChapterSelect($event)"
+              >
+              </app-book-chapter-chooser>
+              <button
+                *ngIf="canCreateScriptureAudio && !chapterHasAudio"
+                type="button"
+                mat-icon-button
+                (click)="addAudioTimingData()"
+              >
+                <mat-icon>audiotrack</mat-icon>
+              </button>
               <button
                 *ngIf="featureFlags.scriptureAudio.enabled && chapterHasAudio"
                 type="button"
@@ -104,32 +93,29 @@
               >
                 <mat-icon>{{ isAudioPlaying() ? "pause" : "play_arrow" }}</mat-icon>
               </button>
+            </div>
+
+            <div class="action-icons">
               <app-font-size [class.hidden]="hideChapterText" (apply)="applyFontChange($event)"></app-font-size>
               <app-share-button *ngIf="canShare" [defaultRole]="defaultShareRole"></app-share-button>
             </div>
           </div>
+          <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">
+            <app-checking-scripture-audio-player
+              [source]="chapterAudioSource"
+              [timing]="chapterTextAudioTiming"
+              [textDocId]="textDocId"
+              [canClose]="!hideChapterText"
+              (currentVerseChanged)="handleAudioTextRefChanged($event)"
+              (closed)="hideChapterAudio()"
+            ></app-checking-scripture-audio-player>
+          </div>
         </header>
         <div id="split-container" #splitContainer>
-          <as-split
-            direction="vertical"
-            [disabled]="!questionsList.activeQuestionDoc"
-            (dragEnd)="checkSliderPosition($event)"
-            [useTransition]="true"
-          >
+          <as-split direction="vertical" [disabled]="!questionsList.activeQuestionDoc" [useTransition]="true">
             <!-- Splitter area sizes are controlled programmatically. -->
-            <as-split-area [size]="100" [maxSize]="scriptureAreaMaxSize">
+            <as-split-area [size]="100">
               <div class="panel-content" #scripturePanelContainer>
-                <!-- TODO (scripture audio) Instead of covering scripture panel, move the audio player below it -->
-                <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">
-                  <app-checking-scripture-audio-player
-                    [source]="chapterAudioSource"
-                    [timing]="chapterTextAudioTiming"
-                    [textDocId]="textDocId"
-                    [canClose]="!hideChapterText"
-                    (currentVerseChanged)="handleAudioTextRefChanged($event)"
-                    (closed)="hideChapterAudio()"
-                  ></app-checking-scripture-audio-player>
-                </div>
                 <app-checking-text
                   #textPanel
                   [id]="textDocId"
@@ -160,14 +146,39 @@
         </div>
       </div>
       <div *ngIf="projectDoc" id="question-nav">
-        <button
-          mat-button
-          *ngIf="!this.isQuestionListPermanent"
-          type="button"
-          (click)="setQuestionsOverlayVisibility(true)"
-        >
-          {{ t("view_questions") }}
-        </button>
+        <div class="questions-nav-wrapper">
+          <a [appRouterLink]="routerLink" id="project-summary">
+            <app-donut-chart
+              [colors]="['#3a3a3a', '#fff', '#B8D332']"
+              [data]="[summary.unread, summary.read, summary.answered]"
+            ></app-donut-chart>
+          </a>
+          <button
+            mat-icon-button
+            *ngIf="!this.isQuestionListPermanent"
+            type="button"
+            (click)="setQuestionsOverlayVisibility(!isQuestionsOverlayVisible)"
+            [class.selected]="isQuestionsOverlayVisible"
+            class="noFocus"
+          >
+            <mat-icon>{{ isQuestionsOverlayVisible ? "expand_more" : "expand_less" }}</mat-icon>
+          </button>
+          <ng-container *ngIf="canCreateQuestions">
+            <button
+              mat-icon-button
+              type="button"
+              title="{{ t('add_question') }}"
+              (click)="questionDialog()"
+              class="add-question-button"
+            >
+              <mat-icon>add</mat-icon>
+            </button>
+            <button mat-button type="button" (click)="questionDialog()" class="add-question-button">
+              <mat-icon class="mirror-rtl">post_add</mat-icon>
+              <span>{{ t("add_question") }}</span>
+            </button>
+          </ng-container>
+        </div>
         <div class="question-nav-wrapper">
           <button
             mat-button
@@ -206,12 +217,26 @@
           >
             <mat-icon>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
           </button>
-          <a [appRouterLink]="routerLink" id="project-summary">
-            <app-donut-chart
-              [colors]="['#3a3a3a', '#fff', '#B8D332']"
-              [data]="[summary.unread, summary.read, summary.answered]"
-            ></app-donut-chart>
-          </a>
+          <button
+            mat-icon-button
+            class="always-shown"
+            [class.selected]="isQuestionPaneVisible && !isQuestionsOverlayVisible"
+            (click)="toggleQuestion()"
+          >
+            <mat-icon>question_answer</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            class="always-shown"
+            [class.selected]="isQuestionPaneVisible && !isQuestionsOverlayVisible"
+            [matMenuTriggerFor]="userOptions"
+          >
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #userOptions="matMenu" class="user-options">
+            <button mat-menu-item (click)="editQuestion()">{{ t("edit") }}</button>
+            <button mat-menu-item (click)="archiveQuestion()">{{ t("archive") }}</button>
+          </mat-menu>
         </div>
       </div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -10,11 +10,11 @@ $questionsHeaderInlineStartPadding: 8px;
 :host {
   flex: 1;
   display: flex;
+  margin-inline: -10px;
 }
 
 header {
-  display: flex;
-  padding: 8px 0;
+  padding-bottom: 12px;
 }
 
 .panel-content {
@@ -71,26 +71,23 @@ header {
     display: none;
   }
 
-  // Expand the side and bottom to fill space
-  @include media-breakpoint('<', md) {
-    margin-inline-start: -20px;
-    margin-bottom: -14px;
-  }
-
   // Override 'sm' breakpoint for this element (also adjusts BreakPointObserver 'SM' for this element)
   @include media-breakpoint('<=', sm, $questionsPanelBreakpoint) {
     position: absolute;
-    top: 0;
-    left: -100%;
+    bottom: 58px;
+    left: 0;
+    right: 0;
     width: 100%;
-    height: 100%;
+    height: 0;
     margin: 0;
     z-index: 7;
+    overflow: hidden;
     background: #fff;
-    transition: transform 0.4s cubic-bezier(0.68, -0.6, 0.265, 1.6); // Snap back effect
+    transition: 0.4s cubic-bezier(0.68, -0.6, 0.265, 1.6); // Snap back effect
 
     &.overlay-visible {
-      transform: translateX(100%);
+      // Full height - bottom bar - top bar
+      height: calc(100vh - 58px - 56px);
 
       .questions-overlay-close {
         display: block;
@@ -125,13 +122,9 @@ header {
   }
 
   #split-container {
+    overflow: auto;
     display: flex;
     flex: 1;
-    max-height: calc(100vh - 200px);
-
-    @include media-breakpoint('<', md) {
-      max-height: calc(100vh - 180px);
-    }
 
     > as-split {
       height: auto; /* fix for SF-754 */
@@ -139,13 +132,15 @@ header {
   }
 
   #scripture-panel {
+    max-height: calc(100vh - 114px - 14px);
+    @include media-breakpoint('<=', sm) {
+      max-height: calc(100vh - 114px);
+    }
+
     display: flex;
     flex-direction: column;
     flex: 1;
-
-    header {
-      align-items: center;
-    }
+    padding: 10px 10px 0px 10px;
 
     .panel-content {
       height: 100%;
@@ -156,11 +151,10 @@ header {
     .panel-nav {
       display: flex;
       justify-content: space-between;
-      flex: 1;
 
       > div {
         display: flex;
-        align-items: center;
+        align-items: end;
         justify-content: flex-start;
 
         h2 {
@@ -188,33 +182,30 @@ header {
 
         &.action-icons {
           justify-content: flex-end;
-
-          .add-question-button.mat-icon-button {
-            display: none;
-          }
-
-          @include media-breakpoint('<', xl) {
-            .add-question-button.mat-button {
-              display: none;
-            }
-
-            .add-question-button.mat-icon-button {
-              display: block;
-            }
-          }
         }
       }
     }
   }
 
   #answer-panel {
-    padding-top: 12px;
-    padding-bottom: 12px;
     padding-inline-start: 15px;
 
     @include media-breakpoint('<', md) {
-      padding-left: 0;
-      padding-right: 0;
+      padding-inline: 0;
+    }
+  }
+
+  .add-question-button.mat-icon-button {
+    display: none;
+  }
+
+  @include media-breakpoint('<', xl) {
+    .add-question-button.mat-button {
+      display: none;
+    }
+
+    .add-question-button.mat-icon-button {
+      display: block;
     }
   }
 
@@ -222,8 +213,17 @@ header {
     background-color: lighten(vars.$sf_grey, 70%);
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: space-between;
     padding: 9px;
+
+    .questions-nav-wrapper {
+      display: flex;
+      align-items: center;
+    }
+
+    .selected {
+      background-color: white;
+    }
 
     .question-nav-wrapper {
       display: flex;
@@ -240,6 +240,10 @@ header {
         display: none;
       }
 
+      .always-shown {
+        display: block;
+      }
+
       // Switch to icon-only prev/next buttons on small screens
       @include media-breakpoint('<=', sm) {
         .mat-button {
@@ -252,29 +256,17 @@ header {
       }
     }
 
-    @include media-breakpoint('<', md) {
-      margin-bottom: -14px;
-      margin-inline: 0 -20px;
-    }
-
-    @include media-breakpoint('<=', sm, $questionsPanelBreakpoint) {
-      // Widen once the questions panel is hidden
-      margin-inline-start: -20px;
-      justify-content: space-between;
-    }
-
     .next-question {
-      margin-inline-end: 8px;
-    }
-
-    @include media-breakpoint('<', sm) {
-      margin: -10px;
+      margin-inline-end: 4px;
     }
   }
 
   #project-summary {
-    width: 36px;
-    height: 36px;
+    margin-inline-end: 6px;
+    app-donut-chart {
+      width: 36px;
+      height: 36px;
+    }
   }
 }
 
@@ -295,7 +287,6 @@ header {
 }
 
 .scripture-audio-player-wrapper {
-  background: #e8eae6;
   padding: 0.25rem;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-block-start: 10px;
 }
 
 .title {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -3,7 +3,7 @@
 
 .container {
   margin: 0;
-  padding: 0;
+  padding: 10px 0px;
   max-width: 800px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -6,12 +6,6 @@
   flex-direction: column;
 }
 
-.content {
-  @include media-breakpoint-only(xs) {
-    margin: -10px;
-  }
-}
-
 .avatar-padding {
   padding-bottom: 2px;
 }
@@ -31,7 +25,7 @@
   @include media-breakpoint-only(xs) {
     margin-top: 0;
     margin-bottom: 0;
-    border-bottom-width: 0;
+    border-width: 0;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -1,5 +1,9 @@
 @import 'src/variables';
 
+:host {
+  padding-block: 14px;
+}
+
 .title {
   margin-bottom: 20px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -12,6 +12,7 @@ h3 {
 
 .invite-user {
   max-width: 800px;
+  padding-block-end: 10px;
 }
 
 .invite-user-btn {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -156,6 +156,8 @@
     }
   },
   "checking": {
+    "archive": "Archive",
+    "edit": "Edit",
     "filter_questions": "Filter questions",
     "me": "Me",
     "next": "Next",
@@ -174,8 +176,7 @@
     "question_scope_chapter": "Current chapter",
     "questions_range": "Questions range",
     "tooltip_questions_filter": "Filter questions",
-    "unknown_author": "Unknown author",
-    "view_questions": "View Questions"
+    "unknown_author": "Unknown author"
   },
   "checking_answers": {
     "add_answer": "Add answer",
@@ -187,14 +188,10 @@
     "confirm_delete": "Are you sure you want to delete this answer?",
     "delete": "Delete",
     "edit": "Edit",
-    "marked_for_export": "Marked for export",
-    "mark_for_export": "Mark for export",
     "no_scripture_selected": "No scripture selected yet.",
     "record_upload": "Record/Upload",
     "record": "Record",
     "recording_automatically_stopped": "The recording for your answer was automatically stopped.",
-    "resolve": "Resolve",
-    "resolved": "Resolved",
     "save_answer": "Save Answer",
     "select_text": "Select Text",
     "select_verses": "Select verses",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -35,7 +35,6 @@
     "add_question": "Add question"
   },
   "checking_answers": {
-    "archive": "Archive",
     "no_permission_to_like": "You don't have permission to like answers."
   },
   "checking_overview": {


### PR DESCRIPTION
Removed global padding from app component and removed negative margins where possible. Avoiding those, even if it means each page needs to specify its own padding.

Made questions list an icon, instead of text. When shown, the question nav bar will now be visible. It also slides up now, instead of right. Introduced question toggle button to indicate when the question is shown, and added ability to hide the question when it's clicked. Moved the edit/archive buttons next to it. Moved the add question button to this bar, as well.

These changes better colocate the question operations, as well as reducing space consumption, horizontal and vertical. The result should be a more streamlined experience.

Made answer actions into icons. Much more space friendly, and it doesn't look awkward anymore on mobile.

Reorganized chapter audio, as well, though the play button situation isn't great. I believe we can hide the verse label and reinstate the play button in its original spot, then hide the play button when this player is shown.

A couple small bugs still. Pane autosize is resizing a little small. Toggle nav button selections are simple circles, instead of more professional highlighting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2157)
<!-- Reviewable:end -->
