### PR TITLE
SF-2411 Restrict resolve option on dialog when restricted tags used

### DIFF
--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -325,6 +325,24 @@ describe('version 12', () => {
       expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingBooks).toEqual([1, 2, 3]);
     });
   });
+
+  describe('version 15', () => {
+    it('adds create resolve property to note tag', async () => {
+      const env = new TestEnvironment(14);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {
+        noteTags: [{ tagId: 1, name: 'Tag 01', icon: '01flag1', creatorResolve: false }]
+      });
+
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.noteTags[0].creatorResolve).toBe(false);
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.noteTags[0].creatorResolve).toBe(true);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -1,6 +1,7 @@
 import { Doc, Op } from 'sharedb/lib/client';
 import { DocMigration, MigrationConstructor } from '../../common/migration';
 import { submitMigrationOp } from '../../common/realtime-server';
+import { NoteTag } from '../models/note-tag';
 import { SFProjectRole } from '../models/sf-project-role';
 import { TextInfoPermission } from '../models/text-info-permission';
 import { TranslateShareLevel } from '../models/translate-config';
@@ -252,6 +253,20 @@ class SFProjectMigration14 extends DocMigration {
   }
 }
 
+class SFProjectMigration15 extends DocMigration {
+  static readonly VERSION = 15;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    for (let i = 0; i < doc.data.noteTags.length; i++) {
+      const noteTag: NoteTag = doc.data.noteTags[i];
+      ops.push({ p: ['noteTags', i, 'creatorResolve'], od: noteTag.creatorResolve });
+      ops.push({ p: ['noteTags', i, 'creatorResolve'], oi: true });
+    }
+    await submitMigrationOp(SFProjectMigration13.VERSION, doc, ops);
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration1,
   SFProjectMigration2,
@@ -266,5 +281,6 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration11,
   SFProjectMigration12,
   SFProjectMigration13,
-  SFProjectMigration14
+  SFProjectMigration14,
+  SFProjectMigration15
 ];

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -260,10 +260,12 @@ class SFProjectMigration15 extends DocMigration {
     const ops: Op[] = [];
     for (let i = 0; i < doc.data.noteTags.length; i++) {
       const noteTag: NoteTag = doc.data.noteTags[i];
-      ops.push({ p: ['noteTags', i, 'creatorResolve'], od: noteTag.creatorResolve });
-      ops.push({ p: ['noteTags', i, 'creatorResolve'], oi: true });
+      if (!noteTag.creatorResolve) {
+        ops.push({ p: ['noteTags', i, 'creatorResolve'], od: noteTag.creatorResolve });
+        ops.push({ p: ['noteTags', i, 'creatorResolve'], oi: true });
+      }
     }
-    await submitMigrationOp(SFProjectMigration13.VERSION, doc, ops);
+    await submitMigrationOp(SFProjectMigration15.VERSION, doc, ops);
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -1,5 +1,8 @@
+import { TestBed } from '@angular/core/testing';
+import { VerseRef } from '@sillsdev/scripture';
 import { mock } from 'ts-mockito';
-import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
+import { NoteTag } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
 import {
   getNoteThreadDocId,
   NoteConflictType,
@@ -7,12 +10,10 @@ import {
   NoteThread,
   NoteType
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
-import { TestBed } from '@angular/core/testing';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
-import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
-import { VerseRef } from '@sillsdev/scripture';
-import { DEFAULT_TAG_ICON, NoteTag } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { SFProjectService } from '../sf-project.service';
 import { NoteThreadDoc, NoteThreadIcon } from './note-thread-doc';
 import { SF_TYPE_REGISTRY } from './sf-type-registry';
@@ -43,9 +44,10 @@ describe('NoteThreadDoc', () => {
 
   it('should use default to do icon if tag cannot be found', async () => {
     const noteThreadDoc = await env.setupDoc([], 5);
+    const defaultIcon: string = env.noteTags.find(t => t.tagId === 1)!.icon;
     const expectedIcon: NoteThreadIcon = {
-      cssVar: '--icon-file: url(/assets/icons/TagIcons/' + DEFAULT_TAG_ICON + '.png);',
-      url: '/assets/icons/TagIcons/' + DEFAULT_TAG_ICON + '.png'
+      cssVar: '--icon-file: url(/assets/icons/TagIcons/' + defaultIcon + '.png);',
+      url: '/assets/icons/TagIcons/' + defaultIcon + '.png'
     };
     expect(noteThreadDoc.getIcon(env.noteTags)).toEqual(expectedIcon);
   });
@@ -138,12 +140,34 @@ describe('NoteThreadDoc', () => {
     expect(noteThreadDoc.currentVerseRef()!.equals(expectedVerseRef)).toBe(true);
   });
 
+  it('should report if user can resolve a thread', async () => {
+    const notes: Note[] = [
+      {
+        dataId: 'note01',
+        type: NoteType.Normal,
+        conflictType: NoteConflictType.DefaultValue,
+        threadId: 'thread01',
+        content: 'note content',
+        deleted: false,
+        tagId: 4,
+        status: NoteStatus.Todo,
+        ownerRef: 'user03',
+        dateCreated: '2021-11-10T12:00:00',
+        dateModified: '2021-11-10T12:00:00'
+      }
+    ];
+    const noteThreadDoc: NoteThreadDoc = await env.setupDoc(notes);
+    expect(noteThreadDoc.canUserResolveThread('user01', SFProjectRole.ParatextAdministrator, env.noteTags)).toBe(true);
+    expect(noteThreadDoc.canUserResolveThread('user02', SFProjectRole.ParatextTranslator, env.noteTags)).toBe(false);
+    expect(noteThreadDoc.canUserResolveThread('user03', SFProjectRole.ParatextTranslator, env.noteTags)).toBe(true);
+  });
+
   it('reports the reattached verse reference', async () => {
     const reattachParts: string[] = ['MAT 1:2', 'reattached selected text', '0', '', ''];
     const reattached: string = reattachParts.join(REATTACH_SEPARATOR);
     const type: NoteType = NoteType.Normal;
     const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
-    const notes = [
+    const notes: Note[] = [
       {
         dataId: 'note01',
         type,
@@ -154,7 +178,6 @@ describe('NoteThreadDoc', () => {
         tagId: 2,
         status: NoteStatus.Todo,
         ownerRef: 'user01',
-        extUserId: 'user01',
         dateCreated: '2021-11-10T12:00:00',
         dateModified: '2021-11-10T12:00:00'
       },
@@ -167,7 +190,6 @@ describe('NoteThreadDoc', () => {
         deleted: false,
         status: NoteStatus.Unspecified,
         ownerRef: 'user01',
-        extUserId: 'user01',
         dateCreated: '2021-11-10T13:00:00',
         dateModified: '2021-11-10T13:00:00',
         reattached
@@ -187,7 +209,7 @@ class TestEnvironment {
     { tagId: 1, name: 'SF 1', icon: 'flag1', creatorResolve: false },
     { tagId: 2, name: 'SF 2', icon: 'flag2', creatorResolve: false },
     { tagId: 3, name: 'SF 3', icon: 'flag3', creatorResolve: false },
-    { tagId: 4, name: 'SF 4', icon: 'flag4', creatorResolve: false }
+    { tagId: 4, name: 'SF 4', icon: 'flag4', creatorResolve: true }
   ];
 
   constructor() {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -162,6 +162,14 @@ describe('NoteThreadDoc', () => {
     expect(noteThreadDoc.canUserResolveThread('user03', SFProjectRole.ParatextTranslator, env.noteTags)).toBe(true);
   });
 
+  it('should default to the to do tag when no tag set', async () => {
+    const noteThreadDoc = await env.setupDoc([]);
+    const noteTags: NoteTag[] = [...env.noteTags];
+    noteTags[0].creatorResolve = true;
+    expect(noteThreadDoc.canUserResolveThread('user01', SFProjectRole.ParatextAdministrator, noteTags)).toBe(true);
+    expect(noteThreadDoc.canUserResolveThread('user02', SFProjectRole.ParatextTranslator, noteTags)).toBe(false);
+  });
+
   it('reports the reattached verse reference', async () => {
     const reattachParts: string[] = ['MAT 1:2', 'reattached selected text', '0', '', ''];
     const reattached: string = reattachParts.join(REATTACH_SEPARATOR);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -83,7 +83,8 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
   canUserResolveThread(userId: string, userRole: string, noteTags: NoteTag[]): boolean {
     if (this.data == null) return true;
     if (userRole === SFProjectRole.ParatextAdministrator) return true;
-    const noteTagOnThread: NoteTag | undefined = this.getActiveTagOnThread(noteTags);
+    const noteTagOnThread: NoteTag | undefined =
+      this.getActiveTagOnThread(noteTags) ?? noteTags.find(t => t.tagId === TO_DO_TAG_ID);
     if (noteTagOnThread?.creatorResolve !== true) return isParatextRole(userRole);
 
     const notesInOrder: Note[] = this.notesInOrderClone(this.data.notes);
@@ -124,8 +125,8 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
     if (this.data == null) return;
 
     const iconDefinedNotes: Note[] = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null);
-    let tagId: number =
-      iconDefinedNotes.length === 0 ? TO_DO_TAG_ID : iconDefinedNotes[iconDefinedNotes.length - 1].tagId!;
+    let tagId: number | undefined =
+      iconDefinedNotes.length === 0 ? undefined : iconDefinedNotes[iconDefinedNotes.length - 1].tagId;
 
     return noteTags.find(t => t.tagId === tagId);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -16,6 +16,7 @@ import { VerseRef } from '@sillsdev/scripture';
 import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { AssignedUsers } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
+import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 
 /** Returns the given tag icon formatted for retrieval in the html template, or the default icon. */
 export function defaultNoteThreadIcon(tagIcon: string | undefined): NoteThreadIcon {
@@ -79,6 +80,16 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
     return new VerseRef(verseStr);
   }
 
+  canUserResolveThread(userId: string, userRole: string, noteTags: NoteTag[]): boolean {
+    if (this.data == null) return true;
+    if (userRole === SFProjectRole.ParatextAdministrator) return true;
+    const noteTagOnThread: NoteTag | undefined = this.getActiveTagOnThread(noteTags);
+    if (noteTagOnThread?.creatorResolve !== true) return isParatextRole(userRole);
+
+    const notesInOrder: Note[] = this.notesInOrderClone(this.data.notes);
+    return notesInOrder.length === 0 || notesInOrder[0].ownerRef === userId;
+  }
+
   isAssignedToOtherUser(currentUserId: string, paratextProjectUsers: ParatextUserProfile[]): boolean {
     switch (this.data?.assignment) {
       case AssignedUsers.TeamUser:
@@ -101,14 +112,22 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
       return '';
     }
 
-    const iconDefinedNotes: Note[] = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null);
-    let tagId: number | undefined =
-      iconDefinedNotes.length === 0 ? undefined : iconDefinedNotes[iconDefinedNotes.length - 1].tagId;
-    if (tagId == null) {
+    const noteTagOnThread: NoteTag | undefined = this.getActiveTagOnThread(noteTags);
+    if (noteTagOnThread == null) {
       if (this.data.publishedToSF === true) return SF_TAG_ICON;
       return noteTags.find(t => t.tagId === TO_DO_TAG_ID)?.icon ?? DEFAULT_TAG_ICON;
     }
-    return noteTags.find(t => t.tagId === tagId)?.icon ?? DEFAULT_TAG_ICON;
+    return noteTagOnThread.icon;
+  }
+
+  private getActiveTagOnThread(noteTags: NoteTag[]): NoteTag | undefined {
+    if (this.data == null) return;
+
+    const iconDefinedNotes: Note[] = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null);
+    let tagId: number | undefined =
+      iconDefinedNotes.length === 0 ? undefined : iconDefinedNotes[iconDefinedNotes.length - 1].tagId;
+    if (tagId == null) return;
+    return noteTags.find(t => t.tagId === tagId);
   }
 
   private getResolvedTag(iconTag: string = ''): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -124,9 +124,9 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
     if (this.data == null) return;
 
     const iconDefinedNotes: Note[] = this.notesInOrderClone(this.data.notes).filter(n => n.tagId != null);
-    let tagId: number | undefined =
-      iconDefinedNotes.length === 0 ? undefined : iconDefinedNotes[iconDefinedNotes.length - 1].tagId;
-    if (tagId == null) return;
+    let tagId: number =
+      iconDefinedNotes.length === 0 ? TO_DO_TAG_ID : iconDefinedNotes[iconDefinedNotes.length - 1].tagId!;
+
     return noteTags.find(t => t.tagId === tagId);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -531,6 +531,28 @@ describe('NoteDialogComponent', () => {
     expect(env.dialogResult).toEqual(undefined);
   }));
 
+  it('hides save options trigger when tag on note thread is restricted resolve', fakeAsync(() => {
+    const noteThread: NoteThread = TestEnvironment.getNoteThread();
+    const note: Note = {
+      dataId: 'note03',
+      threadId: noteThread.dataId,
+      ownerRef: 'user04',
+      content: 'translator note',
+      dateCreated: '',
+      dateModified: '',
+      deleted: true,
+      type: NoteType.Normal,
+      status: NoteStatus.Resolved,
+      conflictType: NoteConflictType.DefaultValue,
+      tagId: 5
+    };
+    noteThread.notes.push(note);
+    env = new TestEnvironment({ noteThread, currentUserId: 'user04' });
+    expect(env.saveOptionsButton).toBeNull();
+    env.closeDialog();
+    expect(env.dialogResult).toEqual(undefined);
+  }));
+
   it('show notes in correct date order', fakeAsync(() => {
     const noteThread = TestEnvironment.getNoteThread();
     const currentTime = new Date('2023-03-14T23:00:00Z').getTime();
@@ -624,7 +646,8 @@ class TestEnvironment {
   static userRoles: { [userId: string]: string } = {
     user01: SFProjectRole.ParatextAdministrator,
     user02: SFProjectRole.Viewer,
-    user03: SFProjectRole.Commenter
+    user03: SFProjectRole.Commenter,
+    user04: SFProjectRole.ParatextTranslator
   };
   static testProjectProfile: SFProjectProfile = createTestProjectProfile({
     texts: [TestEnvironment.matthewText],
@@ -633,7 +656,7 @@ class TestEnvironment {
       { tagId: 2, name: 'PT Tag 2', icon: 'circle01', creatorResolve: false },
       { tagId: 3, name: 'PT Tag 3', icon: 'star01', creatorResolve: false },
       { tagId: 4, name: 'PT Tag 4', icon: 'tag01', creatorResolve: false },
-      { tagId: 5, name: 'PT Tag 5', icon: 'asterisk01', creatorResolve: false },
+      { tagId: 5, name: 'PT Tag 5', icon: 'asterisk01', creatorResolve: true },
       { tagId: 6, name: 'SF Note Tag', icon: 'defaultIcon', creatorResolve: false }
     ],
     userRoles: TestEnvironment.userRoles

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -186,8 +186,15 @@ export class NoteDialogComponent implements OnInit {
   }
 
   get canResolve(): boolean {
-    // a note thread can be resolved only by paratext users who have edit rights and when the thread has existing notes
-    return this.canInsertNote && isParatextRole(this.userRole) && this.threadDataId != null;
+    if (this.threadDoc == null || this.projectProfileDoc?.data == null) return false;
+    const userRole: string = this.projectProfileDoc.data.userRoles[this.userService.currentUserId];
+    // A note thread can be resolved only by paratext users who have edit rights and when the thread has existing notes
+    // Additionally, a thread can be tagged with a tag that restricts resolve
+    return (
+      this.canInsertNote &&
+      this.threadDoc.canUserResolveThread(this.userService.currentUserId, userRole, this.noteTags) &&
+      this.threadDataId != null
+    );
   }
 
   private get defaultNoteTagId(): number | undefined {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -983,7 +983,8 @@ public class ParatextService : DisposableBase, IParatextService
                     {
                         TagId = t.Id,
                         Icon = t.Icon,
-                        Name = t.Name
+                        Name = t.Name,
+                        CreatorResolve = t.CreatorResolve
                     }
             );
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -3388,10 +3388,13 @@ public class ParatextServiceTests
             TagId = 5,
             Icon = "sf05",
             Name = "SF Note Tag",
+            CreatorResolve = true
         };
         env.SetupCommentTags(env.ProjectScrText, noteTag);
         ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
-        Assert.That(settings?.NoteTags.Any(t => t.Name == noteTag.Name), Is.True);
+        NoteTag? resultTag = settings?.NoteTags.Single(t => t.Name == noteTag.Name);
+        Assert.That(resultTag, Is.Not.Null);
+        Assert.That(resultTag.CreatorResolve, Is.True);
     }
 
     [Test]
@@ -3405,7 +3408,8 @@ public class ParatextServiceTests
         {
             TagId = CommentTag.notSetId,
             Icon = "sf05",
-            Name = "SF Note Tag"
+            Name = "SF Note Tag",
+            CreatorResolve = false
         };
         ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
         Assert.That(settings?.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
@@ -5410,9 +5414,18 @@ public class ParatextServiceTests
                 if (tagId < TagCount)
                 {
                     if (noteTag != null && tagId == noteTag.TagId)
-                        tags.Add(new CommentTag(noteTag.Name, noteTag.Icon, tagId));
+                    {
+                        tags.Add(
+                            new CommentTag(noteTag.Name, noteTag.Icon, tagId)
+                            {
+                                CreatorResolve = noteTag.CreatorResolve
+                            }
+                        );
+                    }
                     else
-                        tags.Add(new CommentTag($"tag{tagId}", $"icon{tagId}", tagId));
+                    {
+                        tags.Add(new CommentTag($"tag{tagId}", $"icon{tagId}", tagId) { CreatorResolve = false });
+                    }
                 }
             }
 


### PR DESCRIPTION
* synchronize note tag create resolve property
* add logic to detect if a user is allowed to resolve a thread
* hide the resolve note trigger when user is not allowed to resolve

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2241)
<!-- Reviewable:end -->
