### PR TITLE
SF-2397 Allow rebuilding when Serval data is missing from SF or Serval

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
@@ -137,6 +137,10 @@ describe('RemoteTranslationEngine', () => {
     const env = new TestEnvironment();
     env.addCreateBuild();
 
+    when(env.mockedHttpClient.post<BuildDto>('translation/builds', JSON.stringify('project01'))).thenReturn(
+      of({ status: 200 })
+    );
+
     await env.client.startTraining();
     expect().nothing();
   });
@@ -145,7 +149,7 @@ describe('RemoteTranslationEngine', () => {
     const env = new TestEnvironment();
     env.addCreateBuild();
 
-    when(env.mockedHttpClient.get<EngineDto>('translation/engines/project:project01')).thenReturn(
+    when(env.mockedHttpClient.post<BuildDto>('translation/builds', JSON.stringify('project01'))).thenReturn(
       throwError(new HttpErrorResponse({ status: 404 }))
     );
 
@@ -187,12 +191,12 @@ describe('RemoteTranslationEngine', () => {
     const env = new TestEnvironment();
     env.addCreateBuild();
     when(env.mockedHttpClient.get<BuildDto>('translation/builds/id:build01?minRevision=1')).thenReturn(
-      throwError(new HttpErrorResponse({ status: 404 }))
+      throwError(new HttpErrorResponse({ status: 404, statusText: 'Not Found' }))
     );
 
     env.client.train().subscribe(
       progress => expect(progress.percentCompleted).toEqual(0),
-      err => expect(err.message).toEqual('')
+      err => expect(err.message).toContain('404 Not Found')
     );
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -67,7 +67,7 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
         .toPromise();
       return this.createWordGraph(response.data as WordGraphDto);
     } catch (err: any) {
-      if (err.status === 409) {
+      if (err.status === 404 || err.status === 409) {
         this.noticeService.showError(
           translate('error_messages.suggestion_engine_requires_retrain'),
           translate('error_messages.go_to_retrain'),
@@ -97,10 +97,9 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
     );
   }
 
-  async startTraining(): Promise<void> {
-    await this.getEngine(this.projectId)
+  async startTraining(): Promise<BuildDto | undefined> {
+    return this.createBuild(this.projectId)
       .pipe(
-        mergeMap(e => this.createBuild(e.id)),
         catchError(err => {
           if (err.status === 404) {
             return of(undefined);
@@ -171,13 +170,6 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
           throw new Error('Error occurred during build: ' + res.data.message);
         }
         return res.data;
-      }),
-      catchError(err => {
-        if (err.status === 404) {
-          return of(undefined);
-        } else {
-          return throwError(err);
-        }
       })
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -163,9 +163,9 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     if (this.translationEngine == null) {
       return;
     }
-    this.translationEngine.startTraining();
     this.trainingPercentage = 0;
     this.isTraining = true;
+    this.translationEngine.startTraining().then(() => this.listenForStatus());
   }
 
   getBookName(text: TextInfo): string {
@@ -248,6 +248,16 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     }
 
     this.translationEngine = this.translationEngineService.createTranslationEngine(this.projectDoc.id);
+    this.listenForStatus();
+  }
+
+  private listenForStatus(): void {
+    if (this.translationEngine == null) {
+      return;
+    } else if (this.trainingSub != null) {
+      this.trainingSub.unsubscribe();
+      this.trainingSub = undefined;
+    }
     this.trainingSub = this.translationEngine
       .listenForTrainingStatus()
       .pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -254,10 +254,8 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   private listenForStatus(): void {
     if (this.translationEngine == null) {
       return;
-    } else if (this.trainingSub != null) {
-      this.trainingSub.unsubscribe();
-      this.trainingSub = undefined;
     }
+    this.trainingSub?.unsubscribe();
     this.trainingSub = this.translationEngine
       .listenForTrainingStatus()
       .pipe(

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -7,7 +7,12 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IMachineProjectService
 {
-    Task AddProjectAsync(string curUserId, string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
+    Task<string> AddProjectAsync(
+        string curUserId,
+        string sfProjectId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
     Task<TranslationBuild?> BuildProjectAsync(
         string curUserId,
         BuildConfig buildConfig,
@@ -29,6 +34,12 @@ public interface IMachineProjectService
     Task<bool> SyncProjectCorporaAsync(
         string curUserId,
         BuildConfig buildConfig,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
+    Task<bool> TranslationEngineExistsAsync(
+        string projectId,
+        string translationEngineId,
         bool preTranslate,
         CancellationToken cancellationToken
     );

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -609,12 +609,29 @@ public class MachineApiService : IMachineApiService
                     )
                 )
                 {
-                    // Clear the existing translation engine id
-                    if (!string.IsNullOrWhiteSpace(translationEngineId))
+                    // Clear the existing translation engine id and corpora
+                    // AddProjectAsync() requires the id to be not defined to create the new translation engine.
+                    // We also load the project secret, so we can get the corpora ID to delete
+                    if (
+                        !string.IsNullOrWhiteSpace(translationEngineId)
+                        && (await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret)
+                    )
                     {
+                        string? corporaId = projectSecret
+                            .ServalData
+                            ?.Corpora
+                            .FirstOrDefault(c => !c.Value.PreTranslate)
+                            .Key;
                         await _projectSecrets.UpdateAsync(
                             sfProjectId,
-                            u => u.Unset(p => p.ServalData.TranslationEngineId)
+                            u =>
+                            {
+                                u.Unset(p => p.ServalData.TranslationEngineId);
+                                if (!string.IsNullOrWhiteSpace(corporaId))
+                                {
+                                    u.Unset(p => p.ServalData.Corpora[corporaId]);
+                                }
+                            }
                         );
                     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -596,7 +596,55 @@ public class MachineApiService : IMachineApiService
         // Execute on Serval, if it is enabled
         if (await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
-            string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
+            string? translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: false);
+            try
+            {
+                // If the translation engine is missing or does not exist, recreate it
+                if (
+                    !await _machineProjectService.TranslationEngineExistsAsync(
+                        sfProjectId,
+                        translationEngineId,
+                        preTranslate: false,
+                        cancellationToken
+                    )
+                )
+                {
+                    // Clear the existing translation engine id
+                    if (!string.IsNullOrWhiteSpace(translationEngineId))
+                    {
+                        await _projectSecrets.UpdateAsync(
+                            sfProjectId,
+                            u => u.Unset(p => p.ServalData.TranslationEngineId)
+                        );
+                    }
+
+                    translationEngineId = await _machineProjectService.AddProjectAsync(
+                        curUserId,
+                        sfProjectId,
+                        preTranslate: false,
+                        cancellationToken
+                    );
+                }
+            }
+            catch (Exception e)
+            {
+                // We do not want to throw the error if we are returning from In Process API below
+                await ProcessServalApiExceptionAsync(
+                    e,
+                    doNotThrowIfInProcessEnabled: true,
+                    metadata: new Dictionary<string, string>
+                    {
+                        { "method", "StartBuildAsync" },
+                        { "curUserId", curUserId },
+                        { "sfProjectId", sfProjectId },
+                        { "translationEngineId", translationEngineId },
+                    }
+                );
+
+                // Ensure that the translation engine id is null so a Serval build isn't started
+                translationEngineId = null;
+            }
+
             if (!string.IsNullOrWhiteSpace(translationEngineId))
             {
                 try
@@ -709,7 +757,7 @@ public class MachineApiService : IMachineApiService
             );
         }
 
-        // If we have a alternate training source, sync that next
+        // If we have an alternate training source, sync that next
         string alternateTrainingSourceProjectId = projectDoc
             .Data
             .TranslateConfig

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -118,7 +118,6 @@ public class MachineProjectService : IMachineProjectService
             && !string.IsNullOrWhiteSpace(machineProject.TargetLanguageTag)
         )
         {
-            // We do not need the returned translation engine id
             return await CreateServalProjectAsync(project, preTranslate, cancellationToken);
         }
 
@@ -215,7 +214,12 @@ public class MachineProjectService : IMachineProjectService
                 }
             }
 
-            // Clear the existing translation engine id
+            // Clear the existing translation engine id and corpora
+            string? corporaId = projectSecret
+                .ServalData
+                ?.Corpora
+                .FirstOrDefault(c => preTranslate ? c.Value.PreTranslate : !c.Value.PreTranslate)
+                .Key;
             await _projectSecrets.UpdateAsync(
                 projectDoc.Id,
                 u =>
@@ -227,6 +231,11 @@ public class MachineProjectService : IMachineProjectService
                     else
                     {
                         u.Unset(p => p.ServalData.TranslationEngineId);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(corporaId))
+                    {
+                        u.Unset(p => p.ServalData.Corpora[corporaId]);
                     }
                 }
             );
@@ -284,8 +293,12 @@ public class MachineProjectService : IMachineProjectService
         {
             // A 404 means that the translation engine does not exist
             _logger.LogInformation($"Translation Engine {translationEngineId} does not exist.");
-
-            // Clear the existing translation engine id
+            string? corporaId = projectSecret
+                .ServalData
+                ?.Corpora
+                .FirstOrDefault(c => preTranslate ? c.Value.PreTranslate : !c.Value.PreTranslate)
+                .Key;
+            // Clear the existing translation engine id and corpora
             await _projectSecrets.UpdateAsync(
                 projectDoc.Id,
                 u =>
@@ -297,6 +310,11 @@ public class MachineProjectService : IMachineProjectService
                     else
                     {
                         u.Unset(p => p.ServalData.TranslationEngineId);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(corporaId))
+                    {
+                        u.Unset(p => p.ServalData.Corpora[corporaId]);
                     }
                 }
             );

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -32,8 +32,8 @@ namespace SIL.XForge.Scripture.Services;
 public class MachineProjectService : IMachineProjectService
 {
     // Supported translation engines
-    private const string Echo = "Echo";
-    private const string Nmt = "Nmt";
+    internal const string Echo = "Echo";
+    internal const string Nmt = "Nmt";
     internal const string SmtTransfer = "SmtTransfer";
 
     private readonly IDataFilesClient _dataFilesClient;
@@ -75,7 +75,7 @@ public class MachineProjectService : IMachineProjectService
         _userSecrets = userSecrets;
     }
 
-    public async Task AddProjectAsync(
+    public async Task<string> AddProjectAsync(
         string curUserId,
         string sfProjectId,
         bool preTranslate,
@@ -107,7 +107,7 @@ public class MachineProjectService : IMachineProjectService
         if (!await _featureManager.IsEnabledAsync(FeatureFlags.Serval))
         {
             _logger.LogInformation("Serval feature flag is not enabled");
-            return;
+            return string.Empty;
         }
 
         // We may not have the source language tag or target language tag if either is a back translation
@@ -119,8 +119,11 @@ public class MachineProjectService : IMachineProjectService
         )
         {
             // We do not need the returned translation engine id
-            _ = await CreateServalProjectAsync(project, preTranslate, cancellationToken);
+            return await CreateServalProjectAsync(project, preTranslate, cancellationToken);
         }
+
+        _logger.LogInformation("The source or target language is missing from the project");
+        return string.Empty;
     }
 
     public async Task<TranslationBuild?> BuildProjectAsync(
@@ -157,11 +160,18 @@ public class MachineProjectService : IMachineProjectService
             throw new DataNotFoundException("The project does not exist.");
         }
 
-        // Ensure we have a translation engine id or a pre-translation engine id
+        // Ensure we have a translation engine id or a pre-translation engine id, and that it exists
         string translationEngineId = preTranslate
             ? projectSecret.ServalData?.PreTranslationEngineId
             : projectSecret.ServalData?.TranslationEngineId;
-        if (string.IsNullOrWhiteSpace(translationEngineId))
+        if (
+            !await TranslationEngineExistsAsync(
+                buildConfig.ProjectId,
+                translationEngineId,
+                preTranslate,
+                cancellationToken
+            )
+        )
         {
             // We do not have one, likely because the translation is a back translation
             // We can only get the language tags for back translations from the ScrText,
@@ -205,6 +215,22 @@ public class MachineProjectService : IMachineProjectService
                 }
             }
 
+            // Clear the existing translation engine id
+            await _projectSecrets.UpdateAsync(
+                projectDoc.Id,
+                u =>
+                {
+                    if (preTranslate)
+                    {
+                        u.Unset(p => p.ServalData.PreTranslationEngineId);
+                    }
+                    else
+                    {
+                        u.Unset(p => p.ServalData.TranslationEngineId);
+                    }
+                }
+            );
+
             // If the pre-translate flag is not set, set it now for the front-end UI
             if (preTranslate && !projectDoc.Data.TranslateConfig.PreTranslate)
             {
@@ -225,7 +251,7 @@ public class MachineProjectService : IMachineProjectService
             bool recreateTranslationEngine = false;
 
             // See if the target language has changed
-            string projectTargetLanguage = GetTargetLanguage(projectDoc.Data, translationEngine.Type == Echo);
+            string projectTargetLanguage = await GetTargetLanguageAsync(projectDoc.Data);
             if (translationEngine.TargetLanguage != projectTargetLanguage)
             {
                 string message =
@@ -517,7 +543,7 @@ public class MachineProjectService : IMachineProjectService
         CancellationToken cancellationToken
     )
     {
-        // Used to return whether or not the corpus was updated
+        // Used to return whether the corpus was updated
         bool corpusUpdated = false;
 
         // Ensure that the Serval feature flag is enabled
@@ -690,6 +716,42 @@ public class MachineProjectService : IMachineProjectService
     }
 
     /// <summary>
+    /// Determines whether a translation engine exists for the specified project.
+    /// </summary>
+    /// <param name="projectId">The Scripture Forge project identifier.</param>
+    /// <param name="translationEngineId">The Serval translation engine identifier.</param>
+    /// <param name="preTranslate">The Serval translation engine identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    public async Task<bool> TranslationEngineExistsAsync(
+        string projectId,
+        string? translationEngineId,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(translationEngineId))
+        {
+            return false;
+        }
+
+        try
+        {
+            TranslationEngine translationEngine = await _translationEnginesClient.GetAsync(
+                translationEngineId,
+                cancellationToken
+            );
+            string type = await GetTranslationEngineTypeAsync(preTranslate);
+            return translationEngine.Name == projectId && translationEngine.Type == type;
+        }
+        catch (ServalApiException e)
+            when (e.StatusCode is StatusCodes.Status403Forbidden or StatusCodes.Status404NotFound)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Gets the source language for the project.
     /// </summary>
     /// <param name="project">The project.</param>
@@ -710,16 +772,6 @@ public class MachineProjectService : IMachineProjectService
             ?? project.TranslateConfig.Source?.WritingSystem.Tag
             ?? throw new ArgumentNullException(nameof(project));
     }
-
-    /// <summary>
-    /// Gets the target language for the project
-    /// </summary>
-    /// <param name="project">The project.</param>
-    /// <param name="useEcho">If <c>true</c>, the echo translation engine is in use.</param>
-    /// <returns>The target language.</returns>
-    /// <exception cref="ArgumentNullException"></exception>
-    private static string GetTargetLanguage(SFProject project, bool useEcho) =>
-        useEcho ? GetSourceLanguage(project, useAlternateTrainingSource: false) : project.WritingSystem.Tag;
 
     /// <summary>
     /// Gets the segments from the text with Unix/Linux line endings.
@@ -822,19 +874,12 @@ public class MachineProjectService : IMachineProjectService
             : projectSecret.ServalData?.TranslationEngineId;
         if (string.IsNullOrWhiteSpace(translationEngineId))
         {
-            bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
-            string type = preTranslate switch
-            {
-                true when useEcho => Echo,
-                true => Nmt,
-                false => SmtTransfer,
-            };
             TranslationEngineConfig engineConfig = new TranslationEngineConfig
             {
                 Name = sfProject.Id,
                 SourceLanguage = GetSourceLanguage(sfProject, useAlternateTrainingSource: false),
-                TargetLanguage = GetTargetLanguage(sfProject, useEcho),
-                Type = type,
+                TargetLanguage = await GetTargetLanguageAsync(sfProject),
+                Type = await GetTranslationEngineTypeAsync(preTranslate),
             };
 
             // Add the project to Serval
@@ -888,6 +933,35 @@ public class MachineProjectService : IMachineProjectService
     }
 
     /// <summary>
+    /// Gets the target language for the project
+    /// </summary>
+    /// <param name="project">The project.</param>
+    /// <returns>The target language.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    private async Task<string> GetTargetLanguageAsync(SFProject project)
+    {
+        // Echo requires the target and source language to be the same, as it outputs your source texts
+        bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
+        return useEcho ? GetSourceLanguage(project, useAlternateTrainingSource: false) : project.WritingSystem.Tag;
+    }
+
+    /// <summary>
+    /// Gets the translation engine type string for Serval.
+    /// </summary>
+    /// <param name="preTranslate">If <c>true</c>, then the translation engine is for pre-translation.</param>
+    /// <returns>The translation engine type string for Serval.</returns>
+    private async Task<string> GetTranslationEngineTypeAsync(bool preTranslate)
+    {
+        bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
+        return preTranslate switch
+        {
+            true when useEcho => Echo,
+            true => Nmt,
+            false => SmtTransfer,
+        };
+    }
+
+    /// <summary>
     /// Updates the corpus configuration in the project secrets.
     /// </summary>
     /// <param name="project">The project.</param>
@@ -912,9 +986,6 @@ public class MachineProjectService : IMachineProjectService
         CancellationToken cancellationToken
     )
     {
-        // Echo requires the target and source language to be the same, as it outputs your source texts
-        bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
-
         // Create or update the corpus
         TranslationCorpus corpus;
         TranslationCorpusConfig corpusConfig = new TranslationCorpusConfig
@@ -927,7 +998,7 @@ public class MachineProjectService : IMachineProjectService
             TargetFiles = targetCorpusFiles
                 .Select(f => new TranslationCorpusFileConfig { FileId = f.FileId, TextId = f.TextId })
                 .ToList(),
-            TargetLanguage = GetTargetLanguage(project, useEcho),
+            TargetLanguage = await GetTargetLanguageAsync(project),
         };
 
         // See if we need to create or update the corpus
@@ -1024,7 +1095,7 @@ public class MachineProjectService : IMachineProjectService
     }
 
     /// <summary>
-    /// Syncs an <see cref="ITextCorpus"/> to Serval, creating files on Serval as necessary.
+    /// Syncs the <see cref="ITextCorpus"/> to Serval, creating files on Serval as necessary.
     /// </summary>
     /// <param name="projectId">The project identifier.</param>
     /// <param name="includeBlankSegments">
@@ -1047,7 +1118,7 @@ public class MachineProjectService : IMachineProjectService
         CancellationToken cancellationToken
     )
     {
-        // Used to return whether or not the corpus files were created or updated
+        // Used to return whether the corpus files were created or updated
         bool corpusUpdated = false;
 
         // Sync each text

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1874,9 +1874,6 @@ public class MachineApiServiceTests
         env.MachineProjectService
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine01));
-        env.MachineProjectService
-            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
-            .Returns(Task.FromResult(false));
         env.TranslationEnginesClient
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
             .Returns(
@@ -1891,9 +1888,13 @@ public class MachineApiServiceTests
                 )
             );
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+        // The following substitution is Serval stating that a translation engine SF expects to exist has been removed
+        env.MachineProjectService
+            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
+            .Returns(Task.FromResult(false));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         await env.MachineProjectService
             .Received(1)
@@ -1912,7 +1913,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         await env.MachineProjectService
             .DidNotReceiveWithAnyArgs()
@@ -1947,7 +1948,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project03, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project03, includeAdditionalInfo: false, CancellationToken.None);
 
         await env.MachineProjectService
             .Received(1)

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1867,6 +1867,94 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public async Task StartBuildAsync_ServalCreatesRemovedTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineProjectService
+            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None)
+            .Returns(Task.FromResult(TranslationEngine01));
+        env.MachineProjectService
+            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
+            .Returns(Task.FromResult(false));
+        env.TranslationEnginesClient
+            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new TranslationBuild
+                    {
+                        Url = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceLink { Id = "engineId", Url = "https://example.com" },
+                        State = JobState.Active,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        await env.MachineProjectService
+            .Received(1)
+            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_ServalTranslationEngineRecreationErrorsDoNotCrashIfInProcess()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
+        env.MachineProjectService
+            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
+            .Throws(ServalApiExceptions.InternalServerError);
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
+
+        // SUT
+        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        await env.MachineProjectService
+            .DidNotReceiveWithAnyArgs()
+            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
+        await env.TranslationEnginesClient
+            .DidNotReceiveWithAnyArgs()
+            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
+        await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
+    }
+
+    [Test]
+    public async Task StartBuildAsync_ServalCreatesMissingTranslationEngine()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineProjectService
+            .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None)
+            .Returns(Task.FromResult(TranslationEngine01));
+        env.TranslationEnginesClient
+            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+            .Returns(
+                Task.FromResult(
+                    new TranslationBuild
+                    {
+                        Url = "https://example.com",
+                        Id = Build01,
+                        Engine = new ResourceLink { Id = "engineId", Url = "https://example.com" },
+                        State = JobState.Active,
+                    }
+                )
+            );
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        await env.Service.StartBuildAsync(User01, Project03, CancellationToken.None);
+
+        await env.MachineProjectService
+            .Received(1)
+            .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None);
+    }
+
+    [Test]
     public void StartBuildAsync_ServalNoTranslationEngine()
     {
         // Set up test environment
@@ -2987,6 +3075,14 @@ public class MachineApiServiceTests
             FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
             MachineProjectService = Substitute.For<IMachineProjectService>();
+            MachineProjectService
+                .TranslationEngineExistsAsync(
+                    Project01,
+                    TranslationEngine01,
+                    preTranslate: false,
+                    CancellationToken.None
+                )
+                .Returns(Task.FromResult(true));
             PreTranslationService = Substitute.For<IPreTranslationService>();
             ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]


### PR DESCRIPTION
This Pull Request improves the stability of Scripture Forge for the two following scenarios:

 * When the project's translation engines are deleted from Serval
 * When the `ServalData` property is removed from `sf_project_secrets`

When these scenarios occur, the user can rebuild the SMT or NMT translation engines, and recover from the scenario.

***Note:** Testing should be performed by a developer, as it requires modification of the Mongo database.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2229)
<!-- Reviewable:end -->
