### PR TITLE
SF-2345 Fix MatSlider in audio player in RTL mode

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -1,16 +1,9 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
   <div *ngIf="!hasProblem" class="content" dir="ltr">
     <div class="current-time">{{ audio?.currentTime ?? 0 | audioTime }}</div>
-    <mat-slider
-      class="slider"
-      [disabled]="!isAudioAvailable"
-      [min]="0"
-      [max]="100"
-      [step]="1"
-      [value]="seek"
-      (input)="onSeek($event)"
-      [dir]="i18n.direction"
-    ></mat-slider>
+    <mat-slider class="slider" [disabled]="!isAudioAvailable" [min]="0" [max]="100">
+      <input matSliderThumb [value]="seek" (dragEnd)="onSeek($event)" />
+    </mat-slider>
     <div class="duration">{{ duration | audioTime }}</div>
   </div>
   <div *ngIf="hasProblem" class="audio-not-available">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.scss
@@ -8,17 +8,7 @@
     font-size: 0.8em;
   }
   .slider {
-    flex: 1;
-    width: 100%;
-    ::ng-deep .mat-slider-track-background {
-      background-color: #e0e0e0;
-    }
-    ::ng-deep .mat-slider-thumb {
-      background-color: #000;
-    }
-    &[dir='rtl'] {
-      transform: rotateY(180deg);
-    }
+    flex-grow: 1;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { MatLegacySliderChange as MatSliderChange } from '@angular/material/legacy-slider';
+import { MatSliderDragEvent } from '@angular/material/slider';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { AudioPlayerBaseComponent } from '../audio-player-base/audio-player-base.component';
@@ -26,15 +26,7 @@ export class AudioPlayerComponent extends AudioPlayerBaseComponent {
     return this.audio?.seek ?? 0;
   }
 
-  onSeek(event: MatSliderChange): void {
-    let seek: number | null = event.value;
-    if (seek == null) return;
-    if (this.i18n.direction === 'rtl') {
-      // It appears that a bug in @angular/material@14.x prevents the slider from working in RTL environments.
-      // The workaround is to flip the slider over the y-axis (so it appears LTR). But to allow seeking to work,
-      // the seek value is set to the inverse of the value that is emitted from the slider.
-      seek = 100 - seek;
-    }
-    this.audio?.setSeek(seek);
+  onSeek(event: MatSliderDragEvent): void {
+    this.audio?.setSeek(event.value);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -33,14 +33,9 @@
           <span>{{ confidenceThreshold }}%</span>
           <span>{{ t("better") }}</span>
         </div>
-        <mat-slider
-          id="confidence-threshold-slider"
-          [disabled]="translationSuggestionsDisabled"
-          [min]="0"
-          [max]="100"
-          [(ngModel)]="confidenceThreshold"
-          (input)="confidenceThreshold = $event.value ?? 0"
-        ></mat-slider>
+        <mat-slider id="confidence-threshold-slider" [disabled]="translationSuggestionsDisabled" [min]="0" [max]="100">
+          <input matSliderThumb [(ngModel)]="confidenceThreshold" (dragEnd)="confidenceThreshold = $event.value" />
+        </mat-slider>
       </div>
     </div>
     <div class="row">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -6,7 +6,7 @@ import {
   MatLegacyDialogConfig as MatDialogConfig
 } from '@angular/material/legacy-dialog';
 import { MatLegacySelect as MatSelect } from '@angular/material/legacy-select';
-import { MatLegacySlider as MatSlider } from '@angular/material/legacy-slider';
+import { MatSlider } from '@angular/material/slider';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import cloneDeep from 'lodash-es/cloneDeep';
@@ -89,7 +89,7 @@ describe('SuggestionsSettingsDialogComponent', () => {
   it('shows correct confidence threshold even when suggestions disabled', fakeAsync(() => {
     const env = new TestEnvironment(false);
     env.openDialog();
-    expect(env.confidenceThresholdSlider.value).toEqual(50);
+    expect(env.component?.confidenceThreshold).toEqual(50);
     env.closeDialog();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -121,7 +121,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-select-theme($material-app-theme);
 @include mat.sidenav-theme($material-app-theme);
 @include mat.legacy-slide-toggle-theme($material-app-theme);
-@include mat.legacy-slider-theme($material-app-theme);
+@include mat.slider-theme($material-app-theme);
 @include mat.legacy-snack-bar-theme($material-app-theme);
 @include mat.stepper-theme($material-app-theme);
 @include mat.legacy-table-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -28,7 +28,7 @@ import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
-import { MatLegacySliderModule as MatSliderModule } from '@angular/material/legacy-slider';
+import { MatSliderModule } from '@angular/material/slider';
 import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatStepperModule } from '@angular/material/stepper';


### PR DESCRIPTION
The issue this is fixing is the jumpyness when seeking in RTL mode. The problem is caused by the Material slider which is supposed to support RTL mode, but since this is an audio player, we want it to stay in LTR mode. But it refuses to cooperate, which led to workarounds that don't fully work.

I updated us to the MDC-based Material slider, removed the workarounds, set the direction to LTR, and things now work fine.

In addition, I fixed two other issues:
1. Previously, as you seek, it would immediately jump to that point in the audio, meaning you hear choppiness while seeking. Instead, we now listen to the dragEnd event, which is how I think most decent audio players work.
2. Previously if you dragged towards the end of the audio, and overshot and brought the slider to the end of the audio, it would immediately close the player, since you had "reached the end." This is not intuitive, and clearly not what the user was expecting (they're clearly trying to seek, not close the player). This is also fixed by listening for the dragEnd event instead.

https://github.com/sillsdev/web-xforge/assets/6140710/8eb6fd81-56f2-46b1-ae72-0c6a64aec878



### Audio players in LTR mode, with scripture audio feature flag off
![](https://github.com/sillsdev/web-xforge/assets/6140710/cd031bbf-d835-49a8-b590-af357291a4b7)

### Playing a chapter in RTL mode
![](https://github.com/sillsdev/web-xforge/assets/6140710/5120f9c9-376f-4b73-bb81-2e77f7300986)

### The translate settings dialog was impacted by the update to the MDC-based slider
![](https://github.com/sillsdev/web-xforge/assets/6140710/4cc90f06-4f36-40af-84ef-1aa862de05d3)