### PR TITLE
SF-2309 Support for combined verses in the target text

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
@@ -77,5 +77,21 @@ describe('DraftViewerService', () => {
       ];
       expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
     });
+
+    it('should allow combined verses in the target that are separated in the source', () => {
+      const draft: DraftSegmentMap = {
+        verse_1_1: 'In the beginning ',
+        verse_1_2: 'The earth was formless',
+        verse_1_3: 'Then God said'
+      };
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_1_1-3' } }];
+      const expectedResult: DeltaOperation[] = [
+        {
+          insert: 'In the beginning The earth was formless Then God said',
+          attributes: { segment: 'verse_1_1-3', draft: true }
+        }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
@@ -139,5 +139,20 @@ describe('DraftViewerService', () => {
       ];
       expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
     });
+
+    it('should allow combined verses in the target that only one exists in the source', () => {
+      const draft: DraftSegmentMap = {
+        verse_150_1: 'Praise ye the Lord. ',
+        verse_150_2: 'Praise him for his mighty acts: '
+      };
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_150_1-3' } }];
+      const expectedResult: DeltaOperation[] = [
+        {
+          insert: 'Praise ye the Lord. Praise him for his mighty acts: ',
+          attributes: { segment: 'verse_150_1-3', draft: true }
+        }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
@@ -80,15 +80,61 @@ describe('DraftViewerService', () => {
 
     it('should allow combined verses in the target that are separated in the source', () => {
       const draft: DraftSegmentMap = {
-        verse_1_1: 'In the beginning ',
-        verse_1_2: 'The earth was formless',
-        verse_1_3: 'Then God said'
+        verse_150_1: 'Praise ye the Lord. ',
+        verse_150_2: 'Praise him for his mighty acts: ',
+        verse_150_3: 'Praise him with the sound of the trumpet: '
       };
-      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_1_1-3' } }];
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_150_1-3' } }];
       const expectedResult: DeltaOperation[] = [
         {
-          insert: 'In the beginning The earth was formless Then God said',
-          attributes: { segment: 'verse_1_1-3', draft: true }
+          insert: 'Praise ye the Lord. Praise him for his mighty acts: Praise him with the sound of the trumpet: ',
+          attributes: { segment: 'verse_150_1-3', draft: true }
+        }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
+
+    it('should allow combined verses in the target that are combined in the source', () => {
+      const draft: DraftSegmentMap = {
+        'verse_150_1-3':
+          'Praise ye the Lord. Praise him for his mighty acts: Praise him with the sound of the trumpet: '
+      };
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_150_1-3' } }];
+      const expectedResult: DeltaOperation[] = [
+        {
+          insert: 'Praise ye the Lord. Praise him for his mighty acts: Praise him with the sound of the trumpet: ',
+          attributes: { segment: 'verse_150_1-3', draft: true }
+        }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
+
+    it('should allow partially combined verses in the target that are combined in the source', () => {
+      const draft: DraftSegmentMap = {
+        'verse_150_1-3':
+          'Praise ye the Lord. Praise him for his mighty acts: Praise him with the sound of the trumpet: '
+      };
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_150_1-2' } }];
+      const expectedResult: DeltaOperation[] = [
+        {
+          insert: 'Praise ye the Lord. Praise him for his mighty acts: Praise him with the sound of the trumpet: ',
+          attributes: { segment: 'verse_150_1-2', draft: true }
+        }
+      ];
+      expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
+    });
+
+    it('should allow partially combined verses in the target that are combined in the source', () => {
+      const draft: DraftSegmentMap = {
+        'verse_150_1-2': 'Praise ye the Lord. Praise him for his mighty acts: ',
+        // Known issue: This verse will not be merged into 1-3 in the target
+        verse_150_1_3: 'Praise him with the sound of the trumpet: '
+      };
+      const targetOps: DeltaOperation[] = [{ insert: '', attributes: { segment: 'verse_150_1-3' } }];
+      const expectedResult: DeltaOperation[] = [
+        {
+          insert: 'Praise ye the Lord. Praise him for his mighty acts: ',
+          attributes: { segment: 'verse_150_1-3', draft: true }
         }
       ];
       expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -57,17 +57,18 @@ export class DraftViewerService {
       // No draft (undefined or empty string) for this segment
       if (!isSegmentDraftAvailable) {
         // See if the source verse is combined
-        const combinedVerseNumbers: string[] = Object.keys(draft).filter(key => key.startsWith(segmentRef + '-'));
+        // Note: this will work with combining 1 and 1-2, and 1-3 and 1-2 with the proviso that verse 3 is not merged
+        const combinedVerseNumbers: string[] = Object.keys(draft).filter(key =>
+          key.startsWith(segmentRef.split('-')[0] + '-')
+        );
         if (combinedVerseNumbers.length > 0) {
           // Place the combined verse segment in the verse segment
           draftSegmentText = draft[combinedVerseNumbers[0]];
           isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
         } else if (segmentRef.startsWith('verse_') && segmentRef.indexOf('-') > -1) {
           // Otherwise, if the target verse is combined
-          // Get the book number from the segment ref
-          const bookNum: number = parseInt(segmentRef.split('_')[1]);
-          // Get the verse ref from the segment
-          let segmentVerseRef: VerseRef | undefined = getVerseRefFromSegmentRef(bookNum, segmentRef);
+          // Get the verse ref from the segment. We don't use the book number, so just specify Genesis
+          let segmentVerseRef: VerseRef | undefined = getVerseRefFromSegmentRef(1, segmentRef);
           if (segmentVerseRef != null) {
             // Add the drafts for all of the verses in the segment
             for (var verseRef of segmentVerseRef?.allVerses()) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -77,7 +77,9 @@ export class DraftViewerService {
               } else if (draftSegmentText[draftSegmentText.length - 1] !== ' ') {
                 draftSegmentText += ' ';
               }
-              draftSegmentText += draft[verseSlug(verseRef)];
+              if (draft[verseSlug(verseRef)] != null) {
+                draftSegmentText += draft[verseSlug(verseRef)];
+              }
             }
             isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
+import { VerseRef } from '@sillsdev/scripture';
 import { DeltaOperation } from 'quill';
 import { isString } from '../../../../type-utils';
+import { getVerseRefFromSegmentRef, verseSlug } from '../../../shared/utils';
 import { DraftSegmentMap } from '../draft-generation';
 
 @Injectable({
@@ -47,19 +49,37 @@ export class DraftViewerService {
     }
 
     return targetOps.map(op => {
-      let draftSegmentText: string | undefined = draft[op.attributes?.segment];
+      const segmentRef: string | undefined = op.attributes?.segment;
+      if (segmentRef == null) return op;
+      let draftSegmentText: string | undefined = draft[segmentRef];
       let isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
 
       // No draft (undefined or empty string) for this segment
       if (!isSegmentDraftAvailable) {
         // See if the source verse is combined
-        const combinedVerseNumbers: string[] = Object.keys(draft).filter(key =>
-          key.startsWith(op.attributes?.segment + '-')
-        );
+        const combinedVerseNumbers: string[] = Object.keys(draft).filter(key => key.startsWith(segmentRef + '-'));
         if (combinedVerseNumbers.length > 0) {
           // Place the combined verse segment in the verse segment
           draftSegmentText = draft[combinedVerseNumbers[0]];
           isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
+        } else if (segmentRef.startsWith('verse_') && segmentRef.indexOf('-') > -1) {
+          // Otherwise, if the target verse is combined
+          // Get the book number from the segment ref
+          const bookNum: number = parseInt(segmentRef.split('_')[1]);
+          // Get the verse ref from the segment
+          let segmentVerseRef: VerseRef | undefined = getVerseRefFromSegmentRef(bookNum, segmentRef);
+          if (segmentVerseRef != null) {
+            // Add the drafts for all of the verses in the segment
+            for (var verseRef of segmentVerseRef?.allVerses()) {
+              if (draftSegmentText == null) {
+                draftSegmentText = '';
+              } else if (draftSegmentText[draftSegmentText.length - 1] !== ' ') {
+                draftSegmentText += ' ';
+              }
+              draftSegmentText += draft[verseSlug(verseRef)];
+            }
+            isSegmentDraftAvailable = draftSegmentText != null && draftSegmentText.trim().length > 0;
+          }
         }
 
         // Use the existing translation, if there is still no draft available


### PR DESCRIPTION
This PR adds support for combined verse in the target text that are separate in the source text.

In this case, the verses that are in the draft that are separated, are placed into the combined verse in the target.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2231)
<!-- Reviewable:end -->
