### PR TITLE
SF-2297 Allow editing of scripture audio data

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -13,16 +13,16 @@
       <div class="wrapper wrapper-book-chapter valid">
         <mat-icon *ngIf="!selectionHasAudioAlready">book</mat-icon>
         <app-info
-          *ngIf="selectionHasAudioAlready"
+          *ngIf="selectionHasAudioAlready && !inEditState"
           [text]="t('chapter_audio_dialog.audio_already_exists')"
           icon="warning"
           type="warning"
         ></app-info>
-        <mat-select [(value)]="book" class="book-select-menu">
+        <mat-select [(value)]="book" [disabled]="inEditState" class="book-select-menu">
           <mat-option *ngFor="let b of books" [value]="b">{{ bookName(b) }}</mat-option>
         </mat-select>
         <div class="divider"></div>
-        <mat-select [(value)]="chapter" class="chapter-select-menu">
+        <mat-select [(value)]="chapter" [disabled]="inEditState" class="chapter-select-menu">
           <mat-option *ngFor="let c of chapters" [value]="c">{{ c }}</mat-option>
         </mat-select>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -11,7 +11,7 @@
     </div>
     <div class="data-blocks">
       <div class="wrapper wrapper-book-chapter valid">
-        <mat-icon *ngIf="!selectionHasAudioAlready">book</mat-icon>
+        <mat-icon *ngIf="!selectionHasAudioAlready || inEditState">book</mat-icon>
         <app-info
           *ngIf="selectionHasAudioAlready && !inEditState"
           [text]="t('chapter_audio_dialog.audio_already_exists')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -163,6 +163,7 @@ describe('ChapterAudioDialogComponent', () => {
     };
 
     env = new TestEnvironment(config);
+    tick();
 
     // Ensure that the UI shows that hte chapter has audio
     expect(env.component.book).toEqual(containingBook.bookNum);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -442,14 +442,12 @@ class TestEnvironment {
           projectId: 'project01',
           textsByBookId: TestEnvironment.textsByBookId,
           questionsSorted: this.questions
-          // currentBook: 1,
-          // currentChapter: 3
         }
       };
     }
 
     if (config.data?.currentBook) {
-      this.makeProjectHaveTextAudio(config.data);
+      this.addTextAudioData(config.data);
     }
 
     when(mockedCsvService.parse(anything())).thenResolve([
@@ -563,7 +561,7 @@ class TestEnvironment {
     return this.overlayContainerElement.querySelector(query) as HTMLElement;
   }
 
-  makeProjectHaveTextAudio(data: ChapterAudioDialogData): void {
+  addTextAudioData(data: ChapterAudioDialogData): void {
     const dataId = getTextAudioId(data.projectId, data.currentBook ?? 1, data.currentChapter ?? 1);
     this.realtimeService.addSnapshot<TextAudio>(TextAudioDoc.COLLECTION, {
       id: dataId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, NgModule, NgZone } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import {
   MatLegacyDialog as MatDialog,
   MatLegacyDialogConfig as MatDialogConfig,
@@ -19,21 +19,25 @@ import { anything, mock, when } from 'ts-mockito';
 import { CsvService } from 'xforge-common/csv-service.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FileService } from 'xforge-common/file.service';
-import { FileType } from 'xforge-common/models/file-offline-data';
+import { FileOfflineData, FileType } from 'xforge-common/models/file-offline-data';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import {
   ChildViewContainerComponent,
-  TestTranslocoModule,
   configureTestingModule,
-  getAudioBlob
+  getAudioBlob,
+  TestTranslocoModule
 } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { getTextAudioId, TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { createTestTextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio-test-data';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { CheckingModule } from '../checking.module';
 import { AudioAttachment } from '../checking/checking-audio-recorder/checking-audio-recorder.component';
+import { SFProjectService } from '../../core/sf-project.service';
 import {
   ChapterAudioDialogComponent,
   ChapterAudioDialogData,
@@ -43,6 +47,7 @@ import {
 const mockedDialogService = mock(DialogService);
 const mockedCsvService = mock(CsvService);
 const mockedFileService = mock(FileService);
+const mockedSFProjectService = mock(SFProjectService);
 
 describe('ChapterAudioDialogComponent', () => {
   configureTestingModule(() => ({
@@ -51,6 +56,7 @@ describe('ChapterAudioDialogComponent', () => {
       { provide: DialogService, useMock: mockedDialogService },
       { provide: CsvService, useMock: mockedCsvService },
       { provide: FileService, useMock: mockedFileService },
+      { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
@@ -341,6 +347,35 @@ describe('ChapterAudioDialogComponent', () => {
       .withContext('should show message that user needs to connect to continue')
       .toContain('internet');
   }));
+
+  it('populate with existing data if available', fakeAsync(() => {
+    const expectedBook = 1;
+    const expectedChapter = 3;
+    const config: MatDialogConfig<ChapterAudioDialogData> = {
+      data: {
+        projectId: 'project02',
+        textsByBookId: TestEnvironment.textsByBookId,
+        questionsSorted: env.questions,
+        currentBook: expectedBook,
+        currentChapter: expectedChapter
+      }
+    };
+
+    // Close the dialog opened from beforeEach
+    env.closeDialog();
+
+    env = new TestEnvironment(config);
+    tick();
+    env.fixture.detectChanges();
+
+    expect(env.component.book).toEqual(expectedBook);
+    expect(env.component.chapter).toEqual(expectedChapter);
+    expect(env.component.audioFilename).toEqual('Genesis 3');
+    expect(env.bookSelect.classList.contains('mat-select-disabled')).toBe(true);
+    expect(env.chapterSelect.classList.contains('mat-select-disabled')).toBe(true);
+    expect(env.wrapperAudio.classList.contains('valid')).toBe(true);
+    expect(env.wrapperTiming.classList.contains('valid')).toBe(true);
+  }));
 });
 
 @NgModule({
@@ -398,6 +433,7 @@ class TestEnvironment {
     OnlineStatusService
   ) as TestOnlineStatusService;
   private numTimesClosedFired: number;
+  private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor(config?: MatDialogConfig<ChapterAudioDialogData>) {
     if (!config) {
@@ -406,8 +442,14 @@ class TestEnvironment {
           projectId: 'project01',
           textsByBookId: TestEnvironment.textsByBookId,
           questionsSorted: this.questions
+          // currentBook: 1,
+          // currentChapter: 3
         }
       };
+    }
+
+    if (config.data?.currentBook) {
+      this.makeProjectHaveTextAudio(config.data);
     }
 
     when(mockedCsvService.parse(anything())).thenResolve([
@@ -426,12 +468,26 @@ class TestEnvironment {
         true
       )
     ).thenResolve('audio url');
+    when(mockedSFProjectService.queryAudioText(anything())).thenReturn(
+      this.realtimeService.subscribeQuery(TextAudioDoc.COLLECTION, {})
+    );
+
     this.audioFile = {
       status: 'uploaded',
       blob: getAudioBlob(),
       fileName: 'test-audio-player.webm',
       url: URL.createObjectURL(new File([getAudioBlob()], 'test.wav'))
     };
+
+    when(
+      mockedFileService.findOrUpdateCache(FileType.Audio, TextAudioDoc.COLLECTION, anything(), anything())
+    ).thenResolve({
+      id: 'audio01',
+      dataCollection: TextAudioDoc.COLLECTION,
+      filename: this.audioFile.fileName,
+      blob: this.audioFile.blob,
+      url: this.audioFile.url
+    } as FileOfflineData);
 
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     this.dialogRef = TestBed.inject(MatDialog).open(ChapterAudioDialogComponent, config);
@@ -443,19 +499,17 @@ class TestEnvironment {
     });
   }
 
+  get bookSelect(): HTMLInputElement {
+    return this.overlayContainerElement.querySelector('.book-select-menu') as HTMLInputElement;
+  }
+
+  get chapterSelect(): HTMLInputElement {
+    return this.overlayContainerElement.querySelector('.chapter-select-menu') as HTMLInputElement;
+  }
+
   set onlineStatus(isOnline: boolean) {
     this.testOnlineStatusService.setIsOnline(isOnline);
     tick();
-    this.fixture.detectChanges();
-  }
-
-  clickElement(element: HTMLElement | DebugElement): void {
-    if (element instanceof DebugElement) {
-      element = element.nativeElement as HTMLElement;
-    }
-    element.click();
-    this.fixture.detectChanges();
-    flush();
     this.fixture.detectChanges();
   }
 
@@ -491,13 +545,39 @@ class TestEnvironment {
     return this.fixture.nativeElement.parentElement.querySelector('.cdk-overlay-container');
   }
 
-  playAudio(): void {
-    this.component.chapterAudio?.play();
+  clickElement(element: HTMLElement | DebugElement): void {
+    if (element instanceof DebugElement) {
+      element = element.nativeElement as HTMLElement;
+    }
+    element.click();
     this.fixture.detectChanges();
+    flush();
+    this.fixture.detectChanges();
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
   }
 
   fetchElement(query: string): HTMLElement {
     return this.overlayContainerElement.querySelector(query) as HTMLElement;
+  }
+
+  makeProjectHaveTextAudio(data: ChapterAudioDialogData): void {
+    const dataId = getTextAudioId(data.projectId, data.currentBook ?? 1, data.currentChapter ?? 1);
+    this.realtimeService.addSnapshot<TextAudio>(TextAudioDoc.COLLECTION, {
+      id: dataId,
+      data: createTestTextAudio({
+        dataId,
+        projectRef: data.projectId,
+        timings: [{ textRef: 'v1', from: 0, to: 1 }]
+      })
+    });
+  }
+
+  playAudio(): void {
+    this.component.chapterAudio?.play();
+    this.fixture.detectChanges();
   }
 
   async wait(ms: number = 200): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
 import {
   MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
   MatLegacyDialogRef as MatDialogRef
@@ -49,7 +49,7 @@ export interface ChapterAudioDialogResult {
   templateUrl: './chapter-audio-dialog.component.html',
   styleUrls: ['./chapter-audio-dialog.component.scss']
 })
-export class ChapterAudioDialogComponent extends SubscriptionDisposable implements AfterViewInit {
+export class ChapterAudioDialogComponent extends SubscriptionDisposable implements AfterViewInit, OnDestroy {
   @ViewChild('dropzone') dropzone?: ElementRef<HTMLDivElement>;
   @ViewChild('fileDropzone') fileDropzone?: ElementRef<HTMLInputElement>;
   @ViewChild('chapterAudio') chapterAudio?: SingleButtonAudioPlayerComponent;
@@ -217,6 +217,12 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
       this.textAudioQuery = query;
       this.populateExistingData();
     });
+  }
+
+  ngOnDestroy(): void {
+    if (this.textAudioQuery != null) {
+      this.textAudioQuery.dispose();
+    }
   }
 
   async prepareTimingFileUpload(file: File): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -79,7 +79,6 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
   ) {
     super();
     this.getStartingLocation();
-    this.checkForPreexistingAudio();
   }
 
   get audioErrorMessage(): string {
@@ -366,11 +365,12 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
     this.subscribe(this.textAudioQuery.ready$.pipe(filter(ready => ready)), () => {
       const textAudioId: string = getTextAudioId(this.data.projectId, this.book, this.chapter);
       const doc = this.textAudioQuery?.docs.find(t => t.id === textAudioId)?.data;
+      this.checkForPreexistingAudio();
       if (doc == null) {
         return;
       }
       this._editState = true;
-      this.timing = doc.timings;
+      this.timing = this.timing_processed = doc.timings;
       this.fileService
         .findOrUpdateCache(FileType.Audio, TextAudioDoc.COLLECTION, textAudioId, doc.audioUrl)
         .then(data => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -359,7 +359,8 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
   }
 
   private populateExistingData(): void {
-    if (this.textAudioQuery == null) {
+    if (this.textAudioQuery == null || this.data.currentBook == null || this.data.currentChapter == null) {
+      this.checkForPreexistingAudio();
       return;
     }
     this.subscribe(this.textAudioQuery.ready$.pipe(filter(ready => ready)), () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -130,7 +130,6 @@
                           <button
                             *ngIf="canCreateScriptureAudio"
                             mat-menu-item
-                            disabled
                             (click)="editChapterAudio(text, chapter)"
                             class="edit-audio-btn"
                           >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -280,8 +280,19 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     }
   }
 
-  editChapterAudio(_text: TextInfo, _chapter: Chapter): void {
-    // TODO: Open dialog
+  async editChapterAudio(text: TextInfo, chapter: Chapter): Promise<void> {
+    if (this.projectId == null || this.textsByBookId == null) {
+      return;
+    }
+
+    const dialogConfig: ChapterAudioDialogData = {
+      projectId: this.projectId,
+      textsByBookId: this.textsByBookId,
+      questionsSorted: this.allPublishedQuestions,
+      currentBook: text.bookNum,
+      currentChapter: chapter.number
+    };
+    await this.chapterAudioDialogService.openDialog(dialogConfig);
   }
 
   getRouterLink(bookId: string): string[] {


### PR DESCRIPTION
* Check if a TextAudioDoc is available when opening the chapter audio dialog
* Enable edit chapter audio from checking overview
* Disable book and chapter selectors in edit mode

## Acceptance Tests
* Can edit chapter audio from checking overview
* Timing data and audio is pre-populated in the chapter audio dialog
* Audio can be played from the chapter audio dialog
* Book and chapter is disabled in the chapter audio dialog
* Overwriting with different audio and/or timing data should save and overwrite what was previously saved


**Checking Overview**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/a4280d0f-6723-4b8c-808a-52b4ac117f8a)


**Chapter Audio Dialog**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/ef74f817-1f48-4211-964a-6f86a6ee70d4)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2165)
<!-- Reviewable:end -->
