### PR TITLE
SF-2344 Adjust pre-translation book selection

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'connect_project'">
-  <div class="title mat-display-1">{{ t("connect_paratext_project") }}</div>
+  <div class="title mat-headline-4">{{ t("connect_paratext_project") }}</div>
   <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
   <div class="content" [ngSwitch]="state">
     <div *ngSwitchCase="'login'" class="paratext-login-container">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'settings'">
   <div fxLayout="column" fxLayoutGap="2rem" class="container">
-    <div class="mat-display-1">{{ t("settings") }}</div>
+    <div class="mat-headline-4">{{ t("settings") }}</div>
     <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_change_settings") }} </span>
     <div>
       <mat-card class="card card-outline">
@@ -243,7 +243,7 @@
     </div>
 
     <div id="danger-zone">
-      <div class="mat-title">{{ t("danger_zone") }}</div>
+      <div class="mat-headline-6">{{ t("danger_zone") }}</div>
       <mat-card class="card-content" id="delete-project">
         <h4>{{ t("delete_this_project") }}</h4>
         <p *ngIf="isActiveSourceProject; else deleteMessage" class="source-project-msg">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,8 +1,13 @@
 <ng-container *transloco="let t">
-  <mat-chip-list [multiple]="true" class="book-multi-select" [class.readonly]="readonly">
-    <mat-chip *ngFor="let book of bookOptions" [selected]="book.selected" (click)="!readonly && toggleSelection(book)">
-      <mat-icon *ngIf="book.selected && !readonly">check</mat-icon>
+  <mat-chip-listbox
+    [multiple]="true"
+    [selectable]="!readonly"
+    class="book-multi-select"
+    [class.readonly]="readonly"
+    (change)="onChipListChange($event)"
+  >
+    <mat-chip-option *ngFor="let book of bookOptions" [value]="book" [selected]="book.selected">
       {{ t("canon.book_names." + book.bookId) }}
-    </mat-chip>
-  </mat-chip-list>
+    </mat-chip-option>
+  </mat-chip-listbox>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -1,37 +1,19 @@
-@use 'src/variables' as vars;
-
-// TODO: Mat chips get significant changes in material 15+, so these styles need to be revisited after upgrade
-
-.mat-chip {
-  cursor: pointer;
-}
-
-mat-icon {
-  width: auto;
-  height: auto;
-  font-size: 17px;
-  margin-inline-end: 10px;
-}
-
-.mat-chip-list {
-  .mat-chip-selected {
-    background-color: #4a79c9;
+.book-multi-select {
+  .mat-mdc-standard-chip.mat-primary.mat-mdc-chip-selected,
+  .mat-mdc-standard-chip.mat-primary.mat-mdc-chip-highlighted {
+    --mdc-chip-elevated-container-color: #4a79c9;
   }
 
   &.readonly {
-    .mat-chip {
-      cursor: unset;
+    .mat-mdc-standard-chip.mat-primary.mat-mdc-chip-selected,
+    .mat-mdc-standard-chip.mat-primary.mat-mdc-chip-highlighted {
+      --mdc-chip-elevated-container-color: #627186;
     }
 
-    .mat-chip-selected {
-      background-color: #627186;
+    ::ng-deep {
+      .mat-mdc-chip-action {
+        cursor: unset;
+      }
     }
-  }
-}
-
-// .material-icons class has 'direction: ltr' even when ancestor is rtl
-:host-context([dir='rtl']) {
-  mat-icon {
-    direction: rtl;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
-
-import { configureTestingModule } from 'xforge-common/test-utils';
+import { MatChipsModule } from '@angular/material/chips';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { BookMultiSelectComponent, BookOption } from './book-multi-select.component';
 
 describe('BookMultiSelectComponent', () => {
@@ -12,8 +11,7 @@ describe('BookMultiSelectComponent', () => {
   const mockSelectedBooks: number[] = [1, 3];
 
   configureTestingModule(() => ({
-    imports: [MatChipsModule],
-    declarations: [BookMultiSelectComponent]
+    imports: [MatChipsModule, TestTranslocoModule]
   }));
 
   beforeEach(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -1,4 +1,7 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { MatChipListboxChange, MatChipsModule } from '@angular/material/chips';
+import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 
 export interface BookOption {
@@ -10,6 +13,8 @@ export interface BookOption {
 @Component({
   selector: 'app-book-multi-select',
   templateUrl: './book-multi-select.component.html',
+  standalone: true,
+  imports: [CommonModule, MatChipsModule, TranslocoModule],
   styleUrls: ['./book-multi-select.component.scss']
 })
 export class BookMultiSelectComponent implements OnChanges {
@@ -28,17 +33,17 @@ export class BookMultiSelectComponent implements OnChanges {
   }
 
   initBookOptions(): void {
+    const selectedSet = new Set<number>(this.selectedBooks);
+
     this.bookOptions = this.availableBooks.map((bookNum: number) => ({
       bookNum,
       bookId: Canon.bookNumberToId(bookNum),
-      selected: this.selectedBooks?.includes(bookNum) ?? false
+      selected: selectedSet.has(bookNum)
     }));
   }
 
-  toggleSelection(book: BookOption): void {
-    book.selected = !book.selected;
-    this.bookSelect.emit(
-      this.bookOptions.filter((opt: BookOption) => opt.selected).map((opt: BookOption) => opt.bookNum)
-    );
+  onChipListChange(event: MatChipListboxChange): void {
+    this.selectedBooks = event.value.map((item: BookOption) => item.bookNum);
+    this.bookSelect.emit(this.selectedBooks);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
@@ -6,7 +6,6 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { CheckingQuestionComponent } from '../checking/checking/checking-answers/checking-question/checking-question.component';
 import { SingleButtonAudioPlayerComponent } from '../checking/checking/single-button-audio-player/single-button-audio-player.component';
 import { BookChapterChooserComponent } from './book-chapter-chooser/book-chapter-chooser.component';
-import { BookMultiSelectComponent } from './book-multi-select/book-multi-select.component';
 import { ChapterNavComponent } from './chapter-nav/chapter-nav.component';
 import { InfoComponent } from './info/info.component';
 import { NoticeComponent } from './notice/notice.component';
@@ -27,8 +26,7 @@ const componentExports = [
   TextComponent,
   CheckingQuestionComponent,
   SingleButtonAudioPlayerComponent,
-  WorkingAnimatedIndicatorComponent,
-  BookMultiSelectComponent
+  WorkingAnimatedIndicatorComponent
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,46 +1,14 @@
 <ng-container *transloco="let t; read: 'draft_generation_steps'">
-  <mat-stepper orientation="vertical" [linear]="true">
-    <mat-step>
-      <ng-template matStepLabel>
-        {{ t("choose_books_for_training") }}
-        <mat-icon class="material-icons-outlined" [matMenuTriggerFor]="trainingInfo">info</mat-icon>
-      </ng-template>
-      <app-book-multi-select
-        [availableBooks]="(availableBooks$ | async) ?? []"
-        [selectedBooks]="selectedBooks"
-        (bookSelect)="onBookSelect($event)"
-      ></app-book-multi-select>
-      <div class="stepper-nav">
-        <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext color="primary">
-          {{ t("next") }}
-        </button>
-      </div>
-    </mat-step>
+  <h2>{{ t("choose_books_for_training") }}</h2>
+  <h3>{{ t("choose_books_for_training_subheader") }}</h3>
 
-    <mat-step>
-      <ng-template matStepLabel>
-        {{ t("confirm_books_and_generate") }}
-      </ng-template>
-      <app-book-multi-select
-        [availableBooks]="selectedBooks"
-        [selectedBooks]="selectedBooks"
-        [readonly]="true"
-      ></app-book-multi-select>
-      <p *ngIf="!selectedBooks.length">{{ t("no_books_selected") }}</p>
-      <div class="stepper-nav">
-        <button *ngIf="!selectedBooks.length" mat-flat-button matStepperPrevious color="primary">
-          {{ t("back") }}
-        </button>
-        <button *ngIf="selectedBooks.length" mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-        <button mat-flat-button [disabled]="!selectedBooks.length" matStepperNext (click)="onDone()" color="primary">
-          {{ t("generate_draft") }}
-        </button>
-      </div>
-    </mat-step>
-  </mat-stepper>
+  <app-book-multi-select
+    [availableBooks]="(availableBooks$ | async) ?? []"
+    [selectedBooks]="initialSelectedBooks"
+    (bookSelect)="onBookSelect($event)"
+  ></app-book-multi-select>
 
-  <mat-menu #trainingInfo="matMenu" class="draft-generation-steps-info-menu">
-    <mat-icon class="material-icons-outlined">info</mat-icon>
-    {{ t("choose_books_for_training_info") }}
-  </mat-menu>
+  <button mat-flat-button [disabled]="!finalSelectedBooks.length" (click)="onDone()" color="primary">
+    {{ t("generate_draft") }}
+  </button>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -1,43 +1,18 @@
-@use 'src/xforge-common/media-breakpoints/breakpoints' as *;
+h2 {
+  font-size: 20px;
+  font-weight: 500;
+  margin-bottom: 0;
+}
 
-.stepper-nav {
+h3 {
+  font-size: 15px;
+  font-weight: 400;
+  margin-top: 4px;
+  color: #777;
+}
+
+button {
   margin-top: 20px;
-  display: flex;
-  justify-content: flex-start;
-  gap: 8px;
-}
-
-mat-stepper {
-  ::ng-deep {
-    // Space and vertically center the 'info' icon
-    .mat-step-text-label {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-  }
-}
-
-// Menu exists in overlay, so ::ng-deep cannot be nested under :host
-::ng-deep {
-  .draft-generation-steps-info-menu {
-    .mat-menu-content {
-      padding: 16px;
-      background-color: #f7faff;
-      color: #002546;
-      font-style: italic;
-
-      mat-icon {
-        vertical-align: text-bottom;
-        margin-inline-end: 2px;
-      }
-    }
-
-    // Allow wider info popup on larger screens (default is 280px)
-    @include media-breakpoint('>', sm) {
-      max-width: 460px;
-    }
-  }
 }
 
 app-book-multi-select {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
-import { BookMultiSelectComponent } from 'src/app/shared/book-multi-select/book-multi-select.component';
 import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
@@ -33,7 +32,6 @@ describe('DraftGenerationStepsComponent', () => {
 
   configureTestingModule(() => ({
     imports: [UICommonModule, TestTranslocoModule, NoopAnimationsModule],
-    declarations: [DraftGenerationStepsComponent, BookMultiSelectComponent],
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: SFProjectService, useMock: mockProjectService }
@@ -52,25 +50,20 @@ describe('DraftGenerationStepsComponent', () => {
       tick();
     }));
 
-    it('should set availableBooks$ correctly', () => {
+    it('should set availableBooks$ correctly', fakeAsync(() => {
       component.availableBooks$?.subscribe(books => {
         expect(books).toEqual([1, 2, 3]);
       });
-
-      expect(component.selectedBooks).toEqual([1, 2, 3]);
-    });
+    }));
 
     it('should select all books initially', () => {
-      component.availableBooks$?.subscribe(() => {
-        expect(component.selectedBooks).toEqual([1, 2, 3]);
-      });
-
-      expect(component.selectedBooks).toEqual([1, 2, 3]);
+      expect(component.initialSelectedBooks).toEqual([1, 2, 3]);
+      expect(component.finalSelectedBooks).toEqual([1, 2, 3]);
     });
 
     it('should emit the correct selected books when onDone is called', () => {
       const mockSelectedBooks = [1, 2, 3];
-      component.selectedBooks = mockSelectedBooks;
+      component.finalSelectedBooks = mockSelectedBooks;
 
       spyOn(component.done, 'emit');
 
@@ -113,7 +106,7 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should restore previously selected books', () => {
-      expect(component.selectedBooks).toEqual([2, 3]);
+      expect(component.initialSelectedBooks).toEqual([2, 3]);
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,8 +1,12 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { TranslocoModule } from '@ngneat/transloco';
 import { from, Observable } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
 
 export interface DraftGenerationStepsResult {
   books: number[];
@@ -11,13 +15,16 @@ export interface DraftGenerationStepsResult {
 @Component({
   selector: 'app-draft-generation-steps',
   templateUrl: './draft-generation-steps.component.html',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, TranslocoModule, BookMultiSelectComponent],
   styleUrls: ['./draft-generation-steps.component.scss']
 })
 export class DraftGenerationStepsComponent implements OnInit {
   @Output() done = new EventEmitter<DraftGenerationStepsResult>();
 
   availableBooks$?: Observable<number[]>;
-  selectedBooks: number[] = [];
+  initialSelectedBooks: number[] = [];
+  finalSelectedBooks: number[] = [];
 
   constructor(
     private readonly activatedProject: ActivatedProjectService,
@@ -50,16 +57,17 @@ export class DraftGenerationStepsComponent implements OnInit {
         const intersection = availableBooks.filter(bookNum => previousBooks.has(bookNum));
 
         // Set the selected books to the intersection, or if the intersection is empty, just return all available books
-        this.selectedBooks = intersection.length > 0 ? intersection : availableBooks;
+        this.initialSelectedBooks = intersection.length > 0 ? intersection : availableBooks;
+        this.finalSelectedBooks = this.initialSelectedBooks;
       })
     );
   }
 
   onBookSelect(selectedBooks: number[]): void {
-    this.selectedBooks = selectedBooks;
+    this.finalSelectedBooks = selectedBooks;
   }
 
   onDone(): void {
-    this.done.emit({ books: this.selectedBooks });
+    this.done.emit({ books: this.finalSelectedBooks });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -24,7 +24,6 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { SharedModule } from '../../shared/shared.module';
-import { DraftGenerationStepsComponent } from './draft-generation-steps/draft-generation-steps.component';
 import { DraftGenerationComponent, InfoAlert } from './draft-generation.component';
 import { DraftGenerationService } from './draft-generation.service';
 import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
@@ -74,7 +73,6 @@ describe('DraftGenerationComponent', () => {
       }
 
       TestBed.configureTestingModule({
-        declarations: [DraftGenerationComponent, DraftGenerationStepsComponent],
         imports: [
           UICommonModule,
           SharedModule,
@@ -108,7 +106,10 @@ describe('DraftGenerationComponent', () => {
         'FeatureFlagService',
         {},
         {
-          allowForwardTranslationNmtDrafting: { enabled: false } as ObservableFeatureFlag
+          allowForwardTranslationNmtDrafting: {
+            enabled: false,
+            enabled$: of(false)
+          } as ObservableFeatureFlag
         }
       );
       mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog']);
@@ -283,7 +284,10 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: { enabled: true } as ObservableFeatureFlag
+            allowForwardTranslationNmtDrafting: {
+              enabled: true,
+              enabled$: of(true)
+            } as ObservableFeatureFlag
           }
         );
       });
@@ -323,7 +327,10 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: { enabled: true } as ObservableFeatureFlag
+            allowForwardTranslationNmtDrafting: {
+              enabled: true,
+              enabled$: of(true)
+            } as ObservableFeatureFlag
           }
         );
       });
@@ -342,7 +349,10 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: { enabled: true } as ObservableFeatureFlag
+            allowForwardTranslationNmtDrafting: {
+              enabled: true,
+              enabled$: of(true)
+            } as ObservableFeatureFlag
           }
         );
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
-  <div class="title mat-display-1">{{ t("translate_overview") }}</div>
+  <div class="title mat-headline-4">{{ t("translate_overview") }}</div>
   <div class="card-wrapper">
     <mat-card class="books-card">
       <mat-card-header id="translate-overview-title" class="books-card-title">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -32,8 +32,7 @@ import { TranslateRoutingModule } from './translate-routing.module';
     TrainingProgressComponent,
     TranslateOverviewComponent,
     DraftGenerationComponent,
-    DraftViewerComponent,
-    DraftGenerationStepsComponent
+    DraftViewerComponent
   ],
   imports: [
     AngularSplitModule,
@@ -43,7 +42,8 @@ import { TranslateRoutingModule } from './translate-routing.module';
     UICommonModule,
     XForgeCommonModule,
     TranslocoModule,
-    TranslocoMarkupModule
+    TranslocoMarkupModule,
+    DraftGenerationStepsComponent
   ]
 })
 export class TranslateModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -184,13 +184,9 @@
     "warning_generation_faulted_header": "Last generation attempt failed"
   },
   "draft_generation_steps": {
-    "back": "Back",
     "choose_books_for_training": "Choose books for training",
-    "choose_books_for_training_info": "Choose books with the most polished translations, as these will be used to train the model.",
-    "confirm_books_and_generate": "Confirm books and generate",
-    "generate_draft": "Generate draft",
-    "next": "Next",
-    "no_books_selected": "Click \"{{ draft_generation_steps.back }}\" to select books."
+    "choose_books_for_training_subheader": "Select books that have been proofed.",
+    "generate_draft": "Generate draft"
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -10,7 +10,9 @@
 //  you can delete this line and instead use:
 //    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
 @include mat.all-legacy-component-typographies();
+@include mat.all-component-typographies();
 @include mat.legacy-core();
+@include mat.core();
 
 $mat-sf-purple: (
   200: $purpleLight,
@@ -105,7 +107,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-button-theme($material-app-theme);
 @include mat.legacy-card-theme($material-app-theme);
 @include mat.legacy-checkbox-theme($material-app-theme);
-@include mat.legacy-chips-theme($material-app-theme);
+@include mat.chips-theme($material-app-theme);
 @include mat.legacy-dialog-theme($material-app-theme);
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -8,7 +8,7 @@ import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatLegacyOptionModule as MatOptionModule } from '@angular/material/legacy-core';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatDividerModule } from '@angular/material/divider';


### PR DESCRIPTION
This PR makes changes to the book selector that is presented when generating a new draft.
- Changed info message to be always visible under step heading, and update the text to say: "Select books that have been proofed".
- Removed unnecessary second step.

Additionally:
- Changed the stepper and book selector components to be 'standalone'
- Migrated the `MatChipsModule` to not refer to the legacy module using `ng generate @angular/material:mdc-migration`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2181)
<!-- Reviewable:end -->
