### PR TITLE
SF-2409 Remove tokenization of data sent to Serval

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ISFText.cs
+++ b/src/SIL.XForge.Scripture/Models/ISFText.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using SIL.Machine.Corpora;
+
+namespace SIL.XForge.Scripture.Models;
+
+public interface ISFText : IText
+{
+    IEnumerable<SFTextSegment> Segments { get; }
+}

--- a/src/SIL.XForge.Scripture/Models/SFTextSegment.cs
+++ b/src/SIL.XForge.Scripture/Models/SFTextSegment.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using SIL.Machine.Corpora;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class SFTextSegment : TextSegment
+{
+    public SFTextSegment(
+        string textId,
+        object segRef,
+        string segmentText,
+        IReadOnlyList<string> segment,
+        bool isSentenceStart,
+        bool isInRange,
+        bool isRangeStart,
+        bool isEmpty
+    )
+        : base(textId, segRef, segment, isSentenceStart, isInRange, isRangeStart, isEmpty) => SegmentText = segmentText;
+
+    /// <summary>
+    /// Gets or sets the segment text.
+    /// </summary>
+    /// <returns>The original segment text for Serval.</returns>
+    public string SegmentText { get; }
+}

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -34,7 +34,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.3.0.9" />
-    <PackageReference Include="Serval.Client" Version="0.8.1" />
+    <PackageReference Include="Serval.Client" Version="1.1.0" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />

--- a/src/SIL.XForge.Scripture/Services/ISFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFTextCorpusFactory.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using SIL.Machine.Corpora;
 using SIL.Machine.WebApi.Services;
 using SIL.XForge.Scripture.Models;
 
@@ -8,7 +7,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface ISFTextCorpusFactory
 {
-    Task<ITextCorpus> CreateAsync(
+    Task<IEnumerable<ISFText>> CreateAsync(
         IEnumerable<string> projects,
         TextCorpusType type,
         bool preTranslate,

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -639,7 +639,7 @@ public class MachineProjectService : IMachineProjectService
         var newSourceCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
-            includeBlankSegments: false,
+            includeBlankSegments: true,
             texts,
             oldSourceCorpusFiles,
             newSourceCorpusFiles,
@@ -803,7 +803,6 @@ public class MachineProjectService : IMachineProjectService
     {
         var sb = new StringBuilder();
 
-        // TODO: Only send verse segments
         // For pre-translation, we must upload empty lines with segment refs for the correct references to be returned
         foreach (SFTextSegment segment in text.Segments.Where(s => !s.IsEmpty || includeBlankSegments))
         {

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -629,7 +629,7 @@ public class MachineProjectService : IMachineProjectService
         }
 
         // Reuse the SFTextCorpusFactory implementation
-        ITextCorpus? textCorpus = await _textCorpusFactory.CreateAsync(
+        IEnumerable<ISFText> texts = await _textCorpusFactory.CreateAsync(
             new[] { project.Id },
             TextCorpusType.Source,
             preTranslate,
@@ -640,7 +640,7 @@ public class MachineProjectService : IMachineProjectService
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
             includeBlankSegments: false,
-            textCorpus,
+            texts,
             oldSourceCorpusFiles,
             newSourceCorpusFiles,
             cancellationToken
@@ -653,7 +653,7 @@ public class MachineProjectService : IMachineProjectService
             oldTargetCorpusFiles = projectSecret.ServalData.Corpora[corpusId].TargetFiles;
         }
 
-        textCorpus = await _textCorpusFactory.CreateAsync(
+        texts = await _textCorpusFactory.CreateAsync(
             new[] { project.Id },
             TextCorpusType.Target,
             preTranslate,
@@ -664,7 +664,7 @@ public class MachineProjectService : IMachineProjectService
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
             preTranslate,
-            textCorpus,
+            texts,
             oldTargetCorpusFiles,
             newTargetCorpusFiles,
             cancellationToken
@@ -684,7 +684,7 @@ public class MachineProjectService : IMachineProjectService
                     .SourceFiles;
             }
 
-            textCorpus = await _textCorpusFactory.CreateAsync(
+            texts = await _textCorpusFactory.CreateAsync(
                 new[] { project.Id },
                 TextCorpusType.Source,
                 preTranslate: true,
@@ -694,7 +694,7 @@ public class MachineProjectService : IMachineProjectService
             corpusUpdated |= await UploadNewCorpusFilesAsync(
                 project.Id,
                 includeBlankSegments: true,
-                textCorpus,
+                texts,
                 oldAlternateTrainingSourceCorpusFiles,
                 newAlternateTrainingSourceCorpusFiles,
                 cancellationToken
@@ -794,17 +794,18 @@ public class MachineProjectService : IMachineProjectService
     /// <summary>
     /// Gets the segments from the text with Unix/Linux line endings.
     /// </summary>
-    /// <param name="text">The IText</param>
+    /// <param name="text">The <see cref="ISFText"/>.</param>
     /// <param name="includeBlankSegments">
     /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
     /// </param>
     /// <returns>The text file data to be uploaded to Serval.</returns>
-    private static string GetTextFileData(IText text, bool includeBlankSegments)
+    private static string GetTextFileData(ISFText text, bool includeBlankSegments)
     {
         var sb = new StringBuilder();
 
+        // TODO: Only send verse segments
         // For pre-translation, we must upload empty lines with segment refs for the correct references to be returned
-        foreach (TextSegment segment in text.GetSegments().Where(s => !s.IsEmpty || includeBlankSegments))
+        foreach (SFTextSegment segment in text.Segments.Where(s => !s.IsEmpty || includeBlankSegments))
         {
             // We pad the verse number so the string based key comparisons in Machine will be accurate.
             // If the int does not parse successfully, it will be because it is a Biblical Term - which has a Greek or
@@ -817,7 +818,7 @@ public class MachineProjectService : IMachineProjectService
             // Strip characters from the key that will corrupt the line
             sb.Append(key.Replace('\n', '_').Replace('\t', '_'));
             sb.Append('\t');
-            sb.Append(string.Join(' ', segment.Segment));
+            sb.Append(segment.SegmentText);
             sb.Append('\t');
             if (segment.IsSentenceStart)
             {
@@ -1113,13 +1114,13 @@ public class MachineProjectService : IMachineProjectService
     }
 
     /// <summary>
-    /// Syncs the <see cref="ITextCorpus"/> to Serval, creating files on Serval as necessary.
+    /// Syncs a collection of <see cref="ISFText"/> to Serval, creating files on Serval as necessary.
     /// </summary>
     /// <param name="projectId">The project identifier.</param>
     /// <param name="includeBlankSegments">
     /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
     /// </param>
-    /// <param name="textCorpus">The text corpus created by <see cref="SFTextCorpusFactory"/>.</param>
+    /// <param name="texts">The texts created by <see cref="SFTextCorpusFactory"/>.</param>
     /// <param name="oldCorpusFiles">The existing corpus files (optional).</param>
     /// <param name="newCorpusFiles">The updated list of corpus files.</param>
     /// <param name="cancellationToken"></param>
@@ -1130,7 +1131,7 @@ public class MachineProjectService : IMachineProjectService
     private async Task<bool> UploadNewCorpusFilesAsync(
         string projectId,
         bool includeBlankSegments,
-        ITextCorpus? textCorpus,
+        IEnumerable<ISFText> texts,
         ICollection<ServalCorpusFile>? oldCorpusFiles,
         ICollection<ServalCorpusFile> newCorpusFiles,
         CancellationToken cancellationToken
@@ -1140,7 +1141,7 @@ public class MachineProjectService : IMachineProjectService
         bool corpusUpdated = false;
 
         // Sync each text
-        foreach (IText text in textCorpus?.Texts ?? Array.Empty<IText>())
+        foreach (ISFText text in texts)
         {
             string textFileData = GetTextFileData(text, includeBlankSegments);
             if (!string.IsNullOrWhiteSpace(textFileData))

--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -9,11 +9,10 @@ using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
-public class SFBiblicalTermsText : IText
+public class SFBiblicalTermsText : ISFText
 {
     private static readonly Regex BracketedTextRegex = new Regex(@"\([^)]*\)", RegexOptions.Compiled);
     private static readonly Regex WhitespaceRegex = new Regex(@"\s+", RegexOptions.Compiled);
-    private readonly IEnumerable<TextSegment> _segments;
 
     public SFBiblicalTermsText(
         ITokenizer<string, int, string> wordTokenizer,
@@ -23,7 +22,7 @@ public class SFBiblicalTermsText : IText
     {
         Id = $"{projectId}_biblical_terms";
 
-        _segments = GetSegments(wordTokenizer, biblicalTerms).OrderBy(s => s.SegmentRef).ToArray();
+        Segments = GetSegments(wordTokenizer, biblicalTerms).OrderBy(s => s.SegmentRef).ToArray();
     }
 
     public SFBiblicalTermsText(
@@ -33,15 +32,16 @@ public class SFBiblicalTermsText : IText
     )
     {
         Id = $"{projectId}_biblical_terms";
-
-        _segments = GetSegments(wordTokenizer, termRenderingsDoc).OrderBy(s => s.SegmentRef).ToArray();
+        Segments = GetSegments(wordTokenizer, termRenderingsDoc).OrderBy(s => s.SegmentRef).ToArray();
     }
 
     public string Id { get; }
 
+    public IEnumerable<SFTextSegment> Segments { get; }
+
     public string SortKey => Id;
 
-    public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => _segments;
+    public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => Segments;
 
     /// <summary>
     /// Removes Paratext specific codes from the Biblical Term Rendering.
@@ -61,7 +61,7 @@ public class SFBiblicalTermsText : IText
         return rendering.Trim();
     }
 
-    private IEnumerable<TextSegment> GetSegments(
+    private IEnumerable<SFTextSegment> GetSegments(
         ITokenizer<string, int, string> wordTokenizer,
         IList<BiblicalTerm> biblicalTerms
     )
@@ -85,9 +85,10 @@ public class SFBiblicalTermsText : IText
                 string[] segment = wordTokenizer.Tokenize(rendering).ToArray();
 
                 // Sentence placement is not essential for biblical terms. Set all to false
-                yield return new TextSegment(
+                yield return new SFTextSegment(
                     Id,
                     new TextSegmentRef(biblicalTerm.TermId),
+                    rendering,
                     segment,
                     false,
                     false,
@@ -98,7 +99,7 @@ public class SFBiblicalTermsText : IText
         }
     }
 
-    private IEnumerable<TextSegment> GetSegments(
+    private IEnumerable<SFTextSegment> GetSegments(
         ITokenizer<string, int, string> wordTokenizer,
         XDocument termRenderingsDoc
     )
@@ -138,9 +139,10 @@ public class SFBiblicalTermsText : IText
                 string[] segment = wordTokenizer.Tokenize(rendering).ToArray();
 
                 // Sentence placement is not essential for biblical terms. Set all to false
-                yield return new TextSegment(
+                yield return new SFTextSegment(
                     Id,
                     new TextSegmentRef(id),
+                    rendering,
                     segment,
                     false,
                     false,

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -56,18 +56,15 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
             )
         );
 
-    public async Task<ITextCorpus> CreateAsync(
+    public Task<IEnumerable<ISFText>> CreateAsync(
         IEnumerable<string> projects,
         TextCorpusType type,
         bool preTranslate,
         bool useAlternateTrainingSource,
         BuildConfig buildConfig
-    ) =>
-        new DictionaryTextCorpus(
-            await CreateTextsAsync(projects, type, preTranslate, useAlternateTrainingSource, buildConfig)
-        );
+    ) => CreateTextsAsync(projects, type, preTranslate, useAlternateTrainingSource, buildConfig);
 
-    private async Task<IReadOnlyList<IText>> CreateTextsAsync(
+    private async Task<IEnumerable<ISFText>> CreateTextsAsync(
         IEnumerable<string> projects,
         TextCorpusType type,
         bool preTranslate,
@@ -80,7 +77,7 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
         IMongoCollection<BsonDocument> textDataColl = database.GetCollection<BsonDocument>(
             _realtimeService.GetCollectionName<TextData>()
         );
-        var texts = new List<IText>();
+        var texts = new List<ISFText>();
         foreach (string projectId in projects)
         {
             SFProject project = await _realtimeService.GetSnapshotAsync<SFProject>(projectId);
@@ -121,7 +118,7 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
                         projectTexts = sourceProject.Texts;
                     }
 
-                    // If we are using the alternate training source, the source will be all of the training books,
+                    // If we are using the alternate training source, the source will be all the training books,
                     // otherwise it will be the training and translation lists combined without duplicates.
                     books.AddRange(
                         useAlternateTrainingSource

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -157,7 +157,7 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
                                 projectId,
                                 text.BookNum,
                                 chapter.Number,
-                                includeBlankSegments: preTranslate,
+                                preTranslate,
                                 doNotSendSegmentText,
                                 doc
                             )
@@ -165,6 +165,11 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
                 }
             }
 
+            // If we are pre-translating, do not get Biblical Terms
+            if (preTranslate)
+                break;
+
+            // Get the Biblical Terms
             List<BiblicalTerm> biblicalTerms = await _realtimeService
                 .QuerySnapshots<BiblicalTerm>()
                 .Where(b => b.ProjectRef == textCorpusProjectId)

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -10,7 +10,6 @@ using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Polly.CircuitBreaker;
 using Serval.Client;
-using SIL.Machine.Corpora;
 using SIL.Machine.WebApi.Services;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -1725,27 +1724,25 @@ public class MachineProjectServiceTests
 
         private static string MockTextCorpusChecksum => StringUtils.ComputeMd5Hash("segRef\tsegment01\n");
 
-        private static Task<ITextCorpus> MockTextCorpus =>
-            Task.FromResult<ITextCorpus>(
-                new MockTextCorpus
+        private static Task<IEnumerable<ISFText>> MockTextCorpus =>
+            Task.FromResult<IEnumerable<ISFText>>(
+                new[]
                 {
-                    Texts = new[]
+                    new MockText
                     {
-                        new MockText
+                        Id = "textId",
+                        Segments = new List<SFTextSegment>
                         {
-                            Id = "textId",
-                            Segments = new List<TextSegment>
-                            {
-                                new TextSegment(
-                                    "textId",
-                                    "segRef",
-                                    new string[] { "segment01" },
-                                    false,
-                                    false,
-                                    false,
-                                    false
-                                ),
-                            },
+                            new SFTextSegment(
+                                "textId",
+                                "segRef",
+                                "segment01",
+                                new string[] { "segment01" },
+                                false,
+                                false,
+                                false,
+                                false
+                            ),
                         },
                     },
                 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockText.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
 using SIL.Machine.Corpora;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
-public class MockText : IText
+public class MockText : ISFText
 {
     public IEnumerable<TextSegment> GetSegments(bool includeText = true, IText? basedOn = null) => Segments;
 
-    public string Id { get; set; } = string.Empty;
-    public List<TextSegment> Segments { get; set; } = new List<TextSegment>();
-    public string? SortKey { get; set; }
+    public string Id { get; init; } = string.Empty;
+    public IEnumerable<SFTextSegment> Segments { get; init; } = new List<SFTextSegment>();
+    public string? SortKey => null;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -25,7 +25,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 3;
-        const int numberSegments = 1;
+        const int expectedNumberSegments = 1;
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -44,7 +44,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 2;
-        const int numberSegments = 0;
+        const int expectedNumberSegments = 0;
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -83,7 +83,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -101,7 +101,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 0;
-        const int numberSegments = 0;
+        const int expectedNumberSegments = 0;
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -120,7 +120,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -187,7 +187,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 3;
-        const int numberSegments = 0;
+        const int expectedNumberSegments = 0;
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -206,7 +206,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -221,7 +221,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 3;
-        const int numberSegments = 1;
+        const int expectedNumberSegments = 1;
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -240,11 +240,11 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
-    public void Create_ExcludeNonScriptureSegmentsIfPreTranslateFalse()
+    public void Create_IncludeNonScriptureSegmentsIfPreTranslateFalse()
     {
         var doc = new BsonDocument
         {
@@ -255,7 +255,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 4;
-        const int numberSegments = 2; // The heading and the verse text
+        const int expectedNumberSegments = 2; // The heading and the verse text
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -274,7 +274,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -289,7 +289,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 4;
-        const int numberSegments = 1; // Just the verse text
+        const int expectedNumberSegments = 1; // Just the verse text
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -308,7 +308,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -323,7 +323,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 4;
-        const int numberSegments = 2; // The verse text and the paragraph in the verse
+        const int expectedNumberSegments = 2; // The verse text and the paragraph in the verse
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -342,7 +342,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(expectedNumberSegments));
     }
 
     [Test]
@@ -357,7 +357,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 4;
-        const int numberSegments = 1; // Just the verse text
+        const int expectedNumberSegments = 1; // Just the verse text
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -376,7 +376,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.Segments.Count(), Is.EqualTo(expectedNumberSegments));
         Assert.That(text.Segments.First().SegmentText, Is.EqualTo(string.Empty));
     }
 
@@ -392,7 +392,7 @@ public class SFScriptureTextTests
             },
         };
         const int numberOps = 4;
-        const int numberSegments = 1; // Just the verse text
+        const int expectedNumberSegments = 1; // Just the verse text
         const int bookNumber = 40;
         const int chapterNumber = 1;
         const string projectId = "myProject";
@@ -411,7 +411,7 @@ public class SFScriptureTextTests
         );
 
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.Segments.Count(), Is.EqualTo(expectedNumberSegments));
         Assert.That(text.Segments.First().SegmentText, Is.EqualTo("First verse text here"));
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -9,6 +9,8 @@ namespace SIL.XForge.Scripture.Services;
 [TestFixture]
 public class SFScriptureTextTests
 {
+    private const string Id = "abc123:MAT:1:target";
+
     [Test]
     public void Create_HasDocOps_HasSegments()
     {
@@ -16,345 +18,10 @@ public class SFScriptureTextTests
         // from SF DB - xforge - texts.
         var doc = new BsonDocument
         {
-            { "_id", "abc123:MAT:1:target" },
+            { "_id", Id },
             {
                 "ops",
-                new BsonArray
-                {
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "chapter",
-                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                }
-                            }
-                        }
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "verse",
-                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                }
-                            }
-                        }
-                    },
-                    new BsonDocument
-                    {
-                        { "insert", "First verse text here" },
-                        {
-                            "attributes",
-                            new BsonDocument { { "segment", "verse_1_1" } }
-                        }
-                    }
-                }
-            }
-        };
-        var numberOps = 3;
-        var numberSegments = 1;
-        var bookNumber = 40;
-        var chapterNumber = 1;
-        var projectId = "myProject";
-        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        var text = new SFScriptureText(
-            tokenizer,
-            projectId,
-            bookNumber,
-            chapterNumber,
-            includeBlankSegments: false,
-            doNotSendSegmentText: false,
-            doc
-        );
-
-        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-    }
-
-    [Test]
-    public void Create_NoSegments_EmptySegments()
-    {
-        var doc = new BsonDocument
-        {
-            { "_id", "abc123:MAT:1:target" },
-            {
-                "ops",
-                new BsonArray
-                {
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "chapter",
-                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                }
-                            }
-                        }
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "verse",
-                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                }
-                            }
-                        }
-                    }
-                    // No verse text inserts with a segment reference.
-                }
-            }
-        };
-        var numberOps = 2;
-        var numberSegments = 0;
-        var bookNumber = 40;
-        var chapterNumber = 1;
-        var projectId = "myProject";
-        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        var text = new SFScriptureText(
-            tokenizer,
-            projectId,
-            bookNumber,
-            chapterNumber,
-            includeBlankSegments: false,
-            doNotSendSegmentText: false,
-            doc
-        );
-
-        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-    }
-
-    [Test]
-    public void Create_EmptyOps_EmptySegments()
-    {
-        var doc = new BsonDocument
-        {
-            { "_id", "abc123:MAT:1:target" },
-            {
-                "ops",
-                new BsonArray
-                {
-                    // Empty ops array
-                }
-            }
-        };
-        var numberOps = 0;
-        var numberSegments = 0;
-        var bookNumber = 40;
-        var chapterNumber = 1;
-        var projectId = "myProject";
-        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        var text = new SFScriptureText(
-            tokenizer,
-            projectId,
-            bookNumber,
-            chapterNumber,
-            includeBlankSegments: false,
-            doNotSendSegmentText: false,
-            doc
-        );
-
-        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-    }
-
-    [Test]
-    public void Create_NullDoc_Crash()
-    {
-        BsonDocument doc = null;
-        var bookNumber = 40;
-        var chapterNumber = 1;
-        var projectId = "myProject";
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        Assert.Throws<ArgumentNullException>(
-            () =>
-                new SFScriptureText(
-                    tokenizer,
-                    projectId,
-                    bookNumber,
-                    chapterNumber,
-                    includeBlankSegments: false,
-                    doNotSendSegmentText: false,
-                    doc
-                )
-        );
-    }
-
-    [Test]
-    public void Create_MissingOps_Crash()
-    {
-        var doc = new BsonDocument
-        {
-            { "_id", "abc123:MAT:1:target" },
-            // Missing ops
-        };
-        var bookNumber = 40;
-        var chapterNumber = 1;
-        var projectId = "myProject";
-        Assert.That(doc.Contains("ops"), Is.False, "Setup");
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        Assert.Throws<ArgumentException>(
-            () =>
-                new SFScriptureText(
-                    tokenizer,
-                    projectId,
-                    bookNumber,
-                    chapterNumber,
-                    includeBlankSegments: false,
-                    doNotSendSegmentText: false,
-                    doc
-                )
-        );
-    }
-
-    [Test]
-    public void Create_ExcludeBlankSegmentsIfIncludeBlankSegmentsFalse()
-    {
-        var doc = new BsonDocument
-        {
-            { "_id", "abc123:MAT:1:target" },
-            {
-                "ops",
-                new BsonArray
-                {
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "chapter",
-                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                },
-                            }
-                        },
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "verse",
-                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                },
-                            }
-                        },
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument { { "blank", true } }
-                        },
-                        {
-                            "attributes",
-                            new BsonDocument { { "segment", "verse_1_1" } }
-                        },
-                    },
-                }
-            },
-        };
-        const int numberOps = 3;
-        const int numberSegments = 0;
-        const int bookNumber = 40;
-        const int chapterNumber = 1;
-        const string projectId = "myProject";
-        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
-        var tokenizer = new LatinWordTokenizer();
-
-        // SUT
-        var text = new SFScriptureText(
-            tokenizer,
-            projectId,
-            bookNumber,
-            chapterNumber,
-            includeBlankSegments: false,
-            doNotSendSegmentText: false,
-            doc
-        );
-
-        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
-        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
-    }
-
-    [Test]
-    public void Create_IncludeBlankSegmentsIfIncludeBlankSegmentsTrue()
-    {
-        var doc = new BsonDocument
-        {
-            { "_id", "abc123:MAT:1:target" },
-            {
-                "ops",
-                new BsonArray
-                {
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "chapter",
-                                    new BsonDocument { { "number", "1" }, { "style", "c" } }
-                                },
-                            }
-                        },
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument
-                            {
-                                {
-                                    "verse",
-                                    new BsonDocument { { "number", "1" }, { "style", "v" } }
-                                },
-                            }
-                        },
-                    },
-                    new BsonDocument
-                    {
-                        {
-                            "insert",
-                            new BsonDocument { { "blank", true } }
-                        },
-                        {
-                            "attributes",
-                            new BsonDocument { { "segment", "verse_1_1" } }
-                        },
-                    },
-                }
+                new BsonArray { ChapterMarker, VerseMarker, VerseSegment }
             },
         };
         const int numberOps = 3;
@@ -371,7 +38,7 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            includeBlankSegments: true,
+            preTranslate: false,
             doNotSendSegmentText: false,
             doc
         );
@@ -379,4 +46,439 @@ public class SFScriptureTextTests
         Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
         Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
     }
+
+    [Test]
+    public void Create_NoSegments_EmptySegments()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray
+                {
+                    ChapterMarker,
+                    VerseMarker,
+                    // No verse text inserts with a segment reference.
+                }
+            },
+        };
+        const int numberOps = 2;
+        const int numberSegments = 0;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: false,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_EmptyOps_EmptySegments()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray
+                {
+                    // Empty ops array
+                }
+            },
+        };
+        const int numberOps = 0;
+        const int numberSegments = 0;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: false,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_NullDoc_Crash()
+    {
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new SFScriptureText(
+                    tokenizer,
+                    projectId,
+                    bookNumber,
+                    chapterNumber,
+                    preTranslate: false,
+                    doNotSendSegmentText: false,
+                    doc: null
+                )
+        );
+    }
+
+    [Test]
+    public void Create_MissingOps_Crash()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            // Missing ops
+        };
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(doc.Contains("ops"), Is.False, "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        Assert.Throws<ArgumentException>(
+            () =>
+                new SFScriptureText(
+                    tokenizer,
+                    projectId,
+                    bookNumber,
+                    chapterNumber,
+                    preTranslate: false,
+                    doNotSendSegmentText: false,
+                    doc
+                )
+        );
+    }
+
+    [Test]
+    public void Create_ExcludeBlankSegmentsIfPreTranslateFalse()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { ChapterMarker, VerseMarker, BlankSegment }
+            },
+        };
+        const int numberOps = 3;
+        const int numberSegments = 0;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: false,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_IncludeBlankSegmentsIfPreTranslateTrue()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { ChapterMarker, VerseMarker, BlankSegment }
+            },
+        };
+        const int numberOps = 3;
+        const int numberSegments = 1;
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: true,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_ExcludeNonScriptureSegmentsIfPreTranslateFalse()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { HeadingSegment, ChapterMarker, VerseMarker, VerseSegment }
+            },
+        };
+        const int numberOps = 4;
+        const int numberSegments = 2; // The heading and the verse text
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: false,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_ExcludeNonScriptureSegmentsIfPreTranslateTrue()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { HeadingSegment, ChapterMarker, VerseMarker, VerseSegment }
+            },
+        };
+        const int numberOps = 4;
+        const int numberSegments = 1; // Just the verse text
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: true,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_IncludeVerseStyleSegmentsSeparately()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { ChapterMarker, VerseMarker, VerseSegment, VerseParagraph }
+            },
+        };
+        const int numberOps = 4;
+        const int numberSegments = 2; // The verse text and the paragraph in the verse
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: true,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.GetSegments().Count(), Is.EqualTo(numberSegments));
+    }
+
+    [Test]
+    public void Create_SendBlankSegmentsIfDoNotSendSegmentTextTrue()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { HeadingSegment, ChapterMarker, VerseMarker, VerseSegment }
+            },
+        };
+        const int numberOps = 4;
+        const int numberSegments = 1; // Just the verse text
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: true,
+            doNotSendSegmentText: true,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.Segments.First().SegmentText, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void Create_SendVerseTextIfDoNotSendSegmentTextFalse()
+    {
+        var doc = new BsonDocument
+        {
+            { "_id", Id },
+            {
+                "ops",
+                new BsonArray { HeadingSegment, ChapterMarker, VerseMarker, VerseSegment }
+            },
+        };
+        const int numberOps = 4;
+        const int numberSegments = 1; // Just the verse text
+        const int bookNumber = 40;
+        const int chapterNumber = 1;
+        const string projectId = "myProject";
+        Assert.That(((BsonArray)doc["ops"]).Count, Is.EqualTo(numberOps), "Setup");
+        var tokenizer = new LatinWordTokenizer();
+
+        // SUT
+        var text = new SFScriptureText(
+            tokenizer,
+            projectId,
+            bookNumber,
+            chapterNumber,
+            preTranslate: true,
+            doNotSendSegmentText: false,
+            doc
+        );
+
+        Assert.That(text.Id, Is.EqualTo($"{projectId}_{bookNumber}_{chapterNumber}"));
+        Assert.That(text.Segments.Count(), Is.EqualTo(numberSegments));
+        Assert.That(text.Segments.First().SegmentText, Is.EqualTo("First verse text here"));
+    }
+
+    private static readonly BsonDocument BlankSegment = new BsonDocument
+    {
+        {
+            "insert",
+            new BsonDocument { { "blank", true } }
+        },
+        {
+            "attributes",
+            new BsonDocument { { "segment", "verse_1_1" } }
+        },
+    };
+
+    private static readonly BsonDocument ChapterMarker = new BsonDocument
+    {
+        {
+            "insert",
+            new BsonDocument
+            {
+                {
+                    "chapter",
+                    new BsonDocument { { "number", "1" }, { "style", "c" } }
+                },
+            }
+        },
+    };
+
+    private static readonly BsonDocument HeadingSegment = new BsonDocument
+    {
+        { "insert", "Heading Goes Here" },
+        {
+            "attributes",
+            new BsonDocument { { "segment", "mt1_1" } }
+        },
+    };
+
+    private static readonly BsonDocument VerseMarker = new BsonDocument
+    {
+        {
+            "insert",
+            new BsonDocument
+            {
+                {
+                    "verse",
+                    new BsonDocument { { "number", "1" }, { "style", "v" } }
+                },
+            }
+        },
+    };
+
+    private static readonly BsonDocument VerseParagraph = new BsonDocument
+    {
+        { "insert", "First verse paragraph here" },
+        {
+            "attributes",
+            new BsonDocument { { "segment", "verse_1_1/p_1" } }
+        },
+    };
+
+    private static readonly BsonDocument VerseSegment = new BsonDocument
+    {
+        { "insert", "First verse text here" },
+        {
+            "attributes",
+            new BsonDocument { { "segment", "verse_1_1" } }
+        },
+    };
 }


### PR DESCRIPTION
Because Serval performs its own, more accurate tokenization, we should not do that before sending the data to Serval. However, until the In-Process machine is removed from SF, that logic will need to remain.

This is achieved by:

* Creating data structures that override and are parallel to the SIL.Machine data structures that includes the entire Segment text.
* Only sending verse segment data to Serval Nmt for Pre-Translation.
* Refactoring SFScriptureTextTests for clarity.

In addition, this PR alters the data sent to Serval to Pre-Translation to only include verse data. This will improve the quality of data generated. A later PR (SF-2410) will re-enable this support via a project setting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2239)
<!-- Reviewable:end -->
