### PR TITLE
SF-2317 Improve comment FAB position to not cover text

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -97,6 +97,21 @@ quill-editor {
   }
 }
 
+.comment-enabled-editor {
+  quill-editor:not(.read-only-editor) .ql-editor {
+    padding-inline-start: 10px;
+    padding-inline-end: 40px;
+  }
+
+  // only commenter users on devices with screens larger than large need to account for the add comment FAB
+  quill-editor.read-only-editor .ql-editor {
+    @include media-breakpoint-up(lg) {
+      padding-inline-start: 10px;
+      padding-inline-end: 40px;
+    }
+  }
+}
+
 quill-editor.ltr {
   .question-segment[data-question-count] {
     margin-left: 1.75em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -160,6 +160,7 @@
                   [isRightToLeft]="isTargetRightToLeft"
                   [fontSize]="fontSize"
                   [selectableVerses]="showAddCommentUI"
+                  [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
                 ></app-text>
                 <app-suggestions
                   class="mat-elevation-z2"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -197,7 +197,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private resizeObserver?: ResizeObserver;
   private scrollSubscription?: Subscription;
   private readonly fabDiameter = 40;
-  private readonly fabHorizMargin = 20;
+  private readonly fabHorizMargin = 15;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -585,7 +585,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   ngAfterViewInit(): void {
     this.subscribe(fromEvent(window, 'resize'), () => {
       this.setTextHeight();
-      this.resetInsertNoteFab(false);
       this.positionInsertNoteFab();
     });
     this.subscribe(
@@ -1853,6 +1852,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (selection != null) {
       this.insertNoteFab.nativeElement.style.top = `${this.target.selectionBoundsTop}px`;
       this.insertNoteFab.nativeElement.style.marginTop = `-${this.target.scrollPosition}px`;
+      this.resetInsertNoteFab(false);
     } else {
       // hide the insert note FAB when the user clicks outside of the editor
       // and move to the top left so scrollbars are note affected


### PR DESCRIPTION
This change adds padding to the quill editor on the side where the FAB for adding comments is showing. This makes it much less likely for the FAB to cover text as a user is typing or reading.

Translators and Admins
![FAB Translator Wide Screen](https://github.com/sillsdev/web-xforge/assets/17931130/0ec5feae-814c-49bb-a8a0-bd7c2e6072e5)

Commenters
![FAB Commenter Wide Screen](https://github.com/sillsdev/web-xforge/assets/17931130/7caed6e8-0278-4a26-8c46-51ef830a99dc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2159)
<!-- Reviewable:end -->
