### PR TITLE
Update sidebar to use NMT auth guard

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -272,13 +272,6 @@ describe('AppComponent', () => {
     verify(mockedAuthService.checkOnlineAuth()).once();
   }));
 
-  it('should continue init if login state changes', fakeAsync(() => {
-    const env = new TestEnvironment('online', false);
-    expect(env.component.isLoggedIn).toBeFalse();
-    env.triggerLogin();
-    expect(env.component.isLoggedIn).toBeTrue();
-  }));
-
   describe('Community Checking', () => {
     it('ensure local storage is cleared when removed from project', fakeAsync(() => {
       const env = new TestEnvironment();
@@ -385,7 +378,7 @@ class TestEnvironment {
     when(mockedSFProjectService.getProfile(anything())).thenCall(projectId =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, projectId)
     );
-    when(mockedAuthService.isLoggedIn).thenCall(() => this.loggedInState$.getValue().loggedIn);
+    when(mockedAuthService.isLoggedIn).thenCall(() => Promise.resolve(this.loggedInState$.getValue().loggedIn));
     when(mockedAuthService.loggedInState$).thenReturn(this.loggedInState$);
     this.setCurrentUser('user01');
     when(mockedUserService.currentProjectId(anything())).thenReturn('project01');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -12,7 +12,7 @@
         <mat-icon mat-list-icon class="material-icons-outlined mirror-rtl">article</mat-icon>
         {{ t("draft_review") }}
       </a>
-      <a *ngIf="canGenerateDraft" mat-list-item [appRouterLink]="draftGenerationLink">
+      <a *ngIf="canGenerateDraft$ | async" mat-list-item [appRouterLink]="draftGenerationLink">
         <mat-icon mat-list-icon>edit_note</mat-icon>
         {{ t("generate_draft") }} <span class="nav-label">{{ t("beta") }}</span>
       </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
@@ -20,7 +20,7 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../core/sf-project.service';
-import { SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from '../shared/project-router.guard';
+import { NmtDraftAuthGuard, SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from '../shared/project-router.guard';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
 import { NavigationComponent } from './navigation.component';
@@ -112,6 +112,7 @@ const meta: Meta = {
           { provide: ResumeCheckingService, useValue: instance(mockedResumeCheckingService) },
           { provide: ActivatedProjectService, useValue: testActivatedProjectService },
 
+          { provide: NmtDraftAuthGuard, useClass: NmtDraftAuthGuard },
           { provide: AuthGuard, useClass: AuthGuard },
           { provide: SettingsAuthGuard, useClass: SettingsAuthGuard },
           { provide: SyncAuthGuard, useClass: SyncAuthGuard },


### PR DESCRIPTION
The NMT auth guard did not exist when I last set up the logic for whether to show NMT drafting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2204)
<!-- Reviewable:end -->
