### PR TITLE
SF-2301 Enable resolving note threads in SF

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -69,8 +69,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     answer_comments: ['view'],
     likes: ['view'],
     biblical_terms: ['view'],
-    pt_note_threads: ['view', 'create', 'delete_own'],
-    sf_note_threads: ['view', 'create', 'delete_own'],
+    pt_note_threads: ['view', 'create', 'edit', 'delete_own'],
+    sf_note_threads: ['view', 'create', 'edit', 'delete_own'],
     notes: ['view', 'create', 'edit_own', 'delete_own'],
     text_audio: ['view']
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2827,6 +2827,32 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('allows resolving a note', fakeAsync(() => {
+      const projectId: string = 'project01';
+      const threadDataId: string = 'dataid01';
+      const content: string = 'This thread is resolved.';
+      const env = new TestEnvironment();
+      let noteThread: NoteThreadDoc = env.getNoteThreadDoc(projectId, threadDataId);
+      expect(noteThread.data!.notes.length).toEqual(3);
+
+      env.setProjectUserConfig();
+      env.wait();
+      let noteThreadIconElem: HTMLElement | null = env.getNoteThreadIconElement('verse_1_1', threadDataId);
+      noteThreadIconElem!.click();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+      env.mockNoteDialogRef.close({ noteContent: content, status: NoteStatus.Resolved });
+      env.wait();
+      noteThread = env.getNoteThreadDoc(projectId, threadDataId);
+      expect(noteThread.data!.notes.length).toEqual(4);
+      expect(noteThread.data!.notes[3].content).toEqual(content);
+      expect(noteThread.data!.notes[3].status).toEqual(NoteStatus.Resolved);
+
+      // the icon should be hidden from the editor
+      noteThreadIconElem = env.getNoteThreadIconElement('verse_1_1', threadDataId);
+      expect(noteThreadIconElem).toBeNull();
+      env.dispose();
+    }));
+
     it('can open dialog of the second note on the verse', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -108,11 +108,12 @@ import { TranslateMetricsSession } from './translate-metrics-session';
 export const UPDATE_SUGGESTIONS_TIMEOUT = 100;
 
 export interface SaveNoteParameters {
-  content: string;
+  content?: string;
   dataId?: string;
   threadDataId?: string;
   verseRef?: VerseRef;
   biblicalTermId?: string;
+  status?: NoteStatus;
 }
 
 const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
@@ -1142,7 +1143,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       content: params.content,
       conflictType: NoteConflictType.DefaultValue,
       type: NoteType.Normal,
-      status: NoteStatus.Todo,
+      status: params.status ?? NoteStatus.Todo,
       deleted: false,
       editable: true,
       versionNumber: 1
@@ -1182,7 +1183,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
       } else {
         note.threadId = threadDoc.data!.threadId;
-        await threadDoc.submitJson0Op(op => op.add(t => t.notes, note));
+        await threadDoc.submitJson0Op(op => {
+          op.add(t => t.notes, note);
+          // also set the status of the thread to be the status of the note
+          op.set(t => t.status, note.status);
+        });
         await this.updateNoteReadRefs(note.dataId);
       }
     }
@@ -1257,12 +1262,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const result: NoteDialogResult | undefined = await dialogRef.afterClosed().toPromise();
 
     if (result != null) {
-      if (result.noteContent != null) {
+      if (result.noteContent != null || result.status != null) {
         await this.saveNote({
           content: result.noteContent,
           threadDataId: threadDataId,
           dataId: result.noteDataId,
-          verseRef: currentVerseRef
+          verseRef: currentVerseRef,
+          status: result.status
         });
       }
       this.toggleNoteThreadVerseRefs$.next();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1167,12 +1167,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       };
       await this.projectService.createNoteThread(this.projectId, noteThread);
     } else {
-      // updated the existing note
       const threadDoc: NoteThreadDoc = await this.projectService.getNoteThread(
         getNoteThreadDocId(this.projectId, params.threadDataId)
       );
       const noteIndex: number = threadDoc.data!.notes.findIndex(n => n.dataId === params.dataId);
       if (noteIndex >= 0) {
+        // updated the existing note
         if (threadDoc.data?.notes[noteIndex].editable === true) {
           await threadDoc!.submitJson0Op(op => {
             op.set(t => t.notes[noteIndex].content, params.content);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -56,8 +56,8 @@
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">
     <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
-    <mat-button-toggle-group>
-      <mat-button-toggle *ngIf="canInsertNote" class="save-button save-options" (click)="submit()">{{
+    <mat-button-toggle-group *ngIf="canInsertNote">
+      <mat-button-toggle class="save-button save-options" (click)="submit()">{{
         t(saveOption === "save" ? "save" : "resolve")
       }}</mat-button-toggle>
       <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -55,9 +55,22 @@
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">
-    <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
-    <button *ngIf="canInsertNote" mat-flat-button class="save-button" color="primary" (click)="submit()">
-      {{ t("save") }}
-    </button>
+    <mat-button-toggle-group>
+      <mat-button-toggle class="close-button" (click)="close()">{{ t("close") }}</mat-button-toggle>
+      <mat-button-toggle *ngIf="canInsertNote" class="save-button save-options" (click)="submit()">{{
+        t(saveOption === "save" ? "save" : "save_and_resolve")
+      }}</mat-button-toggle>
+      <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
+        <mat-icon>expand_less</mat-icon>
+      </mat-button-toggle>
+      <mat-menu #saveMenu="matMenu" class="save-options-menu" yPosition="above" xPosition="before">
+        <button *ngIf="saveOption === 'resolve'" mat-menu-item (click)="saveOption = 'save'">
+          <span>{{ t("save") }}</span>
+        </button>
+        <button *ngIf="saveOption === 'save'" mat-menu-item (click)="saveOption = 'resolve'">
+          <span>{{ t("save_and_resolve") }}</span>
+        </button>
+      </mat-menu>
+    </mat-button-toggle-group>
   </mat-dialog-actions>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -55,10 +55,10 @@
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions fxLayoutAlign="end">
+    <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
     <mat-button-toggle-group>
-      <mat-button-toggle class="close-button" (click)="close()">{{ t("close") }}</mat-button-toggle>
       <mat-button-toggle *ngIf="canInsertNote" class="save-button save-options" (click)="submit()">{{
-        t(saveOption === "save" ? "save" : "save_and_resolve")
+        t(saveOption === "save" ? "save" : "resolve")
       }}</mat-button-toggle>
       <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
         <mat-icon>expand_less</mat-icon>
@@ -68,7 +68,7 @@
           <span>{{ t("save") }}</span>
         </button>
         <button *ngIf="saveOption === 'save'" mat-menu-item (click)="saveOption = 'resolve'">
-          <span>{{ t("save_and_resolve") }}</span>
+          <span>{{ t("resolve") }}</span>
         </button>
       </mat-menu>
     </mat-button-toggle-group>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -111,4 +111,11 @@ h1 {
 .save-options {
   background-color: $sf_grey;
   color: white;
+  ::ng-deep .mat-button-toggle-label-content {
+    line-height: 36px;
+  }
+}
+
+.close-button {
+  font-size: 16px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -107,3 +107,8 @@ h1 {
     align-self: flex-end;
   }
 }
+
+.save-options {
+  background-color: $sf_grey;
+  color: white;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -509,12 +509,12 @@ describe('NoteDialogComponent', () => {
     expect(env.saveOptionsMenu).not.toBeNull();
     // select resolve from the menu
     const resolveMenuItem: DebugElement = env.saveOptionsMenu.query(By.css('button'));
-    expect(resolveMenuItem.nativeElement.textContent).toEqual('Save and resolve');
+    expect(resolveMenuItem.nativeElement.textContent).toEqual('Resolve');
     resolveMenuItem.nativeElement.click();
     tick(10);
     env.fixture.detectChanges();
     expect(env.component.saveOption).toEqual('resolve');
-    expect(env.saveButton.nativeElement.textContent).toEqual('Save and resolve');
+    expect(env.saveButton.nativeElement.textContent).toEqual('Resolve');
   }));
 
   it('hides save options trigger when user is a commenter', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -509,12 +509,12 @@ describe('NoteDialogComponent', () => {
     expect(env.saveOptionsMenu).not.toBeNull();
     // select resolve from the menu
     const resolveMenuItem: DebugElement = env.saveOptionsMenu.query(By.css('button'));
-    expect(resolveMenuItem.nativeElement.textContent).toEqual('Resolve');
+    expect(resolveMenuItem.nativeElement.textContent).toEqual('Save and resolve');
     resolveMenuItem.nativeElement.click();
     tick(10);
     env.fixture.detectChanges();
     expect(env.component.saveOption).toEqual('resolve');
-    expect(env.saveButton.nativeElement.textContent).toEqual('Resolve');
+    expect(env.saveButton.nativeElement.textContent).toEqual('Save and resolve');
   }));
 
   it('hides save options trigger when user is a commenter', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -270,6 +270,7 @@
     "paratext_user": "Assigned to a Paratext user",
     "permanently_delete_note": "Permanently delete this comment?",
     "reattached": "(Re-attached)",
+    "save_and_resolve": "Save and resolve",
     "save": "Save",
     "show_changes": "Show changes",
     "status_resolved": "Resolved",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -270,7 +270,7 @@
     "paratext_user": "Assigned to a Paratext user",
     "permanently_delete_note": "Permanently delete this comment?",
     "reattached": "(Re-attached)",
-    "save_and_resolve": "Save and resolve",
+    "resolve": "Resolve",
     "save": "Save",
     "show_changes": "Show changes",
     "status_resolved": "Resolved",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -270,7 +270,7 @@
     "paratext_user": "Assigned to a Paratext user",
     "permanently_delete_note": "Permanently delete this comment?",
     "reattached": "(Re-attached)",
-    "resolve": "Resolve",
+    "resolve": "Save and resolve",
     "save": "Save",
     "show_changes": "Show changes",
     "status_resolved": "Resolved",

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -105,6 +105,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.badge-theme($material-app-theme);
 @include mat.bottom-sheet-theme($material-app-theme);
 @include mat.legacy-button-theme($material-app-theme);
+@include mat.button-toggle-theme($material-app-theme);
 @include mat.legacy-card-theme($material-app-theme);
 @include mat.legacy-checkbox-theme($material-app-theme);
 @include mat.chips-theme($material-app-theme);
@@ -136,7 +137,6 @@ $material-theme-accent-error: mat.define-light-theme(
 
 // Other components that appear to not be used at this time
 
-// @include mat.button-toggle-theme($material-app-theme);
 // @include mat.grid-list-theme($material-app-theme);
 // @include mat.slide-toggle-theme($material-app-theme);
 // @include mat.sort-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -47,7 +47,8 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   background-color: variables.$errorColor !important;
 }
 
-.mat-flat-button {
+.mat-flat-button,
+.mat-button-toggle-button {
   transition: background-color 0.15s, color 0.15s;
   &:not(:disabled):hover {
     background-color: variables.$greenLight;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
@@ -54,6 +55,7 @@ const modules = [
   MatBadgeModule,
   MatBottomSheetModule,
   MatButtonModule,
+  MatButtonToggleModule,
   MatCardModule,
   MatCheckboxModule,
   MatChipsModule,


### PR DESCRIPTION
* specify status when note dialog is closed
* update note thread status to be the status of the saved note
* allow note content to be optional
* add trigger for save options menu next to save button

The PR introduces the logic to allow Paratext users with permission to add notes to resolve a note thread. Users with the Commenter role are unable to resolve note threads. When a thread is resolved, they can no longer be viewed in SF unless a user synchronizes their project to PT and the note is unresolved in PT. I don't expect that it will be often that a user will need to unresolve a note, but it can be done.

Resolve button translator view
![Resolve a note options](https://github.com/sillsdev/web-xforge/assets/17931130/cae435f4-0e4b-4649-9cad-f76699d1582c)

Save button commenter view
![Resolve a note commenter disabled](https://github.com/sillsdev/web-xforge/assets/17931130/211fb0eb-af28-4c52-b732-f0cb40df38d4)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2216)
<!-- Reviewable:end -->
