### PR TITLE
Fix description of admin page drafting setting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -44,7 +44,7 @@
       <ng-container matColumnDef="preTranslate">
         <td mat-cell *matCellDef="let row">
           <mat-checkbox [checked]="row.preTranslate" (change)="onUpdatePreTranslate(row, $event.checked)">
-            NMT Drafting
+            NMT forward drafting
           </mat-checkbox>
         </td>
       </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.scss
@@ -1,5 +1,5 @@
 .body-content {
-  max-width: 800px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
- The setting should only affect forward translation drafting. Wording has been fixed.
- The layout was quite bad because CSS constrained the width of the table to 800px. I increased it to make it more usable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2198)
<!-- Reviewable:end -->
