### PR TITLE
Update drafting message to suggest one book at a time

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -179,7 +179,7 @@
     "preview_last_draft_while_active_build": "While the new draft generation is in progress, you can continue working with the previously generated draft.",
     "requirements": "Requirements",
     "sign_up_for_drafting": "Sign up for drafting",
-    "suggested_workflow": "A suggested workflow is to complete at least a chapter before regenerating a draft.",
+    "suggested_workflow": "A suggested workflow is to draft and edit one book before generating a draft for the next book.",
     "warning_generation_faulted_detail": "Click [em]\"{{ generateButtonText }}\"[/em] below to try again.",
     "warning_generation_faulted_header": "Last generation attempt failed"
   },


### PR DESCRIPTION
The previous string suggested one chapter at a time, which is likely more than our compute resources can keep up with. Field trials in the past have been mostly one book at a time (sometimes several books at a time, if the books are very short).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2192)
<!-- Reviewable:end -->
