### PR TITLE
SF-2314 Allow opening roles & permissions dialog offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -110,7 +110,7 @@
                 <button
                   mat-menu-item
                   (click)="openRolesDialog(userRow)"
-                  [disabled]="!isAppOnline || isAdmin(userRow.role) || userRow.inviteeStatus"
+                  [disabled]="isAdmin(userRow.role) || userRow.inviteeStatus"
                 >
                   {{ t("edit_roles_and_permissions") }}
                 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
@@ -16,6 +16,7 @@
         <a mat-flat-button class="learn-more-btn" [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
       </div>
     </app-notice>
+    <span class="offline-text" *ngIf="form.disabled">{{ t("offline") }}</span>
     <h3>{{ t("roles") }}</h3>
     <mat-radio-group class="roleOptions" formControlName="roles">
       <mat-radio-button class="roleButton" *ngFor="let role of roleOptions" [value]="role">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
@@ -43,6 +43,10 @@ h3 {
   margin: 12px 0px;
 }
 
+.offline-text {
+  margin-top: 6px;
+}
+
 .learn-more-btn {
   background-color: var(--notice-color);
   color: #fff;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -329,7 +329,7 @@
     "cancel": "Cancel",
     "learn_more": "Learn More",
     "none": "None",
-    "offline": "Editing is unavailable while offline.",
+    "offline": "Changing roles & permissions is unavailable while offline.",
     "permissions": "Additional Permissions",
     "pt_administrator": "Administrator",
     "pt_consultant": "Consultant/Reviewer/Archivist/Typesetter",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -329,6 +329,7 @@
     "cancel": "Cancel",
     "learn_more": "Learn More",
     "none": "None",
+    "offline": "Editing is unavailable while offline.",
     "permissions": "Additional Permissions",
     "pt_administrator": "Administrator",
     "pt_consultant": "Consultant/Reviewer/Archivist/Typesetter",


### PR DESCRIPTION
The dialog can be opened while offline, but the fields are still not editable. I added some text to indicate this in the dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2182)
<!-- Reviewable:end -->
