### PR TITLE
SF-2396 Handle pre-translation 409 errors in the editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -140,7 +140,7 @@ export class DraftGenerationService {
         map(res => (res.data && this.toDraftSegmentMap(res.data.preTranslations)) ?? {}),
         catchError(err => {
           // If no pretranslations exist, return empty dictionary
-          if (err.status === 404) {
+          if (err.status === 404 || err.status === 409) {
             return of({});
           }
           return throwError(err);

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -255,6 +255,7 @@ public class MachineApiController : ControllerBase
     /// <response code="200">The pre-translations were successfully queried for.</response>
     /// <response code="403">You do not have permission to retrieve the pre-translations for this project.</response>
     /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="409">The engine has not been built on the ML server.</response>
     /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetPreTranslation)]
     public async Task<ActionResult<PreTranslationDto>> GetPreTranslationAsync(
@@ -287,6 +288,10 @@ public class MachineApiController : ControllerBase
         catch (ForbiddenException)
         {
             return Forbid();
+        }
+        catch (InvalidOperationException)
+        {
+            return Conflict();
         }
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -664,6 +664,26 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetPreTranslationAsync_NotBuilt()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService
+            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new InvalidOperationException());
+
+        // SUT
+        ActionResult<PreTranslationDto> actual = await env.Controller.GetPreTranslationAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ConflictResult>(actual.Result);
+    }
+
+    [Test]
     public async Task GetPreTranslationAsync_Success()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1281,6 +1281,21 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void GetPreTranslationAsync_EngineNotBuilt()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.PreTranslationService
+            .GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(ServalApiExceptions.EngineNotBuilt);
+
+        // SUT
+        Assert.ThrowsAsync<InvalidOperationException>(
+            () => env.Service.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
     public void GetPreTranslationAsync_NoFeatureFlagEnabled()
     {
         // Set up test environment
@@ -1318,7 +1333,7 @@ public class MachineApiServiceTests
     }
 
     [Test]
-    public void GetPreTranslationsAsync_ServalDown()
+    public void GetPreTranslationAsync_ServalDown()
     {
         // Set up test environment
         var env = new TestEnvironment();


### PR DESCRIPTION
This Pull Request correctly traps and handles 409 errors from Serval and stops them throwing exceptions in the editor when checking to see whether or not pre-translations exist for a given book/chapter.

A 409 error means that the Serval translation engine is not ready for retrieving the pre-translations yet.

**Note:** Testing should be completed by a developer, due to the requirement to modify the code to throw the exception (see the JIRA ticket).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2220)
<!-- Reviewable:end -->
