### PR TITLE
SF-2389 Hide pre-translation settings when not approved

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -99,8 +99,8 @@
               </mat-error>
             </div>
           </mat-card-content>
-          <mat-divider *ngIf="isPreTranslationEnabled"></mat-divider>
-          <mat-card-content *ngIf="isPreTranslationEnabled">
+          <mat-divider *ngIf="showPreTranslationSettings"></mat-divider>
+          <mat-card-content *ngIf="showPreTranslationSettings">
             <mat-card-title>{{ t("pre_translation_drafting") }}</mat-card-title>
             <div class="tool-setting">
               <ng-container *ngIf="mainSettingsLoaded">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -99,8 +99,8 @@
               </mat-error>
             </div>
           </mat-card-content>
-          <mat-divider *ngIf="featureFlags.showNmtDrafting.enabled"></mat-divider>
-          <mat-card-content *ngIf="featureFlags.showNmtDrafting.enabled">
+          <mat-divider *ngIf="isPreTranslationEnabled"></mat-divider>
+          <mat-card-content *ngIf="isPreTranslationEnabled">
             <mat-card-title>{{ t("pre_translation_drafting") }}</mat-card-title>
             <div class="tool-setting">
               <ng-container *ngIf="mainSettingsLoaded">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -15,7 +15,7 @@ import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-proj
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { createTestTextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio-test-data';
-import { TranslateConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
+import { ProjectType, TranslateConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { of } from 'rxjs';
 import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
@@ -224,7 +224,8 @@ describe('SettingsComponent', () => {
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: false
-          }
+          },
+          preTranslate: true
         });
         when(mockedParatextService.getProjects()).thenResolve([
           {
@@ -251,11 +252,58 @@ describe('SettingsComponent', () => {
         env.setupProject();
         env.wait();
         env.wait();
-        expect(env.inputElement(env.translationSuggestionsCheckbox).checked).toBe(true);
         expect(env.alternateSourceSelect).not.toBeNull();
         expect(env.alternateSourceSelectProjectsResources.length).toEqual(5);
         expect(env.alternateSourceSelectProjectsResources[1].name).toBe('ParatextP2');
         expect(env.alternateSourceSelectProjectsResources[2].name).toBe('Sob Jonah and Luke');
+      }));
+
+      it('should display for back translations', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: false,
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: []
+          },
+          projectType: ProjectType.BackTranslation
+        });
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).not.toBeNull();
+      }));
+
+      it('should display for forward translations', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).not.toBeNull();
+      }));
+
+      it('should not display when the feature flag is disabled', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).toBeNull();
+      }));
+
+      it('should not display for forward translations when not approved', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: false,
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: []
+          }
+        });
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).toBeNull();
       }));
     });
 
@@ -267,7 +315,8 @@ describe('SettingsComponent', () => {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: []
-          }
+          },
+          preTranslate: true
         });
         env.wait();
         env.wait();
@@ -297,7 +346,8 @@ describe('SettingsComponent', () => {
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: true
-          }
+          },
+          preTranslate: true
         });
         env.wait();
         env.wait();
@@ -329,7 +379,8 @@ describe('SettingsComponent', () => {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: []
-          }
+          },
+          preTranslate: true
         });
         env.wait();
         env.wait();
@@ -356,7 +407,8 @@ describe('SettingsComponent', () => {
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: true
-          }
+          },
+          preTranslate: true
         });
         when(mockedParatextService.getProjects()).thenResolve([
           {
@@ -383,6 +435,58 @@ describe('SettingsComponent', () => {
       it('should not display for non-system administrators', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).toBeNull();
+      }));
+
+      it('should display for system administrators on back translations', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: false,
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: []
+          },
+          projectType: ProjectType.BackTranslation
+        });
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).not.toBeNull();
+      }));
+
+      it('should display for system administrators on forward translations', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).not.toBeNull();
+      }));
+
+      it('should not display for system administrators when the feature flag is disabled', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.servalConfigTextArea).toBeNull();
+      }));
+
+      it('should not display for system administrators on forward translations when not approved', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: false,
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: []
+          }
+        });
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).toBeNull();
@@ -418,7 +522,8 @@ describe('SettingsComponent', () => {
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: false
-          }
+          },
+          preTranslate: true
         });
         when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
         env.wait();
@@ -1097,6 +1202,7 @@ class TestEnvironment {
 
   setupProject(
     translateConfig: Partial<TranslateConfig> = {
+      preTranslate: true,
       translationSuggestionsEnabled: true,
       source: {
         paratextId: 'paratextId01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -258,7 +258,32 @@ describe('SettingsComponent', () => {
         expect(env.alternateSourceSelectProjectsResources[2].name).toBe('Sob Jonah and Luke');
       }));
 
-      it('should display for back translations', fakeAsync(() => {
+      it('should display for back translations for system administrators', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: false,
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: []
+          },
+          projectType: ProjectType.BackTranslation
+        });
+        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).not.toBeNull();
+      }));
+
+      it('should display for forward translations', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        env.wait();
+        env.wait();
+        expect(env.alternateSourceSelect).not.toBeNull();
+      }));
+
+      it('should not display for back translations', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({
           preTranslate: false,
@@ -271,15 +296,7 @@ describe('SettingsComponent', () => {
         });
         env.wait();
         env.wait();
-        expect(env.alternateSourceSelect).not.toBeNull();
-      }));
-
-      it('should display for forward translations', fakeAsync(() => {
-        const env = new TestEnvironment();
-        env.setupProject();
-        env.wait();
-        env.wait();
-        expect(env.alternateSourceSelect).not.toBeNull();
+        expect(env.alternateSourceSelect).toBeNull();
       }));
 
       it('should not display when the feature flag is disabled', fakeAsync(() => {
@@ -476,7 +493,7 @@ describe('SettingsComponent', () => {
         expect(env.servalConfigTextArea).toBeNull();
       }));
 
-      it('should not display for system administrators on forward translations when not approved', fakeAsync(() => {
+      it('should display for system administrators on forward translations when not approved', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({
           preTranslate: false,
@@ -489,7 +506,7 @@ describe('SettingsComponent', () => {
         when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
         env.wait();
         env.wait();
-        expect(env.servalConfigTextArea).toBeNull();
+        expect(env.servalConfigTextArea).not.toBeNull();
       }));
 
       it('should change serval config value', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -4,7 +4,7 @@ import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/lega
 import { ActivatedRoute, Router } from '@angular/router';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
-import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
+import { ProjectType, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { combineLatest } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
@@ -121,6 +121,15 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
   get isAlternateTrainingSourceEnabled(): boolean {
     return this.alternateTrainingSourceEnabled.value ?? false;
+  }
+
+  get isPreTranslationEnabled(): boolean {
+    const translateConfig = this.projectDoc?.data?.translateConfig;
+    if (translateConfig == null || !this.featureFlags.showNmtDrafting.enabled) {
+      return false;
+    } else {
+      return translateConfig.preTranslate === true || translateConfig.projectType === ProjectType.BackTranslation;
+    }
   }
 
   get projectId(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -123,12 +123,14 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     return this.alternateTrainingSourceEnabled.value ?? false;
   }
 
-  get isPreTranslationEnabled(): boolean {
+  get showPreTranslationSettings(): boolean {
     const translateConfig = this.projectDoc?.data?.translateConfig;
     if (translateConfig == null || !this.featureFlags.showNmtDrafting.enabled) {
       return false;
+    } else if (this.authService.currentUserRole === SystemRole.SystemAdmin) {
+      return true;
     } else {
-      return translateConfig.preTranslate === true || translateConfig.projectType === ProjectType.BackTranslation;
+      return translateConfig.preTranslate === true && translateConfig.projectType !== ProjectType.BackTranslation;
     }
   }
 


### PR DESCRIPTION
Currently the pre-translation settings are visible for all projects. This PR changes the settings screen so that they are only visible if:

 * The project is a back translation.
 * The project has been approved for pre-translation drafting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2218)
<!-- Reviewable:end -->
