### PR TITLE
SF-2348 Mirror question mark in RTL contexts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -97,6 +97,10 @@ quill-editor {
   }
 }
 
+.read-only-editor[dir='rtl'] > .ql-container > .ql-editor .question-segment[data-question-count]:before {
+  transform: scaleX(-1);
+}
+
 .comment-enabled-editor {
   quill-editor:not(.read-only-editor) .ql-editor {
     padding-inline-start: 10px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -33,7 +33,7 @@
         </mat-menu>
 
         <button mat-icon-button title="{{ t('help') }}" [matMenuTriggerFor]="helpMenu">
-          <mat-icon>help</mat-icon>
+          <mat-icon class="mirror-rtl">help</mat-icon>
         </button>
         <mat-menu #helpMenu="matMenu" class="help-menu">
           <a mat-menu-item target="_blank" [href]="urls.helps">{{ t("help") }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -243,7 +243,7 @@
         <div class="stat-total">{{ allQuestionsCount }}</div>
         <div class="stat-label">{{ t("questions") }}</div>
       </span>
-      <span fxLayoutAlign="start center"> <mat-icon>help</mat-icon> </span>
+      <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">help</mat-icon> </span>
     </mat-card>
     <mat-card class="card card-content-answer">
       <span fxFlex>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
@@ -21,7 +21,7 @@
     <div class="question-text" [class]="focusedText">
       <span class="spacer"></span>
       <div *ngIf="!questionAudioUrl" id="noQuestionAudio" [class]="focusedText">
-        <mat-icon class="mirror-rtl" fontIcon="question_answer"></mat-icon>
+        <mat-icon class="mirror-rtl">question_answer</mat-icon>
       </div>
       <app-single-button-audio-player
         #questionAudio

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,6 +1,8 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
   <div class="dialog-container">
-    <h1 mat-dialog-title fxLayoutAlign="start center"><i class="material-icons">live_help</i> {{ modeLabel }}</h1>
+    <h1 mat-dialog-title fxLayoutAlign="start center">
+      <mat-icon class="mirror-rtl">live_help</mat-icon> {{ modeLabel }}
+    </h1>
     <mat-dialog-content [formGroup]="questionForm" (ngSubmit)="submit()" class="content-padding" #dialogForm="ngForm">
       <div fxLayout="row wrap" fxLayoutAlign="space-around start" fxLayoutGap.gt-xs="1em">
         <mat-form-field class="scripture-reference" id="scripture-start" appearance="outline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.html
@@ -1,3 +1,3 @@
 <a #tooltip="matTooltip" (click)="tooltip.show()" [matTooltip]="text">
-  <mat-icon [class]="type">{{ icon }}</mat-icon>
+  <mat-icon [class]="type" [class.mirror-rtl]="mirrorRTL">{{ icon }}</mat-icon>
 </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.scss
@@ -11,6 +11,7 @@ a {
 
   mat-icon {
     font-size: 18px;
+    // Work around weird pixelation that happens when icons are scaled down
     // https://github.com/google/material-design-icons/issues/648
     transform: rotate(0.03deg);
     width: unset;
@@ -27,4 +28,10 @@ a {
       color: variables.$orange;
     }
   }
+}
+
+::ng-deep body[dir='rtl'] app-info mat-icon.mirror-rtl {
+  // There's a global mirror-rtl class, but it is overridden by the transform workaround above, so we need to
+  // re-apply the mirroring here.
+  transform: scaleX(-1) rotate(0.03deg);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { ICONS_TO_MIRROR_RTL } from '../utils';
 
 @Component({
   selector: 'app-info',
@@ -11,4 +12,8 @@ export class InfoComponent {
   @Input() text: string = '';
 
   constructor() {}
+
+  get mirrorRTL(): boolean {
+    return ICONS_TO_MIRROR_RTL.includes(this.icon ?? '');
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
@@ -1,4 +1,4 @@
 <div [ngClass]="{ outline }" [class]="type">
-  <mat-icon *ngIf="icon">{{ icon }}</mat-icon>
+  <mat-icon *ngIf="icon" [class.mirror-rtl]="mirrorRTL">{{ icon }}</mat-icon>
   <span class="notice-content"><ng-content></ng-content></span>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { ICONS_TO_MIRROR_RTL } from '../utils';
 
 @Component({
   selector: 'app-notice',
@@ -11,4 +12,8 @@ export class NoticeComponent {
   @Input() outline: boolean = false;
 
   constructor() {}
+
+  get mirrorRTL(): boolean {
+    return ICONS_TO_MIRROR_RTL.includes(this.icon ?? '');
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -268,3 +268,22 @@ export class XmlUtils {
     }
   }
 }
+
+/**
+ * A non-exhaustive list of icons that should be mirrored in RTL languages.
+ * Some icons (as as arrows) should be mirrored in certain contexts and not others, or require more attention to detail
+ * than merely mirroring. This list is ONLY for those icons that can be mirrored in all contexts.
+ */
+export const ICONS_TO_MIRROR_RTL = [
+  'book',
+  'bookmarks',
+  'comment',
+  'forum',
+  'help',
+  'library_books',
+  'live_help',
+  'people',
+  'person_add',
+  'post_add',
+  'question_answer'
+];


### PR DESCRIPTION
Question marks should be mirrored in a RTL context, per https://rtlstyling.com/posts/rtl-styling#bidirectional-icons. This makes sense, since Arabic uses question marks, and they're the other way around.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2184)
<!-- Reviewable:end -->
