### PR TITLE
Fix clipping of icons in nav component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
@@ -9,7 +9,6 @@ mat-nav-list .mat-list-item {
     color: variables.$purpleMedium;
     fill: variables.$purpleMedium;
     transition: color 0.15s;
-    padding: 0;
   }
   &:hover {
     mat-icon {
@@ -23,7 +22,8 @@ mat-nav-list .mat-list-item {
   }
 
   ::ng-deep .mat-list-item-content {
-    column-gap: 16px;
+    padding-inline: 12px;
+    column-gap: 12px;
   }
 
   &.activated-nav-item,
@@ -64,6 +64,8 @@ mat-nav-list .mat-list-item {
   color: variables.$errorColor;
   font-weight: normal;
   font-size: 1.4rem;
+  inset-inline-end: -7px;
+  top: -7px;
 }
 
 .navigation-header:hover {


### PR DESCRIPTION
The Q&A icon, and the users icon, were both being clipped by the mat icon border-radius.
![](https://github.com/sillsdev/web-xforge/assets/6140710/ba7a4c3d-ac31-4964-8435-60a11b9921cb)
![](https://github.com/sillsdev/web-xforge/assets/6140710/fc720014-7a3b-465a-b62f-fd2f5739d4d7)

This could be fixed by just setting border-radius to 0, but the reason this was a problem is because I had set the padding on the icons to 0. I did this to get the spacing how I wanted it. However, there's a more straightforward way to get the spacing than removing the padding.

Before, with padding removed from icon:
![](https://github.com/sillsdev/web-xforge/assets/6140710/0b1ed7a2-35be-4a2b-9a6b-70e5446029b9)
After, with padding restored to icon, padding reduced on left side of icon, and gap between icon and the text adjusted.
![](https://github.com/sillsdev/web-xforge/assets/6140710/af3bd21d-56c2-4d89-b1de-35ecff5d0fee)

See Storybook for a comprehensive understanding of what actually changed visually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2214)
<!-- Reviewable:end -->
