### PR TITLE
SF-2386 Only allow selection of books available in the source and target

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -18,6 +18,7 @@ describe('DraftGenerationStepsComponent', () => {
   const mockProjectService = mock(SFProjectService);
   const mockTargetProjectDoc = {
     data: {
+      texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }],
       translateConfig: {
         source: { projectRef: 'test' },
         draftConfig: {}
@@ -26,7 +27,7 @@ describe('DraftGenerationStepsComponent', () => {
   } as SFProjectProfileDoc;
   const mockSourceProjectDoc = {
     data: {
-      texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }]
+      texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }]
     }
   } as SFProjectProfileDoc;
 
@@ -87,6 +88,7 @@ describe('DraftGenerationStepsComponent', () => {
   describe('target contains previously selected books', () => {
     const mockTargetProjectDoc = {
       data: {
+        texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }],
         translateConfig: {
           source: { projectRef: 'test' },
           draftConfig: { lastSelectedBooks: [2, 3, 4] }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -597,7 +597,7 @@ public class MachineProjectService : IMachineProjectService
             new[] { buildConfig.ProjectId },
             TextCorpusType.Target,
             preTranslate,
-            Array.Empty<int>()
+            buildConfig.TrainingBooks
         );
         List<ServalCorpusFile> newTargetCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(


### PR DESCRIPTION
Only books that are both in the source and target can be used for training. This PR updates SF so that only the source and target books are passed to Serval. The passing of any other source books results in unnecessary processing taking place on the Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2208)
<!-- Reviewable:end -->
