### PR TITLE
SF-2382 Fix combined verse support for pre-translation drafts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
@@ -64,5 +64,18 @@ describe('DraftViewerService', () => {
       const targetOps: DeltaOperation[] = [{ insert: 'existing translation', attributes: { segment: 'verse_1_1' } }];
       expect(service.toDraftOps(draft, targetOps)).toEqual(targetOps);
     });
+
+    it('should allow combined verses in the source that are separated in the target', () => {
+      const draft: DraftSegmentMap = { 'verse_1_1-2': 'In the beginning' };
+      const targetOps: DeltaOperation[] = [
+        { insert: '', attributes: { segment: 'verse_1_1' } },
+        { insert: 'Existing verse 2', attributes: { segment: 'verse_1_2' } }
+      ];
+      const expectedResult: DeltaOperation[] = [
+        { insert: 'In the beginning', attributes: { segment: 'verse_1_1', draft: true } },
+        { insert: 'Existing verse 2', attributes: { segment: 'verse_1_2' } }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -47,12 +47,25 @@ export class DraftViewerService {
     }
 
     return targetOps.map(op => {
-      const draftSegmentText: string | undefined = draft[op.attributes?.segment];
-      const isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
+      let draftSegmentText: string | undefined = draft[op.attributes?.segment];
+      let isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
 
-      // No draft (undefined or empty string) for this segment; use any existing translation
+      // No draft (undefined or empty string) for this segment
       if (!isSegmentDraftAvailable) {
-        return op;
+        // See if the source verse is combined
+        const combinedVerseNumbers: string[] = Object.keys(draft).filter(key =>
+          key.startsWith(op.attributes?.segment + '-')
+        );
+        if (combinedVerseNumbers.length > 0) {
+          // Place the combined verse segment in the verse segment
+          draftSegmentText = draft[combinedVerseNumbers[0]];
+          isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
+        }
+
+        // Use the existing translation, if there is still no draft available
+        if (!isSegmentDraftAvailable) {
+          return op;
+        }
       }
 
       if (isString(op.insert)) {


### PR DESCRIPTION
This PR allows pre-translations for verses that are combined (i.e. `\v 1-2`) in the source to be correctly added to the draft preview and generated draft when the target does not have a combined verse at that same position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2209)
<!-- Reviewable:end -->
