### PR TITLE
SF-2353 Correctly handle a 409 error from Serval

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { InteractiveTranslator, InteractiveTranslatorFactory, LatinWordTokenizer } from '@sillsdev/machine';
 import { Canon } from '@sillsdev/scripture';
 import * as crc from 'crc-32';
@@ -36,7 +37,8 @@ export class TranslationEngineService extends SubscriptionDisposable {
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
     private readonly machineHttp: HttpClient,
-    private readonly noticeService: NoticeService
+    private readonly noticeService: NoticeService,
+    private readonly router: Router
   ) {
     super();
     this.onlineStatus$ = this.onlineStatusService.onlineStatus$.pipe(
@@ -56,7 +58,7 @@ export class TranslationEngineService extends SubscriptionDisposable {
     if (!this.translationEngines.has(projectId)) {
       this.translationEngines.set(
         projectId,
-        new RemoteTranslationEngine(projectId, this.machineHttp, this.noticeService)
+        new RemoteTranslationEngine(projectId, this.machineHttp, this.noticeService, this.router)
       );
     }
     return this.translationEngines.get(projectId)!;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgModule, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { TranslationSources, WordGraph } from '@sillsdev/machine';
 import { of, throwError } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -456,6 +457,7 @@ class TestEnvironment {
   readonly mockedHttpClient: HttpClient;
   readonly client: RemoteTranslationEngine;
   readonly mockedNoticeService: NoticeService;
+  readonly mockedRouter: Router;
   readonly ngZone: NgZone;
 
   constructor() {
@@ -476,10 +478,12 @@ class TestEnvironment {
       })
     );
     this.mockedNoticeService = mock(NoticeService);
+    this.mockedRouter = mock(Router);
     this.client = new RemoteTranslationEngine(
       'project01',
       instance(this.mockedHttpClient),
-      instance(this.mockedNoticeService)
+      instance(this.mockedNoticeService),
+      instance(this.mockedRouter)
     );
 
     this.ngZone = TestBed.inject(NgZone);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -1,29 +1,30 @@
+import { Router } from '@angular/router';
+import { translate } from '@ngneat/transloco';
 import {
   createRange,
   InteractiveTranslationEngine,
   Phrase,
   ProgressStatus,
   TranslationResult,
+  TranslationSources,
   WordAlignmentMatrix,
   WordGraph,
-  WordGraphArc,
-  TranslationSources
+  WordGraphArc
 } from '@sillsdev/machine';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, expand, filter, map, mergeMap, share, startWith, takeWhile } from 'rxjs/operators';
-import { translate } from '@ngneat/transloco';
 import { NoticeService } from 'xforge-common/notice.service';
 import { AlignedWordPairDto } from './aligned-word-pair-dto';
 import { BuildDto } from './build-dto';
 import { BuildStates } from './build-states';
-import { HttpClient } from './http-client';
 import { EngineDto } from './engine-dto';
+import { HttpClient } from './http-client';
 import { PhraseDto } from './phrase-dto';
-import { TranslationEngineStats } from './translation-engine-stats';
 import { SegmentPairDto } from './segment-pair-dto';
+import { TranslationEngineStats } from './translation-engine-stats';
 import { TranslationResultDto } from './translation-result-dto';
-import { WordGraphDto } from './word-graph-dto';
 import { TranslationSource } from './translation-source';
+import { WordGraphDto } from './word-graph-dto';
 
 export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   private trainingStatus$?: Observable<ProgressStatus>;
@@ -31,7 +32,8 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   constructor(
     public readonly projectId: string,
     private readonly httpClient: HttpClient,
-    private readonly noticeService: NoticeService
+    private readonly noticeService: NoticeService,
+    private readonly router: Router
   ) {}
 
   async translate(segment: string): Promise<TranslationResult> {
@@ -64,8 +66,29 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
         )
         .toPromise();
       return this.createWordGraph(response.data as WordGraphDto);
-    } catch (err) {
-      this.noticeService.showError(translate('error_messages.failed_to_retrieve_suggestions'));
+    } catch (err: any) {
+      if (err.status === 409) {
+        this.noticeService.showError(
+          translate('error_messages.suggestion_engine_requires_retrain'),
+          translate('translate_overview.retrain'),
+          () => {
+            this.getEngine(this.projectId).pipe(
+              mergeMap(e => this.createBuild(e.id)),
+              catchError(err => {
+                if (err.status === 404) {
+                  return of(undefined);
+                } else {
+                  return throwError(err);
+                }
+              })
+            );
+            // Take the user to the translate overview page as this will allow some of the trappable errors to display
+            this.router.navigate(['projects', this.projectId, 'translate']);
+          }
+        );
+      } else {
+        this.noticeService.showError(translate('error_messages.failed_to_retrieve_suggestions'));
+      }
     }
 
     return new WordGraph([]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -70,19 +70,8 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
       if (err.status === 409) {
         this.noticeService.showError(
           translate('error_messages.suggestion_engine_requires_retrain'),
-          translate('translate_overview.retrain'),
+          translate('error_messages.go_to_retrain'),
           () => {
-            this.getEngine(this.projectId).pipe(
-              mergeMap(e => this.createBuild(e.id)),
-              catchError(err => {
-                if (err.status === 404) {
-                  return of(undefined);
-                } else {
-                  return throwError(err);
-                }
-              })
-            );
-            // Take the user to the translate overview page as this will allow some of the trappable errors to display
             this.router.navigate(['projects', this.projectId, 'translate']);
           }
         );

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -308,6 +308,7 @@
     "error_occurred_login": "An error occurred during login.",
     "failed_to_update_avatar": "Your avatar image could not be updated.",
     "failed_to_retrieve_suggestions": "Couldn't get translation suggestions.",
+    "suggestion_engine_requires_retrain": "Couldn't get translation suggestions. Please retrain the translation engine.",
     "try_again": "Try Again"
   },
   "exception_handling_service": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -308,7 +308,8 @@
     "error_occurred_login": "An error occurred during login.",
     "failed_to_update_avatar": "Your avatar image could not be updated.",
     "failed_to_retrieve_suggestions": "Couldn't get translation suggestions.",
-    "suggestion_engine_requires_retrain": "Couldn't get translation suggestions. Please retrain the translation engine.",
+    "suggestion_engine_requires_retrain": "Couldn't get translation suggestions. Please retrain the suggestions on the Overview page.",
+    "go_to_retrain": "Go to Overview",
     "try_again": "Try Again"
   },
   "exception_handling_service": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -38,19 +38,37 @@ export class NoticeService {
     return this.showSnackBar(message);
   }
 
-  async showError(message: string): Promise<void> {
-    return this.showSnackBar(message, ['snackbar-error']);
+  async showError(
+    message: string,
+    action: string | undefined = undefined,
+    onAction: (() => void) | undefined = undefined
+  ): Promise<void> {
+    return this.showSnackBar(message, ['snackbar-error'], action, onAction);
   }
 
-  private async showSnackBar(message: string, classes: string[] = []): Promise<void> {
+  private async showSnackBar(
+    message: string,
+    classes: string[] = [],
+    action: string | undefined = undefined,
+    onAction: (() => void) | undefined = undefined
+  ): Promise<void> {
     let config: MatSnackBarConfig<any> | undefined;
     config = { panelClass: classes.join(' '), direction: this.i18n.direction, duration: 5000 };
     if (this.messageOnDisplay === message) {
       // Do nothing if the message is the same as one currently on display
       return;
     }
-    const snackBarRef = this.snackBar.open(message, undefined, config);
+    const snackBarRef = this.snackBar.open(message, action, config);
+
+    if (onAction !== undefined) {
+      snackBarRef.onAction().subscribe(() => {
+        onAction();
+        this.messageOnDisplay = undefined;
+      });
+    }
+
     this.messageOnDisplay = message;
+
     snackBarRef
       .afterDismissed()
       .toPromise()

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -299,6 +299,7 @@ public class MachineApiController : ControllerBase
     /// <response code="200">The word graph was successfully generated.</response>
     /// <response code="403">You do not have permission to retrieve the word graph for this project.</response>
     /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="409">The engine has not been built on the ML server.</response>
     /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpPost(MachineApi.GetWordGraph)]
     public async Task<ActionResult<WordGraph>> GetWordGraphAsync(
@@ -329,6 +330,10 @@ public class MachineApiController : ControllerBase
         catch (ForbiddenException)
         {
             return Forbid();
+        }
+        catch (InvalidOperationException)
+        {
+            return Conflict();
         }
     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1076,7 +1076,7 @@ public class MachineApiService : IMachineApiService
             case ServalApiException { StatusCode: StatusCodes.Status408RequestTimeout }:
                 return;
             case ServalApiException { StatusCode: StatusCodes.Status409Conflict }:
-                throw new DataNotFoundException("Entity Deleted");
+                throw new InvalidOperationException();
             case BrokenCircuitException
                 when doNotThrowIfInProcessEnabled
                     && await _featureManager.IsEnabledAsync(FeatureFlags.MachineInProcess):

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -743,6 +743,25 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetWordGraphAsync_NotBuilt()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+            .Throws(new InvalidOperationException());
+
+        // SUT
+        ActionResult<WordGraph> actual = await env.Controller.GetWordGraphAsync(
+            Project01,
+            string.Empty,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ConflictResult>(actual.Result);
+    }
+
+    [Test]
     public async Task GetWordGraphAsync_Success()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1585,7 +1585,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
         // SUT
-        Assert.ThrowsAsync<DataNotFoundException>(
+        Assert.ThrowsAsync<InvalidOperationException>(
             () => env.Service.GetWordGraphAsync(User01, Project01, Segment, CancellationToken.None)
         );
     }


### PR DESCRIPTION
This PR modifies the Serval integration layer to correctly pass a 409 error to the frontend.

When these occur, the user is given the option of retraining the model, and is redirected to the translate overview to view the progress of the build.

To trigger the error scenario, the backend must be temporarily modified by a developer (see the JIRA ticket), so testing should be performed by a developer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2207)
<!-- Reviewable:end -->
