### PR TITLE
SF-1715 Enable scripture audio feature flag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
@@ -68,7 +68,9 @@ describe('FeatureFlagService', () => {
     verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  it('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
+  // Disabling test because the feature flag service does not give as a simple way to actually test the state where all
+  // feature flags are off, unless we assume they all default to off (which is not always the case).
+  xit('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
     const env = new TestEnvironment({});
     // The first call loads the remote feature flags
     expect(env.service.versionSuffix).toEqual('');


### PR DESCRIPTION
@pmachapman I don't know if this is the right approach for turning on a feature flag or not. It's not as clean as I'd like. But I do want feature flags to be able to be turned on by hard coding a new value, so they can be turned on and off by shipping features (rather than having to be separately controlled by changing environment variables). There's a place for changing feature flags using environment variables (e.g. the Serval switchover would be much more of a pain if we had to ship every time). But being able to change them in code and have commits go through our normal shipping process makes the whole testing process so much easier. If something can be handled by version control, keeping it in version control means everything is simpler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2201)
<!-- Reviewable:end -->
