### PR TITLE
SF-2390 Allow multiple roles per user

### DIFF
--- a/src/RealtimeServer/common/connect-session.ts
+++ b/src/RealtimeServer/common/connect-session.ts
@@ -3,6 +3,6 @@
  */
 export interface ConnectSession {
   userId: string;
-  role?: string;
+  roles: string[];
   isServer: boolean;
 }

--- a/src/RealtimeServer/common/models/user-test-data.ts
+++ b/src/RealtimeServer/common/models/user-test-data.ts
@@ -15,7 +15,7 @@ function testUser(ordinal: number): User {
     ...testUserProfile(ordinal),
     name: `Name of test user ${ordinal}`,
     email: `user${ordinal}@example.com`,
-    role: SystemRole.User,
+    roles: [SystemRole.User],
     isDisplayNameConfirmed: false,
     interfaceLanguage: 'en',
     authId: `authId${ordinal}`,

--- a/src/RealtimeServer/common/models/user.ts
+++ b/src/RealtimeServer/common/models/user.ts
@@ -48,7 +48,7 @@ export interface User extends UserProfile {
   name: string;
   email: string;
   paratextId?: string;
-  role: string;
+  roles: string[];
   isDisplayNameConfirmed: boolean;
   interfaceLanguage?: string;
   authId: string;

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -475,11 +475,11 @@ export class RealtimeServer extends ShareDB {
   private async setConnectSession(context: ShareDB.middleware.ConnectContext): Promise<void> {
     let session: ConnectSession;
     if (context.req != null && context.req.user != null) {
-      const userId = context.req.user[XF_USER_ID_CLAIM];
-      const role = context.req.user[XF_ROLE_CLAIM];
+      const userId: string = context.req.user[XF_USER_ID_CLAIM];
+      const roles: string[] = [context.req.user[XF_ROLE_CLAIM]];
       session = {
         userId,
-        role,
+        roles,
         isServer: false
       };
     } else {
@@ -487,7 +487,7 @@ export class RealtimeServer extends ShareDB {
       if (context.req != null && context.req.userId != null) {
         userId = context.req.userId;
       }
-      session = { isServer: true, userId };
+      session = { isServer: true, userId, roles: [] };
     }
     context.agent.connectSession = session;
   }

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -476,7 +476,8 @@ export class RealtimeServer extends ShareDB {
     let session: ConnectSession;
     if (context.req != null && context.req.user != null) {
       const userId: string = context.req.user[XF_USER_ID_CLAIM];
-      const roles: string[] = [context.req.user[XF_ROLE_CLAIM]];
+      const role: string | undefined = context.req.user[XF_ROLE_CLAIM];
+      const roles: string[] = role?.split(',') ?? [];
       session = {
         userId,
         roles,

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -476,8 +476,8 @@ export class RealtimeServer extends ShareDB {
     let session: ConnectSession;
     if (context.req != null && context.req.user != null) {
       const userId: string = context.req.user[XF_USER_ID_CLAIM];
-      const role: string | undefined = context.req.user[XF_ROLE_CLAIM];
-      const roles: string[] = role?.split(',') ?? [];
+      const role: string | string[] | undefined = context.req.user[XF_ROLE_CLAIM];
+      const roles: string[] = typeof role === 'string' ? [role] : role || [];
       session = {
         userId,
         roles,

--- a/src/RealtimeServer/common/services/project-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-service.spec.ts
@@ -123,7 +123,7 @@ class TestEnvironment {
       'systemAdmin',
       createTestUser(
         {
-          role: SystemRole.SystemAdmin
+          roles: [SystemRole.SystemAdmin]
         },
         1
       )

--- a/src/RealtimeServer/common/services/project-service.ts
+++ b/src/RealtimeServer/common/services/project-service.ts
@@ -53,7 +53,7 @@ export abstract class ProjectService<T extends Project = Project> extends JsonDo
   };
 
   protected allowRead(_docId: string, doc: T, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin || Object.keys(doc).length === 0) {
+    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin) || Object.keys(doc).length === 0) {
       return true;
     }
 
@@ -61,7 +61,7 @@ export abstract class ProjectService<T extends Project = Project> extends JsonDo
   }
 
   protected allowUpdate(_docId: string, _oldDoc: T, newDoc: T, ops: any, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin) {
+    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin)) {
       return true;
     }
 

--- a/src/RealtimeServer/common/services/user-migrations.spec.ts
+++ b/src/RealtimeServer/common/services/user-migrations.spec.ts
@@ -9,13 +9,13 @@ import { SchemaVersionRepository } from '../../common/schema-version-repository'
 import { createDoc, fetchDoc } from '../../common/utils/test-utils';
 import { UserService } from './user-service';
 
-describe('SFProjectMigrations', () => {
+describe('UserMigrations', () => {
   describe('version 1', () => {
     it('migrates users with a role', async () => {
       const env = new TestEnvironment(0);
       const conn = env.server.connect();
       await createDoc(conn, USERS_COLLECTION, 'user01', {
-        roles: [SystemRole.SystemAdmin]
+        role: SystemRole.SystemAdmin
       });
       await env.server.migrateIfNecessary();
 

--- a/src/RealtimeServer/common/services/user-migrations.spec.ts
+++ b/src/RealtimeServer/common/services/user-migrations.spec.ts
@@ -1,0 +1,64 @@
+import ShareDB from 'sharedb';
+import ShareDBMingo from 'sharedb-mingo-memory';
+import { instance, mock, when } from 'ts-mockito';
+import { MetadataDB } from '../../common/metadata-db';
+import { SystemRole } from '../../common/models/system-role';
+import { USERS_COLLECTION } from '../../common/models/user';
+import { RealtimeServer } from '../../common/realtime-server';
+import { SchemaVersionRepository } from '../../common/schema-version-repository';
+import { createDoc, fetchDoc } from '../../common/utils/test-utils';
+import { UserService } from './user-service';
+
+describe('SFProjectMigrations', () => {
+  describe('version 1', () => {
+    it('migrates users with a role', async () => {
+      const env = new TestEnvironment(0);
+      const conn = env.server.connect();
+      await createDoc(conn, USERS_COLLECTION, 'user01', {
+        roles: [SystemRole.SystemAdmin]
+      });
+      await env.server.migrateIfNecessary();
+
+      const projectDoc = await fetchDoc(conn, USERS_COLLECTION, 'user01');
+      expect(projectDoc.data.roles[0]).toBe(SystemRole.SystemAdmin);
+      expect(projectDoc.data.role).toBeUndefined();
+    });
+    it('migrates users without a role', async () => {
+      const env = new TestEnvironment(0);
+      const conn = env.server.connect();
+      await createDoc(conn, USERS_COLLECTION, 'user01', {});
+      await env.server.migrateIfNecessary();
+
+      const projectDoc = await fetchDoc(conn, USERS_COLLECTION, 'user01');
+      expect(projectDoc.data.roles.length).toBe(0);
+      expect(projectDoc.data.role).toBeUndefined();
+    });
+  });
+});
+
+class TestEnvironment {
+  readonly db: ShareDBMingo;
+  readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+  readonly server: RealtimeServer;
+
+  /**
+   * @param version The version the document is currently at (so migrations prior to this version will not be run
+   * on the document)
+   */
+  constructor(version: number) {
+    const ShareDBMingoType = MetadataDB(ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB));
+    this.db = new ShareDBMingoType();
+    when(this.mockedSchemaVersionRepository.getAll()).thenResolve([
+      { _id: USERS_COLLECTION, collection: USERS_COLLECTION, version }
+    ]);
+    this.server = new RealtimeServer(
+      'TEST',
+      false,
+      true,
+      [new UserService()],
+      USERS_COLLECTION,
+      this.db,
+      instance(this.mockedSchemaVersionRepository)
+    );
+  }
+}

--- a/src/RealtimeServer/common/services/user-migrations.ts
+++ b/src/RealtimeServer/common/services/user-migrations.ts
@@ -1,3 +1,24 @@
-import { MigrationConstructor } from '../migration';
+import { Doc, Op } from 'sharedb/lib/client';
+import { submitMigrationOp } from '../../common/realtime-server';
+import { DocMigration, MigrationConstructor } from '../migration';
 
-export const USER_MIGRATIONS: MigrationConstructor[] = [];
+class UserMigration1 extends DocMigration {
+  static readonly VERSION = 1;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    if (doc.data.roles == null) {
+      if (doc.data.role != null) {
+        ops.push({ p: ['role'], od: doc.data.role });
+        ops.push({ p: ['roles'], oi: [doc.data.role] });
+      } else {
+        ops.push({ p: ['roles'], oi: [] });
+      }
+    }
+    if (ops.length > 0) {
+      await submitMigrationOp(UserMigration1.VERSION, doc, ops);
+    }
+  }
+}
+
+export const USER_MIGRATIONS: MigrationConstructor[] = [UserMigration1];

--- a/src/RealtimeServer/common/services/user-service.spec.ts
+++ b/src/RealtimeServer/common/services/user-service.spec.ts
@@ -73,7 +73,9 @@ describe('UserService', () => {
 
     const conn = clientConnect(env.server, 'user01', SystemRole.SystemAdmin);
     await expect(
-      submitJson0Op<User>(conn, USERS_COLLECTION, 'user02', ops => ops.set<string>(u => u.role, SystemRole.SystemAdmin))
+      submitJson0Op<User>(conn, USERS_COLLECTION, 'user02', ops =>
+        ops.set<string[]>(u => u.roles, [SystemRole.SystemAdmin])
+      )
     ).resolves.not.toThrow();
   });
 
@@ -83,7 +85,9 @@ describe('UserService', () => {
 
     const conn = clientConnect(env.server, 'user02', SystemRole.User);
     await expect(
-      submitJson0Op<User>(conn, USERS_COLLECTION, 'user02', ops => ops.set<string>(u => u.role, SystemRole.SystemAdmin))
+      submitJson0Op<User>(conn, USERS_COLLECTION, 'user02', ops =>
+        ops.set<string[]>(u => u.roles, [SystemRole.SystemAdmin])
+      )
     ).rejects.toThrow();
   });
 
@@ -154,7 +158,7 @@ class TestEnvironment {
       'user01',
       createTestUser(
         {
-          role: SystemRole.SystemAdmin
+          roles: [SystemRole.SystemAdmin]
         },
         1
       )

--- a/src/RealtimeServer/common/services/user-service.ts
+++ b/src/RealtimeServer/common/services/user-service.ts
@@ -24,7 +24,7 @@ export class UserService extends JsonDocService<User> {
   protected readonly immutableProps: ObjPathTemplate[] = [
     this.pathTemplate(u => u.authId),
     this.pathTemplate(u => u.paratextId!),
-    this.pathTemplate(u => u.role),
+    this.pathTemplate(u => u.roles),
     this.pathTemplate(u => u.avatarUrl),
     this.pathTemplate(u => u.email),
     this.pathTemplate(u => u.name),
@@ -51,8 +51,11 @@ export class UserService extends JsonDocService<User> {
       paratextId: {
         bsonType: 'string'
       },
-      role: {
-        bsonType: 'string'
+      roles: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string'
+        }
       },
       isDisplayNameConfirmed: {
         bsonType: 'bool'
@@ -103,7 +106,7 @@ export class UserService extends JsonDocService<User> {
   }
 
   protected allowRead(docId: string, doc: User, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin) {
+    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin)) {
       return true;
     }
     if (docId === session.userId) {
@@ -120,7 +123,7 @@ export class UserService extends JsonDocService<User> {
   }
 
   protected allowUpdate(docId: string, _oldDoc: User, _newDoc: User, ops: any, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin) {
+    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin)) {
       return true;
     }
     if (docId !== session.userId) {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -457,7 +457,7 @@ export class SFProjectService extends ProjectService<SFProject> {
   }
 
   protected allowRead(docId: string, doc: SFProject, session: ConnectSession): boolean {
-    if (session.isServer || session.role === SystemRole.SystemAdmin || Object.keys(doc).length === 0) {
+    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin) || Object.keys(doc).length === 0) {
       return true;
     }
     if (this.hasRight(session.userId, doc, Operation.View)) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -374,6 +374,7 @@ class TestEnvironment {
     when(mockedSFProjectService.getProfile(anything())).thenCall(projectId =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, projectId)
     );
+    when(mockedAuthService.currentUserRoles).thenReturn([]);
     when(mockedAuthService.isLoggedIn).thenCall(() => Promise.resolve(this.loggedInState$.getValue().loggedIn));
     when(mockedAuthService.loggedInState$).thenReturn(this.loggedInState$);
     this.setCurrentUser('user01');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -168,7 +168,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   get isSystemAdmin(): boolean {
-    return this.authService.currentUserRole === SystemRole.SystemAdmin;
+    return this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
   }
 
   get currentUser(): User | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -271,7 +271,7 @@ describe('SettingsComponent', () => {
           },
           projectType: ProjectType.BackTranslation
         });
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.alternateSourceSelect).not.toBeNull();
@@ -513,7 +513,7 @@ describe('SettingsComponent', () => {
           },
           projectType: ProjectType.BackTranslation
         });
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -522,7 +522,7 @@ describe('SettingsComponent', () => {
       it('should display for system administrators on forward translations', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -532,7 +532,7 @@ describe('SettingsComponent', () => {
         const env = new TestEnvironment();
         env.setupProject();
         when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).toBeNull();
@@ -549,7 +549,7 @@ describe('SettingsComponent', () => {
             sendAllSegments: false
           }
         });
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -558,7 +558,7 @@ describe('SettingsComponent', () => {
       it('should change serval config value', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -589,7 +589,7 @@ describe('SettingsComponent', () => {
           },
           preTranslate: true
         });
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -611,7 +611,7 @@ describe('SettingsComponent', () => {
       it('should not update an unchanged serval config value', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -964,6 +964,7 @@ class TestEnvironment {
 
   constructor(hasConnection: boolean = true, isSource: boolean = false) {
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
+    when(mockedAuthService.currentUserRoles).thenReturn([]);
     when(mockedSFProjectService.onlineIsSourceProject('project01')).thenResolve(isSource);
     when(mockedSFProjectService.onlineDelete(anything())).thenResolve();
     when(mockedSFProjectService.onlineUpdateSettings('project01', anything())).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -129,7 +129,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     const translateConfig = this.projectDoc?.data?.translateConfig;
     if (translateConfig == null || !this.featureFlags.showNmtDrafting.enabled) {
       return false;
-    } else if (this.authService.currentUserRole === SystemRole.SystemAdmin) {
+    } else if (this.authService.currentUserRoles.includes(SystemRole.SystemAdmin)) {
       return true;
     } else {
       return translateConfig.preTranslate === true && translateConfig.projectType !== ProjectType.BackTranslation;
@@ -162,7 +162,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   get canUpdateServalConfig(): boolean {
-    return this.authService.currentUserRole === SystemRole.SystemAdmin;
+    return this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -103,7 +103,7 @@ describe('DraftGenerationComponent', () => {
 
     // Default setup
     setup(): void {
-      mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.User });
+      mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.User] });
       mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
         'FeatureFlagService',
         {},
@@ -896,14 +896,14 @@ describe('DraftGenerationComponent', () => {
   describe('canShowAdditionalInfo', () => {
     it('should return true if the user is system admin, and build has additional info', () => {
       let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.SystemAdmin] });
       });
       expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(true);
     });
 
     it('should return false if the draft build has no additional info', () => {
       let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRole: SystemRole.SystemAdmin });
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.SystemAdmin] });
       });
       expect(env.component.canShowAdditionalInfo({} as BuildDto)).toBe(false);
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -335,7 +335,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   }
 
   canShowAdditionalInfo(job?: BuildDto): boolean {
-    return job?.additionalInfo != null && this.authService.currentUserRole === SystemRole.SystemAdmin;
+    return job?.additionalInfo != null && this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
   }
 
   canCancel(job?: BuildDto): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -249,6 +249,31 @@ describe('AuthService', () => {
     env.discardTokenExpiryTimer();
   }));
 
+  it('should handle a role array', fakeAsync(() => {
+    const env = new TestEnvironment({
+      isOnline: true,
+      isNewlyLoggedIn: true,
+      auth0Response: {
+        token: {
+          id_token: '12345',
+          access_token: TestEnvironment.encodeAccessToken({
+            [XF_ROLE_CLAIM]: [SystemRole.SystemAdmin, SystemRole.User],
+            [XF_USER_ID_CLAIM]: TestEnvironment.userId
+          }),
+          expires_in: 720
+        },
+        idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
+        loginResult: {
+          appState: JSON.stringify({ returnUrl: '' })
+        }
+      }
+    });
+
+    expect(env.isLoggedIn).withContext('setup').toBe(true);
+    expect(env.localSettings.get(ROLES_SETTING)).toEqual([SystemRole.SystemAdmin, SystemRole.User]);
+    env.discardTokenExpiryTimer();
+  }));
+
   it('should renew tokens if expired and authenticating', fakeAsync(() => {
     const env = new TestEnvironment({ isOnline: true, isLoggedIn: true });
     expect(env.isAuthenticated).toBe(true);
@@ -683,7 +708,7 @@ interface TestEnvironmentConstructorArgs {
 }
 
 interface Auth0AccessToken {
-  [XF_ROLE_CLAIM]?: SystemRole;
+  [XF_ROLE_CLAIM]?: SystemRole | SystemRole[];
   [XF_USER_ID_CLAIM]?: string;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -642,7 +642,7 @@ export class AuthService {
   private async localLogIn(accessToken: string, idToken: string, expiresIn: number): Promise<void> {
     const claims: any = jwtDecode(accessToken);
     const prevUserId: string | undefined = this.currentUserId;
-    const role: string | undefined = claims[XF_ROLE_CLAIM];
+    const role: string | string[] | undefined = claims[XF_ROLE_CLAIM];
     const userId: string | undefined = claims[XF_USER_ID_CLAIM];
     if (prevUserId != null && prevUserId !== userId) {
       await this.offlineStore.deleteDB();
@@ -655,7 +655,7 @@ export class AuthService {
     this.localSettings.set(EXPIRES_AT_SETTING, expiresAt);
     this.localSettings.set(USER_ID_SETTING, userId);
     this.localSettings.remove(ROLE_SETTING);
-    this.localSettings.set(ROLES_SETTING, role == null ? [] : role.split(','));
+    this.localSettings.set(ROLES_SETTING, typeof role === 'string' ? [role] : role || []);
     this.scheduleRenewal();
     this.bugsnagService.leaveBreadcrumb(
       'Local Login',

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -47,7 +47,7 @@ export const AUTH0_SCOPE = `openid profile email ${environment.scope} offline_ac
 /**
  * @deprecated This value is deprecated, but maintained to ensure compatibility with older login sessions
  */
-const ROLE_SETTING = 'role';
+export const ROLE_SETTING = 'role';
 
 export interface AuthState {
   returnUrl: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -641,8 +641,9 @@ export class AuthService {
 
   private async localLogIn(accessToken: string, idToken: string, expiresIn: number): Promise<void> {
     const claims: any = jwtDecode(accessToken);
-    const prevUserId = this.currentUserId;
-    const userId = claims[XF_USER_ID_CLAIM];
+    const prevUserId: string | undefined = this.currentUserId;
+    const role: string | undefined = claims[XF_ROLE_CLAIM];
+    const userId: string | undefined = claims[XF_USER_ID_CLAIM];
     if (prevUserId != null && prevUserId !== userId) {
       await this.offlineStore.deleteDB();
       this.localSettings.clear();
@@ -654,7 +655,7 @@ export class AuthService {
     this.localSettings.set(EXPIRES_AT_SETTING, expiresAt);
     this.localSettings.set(USER_ID_SETTING, userId);
     this.localSettings.remove(ROLE_SETTING);
-    this.localSettings.set(ROLES_SETTING, [claims[XF_ROLE_CLAIM]]);
+    this.localSettings.set(ROLES_SETTING, role == null ? [] : role.split(','));
     this.scheduleRenewal();
     this.bugsnagService.leaveBreadcrumb(
       'Local Login',

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-admin-auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-admin-auth.guard.ts
@@ -20,7 +20,7 @@ export class SystemAdminAuthGuard {
     return this.authGuard.allowTransition().pipe(
       map(isLoggedIn => {
         if (isLoggedIn) {
-          return this.authService.currentUserRole === SystemRole.SystemAdmin;
+          return this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
         }
         return false;
       })

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -219,7 +219,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.UpdateRoleAsync(UserId, SystemRole, projectId, userId, projectRole);
+            await _projectService.UpdateRoleAsync(UserId, SystemRoles, projectId, userId, projectRole);
             return Ok();
         }
         catch (ForbiddenException)
@@ -545,7 +545,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetPreTranslateAsync(UserId, SystemRole, projectId, preTranslate);
+            await _projectService.SetPreTranslateAsync(UserId, SystemRoles, projectId, preTranslate);
             return Ok();
         }
         catch (ForbiddenException)
@@ -574,7 +574,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetSyncDisabledAsync(UserId, SystemRole, projectId, isDisabled);
+            await _projectService.SetSyncDisabledAsync(UserId, SystemRoles, projectId, isDisabled);
             return Ok();
         }
         catch (ForbiddenException)
@@ -603,7 +603,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetServalConfigAsync(UserId, SystemRole, projectId, servalConfig);
+            await _projectService.SetServalConfigAsync(UserId, SystemRoles, projectId, servalConfig);
             return Ok();
         }
         catch (ForbiddenException)

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -40,6 +40,6 @@ public interface ISFProjectService : IProjectService
         string audioUrl
     );
     Task DeleteAudioTimingData(string userId, string projectId, int book, int chapter);
-    Task SetPreTranslateAsync(string curUserId, string systemRole, string projectId, bool preTranslate);
-    Task SetServalConfigAsync(string curUserId, string systemRole, string projectId, string? servalConfig);
+    Task SetPreTranslateAsync(string curUserId, string[] systemRoles, string projectId, bool preTranslate);
+    Task SetServalConfigAsync(string curUserId, string[] systemRoles, string projectId, string? servalConfig);
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1005,9 +1005,9 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         );
     }
 
-    public async Task SetPreTranslateAsync(string curUserId, string systemRole, string projectId, bool preTranslate)
+    public async Task SetPreTranslateAsync(string curUserId, string[] systemRoles, string projectId, bool preTranslate)
     {
-        if (systemRole != SystemRole.SystemAdmin)
+        if (!systemRoles.Contains(SystemRole.SystemAdmin))
             throw new ForbiddenException();
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
@@ -1015,9 +1015,14 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.PreTranslate, preTranslate));
     }
 
-    public async Task SetServalConfigAsync(string curUserId, string systemRole, string projectId, string? servalConfig)
+    public async Task SetServalConfigAsync(
+        string curUserId,
+        string[] systemRoles,
+        string projectId,
+        string? servalConfig
+    )
     {
-        if (systemRole != SystemRole.SystemAdmin)
+        if (!systemRoles.Contains(SystemRole.SystemAdmin))
             throw new ForbiddenException();
 
         // Normalize whitespace and empty values to null

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -23,7 +23,7 @@ public abstract class RpcControllerBase : RpcController
     }
 
     protected string UserId => _userAccessor.UserId;
-    protected string SystemRole => _userAccessor.SystemRole;
+    protected string[] SystemRoles => _userAccessor.SystemRoles;
     protected string AuthId => _userAccessor.AuthId;
 
     protected IRpcMethodResult InvalidParamsError(string message) => Error((int)RpcErrorCode.InvalidParams, message);

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -149,7 +149,7 @@ public class UsersRpcController : RpcControllerBase
     {
         try
         {
-            await _userService.DeleteAsync(UserId, SystemRole, userId);
+            await _userService.DeleteAsync(UserId, SystemRoles, userId);
             return Ok();
         }
         catch (ForbiddenException)

--- a/src/SIL.XForge/Models/User.cs
+++ b/src/SIL.XForge/Models/User.cs
@@ -6,7 +6,7 @@ public class User : Json0Snapshot
 {
     public string Name { get; set; }
     public string Email { get; set; }
-    public string Role { get; set; }
+    public List<string> Roles { get; set; } = new List<string>();
     public string AvatarUrl { get; set; }
 
     /// <summary>PT user id, as determined from auth0 profile, from authenticating with Paratext.</summary>

--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -9,10 +9,10 @@ public interface IProjectService
     Task RemoveUserAsync(string curUserId, string projectId, string projectUserId);
     Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
     Task<string> GetProjectRoleAsync(string curUserId, string projectId);
-    Task UpdateRoleAsync(string curUserId, string systemRole, string projectId, string userId, string projectRole);
+    Task UpdateRoleAsync(string curUserId, string[] systemRoles, string projectId, string userId, string projectRole);
     Task<Uri> SaveAudioAsync(string curUserId, string projectId, string dataId, string path);
     Task DeleteAudioAsync(string curUserId, string projectId, string ownerId, string dataId);
-    Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled);
+    Task SetSyncDisabledAsync(string curUserId, string[] systemRoles, string projectId, bool isDisabled);
     Task RemoveUserFromAllProjectsAsync(string curUserId, string projectUserId);
     Task SetUserProjectPermissions(string curUserId, string projectId, string userId, string[] permissions);
 }

--- a/src/SIL.XForge/Services/IUserAccessor.cs
+++ b/src/SIL.XForge/Services/IUserAccessor.cs
@@ -4,7 +4,7 @@ public interface IUserAccessor
 {
     bool IsAuthenticated { get; }
     string UserId { get; }
-    string SystemRole { get; }
+    string[] SystemRoles { get; }
     string Name { get; }
     string AuthId { get; }
 }

--- a/src/SIL.XForge/Services/IUserService.cs
+++ b/src/SIL.XForge/Services/IUserService.cs
@@ -11,5 +11,5 @@ public interface IUserService
     Task<Dictionary<string, string>> DisplayNamesFromUserIds(string curUserId, string[] userId);
     Task UpdateAvatarFromDisplayNameAsync(string curUserId, string authId);
     Task UpdateInterfaceLanguageAsync(string curUserId, string authId, string language);
-    Task DeleteAsync(string curUserId, string systemRole, string userId);
+    Task DeleteAsync(string curUserId, string[] systemRoles, string userId);
 }

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -144,14 +144,14 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
 
     public async Task UpdateRoleAsync(
         string curUserId,
-        string systemRole,
+        string[] systemRoles,
         string projectId,
         string idOfUserToUpdate,
         string projectRole
     )
     {
         TModel project = await GetProjectAsync(projectId);
-        if (systemRole != SystemRole.SystemAdmin && !IsProjectAdmin(project, curUserId))
+        if (!systemRoles.Contains(SystemRole.SystemAdmin) && !IsProjectAdmin(project, curUserId))
             throw new ForbiddenException();
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
@@ -235,9 +235,9 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         return project;
     }
 
-    public async Task SetSyncDisabledAsync(string curUserId, string systemRole, string projectId, bool isDisabled)
+    public async Task SetSyncDisabledAsync(string curUserId, string[] systemRoles, string projectId, bool isDisabled)
     {
-        if (systemRole != SystemRole.SystemAdmin)
+        if (!systemRoles.Contains(SystemRole.SystemAdmin))
             throw new ForbiddenException();
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -50,7 +50,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
 
         IDocument<User> userDoc = await GetUserDocAsync(curUserId, conn);
 
-        if (userDoc.Data.Role != SystemRole.SystemAdmin || projectRole == null)
+        if (!userDoc.Data.Roles.Contains(SystemRole.SystemAdmin) || projectRole is null)
         {
             Attempt<string> attempt = await TryGetProjectRoleAsync(projectDoc.Data, curUserId);
             if (!attempt.TryResult(out projectRole))

--- a/src/SIL.XForge/Services/UserAccessor.cs
+++ b/src/SIL.XForge/Services/UserAccessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Claims;
 using IdentityModel;
 using Microsoft.AspNetCore.Http;
@@ -11,26 +12,22 @@ public class UserAccessor : IUserAccessor
 
     public UserAccessor(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
 
-    private ClaimsPrincipal User => _httpContextAccessor.HttpContext.User;
+    private ClaimsPrincipal? User => _httpContextAccessor.HttpContext?.User;
 
-    public bool IsAuthenticated => User.Identity.IsAuthenticated;
-    public string UserId => User.FindFirst(XFClaimTypes.UserId)?.Value;
-    public string SystemRole => User.FindFirst(XFClaimTypes.Role)?.Value;
+    public string AuthId => User?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+    public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
     public string Name
     {
         get
         {
-            string name = User.Identity.Name;
+            string name = User?.Identity?.Name;
             if (!string.IsNullOrWhiteSpace(name))
                 return name;
 
-            Claim sub = User.FindFirst(JwtClaimTypes.Subject);
-            if (sub != null)
-                return sub.Value;
-
-            return string.Empty;
+            return User?.FindFirst(JwtClaimTypes.Subject)?.Value ?? string.Empty;
         }
     }
-
-    public string AuthId => User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    public string[] SystemRoles =>
+        (User?.FindFirst(XFClaimTypes.Role)?.Value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
+    public string UserId => User?.FindFirst(XFClaimTypes.UserId)?.Value ?? string.Empty;
 }

--- a/src/SIL.XForge/Services/UserAccessor.cs
+++ b/src/SIL.XForge/Services/UserAccessor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Claims;
 using IdentityModel;
 using Microsoft.AspNetCore.Http;
@@ -28,6 +29,6 @@ public class UserAccessor : IUserAccessor
         }
     }
     public string[] SystemRoles =>
-        (User?.FindFirst(XFClaimTypes.Role)?.Value ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
+        User?.FindAll(XFClaimTypes.Role).Select(c => c.Value).ToArray() ?? Array.Empty<string>();
     public string UserId => User?.FindFirst(XFClaimTypes.UserId)?.Value ?? string.Empty;
 }

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
+using SIL.Extensions;
 using SIL.ObjectModel;
 using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
@@ -90,9 +91,20 @@ public class UserService : IUserService
                 op.Set(u => u.Name, name);
                 op.Set(u => u.Email, (string)userProfile["email"]);
                 op.Set(u => u.AvatarUrl, avatarUrl);
-                string? role = (string?)userProfile["app_metadata"]?["xf_role"];
-                string[] roles = role is null ? Array.Empty<string>() : new[] { role };
-                op.Set(u => u.Roles, roles.ToList(), _listStringComparer);
+                List<string> roles = new List<string>();
+                if (userProfile["app_metadata"]?["xf_role"] is JArray)
+                {
+                    roles.AddRange(userProfile["app_metadata"]["xf_role"].Select(r => r.ToString()));
+                }
+                else
+                {
+                    string? role = (string?)userProfile["app_metadata"]?["xf_role"];
+                    if (role is not null)
+                    {
+                        roles.Add(role);
+                    }
+                }
+                op.Set(u => u.Roles, roles, _listStringComparer);
                 if (ptIdentity != null)
                 {
                     var ptId = (string)ptIdentity["user_id"];

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -245,13 +245,19 @@ public class UserService : IUserService
     /// <summary>
     /// Delete user with SF user id userId, as requested by SF user curUserId who has systemRole.
     /// </summary>
-    public async Task DeleteAsync(string curUserId, string systemRole, string userId)
+    public async Task DeleteAsync(string curUserId, string[] systemRoles, string userId)
     {
-        if (curUserId == null || systemRole == null || userId == null)
+        if (curUserId is null)
         {
-            throw new ArgumentNullException();
+            throw new ArgumentNullException(nameof(curUserId));
         }
-        if (systemRole != SystemRole.SystemAdmin && userId != curUserId)
+
+        if (userId is null)
+        {
+            throw new ArgumentNullException(nameof(userId));
+        }
+
+        if (!systemRoles.Contains(SystemRole.SystemAdmin) && userId != curUserId)
         {
             throw new ForbiddenException();
         }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -58,8 +58,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string projectRole = SFProjectRole.Viewer;
-        env.SFProjectService
-            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+        env.SFProjectService.UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -73,8 +72,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const string projectRole = SFProjectRole.Viewer;
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+        env.SFProjectService.UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -88,8 +86,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string projectRole = SFProjectRole.Viewer;
-        env.SFProjectService
-            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+        env.SFProjectService.UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
             .Throws(new ArgumentNullException());
 
         // SUT
@@ -114,8 +111,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const bool preTranslate = true;
-        env.SFProjectService
-            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+        env.SFProjectService.SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -129,8 +125,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const bool preTranslate = true;
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+        env.SFProjectService.SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -144,8 +139,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const bool preTranslate = true;
-        env.SFProjectService
-            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+        env.SFProjectService.SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
             .Throws(new ArgumentNullException());
 
         // SUT
@@ -170,8 +164,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const bool syncDisabled = true;
-        env.SFProjectService
-            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+        env.SFProjectService.SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -185,8 +178,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const bool syncDisabled = true;
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+        env.SFProjectService.SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -200,8 +192,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const bool syncDisabled = true;
-        env.SFProjectService
-            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+        env.SFProjectService.SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
             .Throws(new ArgumentNullException());
 
         // SUT
@@ -225,8 +216,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -240,8 +230,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -255,8 +244,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new ArgumentNullException());
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -17,6 +17,7 @@ public class SFProjectsRpcControllerTests
 {
     private const string Project01 = "project01";
     private const string User01 = "user01";
+    private const string User02 = "user02";
     private static readonly string[] Roles = { SystemRole.User };
 
     [Test]
@@ -38,6 +39,174 @@ public class SFProjectsRpcControllerTests
         // SUT
         var result = await env.Controller.UninviteUser(Project01, emailAddress);
         Assert.IsInstanceOf<RpcMethodSuccessResult>(result);
+    }
+
+    [Test]
+    public async Task UpdateRole_Success()
+    {
+        var env = new TestEnvironment();
+        const string projectRole = SFProjectRole.Viewer;
+
+        // SUT
+        var result = await env.Controller.UpdateRole(Project01, User02, projectRole);
+        Assert.IsInstanceOf<RpcMethodSuccessResult>(result);
+        await env.SFProjectService.UpdateRoleAsync(User01, Roles, Project01, User02, projectRole);
+    }
+
+    [Test]
+    public async Task UpdateRole_Forbidden()
+    {
+        var env = new TestEnvironment();
+        const string projectRole = SFProjectRole.Viewer;
+        env.SFProjectService
+            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        var result = await env.Controller.UpdateRole(Project01, User02, projectRole);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+    }
+
+    [Test]
+    public async Task UpdateRole_NotFound()
+    {
+        var env = new TestEnvironment();
+        const string projectRole = SFProjectRole.Viewer;
+        const string errorMessage = "Not Found";
+        env.SFProjectService
+            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+            .Throws(new DataNotFoundException(errorMessage));
+
+        // SUT
+        var result = await env.Controller.UpdateRole(Project01, User02, projectRole);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+        Assert.AreEqual(errorMessage, (result as RpcMethodErrorResult)!.Message);
+    }
+
+    [Test]
+    public void UpdateRole_UnknownError()
+    {
+        var env = new TestEnvironment();
+        const string projectRole = SFProjectRole.Viewer;
+        env.SFProjectService
+            .UpdateRoleAsync(User01, Roles, Project01, User02, projectRole)
+            .Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Controller.UpdateRole(Project01, User02, projectRole));
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
+    }
+
+    [Test]
+    public async Task SetPreTranslate_Success()
+    {
+        var env = new TestEnvironment();
+        const bool preTranslate = true;
+
+        // SUT
+        var result = await env.Controller.SetPreTranslate(Project01, preTranslate);
+        Assert.IsInstanceOf<RpcMethodSuccessResult>(result);
+        await env.SFProjectService.SetPreTranslateAsync(User01, Roles, Project01, preTranslate);
+    }
+
+    [Test]
+    public async Task SetPreTranslate_Forbidden()
+    {
+        var env = new TestEnvironment();
+        const bool preTranslate = true;
+        env.SFProjectService
+            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        var result = await env.Controller.SetPreTranslate(Project01, preTranslate);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+    }
+
+    [Test]
+    public async Task SetPreTranslate_NotFound()
+    {
+        var env = new TestEnvironment();
+        const bool preTranslate = true;
+        const string errorMessage = "Not Found";
+        env.SFProjectService
+            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+            .Throws(new DataNotFoundException(errorMessage));
+
+        // SUT
+        var result = await env.Controller.SetPreTranslate(Project01, preTranslate);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+        Assert.AreEqual(errorMessage, (result as RpcMethodErrorResult)!.Message);
+    }
+
+    [Test]
+    public void SetPreTranslate_UnknownError()
+    {
+        var env = new TestEnvironment();
+        const bool preTranslate = true;
+        env.SFProjectService
+            .SetPreTranslateAsync(User01, Roles, Project01, preTranslate)
+            .Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Controller.SetPreTranslate(Project01, preTranslate));
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
+    }
+
+    [Test]
+    public async Task SetSyncDisabled_Success()
+    {
+        var env = new TestEnvironment();
+        const bool syncDisabled = true;
+
+        // SUT
+        var result = await env.Controller.SetSyncDisabled(Project01, syncDisabled);
+        Assert.IsInstanceOf<RpcMethodSuccessResult>(result);
+        await env.SFProjectService.SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled);
+    }
+
+    [Test]
+    public async Task SetSyncDisabled_Forbidden()
+    {
+        var env = new TestEnvironment();
+        const bool syncDisabled = true;
+        env.SFProjectService
+            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        var result = await env.Controller.SetSyncDisabled(Project01, syncDisabled);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+    }
+
+    [Test]
+    public async Task SetSyncDisabled_NotFound()
+    {
+        var env = new TestEnvironment();
+        const bool syncDisabled = true;
+        const string errorMessage = "Not Found";
+        env.SFProjectService
+            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+            .Throws(new DataNotFoundException(errorMessage));
+
+        // SUT
+        var result = await env.Controller.SetSyncDisabled(Project01, syncDisabled);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+        Assert.AreEqual(errorMessage, (result as RpcMethodErrorResult)!.Message);
+    }
+
+    [Test]
+    public void SetSyncDisabled_UnknownError()
+    {
+        var env = new TestEnvironment();
+        const bool syncDisabled = true;
+        env.SFProjectService
+            .SetSyncDisabledAsync(User01, Roles, Project01, syncDisabled)
+            .Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Controller.SetSyncDisabled(Project01, syncDisabled));
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -17,7 +17,7 @@ public class SFProjectsRpcControllerTests
 {
     private const string Project01 = "project01";
     private const string User01 = "user01";
-    private const string Role = SystemRole.User;
+    private static readonly string[] Roles = { SystemRole.User };
 
     [Test]
     public async Task InvitedUsers_Available()
@@ -56,7 +56,8 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService
+            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -70,7 +71,8 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
         const string errorMessage = "Not Found";
-        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService
+            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -84,7 +86,8 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService
+            .SetServalConfigAsync(User01, Roles, Project01, servalConfig)
             .Throws(new ArgumentNullException());
 
         // SUT
@@ -164,7 +167,7 @@ public class SFProjectsRpcControllerTests
             SFProjectService = Substitute.For<ISFProjectService>();
             var userAccessor = Substitute.For<IUserAccessor>();
             userAccessor.UserId.Returns(User01);
-            userAccessor.SystemRole.Returns(Role);
+            userAccessor.SystemRoles.Returns(Roles);
             Controller = new SFProjectsRpcController(userAccessor, SFProjectService, ExceptionHandler);
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1394,7 +1394,7 @@ public class SFProjectServiceTests
 
         // User04 is a system admin, but not a project-admin or even a user on Project03
         Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
-        Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
+        Assert.That(env.GetUser(User04).Roles.First(), Is.EqualTo(SystemRole.SystemAdmin), "test setup");
 
         Assert.ThrowsAsync<ForbiddenException>(
             () => (env.Service.InvitedUsersAsync(User04, Project03)),
@@ -1412,7 +1412,7 @@ public class SFProjectServiceTests
             Is.Not.EqualTo(SFProjectRole.Administrator),
             "test setup"
         );
-        Assert.That(env.GetUser(User02).Role, Is.Not.EqualTo(SystemRole.SystemAdmin), "test setup");
+        Assert.That(env.GetUser(User02).Roles.First(), Is.Not.EqualTo(SystemRole.SystemAdmin), "test setup");
         Assert.ThrowsAsync<ForbiddenException>(
             () => env.Service.InvitedUsersAsync(User02, Project01),
             "should have been forbidden"
@@ -1561,7 +1561,7 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
         // User04 is a system admin, but not a project-admin or even a user on Project03
         Assert.That(env.GetProject(Project03).UserRoles.ContainsKey(User04), Is.False, "test setup");
-        Assert.That(env.GetUser(User04).Role, Is.EqualTo(SystemRole.SystemAdmin), "test setup");
+        Assert.That(env.GetUser(User04).Roles.First(), Is.EqualTo(SystemRole.SystemAdmin), "test setup");
 
         Assert.ThrowsAsync<ForbiddenException>(
             () => env.Service.UninviteUserAsync(User04, Project03, "bob@example.com"),
@@ -3179,91 +3179,91 @@ public class SFProjectServiceTests
                             Id = User01,
                             Email = "user01@example.com",
                             ParatextId = "pt-user01",
-                            Role = SystemRole.User,
+                            Roles = new List<string> { SystemRole.User },
                             Sites = new Dictionary<string, Site>
                             {
                                 {
                                     SiteId,
                                     new Site { Projects = { Project01, Project03, SourceOnly } }
-                                }
-                            }
+                                },
+                            },
                         },
                         new User
                         {
                             Id = User02,
                             Email = "user02@example.com",
                             ParatextId = "pt-user02",
-                            Role = SystemRole.User,
+                            Roles = new List<string> { SystemRole.User },
                             Sites = new Dictionary<string, Site>
                             {
                                 {
                                     SiteId,
                                     new Site { Projects = { Project01, Project02, Project03, Project04, Project06 } }
-                                }
-                            }
+                                },
+                            },
                         },
                         new User
                         {
                             Id = User03,
                             Email = "user03@example.com",
                             ParatextId = "pt-user03",
-                            Role = SystemRole.User,
-                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
+                            Roles = new List<string> { SystemRole.User },
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
                         },
                         new User
                         {
                             Id = User04,
                             Email = "user04@example.com",
+                            Roles = new List<string> { SystemRole.SystemAdmin },
                             Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
-                            Role = SystemRole.SystemAdmin
                         },
                         new User
                         {
                             Id = LinkExpiredUser,
                             Email = "expired@example.com",
-                            Role = SystemRole.User,
-                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } }
+                            Roles = new List<string> { SystemRole.User },
+                            Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
                         },
                         new User
                         {
                             Id = User05,
                             Email = "user05@example.com",
                             ParatextId = "pt-user05",
-                            Role = SystemRole.User,
+                            Roles = new List<string> { SystemRole.User },
                             Sites = new Dictionary<string, Site>
                             {
                                 {
                                     SiteId,
                                     new Site { Projects = { Project01 } }
-                                }
-                            }
+                                },
+                            },
                         },
                         new User
                         {
                             Id = User06,
                             Email = "user06@example.com",
-                            Role = SystemRole.User,
+                            Roles = new List<string> { SystemRole.User },
                             Sites = new Dictionary<string, Site>
                             {
                                 {
                                     SiteId,
                                     new Site { Projects = { Project01 } }
-                                }
-                            }
+                                },
+                            },
                         },
                         new User
                         {
                             Id = User07,
                             Email = "user07@example.com",
-                            Role = SystemRole.SystemAdmin,
+                            Roles = new List<string> { SystemRole.SystemAdmin },
                             Sites = new Dictionary<string, Site>
                             {
                                 {
                                     SiteId,
                                     new Site { Projects = { Project06 } }
-                                }
-                            }
-                        }
+                                },
+                            },
+                        },
                     }
                 )
             );

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -3039,15 +3039,23 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
         // SUT 1
         Assert.ThrowsAsync<ForbiddenException>(
-            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.User, Project01, false)
+            async () =>
+                await env.Service.SetPreTranslateAsync(User03, new string[] { SystemRole.User }, Project01, false)
         );
         // SUT 2
         Assert.ThrowsAsync<ForbiddenException>(
-            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.None, Project01, false)
+            async () =>
+                await env.Service.SetPreTranslateAsync(User03, new string[] { SystemRole.None }, Project01, false)
         );
         // SUT 3
         Assert.DoesNotThrowAsync(
-            async () => await env.Service.SetPreTranslateAsync(User03, SystemRole.SystemAdmin, Project01, false)
+            async () =>
+                await env.Service.SetPreTranslateAsync(
+                    User03,
+                    new string[] { SystemRole.SystemAdmin },
+                    Project01,
+                    false
+                )
         );
     }
 
@@ -3058,12 +3066,12 @@ public class SFProjectServiceTests
 
         Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(false));
         // SUT 1
-        await env.Service.SetPreTranslateAsync(User01, SystemRole.SystemAdmin, Project02, true);
+        await env.Service.SetPreTranslateAsync(User01, new string[] { SystemRole.SystemAdmin }, Project02, true);
         Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(true));
 
         Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(true));
         // SUT 2
-        await env.Service.SetPreTranslateAsync(User01, SystemRole.SystemAdmin, Project01, false);
+        await env.Service.SetPreTranslateAsync(User01, new string[] { SystemRole.SystemAdmin }, Project01, false);
         Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(false));
     }
 
@@ -3088,7 +3096,12 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SetServalConfigAsync(User01, SystemRole.SystemAdmin, Project01, servalConfig: null);
+        await env.Service.SetServalConfigAsync(
+            User01,
+            new string[] { SystemRole.SystemAdmin },
+            Project01,
+            servalConfig: null
+        );
 
         // Verify project document
         SFProject project = env.GetProject(Project01);
@@ -3103,7 +3116,13 @@ public class SFProjectServiceTests
 
         // SUT
         Assert.ThrowsAsync<JsonReaderException>(
-            () => env.Service.SetServalConfigAsync(User01, SystemRole.SystemAdmin, Project01, servalConfig)
+            () =>
+                env.Service.SetServalConfigAsync(
+                    User01,
+                    new string[] { SystemRole.SystemAdmin },
+                    Project01,
+                    servalConfig
+                )
         );
     }
 
@@ -3114,7 +3133,12 @@ public class SFProjectServiceTests
         const string servalConfig = "  ";
 
         // SUT
-        await env.Service.SetServalConfigAsync(User01, SystemRole.SystemAdmin, Project01, servalConfig);
+        await env.Service.SetServalConfigAsync(
+            User01,
+            new string[] { SystemRole.SystemAdmin },
+            Project01,
+            servalConfig
+        );
 
         // Verify project document
         SFProject project = env.GetProject(Project01);
@@ -3129,7 +3153,13 @@ public class SFProjectServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.SetServalConfigAsync(User01, SystemRole.SystemAdmin, "invalid_project", servalConfig)
+            () =>
+                env.Service.SetServalConfigAsync(
+                    User01,
+                    new string[] { SystemRole.SystemAdmin },
+                    "invalid_project",
+                    servalConfig
+                )
         );
     }
 
@@ -3144,7 +3174,12 @@ public class SFProjectServiceTests
         Assert.IsNotNull(project.TranslateConfig.DraftConfig);
 
         // SUT
-        await env.Service.SetServalConfigAsync(User01, SystemRole.SystemAdmin, Project01, servalConfig);
+        await env.Service.SetServalConfigAsync(
+            User01,
+            new string[] { SystemRole.SystemAdmin },
+            Project01,
+            servalConfig
+        );
 
         // Verify project document
         project = env.GetProject(Project01);
@@ -3159,7 +3194,7 @@ public class SFProjectServiceTests
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.SetServalConfigAsync(User01, SystemRole.User, Project01, servalConfig)
+            () => env.Service.SetServalConfigAsync(User01, new string[] { SystemRole.User }, Project01, servalConfig)
         );
     }
 

--- a/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
+++ b/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EdjCase.JsonRpc.Router.Defaults;
+using Microsoft.AspNetCore.Hosting;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using SIL.XForge.Models;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Controllers;
+
+[TestFixture]
+public class UsersRpcControllerTests
+{
+    private static readonly string[] Roles = { SystemRole.User };
+    private const string User01 = "user01";
+    private const string User02 = "user02";
+
+    [Test]
+    public async Task Delete_Forbidden()
+    {
+        var env = new TestEnvironment();
+        env.UserService.DeleteAsync(User01, Roles, User02).Throws(new ForbiddenException());
+
+        // SUT
+        var result = await env.Controller.Delete(User02);
+        Assert.IsInstanceOf<RpcMethodErrorResult>(result);
+    }
+
+    [Test]
+    public async Task Delete_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        var result = await env.Controller.Delete(User02);
+        Assert.IsInstanceOf<RpcMethodSuccessResult>(result);
+        await env.UserService.Received(1).DeleteAsync(User01, Roles, User02);
+    }
+
+    [Test]
+    public void Delete_UnknownError()
+    {
+        var env = new TestEnvironment();
+        env.UserService.DeleteAsync(User01, Roles, User02).Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Controller.Delete(User02));
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            var userAccessor = Substitute.For<IUserAccessor>();
+            userAccessor.UserId.Returns(User01);
+            userAccessor.SystemRoles.Returns(Roles);
+            UserService = Substitute.For<IUserService>();
+            var authService = Substitute.For<IAuthService>();
+            var hostingEnv = Substitute.For<IWebHostEnvironment>();
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            Controller = new UsersRpcController(userAccessor, UserService, authService, hostingEnv, ExceptionHandler);
+        }
+
+        public UsersRpcController Controller { get; }
+        public IExceptionHandler ExceptionHandler { get; }
+        public IUserService UserService { get; }
+    }
+}

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -150,7 +150,7 @@ public class ProjectServiceTests
 
         await env.Service.UpdateRoleAsync(
             User02,
-            SystemRole.SystemAdmin,
+            new string[] { SystemRole.SystemAdmin },
             Project01,
             User02,
             TestProjectRole.Administrator
@@ -164,7 +164,13 @@ public class ProjectServiceTests
     {
         var env = new TestEnvironment();
 
-        await env.Service.UpdateRoleAsync(User01, SystemRole.User, Project01, User02, TestProjectRole.Administrator);
+        await env.Service.UpdateRoleAsync(
+            User01,
+            new string[] { SystemRole.User },
+            Project01,
+            User02,
+            TestProjectRole.Administrator
+        );
         TestProject project = env.GetProject(Project01);
         Assert.That(project.UserRoles[User02], Is.EqualTo(TestProjectRole.Administrator));
     }
@@ -175,7 +181,14 @@ public class ProjectServiceTests
         var env = new TestEnvironment();
 
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.UpdateRoleAsync(User02, SystemRole.User, Project01, User02, TestProjectRole.Administrator)
+            () =>
+                env.Service.UpdateRoleAsync(
+                    User02,
+                    new string[] { SystemRole.User },
+                    Project01,
+                    User02,
+                    TestProjectRole.Administrator
+                )
         );
     }
 
@@ -185,15 +198,23 @@ public class ProjectServiceTests
         var env = new TestEnvironment();
         // SUT 1
         Assert.ThrowsAsync<ForbiddenException>(
-            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.User, Project01, false)
+            async () =>
+                await env.Service.SetSyncDisabledAsync(User03, new string[] { SystemRole.User }, Project01, false)
         );
         // SUT 2
         Assert.ThrowsAsync<ForbiddenException>(
-            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.None, Project01, false)
+            async () =>
+                await env.Service.SetSyncDisabledAsync(User03, new string[] { SystemRole.None }, Project01, false)
         );
         // SUT 3
         Assert.DoesNotThrowAsync(
-            async () => await env.Service.SetSyncDisabledAsync(User03, SystemRole.SystemAdmin, Project01, false)
+            async () =>
+                await env.Service.SetSyncDisabledAsync(
+                    User03,
+                    new string[] { SystemRole.SystemAdmin },
+                    Project01,
+                    false
+                )
         );
     }
 
@@ -204,12 +225,12 @@ public class ProjectServiceTests
 
         Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(false));
         // SUT 1
-        await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project01, true);
+        await env.Service.SetSyncDisabledAsync(User01, new string[] { SystemRole.SystemAdmin }, Project01, true);
         Assert.That(env.GetProject(Project01).SyncDisabled, Is.EqualTo(true));
 
         Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(true));
         // SUT 2
-        await env.Service.SetSyncDisabledAsync(User01, SystemRole.SystemAdmin, Project02, false);
+        await env.Service.SetSyncDisabledAsync(User01, new string[] { SystemRole.SystemAdmin }, Project02, false);
         Assert.That(env.GetProject(Project02).SyncDisabled, Is.EqualTo(false));
     }
 

--- a/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
@@ -117,9 +117,14 @@ public class UserAccessorTests
     public void UserAccessor_SystemRoles_MultipleRoles()
     {
         var env = new TestEnvironment();
-        const string role = $"{SystemRole.SystemAdmin},{SystemRole.User}";
         env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
-            new ClaimsIdentity(new[] { new Claim(XFClaimTypes.Role, role) })
+            new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(XFClaimTypes.Role, SystemRole.SystemAdmin),
+                    new Claim(XFClaimTypes.Role, SystemRole.User),
+                }
+            )
         );
 
         // SUT

--- a/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
@@ -76,6 +76,31 @@ public class UserAccessorTests
     }
 
     [Test]
+    public void UserAccessor_Name_NoIdentity()
+    {
+        var env = new TestEnvironment();
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal();
+
+        // SUT
+        string actual = env.Service.Name;
+        Assert.AreEqual(string.Empty, actual);
+    }
+
+    [Test]
+    public void UserAccessor_NoClaims()
+    {
+        var env = new TestEnvironment();
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(new ClaimsIdentity(null, string.Empty));
+
+        // SUT
+        Assert.AreEqual(string.Empty, env.Service.AuthId);
+        Assert.IsFalse(env.Service.IsAuthenticated);
+        Assert.AreEqual(string.Empty, env.Service.Name);
+        Assert.IsEmpty(env.Service.SystemRoles);
+        Assert.AreEqual(string.Empty, env.Service.UserId);
+    }
+
+    [Test]
     public void UserAccessor_NullHttpContext()
     {
         var env = new TestEnvironment { HttpContextAccessor = { HttpContext = null } };

--- a/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserAccessorTests.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+using IdentityModel;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Models;
+using SIL.XForge.Utils;
+
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class UserAccessorTests
+{
+    [Test]
+    public void UserAccessor_AuthId()
+    {
+        var env = new TestEnvironment();
+        const string expected = "auth_id";
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, expected) })
+        );
+
+        // SUT
+        string actual = env.Service.AuthId;
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void UserAccessor_IsAuthenticated_False()
+    {
+        var env = new TestEnvironment();
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal();
+
+        // SUT
+        Assert.IsFalse(env.Service.IsAuthenticated);
+    }
+
+    [Test]
+    public void UserAccessor_IsAuthenticated_True()
+    {
+        var env = new TestEnvironment();
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(new ClaimsIdentity(null, "AuthType"));
+
+        // SUT
+        Assert.IsTrue(env.Service.IsAuthenticated);
+    }
+
+    [Test]
+    public void UserAccessor_Name_FromClaim()
+    {
+        var env = new TestEnvironment();
+        const string expected = "user_name";
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new ClaimsIdentity(new[] { new Claim(JwtClaimTypes.Subject, expected) })
+        );
+
+        // SUT
+        string actual = env.Service.Name;
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void UserAccessor_Name_FromIdentity()
+    {
+        var env = new TestEnvironment();
+        const string expected = "user_name";
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new HttpListenerBasicIdentity(expected, string.Empty)
+        );
+
+        // SUT
+        string actual = env.Service.Name;
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void UserAccessor_NullHttpContext()
+    {
+        var env = new TestEnvironment { HttpContextAccessor = { HttpContext = null } };
+
+        // SUT
+        Assert.AreEqual(string.Empty, env.Service.AuthId);
+        Assert.IsFalse(env.Service.IsAuthenticated);
+        Assert.AreEqual(string.Empty, env.Service.Name);
+        Assert.IsEmpty(env.Service.SystemRoles);
+        Assert.AreEqual(string.Empty, env.Service.UserId);
+    }
+
+    [Test]
+    public void UserAccessor_SystemRoles_MultipleRoles()
+    {
+        var env = new TestEnvironment();
+        const string role = $"{SystemRole.SystemAdmin},{SystemRole.User}";
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new ClaimsIdentity(new[] { new Claim(XFClaimTypes.Role, role) })
+        );
+
+        // SUT
+        string[] actual = env.Service.SystemRoles;
+        Assert.AreEqual(2, actual.Length);
+        Assert.AreEqual(SystemRole.SystemAdmin, actual.First());
+        Assert.AreEqual(SystemRole.User, actual.Last());
+    }
+
+    [Test]
+    public void UserAccessor_SystemRoles_SingleRole()
+    {
+        var env = new TestEnvironment();
+        const string expected = SystemRole.SystemAdmin;
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new ClaimsIdentity(new[] { new Claim(XFClaimTypes.Role, expected) })
+        );
+
+        // SUT
+        string[] actual = env.Service.SystemRoles;
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreEqual(expected, actual.First());
+    }
+
+    [Test]
+    public void UserAccessor_UserId()
+    {
+        var env = new TestEnvironment();
+        const string expected = "user_id";
+        env.HttpContextAccessor.HttpContext!.User = new ClaimsPrincipal(
+            new ClaimsIdentity(new[] { new Claim(XFClaimTypes.UserId, expected) })
+        );
+
+        // SUT
+        string actual = env.Service.UserId;
+        Assert.AreEqual(expected, actual);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            HttpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            HttpContextAccessor.HttpContext = new DefaultHttpContext();
+            Service = new UserAccessor(HttpContextAccessor);
+        }
+
+        public IHttpContextAccessor HttpContextAccessor { get; }
+        public UserAccessor Service { get; }
+    }
+}

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -269,9 +269,12 @@ public class UserServiceTests
     public void DeleteAsync_BadArguments()
     {
         var env = new TestEnvironment();
-        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync(null, "systemRole", "userId"));
-        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", null, "userId"));
-        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", "systemRole", null));
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.DeleteAsync(null, new string[] { "systemRole" }, "userId")
+        );
+        Assert.ThrowsAsync<ArgumentNullException>(
+            () => env.Service.DeleteAsync("curUserId", new string[] { "systemRole" }, null)
+        );
     }
 
     [Test]
@@ -280,12 +283,12 @@ public class UserServiceTests
         var env = new TestEnvironment();
         string curUserId = "user01";
         // Role is not a system admin
-        string curUserSystemRole = SystemRole.User;
+        string[] curUserSystemRoles = { SystemRole.User };
         string userIdToDelete = "user02";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(
-            () => env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete)
+            () => env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete)
         );
         Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(0));
     }
@@ -296,11 +299,11 @@ public class UserServiceTests
         var env = new TestEnvironment();
         string curUserId = "user01";
         // Role is not a system admin
-        string curUserSystemRole = SystemRole.User;
+        string[] curUserSystemRoles = { SystemRole.User };
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
     }
 
@@ -309,11 +312,11 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string curUserSystemRole = SystemRole.SystemAdmin;
+        string[] curUserSystemRoles = { SystemRole.SystemAdmin };
         string userIdToDelete = "user02";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
     }
 
@@ -322,11 +325,11 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string curUserSystemRole = SystemRole.SystemAdmin;
+        string[] curUserSystemRoles = { SystemRole.SystemAdmin };
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         Assert.That(env.RealtimeService.CallCountDeleteUserAsync, Is.EqualTo(1));
     }
 
@@ -335,10 +338,10 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string curUserSystemRole = SystemRole.User;
+        string[] curUserSystemRoles = { SystemRole.User };
         string userIdToDelete = "user01";
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         await env.ProjectService.Received(1).RemoveUserFromAllProjectsAsync(curUserId, userIdToDelete);
     }
 
@@ -347,11 +350,11 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string curUserSystemRole = SystemRole.User;
+        string[] curUserSystemRoles = { SystemRole.User };
         string userIdToDelete = "user01";
         Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.True);
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.False);
     }
 
@@ -363,11 +366,11 @@ public class UserServiceTests
         // page.
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string curUserSystemRole = SystemRole.User;
+        string[] curUserSystemRoles = { SystemRole.User };
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
-        await env.Service.DeleteAsync(curUserId, curUserSystemRole, userIdToDelete);
+        await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
         Assert.That(env.ContainsUser(userIdToDelete), Is.False);
     }
 


### PR DESCRIPTION
This Pull Request changes the current "one role per user" system to allow multiple roles per user.

This PR does not add any additional roles, but lays the foundation for this to be done in a completely backwards compatible manner. Backwards compatibility is required to stop the breaking of any current tokens in use, and because if Auth0 was updated to always return the Role claim as an array, it would break all other developer environments not running this branch.

**Adding multiple roles to a user**

Although this will be able to be done in the future using the Auth0 API when system wide roles need to be edited for many users, currently this must be done by editing the `app_metadata` for the user in the Auth0 dashboard.

To test multiple roles for a user:

1. Log into the Auth0 Dashboard
2. Click User Management -> Users
3. Click on the user you wish to edit
4. Change the `app_metadata` from:
```json
{
  "xf_role": "user",
  "xf_user_id": "your_user_id_here"
}
```
to:
```json
{
  "xf_role": ["system_admin", "user"],
  "xf_user_id": "your_user_id_here"
}
```
5. Click Save.
6. Log out then in to Scripture Forge to use the new roles

***Note:** When you are finished testing this branch, be sure to log off, and revert the change made to `app_metadata` in Auth0.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2234)
<!-- Reviewable:end -->
