### PR TITLE
Fix inconsistent use of icons, and remove unneeded quote

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'checking_overview'">
   <div [ngClass]="{ 'reviewer-panels': !canCreateQuestion }" class="header">
-    <mat-icon class="mirror-rtl">library_books</mat-icon>
+    <mat-icon class="mirror-rtl">list</mat-icon>
     <h2>{{ t(canCreateQuestion ? "manage_questions" : "my_progress") }}</h2>
     <ng-container *ngIf="canCreateQuestion; else overallProgressChart" class="primary-actions">
       <button mat-button type="button" *ngIf="showImportButton" (click)="importDialog()" id="import-btn">
@@ -233,7 +233,7 @@
   </ng-template>
 
   <div class="header">
-    <mat-icon>donut_large</mat-icon>
+    <mat-icon class="mirror-rtl">bar_chart</mat-icon>
     <h2>{{ t(canCreateQuestion ? "project_stats" : "my_contributions") }}</h2>
   </div>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'checking_comment_form'">
   <form [formGroup]="commentForm" (ngSubmit)="submit()" autocomplete="off" appScrollIntoView>
     <mat-form-field appearance="outline">
-      <mat-label>{{ t("your_comment") }}"</mat-label>
+      <mat-label>{{ t("your_comment") }}</mat-label>
       <input matInput type="text" appAutofocus formControlName="commentText" />
       <mat-error *ngIf="showValidationError">{{ t("comment_cannot_be_blank") }}</mat-error>
     </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -13,7 +13,7 @@
         {{ t("draft_review") }}
       </a>
       <a *ngIf="canGenerateDraft$ | async" mat-list-item [appRouterLink]="draftGenerationLink">
-        <mat-icon mat-list-icon>edit_note</mat-icon>
+        <mat-icon mat-list-icon class="mirror-rtl">model_training</mat-icon>
         {{ t("generate_draft") }} <span class="nav-label">{{ t("beta") }}</span>
       </a>
     </ng-container>
@@ -27,7 +27,7 @@
         {{ t("manage_questions") }}
       </a>
       <a *ngIf="!canManageQuestions" mat-list-item [appRouterLink]="getProjectLink('checking')">
-        <mat-icon mat-list-icon>bar_chart</mat-icon>
+        <mat-icon mat-list-icon class="mirror-rtl">bar_chart</mat-icon>
         {{ t("my_progress") }}
       </a>
       <a mat-list-item [appRouterLink]="answerQuestionsLink" [class.active]="answerQuestionsActive">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -275,13 +275,16 @@ export class XmlUtils {
  * than merely mirroring. This list is ONLY for those icons that can be mirrored in all contexts.
  */
 export const ICONS_TO_MIRROR_RTL = [
+  'bar_chart',
   'book',
   'bookmarks',
   'comment',
   'forum',
   'help',
   'library_books',
+  'list',
   'live_help',
+  'model_training',
   'people',
   'person_add',
   'post_add',


### PR DESCRIPTION
- Removed this rogue quote

![](https://github.com/sillsdev/web-xforge/assets/6140710/e7ccb17a-fb85-4a27-b4bd-e88d6f6c3d85)

- On admin pages, generate draft no longer looks like it means "edit"
- The icon for "manage questions" has been changed to the list icon, for consistency with the sidebar. Also, what follows that heading is a list of books, so there's a visual match.
- The project stats icon has been changed from a donut chart icon, to a bar chart icon

![](https://github.com/sillsdev/web-xforge/assets/6140710/08566d98-128b-418d-8f42-bb746d554b38)

For community checkers, I thought it was weird that there were actual donut charts by each book, but we used the donut chart icon for the section with numerical stats. That seemed like a mismatch:

![](https://github.com/sillsdev/web-xforge/assets/6140710/405e112e-1afe-479c-94ef-73118c5eed36)

So I changed it to the bar chart icon, which matches with the icon in the sidebar. I don't like that the top heading on this page is "my progress" and the icon doesn't match the icon in the sidebar, but that's related to the fact that this page is poorly designed due to trying to serve both the admin and the checker. A completely new progress page for checkers is going to be in the works, so unless we can see a small incremental improvement to make, we're not going to invest a ton in improving this UI.

![](https://github.com/sillsdev/web-xforge/assets/6140710/e4293468-4d1f-4558-adbc-7d14f99c477d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2213)
<!-- Reviewable:end -->
