### PR TITLE
SF-2318 Right align suggestions when there's overflow

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
@@ -48,12 +48,12 @@ mat-selection-list[dense] {
   padding: 0;
 
   > mat-list-option {
-    height: 32px;
+    height: auto;
   }
 }
 
 .mat-list-option ::ng-deep .mat-list-item-content {
-  padding: 0 8px !important;
+  padding: 6px 8px !important;
   .mat-list-text {
     padding: 0 !important;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.scss
@@ -4,7 +4,6 @@
   background-color: #faf9f7;
   position: absolute;
   z-index: 2;
-  white-space: nowrap;
   font-size: 14px;
   border-radius: 2px;
   overflow: hidden;
@@ -49,7 +48,7 @@ mat-selection-list[dense] {
   padding: 0;
 
   > mat-list-option {
-    height: 30px;
+    height: 32px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -265,7 +265,10 @@ export class SuggestionsComponent extends SubscriptionDisposable implements OnDe
 
     let newLeft;
     if (referenceLeft + suggestions.width > editor.width) {
-      newLeft = editor.width - suggestions.width; //right align
+      // Most cases are fine with simply referenceLeft, but when the cursor
+      // is at the far right of the editor, the suggestions don't have enough
+      // room, even when auto-sized.
+      newLeft = referenceLeft - 20;
     } else if (clientLeft < body.left) {
       const shift = body.left - clientLeft;
       newLeft = referenceLeft + shift;
@@ -273,7 +276,7 @@ export class SuggestionsComponent extends SubscriptionDisposable implements OnDe
       newLeft = referenceLeft;
     }
 
-    return newLeft > 0 ? newLeft : 0;
+    return newLeft;
   }
 
   private isSuggestionEvent(event: KeyboardEvent): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -234,9 +234,8 @@ export class SuggestionsComponent extends SubscriptionDisposable implements OnDe
     const bodyBounds = document.body.getBoundingClientRect();
     const clientLeft = reference.left + editorBounds.left;
     const clientTop = reference.bottom + editorBounds.top + 5;
-    if (clientLeft + rootBounds.width > bodyBounds.right) {
-      const shift = bodyBounds.right - (clientLeft + rootBounds.width);
-      this.root.style.left = left + shift + 'px';
+    if (left + rootBounds.width > editorBounds.width) {
+      this.root.style.left = editorBounds.width - rootBounds.width + 'px'; //right align
     } else if (clientLeft < bodyBounds.left) {
       const shift = bodyBounds.left - clientLeft;
       this.root.style.left = left + shift + 'px';


### PR DESCRIPTION
Simplified the overflow repositioning logic a little. Before, it was basing its calculations off of the entire body, which resulted in some incorrect assumptions, namely that that logic was not accounting for margins. The old code only resized when the overflow was greater than the body width, but there could have been and was nonetheless cutoff due to the righthand margin between the editor and the right side of the body.

The updated logic bases its computations off of the editor alone, resulting in a cleaner and more accurate solution.

![image](https://github.com/sillsdev/web-xforge/assets/43733878/37aa2cee-5037-4d6b-aabf-5c29a84fb674)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2188)
<!-- Reviewable:end -->
