### PR TITLE
SF-1916 Allow admins to send a general share link when sharing disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -204,15 +204,15 @@ describe('ShareDialogComponent', () => {
     expect(roles).toContain(SFProjectRole.Commenter);
   }));
 
-  it('admin users can not share with anyone if sharing is disabled', fakeAsync(() => {
-    env = new TestEnvironment({ userId: TestUsers.Admin, checkingEnabled: false, translateShareEnabled: false });
-    expect(env.component.shareRole).toEqual(SF_DEFAULT_TRANSLATE_SHARE_ROLE);
-    expect(env.canChangeLinkUsage).toBeFalse();
+  it('admin users can share with anyone if sharing is disabled', fakeAsync(() => {
+    env = new TestEnvironment({ userId: TestUsers.Admin, checkingShareEnabled: false, translateShareEnabled: false });
+    expect(env.component.shareRole).toEqual(SFProjectRole.CommunityChecker);
+    expect(env.canChangeLinkUsage).toBeTrue();
 
     env.component.setRole(SFProjectRole.CommunityChecker);
     env.wait();
     expect(env.component.shareRole).toEqual(SFProjectRole.CommunityChecker);
-    expect(env.canChangeLinkUsage).toBeFalse();
+    expect(env.canChangeLinkUsage).toBeTrue();
   }));
 
   it('admin users can share with anyone if sharing is enabled', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -123,11 +123,13 @@ export class ShareDialogComponent extends SubscriptionDisposable {
     if (this.isProjectAdmin) {
       options.push(ShareLinkType.Recipient);
     }
+
     if (
       (this.shareRole === SFProjectRole.CommunityChecker &&
         this.projectDoc?.data?.checkingConfig.checkingEnabled &&
-        this.projectDoc?.data?.checkingConfig.shareEnabled) ||
-      (this.shareRole !== SFProjectRole.CommunityChecker && this.projectDoc?.data?.translateConfig.shareEnabled)
+        (this.projectDoc?.data?.checkingConfig.shareEnabled || this.isProjectAdmin)) ||
+      (this.shareRole !== SFProjectRole.CommunityChecker &&
+        (this.projectDoc?.data?.translateConfig.shareEnabled || this.isProjectAdmin))
     ) {
       options.push(ShareLinkType.Anyone);
     }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -805,12 +805,9 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         {
             string[] availableRoles = new Dictionary<string, bool>
             {
-                {
-                    SFProjectRole.CommunityChecker,
-                    project.CheckingConfig.CheckingEnabled && project.CheckingConfig.ShareEnabled
-                },
-                { SFProjectRole.Viewer, project.TranslateConfig.ShareEnabled },
-                { SFProjectRole.Commenter, project.TranslateConfig.ShareEnabled },
+                { SFProjectRole.CommunityChecker, project.CheckingConfig.CheckingEnabled },
+                { SFProjectRole.Viewer, true },
+                { SFProjectRole.Commenter, true },
             }
                 .Where(entry => entry.Value)
                 .Select(entry => entry.Key)

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -546,7 +546,7 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public async Task JoinWithShareKeyAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
+    public async Task JoinWithShareKeyAsync_LinkSharingDisabledAndUserNotOnProject_UserJoined()
     {
         var env = new TestEnvironment();
         SFProject project = env.GetProject(Project02);
@@ -556,7 +556,13 @@ public class SFProjectServiceTests
             Project02,
             new SFProjectSettings { CheckingShareEnabled = false }
         );
-        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.JoinWithShareKeyAsync(User03, "linksharing02"));
+
+        // For 'anyone' links, allow the user to join even when sharing is disabled
+        await env.Service.JoinWithShareKeyAsync(User03, "linksharing02");
+        project = env.GetProject(Project02);
+        Assert.That(project.UserRoles.ContainsKey(User03), Is.True);
+        User user = env.GetUser(User03);
+        Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project02));
     }
 
     [Test]


### PR DESCRIPTION
Admins were originally restricted from sharing general links where anyone with the link can join unless sharing was enabled. This change allows admin users to share 'anyone' links while keeping a project un-shareable by non-admin users.

Unfortunately, users who received a link to the project can still pass that link on to other users, so being un-shareable is not accurate. A follow-up for this would be to allow admins to revoke a share link. Maybe this change should not be submitted before that is complete. I'm not sure what the security concerns may be in the real world.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2221)
<!-- Reviewable:end -->
