### PR TITLE
SF-2311 Allow playing chapter audio immediately after upload

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2504,6 +2504,7 @@ class TestEnvironment {
 
     const query = mock(RealtimeQuery<TextAudioDoc>) as RealtimeQuery<TextAudioDoc>;
     when(query.remoteChanges$).thenReturn(new BehaviorSubject<void>(undefined));
+    when(query.localChanges$).thenReturn(new BehaviorSubject<void>(undefined));
     const doc = mock(TextAudioDoc);
     const textAudio = mock<TextAudio>();
     when(textAudio.audioUrl).thenReturn('test-audio-short.webm');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1057,6 +1057,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     };
     await this.chapterAudioDialogService.openDialog(dialogConfig);
     this.updateAudioMissingWarning();
+    this.textAudioQuery?.localUpdate();
     this.calculateScriptureSliderPosition();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -639,11 +639,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             // TODO (scripture audio) Only fetch the timing data for the currently active chapter
             this.projectService.queryAudioText(routeProjectId).then(query => {
               this.textAudioQuery = query;
-              this.audioChangedSub = this.textAudioQuery.remoteChanges$.subscribe(() => {
-                if (this.chapterAudioSource === '') {
-                  this.hideChapterAudio();
+              this.audioChangedSub = this.subscribe(
+                merge(this.textAudioQuery.remoteChanges$, this.textAudioQuery.localChanges$),
+                () => {
+                  if (this.chapterAudioSource === '') {
+                    this.hideChapterAudio();
+                  }
                 }
-              });
+              );
             });
 
             // TODO: check for remote changes to file data more generically


### PR DESCRIPTION
The text audio query does not update automatically when audio is uploaded. Local update needs to be called on the query so that the locally uploaded audio is added to the query. I would have expected this to be automatic, but in other PRs such as SF-993 it appears to be the responsibility of the component to update the query.
I spend a couple hours trying to add a test for this behaviour, but didn't get far and decided it was not worth the effort.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2158)
<!-- Reviewable:end -->
