### PR TITLE
SF-2322 Display copyright banner for translations that request it

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -30,6 +30,8 @@ export interface SFProjectProfile extends Project {
   defaultFont?: string;
   maxGeneratedUsersPerShareKey?: number;
   biblicalTermsConfig: BiblicalTermsConfig;
+  copyrightBanner?: string;
+  copyrightNotice?: string;
 }
 
 export interface SFProject extends SFProjectProfile {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -33,7 +33,9 @@ const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   texts: true,
   syncDisabled: true,
   sync: true,
-  noteTags: true
+  noteTags: true,
+  copyrightBanner: true,
+  copyrightNotice: true
 };
 
 /**
@@ -356,6 +358,12 @@ export class SFProjectService extends ProjectService<SFProject> {
         },
         additionalProperties: false
       },
+      copyrightBanner: {
+        bsonType: 'string'
+      },
+      copyrightNotice: {
+        bsonType: 'string'
+      },
       paratextUsers: {
         bsonType: 'array',
         items: {
@@ -390,7 +398,9 @@ export class SFProjectService extends ProjectService<SFProject> {
       this.pathTemplate(p => p.translateConfig),
       this.pathTemplate(p => p.checkingConfig),
       this.pathTemplate(p => p.shortName),
-      this.pathTemplate(p => p.writingSystem)
+      this.pathTemplate(p => p.writingSystem),
+      this.pathTemplate(p => p.copyrightBanner),
+      this.pathTemplate(p => p.copyrightNotice)
     ];
     this.immutableProps.push(...immutableProps);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -54,10 +54,18 @@
     <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" class="both-editors-wrapper">
       <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
         <div class="language-label">{{ sourceLabel }}</div>
-        <div *ngIf="hasSourceCopyrightBanner" class="copyright-banner">
-          <mat-icon>copyright</mat-icon> {{ sourceCopyrightBanner }}
-          <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
-        </div>
+        <app-notice
+          *ngIf="hasSourceCopyrightBanner"
+          icon="copyright"
+          type="warning"
+          [outline]="true"
+          class="copyright-banner"
+        >
+          <div>
+            {{ sourceCopyrightBanner }}
+            <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
+          </div>
+        </app-notice>
         <div #sourceSplitContainer>
           <as-split direction="vertical" [style.height]="sourceSplitHeight">
             <as-split-area [size]="75" [minSize]="20">
@@ -93,12 +101,20 @@
         ngClass.xs="text-area-full-width"
       >
         <div class="language-label" [fxShow.gt-xs]="showSource" fxHide.xs>{{ targetLabel }}</div>
+        <app-notice
+          *ngIf="hasTargetCopyrightBanner"
+          icon="copyright"
+          type="warning"
+          [outline]="true"
+          class="copyright-banner"
+        >
+          <div>
+            {{ targetCopyrightBanner }}
+            <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
+          </div>
+        </app-notice>
         <div *ngIf="!isUsfmValid && hasEditRight" class="formatting-invalid-warning">
           <mat-icon>warning</mat-icon> {{ t("cannot_edit_chapter_formatting_invalid") }}
-        </div>
-        <div *ngIf="hasTargetCopyrightBanner" class="copyright-banner">
-          <mat-icon>copyright</mat-icon> {{ targetCopyrightBanner }}
-          <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
         </div>
         <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
           <mat-icon>warning</mat-icon> {{ t("project_data_out_of_sync") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -54,6 +54,10 @@
     <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" class="both-editors-wrapper">
       <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
         <div class="language-label">{{ sourceLabel }}</div>
+        <div *ngIf="hasSourceCopyrightBanner" class="copyright-banner">
+          <mat-icon>copyright</mat-icon> {{ sourceCopyrightBanner }}
+          <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
+        </div>
         <div #sourceSplitContainer>
           <as-split direction="vertical" [style.height]="sourceSplitHeight">
             <as-split-area [size]="75" [minSize]="20">
@@ -91,6 +95,10 @@
         <div class="language-label" [fxShow.gt-xs]="showSource" fxHide.xs>{{ targetLabel }}</div>
         <div *ngIf="!isUsfmValid && hasEditRight" class="formatting-invalid-warning">
           <mat-icon>warning</mat-icon> {{ t("cannot_edit_chapter_formatting_invalid") }}
+        </div>
+        <div *ngIf="hasTargetCopyrightBanner" class="copyright-banner">
+          <mat-icon>copyright</mat-icon> {{ targetCopyrightBanner }}
+          <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
         </div>
         <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
           <mat-icon>warning</mat-icon> {{ t("project_data_out_of_sync") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -79,6 +79,7 @@ app-text {
   overflow: hidden;
 }
 
+.copyright-banner,
 .formatting-invalid-warning,
 .out-of-sync-warning,
 .doc-corrupted-warning,
@@ -127,4 +128,13 @@ app-text {
     display: flex;
     justify-content: flex-end;
   }
+}
+
+.copyright-more-info {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.copyright-more-info:hover {
+  text-decoration: underline;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -79,7 +79,6 @@ app-text {
   overflow: hidden;
 }
 
-.copyright-banner,
 .formatting-invalid-warning,
 .out-of-sync-warning,
 .doc-corrupted-warning,
@@ -130,11 +129,14 @@ app-text {
   }
 }
 
+.copyright-banner {
+  margin-bottom: 10px;
+}
+
 .copyright-more-info {
   cursor: pointer;
   font-weight: bold;
-}
-
-.copyright-more-info:hover {
-  text-decoration: underline;
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3424,6 +3424,34 @@ describe('EditorComponent', () => {
       expect(env.sourceBiblicalTerms).toBeFalsy();
       env.dispose();
     }));
+
+    it('shows the copyright banner', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setupProject({ translateConfig: defaultTranslateConfig, copyrightBanner: 'banner text' });
+      env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 3 });
+      env.updateParams({ projectId: 'project01', bookId: 'MAT' });
+      env.wait();
+      expect(env.copyrightBanner).not.toBeNull();
+      env.dispose();
+    }));
+
+    it('shows the copyright notice dialog', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setupProject({ translateConfig: defaultTranslateConfig, copyrightBanner: 'banner text' });
+      env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 3 });
+      env.updateParams({ projectId: 'project01', bookId: 'MAT' });
+      env.wait();
+
+      // SUT
+      const dialogMessage = spyOn((env.component as any).dialogService, 'openGenericDialog').and.callThrough();
+      expect(env.copyrightBanner).not.toBeNull();
+      env.copyrightMoreInfo.nativeElement.click();
+      tick();
+      env.fixture.detectChanges();
+      expect(dialogMessage).toHaveBeenCalledTimes(1);
+
+      env.dispose();
+    }));
   });
 
   describe('Back translation draft', () => {
@@ -3944,6 +3972,14 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('.no-edit-permission-message'));
   }
 
+  get copyrightBanner(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.copyright-banner'));
+  }
+
+  get copyrightMoreInfo(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.copyright-banner > .copyright-more-info'));
+  }
+
   get isSourceAreaHidden(): boolean {
     return this.sourceTextArea.nativeElement.style.display === 'none';
   }
@@ -4045,6 +4081,12 @@ class TestEnvironment {
     }
     if (data.defaultFontSize != null) {
       projectProfileData.defaultFontSize = data.defaultFontSize;
+    }
+    if (data.copyrightBanner != null) {
+      projectProfileData.copyrightBanner = data.copyrightBanner;
+    }
+    if (data.copyrightNotice != null) {
+      projectProfileData.copyrightNotice = data.copyrightNotice;
     }
     if (data.texts != null) {
       projectProfileData.texts = merge(projectProfileData.texts, data.texts);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3977,7 +3977,7 @@ class TestEnvironment {
   }
 
   get copyrightMoreInfo(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.copyright-banner > .copyright-more-info'));
+    return this.fixture.debugElement.query(By.css('.copyright-banner .copyright-more-info'));
   }
 
   get isSourceAreaHidden(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1089,7 +1089,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   showCopyrightNotice(textType: TextType): void {
-    let copyrightNotice =
+    let copyrightNotice: string =
       textType === 'source'
         ? this.sourceProjectDoc?.data?.copyrightNotice ?? ''
         : this.projectDoc?.data?.copyrightNotice ?? '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -50,7 +50,7 @@ import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-inf
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DeltaOperation } from 'rich-text';
-import { BehaviorSubject, combineLatest, fromEvent, merge, Subject, Subscription, timer } from 'rxjs';
+import { BehaviorSubject, combineLatest, fromEvent, merge, of, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, delayWhen, filter, first, repeat, retryWhen, switchMap, take, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
@@ -541,6 +541,22 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   private get canShowInsertNoteFab(): boolean {
     return this.targetLoaded && this.dialogService.openDialogCount < 1;
+  }
+
+  get hasSourceCopyrightBanner(): boolean {
+    return this.sourceProjectDoc?.data?.copyrightBanner != null;
+  }
+
+  get sourceCopyrightBanner(): string {
+    return this.sourceProjectDoc?.data?.copyrightBanner ?? '';
+  }
+
+  get hasTargetCopyrightBanner(): boolean {
+    return this.projectDoc?.data?.copyrightBanner != null;
+  }
+
+  get targetCopyrightBanner(): string {
+    return this.projectDoc?.data?.copyrightBanner ?? '';
   }
 
   /**
@@ -1070,6 +1086,34 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.router.navigateByUrl(
       `/projects/${this.activatedProjectService.projectId}/draft-preview/${book}/${this.chapter}`
     );
+  }
+
+  showCopyrightNotice(textType: TextType): void {
+    let copyrightNotice =
+      textType === 'source'
+        ? this.sourceProjectDoc?.data?.copyrightNotice ?? ''
+        : this.projectDoc?.data?.copyrightNotice ?? '';
+
+    // If we do not have a copyright notice, just use the copyright banner
+    if (copyrightNotice === '') {
+      copyrightNotice = textType === 'source' ? this.sourceCopyrightBanner : this.targetCopyrightBanner;
+    }
+
+    copyrightNotice = copyrightNotice.trim();
+    if (copyrightNotice[0] !== '<') {
+      // If copyright is plain text, remove the first line and add paragraph markers.
+      const lines: string[] = copyrightNotice.split('\n');
+      copyrightNotice = '<p>' + lines.slice(1).join('</p><p>') + '</p>';
+    } else {
+      // Just remove the first paragraph that contains the notification.
+      copyrightNotice = copyrightNotice.replace(/^<p>.*?<\/p>/, '');
+    }
+
+    // Show the copyright notice
+    this.dialogService.openGenericDialog({
+      message: of(this.stripXml(copyrightNotice)),
+      options: [{ value: undefined, label: this.i18n.translate('dialog.close'), highlight: true }]
+    });
   }
 
   private async saveNote(params: SaveNoteParameters): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -204,6 +204,7 @@
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_note_paratext": "You cannot edit this note as it has been edited in Paratext.",
     "configure_translation_suggestions": "Configure translation suggestions",
+    "more_info": "More Info...",
     "more_notes": "--- {{ count }} more note(s) ---",
     "navigate_to_a_valid_text": "Navigate to a valid text to insert a note",
     "no_permission_edit_chapter": "You don't have permission to edit this chapter, even though you have the {{ userRole }} role. Permissions can only be changed in Paratext.",

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -21,4 +21,6 @@ public class ParatextSettings
     public string ProjectType { get; set; } = string.Empty;
     public string BaseProjectShortName { get; set; } = string.Empty;
     public string? BaseProjectParatextId { get; set; }
+    public string? CopyrightBanner { get; set; }
+    public string? CopyrightNotice { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -31,4 +31,18 @@ public class SFProject : Project
     /// There may be some projects that will want this increased which can be done manually in the database
     /// </summary>
     public int? MaxGeneratedUsersPerShareKey { get; set; } = 250;
+
+    /// <summary>
+    /// Gets or sets the copyright banner that must be displayed when the text is displayed.
+    /// </summary>
+    /// <value>The copyright banner.</value>
+    /// <remarks>This is plain text.</remarks>
+    public string? CopyrightBanner { get; set; }
+
+    /// <summary>
+    /// Gets or sets the full copyright notice.
+    /// </summary>
+    /// <value>The copyright notice.</value>
+    /// <remarks>This is may be plain text or HTML formatted.</remarks>
+    public string? CopyrightNotice { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -986,6 +986,20 @@ public class ParatextService : DisposableBase, IParatextService
                     }
             );
 
+        // If the copyright banner is blank or empty, make it null so it will not be displayed
+        string? copyrightBanner = scrText.CopyrightBannerText;
+        if (string.IsNullOrWhiteSpace(copyrightBanner))
+        {
+            copyrightBanner = null;
+        }
+
+        // Get the copyright notice in the same way
+        string? copyrightNotice = scrText.Settings.Copyright;
+        if (string.IsNullOrWhiteSpace(copyrightNotice))
+        {
+            copyrightNotice = null;
+        }
+
         return new ParatextSettings
         {
             FullName = scrText.FullName,
@@ -998,6 +1012,8 @@ public class ParatextService : DisposableBase, IParatextService
             ProjectType = scrText.Settings.TranslationInfo.Type.ToString(),
             BaseProjectParatextId = scrText.Settings.TranslationInfo.BaseProjectGuid?.Id,
             BaseProjectShortName = scrText.Settings.TranslationInfo.BaseProjectName,
+            CopyrightBanner = copyrightBanner,
+            CopyrightNotice = copyrightNotice,
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1808,7 +1808,30 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     // There is no longer a base project, so remove the base project record
                     op.Unset(pd => pd.TranslateConfig.BaseProject);
                 }
+
+                // Update the copyright banner
+                if (settings.CopyrightBanner is not null)
+                {
+                    op.Set(pd => pd.CopyrightBanner, settings.CopyrightBanner);
+                }
+                else if (_projectDoc.Data.CopyrightBanner is not null)
+                {
+                    // There is no longer a copyright banner, so remove it
+                    op.Unset(pd => pd.CopyrightBanner);
+                }
+
+                // Update the copyright notice
+                if (settings.CopyrightNotice is not null)
+                {
+                    op.Set(pd => pd.CopyrightNotice, settings.CopyrightNotice);
+                }
+                else if (_projectDoc.Data.CopyrightNotice is not null)
+                {
+                    // There is no longer a copyright notice, so remove it
+                    op.Unset(pd => pd.CopyrightNotice);
+                }
             }
+
             // The source can be null if there was an error getting a resource from the DBL
             if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -800,6 +800,8 @@ public class ParatextSyncRunnerTests
         Assert.That(project.DefaultFontSize, Is.EqualTo(fontSize));
         Assert.That(project.DefaultFont, Is.EqualTo(font));
         Assert.IsNull(project.WritingSystem.Tag);
+        Assert.IsNull(project.CopyrightBanner);
+        Assert.IsNull(project.CopyrightNotice);
         Assert.That(project.TranslateConfig.Source.WritingSystem.Tag, Is.EqualTo(sourceWritingSystemTag));
         int newFontSize = 16;
         string newFont = "Doulos SIL";
@@ -817,6 +819,8 @@ public class ParatextSyncRunnerTests
         string newProjectType = ProjectType.BackTranslation.ToString();
         string? newBaseProjectParatextId = "base_pt";
         string newBaseProjectShortName = "BPT";
+        const string newCopyrightBanner = "Copyright Banner Goes Here";
+        const string newCopyrightNotice = $"<p>Notification: {newCopyrightBanner}</p><p>Copyright Notice Goes Here</p>";
         env.ParatextService
             .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(
@@ -829,6 +833,8 @@ public class ParatextSyncRunnerTests
                     ProjectType = newProjectType,
                     BaseProjectParatextId = newBaseProjectParatextId,
                     BaseProjectShortName = newBaseProjectShortName,
+                    CopyrightBanner = newCopyrightBanner,
+                    CopyrightNotice = newCopyrightNotice,
                 }
             );
 
@@ -843,8 +849,10 @@ public class ParatextSyncRunnerTests
         Assert.That(project.TranslateConfig.ProjectType, Is.EqualTo(newProjectType));
         Assert.That(project.TranslateConfig.BaseProject.ParatextId, Is.EqualTo(newBaseProjectParatextId));
         Assert.That(project.TranslateConfig.BaseProject.ShortName, Is.EqualTo(newBaseProjectShortName));
+        Assert.That(project.CopyrightBanner, Is.EqualTo(newCopyrightBanner));
+        Assert.That(project.CopyrightNotice, Is.EqualTo(newCopyrightNotice));
 
-        // Change the base project configuration
+        // Change the base project configuration and remove copyright banner & message
         newProjectType = ProjectType.Daughter.ToString();
         newBaseProjectParatextId = "daughter_pt";
         newBaseProjectShortName = "DPT";
@@ -856,6 +864,8 @@ public class ParatextSyncRunnerTests
                     ProjectType = newProjectType,
                     BaseProjectParatextId = newBaseProjectParatextId,
                     BaseProjectShortName = newBaseProjectShortName,
+                    CopyrightBanner = null,
+                    CopyrightNotice = null,
                 }
             );
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -863,6 +873,8 @@ public class ParatextSyncRunnerTests
         Assert.That(project.TranslateConfig.ProjectType, Is.EqualTo(newProjectType));
         Assert.That(project.TranslateConfig.BaseProject.ParatextId, Is.EqualTo(newBaseProjectParatextId));
         Assert.That(project.TranslateConfig.BaseProject.ShortName, Is.EqualTo(newBaseProjectShortName));
+        Assert.That(project.CopyrightBanner, Is.Null);
+        Assert.That(project.CopyrightNotice, Is.Null);
 
         // Remove the base project configuration
         newProjectType = ProjectType.Standard.ToString();


### PR DESCRIPTION
Some translations specifically request that a copyright banner is displayed above the text in Paratext.

This PR updates Scripture Forge so that translations that request a copyright notice to be displayed have the copyright notice of their specification displayed. Because this message is stored in the Project's Settings, it is not localized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2161)
<!-- Reviewable:end -->
