### PR TITLE
SF-2403 Fix skip previous or next to skip past phrases

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
@@ -97,7 +97,7 @@ export class CheckingUtils {
     // return if the text ref is for a heading and not a verse
     if (audioTimingMatch == null) return;
     const audioTextRef: AudioTextRef = { verseStr: audioTimingMatch[1] };
-    if (audioTimingMatch[2] !== '') audioTextRef.phrase = audioTimingMatch[2];
+    if (audioTimingMatch[2] !== '') audioTextRef.phrase = audioTimingMatch[2].toLowerCase();
     return audioTextRef;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -156,6 +156,24 @@ describe('ScriptureAudioComponent', () => {
     expect(env.currentTime).toEqual(3);
   }));
 
+  it('skipping next or previous goes to the next or previous verse when timing is phrase level', fakeAsync(() => {
+    const env = new TestEnvironment({
+      timings: [
+        { textRef: '1a', from: 0.0, to: 1.0 },
+        { textRef: '1b', from: 1.0, to: 2.0 },
+        { textRef: '2a', from: 2.0, to: 3.0 },
+        { textRef: '2b', from: 3.0, to: 4.0 }
+      ]
+    });
+
+    expect(env.currentTime).toEqual(0);
+    env.clickNextRef();
+    expect(env.currentTime).toEqual(2);
+    env.currentTime = 3.5;
+    env.clickPreviousRef();
+    expect(env.currentTime).toEqual(0);
+  }));
+
   it('emits once when chapter audio finishes', fakeAsync(() => {
     const env = new TestEnvironment();
 


### PR DESCRIPTION
Phrase level timing files have multiple timing entries for a verse. When using a phrase level timing file, we do not currently support phrase level highlight, but we do need to account for phrases when a user clicks the skip next or skip previous buttons.

This PR handles the case where a user clicks skip next or skip previous. The first phrase of the next or previous verse will be used to update the current time of the audio player.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2228)
<!-- Reviewable:end -->
