### PR TITLE
SF-2325 Fix draft percent complete display

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -210,7 +210,7 @@
                     {{ t("preview_last_draft_while_active_build") }}
                   </p>
                 </div>
-                <circle-progress [percent]="draftJob!.percentCompleted"></circle-progress>
+                <circle-progress [percent]="draftJob!.percentCompleted * 100"></circle-progress>
 
                 <div class="button-strip">
                   <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/mock-pretranslation-machine-api.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/mock-pretranslation-machine-api.ts
@@ -49,7 +49,7 @@ export class MockPreTranslationHttpClient {
     engine: { id: '', href: '' },
     revision: 0,
     state: BuildStates.Completed,
-    percentCompleted: 100,
+    percentCompleted: 1.0,
     message: ''
   };
 
@@ -142,7 +142,7 @@ export class MockPreTranslationHttpClient {
     const stepOffset: number =
       isContinue && this.mostRecentJobState?.state === BuildStates.Active
         ? activeAfter / interval +
-          Math.floor((this.mostRecentJobState!.percentCompleted / 100) * ((duration - activeAfter) / interval))
+          Math.floor(this.mostRecentJobState!.percentCompleted * ((duration - activeAfter) / interval))
         : 0;
 
     const generationTimer$: Observable<number> = timer(0, interval).pipe(
@@ -182,12 +182,12 @@ export class MockPreTranslationHttpClient {
 
       if (elapsed >= duration) {
         this.mostRecentJobState.state = BuildStates.Completed;
-        this.mostRecentJobState.percentCompleted = 100;
+        this.mostRecentJobState.percentCompleted = 1.0;
         this.setHasCompletedBuild(true);
       }
 
       if (this.mostRecentJobState.state === BuildStates.Active) {
-        this.mostRecentJobState.percentCompleted = ((elapsed - activeAfter) / (duration - activeAfter)) * 100;
+        this.mostRecentJobState.percentCompleted = (elapsed - activeAfter) / (duration - activeAfter);
       }
 
       // Store most recent job state in browser session


### PR DESCRIPTION
Eli pointed out that Serval returns the percent complete for a build as a 0-1 percentage, while our frontend is expecting a 0-100 percentage. Thus, the value never goes above 1 in the progress circle.

The translation suggestions engine already works with a 0-1 percentage, so I have updated the frontend to use the 0 to 1 percent complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2164)
<!-- Reviewable:end -->
