### PR TITLE
SF-2406 Support timing files with headings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -321,6 +321,21 @@ describe('ChapterAudioDialogComponent', () => {
     expect(env.component.timingErrorMessage).toEqual('');
   }));
 
+  it('can parse audacity style timing data with headings', fakeAsync(async () => {
+    when(mockedCsvService.parse(anything())).thenResolve([
+      ['\\id ROM'],
+      ['\\c 1'],
+      ['\\level verse'],
+      ['0.0', '0.5', '1'],
+      ['0.5', '1.0', '2']
+    ]);
+
+    await env.component.audioUpdate(env.audioFile);
+    await env.component.prepareTimingFileUpload(anything());
+
+    expect(env.component.timingErrorMessage).toEqual('');
+  }));
+
   it('can also parse adobe audition style timing data with decimal time format', fakeAsync(async () => {
     when(mockedCsvService.parse(anything())).thenResolve([
       ['Name', 'Start', 'Duration', 'Time Format', 'Type', 'Description'],

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -235,13 +235,12 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
     this.deleteTimingData();
 
     let timing: AudioTiming[] = [];
-
     if (result.length !== 0) {
       if (result[0].length === 6 && result[0][0] === 'Name') {
         // Adobe Audition style timing files have 6 columns and the first heading is "Name"
         timing = this.parseAdobeAuditionStyleTimingFile(result);
-      } else if (result[0].length === 3) {
-        // Audacity style timing files have 3 columns
+      } else if (result.some(row => row.length === 3)) {
+        // Assume Audacity style timing files with 3 columns
         timing = this.parseAudacityStyleTimingFile(result);
       } else {
         this._timingParseErrorText = 'chapter_audio_dialog.unrecognized_timing_file_format';


### PR DESCRIPTION
The timing files that are exported from HearThis likely have headers. This change assumes that any timing file with some row with 3 columns is audacity style, the same style that HearThis uses. It then allows parsing the entries. Previously, if the first entry does not have 3 columns, it would mark the files as invalid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2235)
<!-- Reviewable:end -->
