### PR TITLE
Update translate link to "Edit & review"

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -125,7 +125,7 @@ describe('AppComponent', () => {
 
     expect(env.isDrawerVisible).toEqual(true);
     expect(env.selectedProjectId).toEqual('project01');
-    // Translate | Overview | Draft & review | Community Checking | Manage questions | Questions & answers |
+    // Translate | Overview | Edit & review | Community Checking | Manage questions | Questions & answers |
     // Synchronize | Users | Settings
     expect(env.menuLength).toEqual(9);
     verify(mockedUserService.setCurrentProjectId(anything(), 'project01')).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -8,9 +8,9 @@
         <mat-icon mat-list-icon>apps</mat-icon>
         {{ t("overview") }}
       </a>
-      <a mat-list-item [appRouterLink]="(draftReviewLink$ | async) || ['']" [class.active]="draftReviewActive">
-        <mat-icon mat-list-icon class="material-icons-outlined mirror-rtl">article</mat-icon>
-        {{ t("draft_review") }}
+      <a mat-list-item [appRouterLink]="(translateLink$ | async) || ['']" [class.active]="draftReviewActive">
+        <mat-icon mat-list-icon>edit_note</mat-icon>
+        {{ t("edit_review") }}
       </a>
       <a *ngIf="canGenerateDraft$ | async" mat-list-item [appRouterLink]="draftGenerationLink">
         <mat-icon mat-list-icon class="mirror-rtl">model_training</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
@@ -48,7 +48,7 @@ export class NavigationComponent extends SubscriptionDisposable {
 
   projectUserConfigDoc$ = new BehaviorSubject<SFProjectUserConfigDoc | undefined>(undefined);
 
-  draftReviewLink$ = combineLatest([
+  translateLink$ = combineLatest([
     this.activatedProjectService.changes$,
     this.projectUserConfigDoc$.pipe(
       switchMap(doc => doc?.changes$.pipe(startWith(undefined)) ?? of(undefined)),
@@ -66,8 +66,8 @@ export class NavigationComponent extends SubscriptionDisposable {
       return this.getProjectLink('translate', [bookId, String(chapterNum)]);
     }),
     // The selected book and chapter is updated by CheckingQuestionsComponent in the middle of a change detection cycle.
-    // This causes the draft & review link to cause ExpressionChangedAfterItHasBeenCheckedError. To avoid this, delay
-    // the link update until the next change detection cycle.
+    // This causes the link to the translate page to cause ExpressionChangedAfterItHasBeenCheckedError. To avoid this,
+    // delay the link update until the next change detection cycle.
     delay(0)
   );
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
@@ -158,7 +158,7 @@ export const Administrator: Story = {
   play: async ({ canvasElement }) => {
     expect(menuItems(canvasElement)).toEqual([
       'Overview',
-      'Draft & review',
+      'Edit & review',
       'Generate draft',
       'Manage questions',
       'Questions & answers',
@@ -174,7 +174,7 @@ export const Translator: Story = {
   play: async ({ canvasElement }) => {
     expect(menuItems(canvasElement)).toEqual([
       'Overview',
-      'Draft & review',
+      'Edit & review',
       'Generate draft',
       'My progress',
       'Questions & answers',
@@ -186,14 +186,14 @@ export const Translator: Story = {
 export const Consultant: Story = {
   args: { ...Default.args, role: SFProjectRole.ParatextConsultant },
   play: async ({ canvasElement }) => {
-    expect(menuItems(canvasElement)).toEqual(['Overview', 'Draft & review', 'My progress', 'Questions & answers']);
+    expect(menuItems(canvasElement)).toEqual(['Overview', 'Edit & review', 'My progress', 'Questions & answers']);
   }
 };
 
 export const Observer: Story = {
   args: { ...Default.args, role: SFProjectRole.ParatextObserver },
   play: async ({ canvasElement }) => {
-    expect(menuItems(canvasElement)).toEqual(['Overview', 'Draft & review', 'My progress', 'Questions & answers']);
+    expect(menuItems(canvasElement)).toEqual(['Overview', 'Edit & review', 'My progress', 'Questions & answers']);
   }
 };
 
@@ -207,14 +207,14 @@ export const Checker: Story = {
 export const Viewer: Story = {
   args: { ...Default.args, role: SFProjectRole.Viewer },
   play: async ({ canvasElement }) => {
-    expect(menuItems(canvasElement)).toEqual(['Overview', 'Draft & review']);
+    expect(menuItems(canvasElement)).toEqual(['Overview', 'Edit & review']);
   }
 };
 
 export const Commenter: Story = {
   args: { ...Default.args, role: SFProjectRole.Commenter },
   play: async ({ canvasElement }) => {
-    expect(menuItems(canvasElement)).toEqual(['Overview', 'Draft & review']);
+    expect(menuItems(canvasElement)).toEqual(['Overview', 'Edit & review']);
   }
 };
 
@@ -247,7 +247,7 @@ export const CheckingDisabled: Story = {
   play: async ({ canvasElement }) => {
     expect(menuItems(canvasElement)).toEqual([
       'Overview',
-      'Draft & review',
+      'Edit & review',
       'Generate draft',
       'Synchronize',
       'Users',
@@ -266,7 +266,7 @@ export const TranslateOverviewActive: Story = {
 export const TranslateEditorActive: Story = {
   args: { ...Administrator.args, path: 'translate/GEN' },
   play: async ({ canvasElement }) => {
-    expect(activeMenuItemText(canvasElement)).toBe('Draft & review');
+    expect(activeMenuItemText(canvasElement)).toBe('Edit & review');
   }
 };
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -7,7 +7,7 @@
     "synchronize": "Synchronize",
     "system_administration": "System Administration",
     "translate": "Translate",
-    "draft_review": "Draft & review",
+    "edit_review": "Edit & review",
     "users": "Users"
   },
   "biblical_term_dialog": {


### PR DESCRIPTION
There are definitely arguments for "translate" over "edit", but there doesn't seem to be a clear consensus, except that both "edit" and "translate" are preferable to "draft", and the changing of the icon.

Here's how it looks now:

![](https://github.com/sillsdev/web-xforge/assets/6140710/b6876394-17b7-45ba-b4cc-7a7633a5d762)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2233)
<!-- Reviewable:end -->
