### PR TITLE
SF-2383 Adjust and add styling options to notice component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -61,7 +61,7 @@
         >
       </div>
     </div>
-    <app-notice id="offline-error" *ngIf="!isOnline" [type]="'error'" [outline]="true" [icon]="'cloud_off'">
+    <app-notice id="offline-error" *ngIf="!isOnline" type="error" icon="cloud_off">
       {{ t("chapter_audio_dialog.not_upload_audio_offline") }}
     </app-notice>
   </mat-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -44,9 +44,8 @@
     <app-notice
       id="warning-some-actions-unavailable-offline"
       *ngIf="!isOnline && (canCreateScriptureAudio || canDeleteScriptureAudio)"
-      [icon]="'cloud_off'"
-      [type]="'warning'"
-      [outline]="true"
+      icon="cloud_off"
+      type="warning"
       >{{ t("some_actions_unavailable_offline") }}</app-notice
     >
     <ng-container *ngFor="let text of texts">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -38,14 +38,15 @@ const mockedSFProjectService = mock(SFProjectService);
 
 describe('JoinComponent', () => {
   configureTestingModule(() => ({
-    declarations: [JoinComponent, NoticeComponent],
+    declarations: [JoinComponent],
     imports: [
       HttpClientTestingModule,
       NoopAnimationsModule,
       TestTranslocoModule,
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
       TestOnlineStatusModule.forRoot(),
-      UICommonModule
+      UICommonModule,
+      NoticeComponent
     ],
     providers: [
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.stories.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { userEvent, within } from '@storybook/testing-library';
 import { of } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -71,8 +71,8 @@ const meta: Meta = {
   },
   decorators: [
     moduleMetadata({
-      imports: [UICommonModule, CommonModule, I18nStoryModule],
-      declarations: [NoticeComponent, GenericDialogComponent],
+      imports: [UICommonModule, CommonModule, I18nStoryModule, NoticeComponent],
+      declarations: [GenericDialogComponent],
       providers: [
         { provide: ActivatedRoute, useValue: instance(mockedActivatedRoute) },
         { provide: AnonymousService, useValue: instance(mockedAnonymousService) },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/info/info.component.ts
@@ -14,6 +14,6 @@ export class InfoComponent {
   constructor() {}
 
   get mirrorRTL(): boolean {
-    return ICONS_TO_MIRROR_RTL.includes(this.icon ?? '');
+    return ICONS_TO_MIRROR_RTL.has(this.icon);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
@@ -1,4 +1,2 @@
-<div [ngClass]="{ outline }" [class]="type">
-  <mat-icon *ngIf="icon" [class.mirror-rtl]="mirrorRTL">{{ icon }}</mat-icon>
-  <span class="notice-content"><ng-content></ng-content></span>
-</div>
+<mat-icon *ngIf="icon" [class.mirror-rtl]="mirrorRtl">{{ icon }}</mat-icon>
+<span class="notice-content"><ng-content></ng-content></span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -1,17 +1,23 @@
 @use 'sass:color';
 @use 'sass:list';
+@use 'src/variables' as sfColors;
 
 // prettier-ignore
 $colors: (
-  primary:   (#cfe2fd, #305993),
-  secondary: (#d6d4e8, #4a4959),
-  success:   (#c4ead9, #125235),
-  warning:   (#fff3d0, #6a5117),
-  error:     (#f8d7da, #952633),
-  info:      (#d0f4fb, #345564),
-  light:     (#f7f7f7, #6a6b6b),
-  dark:      (#d3d3d4, #181a1d)
+  primary:   (sfColors.$blueMedium, #cfe2fd),
+  secondary: (sfColors.$purpleDark, #d6d4e8),
+  success:   (#125235, #c4ead9),
+  warning:   (#6a5117, #fff3d0),
+  error:     (sfColors.$errorColor, #f8d7da),
+  info:      (#345564, #d0f4fb),
+  light:     (#6a6b6b, #f7f7f7),
+  dark:      (#181a1d, #d3d3d4),
 );
+
+// Helper function just to clean up the syntax
+@function scaleLightness($color, $lightness) {
+  @return color.scale($color, $lightness: $lightness);
+}
 
 :host {
   display: flex;
@@ -24,8 +30,8 @@ $colors: (
   color: var(--notice-color-text);
   background-color: var(--notice-color);
 
-  --notice-color-button-bg: var(--notice-color-outline);
   --notice-color-button-text: #fff;
+  --notice-color-button-hover-text: var(--notice-color-button-text);
 
   mat-icon {
     flex-shrink: 0;
@@ -33,14 +39,26 @@ $colors: (
   }
 
   @each $name, $palette in $colors {
+    $colorDark: list.nth($palette, 1);
+    $colorLight: list.nth($palette, 2);
+
     &.#{$name} {
-      --notice-color: #{list.nth($palette, 1)};
-      --notice-color-text: #{list.nth($palette, 2)};
-      --notice-color-outline-text: #{color.scale(list.nth($palette, 2), $lightness: 20%)};
-      --notice-color-icon: #{color.scale(list.nth($palette, 2), $lightness: 30%)};
-      --notice-color-outline: #{color.scale(list.nth($palette, 1), $lightness: -30%)};
-      --notice-color-light: #{color.scale(list.nth($palette, 1), $lightness: 50%)};
-      --notice-color-extra-dark: #{color.scale(list.nth($palette, 1), $lightness: -50%)};
+      --notice-color: #{$colorLight};
+      --notice-color-text: #{$colorDark};
+      --notice-color-outline-text: #{scaleLightness($colorDark, 20%)};
+      --notice-color-icon: #{scaleLightness($colorDark, 30%)};
+      --notice-color-outline: #{scaleLightness($colorLight, -30%)};
+      --notice-color-light: #{scaleLightness($colorLight, 50%)};
+      --notice-color-extra-dark: #{scaleLightness($colorLight, -50%)};
+
+      // Used for buttons inside all notice types except 'extra-dark'
+      --notice-color-button-bg: #{scaleLightness($colorLight, -40%)};
+      --notice-color-button-hover-bg: #{scaleLightness($colorLight, -50%)};
+
+      // Used for button inside 'extra-dark' notice type
+      --notice-color-button-bg-alt: #{scaleLightness($colorLight, 20%)};
+      --notice-color-button-hover-bg-alt: #{scaleLightness($colorLight, 80%)};
+      --notice-color-button-text-alt: #{scaleLightness($colorLight, -60%)};
     }
   }
 
@@ -57,6 +75,11 @@ $colors: (
     background-color: var(--notice-color-extra-dark);
     color: #fff;
 
+    // Extra dark mode button need different colors for contrast
+    --notice-color-button-bg: var(--notice-color-button-bg-alt);
+    --notice-color-button-text: var(--notice-color-button-text-alt);
+    --notice-color-button-hover-bg: var(--notice-color-button-hover-bg-alt);
+
     mat-icon {
       color: #fff;
     }
@@ -65,6 +88,18 @@ $colors: (
     background-color: unset;
     border-color: var(--notice-color-outline);
     color: var(--notice-color-outline-text);
+  }
+
+  // Style buttons inside notices
+  ::ng-deep .mat-button-base {
+    flex-shrink: 0;
+    background-color: var(--notice-color-button-bg);
+    color: var(--notice-color-button-text);
+
+    &:hover {
+      background-color: var(--notice-color-button-hover-bg);
+      color: var(--notice-color-button-hover-text);
+    }
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -16,12 +16,16 @@ $colors: (
 :host {
   display: flex;
   align-items: center;
-  padding: 16px 24px 16px 16px;
+  padding: 16px;
+  padding-inline: 16px 24px; // Extra right padding for inline notices
   border-radius: 4px;
   column-gap: 16px;
   border: 2px solid;
   color: var(--notice-color-text);
   background-color: var(--notice-color);
+
+  --notice-color-button-bg: var(--notice-color-outline);
+  --notice-color-button-text: #fff;
 
   mat-icon {
     flex-shrink: 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -1,34 +1,66 @@
-@use 'src/variables';
+@use 'sass:color';
+@use 'sass:list';
+
+// prettier-ignore
+$colors: (
+  primary:   (#cfe2fd, #305993),
+  secondary: (#d6d4e8, #4a4959),
+  success:   (#c4ead9, #125235),
+  warning:   (#fff3d0, #6a5117),
+  error:     (#f8d7da, #952633),
+  info:      (#d0f4fb, #345564),
+  light:     (#f7f7f7, #6a6b6b),
+  dark:      (#d3d3d4, #181a1d)
+);
 
 :host {
-  display: block;
-}
-
-div {
   display: flex;
   align-items: center;
-  padding: 16px;
+  padding: 16px 24px 16px 16px;
   border-radius: 4px;
   column-gap: 16px;
-  &.normal {
-    --notice-color: #{variables.$purpleLight};
-  }
-  &.error {
-    --notice-color: #{variables.$errorColor};
-  }
-  &.warning {
-    --notice-color: #{variables.$orange};
-  }
-  &.outline {
-    border: 1px solid var(--notice-color);
-    color: var(--notice-color);
-  }
-  &:not(.outline) {
-    background-color: var(--notice-color);
-    color: #fff;
-  }
+  border: 2px solid;
+  color: var(--notice-color-text);
+  background-color: var(--notice-color);
+
   mat-icon {
     flex-shrink: 0;
+    color: var(--notice-color-icon);
+  }
+
+  @each $name, $palette in $colors {
+    &.#{$name} {
+      --notice-color: #{list.nth($palette, 1)};
+      --notice-color-text: #{list.nth($palette, 2)};
+      --notice-color-outline-text: #{color.scale(list.nth($palette, 2), $lightness: 20%)};
+      --notice-color-icon: #{color.scale(list.nth($palette, 2), $lightness: 30%)};
+      --notice-color-outline: #{color.scale(list.nth($palette, 1), $lightness: -30%)};
+      --notice-color-light: #{color.scale(list.nth($palette, 1), $lightness: 50%)};
+      --notice-color-extra-dark: #{color.scale(list.nth($palette, 1), $lightness: -50%)};
+    }
+  }
+
+  &.mode-fill-light {
+    border-color: var(--notice-color-outline);
+    background-color: var(--notice-color-light);
+  }
+  &.mode-fill-dark {
+    border-color: var(--notice-color);
+    background-color: var(--notice-color);
+  }
+  &.mode-fill-extra-dark {
+    border-color: var(--notice-color-extra-dark);
+    background-color: var(--notice-color-extra-dark);
+    color: #fff;
+
+    mat-icon {
+      color: #fff;
+    }
+  }
+  &.mode-outline {
+    background-color: unset;
+    border-color: var(--notice-color-outline);
+    color: var(--notice-color-outline-text);
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
@@ -20,7 +20,7 @@ describe('NoticeComponent', () => {
     expect(env.icon).toBeTruthy();
   });
 
-  for (const type of noticeTypes.filter(t => t !== 'normal')) {
+  for (const type of noticeTypes) {
     it(`should set "${type}" class`, () => {
       const template = `<app-notice type="${type}">This is a ${type}</app-notice>`;
       const env = new TestEnvironment(template);
@@ -42,24 +42,10 @@ describe('NoticeComponent', () => {
     expect(env.container.classes['primary']).toBeTrue();
   });
 
-  it('should set "mode-fill-dark" class if no mode specified', () => {
+  it('should set "mode-fill-light" class if no mode specified', () => {
     const template = '<app-notice>This is a notice</app-notice>';
     const env = new TestEnvironment(template);
-    expect(env.container.classes['mode-fill-dark']).toBeTrue();
-  });
-
-  describe('legacy props', () => {
-    it('should set "primary" class if "normal" type specified', () => {
-      const template = '<app-notice type="normal">This is a notice</app-notice>';
-      const env = new TestEnvironment(template);
-      expect(env.container.classes['primary']).toBeTrue();
-    });
-
-    it('should set "mode-outline" class if "outline" specified', () => {
-      const template = '<app-notice [outline]="true">This is a notice</app-notice>';
-      const env = new TestEnvironment(template);
-      expect(env.container.classes['mode-outline']).toBeTrue();
-    });
+    expect(env.container.classes['mode-fill-light']).toBeTrue();
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.spec.ts
@@ -1,9 +1,8 @@
+import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TestTranslocoModule } from 'xforge-common/test-utils';
-import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { UICommonModule } from 'xforge-common/ui-common.module';
 import { NoticeComponent } from './notice.component';
+import { noticeModes, noticeTypes } from './notice.types';
 
 describe('NoticeComponent', () => {
   it('should create', () => {
@@ -12,7 +11,7 @@ describe('NoticeComponent', () => {
     expect(env.fixture.componentInstance).toBeTruthy();
     expect(env.noticeText).toEqual('This is a notice');
     expect(env.icon).toBeFalsy();
-    expect(env.container.classes['normal']).toBeTrue();
+    expect(env.container.classes['primary']).toBeTrue();
   });
 
   it('should show icon', () => {
@@ -21,22 +20,52 @@ describe('NoticeComponent', () => {
     expect(env.icon).toBeTruthy();
   });
 
-  it('should set error class', () => {
-    const template = '<app-notice type="error">This is an error</app-notice>';
+  for (const type of noticeTypes.filter(t => t !== 'normal')) {
+    it(`should set "${type}" class`, () => {
+      const template = `<app-notice type="${type}">This is a ${type}</app-notice>`;
+      const env = new TestEnvironment(template);
+      expect(env.container.classes[type]).toBeTrue();
+    });
+  }
+
+  for (const mode of noticeModes) {
+    it(`should set "mode-${mode}" class`, () => {
+      const template = `<app-notice mode="${mode}">This is a ${mode}</app-notice>`;
+      const env = new TestEnvironment(template);
+      expect(env.container.classes[`mode-${mode}`]).toBeTrue();
+    });
+  }
+
+  it('should set "primary" class if no type specified', () => {
+    const template = '<app-notice>This is a notice</app-notice>';
     const env = new TestEnvironment(template);
-    expect(env.container.classes['error']).toBeTrue();
+    expect(env.container.classes['primary']).toBeTrue();
   });
 
-  it('should set warning class', () => {
-    const template = '<app-notice type="warning">This is a warning</app-notice>';
+  it('should set "mode-fill-dark" class if no mode specified', () => {
+    const template = '<app-notice>This is a notice</app-notice>';
     const env = new TestEnvironment(template);
-    expect(env.container.classes['warning']).toBeTrue();
+    expect(env.container.classes['mode-fill-dark']).toBeTrue();
+  });
+
+  describe('legacy props', () => {
+    it('should set "primary" class if "normal" type specified', () => {
+      const template = '<app-notice type="normal">This is a notice</app-notice>';
+      const env = new TestEnvironment(template);
+      expect(env.container.classes['primary']).toBeTrue();
+    });
+
+    it('should set "mode-outline" class if "outline" specified', () => {
+      const template = '<app-notice [outline]="true">This is a notice</app-notice>';
+      const env = new TestEnvironment(template);
+      expect(env.container.classes['mode-outline']).toBeTrue();
+    });
   });
 });
 
 @Component({ selector: 'app-host', template: '' })
 class HostComponent {
-  @ViewChild('container', { static: true }) container!: ElementRef;
+  @ViewChild(NoticeComponent, { static: true }) component!: NoticeComponent;
 }
 
 class TestEnvironment {
@@ -44,17 +73,18 @@ class TestEnvironment {
 
   constructor(template: string) {
     TestBed.configureTestingModule({
-      declarations: [HostComponent, NoticeComponent],
-      imports: [TestTranslocoModule, UICommonModule]
+      declarations: [HostComponent],
+      imports: [NoticeComponent]
     });
 
     TestBed.overrideComponent(HostComponent, { set: { template } });
     this.fixture = TestBed.createComponent(HostComponent);
+    this.fixture.componentInstance.component.ngOnChanges();
     this.fixture.detectChanges();
   }
 
   get container(): DebugElement {
-    return this.fetchElement('div');
+    return this.fetchElement('app-notice');
   }
 
   get icon(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
@@ -13,19 +13,14 @@ import { NoticeMode, NoticeType } from './notice.types';
 })
 export class NoticeComponent implements OnChanges {
   @Input() type: NoticeType = 'primary';
-  @Input() mode: NoticeMode = 'fill-dark';
+  @Input() mode: NoticeMode = 'fill-light';
   @Input() icon?: string;
-  // TODO: remove 'outline' once all components are migrated to use 'mode'
-  @Input() outline: boolean = false;
 
   @HostBinding('class') classes!: string;
 
   readonly mirrorRtl = ICONS_TO_MIRROR_RTL.has(this.icon);
 
   ngOnChanges(): void {
-    // TODO: remove references to 'normal' and 'outline'
-    this.mode = this.outline ? 'outline' : this.mode;
-    this.type = this.type === 'normal' ? 'primary' : this.type;
     this.classes = `${this.type} mode-${this.mode}`;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
@@ -1,19 +1,31 @@
-import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, HostBinding, Input, OnChanges } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
 import { ICONS_TO_MIRROR_RTL } from '../utils';
+import { NoticeMode, NoticeType } from './notice.types';
 
 @Component({
   selector: 'app-notice',
   templateUrl: './notice.component.html',
-  styleUrls: ['./notice.component.scss']
+  styleUrls: ['./notice.component.scss'],
+  standalone: true,
+  imports: [CommonModule, MatIconModule]
 })
-export class NoticeComponent {
+export class NoticeComponent implements OnChanges {
+  @Input() type: NoticeType = 'primary';
+  @Input() mode: NoticeMode = 'fill-dark';
   @Input() icon?: string;
-  @Input() type: 'normal' | 'warning' | 'error' = 'normal';
+  // TODO: remove 'outline' once all components are migrated to use 'mode'
   @Input() outline: boolean = false;
 
-  constructor() {}
+  @HostBinding('class') classes!: string;
 
-  get mirrorRTL(): boolean {
-    return ICONS_TO_MIRROR_RTL.includes(this.icon ?? '');
+  readonly mirrorRtl = ICONS_TO_MIRROR_RTL.has(this.icon);
+
+  ngOnChanges(): void {
+    // TODO: remove references to 'normal' and 'outline'
+    this.mode = this.outline ? 'outline' : this.mode;
+    this.type = this.type === 'normal' ? 'primary' : this.type;
+    this.classes = `${this.type} mode-${this.mode}`;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
@@ -1,26 +1,40 @@
-import { Meta, StoryObj } from '@storybook/angular';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { NoticeComponent } from '../../shared/notice/notice.component';
-import { NoticeMode } from './notice.types';
+import { NoticeMode, noticeModes } from './notice.types';
 
 interface NoticeComponentStoryState {
   mode: NoticeMode;
   showIcon: boolean;
+  showButton: boolean;
   inline: boolean;
 }
 
 const defaultArgs: NoticeComponentStoryState = {
   mode: 'fill-dark',
   showIcon: true,
+  showButton: false,
   inline: false
 };
 
 export default {
   title: 'Utility/Notice',
   component: NoticeComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [MatButtonModule]
+    })
+  ],
   args: defaultArgs,
   parameters: {
     controls: {
       include: Object.keys(defaultArgs)
+    }
+  },
+  argTypes: {
+    mode: {
+      options: noticeModes,
+      control: { type: 'radio' }
     }
   }
 } as Meta<NoticeComponentStoryState>;
@@ -36,22 +50,35 @@ const Template: Story = {
           margin-bottom: 20px;
         }
 
-        div {
+        .notices {
           display: ${args.inline ? 'flex' : 'block'};
           flex-direction: column;
           align-items: flex-start;
         }
+
+        .innards {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+        }
+
+        button {
+          display: ${args.showButton ? 'block' : 'none'};
+          background-color: var(--notice-color-button-bg);
+          color: var(--notice-color-button-text);
+          margin-inline-start: 20px;
+        }
       </style>
 
-      <div>
-        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="primary" [mode]="mode">Primary notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="secondary" [mode]="mode">Secondary notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'check'): null" type="success" [mode]="mode">Success notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'warning'): null" type="warning" [mode]="mode">Warning notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'error'): null" type="error" [mode]="mode">Error notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="info" [mode]="mode">Info notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="light" [mode]="mode">Light notice - stuff happened!</app-notice>
-        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="dark" [mode]="mode">Dark notice - stuff happened!</app-notice>
+      <div class="notices">
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="primary" [mode]="mode"><div class="innards">Primary notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="secondary" [mode]="mode"><div class="innards">Secondary notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'check'): null" type="success" [mode]="mode"><div class="innards">Success notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'warning'): null" type="warning" [mode]="mode"><div class="innards">Warning notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'error'): null" type="error" [mode]="mode"><div class="innards">Error notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="info" [mode]="mode"><div class="innards">Info notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="light" [mode]="mode"><div class="innards">Light notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="dark" [mode]="mode"><div class="innards">Dark notice - stuff happened! <button mat-flat-button>Learn more</button></div></app-notice>
       </div>
     `
   })
@@ -82,6 +109,22 @@ export const Outline: Story = {
   ...Template,
   args: {
     mode: 'outline'
+  }
+};
+
+export const NoIcon: Story = {
+  ...Template,
+  args: {
+    mode: 'fill-light',
+    showIcon: false
+  }
+};
+
+export const WithButton: Story = {
+  ...Template,
+  args: {
+    mode: 'fill-light',
+    showButton: true
   }
 };
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
@@ -1,46 +1,93 @@
-import { CommonModule } from '@angular/common';
-import { Meta, StoryFn } from '@storybook/angular';
-import { UICommonModule } from 'xforge-common/ui-common.module';
+import { Meta, StoryObj } from '@storybook/angular';
 import { NoticeComponent } from '../../shared/notice/notice.component';
+import { NoticeMode } from './notice.types';
 
-const meta: Meta<NoticeComponent> = {
-  title: 'Utility/Notice',
-  component: NoticeComponent
+interface NoticeComponentStoryState {
+  mode: NoticeMode;
+  showIcon: boolean;
+  inline: boolean;
+}
+
+const defaultArgs: NoticeComponentStoryState = {
+  mode: 'fill-dark',
+  showIcon: true,
+  inline: false
 };
-export default meta;
 
-const Template: StoryFn = args => ({
-  moduleMetadata: { imports: [UICommonModule, CommonModule] },
-  props: args,
-  template: `<app-notice [icon]="icon" [type]="type" [outline]="outline">{{ text }}</app-notice>`
-});
+export default {
+  title: 'Utility/Notice',
+  component: NoticeComponent,
+  args: defaultArgs,
+  parameters: {
+    controls: {
+      include: Object.keys(defaultArgs)
+    }
+  }
+} as Meta<NoticeComponentStoryState>;
 
-export const Basic = Template.bind({});
-Basic.args = { text: 'This is a notice', type: 'normal' };
+type Story = StoryObj<NoticeComponentStoryState>;
 
-export const BasicWithIcon = Template.bind({});
-BasicWithIcon.args = { ...Basic.args, icon: 'info' };
+const Template: Story = {
+  render: args => ({
+    props: args,
+    template: `
+      <style>
+        app-notice {
+          margin-bottom: 20px;
+        }
 
-export const Warning = Template.bind({});
-Warning.args = { text: 'This is a warning', type: 'warning' };
+        div {
+          display: ${args.inline ? 'flex' : 'block'};
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      </style>
 
-export const WarningWithIcon = Template.bind({});
-WarningWithIcon.args = { ...Warning.args, icon: 'warning' };
+      <div>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="primary" [mode]="mode">Primary notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="secondary" [mode]="mode">Secondary notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'check'): null" type="success" [mode]="mode">Success notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'warning'): null" type="warning" [mode]="mode">Warning notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'error'): null" type="error" [mode]="mode">Error notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="info" [mode]="mode">Info notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="light" [mode]="mode">Light notice - stuff happened!</app-notice>
+        <app-notice [icon]="showIcon ? (icon || 'info'): null" type="dark" [mode]="mode">Dark notice - stuff happened!</app-notice>
+      </div>
+    `
+  })
+};
 
-export const Error = Template.bind({});
-Error.args = { text: 'This is an error', type: 'error' };
+export const FillExtraDark: Story = {
+  ...Template,
+  args: {
+    mode: 'fill-extra-dark'
+  }
+};
 
-export const ErrorWithIcon = Template.bind({});
-ErrorWithIcon.args = { ...Error.args, icon: 'error' };
+export const FillDark: Story = {
+  ...Template,
+  args: {
+    mode: 'fill-dark'
+  }
+};
 
-export const Outline = Template.bind({});
-Outline.args = { ...Basic.args, outline: true };
+export const FillLight: Story = {
+  ...Template,
+  args: {
+    mode: 'fill-light'
+  }
+};
 
-export const IconAndOutline = Template.bind({});
-IconAndOutline.args = { ...Basic.args, icon: 'info', outline: true };
+export const Outline: Story = {
+  ...Template,
+  args: {
+    mode: 'outline'
+  }
+};
 
-export const WrappingNoticeWithIcon = Template.bind({});
-WrappingNoticeWithIcon.args = { text: 'This is a notice that wraps to multiple lines', type: 'normal', icon: 'info' };
-WrappingNoticeWithIcon.parameters = {
-  viewport: { defaultViewport: 'mobile1' }
+export const WrappingText: Story = {
+  ...FillDark,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' }
+  }
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.stories.ts
@@ -64,8 +64,6 @@ const Template: Story = {
 
         button {
           display: ${args.showButton ? 'block' : 'none'};
-          background-color: var(--notice-color-button-bg);
-          color: var(--notice-color-button-text);
           margin-inline-start: 20px;
         }
       </style>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
@@ -1,15 +1,4 @@
-// TODO: remove 'normal' once all components are migrated to use 'primary'
-export const noticeTypes = [
-  'normal',
-  'primary',
-  'secondary',
-  'success',
-  'warning',
-  'error',
-  'info',
-  'light',
-  'dark'
-] as const;
+export const noticeTypes = ['primary', 'secondary', 'success', 'warning', 'error', 'info', 'light', 'dark'] as const;
 export type NoticeType = (typeof noticeTypes)[number];
 
 export const noticeModes = ['fill-light', 'fill-dark', 'fill-extra-dark', 'outline'] as const;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
@@ -1,0 +1,16 @@
+// TODO: remove 'normal' once all components are migrated to use 'primary'
+export const noticeTypes = [
+  'normal',
+  'primary',
+  'secondary',
+  'success',
+  'warning',
+  'error',
+  'info',
+  'light',
+  'dark'
+] as const;
+export type NoticeType = (typeof noticeTypes)[number];
+
+export const noticeModes = ['fill-light', 'fill-dark', 'fill-extra-dark', 'outline'] as const;
+export type NoticeMode = (typeof noticeModes)[number];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -63,7 +63,7 @@
           </mat-selection-list>
         </mat-menu>
       </div>
-      <app-notice *ngIf="isRecipientOnlyLink" icon="info" [outline]="true">
+      <app-notice *ngIf="isRecipientOnlyLink" icon="info">
         {{ t("recipient_only_notice") }}
       </app-notice>
     </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
@@ -16,7 +16,6 @@ import { TextComponent } from './text/text.component';
 const componentExports = [
   BookChapterChooserComponent,
   InfoComponent,
-  NoticeComponent,
   ShareButtonComponent,
   ShareControlComponent,
   ShareDialogComponent,
@@ -26,8 +25,8 @@ const componentExports = [
 ];
 
 @NgModule({
-  imports: [CommonModule, QuillModule.forRoot(), UICommonModule, TranslocoModule],
+  imports: [CommonModule, QuillModule.forRoot(), UICommonModule, TranslocoModule, NoticeComponent],
   declarations: componentExports,
-  exports: componentExports
+  exports: [...componentExports, NoticeComponent]
 })
 export class SharedModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -274,7 +274,7 @@ export class XmlUtils {
  * Some icons (as as arrows) should be mirrored in certain contexts and not others, or require more attention to detail
  * than merely mirroring. This list is ONLY for those icons that can be mirrored in all contexts.
  */
-export const ICONS_TO_MIRROR_RTL = [
+export const ICONS_TO_MIRROR_RTL = new Set<string | undefined>([
   'bar_chart',
   'book',
   'bookmarks',
@@ -289,4 +289,4 @@ export const ICONS_TO_MIRROR_RTL = [
   'person_add',
   'post_add',
   'question_answer'
-];
+]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -10,7 +10,7 @@
     <p><transloco key="draft_generation.instructions_keep_in_mind"></transloco></p>
     <p>{{ t("instructions_draft_process") }}</p>
 
-    <app-notice *ngIf="isBackTranslationMode" type="normal" [outline]="true" class="requirements">
+    <app-notice *ngIf="isBackTranslationMode" type="primary" class="requirements">
       <p>
         <transloco key="draft_generation.back_translation_requirement" [params]="{ supportedLanguagesUrl }"></transloco>
       </p>
@@ -36,13 +36,7 @@
 
     <!-- Only show warnings if target language is supported -->
     <ng-container *ngIf="isTargetLanguageSupported">
-      <app-notice
-        *ngIf="!isSourceProjectSet"
-        type="warning"
-        icon="warning"
-        [outline]="true"
-        data-test-id="warning-source-text-missing"
-      >
+      <app-notice *ngIf="!isSourceProjectSet" type="warning" icon="warning" data-test-id="warning-source-text-missing">
         <transloco
           key="draft_generation.info_alert_source_text_not_selected"
           [params]="{ projectSettingsUrl: { route: projectSettingsUrl } }"
@@ -53,7 +47,6 @@
         *ngIf="isSourceProjectSet && !isSourceAndTargetDifferent"
         type="warning"
         icon="warning"
-        [outline]="true"
         data-test-id="warning-source-target-same"
       >
         <transloco
@@ -66,7 +59,6 @@
         *ngIf="isSourceProjectSet && isSourceAndTargetDifferent && !isSourceAndTrainingSourceLanguageIdentical"
         type="warning"
         icon="warning"
-        [outline]="true"
         data-test-id="warning-source-target-same"
       >
         <transloco

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -60,13 +60,7 @@
     <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" class="both-editors-wrapper">
       <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
         <div class="language-label">{{ sourceLabel }}</div>
-        <app-notice
-          *ngIf="hasSourceCopyrightBanner"
-          icon="copyright"
-          type="warning"
-          [outline]="true"
-          class="copyright-banner"
-        >
+        <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
           <div>
             {{ sourceCopyrightBanner }}
             <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
@@ -108,13 +102,7 @@
         ngClass.xs="text-area-full-width"
       >
         <div class="language-label" [fxShow.gt-xs]="showSource" fxHide.xs>{{ targetLabel }}</div>
-        <app-notice
-          *ngIf="hasTargetCopyrightBanner"
-          icon="copyright"
-          type="warning"
-          [outline]="true"
-          class="copyright-banner"
-        >
+        <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
           <div>
             {{ targetCopyrightBanner }}
             <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -3,7 +3,7 @@
     <span *ngIf="!isAppOnline" id="collaborators-offline-message" class="offline-text">{{
       t("connect_network_to_manage_users")
     }}</span>
-    <app-notice icon="live_help" [outline]="true">
+    <app-notice icon="live_help">
       <div class="help-message">
         {{ t("uses_roles_to_access_project") }}
         <a mat-flat-button class="learn-more-btn" [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -6,7 +6,7 @@
     <app-notice icon="live_help">
       <div class="help-message">
         {{ t("uses_roles_to_access_project") }}
-        <a mat-flat-button class="learn-more-btn" [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
+        <a mat-flat-button [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
       </div>
     </app-notice>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -4,12 +4,6 @@ h3 {
   font-weight: 500;
 }
 
-.learn-more-btn {
-  background-color: var(--notice-color-button-bg);
-  color: var(--notice-color-button-text);
-  flex-shrink: 0;
-}
-
 .invite-user {
   max-width: 800px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -5,8 +5,8 @@ h3 {
 }
 
 .learn-more-btn {
-  background-color: var(--notice-color);
-  color: #fff;
+  background-color: var(--notice-color-button-bg);
+  color: var(--notice-color-button-text);
   flex-shrink: 0;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
@@ -10,7 +10,7 @@
     </div>
   </div>
   <mat-dialog-content [formGroup]="form">
-    <app-notice *ngIf="isParatextUser()" icon="live_help" [outline]="true">
+    <app-notice *ngIf="isParatextUser()" icon="live_help">
       <div class="help-message">
         {{ t("roles_from_pt_cannot_be_changed") }}
         <a mat-flat-button class="learn-more-btn" [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
@@ -13,7 +13,7 @@
     <app-notice *ngIf="isParatextUser()" icon="live_help">
       <div class="help-message">
         {{ t("roles_from_pt_cannot_be_changed") }}
-        <a mat-flat-button class="learn-more-btn" [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
+        <a mat-flat-button [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
       </div>
     </app-notice>
     <span class="offline-text" *ngIf="form.disabled">{{ t("offline") }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
@@ -48,8 +48,8 @@ h3 {
 }
 
 .learn-more-btn {
-  background-color: var(--notice-color);
-  color: #fff;
+  background-color: var(--notice-color-button-bg);
+  color: var(--notice-color-button-text);
   flex-shrink: 0;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
@@ -47,12 +47,6 @@ h3 {
   margin-top: 6px;
 }
 
-.learn-more-btn {
-  background-color: var(--notice-color-button-bg);
-  color: var(--notice-color-button-text);
-  flex-shrink: 0;
-}
-
 .help-message {
   display: flex;
   justify-content: space-between;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { Component, DebugElement, Input, NgModule } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import {
   MatLegacyDialog as MatDialog,
   MatLegacyDialogConfig as MatDialogConfig
@@ -13,16 +13,17 @@ import { UserProfile } from 'realtime-server/common/models/user';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
-import { SFProjectRole, isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import {
   createTestProject,
   createTestProjectProfile
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
-  SF_PROJECT_USER_CONFIGS_COLLECTION,
-  getSFProjectUserConfigDocId
+  getSFProjectUserConfigDocId,
+  SF_PROJECT_USER_CONFIGS_COLLECTION
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { BehaviorSubject } from 'rxjs';
+import { NoticeComponent } from 'src/app/shared/notice/notice.component';
 import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -31,9 +32,9 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import {
   ChildViewContainerComponent,
-  TestTranslocoModule,
   configureTestingModule,
-  matDialogCloseDelay
+  matDialogCloseDelay,
+  TestTranslocoModule
 } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -41,7 +42,6 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { SFProjectService } from '../../core/sf-project.service';
-import { NoticeComponent } from '../../shared/notice/notice.component';
 import { paratextUsersFromRoles } from '../../shared/test-utils';
 import { RolesAndPermissionsDialogComponent, UserData } from './roles-and-permissions-dialog.component';
 
@@ -201,8 +201,8 @@ class FakeAvatarComponent {
 }
 
 @NgModule({
-  imports: [CommonModule, BrowserModule, UICommonModule, TestTranslocoModule],
-  declarations: [RolesAndPermissionsDialogComponent, FakeAvatarComponent, NoticeComponent]
+  imports: [CommonModule, BrowserModule, UICommonModule, TestTranslocoModule, NoticeComponent],
+  declarations: [RolesAndPermissionsDialogComponent, FakeAvatarComponent]
 })
 class DialogTestModule {}
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title><mat-icon>science</mat-icon> Developer settings</h2>
-<app-notice type="warning" icon="warning" [outline]="true">
+<app-notice type="warning" icon="warning">
   These settings are for developers and testers of Scripture Forge. Do not use them for real projects. Doing so will
   cause unexpected problems and errors.
 </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
@@ -70,9 +70,10 @@ describe('FeatureFlagsComponent', () => {
     ReactiveFormsModule,
     TestTranslocoModule,
     NoopAnimationsModule,
-    HttpClientTestingModule
+    HttpClientTestingModule,
+    NoticeComponent
   ],
-  declarations: [FeatureFlagsDialogComponent, NoticeComponent],
+  declarations: [FeatureFlagsDialogComponent],
   exports: [FeatureFlagsDialogComponent]
 })
 class DialogTestModule {}


### PR DESCRIPTION
Updated notice component to have softer styles and more styling options as mentioned in [this github comment](https://github.com/sillsdev/web-xforge/pull/2182#pullrequestreview-1751463413).

`<app-notice type="normal">` will still work, but the new way is to use 'primary' `<app-notice type="primary">`.
`<app-notice [outline]="true">` will still work, but the new way is to use the `mode` input `<app-notice mode="outline">`.

- Updated Storybook with the new options.
- Converted NoticeComponent to be a standalone component.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2200)
<!-- Reviewable:end -->
