### PR TITLE
SF-2354 Display Serval Build diagnostic information to System Admins

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
@@ -7,4 +7,13 @@ export interface BuildDto extends ResourceDto {
   message: string;
   state: string;
   queueDepth: number;
+  additionalInfo?: ServalBuildAdditionalInfo;
+}
+
+export interface ServalBuildAdditionalInfo {
+  buildId: string;
+  corporaIds?: string[];
+  dateFinished?: Date;
+  step: number;
+  translationEngineId: string;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -242,3 +242,21 @@
     </mat-tab-group>
   </ng-container>
 </mat-card>
+
+<section *ngIf="this.canShowAdditionalInfo(draftJob)">
+  <mat-expansion-panel class="diagnostic-info">
+    <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
+    <ng-template matExpansionPanelContent>
+      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
+      <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+      <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
+      <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+      <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
+      <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
+      <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
+      <div><strong>State:</strong> {{ draftJob?.state }}</div>
+      <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
+      <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
+    </ng-template>
+  </mat-expansion-panel>
+</section>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -6,11 +6,13 @@ import {
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { EMPTY, of } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -28,6 +30,7 @@ import { DraftGenerationService } from './draft-generation.service';
 import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
 
 describe('DraftGenerationComponent', () => {
+  let mockAuthService: jasmine.SpyObj<AuthService>;
   let mockFeatureFlagService: jasmine.SpyObj<FeatureFlagService>;
   let mockDialogService: jasmine.SpyObj<DialogService>;
   let mockDraftGenerationService: jasmine.SpyObj<DraftGenerationService>;
@@ -80,6 +83,7 @@ describe('DraftGenerationComponent', () => {
           NoopAnimationsModule
         ],
         providers: [
+          { provide: AuthService, useValue: mockAuthService },
           { provide: FeatureFlagService, useValue: mockFeatureFlagService },
           { provide: DraftGenerationService, useValue: mockDraftGenerationService },
           { provide: ActivatedProjectService, useValue: mockActivatedProjectService },
@@ -99,6 +103,7 @@ describe('DraftGenerationComponent', () => {
 
     // Default setup
     setup(): void {
+      mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.User });
       mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
         'FeatureFlagService',
         {},
@@ -820,6 +825,22 @@ describe('DraftGenerationComponent', () => {
     });
   });
 
+  describe('isDraftFaulted', () => {
+    it('should return true if the draft build is faulted', () => {
+      let env = new TestEnvironment();
+      expect(env.component.isDraftFaulted({ state: BuildStates.Faulted } as BuildDto)).toBe(true);
+    });
+
+    it('should return false if the draft build is not faulted', () => {
+      let env = new TestEnvironment();
+      expect(env.component.isDraftFaulted({ state: BuildStates.Active } as BuildDto)).toBe(false);
+      expect(env.component.isDraftFaulted({ state: BuildStates.Completed } as BuildDto)).toBe(false);
+      expect(env.component.isDraftFaulted({ state: BuildStates.Canceled } as BuildDto)).toBe(false);
+      expect(env.component.isDraftFaulted({ state: BuildStates.Pending } as BuildDto)).toBe(false);
+      expect(env.component.isDraftFaulted({ state: BuildStates.Queued } as BuildDto)).toBe(false);
+    });
+  });
+
   describe('canCancel', () => {
     it('should return true if the draft build is in progress', () => {
       let env = new TestEnvironment();
@@ -833,6 +854,40 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isDraftInProgress({ state: BuildStates.Completed } as BuildDto)).toBe(false);
       expect(env.component.isDraftInProgress({ state: BuildStates.Canceled } as BuildDto)).toBe(false);
       expect(env.component.isDraftInProgress({ state: BuildStates.Faulted } as BuildDto)).toBe(false);
+    });
+  });
+
+  describe('canShowAdditionalInfo', () => {
+    it('should return true if the draft build is faulted, user is system admin, and build has additional info', () => {
+      let env = new TestEnvironment(() => {
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
+      });
+      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted, additionalInfo: {} } as BuildDto)).toBe(
+        true
+      );
+    });
+
+    it('should return false if the draft build is not faulted', () => {
+      let env = new TestEnvironment(() => {
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
+      });
+      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Active, additionalInfo: {} } as BuildDto)).toBe(
+        false
+      );
+    });
+
+    it('should return false if the draft build has no additional info', () => {
+      let env = new TestEnvironment(() => {
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
+      });
+      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted } as BuildDto)).toBe(false);
+    });
+
+    it('should return false if the user is not system admin', () => {
+      let env = new TestEnvironment();
+      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted, additionalInfo: {} } as BuildDto)).toBe(
+        false
+      );
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -858,36 +858,23 @@ describe('DraftGenerationComponent', () => {
   });
 
   describe('canShowAdditionalInfo', () => {
-    it('should return true if the draft build is faulted, user is system admin, and build has additional info', () => {
+    it('should return true if the user is system admin, and build has additional info', () => {
       let env = new TestEnvironment(() => {
         mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
       });
-      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted, additionalInfo: {} } as BuildDto)).toBe(
-        true
-      );
-    });
-
-    it('should return false if the draft build is not faulted', () => {
-      let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
-      });
-      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Active, additionalInfo: {} } as BuildDto)).toBe(
-        false
-      );
+      expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(true);
     });
 
     it('should return false if the draft build has no additional info', () => {
       let env = new TestEnvironment(() => {
         mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
       });
-      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted } as BuildDto)).toBe(false);
+      expect(env.component.canShowAdditionalInfo({} as BuildDto)).toBe(false);
     });
 
     it('should return false if the user is not system admin', () => {
       let env = new TestEnvironment();
-      expect(env.component.canShowAdditionalInfo({ state: BuildStates.Faulted, additionalInfo: {} } as BuildDto)).toBe(
-        false
-      );
+      expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(false);
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -10,10 +10,12 @@ import { TranslocoModule } from '@ngneat/transloco';
 import { isEmpty } from 'lodash-es';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { RouterLink } from 'ngx-transloco-markup-router-link';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { combineLatest, of, Subscription } from 'rxjs';
 import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -97,6 +99,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     private readonly router: Router,
     private readonly dialogService: DialogService,
     public readonly activatedProject: ActivatedProjectService,
+    private readonly authService: AuthService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly featureFlags: FeatureFlagService,
     private readonly nllbService: NllbLanguageService,
@@ -319,6 +322,14 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
 
   isDraftFaulted(job?: BuildDto): boolean {
     return (job?.state as BuildStates) === BuildStates.Faulted;
+  }
+
+  canShowAdditionalInfo(job?: BuildDto): boolean {
+    return (
+      job?.additionalInfo != null &&
+      this.isDraftFaulted(job) &&
+      this.authService.currentUserRole === SystemRole.SystemAdmin
+    );
   }
 
   canCancel(job?: BuildDto): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -325,11 +325,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   }
 
   canShowAdditionalInfo(job?: BuildDto): boolean {
-    return (
-      job?.additionalInfo != null &&
-      this.isDraftFaulted(job) &&
-      this.authService.currentUserRole === SystemRole.SystemAdmin
-    );
+    return job?.additionalInfo != null && this.authService.currentUserRole === SystemRole.SystemAdmin;
   }
 
   canCancel(job?: BuildDto): boolean {

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Polly.CircuitBreaker;
 using Serval.Client;
 using SIL.Machine.WebApi;
+using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
@@ -124,6 +125,7 @@ public class MachineApiController : ControllerBase
                     sfProjectId,
                     minRevision,
                     preTranslate,
+                    includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -132,6 +134,7 @@ public class MachineApiController : ControllerBase
                     buildId,
                     minRevision,
                     preTranslate,
+                    includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                     cancellationToken
                 );
 
@@ -215,6 +218,7 @@ public class MachineApiController : ControllerBase
             ServalBuildDto? build = await _machineApiService.GetLastCompletedPreTranslationBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
+                includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                 cancellationToken
             );
 
@@ -359,6 +363,7 @@ public class MachineApiController : ControllerBase
             ServalBuildDto build = await _machineApiService.StartBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
+                includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                 cancellationToken
             );
             return Ok(build);

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
@@ -60,6 +60,7 @@ public class MachineApiV2Controller : ControllerBase
                     sfProjectId,
                     minRevision,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -68,6 +69,7 @@ public class MachineApiV2Controller : ControllerBase
                     buildId,
                     minRevision,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     cancellationToken
                 );
 
@@ -164,6 +166,7 @@ public class MachineApiV2Controller : ControllerBase
             BuildDto build = await _machineApiService.StartBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
+                includeAdditionalInfo: false,
                 cancellationToken
             );
             return Ok(UpdateDto(build));

--- a/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class ServalBuildAdditionalInfo
+{
+    public string BuildId { get; set; } = string.Empty;
+    public IEnumerable<string>? CorporaIds { get; set; }
+    public DateTimeOffset? DateFinished { get; set; }
+    public int Step { get; set; }
+    public string TranslationEngineId { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
@@ -5,4 +5,5 @@ namespace SIL.XForge.Scripture.Models;
 public class ServalBuildDto : BuildDto
 {
     public int QueueDepth { get; set; }
+    public ServalBuildAdditionalInfo? AdditionalInfo { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -15,6 +15,7 @@ public interface IMachineApiService
         string buildId,
         long? minRevision,
         bool preTranslate,
+        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<ServalBuildDto?> GetCurrentBuildAsync(
@@ -22,12 +23,14 @@ public interface IMachineApiService
         string sfProjectId,
         long? minRevision,
         bool preTranslate,
+        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task<ServalBuildDto?> GetLastCompletedPreTranslationBuildAsync(
         string curUserId,
         string sfProjectId,
+        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<PreTranslationDto> GetPreTranslationAsync(
@@ -48,7 +51,12 @@ public interface IMachineApiService
         string segment,
         CancellationToken cancellationToken
     );
-    Task<ServalBuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<ServalBuildDto> StartBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        bool includeAdditionalInfo,
+        CancellationToken cancellationToken
+    );
     Task StartPreTranslationBuildAsync(string curUserId, BuildConfig buildConfig, CancellationToken cancellationToken);
     Task TrainSegmentAsync(
         string curUserId,

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using Polly.CircuitBreaker;
 using Serval.Client;
 using SIL.Machine.WebApi;
+using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
@@ -107,7 +108,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -123,12 +124,33 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetBuildAsync_IncludesAdditionalInfoForSystemAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
+
+        // SUT
+        await env.Controller.GetBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: false,
+            CancellationToken.None
+        );
+
+        await env.MachineApiService
+            .Received(1)
+            .GetBuildAsync(User01, Project01, Build01, null, false, true, CancellationToken.None);
+    }
+
+    [Test]
     public async Task GetBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -151,7 +173,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -172,7 +194,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -193,7 +215,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -232,10 +254,10 @@ public class MachineApiControllerTests
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService
             .DidNotReceiveWithAnyArgs()
-            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
         await env.MachineApiService
             .DidNotReceiveWithAnyArgs()
-            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
     [Test]
@@ -244,7 +266,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -262,10 +284,10 @@ public class MachineApiControllerTests
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService
             .Received(1)
-            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
         await env.MachineApiService
             .DidNotReceiveWithAnyArgs()
-            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
     [Test]
@@ -274,7 +296,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -292,10 +314,10 @@ public class MachineApiControllerTests
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService
             .DidNotReceiveWithAnyArgs()
-            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
         await env.MachineApiService
             .Received(1)
-            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
     [Test]
@@ -304,7 +326,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -317,6 +339,30 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .Received(1)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_NoBuildIdIncludesAdditionalInfoForSystemAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
+
+        // SUT
+        await env.Controller.GetBuildAsync(
+            Project01,
+            buildId: null,
+            minRevision: null,
+            preTranslate: false,
+            CancellationToken.None
+        );
+
+        await env.MachineApiService
+            .Received(1)
+            .GetCurrentBuildAsync(User01, Project01, null, false, true, CancellationToken.None);
     }
 
     [Test]
@@ -325,7 +371,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -346,7 +392,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -369,7 +415,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -390,7 +436,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -411,7 +457,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -432,7 +478,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -445,6 +491,9 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .Received(1)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None);
     }
 
     [Test]
@@ -510,12 +559,32 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetLastCompletedPreTranslationBuildAsync_IncludesAdditionalInfoForSystemAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
+
+        // SUT
+        await env.Controller.GetLastCompletedPreTranslationBuildAsync(Project01, CancellationToken.None);
+
+        await env.MachineApiService
+            .Received(1)
+            .GetLastCompletedPreTranslationBuildAsync(
+                User01,
+                Project01,
+                includeAdditionalInfo: true,
+                CancellationToken.None
+            );
+    }
+
+    [Test]
     public async Task GetLastCompletedPreTranslationBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -535,7 +604,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -553,7 +622,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -571,7 +640,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -589,7 +658,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -599,6 +668,15 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+
+        await env.MachineApiService
+            .Received(1)
+            .GetLastCompletedPreTranslationBuildAsync(
+                User01,
+                Project01,
+                includeAdditionalInfo: false,
+                CancellationToken.None
+            );
     }
 
     [Test]
@@ -801,12 +879,27 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task StartBuildAsync_IncludesAdditionalInfoForSystemAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
+
+        // SUT
+        await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        await env.MachineApiService
+            .Received(1)
+            .StartBuildAsync(User01, Project01, includeAdditionalInfo: true, CancellationToken.None);
+    }
+
+    [Test]
     public async Task StartBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -823,7 +916,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -838,7 +931,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -853,13 +946,16 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        await env.MachineApiService
+            .Received(1)
+            .StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
     }
 
     [Test]
@@ -1182,16 +1278,17 @@ public class MachineApiControllerTests
     {
         public TestEnvironment()
         {
-            var userAccessor = Substitute.For<IUserAccessor>();
-            userAccessor.UserId.Returns(User01);
             ExceptionHandler = Substitute.For<IExceptionHandler>();
             MachineApiService = Substitute.For<IMachineApiService>();
+            UserAccessor = Substitute.For<IUserAccessor>();
+            UserAccessor.UserId.Returns(User01);
 
-            Controller = new MachineApiController(ExceptionHandler, MachineApiService, userAccessor);
+            Controller = new MachineApiController(ExceptionHandler, MachineApiService, UserAccessor);
         }
 
         public MachineApiController Controller { get; }
         public IExceptionHandler ExceptionHandler { get; }
         public IMachineApiService MachineApiService { get; }
+        public IUserAccessor UserAccessor { get; }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
@@ -29,7 +29,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -49,7 +49,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -71,7 +71,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -91,7 +91,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -111,7 +111,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -131,7 +131,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
+            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -151,7 +151,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -171,7 +171,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -193,7 +193,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -213,7 +213,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -233,7 +233,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -253,7 +253,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
+            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -413,7 +413,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -430,7 +430,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -445,7 +445,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -460,7 +460,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService
-            .StartBuildAsync(User01, Project01, CancellationToken.None)
+            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -158,6 +158,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -185,6 +186,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: 1,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -210,6 +212,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -232,6 +235,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -255,6 +259,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -275,6 +280,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -295,6 +301,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -316,6 +323,7 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -354,6 +362,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -403,6 +412,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -415,6 +425,87 @@ public class MachineApiServiceTests
         Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
         Assert.AreEqual(Project01, actual.Engine.Id);
         Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+        Assert.IsNull(actual.AdditionalInfo);
+    }
+
+    [Test]
+    public async Task GetBuildAsync_ServalIncludesAdditionalInfo()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        const string buildDtoId = $"{Project01}.{Build01}";
+        const string message = "Finalizing";
+        const double percentCompleted = 0.95;
+        const int revision = 553;
+        const JobState state = JobState.Active;
+        const int queueDepth = 7;
+        DateTimeOffset dateFinished = DateTimeOffset.UtcNow;
+        const string engineId = "engineId1";
+        const string corpusId1 = "corpusId1";
+        const string corpusId2 = "corpusId2";
+        const int step = 123;
+        env.TranslationEnginesClient
+            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new TranslationBuild
+                    {
+                        Url = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceLink { Id = engineId, Url = "https://example.com" },
+                        Message = message,
+                        PercentCompleted = percentCompleted,
+                        Revision = revision,
+                        State = state,
+                        DateFinished = dateFinished,
+                        QueueDepth = queueDepth,
+                        Step = step,
+                        Pretranslate = new List<PretranslateCorpus>
+                        {
+                            new PretranslateCorpus
+                            {
+                                Corpus = new ResourceLink { Id = corpusId1, Url = "https://example.com" },
+                            },
+                            new PretranslateCorpus
+                            {
+                                Corpus = new ResourceLink { Id = corpusId2, Url = "https://example.com" },
+                            },
+                        },
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        ServalBuildDto? actual = await env.Service.GetBuildAsync(
+            User01,
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: false,
+            includeAdditionalInfo: true,
+            CancellationToken.None
+        );
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(message, actual.Message);
+        Assert.AreEqual(percentCompleted, actual.PercentCompleted);
+        Assert.AreEqual(revision, actual.Revision);
+        Assert.AreEqual(state.ToString().ToUpperInvariant(), actual.State);
+        Assert.AreEqual(buildDtoId, actual.Id);
+        Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
+        Assert.AreEqual(Project01, actual.Engine.Id);
+        Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
+        Assert.AreEqual(queueDepth, actual.QueueDepth);
+        Assert.IsNotNull(actual.AdditionalInfo);
+        Assert.AreEqual(Build01, actual.AdditionalInfo.BuildId);
+        Assert.AreEqual(dateFinished, actual.AdditionalInfo.DateFinished);
+        Assert.AreEqual(step, actual.AdditionalInfo.Step);
+        Assert.AreEqual(engineId, actual.AdditionalInfo.TranslationEngineId);
+        Assert.IsNotNull(actual.AdditionalInfo.CorporaIds);
+        Assert.AreEqual(2, actual.AdditionalInfo.CorporaIds.Count());
+        Assert.AreEqual(corpusId1, actual.AdditionalInfo.CorporaIds.First());
+        Assert.AreEqual(corpusId2, actual.AdditionalInfo.CorporaIds.Last());
     }
 
     [Test]
@@ -433,6 +524,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: true,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -457,6 +549,7 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -482,6 +575,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -508,6 +602,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: 1,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -532,6 +627,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -553,6 +649,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -575,6 +672,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -594,6 +692,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -613,6 +712,7 @@ public class MachineApiServiceTests
                     "invalid_project_id",
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -636,6 +736,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -656,6 +757,7 @@ public class MachineApiServiceTests
                     Project03,
                     minRevision: null,
                     preTranslate: false,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -693,6 +795,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -741,6 +844,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -796,6 +900,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: true,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -831,6 +936,7 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: true,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -851,6 +957,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: true,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -874,6 +981,7 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1153,6 +1261,7 @@ public class MachineApiServiceTests
         ServalBuildDto? actual = await env.Service.GetLastCompletedPreTranslationBuildAsync(
             User01,
             Project01,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1171,6 +1280,7 @@ public class MachineApiServiceTests
                 env.Service.GetLastCompletedPreTranslationBuildAsync(
                     "invalid_user_id",
                     Project01,
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -1188,6 +1298,7 @@ public class MachineApiServiceTests
                 env.Service.GetLastCompletedPreTranslationBuildAsync(
                     User01,
                     "invalid_project_id",
+                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -1202,7 +1313,13 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            () =>
+                env.Service.GetLastCompletedPreTranslationBuildAsync(
+                    User01,
+                    Project01,
+                    includeAdditionalInfo: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -1214,7 +1331,13 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project03, CancellationToken.None)
+            () =>
+                env.Service.GetLastCompletedPreTranslationBuildAsync(
+                    User01,
+                    Project03,
+                    includeAdditionalInfo: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -1227,7 +1350,13 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<BrokenCircuitException>(
-            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+            () =>
+                env.Service.GetLastCompletedPreTranslationBuildAsync(
+                    User01,
+                    Project01,
+                    includeAdditionalInfo: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -1266,6 +1395,7 @@ public class MachineApiServiceTests
         ServalBuildDto? actual = await env.Service.GetLastCompletedPreTranslationBuildAsync(
             User01,
             Project01,
+            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1680,7 +1810,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
         );
     }
 
@@ -1692,7 +1822,13 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.StartBuildAsync("invalid_user_id", Project01, CancellationToken.None)
+            () =>
+                env.Service.StartBuildAsync(
+                    "invalid_user_id",
+                    Project01,
+                    includeAdditionalInfo: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -1704,7 +1840,13 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, "invalid_project_id", CancellationToken.None)
+            () =>
+                env.Service.StartBuildAsync(
+                    User01,
+                    "invalid_project_id",
+                    includeAdditionalInfo: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -1720,7 +1862,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
         );
     }
 
@@ -1733,7 +1875,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project03, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project03, includeAdditionalInfo: false, CancellationToken.None)
         );
     }
 
@@ -1749,7 +1891,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<BrokenCircuitException>(
-            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
         );
     }
 
@@ -1764,7 +1906,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<ServalApiException>());
     }
@@ -1780,7 +1922,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
     }
@@ -1812,7 +1954,12 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
 
         // SUT
-        ServalBuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        ServalBuildDto actual = await env.Service.StartBuildAsync(
+            User01,
+            Project01,
+            includeAdditionalInfo: false,
+            CancellationToken.None
+        );
 
         Assert.AreEqual(message, actual.Message);
         Assert.AreEqual(percentCompleted, actual.PercentCompleted);
@@ -1853,7 +2000,12 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
         // SUT
-        ServalBuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        ServalBuildDto actual = await env.Service.StartBuildAsync(
+            User01,
+            Project01,
+            includeAdditionalInfo: false,
+            CancellationToken.None
+        );
 
         await env.MachineProjectService
             .Received(1)
@@ -1884,7 +2036,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
         await env.MachineProjectService


### PR DESCRIPTION
This Pull Request adds a new Diagnostic Information section to the Generate Draft screen that appears only for System Administrators.

**Note:** This new section is not localized, as it is for System Administrators only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2210)
<!-- Reviewable:end -->
