### PR TITLE
Make audio icons in checking area more consistent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -24,7 +24,8 @@
         (click)="chapterAudioDialog()"
         id="add-chapter-audio-button"
       >
-        <mat-icon class="mirror-rtl">audiotrack</mat-icon> <span fxHide.xs>{{ t("add_chapter_audio") }}</span>
+        <mat-icon class="material-icons-outlined">audio_file</mat-icon>
+        <span fxHide.xs>{{ t("add_chapter_audio") }}</span>
       </button>
     </ng-container>
     <ng-template #overallProgressChart>
@@ -97,7 +98,8 @@
                       <mat-icon
                         *ngIf="featureFlagsService.scriptureAudio.enabled && chapter.hasAudio"
                         title="{{ t('chapter_audio_attached') }}"
-                        >headset</mat-icon
+                        class="material-icons-outlined"
+                        >audio_file</mat-icon
                       ></span
                     >
                     <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
@@ -161,7 +163,9 @@
                           <mat-icon>edit</mat-icon>
                         </button>
                         v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
-                        <mat-icon class="audio-icon" *ngIf="questionDoc.data?.audioUrl">headset</mat-icon>
+                        <mat-icon class="audio-icon material-icons-outlined" *ngIf="questionDoc.data?.audioUrl">
+                          audio_file
+                        </mat-icon>
                         <span fxFlex class="no-overflow-ellipsis">
                           <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
                         </span>
@@ -332,7 +336,9 @@
                   >
                     <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
                       v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
-                      <mat-icon class="audio-icon" *ngIf="questionDoc.data?.audioUrl">headset</mat-icon>
+                      <mat-icon *ngIf="questionDoc.data?.audioUrl" class="audio-icon material-icons-outlined">
+                        audio_file
+                      </mat-icon>
                       <span fxFlex class="no-overflow-ellipsis">
                         <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
                       </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -13,7 +13,6 @@
       [matTooltip]="questionTooltip(questionDoc)"
     >
       <div class="question-title">
-        <mat-icon *ngIf="questionDoc.data?.audioUrl">headset</mat-icon>
         <span class="question-text">{{ questionText(questionDoc) }}</span>
       </div>
       <a *ngIf="getUnreadAnswers(questionDoc) > 0" class="view-answers" title="{{ t('view_answers') }}">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -100,7 +100,7 @@
                   mat-icon-button
                   (click)="addAudioTimingData()"
                 >
-                  <mat-icon>audiotrack</mat-icon>
+                  <mat-icon class="material-icons-outlined">audio_file</mat-icon>
                 </button>
               </ng-container>
               <button
@@ -109,7 +109,7 @@
                 mat-icon-button
                 (click)="toggleAudio()"
               >
-                <mat-icon>{{ isAudioPlaying() ? "pause" : "play_arrow" }}</mat-icon>
+                <mat-icon>{{ isAudioPlaying() ? "pause" : "play_circle_outline" }}</mat-icon>
               </button>
               <app-font-size [class.hidden]="hideChapterText" (apply)="applyFontChange($event)"></app-font-size>
               <app-share-button *ngIf="canShare" [defaultRole]="defaultShareRole"></app-share-button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -74,7 +74,7 @@
           <ng-container matColumnDef="audio_permission">
             <td mat-cell *matCellDef="let userRow">
               <div [matTooltip]="t('allow_manage_audio')" *ngIf="userRow.canManageAudio">
-                <mat-icon class="shift-left">audiotrack</mat-icon>
+                <mat-icon class="shift-left material-icons-outlined">audio_file</mat-icon>
               </div>
             </td>
           </ng-container>


### PR DESCRIPTION
- Removed headset icon from question list
- Used circle play icon for playing chapter audio
- The audio file icon is used for indicating upload of audio

### Checking overview
![](https://github.com/sillsdev/web-xforge/assets/6140710/c0044ffb-b585-498f-9b21-a987d3e9e90c)

### Checking page, audio available
![](https://github.com/sillsdev/web-xforge/assets/6140710/dcd41459-f9cd-40ef-9a83-1da8280f9688)

### Checking page, admin to upload audio
![](https://github.com/sillsdev/web-xforge/assets/6140710/5a271d04-41a5-4d8f-9173-ae854a464c06)

### User management page
![](https://github.com/sillsdev/web-xforge/assets/6140710/873ce7a0-9c6b-4950-add6-d01060e6e856)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2177)
<!-- Reviewable:end -->
