### PR TITLE
SF-2321 Update typescript and @types/node

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -90,7 +90,7 @@
         "@types/jasmine": "~3.10.3",
         "@types/jasminewd2": "~2.0.10",
         "@types/lodash-es": "^4.17.6",
-        "@types/node": "^16.11.36",
+        "@types/node": "^16.18.60",
         "@types/papaparse": "^5.3.2",
         "@types/quill": "^1.3.10",
         "@types/sharedb": "^1.0.24",
@@ -125,7 +125,7 @@
         "storybook": "^7.0.18",
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.7.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-bundle-analyzer": "^4.5.0"
       }
     },
@@ -19208,9 +19208,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.36",
-      "dev": true,
-      "license": "MIT"
+      "version": "16.18.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.60.tgz",
+      "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -41758,9 +41759,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -51883,7 +51884,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.36",
+      "version": "16.18.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.60.tgz",
+      "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -72695,9 +72698,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -110,7 +110,7 @@
     "@types/jasmine": "~3.10.3",
     "@types/jasminewd2": "~2.0.10",
     "@types/lodash-es": "^4.17.6",
-    "@types/node": "^16.11.36",
+    "@types/node": "^16.18.60",
     "@types/papaparse": "^5.3.2",
     "@types/quill": "^1.3.10",
     "@types/sharedb": "^1.0.24",
@@ -145,7 +145,7 @@
     "storybook": "^7.0.18",
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.7.0",
-    "typescript": "~4.8.4",
+    "typescript": "~4.9.5",
     "webpack-bundle-analyzer": "^4.5.0"
   },
   "browser": {


### PR DESCRIPTION
This PR updates npm `typescript` and `@types/node` packages in preparation for update to Angular 16.

Updating only the typescript package causes a compilation error due to conflicting type definitions.  Updating package @types/node fixes this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2162)
<!-- Reviewable:end -->
