### PR TITLE
SF-2381 Support phrase level audio scripture playback on questions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
@@ -21,6 +21,15 @@ export function getAudioTimingWithHeadings(): AudioTiming[] {
   ];
 }
 
+export function getAudioTimingsPhraseLevel(): AudioTiming[] {
+  return [
+    { textRef: '1a', from: 0.0, to: 1.0 },
+    { textRef: '1b', from: 1.0, to: 2.0 },
+    { textRef: '2a', from: 2.0, to: 3.0 },
+    { textRef: '2b', from: 3.0, to: 4.0 }
+  ];
+}
+
 export class AudioPlayerStub extends AudioPlayer {
   htmlAudioMock: HTMLAudioElement = mock(HTMLAudioElement);
   protected override audio: HTMLAudioElement = instance(this.htmlAudioMock);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
@@ -18,8 +18,9 @@ import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
-import { SingleButtonAudioPlayerComponent } from '../../single-button-audio-player/single-button-audio-player.component';
 import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
+import { getAudioTimingsPhraseLevel } from '../../../checking-test.utils';
+import { SingleButtonAudioPlayerComponent } from '../../single-button-audio-player/single-button-audio-player.component';
 import { CheckingQuestionComponent } from './checking-question.component';
 
 const mockedSFProjectService = mock(SFProjectService);
@@ -47,8 +48,8 @@ class MockComponent {
     when(mockedQuestion.audioUrl).thenReturn('test-audio-player.webm');
     const verseRef: VerseRefData = {
       bookNum: 8,
-      chapterNum: 22,
-      verseNum: 17
+      chapterNum: 1,
+      verseNum: 1
     };
     when(mockedQuestion.verseRef).thenReturn(verseRef);
     when(mockedQuestionDoc.data).thenReturn(instance(mockedQuestion));
@@ -93,7 +94,7 @@ describe('CheckingQuestionComponent', () => {
 
   it('selects question when scripture audio has already been played', async () => {
     const env = new TestEnvironment();
-    when(mockedSFProjectUserConfig.audioRefsPlayed).thenReturn(['RUT 22:17']);
+    when(mockedSFProjectUserConfig.audioRefsPlayed).thenReturn(['RUT 1:1']);
     await env.wait();
     await env.wait();
 
@@ -104,12 +105,12 @@ describe('CheckingQuestionComponent', () => {
 
   it('selects scripture if not all scripture audio has already been played for question', async () => {
     const env = new TestEnvironment();
-    when(mockedSFProjectUserConfig.audioRefsPlayed).thenReturn(['RUT 22:17']);
+    when(mockedSFProjectUserConfig.audioRefsPlayed).thenReturn(['RUT 1:1']);
     const verseRef: VerseRefData = {
       bookNum: 8,
-      chapterNum: 22,
-      verseNum: 17,
-      verse: '17-18'
+      chapterNum: 1,
+      verseNum: 1,
+      verse: '1-2'
     };
     when(mockedQuestion.verseRef).thenReturn(verseRef);
     await env.wait();
@@ -160,6 +161,19 @@ describe('CheckingQuestionComponent', () => {
 
     await env.wait(1000); //wait for the audio to finish playing
     expect(env.component.question.focusedText).toBe('scripture-audio-label');
+  });
+
+  it('plays the entire verse when timing files are phrase level', async () => {
+    const env = new TestEnvironment();
+    await env.wait();
+    await env.wait();
+
+    env.component.question.playScripture();
+    await env.wait(1200);
+
+    expect(env.component.question.scriptureAudioStart).toBe(0);
+    expect(env.component.question.scriptureAudioEnd).toBe(2);
+    expect(env.component.question.focusedText).toBe('question-audio-label');
   });
 
   it('does not select question if scriptureAudio is set to the same value', async () => {
@@ -269,7 +283,7 @@ class TestEnvironment {
   readonly queryChanged$: Subject<void> = new Subject<void>();
 
   constructor() {
-    const audio1 = this.createTextAudioDoc(getTextAudioId('project01', 8, 22), 'test-audio-player-b.webm');
+    const audio1 = this.createTextAudioDoc(getTextAudioId('project01', 8, 1), 'test-audio-player-b.webm');
     const audio2 = this.createTextAudioDoc(getTextAudioId('project01', 1, 11), 'test-audio-player.webm');
 
     when(this.query.remoteChanges$).thenReturn(this.queryChanged$);
@@ -289,7 +303,7 @@ class TestEnvironment {
     const audioDoc = mock(TextAudioDoc);
     const textAudio = mock<TextAudio>();
     when(textAudio.audioUrl).thenReturn(url);
-    when(textAudio.timings).thenReturn([]);
+    when(textAudio.timings).thenReturn(getAudioTimingsPhraseLevel());
     when(audioDoc.data).thenReturn(instance(textAudio));
     when(audioDoc.id).thenReturn(id);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
@@ -168,12 +168,9 @@ describe('CheckingQuestionComponent', () => {
     await env.wait();
     await env.wait();
 
-    env.component.question.playScripture();
-    await env.wait(1200);
-
+    // The timing follows shows 1a (0-1sec), 1b (1-2sec), 2a (2-3sec), 2b (3-4sec)
     expect(env.component.question.scriptureAudioStart).toBe(0);
     expect(env.component.question.scriptureAudioEnd).toBe(2);
-    expect(env.component.question.focusedText).toBe('question-audio-label');
   });
 
   it('does not select question if scriptureAudio is set to the same value', async () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
@@ -11,6 +11,7 @@ import { Subscription } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
@@ -86,9 +87,12 @@ export class CheckingQuestionComponent extends SubscriptionDisposable implements
   }
 
   get scriptureAudioEnd(): number | undefined {
-    return this._scriptureTextAudioData?.timings.find(
+    // Get the last record of a timing that matches the last verse
+    const verseTimings: AudioTiming[] | undefined = this._scriptureTextAudioData?.timings.filter(
       t => CheckingUtils.parseAudioRef(t.textRef)?.verseStr === this.endVerse.toString()
-    )?.to;
+    );
+    if (verseTimings == null || verseTimings.length === 0) return;
+    return verseTimings.sort((a, b) => b.to - a.to)[0].to;
   }
 
   get questionText(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
@@ -81,18 +81,22 @@ export class CheckingQuestionComponent extends SubscriptionDisposable implements
   }
 
   get scriptureAudioStart(): number | undefined {
-    return this._scriptureTextAudioData?.timings.find(
+    // Audio timings are not guaranteed to be in order, some timing files group section headings and verses together
+    const verseTimings: AudioTiming[] | undefined = this._scriptureTextAudioData?.timings.filter(
       t => CheckingUtils.parseAudioRef(t.textRef)?.verseStr === this.startVerse.toString()
-    )?.from;
+    );
+    if (verseTimings == null || verseTimings.length === 0) return;
+    return Math.min(...verseTimings.map(t => t.from));
   }
 
   get scriptureAudioEnd(): number | undefined {
-    // Get the last record of a timing that matches the last verse
+    // Audio timings are not guaranteed to be in order, some timing files group section headings and verses together
+    // Get the timing for the latest record for a verse
     const verseTimings: AudioTiming[] | undefined = this._scriptureTextAudioData?.timings.filter(
       t => CheckingUtils.parseAudioRef(t.textRef)?.verseStr === this.endVerse.toString()
     );
     if (verseTimings == null || verseTimings.length === 0) return;
-    return verseTimings.sort((a, b) => b.to - a.to)[0].to;
+    return Math.max(...verseTimings.map(t => t.to));
   }
 
   get questionText(): string {


### PR DESCRIPTION
Timing files can be broken down into phrase level (and even word level) components. The Single button audio player accepts the timing for the section of the audio for the verse that a question pertains to. Previously, the component that extracted the data for the timing range did not account for the phrase level timings, meaning that for a single verse, there may be multiple timings.
This change ensures that all the timings for a timing range is considered so that single button audio player is given the correct timing information for the verse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2199)
<!-- Reviewable:end -->
