### PR TITLE
SF-2398 Make tooltips for icon buttons in checking area consistent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -84,7 +84,7 @@
                 <button
                   mat-icon-button
                   type="button"
-                  title="{{ t('add_question') }}"
+                  [matTooltip]="t('add_question')"
                   (click)="questionDialog()"
                   class="add-question-button"
                 >
@@ -95,9 +95,10 @@
                   <span>{{ t("add_question") }}</span>
                 </button>
                 <button
-                  *ngIf="canCreateScriptureAudio && !chapterHasAudio"
+                  *ngIf="canCreateScriptureAudio"
                   type="button"
                   mat-icon-button
+                  [matTooltip]="t('manage_audio')"
                   (click)="addAudioTimingData()"
                 >
                   <mat-icon class="material-icons-outlined">audio_file</mat-icon>
@@ -107,6 +108,8 @@
                 *ngIf="featureFlags.scriptureAudio.enabled && chapterHasAudio"
                 type="button"
                 mat-icon-button
+                [matTooltip]="t('play_chapter')"
+                [matTooltipDisabled]="isAudioPlaying()"
                 (click)="toggleAudio()"
               >
                 <mat-icon>{{ isAudioPlaying() ? "pause" : "play_circle_outline" }}</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.html
@@ -1,29 +1,22 @@
-<button
-  #trigger="matMenuTrigger"
-  mat-icon-button
-  [mat-menu-trigger-for]="menu"
-  class="font-size-menu-trigger"
-  [ngClass]="{ 'menu-open': trigger.menuOpen }"
->
-  <mat-icon>format_size</mat-icon>
-</button>
-<mat-menu #menu="matMenu" class="font-size-menu" [xPosition]="'before'">
-  <div mat-menu-item disableRipple class="button-group">
-    <button
-      mat-icon-button
-      (click)="adjustFontSize($event, -1)"
-      [disabled]="fontSize === min"
-      title="Decrease font size"
-    >
-      <mat-icon>remove</mat-icon>
-    </button>
-    <button
-      mat-icon-button
-      (click)="adjustFontSize($event, 1)"
-      [disabled]="fontSize === max"
-      title="Increase font size"
-    >
-      <mat-icon>add</mat-icon>
-    </button>
-  </div>
-</mat-menu>
+<ng-container *transloco="let t; read: 'font_size'">
+  <button
+    #trigger="matMenuTrigger"
+    mat-icon-button
+    [mat-menu-trigger-for]="menu"
+    class="font-size-menu-trigger"
+    [ngClass]="{ 'menu-open': trigger.menuOpen }"
+    [matTooltip]="t('text_size')"
+  >
+    <mat-icon>format_size</mat-icon>
+  </button>
+  <mat-menu #menu="matMenu" class="font-size-menu" [xPosition]="'before'">
+    <div mat-menu-item disableRipple class="button-group">
+      <button mat-icon-button (click)="adjustFontSize($event, -1)" [disabled]="fontSize === min">
+        <mat-icon>remove</mat-icon>
+      </button>
+      <button mat-icon-button (click)="adjustFontSize($event, 1)" [disabled]="fontSize === max">
+        <mat-icon>add</mat-icon>
+      </button>
+    </div>
+  </mat-menu>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.spec.ts
@@ -7,6 +7,7 @@ import {
   MatLegacyMenuItemHarness as MatMenuItemHarness
 } from '@angular/material/legacy-menu/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { FontSizeComponent } from './font-size.component';
 
@@ -33,7 +34,7 @@ describe('FontSizeComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [UICommonModule, NoopAnimationsModule],
+      imports: [UICommonModule, NoopAnimationsModule, TestTranslocoModule],
       declarations: [FontSizeComponent]
     }).compileComponents();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.stories.ts
@@ -3,6 +3,7 @@ import { AngularRenderer, componentWrapperDecorator, Meta, moduleMetadata, Story
 import { expect } from '@storybook/jest';
 import { userEvent } from '@storybook/testing-library';
 import { PlayFunction, PlayFunctionContext } from '@storybook/types';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { FontSizeComponent } from './font-size.component';
 
@@ -11,7 +12,7 @@ export default {
   component: FontSizeComponent,
   decorators: [
     moduleMetadata({
-      imports: [CommonModule, UICommonModule]
+      imports: [CommonModule, UICommonModule, TestTranslocoModule]
     }),
     componentWrapperDecorator(
       story => `
@@ -54,7 +55,7 @@ export const OpenMenuWithEndSpace: Story = {
 
 export const IncreaseFontAllowed: Story = {
   args: { fontSize: 2 },
-  play: playForAdjustFontButton('Increase')
+  play: playForAdjustFontButton('+')
 };
 
 export const IncreaseFontNotAllowed: Story = {
@@ -64,7 +65,7 @@ export const IncreaseFontNotAllowed: Story = {
 
 export const DecreaseFontAllowed: Story = {
   args: { fontSize: 2 },
-  play: playForAdjustFontButton('Decrease')
+  play: playForAdjustFontButton('-')
 };
 
 export const DecreaseFontNotAllowed: Story = {
@@ -75,12 +76,12 @@ export const DecreaseFontNotAllowed: Story = {
 /**
  * Return 'play' function to open menu and click the specified button.
  */
-function playForAdjustFontButton(which: 'Increase' | 'Decrease'): PlayFunction<AngularRenderer, FontSizeComponent> {
+function playForAdjustFontButton(which: '+' | '-'): PlayFunction<AngularRenderer, FontSizeComponent> {
   return (context: PlayFunctionContext<AngularRenderer, FontSizeComponent>) => {
     OpenMenu.play?.(context);
 
     const adjustFontButton: HTMLElement | null = document.body.querySelector(
-      `.font-size-menu  button[title="${which} font size"]`
+      `.font-size-menu button:nth-of-type(${which === '-' ? 1 : 2})`
     );
 
     expect(adjustFontButton).not.toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'share'">
-  <button *ngIf="iconOnlyButton" (click)="openDialog()" mat-icon-button title="{{ t('share') }}" id="share-btn">
+  <button *ngIf="iconOnlyButton" (click)="openDialog()" mat-icon-button [matTooltip]="t('share')" id="share-btn">
     <mat-icon class="mirror-rtl">person_add</mat-icon>
   </button>
   <button *ngIf="!iconOnlyButton" mat-flat-button (click)="openDialog()" color="primary" class="button-with-text">

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -159,8 +159,10 @@
   },
   "checking": {
     "filter_questions": "Filter questions",
+    "manage_audio": "Manage audio",
     "me": "Me",
     "next": "Next",
+    "play_chapter": "Play chapter",
     "previous": "Previous",
     "questions": "Questions",
     "question_does_not_have_audio": "No audio recordings have been uploaded for this chapter. Contact the project administrator to upload audio.",
@@ -324,6 +326,9 @@
     "failed_to_save": "Failed to save your changes. Please check that you have the recommended 500 MB of free space on your device.",
     "i_understand": "I understand",
     "storage_space_is_limited": "The storage space on this device is limited. It is recommended to have a minimum of 500 MB of free space to ensure all feature are available. Please free up storage space."
+  },
+  "font_size": {
+    "text_size": "Text size"
   },
   "issue_email": {
     "body": "Thanks for reporting the issue!\nIt would help us if you fill out some of the information below, but please submit even if you can't fill out much.\nIf you are requesting a feature many of the fields may not be applicable.\nBe aware your bug report will be publicly available. Never submit passwords or other secrets.\n\nBug report\nA clear and concise description of what the bug is.\n\nSteps to reproduce\nFor example:\n1. Go to ...\n2. Click on ...\n3. Scroll down to ...\n4. See error\n\nActual behavior\nPlease describe actual behavior of the issue you are observing.\n\nExpected behavior\nA clear and concise description of what you expected to happen.\n\nScreenshots\nIf applicable, add screenshots to help explain your issue.\n\nAdditional context\nAdd any other context about the problem here.\n\nPossible solution\nAdd any possible solutions to the problem here.\n\nYour environment:\nSoftware                 Version\n-----------------------------------------\n{{ siteName }} - {{ siteVersion }}\n{{ browserName }} - {{ browserVersion }}\n{{ operatingSystem }} - {{ operatingSystemVersion }}\n\nURL: {{ url }}\nError id: {{ errorId }}",


### PR DESCRIPTION
Before there was a mix of tool tips, no tool tips, different types of tool tips (hover text, versus Material).

- No tool tip on "Add question" button when the text is shown
- Tool tip on "Play chapter" is shown, but not for pause. If you've already hit play, it should be pretty obvious what the button is for.

https://github.com/sillsdev/web-xforge/assets/6140710/ec544509-2301-41dd-a802-739937a23db1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2223)
<!-- Reviewable:end -->
