### PR TITLE
SF-2387 Convert ResumeCheckingService to be reactive

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -130,6 +130,7 @@ describe('AppComponent', () => {
     expect(env.menuLength).toEqual(9);
     verify(mockedUserService.setCurrentProjectId(anything(), 'project01')).once();
     tick();
+    discardPeriodicTasks();
   }));
 
   it('navigate to different project', fakeAsync(() => {
@@ -144,6 +145,7 @@ describe('AppComponent', () => {
     // Expect: Community Checking | Manage Questions | Overview | Sync | Settings | Users
     expect(env.menuLength).toEqual(6);
     verify(mockedUserService.setCurrentProjectId(anything(), 'project02')).once();
+    discardPeriodicTasks();
   }));
 
   it('change project', fakeAsync(() => {
@@ -237,6 +239,7 @@ describe('AppComponent', () => {
     env.wait();
     verify(mockedPwaService.activateUpdates()).once();
     tick();
+    discardPeriodicTasks();
   }));
 
   it('user added to project after init', fakeAsync(() => {
@@ -249,6 +252,7 @@ describe('AppComponent', () => {
     env.wait();
     expect(env.isDrawerVisible).toEqual(true);
     expect(env.selectedProjectId).toEqual('project04');
+    discardPeriodicTasks();
   }));
 
   it('user data is set for Bugsnag', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/resume-checking.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/resume-checking.service.ts
@@ -1,13 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Canon } from '@sillsdev/scripture';
+import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
+import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { asyncScheduler, from, merge, Observable, of } from 'rxjs';
+import { map, shareReplay, switchMap, throttleTime } from 'rxjs/operators';
+import { QuestionDoc } from 'src/app/core/models/question-doc';
+import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserService } from 'xforge-common/user.service';
-import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { QuestionDoc } from 'src/app/core/models/question-doc';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
-import { Injectable } from '@angular/core';
-import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
-import { Canon } from '@sillsdev/scripture';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
-import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
 import { CheckingQuestionsService } from './checking-questions.service';
 
 /**
@@ -16,77 +16,88 @@ import { CheckingQuestionsService } from './checking-questions.service';
  *
  * At present, this means sending the user to the first question that is unanswered, and limiting the scope of questions
  * to the chapter level.
- *
- * TODO Consider making question and link observable.
  */
 @Injectable({ providedIn: 'root' })
-export class ResumeCheckingService extends SubscriptionDisposable {
-  firstUnansweredQuestionQuery?: RealtimeQuery<QuestionDoc>;
+export class ResumeCheckingService {
+  private readonly questionLink$: Observable<string[] | undefined> = this.createLink().pipe(shareReplay(1));
 
   constructor(
     private readonly userService: UserService,
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly questionService: CheckingQuestionsService
-  ) {
-    super();
-    this.subscribe(this.activatedProjectService.projectDoc$, projectDoc => this.refreshQuestionQuery(projectDoc));
-  }
+  ) {}
 
   /**
-   * @returns The question for the user to resume community checking on, or undefined, if no project is selected, the
-   * question has not yet been loaded, or no question matches the criteria (e.g. user has answered all questions'
-   * already)
+   * Gets a path to navigate to the community checking component and resume checking. In general, this will lead
+   * the user to first unanswered question.  If there are no unanswered questions, the path will be to the first
+   * book/chapter in the project.
+   * @returns The path tokens, or undefined if project has no texts.
    */
-  getQuestion(): QuestionDoc | undefined {
-    return this.firstUnansweredQuestionQuery?.docs[0];
+  getLink(): Observable<string[] | undefined> {
+    return this.questionLink$;
   }
 
-  /**
-   * @returns An path to navigate to the community checking component and resume checking. In general this will lead
-   * the user to first unanswered question.
-   */
-  getLink(): string[] {
-    const verseRef = this.getQuestion()?.data?.verseRef;
-    const projectId = this.activatedProjectService.projectId;
+  private createLink(): Observable<string[] | undefined> {
+    return this.activatedProjectService.projectDoc$.pipe(
+      switchMap(projectDoc =>
+        this.getQuestion(projectDoc).pipe(map(question => this.getLinkTokens(projectDoc, question)))
+      )
+    );
+  }
 
-    // TODO Make the code that ultimately consumes this value capable of handling the case where there is no link at
-    // this time without having to resort to this workaround.
-    if (projectId == null) return [''];
+  private getLinkTokens(
+    projectDoc: SFProjectProfileDoc | undefined,
+    questionDoc: QuestionDoc | undefined
+  ): string[] | undefined {
+    if (projectDoc == null) {
+      return undefined;
+    }
 
-    let book: string;
-    let chapter: number;
+    const verseRef = questionDoc?.data?.verseRef;
+    let bookNum: number;
+    let chapterNum: number;
+
     if (verseRef != null) {
-      book = Canon.bookNumberToId(verseRef.bookNum);
-      chapter = verseRef.chapterNum;
-    } else if (this.activatedProjectService.projectDoc != null) {
-      const projectDoc = this.activatedProjectService.projectDoc;
-      const firstText = projectDoc.data?.texts[0];
-      book = Canon.bookNumberToId(firstText?.bookNum ?? Canon.firstBook);
-      chapter = firstText?.chapters[0]?.number ?? 1;
+      bookNum = verseRef.bookNum;
+      chapterNum = verseRef.chapterNum;
     } else {
-      book = Canon.bookNumberToId(Canon.firstBook);
-      chapter = 1;
+      // No questions, or all questions already answered.  Send user to first book/chapter.
+      const firstTextWithChapters = projectDoc.data?.texts.find(t => t.chapters.length > 0);
+
+      if (firstTextWithChapters == null) {
+        return undefined;
+      }
+
+      bookNum = firstTextWithChapters.bookNum;
+      chapterNum = firstTextWithChapters.chapters[0].number;
     }
-    return ['projects', projectId, 'checking', book, String(chapter)];
+
+    return ['projects', projectDoc.id, 'checking', Canon.bookNumberToId(bookNum), chapterNum.toString()];
   }
 
-  private async refreshQuestionQuery(projectDoc: SFProjectProfileDoc | undefined): Promise<void> {
-    this.firstUnansweredQuestionQuery = undefined;
+  /**
+   * Gets the question for the user to resume community checking on.
+   * @returns A question doc, or undefined if no project is selected
+   * or no question matches the criteria (e.g. user has answered all questions' already)
+   */
+  private getQuestion(projectDoc: SFProjectProfileDoc | undefined): Observable<QuestionDoc | undefined> {
     if (projectDoc?.data == null) {
-      return;
+      return of(undefined);
     }
 
-    // ensure user has permission to view questions
+    // Ensure user has permission to view questions
     const userId = this.userService.currentUserId;
     if (!SF_PROJECT_RIGHTS.hasRight(projectDoc.data, userId, SFProjectDomain.Answers, Operation.View)) {
-      return;
+      return of(undefined);
     }
 
-    const query = await this.questionService.queryFirstUnansweredQuestion(projectDoc.id, userId);
-
-    // ensure the project has not changed while awaiting the query
-    if (this.activatedProjectService.projectId === projectDoc.id) {
-      this.firstUnansweredQuestionQuery = query;
-    }
+    return from(this.questionService.queryFirstUnansweredQuestion(projectDoc.id, userId)).pipe(
+      switchMap(query =>
+        merge(query.ready$, query.remoteChanges$, query.localChanges$, query.remoteDocChanges$).pipe(
+          throttleTime(100, asyncScheduler, { leading: false, trailing: true }),
+          map(() => query?.docs[0])
+        )
+      )
+    );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -30,7 +30,7 @@
         <mat-icon mat-list-icon>bar_chart</mat-icon>
         {{ t("my_progress") }}
       </a>
-      <a mat-list-item [appRouterLink]="answerQuestionsLink" [class.active]="answerQuestionsActive">
+      <a mat-list-item [appRouterLink]="(answerQuestionsLink$ | async) ?? ['']" [class.active]="answerQuestionsActive">
         <mat-icon mat-list-icon class="mirror-rtl">question_answer</mat-icon>
         {{ t("questions_answers") }}
       </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
@@ -6,18 +6,18 @@ import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scri
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
 import { delay, map, startWith, switchMap } from 'rxjs/operators';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { UserService } from 'xforge-common/user.service';
-import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { UserService } from 'xforge-common/user.service';
+import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
 import { SFProjectService } from '../core/sf-project.service';
 import { NmtDraftAuthGuard, SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from '../shared/project-router.guard';
-import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 
 @Component({
   selector: 'app-navigation',
@@ -43,6 +43,7 @@ export class NavigationComponent extends SubscriptionDisposable {
   );
 
   projectUserConfigDoc?: SFProjectUserConfigDoc;
+  answerQuestionsLink$: Observable<string[] | undefined> = this.resumeCheckingService.getLink();
 
   @Output() menuItemClicked = new EventEmitter<void>();
 
@@ -165,10 +166,6 @@ export class NavigationComponent extends SubscriptionDisposable {
 
   get draftGenerationLink(): string[] {
     return this.getProjectLink('draft-generation');
-  }
-
-  get answerQuestionsLink(): string[] {
-    return this.resumeCheckingService.getLink();
   }
 
   // draftReviewActive and answerQuestionsActive are needed because appRouterLink only highlights the link if the url

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -19,6 +19,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
@@ -32,6 +33,7 @@ const mockedRouter = mock(Router);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedTranslocoService = mock(TranslocoService);
 const mockedPermissions = mock(PermissionsService);
+const mockResumeCheckingService = mock(ResumeCheckingService);
 
 describe('ProjectComponent', () => {
   configureTestingModule(() => ({
@@ -43,7 +45,8 @@ describe('ProjectComponent', () => {
       { provide: Router, useMock: mockedRouter },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: TranslocoService, useMock: mockedTranslocoService },
-      { provide: PermissionsService, useMock: mockedPermissions }
+      { provide: PermissionsService, useMock: mockedPermissions },
+      { provide: ResumeCheckingService, useMock: mockResumeCheckingService }
     ]
   }));
 
@@ -67,34 +70,24 @@ describe('ProjectComponent', () => {
     expect().nothing();
   }));
 
-  it('navigate to checking tool if a checker and no last selected text', fakeAsync(() => {
+  it('navigate to checking tool if a checker and no last selected task', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedPermissions.canAccessTranslate(anything())).thenReturn(false);
     env.setProjectData({ role: SFProjectRole.CommunityChecker, memberProjectIdSuffixes: [1] });
     env.fixture.detectChanges();
     tick();
 
-    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'checking', 'ALL']), anything())).once();
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'checking', 'JHN', '1']), anything())).once();
     expect().nothing();
   }));
 
-  it('navigates to last checking question if question stored but bookNum is null', fakeAsync(() => {
+  it('navigates to checking tool if selected task is checking', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setProjectData({ selectedTask: 'checking', memberProjectIdSuffixes: [1] });
     env.fixture.detectChanges();
     tick();
 
-    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'checking', 'ALL']), anything())).once();
-    expect().nothing();
-  }));
-
-  it('navigates to last checking book if the last book was saved', fakeAsync(() => {
-    const env = new TestEnvironment();
-    env.setProjectData({ selectedTask: 'checking', selectedBooknum: 41, memberProjectIdSuffixes: [1] });
-    env.fixture.detectChanges();
-    tick();
-
-    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'checking', 'MRK']), anything())).once();
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'checking', 'JHN', '1']), anything())).once();
     expect().nothing();
   }));
 
@@ -121,7 +114,7 @@ describe('ProjectComponent', () => {
     env.fixture.detectChanges();
     tick();
 
-    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'MAT']), anything())).once();
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'MRK']), anything())).once();
     expect().nothing();
   }));
 
@@ -137,7 +130,7 @@ describe('ProjectComponent', () => {
     env.fixture.detectChanges();
     tick();
 
-    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'MAT']), anything())).once();
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'MRK']), anything())).once();
     expect().nothing();
   }));
 
@@ -198,6 +191,9 @@ class TestEnvironment {
     const snapshot = new ActivatedRouteSnapshot();
     snapshot.queryParams = enableSharing ? { sharing: 'true', shareKey: 'shareKey01' } : {};
     when(mockedActivatedRoute.snapshot).thenReturn(snapshot);
+
+    // Just mock the response.  Testing of the actual service functionality can be in the service spec.
+    when(mockResumeCheckingService.getLink()).thenReturn(of(['projects', 'project1', 'checking', 'JHN', '1']));
 
     this.fixture = TestBed.createComponent(ProjectComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -1,14 +1,19 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Canon } from '@sillsdev/scripture';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
 import { environment } from '../../environments/environment';
-import { SFProjectService } from '../core/sf-project.service';
+import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { PermissionsService } from '../core/permissions.service';
+import { SFProjectService } from '../core/sf-project.service';
+
+type TaskType = 'translate' | 'checking';
 
 @Component({
   selector: 'app-projects',
@@ -22,6 +27,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     private readonly router: Router,
     private readonly userService: UserService,
     private readonly permissions: PermissionsService,
+    private readonly resumeCheckingService: ResumeCheckingService,
     noticeService: NoticeService
   ) {
     super(noticeService);
@@ -64,47 +70,70 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
 
   private async navigateToProject(projectId: string): Promise<void> {
     this.loadingStarted();
-    const projectUserConfigDoc = await this.projectService.getUserConfig(projectId, this.userService.currentUserId);
-    const projectUserConfig = projectUserConfigDoc.data;
-    const projectDoc = await this.projectService.getProfile(projectId);
-    const project = projectDoc.data;
-    if (project == null || projectUserConfig == null) {
-      return;
-    }
-    const selectedTask = projectUserConfig.selectedTask;
-    const isTranslateAccessible = this.permissions.canAccessTranslate(projectDoc);
-    const isCheckingAccessible = this.permissions.canAccessCommunityChecking(projectDoc);
 
-    // navigate to last location
-    if (
-      (selectedTask === 'translate' && isTranslateAccessible) ||
-      (selectedTask === 'checking' && isCheckingAccessible)
-    ) {
-      const taskRoute = ['projects', projectId, selectedTask];
-      // the user has previously navigated to a location in a task
-      const bookNum = projectUserConfig.selectedBookNum;
-      if (bookNum != null) {
-        taskRoute.push(Canon.bookNumberToId(bookNum));
-      } else if (selectedTask === 'checking') {
-        taskRoute.push('ALL');
+    try {
+      const [projectUserConfigDoc, projectDoc] = await Promise.all([
+        this.projectService.getUserConfig(projectId, this.userService.currentUserId),
+        this.projectService.getProfile(projectId)
+      ]);
+
+      const projectUserConfig = projectUserConfigDoc.data;
+      const project = projectDoc.data;
+
+      if (project == null || projectUserConfig == null) {
+        return;
       }
-      this.router.navigate(taskRoute, { replaceUrl: true });
-    } else {
-      // navigate to the default location in the first enabled task
-      let task: string | undefined;
-      if (isTranslateAccessible) {
-        task = 'translate';
-      } else if (isCheckingAccessible) {
-        task = 'checking';
+
+      const selectedTask = projectUserConfig.selectedTask;
+      const isTranslateAccessible = this.permissions.canAccessTranslate(projectDoc);
+      const isCheckingAccessible = this.permissions.canAccessCommunityChecking(projectDoc);
+
+      const tasks: { task: TaskType; accessible: boolean }[] = [
+        // first listed task will be treated as default
+        { task: 'translate', accessible: isTranslateAccessible },
+        { task: 'checking', accessible: isCheckingAccessible }
+      ];
+      const task =
+        tasks.find(t => t.task === selectedTask && t.accessible)?.task ?? tasks.find(t => t.accessible)?.task;
+
+      if (task === 'translate') {
+        this.navigateToTranslate(projectId, task, project, projectUserConfig);
+      } else if (task === 'checking') {
+        this.navigateToChecking(projectId);
       }
-      if (task != null) {
-        const taskRoute = ['projects', projectId, task];
-        if (project.texts.length > 0) {
-          taskRoute.push(task === 'checking' ? 'ALL' : Canon.bookNumberToId(project.texts[0].bookNum));
-        }
-        this.router.navigate(taskRoute, { replaceUrl: true });
+    } finally {
+      this.loadingFinished();
+    }
+  }
+
+  private navigateToTranslate(
+    projectId: string,
+    task: TaskType,
+    project: SFProjectProfile,
+    projectUserConfig: SFProjectUserConfig
+  ): void {
+    const routePath = ['projects', projectId, task];
+    const bookNum: number | undefined = projectUserConfig.selectedBookNum ?? project.texts[0]?.bookNum;
+
+    if (bookNum != null) {
+      routePath.push(Canon.bookNumberToId(bookNum));
+
+      const chapterNum: number | undefined =
+        projectUserConfig.selectedChapterNum ?? project.texts[bookNum]?.chapters[0].number;
+
+      if (chapterNum != null) {
+        routePath.push(chapterNum.toString());
       }
     }
-    this.loadingFinished();
+
+    this.router.navigate(routePath, { replaceUrl: true });
+  }
+
+  private navigateToChecking(projectId: string, task: TaskType = 'checking'): void {
+    const defaultCheckingLink: string[] = ['/projects', projectId, task];
+
+    this.resumeCheckingService.getLink().subscribe(link => {
+      this.router.navigate(link ?? defaultCheckingLink, { replaceUrl: true });
+    });
   }
 }


### PR DESCRIPTION
This should help fix some timing issues surrounding question query and project doc.

The timing issues are evident when a new checking user joins the project and then is incorrectly sent to the 'ALL' book link instead of the book/chapter for the first unanswered question in the project.