### PR TITLE
SF-2268 Custom Configuration for MT Drafting

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -29,6 +29,7 @@ export interface BaseProject {
 export interface DraftConfig {
   alternateSource?: TranslateSource;
   lastSelectedBooks: number[];
+  servalConfig?: string;
 }
 
 export interface TranslateConfig {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -154,6 +154,9 @@ export class SFProjectService extends ProjectService<SFProject> {
                 items: {
                   bsonType: 'int'
                 }
+              },
+              servalConfig: {
+                bsonType: 'string'
               }
             },
             additionalProperties: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
@@ -10,6 +10,7 @@ export interface SFProjectSettings {
   translateShareEnabled?: boolean | null;
 
   alternateSourceParatextId?: string | null;
+  servalConfig?: string | null;
 
   checkingEnabled?: boolean | null;
   usersSeeEachOthersResponses?: boolean | null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -228,4 +228,8 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   async onlineDeleteAudioTimingData(projectId: string, book: number, chapter: number): Promise<void> {
     return await this.onlineInvoke('deleteAudioTimingData', { projectId, book, chapter });
   }
+
+  async onlineSetServalConfig(projectId: string, servalConfig: string | null | undefined): Promise<void> {
+    return await this.onlineInvoke<void>('setServalConfig', { projectId, servalConfig });
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -123,6 +123,28 @@
                   ></app-write-status>
                 </div>
               </ng-container>
+              <ng-container *ngIf="canUpdateServalConfig">
+                <p
+                  class="helper-text"
+                  [innerHTML]="i18n.translateAndInsertTags('settings.serval_config_description')"
+                ></p>
+                <mat-form-field [formGroup]="form" appearance="outline">
+                  <mat-label>{{ t("serval_config") }}</mat-label>
+                  <textarea
+                    appAutofocus
+                    matInput
+                    cdkTextareaAutosize
+                    id="serval-config"
+                    formControlName="servalConfig"
+                    (blur)="updateServalConfig()"
+                  ></textarea>
+                  <app-write-status
+                    [state]="getControlState('servalConfig')"
+                    [formGroup]="form"
+                    id="serval-config-status"
+                  ></app-write-status>
+                </mat-form-field>
+              </ng-container>
             </div>
           </mat-card-content>
           <mat-divider></mat-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -131,7 +131,6 @@
                 <mat-form-field [formGroup]="form" appearance="outline">
                   <mat-label>{{ t("serval_config") }}</mat-label>
                   <textarea
-                    appAutofocus
                     matInput
                     cdkTextareaAutosize
                     id="serval-config"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -287,6 +287,50 @@ describe('SettingsComponent', () => {
         verify(mockedSFProjectService.onlineSetServalConfig('project01', anything())).once();
         expect(env.statusDone(env.servalConfigStatus)).not.toBeNull();
       }));
+
+      it('should clear the serval config value', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({ draftConfig: { servalConfig: '{}', lastSelectedBooks: [] } });
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).not.toBeNull();
+        expect(env.servalConfigTextAreaElement.value).toBe('{}');
+        expect(env.statusDone(env.servalConfigStatus)).toBeNull();
+
+        env.setServalConfigValue('');
+
+        expect(env.servalConfigTextAreaElement.value).toBe('');
+
+        // Trigger the onblur, which will save the value
+        env.servalConfigTextAreaElement.dispatchEvent(new InputEvent('blur'));
+        env.wait();
+
+        verify(mockedSFProjectService.onlineSetServalConfig('project01', anything())).once();
+        expect(env.statusDone(env.servalConfigStatus)).not.toBeNull();
+      }));
+
+      it('should not update an unchanged serval config value', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).not.toBeNull();
+        expect(env.servalConfigTextAreaElement.value).toBe('');
+        expect(env.statusDone(env.servalConfigStatus)).toBeNull();
+
+        env.setServalConfigValue('');
+
+        expect(env.servalConfigTextAreaElement.value).toBe('');
+
+        // Trigger the onblur, which will trigger the save
+        env.servalConfigTextAreaElement.dispatchEvent(new InputEvent('blur'));
+        env.wait();
+
+        verify(mockedSFProjectService.onlineSetServalConfig('project01', anything())).never();
+        expect(env.statusDone(env.servalConfigStatus)).toBeNull();
+      }));
     });
 
     describe('Translation Suggestions options', () => {
@@ -870,6 +914,7 @@ class TestEnvironment {
 
   setServalConfigValue(value: string): void {
     this.servalConfigTextAreaElement.value = value;
+    this.servalConfigTextAreaElement.dispatchEvent(new Event('input'));
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnInit } from '@angular/core';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
 import { ActivatedRoute, Router } from '@angular/router';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { combineLatest } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -32,6 +34,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   sourceParatextId = new UntypedFormControl(undefined);
   biblicalTermsEnabled = new UntypedFormControl(false);
   alternateSourceParatextId = new UntypedFormControl(undefined);
+  servalConfig = new UntypedFormControl(undefined);
   translateShareEnabled = new UntypedFormControl(false);
   checkingEnabled = new UntypedFormControl(false);
   usersSeeEachOthersResponses = new UntypedFormControl(false);
@@ -46,6 +49,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     sourceParatextId: this.sourceParatextId,
     biblicalTermsEnabled: this.biblicalTermsEnabled,
     alternateSourceParatextId: this.alternateSourceParatextId,
+    servalConfig: this.servalConfig,
     translateShareEnabled: this.translateShareEnabled,
     checkingEnabled: this.checkingEnabled,
     usersSeeEachOthersResponses: this.usersSeeEachOthersResponses,
@@ -79,6 +83,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly router: Router,
     private readonly onlineStatusService: OnlineStatusService,
     readonly i18n: I18nService,
+    readonly authService: AuthService,
     readonly featureFlags: FeatureFlagService
   ) {
     super(noticeService);
@@ -132,6 +137,10 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
   get deleteButtonDisabled(): boolean {
     return !this.isAppOnline || !this.mainSettingsLoaded || this.isActiveSourceProject;
+  }
+
+  get canUpdateServalConfig(): boolean {
+    return this.authService.currentUserRole === SystemRole.SystemAdmin;
   }
 
   ngOnInit(): void {
@@ -237,6 +246,20 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     }
   }
 
+  updateServalConfig(): void {
+    if (this.projectDoc == null || this.projectDoc.data == null) {
+      return;
+    }
+
+    // Update Serval Configuration
+    const updateTaskPromise = this.projectService.onlineSetServalConfig(
+      this.projectDoc.id,
+      this.form.value.servalConfig
+    );
+    this.checkUpdateStatus('servalConfig', updateTaskPromise);
+    this.previousFormValues = this.form.value;
+  }
+
   set loading(loading: boolean) {
     loading ? this.loadingStarted() : this.loadingFinished();
     this.updateFormEnabled();
@@ -274,6 +297,11 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
     if (this.settingChanged(newValue, 'biblicalTermsEnabled') && this.biblicalTermsMessage == null) {
       this.updateSetting(newValue, 'biblicalTermsEnabled');
+      return;
+    }
+
+    // We only update the Serval config on blur
+    if (this.settingChanged(newValue, 'servalConfig')) {
       return;
     }
 
@@ -347,6 +375,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       sourceParatextId: this.projectDoc.data.translateConfig.source?.paratextId,
       biblicalTermsEnabled: this.projectDoc.data.biblicalTermsConfig.biblicalTermsEnabled,
       alternateSourceParatextId: this.projectDoc.data.translateConfig.draftConfig?.alternateSource?.paratextId,
+      servalConfig: this.projectDoc.data.translateConfig.draftConfig.servalConfig,
       translateShareEnabled: !!this.projectDoc.data.translateConfig.shareEnabled,
       checkingEnabled: this.projectDoc.data.checkingConfig.checkingEnabled,
       usersSeeEachOthersResponses: this.projectDoc.data.checkingConfig.usersSeeEachOthersResponses,
@@ -376,6 +405,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     this.controlStates.set('sourceParatextId', ElementState.InSync);
     this.controlStates.set('biblicalTermsEnabled', ElementState.InSync);
     this.controlStates.set('alternateSourceParatextId', ElementState.InSync);
+    this.controlStates.set('servalConfig', ElementState.InSync);
     this.controlStates.set('translateShareEnabled', ElementState.InSync);
     this.controlStates.set('checkingEnabled', ElementState.InSync);
     this.controlStates.set('usersSeeEachOthersResponses', ElementState.InSync);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -248,8 +248,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
   updateServalConfig(): void {
     if (
-      this.projectDoc == null ||
-      this.projectDoc.data == null ||
+      this.projectDoc?.data == null ||
       (this.form.value.servalConfig ?? '') === (this.projectDoc.data.translateConfig.draftConfig.servalConfig ?? '')
     ) {
       // Do not save if we do not have the project doc or if the configuration has not changed

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -247,7 +247,12 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   updateServalConfig(): void {
-    if (this.projectDoc == null || this.projectDoc.data == null) {
+    if (
+      this.projectDoc == null ||
+      this.projectDoc.data == null ||
+      (this.form.value.servalConfig ?? '') === (this.projectDoc.data.translateConfig.draftConfig.servalConfig ?? '')
+    ) {
+      // Do not save if we do not have the project doc or if the configuration has not changed
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -380,6 +380,8 @@
     "pre_translation_source_text_placeholder": "Alternate Drafting Source Text (optional)",
     "see_others_answers_and_comments": "Allow checkers to see each other's answers and comments",
     "select_project_or_resource": "Select the Paratext project or Digital Bible Library resource that your project is based on. If your project is based on a Paratext project, it's best to set it up as a daughter project in Paratext.",
+    "serval_config": "Serval Configuration (JSON)",
+    "serval_config_description": "{{ boldStart }}Warning:{{ boldEnd }} The following configuration is for Serval Technicians only:",
     "settings": "Settings",
     "shareTranslate": "Allow users of Translate to invite others",
     "shareChecking": "Allow users of Community Checking to invite others",

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -596,6 +596,35 @@ public class SFProjectsRpcController : RpcControllerBase
         }
     }
 
+    public async Task<IRpcMethodResult> SetServalConfig(string projectId, string? servalConfig)
+    {
+        try
+        {
+            await _projectService.SetServalConfigAsync(UserId, SystemRole, projectId, servalConfig);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "SetServalConfig" },
+                    { "projectId", projectId },
+                    { "servalConfig", servalConfig },
+                }
+            );
+            throw;
+        }
+    }
+
     public async Task<IRpcMethodResult> TransceleratorQuestions(string projectId)
     {
         try

--- a/src/SIL.XForge.Scripture/Models/DraftConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftConfig.cs
@@ -5,6 +5,6 @@ namespace SIL.XForge.Scripture.Models;
 public class DraftConfig
 {
     public TranslateSource? AlternateSource { get; set; }
-
     public IList<int> LastSelectedBooks { get; set; } = new List<int>();
+    public string? ServalConfig { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -41,4 +41,5 @@ public interface ISFProjectService : IProjectService
     );
     Task DeleteAudioTimingData(string userId, string projectId, int book, int chapter);
     Task SetPreTranslateAsync(string curUserId, string systemRole, string projectId, bool preTranslate);
+    Task SetServalConfigAsync(string curUserId, string systemRole, string projectId, string? servalConfig);
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.FeatureManagement;
+using Newtonsoft.Json.Linq;
 using Serval.Client;
 using SIL.Machine.Corpora;
 using SIL.Machine.WebApi.Services;
@@ -295,7 +296,10 @@ public class MachineProjectService : IMachineProjectService
                 translationEngineId = projectSecret.ServalData!.PreTranslationEngineId!;
 
                 // Execute a complete pre-translation
-                translationBuildConfig = GetTranslationBuildConfig(projectSecret.ServalData);
+                translationBuildConfig = GetTranslationBuildConfig(
+                    projectSecret.ServalData,
+                    projectDoc.Data.TranslateConfig.DraftConfig
+                );
             }
             else
             {
@@ -744,12 +748,16 @@ public class MachineProjectService : IMachineProjectService
     /// <summary>
     /// Gets the TranslationBuildConfig for the specified ServalData object.
     /// </summary>
-    /// <param name="servalData">The Serval data.</param>
+    /// <param name="servalData">The Serval data from <see cref="SFProjectSecret"/>.</param>
+    /// <param name="draftConfig">
+    /// The Draft configuration from <see cref="SFProject"/>.<see cref="TranslateConfig"/>.
+    /// </param>
     /// <returns>The TranslationBuildConfig for a Pre-Translate build.</returns>
     /// <remarks>Do not use with SMT builds.</remarks>
-    private static TranslationBuildConfig GetTranslationBuildConfig(ServalData servalData) =>
+    private static TranslationBuildConfig GetTranslationBuildConfig(ServalData servalData, DraftConfig draftConfig) =>
         new TranslationBuildConfig
         {
+            Options = draftConfig.ServalConfig is null ? null : JObject.Parse(draftConfig.ServalConfig),
             Pretranslate = servalData
                 .Corpora
                 .Where(s => s.Value.PreTranslate)

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -966,6 +966,18 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.PreTranslate, preTranslate));
     }
 
+    public async Task SetServalConfigAsync(string curUserId, string systemRole, string projectId, string? servalConfig)
+    {
+        if (systemRole != SystemRole.SystemAdmin)
+            throw new ForbiddenException();
+
+        await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
+        await projectDoc.SubmitJson0OpAsync(
+            op => op.Set(p => p.TranslateConfig.DraftConfig.ServalConfig, servalConfig)
+        );
+    }
+
     protected override async Task AddUserToProjectAsync(
         IConnection conn,
         IDocument<SFProject> projectDoc,

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
+using Newtonsoft.Json.Linq;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -970,6 +971,14 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     {
         if (systemRole != SystemRole.SystemAdmin)
             throw new ForbiddenException();
+
+        // Normalize whitespace and empty values to null
+        if (string.IsNullOrWhiteSpace(servalConfig))
+            servalConfig = null;
+
+        // Ensure that the config is valid JSON
+        if (servalConfig is not null)
+            JObject.Parse(servalConfig);
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
         IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);


### PR DESCRIPTION
This PR adds support for custom configuration for MT drafting. This config can be set in the Settings page for a project, and for security reasons, can only be set by a System Administrator.

A sample configuration to use on QA that would make it behave like Production would be:
```json
{"max_steps":20000}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2173)
<!-- Reviewable:end -->
