### PR TITLE
Fix nav bar font size when user has custom font size

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
@@ -71,7 +71,7 @@ mat-nav-list .mat-list-item {
   cursor: initial;
 }
 .navigation-header ::ng-deep .mat-list-item-content {
-  font-size: small;
+  font-size: 0.95em;
   text-align: center;
   justify-content: space-around;
   color: #777;
@@ -89,7 +89,7 @@ mat-nav-list .mat-list-item {
   color: white;
   padding: 2px 6px;
   border-radius: 100px;
-  font-size: small;
+  font-size: 0.95em;
   background: #4678d6;
   margin-inline-start: auto;
 }


### PR DESCRIPTION
I was very surprised to see a screenshot of SF that looked like this:

![](https://github.com/sillsdev/web-xforge/assets/6140710/73c912f7-5378-4d2f-bfdf-6a893828f3af)

This happens when the user sets the default font size to something larger than the default. And while it makes some sense for text to get bigger when you do this, it makes no sense for the things that should be smallest to get bigger, and everything else to stay the same.

What I didn't realize when I wrote the nav bar was that `font-size: small` is a relative value. I've changed it to `em` values that are _almost_ identical to what we had before.

There are other places in the application that could use improvement, but this one is glaring, is nearly always present, and jumps out to me more than anything else.

I expect Storybook to show some very slight changes to the font size.