### PR TITLE
Update TypeScript to 4.9.5 in realtime server

### DIFF
--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -33,7 +33,7 @@
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/lodash-es": "^4.17.7",
-        "@types/node": "^16.11.36",
+        "@types/node": "^16.18.63",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -50,7 +50,7 @@
         "sharedb-mingo-memory": "^1.2.0",
         "ts-jest": "^29.0.3",
         "ts-mockito": "^2.6.1",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1499,9 +1499,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
-      "integrity": "sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA=="
+      "version": "16.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.63.tgz",
+      "integrity": "sha512-Q2VSI/lVKza0Z5qeY/JrHcwi9fxzBktDvNHthr0TVA/D3yMdHDw9syggng+wJPlsBLgx4jPpOrcJ100wnpniTg=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -6938,9 +6938,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8375,9 +8375,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "16.11.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.36.tgz",
-      "integrity": "sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA=="
+      "version": "16.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.63.tgz",
+      "integrity": "sha512-Q2VSI/lVKza0Z5qeY/JrHcwi9fxzBktDvNHthr0TVA/D3yMdHDw9syggng+wJPlsBLgx4jPpOrcJ100wnpniTg=="
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -12380,9 +12380,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -45,7 +45,7 @@
     "@types/jest": "^29.2.4",
     "@types/jsonwebtoken": "^9.0.0",
     "@types/lodash-es": "^4.17.7",
-    "@types/node": "^16.11.36",
+    "@types/node": "^16.18.63",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -62,6 +62,6 @@
     "sharedb-mingo-memory": "^1.2.0",
     "ts-jest": "^29.0.3",
     "ts-mockito": "^2.6.1",
-    "typescript": "~4.8.4"
+    "typescript": "~4.9.5"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -158,7 +158,7 @@
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/lodash-es": "^4.17.7",
-        "@types/node": "^16.11.36",
+        "@types/node": "^16.18.63",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -175,7 +175,7 @@
         "sharedb-mingo-memory": "^1.2.0",
         "ts-jest": "^29.0.3",
         "ts-mockito": "^2.6.1",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
       }
     },
     "../../RealtimeServer/node_modules/@ampproject/remapping": {
@@ -65764,7 +65764,7 @@
         "@types/jest": "^29.2.4",
         "@types/jsonwebtoken": "^9.0.0",
         "@types/lodash-es": "^4.17.7",
-        "@types/node": "^16.11.36",
+        "@types/node": "^16.18.63",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -65795,7 +65795,7 @@
         "ts-jest": "^29.0.3",
         "ts-mockito": "^2.6.1",
         "ts-object-path": "^0.1.2",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "websocket-json-stream": "^0.0.3",
         "ws": "^8.6.0"
       },
@@ -70365,8 +70365,7 @@
           }
         },
         "typescript": {
-          "version": "4.8.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+          "version": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
           "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
           "dev": true
         },


### PR DESCRIPTION
We already updated TypeScript and `@types/node` in ClientApp, but didn't do so for the realtime server. We should keep package versions in sync as much as possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2180)
<!-- Reviewable:end -->
