### PR TITLE
SF-2349 Align all projects to the left in project picker

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.html
@@ -1,14 +1,14 @@
 <ng-container *transloco="let t; read: 'navigation-project_selector'">
-  <mat-form-field appearance="fill" *ngIf="hasProjects">
+  <mat-form-field appearance="fill" *ngIf="hasProjects" dir="ltr">
     <mat-select
-      dir="auto"
       [value]="selectedProjectId"
       (valueChange)="changed.emit($event)"
       [hideSingleSelectionIndicator]="true"
+      panelClass="app-navigation-project-selector-panel"
     >
-      <mat-option class="project-option" *ngFor="let projectDoc of projectDocs" [value]="projectDoc.id">{{
-        projectLabel(projectDoc)
-      }}</mat-option>
+      <mat-option class="project-option" *ngFor="let projectDoc of projectDocs" [value]="projectDoc.id">
+        {{ projectLabel(projectDoc) }}
+      </mat-option>
       <mat-divider></mat-divider>
       <mat-option [dir]="i18n.direction" value="*connect-project*" [class.list-item-disabled]="!isOnline">
         <mat-icon>add</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
@@ -1,24 +1,19 @@
-@use '@angular/material' as mat;
-
-// All mat-styles @include can be removed once the legacy versions are replaced in material-styles.scss
-@use 'src/material-styles' as mat-styles;
-
 // The select overlay container is positioned outside of the component
-::ng-deep {
-  @include mat.select-theme(mat-styles.$material-app-theme);
-  @include mat.option-theme(mat-styles.$material-app-theme);
-  .project-option {
+::ng-deep .app-navigation-project-selector-panel {
+  // .project-option added to increase CSS rule specificity
+  mat-option.project-option {
     .mdc-list-item__primary-text {
       // Fix overflow in Firefox when a project name uses the Khmer script. As of 2022-11-11, the DBL resource
       // KHSV05 is one example that will cause overflow, which looks particularly bad in RTL mode because it
       // overflows to the left in a menu that is laid out in LTR.
       overflow-wrap: anywhere;
+      // Material wants to right-align everything when any parent element has dir="rtl". Prevent that.
+      margin-left: 0;
     }
   }
 }
 
 :host ::ng-deep {
-  @include mat.form-field-theme(mat-styles.$material-theme-accent-error);
   .mat-mdc-text-field-wrapper {
     border-radius: 0;
   }
@@ -29,6 +24,8 @@
   }
 }
 
-mat-form-field {
+// :host is here only to increase CSS rule specificity
+:host mat-form-field {
   display: block;
+  text-align: left;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -112,6 +112,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);
 @include mat.legacy-form-field-theme($material-theme-accent-error);
+@include mat.form-field-theme($material-theme-accent-error);
 @include mat.icon-theme($material-app-theme);
 @include mat.legacy-input-theme($material-app-theme);
 @include mat.legacy-list-theme($material-app-theme);
@@ -121,6 +122,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-progress-spinner-theme($material-app-theme);
 @include mat.legacy-radio-theme($material-app-theme);
 @include mat.legacy-select-theme($material-app-theme);
+@include mat.select-theme($material-app-theme);
 @include mat.sidenav-theme($material-app-theme);
 @include mat.legacy-slide-toggle-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
@@ -130,6 +132,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-tabs-theme($material-app-theme);
 @include mat.toolbar-theme($material-app-theme);
 @include mat.legacy-tooltip-theme($material-app-theme);
+@include mat.option-theme($material-app-theme);
 
 // Other components that appear to not be used at this time
 


### PR DESCRIPTION
Project picker in RTL mode:

Before | After
-------|------
![](https://github.com/sillsdev/web-xforge/assets/6140710/9f9024a7-938a-4c8a-bad1-c1329238a38c) | ![](https://github.com/sillsdev/web-xforge/assets/6140710/a5464818-1bef-4305-8a3e-5615386a6aa0)

Rationale: Aligning some projects to the right, and some to the left, is not very helpful. Additionally, every line starts with the project short name, which is always going to be in a Latin script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2190)
<!-- Reviewable:end -->
