### PR TITLE
SF-2332 Improve verse segment alignment for MT Drafting

### DIFF
--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -99,7 +99,7 @@ public class PreTranslationService : IPreTranslationService
 
             referenceParts = reference.Split('_', StringSplitOptions.RemoveEmptyEntries);
             if (
-                referenceParts.Length != 3
+                referenceParts.Length < 3
                 || !int.TryParse(referenceParts[1], out int refChapterNum)
                 || refChapterNum != chapterNum
             )
@@ -108,7 +108,7 @@ public class PreTranslationService : IPreTranslationService
             }
 
             // Get the reference in the form MAT 1:2
-            string verse = referenceParts.Last();
+            string verse = referenceParts[2];
             VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
             reference = verseRef.Text;
 
@@ -132,8 +132,15 @@ public class PreTranslationService : IPreTranslationService
             sb.TrimEnd();
             string translation = sb.ToString();
 
-            // Add the pre-translation
-            preTranslations.Add(new PreTranslation { Reference = reference, Translation = translation, });
+            // Add the pre-translation, or update if this is a segment of it
+            if (preTranslations.Any(p => p.Reference == reference))
+            {
+                preTranslations.First(p => p.Reference == reference).Translation += " " + translation;
+            }
+            else
+            {
+                preTranslations.Add(new PreTranslation { Reference = reference, Translation = translation });
+            }
         }
 
         return preTranslations.ToArray();

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -21,6 +21,64 @@ public class PreTranslationServiceTests
     private const string TranslationEngine01 = "translationEngine01";
 
     [Test]
+    public async Task GetPreTranslationsAsync_CombinesSegmentedVerses()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        const int bookNum = 64;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
+        env.TranslationEnginesClient
+            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<Pretranslation>>(
+                    new List<Pretranslation>
+                    {
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:h_001" },
+                            Translation = "3 John",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001" },
+                            Translation = "By the old man,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_001" },
+                            Translation = "To my dear friend Gaius,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_002" },
+                            Translation = "whom I love in the truth:",
+                        },
+                    }
+                )
+            );
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            bookNum,
+            chapterNum,
+            CancellationToken.None
+        );
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreEqual("3JN 1:1", actual.First().Reference);
+        Assert.AreEqual(
+            "By the old man, To my dear friend Gaius, whom I love in the truth:",
+            actual.First().Translation
+        );
+    }
+
+    [Test]
     public void GetPreTranslationsAsync_ThrowsExceptionWhenProjectSecretMissing()
     {
         // Set up test environment
@@ -60,8 +118,8 @@ public class PreTranslationServiceTests
         PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
             User01,
             Project01,
-            40,
-            1,
+            bookNum,
+            chapterNum,
             CancellationToken.None
         );
         Assert.Zero(actual.Length);
@@ -81,7 +139,7 @@ public class PreTranslationServiceTests
                 Task.FromResult<IList<Pretranslation>>(
                     new List<Pretranslation>
                     {
-                        new Pretranslation { TextId = "40_1", Translation = "Matthew", },
+                        new Pretranslation { TextId = "40_1", Translation = "Matthew" },
                         new Pretranslation
                         {
                             TextId = "40_1",
@@ -104,8 +162,8 @@ public class PreTranslationServiceTests
         PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
             User01,
             Project01,
-            40,
-            1,
+            bookNum,
+            chapterNum,
             CancellationToken.None
         );
         Assert.AreEqual(2, actual.Length);


### PR DESCRIPTION
This Pull Request updates the data retrieved from Serval for Pre-Translation drafting so that verses that are broken into multiple style segments, e.g. `\p` or `\q1` are combined into one verse segment.

This will improve the quality of translation drafts for back translations and forward translations where the source translation uses these features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2171)
<!-- Reviewable:end -->
