### PR TITLE
SF-2324 Update angular-split to 15.0.0

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -30,7 +30,7 @@
         "@sillsdev/machine": "^2.4.2",
         "@sillsdev/scripture": "^1.4.0",
         "angular-file": "^3.6.0",
-        "angular-split": "^5.0.0",
+        "angular-split": "~15.0.0",
         "arraydiff": "^0.1.3",
         "bootstrap": "^4.6.1",
         "bowser": "^2.11.0",
@@ -20618,8 +20618,9 @@
       }
     },
     "node_modules/angular-split": {
-      "version": "5.0.0",
-      "license": "Apache-2.0",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/angular-split/-/angular-split-15.0.0.tgz",
+      "integrity": "sha512-An/f0NobbxHxA9bowwYIuKHPoP2yoQldrPklpMvmQdqntExys+B92m7kkfs4K0ANuowyFIZHMeEzounC4j7ocQ==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -52887,7 +52888,9 @@
       }
     },
     "angular-split": {
-      "version": "5.0.0",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/angular-split/-/angular-split-15.0.0.tgz",
+      "integrity": "sha512-An/f0NobbxHxA9bowwYIuKHPoP2yoQldrPklpMvmQdqntExys+B92m7kkfs4K0ANuowyFIZHMeEzounC4j7ocQ==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -50,7 +50,7 @@
     "@sillsdev/machine": "^2.4.2",
     "@sillsdev/scripture": "^1.4.0",
     "angular-file": "^3.6.0",
-    "angular-split": "^5.0.0",
+    "angular-split": "~15.0.0",
     "arraydiff": "^0.1.3",
     "bootstrap": "^4.6.1",
     "bowser": "^2.11.0",


### PR DESCRIPTION
This is necessary before updating to Angular 16, because Angular 16 no longer compiles from the View Engine format to the Ivy format.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2163)
<!-- Reviewable:end -->
