### PR TITLE
Update CSharpier to 0.26.7

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.26.3",
+      "version": "0.26.7",
       "commands": ["dotnet-csharpier"]
     }
   }

--- a/src/Migrations/BackoutCommits/Program.cs
+++ b/src/Migrations/BackoutCommits/Program.cs
@@ -118,9 +118,9 @@ public class Program
         foreach (CommitData commit in relevantCommits)
         {
             foreach (
-                string notesFile in commit
-                    .Files
-                    .Where(f => Regex.Match(f, "notes.*.xml", RegexOptions.IgnoreCase).Length > 0)
+                string notesFile in commit.Files.Where(
+                    f => Regex.Match(f, "notes.*.xml", RegexOptions.IgnoreCase).Length > 0
+                )
             )
             {
                 ProblemCommit problemCommit = await ProcessNotesFileAsync(commit, notesFile);
@@ -174,9 +174,7 @@ public class Program
         }
 
         string adminUser = projectDoc
-            .Data
-            .UserRoles
-            .Where(ur => ur.Value == SFProjectRole.Administrator)
+            .Data.UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator)
             .Select(ur => projectDoc.Data.ParatextUsers.SingleOrDefault(pu => pu.SFUserId == ur.Key)?.Username)
             .FirstOrDefault(user => !string.IsNullOrEmpty(user));
         if (string.IsNullOrEmpty(adminUser))

--- a/src/Migrations/BackoutCommits/SyncAllService.cs
+++ b/src/Migrations/BackoutCommits/SyncAllService.cs
@@ -72,8 +72,7 @@ public class SyncAllService : ISyncAllService
                     + $"PT project id {sfProject.ParatextId}, SF project id {sfProject.Id}."
             );
             List<string> projectSfAdminUserIds = sfProject
-                .UserRoles
-                .Where(ur => ur.Value == SFProjectRole.Administrator)
+                .UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator)
                 .Select(ur => ur.Key)
                 .ToList<string>();
             if (projectSfAdminUserIds.Count < 1)

--- a/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
+++ b/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
@@ -28,8 +28,7 @@ namespace PTDDCloneAll
             IEnumerable<SFProject> projectsToClone = await env.GetSFProjects(projectIds);
             await env.Service.CloneSFProjects(CloneAllService.CLONE, projectsToClone);
             await env.PTDDSyncRunner.Received(1).RunAsync("project01", "user01", Arg.Any<bool>(), Arg.Any<bool>());
-            await env.PTDDSyncRunner
-                .DidNotReceive()
+            await env.PTDDSyncRunner.DidNotReceive()
                 .RunAsync("project02", Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
         }
 
@@ -41,8 +40,7 @@ namespace PTDDCloneAll
             IEnumerable<SFProject> projectsToClone = await env.GetSFProjects(projectIds);
             await env.Service.CloneSFProjects(CloneAllService.CLONE, projectsToClone);
             await env.PTDDSyncRunner.Received(1).RunAsync("project01", "user01", Arg.Any<bool>(), Arg.Any<bool>());
-            await env.PTDDSyncRunner
-                .Received(1)
+            await env.PTDDSyncRunner.Received(1)
                 .RunAsync("project02", Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
         }
 
@@ -56,11 +54,9 @@ namespace PTDDCloneAll
             env.FileSystemService.DirectoryExists(project01Path).Returns(true);
             await env.Service.CloneSFProjects(CloneAllService.CLONE, projectsToClone);
             env.FileSystemService.Received(2).DirectoryExists(Arg.Any<string>());
-            await env.PTDDSyncRunner
-                .DidNotReceive()
+            await env.PTDDSyncRunner.DidNotReceive()
                 .RunAsync("project01", Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
-            await env.PTDDSyncRunner
-                .Received(1)
+            await env.PTDDSyncRunner.Received(1)
                 .RunAsync("project02", Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>());
         }
     }

--- a/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
+++ b/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
@@ -196,10 +196,7 @@ namespace PTDDCloneAll
                     {
                         // Add new users who are in the target project, but not the source project
                         List<string> usersToAdd = _projectDoc
-                            .Data
-                            .UserRoles
-                            .Keys
-                            .Except(sourceProject.Data.UserRoles.Keys)
+                            .Data.UserRoles.Keys.Except(sourceProject.Data.UserRoles.Keys)
                             .ToList();
                         foreach (string uid in usersToAdd)
                         {
@@ -437,8 +434,7 @@ namespace PTDDCloneAll
             var oldUsxDoc = XDocument.Parse(bookText);
             XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
                 oldUsxDoc,
-                text.Chapters
-                    .OrderBy(c => c.Number)
+                text.Chapters.OrderBy(c => c.Number)
                     .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data))
             );
 

--- a/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
+++ b/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
@@ -202,18 +202,14 @@ namespace PtdaSyncAll
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
             var delta = Delta.New().InsertText("text");
@@ -227,8 +223,7 @@ namespace PtdaSyncAll
             Assert.That(env.GetText("MRK", 1, TextType.Source).DeepEquals(delta), Is.True);
             Assert.That(env.GetText("MRK", 2, TextType.Source).DeepEquals(delta), Is.True);
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateNotesAsync(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
 
             SFProjectSecret projectSecret = env.GetProjectSecret();
@@ -251,18 +246,14 @@ namespace PtdaSyncAll
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            await env.ParatextService
-                .Received()
+            await env.ParatextService.Received()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .Received()
+            await env.ParatextService.Received()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
             var delta = Delta.New().InsertText("text");
@@ -296,22 +287,17 @@ namespace PtdaSyncAll
 
             await env.Runner.RunAsync("project01", "user01", false);
 
-            await env.ParatextService
-                .Received()
+            await env.ParatextService.Received()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .Received()
+            await env.ParatextService.Received()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "target", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MAT", Arg.Any<string>(), Arg.Any<string>());
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateBookTextAsync(Arg.Any<UserSecret>(), "source", "MRK", Arg.Any<string>(), Arg.Any<string>());
 
-            await env.ParatextService
-                .DidNotReceive()
+            await env.ParatextService.DidNotReceive()
                 .UpdateNotesAsync(Arg.Any<UserSecret>(), "target", Arg.Any<string>());
 
             var delta = Delta.New().InsertText("text");
@@ -411,8 +397,7 @@ namespace PtdaSyncAll
             Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
             env.SetupSFData(false, true, true, books);
             env.FileSystemService.FileExists(TestEnvironment.GetUsxFileName(TextType.Target, "MAT")).Returns(false);
-            env.FileSystemService
-                .EnumerateFiles(TestEnvironment.GetProjectPath(TextType.Target))
+            env.FileSystemService.EnumerateFiles(TestEnvironment.GetProjectPath(TextType.Target))
                 .Returns(new[] { "MRK.xml" });
             env.SetupPTData(books);
 
@@ -435,8 +420,7 @@ namespace PtdaSyncAll
             env.SetupSFData(true, true, false, books);
             env.SetupPTData(books);
             var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-            env.ParatextService
-                .GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
             await env.Runner.RunAsync("project01", "user01", false);
@@ -456,8 +440,7 @@ namespace PtdaSyncAll
             env.SetupSFData(true, true, false, books);
             env.SetupPTData(books);
             var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-            env.ParatextService
-                .GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
+            env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
                 .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
             await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
@@ -476,8 +459,7 @@ namespace PtdaSyncAll
         {
             var env = new TestEnvironment();
             env.SetupSFData(false, false, false, new Book("MAT", 2), new Book("MRK", 2));
-            env.RealtimeService
-                .GetRepository<TextData>()
+            env.RealtimeService.GetRepository<TextData>()
                 .Add(
                     new TextData(Delta.New().InsertText("old text"))
                     {
@@ -837,11 +819,9 @@ namespace PtdaSyncAll
 
             public TestEnvironment()
             {
-                IOptions<SiteOptions> siteOptions = Microsoft
-                    .Extensions
-                    .Options
-                    .Options
-                    .Create(new SiteOptions() { SiteDir = "scriptureforge" });
+                IOptions<SiteOptions> siteOptions = Microsoft.Extensions.Options.Options.Create(
+                    new SiteOptions() { SiteDir = "scriptureforge" }
+                );
                 var userSecrets = new MemoryRepository<UserSecret>(new[] { new UserSecret { Id = "user01" } });
                 _projectSecrets = new MemoryRepository<SFProjectSecret>(
                     new[] { new SFProjectSecret { Id = "project01" } }

--- a/src/Migrations/PtdaSyncAll.Tests/SyncAllServiceTests.cs
+++ b/src/Migrations/PtdaSyncAll.Tests/SyncAllServiceTests.cs
@@ -30,14 +30,11 @@ namespace PtdaSyncAll
             await env.Service.SynchronizeAllProjectsAsync(false);
 
             await env.ParatextService.Received().GetProjectsAsync(Arg.Any<UserSecret>());
-            await env.ParatextSyncRunner
-                .DidNotReceive()
+            await env.ParatextSyncRunner.DidNotReceive()
                 .RunAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(Arg.Is<string>((string message) => message.Contains("Starting an asynchronous synchronization")));
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>((string message) => message.Contains("Waiting for synchronization tasks to finish"))
                 );
@@ -48,8 +45,7 @@ namespace PtdaSyncAll
         {
             var env = new TestEnvironment();
             Task syncTask = null;
-            env.ParatextSyncRunner
-                .RunAsync("project01", "user01", Arg.Any<bool>())
+            env.ParatextSyncRunner.RunAsync("project01", "user01", Arg.Any<bool>())
                 .Returns(
                     (callInfo) =>
                     {
@@ -69,8 +65,7 @@ namespace PtdaSyncAll
             await env.ParatextService.Received().GetProjectsAsync(Arg.Any<UserSecret>());
             await env.ParatextSyncRunner.Received().RunAsync("project01", "user01", Arg.Any<bool>());
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -79,8 +74,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -107,8 +101,7 @@ namespace PtdaSyncAll
             await env.ParatextSyncRunner.Received().RunAsync("project01", "user01", Arg.Any<bool>());
             await env.ParatextSyncRunner.Received().RunAsync("project02", "user01", Arg.Any<bool>());
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -117,8 +110,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -129,8 +121,7 @@ namespace PtdaSyncAll
             env.ProgramLogger.Received().Log(Arg.Is<string>((string message) => message.Contains("> PT project P01")));
             env.ProgramLogger.Received().Log(Arg.Is<string>((string message) => message.Contains("> PT project P02")));
 
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(Arg.Is<string>((string message) => message.Contains("subset of projects")));
         }
 
@@ -155,8 +146,7 @@ namespace PtdaSyncAll
             await env.ParatextSyncRunner.Received().RunAsync("project01", "user01", Arg.Any<bool>());
             await env.ParatextSyncRunner.Received().RunAsync("project02", "user01", Arg.Any<bool>());
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -165,8 +155,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -177,8 +166,7 @@ namespace PtdaSyncAll
             env.ProgramLogger.Received().Log(Arg.Is<string>((string message) => message.Contains("> PT project P01")));
             env.ProgramLogger.Received().Log(Arg.Is<string>((string message) => message.Contains("> PT project P02")));
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(Arg.Is<string>((string message) => message.Contains("subset of projects")));
         }
 
@@ -202,8 +190,7 @@ namespace PtdaSyncAll
             await env.ParatextSyncRunner.Received().RunAsync("project01", "user01", Arg.Any<bool>());
             await env.ParatextSyncRunner.DidNotReceive().RunAsync("project02", "user01", Arg.Any<bool>());
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -212,8 +199,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -222,12 +208,10 @@ namespace PtdaSyncAll
                 );
 
             env.ProgramLogger.Received().Log(Arg.Is<string>((string message) => message.Contains("> PT project P01")));
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(Arg.Is<string>((string message) => message.Contains("> PT project P02")));
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(Arg.Is<string>((string message) => message.Contains("subset of projects")));
         }
 
@@ -236,8 +220,7 @@ namespace PtdaSyncAll
         {
             var env = new TestEnvironment();
             Task syncTask = null;
-            env.ParatextSyncRunner
-                .RunAsync("project01", "user01", Arg.Any<bool>())
+            env.ParatextSyncRunner.RunAsync("project01", "user01", Arg.Any<bool>())
                 .Returns(
                     (callInfo) =>
                     {
@@ -255,16 +238,14 @@ namespace PtdaSyncAll
 
             // Exceptions thrown from the synchronization are reported.
             Assert.That(syncTask?.Status, Is.EqualTo(TaskStatus.Faulted));
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
                             message.Contains("There was a problem with one or more synchronization tasks")
                     )
                 );
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) => message.Contains("One or more sync tasks did not complete successfully")
@@ -294,8 +275,7 @@ namespace PtdaSyncAll
             // intentionally use the admin user that was requested to be used for project01.
             await env.ParatextSyncRunner.Received().RunAsync("project02", "user01", Arg.Any<bool>());
 
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -304,8 +284,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -314,8 +293,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -324,8 +302,7 @@ namespace PtdaSyncAll
                             )
                     )
                 );
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>
@@ -335,11 +312,9 @@ namespace PtdaSyncAll
                     )
                 );
 
-            env.ProgramLogger
-                .DidNotReceive()
+            env.ProgramLogger.DidNotReceive()
                 .Log(Arg.Is<string>((string message) => message.Contains("For SF Project project02")));
-            env.ProgramLogger
-                .Received()
+            env.ProgramLogger.Received()
                 .Log(
                     Arg.Is<string>(
                         (string message) =>

--- a/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
+++ b/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
@@ -417,8 +417,7 @@ namespace PtdaSyncAll
                 var oldUsxDoc = new XDocument(bookTextElem.Element("usx"));
                 XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
                     oldUsxDoc,
-                    text.Chapters
-                        .OrderBy(c => c.Number)
+                    text.Chapters.OrderBy(c => c.Number)
                         .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, dbChapterDocs[c.Number].Data))
                 );
 

--- a/src/Migrations/PtdaSyncAll/SyncAllService.cs
+++ b/src/Migrations/PtdaSyncAll/SyncAllService.cs
@@ -78,8 +78,7 @@ namespace PtdaSyncAll
                         + $"PT project id {sfProject.ParatextId}, SF project id {sfProject.Id}."
                 );
                 List<string> projectSfAdminUserIds = sfProject
-                    .UserRoles
-                    .Where(ur => ur.Value == SFProjectRole.Administrator)
+                    .UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator)
                     .Select(ur => ur.Key)
                     .ToList<string>();
                 if (projectSfAdminUserIds.Count() < 1)

--- a/src/Migrations/ServalMigration/ServalMigrator.cs
+++ b/src/Migrations/ServalMigration/ServalMigrator.cs
@@ -115,8 +115,7 @@ public class ServalMigrator : DisposableBase
 
             // Get the admin users
             List<string> projectSfAdminUserIds = project
-                .UserRoles
-                .Where(ur => ur.Value == SFProjectRole.Administrator)
+                .UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator)
                 .Select(ur => ur.Key)
                 .ToList();
             if (!projectSfAdminUserIds.Any())

--- a/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
+++ b/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
@@ -124,8 +124,7 @@ namespace SourceTargetSplitting
         public async Task CreateProjectFromSourceAsync(string sourceId, string targetId)
         {
             // Get the administrator for the specified project
-            var targetProject = this._realtimeService
-                .QuerySnapshots<SFProject>()
+            var targetProject = this._realtimeService.QuerySnapshots<SFProject>()
                 .FirstOrDefault(p => p.ParatextId == targetId);
             if (targetProject == null)
             {
@@ -134,8 +133,7 @@ namespace SourceTargetSplitting
 
             // Get the highest ranked for this project, that probably has source access
             string[] userIds = targetProject
-                .UserRoles
-                .Where(ur => ur.Value == SFProjectRole.Administrator || ur.Value == SFProjectRole.Translator)
+                .UserRoles.Where(ur => ur.Value == SFProjectRole.Administrator || ur.Value == SFProjectRole.Translator)
                 .OrderBy(ur => ur.Value)
                 .Select(ur => ur.Key)
                 .ToArray();
@@ -414,8 +412,7 @@ namespace SourceTargetSplitting
             }
 
             // Get every user id and username from the user secrets
-            Dictionary<string, string> userMapping = await this._userSecrets
-                .Query()
+            Dictionary<string, string> userMapping = await this._userSecrets.Query()
                 .ToDictionaryAsync(u => u.Id, u => this._paratextService.GetParatextUsername(u));
 
             // Iterate over every project
@@ -482,9 +479,10 @@ namespace SourceTargetSplitting
                             else
                             {
                                 string textInfoPermission = TextInfoPermission.Read;
-                                IEnumerable<int> editable = scrText
-                                    .Permissions
-                                    .GetEditableBooks(Paratext.Data.Users.PermissionSet.Merged, userName);
+                                IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
+                                    Paratext.Data.Users.PermissionSet.Merged,
+                                    userName
+                                );
                                 if (editable == null || !editable.Any())
                                 {
                                     // If there are no editable book permissions, check if they can edit all books
@@ -526,14 +524,12 @@ namespace SourceTargetSplitting
                                 else
                                 {
                                     string textInfoPermission = TextInfoPermission.Read;
-                                    IEnumerable<int>? editable = scrText
-                                        .Permissions
-                                        .GetEditableChapters(
-                                            project.Texts[i].BookNum,
-                                            scrText.Settings.Versification,
-                                            userName,
-                                            Paratext.Data.Users.PermissionSet.Merged
-                                        );
+                                    IEnumerable<int>? editable = scrText.Permissions.GetEditableChapters(
+                                        project.Texts[i].BookNum,
+                                        scrText.Settings.Versification,
+                                        userName,
+                                        Paratext.Data.Users.PermissionSet.Merged
+                                    );
                                     if (editable?.Contains(project.Texts[i].Chapters[j].Number) ?? false)
                                     {
                                         textInfoPermission = TextInfoPermission.Write;
@@ -594,8 +590,7 @@ namespace SourceTargetSplitting
         public async Task MigrateTargetPermissionsAsync(string sourceId, string targetId)
         {
             // Get the target project
-            var targetProject = this._realtimeService
-                .QuerySnapshots<SFProject>()
+            var targetProject = this._realtimeService.QuerySnapshots<SFProject>()
                 .FirstOrDefault(p => p.ParatextId == targetId);
             if (targetProject == null)
             {
@@ -603,8 +598,7 @@ namespace SourceTargetSplitting
             }
 
             // Get the source project
-            var sourceProject = this._realtimeService
-                .QuerySnapshots<SFProject>()
+            var sourceProject = this._realtimeService.QuerySnapshots<SFProject>()
                 .FirstOrDefault(p => p.ParatextId == sourceId);
             if (sourceProject == null)
             {
@@ -613,8 +607,7 @@ namespace SourceTargetSplitting
 
             // Get the highest ranked for this project, that probably has source access
             string[] userIds = targetProject
-                .UserRoles
-                .Select(ur => ur.Key)
+                .UserRoles.Select(ur => ur.Key)
                 .Where(u => !sourceProject.UserRoles.Keys.Contains(u))
                 .ToArray();
 
@@ -670,8 +663,7 @@ namespace SourceTargetSplitting
                         string usfm = scrText.GetText(bookNum);
                         string bookText = UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
                         var usxDoc = XDocument.Parse(bookText);
-                        Dictionary<int, ChapterDelta> deltas = this._deltaUsxMapper
-                            .ToChapterDeltas(usxDoc)
+                        Dictionary<int, ChapterDelta> deltas = this._deltaUsxMapper.ToChapterDeltas(usxDoc)
                             .ToDictionary(cd => cd.Number);
                         var chapters = new List<Chapter>();
                         foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)
@@ -686,8 +678,7 @@ namespace SourceTargetSplitting
                 }
 
                 // See that at least one user in the target project has permission to create the source project
-                var targetProject = this._realtimeService
-                    .QuerySnapshots<SFProject>()
+                var targetProject = this._realtimeService.QuerySnapshots<SFProject>()
                     .FirstOrDefault(p => p.ParatextId == targetId);
                 if (targetProject == null)
                 {
@@ -696,8 +687,9 @@ namespace SourceTargetSplitting
 
                 // Get the highest ranked users for this project, that probably have source access
                 string[] userIds = targetProject
-                    .UserRoles
-                    .Where(ur => ur.Value == SFProjectRole.Administrator || ur.Value == SFProjectRole.Translator)
+                    .UserRoles.Where(
+                        ur => ur.Value == SFProjectRole.Administrator || ur.Value == SFProjectRole.Translator
+                    )
                     .OrderBy(ur => ur.Value)
                     .Select(ur => ur.Key)
                     .ToArray();
@@ -773,8 +765,7 @@ namespace SourceTargetSplitting
             string bookText = this._paratextService.GetBookText(userSecret, paratextId, text.BookNum);
             var usxDoc = XDocument.Parse(bookText);
             var tasks = new List<Task>();
-            Dictionary<int, ChapterDelta> deltas = this._deltaUsxMapper
-                .ToChapterDeltas(usxDoc)
+            Dictionary<int, ChapterDelta> deltas = this._deltaUsxMapper.ToChapterDeltas(usxDoc)
                 .ToDictionary(cd => cd.Number);
             var chapters = new List<Chapter>();
             foreach (KeyValuePair<int, ChapterDelta> kvp in deltas)

--- a/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
@@ -122,13 +122,11 @@ public class AnonymousController : ControllerBase
                 request.Language
             );
             // Store credentials in a cookie as a fallback to the auth0 tokens expiring so the user can log in again
-            Response
-                .Cookies
-                .Append(
-                    CookieConstants.TransparentAuthentication,
-                    Newtonsoft.Json.JsonConvert.SerializeObject(credentials),
-                    new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(2) }
-                );
+            Response.Cookies.Append(
+                CookieConstants.TransparentAuthentication,
+                Newtonsoft.Json.JsonConvert.SerializeObject(credentials),
+                new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(2) }
+            );
             return Ok(true);
         }
         catch (DataNotFoundException e)

--- a/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/LanguageController.cs
@@ -30,9 +30,11 @@ public class LanguageController : ControllerBase
 
         var cookieName = CookieRequestCultureProvider.DefaultCookieName;
         var cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-        Response
-            .Cookies
-            .Append(cookieName, cookieValue, new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) });
+        Response.Cookies.Append(
+            cookieName,
+            cookieValue,
+            new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) }
+        );
 
         return LocalRedirect(returnUrl);
     }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -618,8 +618,7 @@ public class MachineApiService : IMachineApiService
                     )
                     {
                         string? corporaId = projectSecret
-                            .ServalData
-                            ?.Corpora
+                            .ServalData?.Corpora
                             .FirstOrDefault(c => !c.Value.PreTranslate)
                             .Key;
                         await _projectSecrets.UpdateAsync(

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -216,8 +216,7 @@ public class MachineProjectService : IMachineProjectService
 
             // Clear the existing translation engine id and corpora
             string? corporaId = projectSecret
-                .ServalData
-                ?.Corpora
+                .ServalData?.Corpora
                 .FirstOrDefault(c => preTranslate ? c.Value.PreTranslate : !c.Value.PreTranslate)
                 .Key;
             await _projectSecrets.UpdateAsync(
@@ -294,8 +293,7 @@ public class MachineProjectService : IMachineProjectService
             // A 404 means that the translation engine does not exist
             _logger.LogInformation($"Translation Engine {translationEngineId} does not exist.");
             string? corporaId = projectSecret
-                .ServalData
-                ?.Corpora
+                .ServalData?.Corpora
                 .FirstOrDefault(c => preTranslate ? c.Value.PreTranslate : !c.Value.PreTranslate)
                 .Key;
             // Clear the existing translation engine id and corpora
@@ -464,10 +462,8 @@ public class MachineProjectService : IMachineProjectService
         {
             foreach (
                 string fileId in projectSecret
-                    .ServalData
-                    .Corpora[corpusId]
-                    .SourceFiles
-                    .Concat(projectSecret.ServalData.Corpora[corpusId].TargetFiles)
+                    .ServalData.Corpora[corpusId]
+                    .SourceFiles.Concat(projectSecret.ServalData.Corpora[corpusId].TargetFiles)
                     .Select(f => f.FileId)
             )
             {
@@ -601,9 +597,9 @@ public class MachineProjectService : IMachineProjectService
 
         // See if there is a translation corpus
         string? corpusId = projectSecret
-            .ServalData
-            .Corpora
-            .FirstOrDefault(c => c.Value.PreTranslate == preTranslate && !c.Value.AlternateTrainingSource)
+            .ServalData.Corpora.FirstOrDefault(
+                c => c.Value.PreTranslate == preTranslate && !c.Value.AlternateTrainingSource
+            )
             .Key;
 
         // See if there is a training corpus
@@ -615,9 +611,7 @@ public class MachineProjectService : IMachineProjectService
         if (useAlternateTrainingSource)
         {
             alternateTrainingSourceCorpusId = projectSecret
-                .ServalData
-                .Corpora
-                .FirstOrDefault(c => c.Value.PreTranslate && c.Value.AlternateTrainingSource)
+                .ServalData.Corpora.FirstOrDefault(c => c.Value.PreTranslate && c.Value.AlternateTrainingSource)
                 .Key;
         }
 
@@ -858,14 +852,12 @@ public class MachineProjectService : IMachineProjectService
         {
             Options = draftConfig.ServalConfig is null ? null : JObject.Parse(draftConfig.ServalConfig),
             Pretranslate = servalData
-                .Corpora
-                .Where(s => s.Value.PreTranslate && !s.Value.AlternateTrainingSource)
+                .Corpora.Where(s => s.Value.PreTranslate && !s.Value.AlternateTrainingSource)
                 .Select(c => new PretranslateCorpusConfig { CorpusId = c.Key })
                 .ToList(),
             TrainOn = draftConfig.AlternateTrainingSourceEnabled
                 ? servalData
-                    .Corpora
-                    .Where(s => s.Value.PreTranslate && s.Value.AlternateTrainingSource)
+                    .Corpora.Where(s => s.Value.PreTranslate && s.Value.AlternateTrainingSource)
                     .Select(c => new TrainingCorpusConfig { CorpusId = c.Key })
                     .ToList()
                 : null,

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -48,19 +48,16 @@ public static class MachineServiceCollectionExtensions
         var servalOptions = configuration.GetOptions<ServalOptions>();
         services.AddAccessTokenManagement(options =>
         {
-            options
-                .Client
-                .Clients
-                .Add(
-                    MachineApi.HttpClientName,
-                    new ClientCredentialsTokenRequest
-                    {
-                        Address = servalOptions.TokenUrl,
-                        ClientId = servalOptions.ClientId,
-                        ClientSecret = servalOptions.ClientSecret,
-                        Parameters = new Parameters { { "audience", servalOptions.Audience } },
-                    }
-                );
+            options.Client.Clients.Add(
+                MachineApi.HttpClientName,
+                new ClientCredentialsTokenRequest
+                {
+                    Address = servalOptions.TokenUrl,
+                    ClientId = servalOptions.ClientId,
+                    ClientSecret = servalOptions.ClientSecret,
+                    Parameters = new Parameters { { "audience", servalOptions.Audience } },
+                }
+            );
         });
         services
             .AddClientAccessTokenHttpClient(

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -497,8 +497,7 @@ public class ParatextService : DisposableBase, IParatextService
                 remotePtProjects
                     .SingleOrDefault(p => p.SendReceiveId.Id == paratextId)
                     ?.SourceUsers
-                    .Users
-                    .FirstOrDefault(u => u.UserName == username)
+                    .Users.FirstOrDefault(u => u.UserName == username)
                     ?.Role
             );
             if (string.IsNullOrEmpty(role))
@@ -764,9 +763,10 @@ public class ParatextService : DisposableBase, IParatextService
                     else if (chapter == 0)
                     {
                         // Book level
-                        IEnumerable<int> editable = scrText
-                            .Permissions
-                            .GetEditableBooks(PermissionSet.Merged, userName);
+                        IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
+                            PermissionSet.Merged,
+                            userName
+                        );
                         if (editable == null || !editable.Any())
                         {
                             // If there are no editable book permissions, check if they can edit all books
@@ -783,9 +783,12 @@ public class ParatextService : DisposableBase, IParatextService
                     else
                     {
                         // Chapter level
-                        IEnumerable<int> editable = scrText
-                            .Permissions
-                            .GetEditableChapters(book, scrText.Settings.Versification, userName, PermissionSet.Merged);
+                        IEnumerable<int> editable = scrText.Permissions.GetEditableChapters(
+                            book,
+                            scrText.Settings.Versification,
+                            userName,
+                            PermissionSet.Merged
+                        );
                         if (editable?.Contains(chapter) ?? false)
                         {
                             textInfoPermission = TextInfoPermission.Write;
@@ -934,9 +937,7 @@ public class ParatextService : DisposableBase, IParatextService
                 }
                 string role = ConvertFromUserRole(
                     remotePtProject
-                        .SourceUsers
-                        .Users
-                        .SingleOrDefault(u =>
+                        .SourceUsers.Users.SingleOrDefault(u =>
                         {
                             if (u is null)
                             {
@@ -1272,9 +1273,7 @@ public class ParatextService : DisposableBase, IParatextService
             {
                 // The thread has been removed
                 threadChange.NoteIdsRemoved = threadDoc
-                    .Data
-                    .Notes
-                    .Where(n => !n.Deleted)
+                    .Data.Notes.Where(n => !n.Deleted)
                     .Select(n => n.DataId)
                     .ToList();
                 if (threadChange.NoteIdsRemoved.Count > 0)
@@ -1550,15 +1549,16 @@ public class ParatextService : DisposableBase, IParatextService
 
             // Get the term localizations
             Dictionary<string, TermLocalizations> allTermLocalizations = TermLocalizations
-                .LanguagesAvailable
-                .Select(language => (language, termLocalizations: TermLocalizations.GetTermLocalizations(language)))
+                .LanguagesAvailable.Select(
+                    language => (language, termLocalizations: TermLocalizations.GetTermLocalizations(language))
+                )
                 .ToDictionary(l => l.language, l => l.termLocalizations);
 
             // Create the collection of Biblical Terms with Renderings
             foreach (
-                Term term in projectSettingsBiblicalTerms
-                    .Terms
-                    .Where(t => t.VerseRefs().Any(v => books.Contains(v.BookNum)))
+                Term term in projectSettingsBiblicalTerms.Terms.Where(
+                    t => t.VerseRefs().Any(v => books.Contains(v.BookNum))
+                )
             )
             {
                 TermRendering termRendering = termRenderings.GetRendering(term.Id);
@@ -1569,8 +1569,7 @@ public class ParatextService : DisposableBase, IParatextService
                     TermLocalization termLocalization = termLocalizations.GetTermLocalization(term.Id);
                     BiblicalTermDefinition biblicalTermDefinition = new BiblicalTermDefinition
                     {
-                        Categories = term.CategoryIds
-                            .Select(c => termLocalizations.GetCategoryLocalization(c))
+                        Categories = term.CategoryIds.Select(c => termLocalizations.GetCategoryLocalization(c))
                             .ToList(),
                         Domains = term.SemanticDomains.Select(d => termLocalizations.GetDomainLocalization(d)).ToList(),
                         Gloss = termLocalization.Gloss,
@@ -2501,8 +2500,9 @@ public class ParatextService : DisposableBase, IParatextService
         // Try another method to find the comment
         DateTime noteTime = note.DateCreated.ToUniversalTime();
         return thread
-            .Comments
-            .Where(c => DateTime.Equals(noteTime, DateTime.Parse(c.Date, null, DateTimeStyles.AdjustToUniversal)))
+            .Comments.Where(
+                c => DateTime.Equals(noteTime, DateTime.Parse(c.Date, null, DateTimeStyles.AdjustToUniversal))
+            )
             .LastOrDefault(c => c.User == ptUser.Username);
     }
 
@@ -2981,17 +2981,15 @@ public class ParatextService : DisposableBase, IParatextService
 
         string verseText = GetVerseText(chapterDelta.Delta, verseRef);
         verseText = verseText.Replace("\n", "\0");
-        PtxUtils
-            .StringUtils
-            .MatchContexts(
-                verseText,
-                contextBefore,
-                selectedText,
-                contextAfter,
-                null,
-                ref startPos,
-                out int posJustPastLastCharacter
-            );
+        PtxUtils.StringUtils.MatchContexts(
+            verseText,
+            contextBefore,
+            selectedText,
+            contextAfter,
+            null,
+            ref startPos,
+            out int posJustPastLastCharacter
+        );
         // The text anchor is relative to the text in the verse
         return new TextAnchor { Start = startPos, Length = posJustPastLastCharacter - startPos };
     }
@@ -3105,9 +3103,10 @@ public class ParatextService : DisposableBase, IParatextService
         {
             // if the current user is an administrator, then always allow editing the book text even if the user
             // doesn't have permission. This will ensure that a sync by an administrator never fails.
-            scrText
-                .Permissions
-                .RunWithEditPermision(bookNum, () => scrText.PutText(bookNum, chapterNum, false, usfm, null));
+            scrText.Permissions.RunWithEditPermision(
+                bookNum,
+                () => scrText.PutText(bookNum, chapterNum, false, usfm, null)
+            );
         }
         else
         {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -346,9 +346,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
                     // Add new PT users who are in the target project, but not the source project
                     List<string> usersToAdd = _projectDoc
-                        .Data
-                        .UserRoles
-                        .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                        .Data.UserRoles.Where(u => SFProjectRole.IsParatextRole(u.Value))
                         .Select(u => u.Key)
                         .Except(sourceProject.Data.UserRoles.Keys)
                         .ToList();
@@ -369,9 +367,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
                     // Remove PT users who are in the target project, and no longer have access to the resource
                     List<string> usersToCheck = _projectDoc
-                        .Data
-                        .UserRoles
-                        .Where(u => SFProjectRole.IsParatextRole(u.Value))
+                        .Data.UserRoles.Where(u => SFProjectRole.IsParatextRole(u.Value))
                         .Select(u => u.Key)
                         .Except(usersToAdd)
                         .ToList();
@@ -511,9 +507,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
     {
         // Get the Text Data
         List<string> textIds = _projectDoc
-            .Data
-            .Texts
-            .SelectMany(t => t.Chapters.Select(c => TextData.GetTextDocId(_projectDoc.Id, t.BookNum, c.Number)))
+            .Data.Texts.SelectMany(
+                t => t.Chapters.Select(c => TextData.GetTextDocId(_projectDoc.Id, t.BookNum, c.Number))
+            )
             .ToList();
         IReadOnlyCollection<IDocument<TextData>> textDocs = await _conn.GetAndFetchDocsAsync<TextData>(textIds);
 
@@ -659,9 +655,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
         {
             i++;
             await NotifySyncProgress(syncPhase, 50 + (i / biblicalTermDocs.Count / 3));
-            BiblicalTerm? biblicalTerm = biblicalTermsChanges
-                .BiblicalTerms
-                .FirstOrDefault(b => b.TermId == biblicalTermDoc.Data.TermId);
+            BiblicalTerm? biblicalTerm = biblicalTermsChanges.BiblicalTerms.FirstOrDefault(
+                b => b.TermId == biblicalTermDoc.Data.TermId
+            );
             if (
                 biblicalTerm is not null
                 && (
@@ -764,10 +760,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         foreach ((string language, BiblicalTermDefinition definition) in biblicalTerm.Definitions)
                         {
                             if (
-                                biblicalTermDoc
-                                    .Data
-                                    .Definitions
-                                    .TryGetValue(language, out BiblicalTermDefinition existingDefinition)
+                                biblicalTermDoc.Data.Definitions.TryGetValue(
+                                    language,
+                                    out BiblicalTermDefinition existingDefinition
+                                )
                             )
                             {
                                 if (!_listStringComparer.Equals(existingDefinition.Categories, definition.Categories))
@@ -798,10 +794,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
                         // Remove missing definitions
                         foreach (
-                            (string language, _) in biblicalTermDoc
-                                .Data
-                                .Definitions
-                                .Where(d => !biblicalTerm.Definitions.ContainsKey(d.Key))
+                            (string language, _) in biblicalTermDoc.Data.Definitions.Where(
+                                d => !biblicalTerm.Definitions.ContainsKey(d.Key)
+                            )
                         )
                         {
                             op.Unset(b => b.Definitions[language]);
@@ -1046,8 +1041,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         var oldUsxDoc = XDocument.Parse(bookText);
         XDocument newUsxDoc = _deltaUsxMapper.ToUsx(
             oldUsxDoc,
-            text.Chapters
-                .OrderBy(c => c.Number)
+            text.Chapters.OrderBy(c => c.Number)
                 .Select(c => new ChapterDelta(c.Number, c.LastVerse, c.IsValid, textDocs[c.Number].Data))
         );
 
@@ -1129,9 +1123,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     if (string.IsNullOrEmpty(userSFId))
                     {
                         userSFId = _projectDoc
-                            .Data
-                            .UserRoles
-                            .FirstOrDefault(p => p.Value == SFProjectRole.Administrator)
+                            .Data.UserRoles.FirstOrDefault(p => p.Value == SFProjectRole.Administrator)
                             .Key;
                     }
                 }
@@ -1513,8 +1505,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             List<int> removedIndices = change
-                .NoteIdsRemoved
-                .Select(id => threadDoc.Data.Notes.FindIndex(n => n.DataId == id))
+                .NoteIdsRemoved.Select(id => threadDoc.Data.Notes.FindIndex(n => n.DataId == id))
                 .Where(index => index >= 0)
                 .ToList();
             // Go through the indices in reverse order so subsequent removal indices are not affected
@@ -1874,18 +1865,16 @@ public class ParatextSyncRunner : IParatextSyncRunner
             {
                 foreach (ParatextUserProfile activePtSyncUser in _currentPtSyncUsers.Values)
                 {
-                    ParatextUserProfile existingUser = _projectDoc
-                        .Data
-                        .ParatextUsers
-                        .SingleOrDefault(u => u.Username == activePtSyncUser.Username);
+                    ParatextUserProfile existingUser = _projectDoc.Data.ParatextUsers.SingleOrDefault(
+                        u => u.Username == activePtSyncUser.Username
+                    );
                     if (existingUser == null)
                         op.Add(pd => pd.ParatextUsers, activePtSyncUser);
                     else if (existingUser.SFUserId == null)
                     {
-                        int index = _projectDoc
-                            .Data
-                            .ParatextUsers
-                            .FindIndex(u => u.Username == activePtSyncUser.Username);
+                        int index = _projectDoc.Data.ParatextUsers.FindIndex(
+                            u => u.Username == activePtSyncUser.Username
+                        );
                         string userId = _currentPtSyncUsers[existingUser.Username].SFUserId;
                         if (!string.IsNullOrEmpty(userId))
                             op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
@@ -2018,10 +2007,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
     {
         IReadOnlyDictionary<string, string> sfUserIdsToUsernames =
             await _paratextService.GetParatextUsernameMappingAsync(_userSecret, _projectDoc.Data, token);
-        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc
-            .Data
-            .ParatextUsers
-            .ToDictionary(p => p.Username);
+        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(
+            p => p.Username
+        );
         foreach (var (sfUserId, username) in sfUserIdsToUsernames)
         {
             if (!paratextUsers.TryGetValue(username, out ParatextUserProfile profile))

--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -111,8 +111,7 @@ public class SFBiblicalTermsText : ISFText
 
         foreach (
             XElement termRenderingElem in termRenderingsDoc
-                .Root
-                .Elements("TermRendering")
+                .Root.Elements("TermRendering")
                 .Where(t => !(bool)t.Attribute("Guess"))
                 .OrderBy(t => t.Attribute("Id")?.Value)
         )

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -557,8 +557,7 @@ public class SFInstallableDblResource : InstallableResource
                         )
                         {
                             string revisionFilename = entry
-                                .FileName
-                                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                                .FileName.Split('/', StringSplitOptions.RemoveEmptyEntries)
                                 .Last();
                             if (!int.TryParse(revisionFilename, out revision))
                             {

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -110,8 +110,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
         {
             if (
-                this.RealtimeService
-                    .QuerySnapshots<SFProject>()
+                this.RealtimeService.QuerySnapshots<SFProject>()
                     .Any((SFProject sfProject) => sfProject.ParatextId == project.ParatextId)
             )
             {
@@ -596,8 +595,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         SFProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectId);
         // Link sharing keys have Email set to null and ExpirationTime set to null.
         string key = projectSecret
-            .ShareKeys
-            .FirstOrDefault(
+            .ShareKeys.FirstOrDefault(
                 sk =>
                     sk.Email == null
                     && sk.ProjectRole == role
@@ -713,8 +711,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
 
         DateTime now = DateTime.UtcNow;
         return projectSecret
-            .ShareKeys
-            .Where(s => s.Email != null)
+            .ShareKeys.Where(s => s.Email != null)
             .Select(
                 sk =>
                     new InviteeStatus

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -32,11 +32,9 @@ public static class AuthServiceCollectionExtensions
                         string? accessToken = context.Request.Query["access_token"];
                         if (
                             !string.IsNullOrEmpty(accessToken)
-                            && context
-                                .HttpContext
-                                .Request
-                                .Path
-                                .StartsWithSegments($"/{UrlConstants.ProjectNotifications}")
+                            && context.HttpContext.Request.Path.StartsWithSegments(
+                                $"/{UrlConstants.ProjectNotifications}"
+                            )
                         )
                         {
                             // Get the token from the query string

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -117,10 +117,8 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
         IDocument<User> userDoc = await GetUserDocAsync(projectUserId, conn);
         IEnumerable<Task> removalTasks = userDoc
-            .Data
-            .Sites[SiteOptions.Value.Id]
-            .Projects
-            .Select((string projectId) => RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId));
+            .Data.Sites[SiteOptions.Value.Id]
+            .Projects.Select((string projectId) => RemoveUserCoreAsync(conn, curUserId, projectId, projectUserId));
         // The removals can be processed in parallel in production, but for unit tests, MemoryRealtimeService
         // does not fully implement concurrent editing of docs, so run them in a sequence.
         foreach (Task task in removalTasks)
@@ -278,12 +276,9 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         ProjectSecret projectSecret = await ProjectSecrets.GetAsync(projectDoc.Id);
         if (!string.IsNullOrWhiteSpace(shareKey) && projectSecret != null)
         {
-            int index = projectSecret
-                .ShareKeys
-                .FindIndex(
-                    sk =>
-                        sk.RecipientUserId == null && sk.ShareLinkType == ShareLinkType.Recipient && sk.Key == shareKey
-                );
+            int index = projectSecret.ShareKeys.FindIndex(
+                sk => sk.RecipientUserId == null && sk.ShareLinkType == ShareLinkType.Recipient && sk.Key == shareKey
+            );
             if (index > -1)
             {
                 await ProjectSecrets.UpdateAsync(

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -124,13 +124,14 @@ public class UserService : IUserService
             }
             else if (newPTTokens.IssuedAt < userSecret.ParatextTokens.IssuedAt)
             {
-                string incomingIAt = newPTTokens
-                    .IssuedAt
-                    .ToString("o", System.Globalization.CultureInfo.InvariantCulture);
-                string currentIAt = userSecret
-                    .ParatextTokens
-                    .IssuedAt
-                    .ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+                string incomingIAt = newPTTokens.IssuedAt.ToString(
+                    "o",
+                    System.Globalization.CultureInfo.InvariantCulture
+                );
+                string currentIAt = userSecret.ParatextTokens.IssuedAt.ToString(
+                    "o",
+                    System.Globalization.CultureInfo.InvariantCulture
+                );
                 _logger.LogWarning(
                     $"When updating user with SF id {curUserId} from auth0 profile, ignoring incoming tokens which were issued at {incomingIAt}, which is earlier than the current tokens {currentIAt}."
                 );
@@ -196,9 +197,7 @@ public class UserService : IUserService
 
         string initials = string.Concat(
             userDoc
-                .Data
-                .DisplayName
-                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Data.DisplayName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => x.Length > 1 && char.IsLetter(x[0]))
                 .Select(x => char.ToLower(x[0]))
         );

--- a/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
@@ -55,8 +55,7 @@ public class AnonymousControllerTests
             Name = CookieConstants.TransparentAuthentication,
             Value = Uri.EscapeDataString(Newtonsoft.Json.JsonConvert.SerializeObject(credentials))
         };
-        env.AnonymousService
-            .GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
+        env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Returns(Task.FromResult(credentials));
 
         // SUT
@@ -77,8 +76,7 @@ public class AnonymousControllerTests
             DisplayName = "Test User",
             Language = "en"
         };
-        env.AnonymousService
-            .GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
+        env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Throws(new DataNotFoundException(""));
 
         // SUT
@@ -96,8 +94,7 @@ public class AnonymousControllerTests
             DisplayName = "Test User",
             Language = "en"
         };
-        env.AnonymousService
-            .GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
+        env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Throws(new HttpRequestException(""));
 
         // SUT
@@ -115,8 +112,7 @@ public class AnonymousControllerTests
             DisplayName = "Test User",
             Language = "en"
         };
-        env.AnonymousService
-            .GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
+        env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Throws(new SecurityException());
 
         // SUT
@@ -134,8 +130,7 @@ public class AnonymousControllerTests
             DisplayName = "Test User",
             Language = "en"
         };
-        env.AnonymousService
-            .GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
+        env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Throws(new TaskCanceledException());
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -29,8 +29,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -46,8 +45,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -61,8 +59,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -76,8 +73,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new NotSupportedException());
 
         // SUT
@@ -92,8 +88,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.CompletedTask);
 
         // SUT
@@ -107,8 +102,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -139,8 +133,7 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetBuildAsync(User01, Project01, Build01, null, false, true, CancellationToken.None);
     }
 
@@ -149,8 +142,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -172,8 +164,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -193,8 +184,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -214,8 +204,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -235,8 +224,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -249,14 +237,11 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
-        await env.MachineApiService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
-        await env.MachineApiService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
@@ -265,8 +250,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -279,14 +263,11 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
-        await env.MachineApiService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
@@ -295,8 +276,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -309,14 +289,11 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
-        await env.MachineApiService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
     }
 
@@ -325,8 +302,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -339,8 +315,7 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None);
     }
 
@@ -360,8 +335,7 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetCurrentBuildAsync(User01, Project01, null, false, true, CancellationToken.None);
     }
 
@@ -370,8 +344,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -391,8 +364,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -414,8 +386,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -435,8 +406,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -456,8 +426,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -477,8 +446,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -491,8 +459,7 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None);
     }
 
@@ -501,8 +468,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -518,8 +484,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -533,8 +498,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -548,8 +512,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new EngineDto()));
 
         // SUT
@@ -568,8 +531,7 @@ public class MachineApiControllerTests
         // SUT
         await env.Controller.GetLastCompletedPreTranslationBuildAsync(Project01, CancellationToken.None);
 
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetLastCompletedPreTranslationBuildAsync(
                 User01,
                 Project01,
@@ -583,8 +545,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -603,8 +564,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -621,8 +581,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -639,8 +598,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -657,8 +615,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -669,8 +626,7 @@ public class MachineApiControllerTests
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
 
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .GetLastCompletedPreTranslationBuildAsync(
                 User01,
                 Project01,
@@ -684,8 +640,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -706,8 +661,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -726,8 +680,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -746,8 +699,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(new InvalidOperationException());
 
         // SUT
@@ -766,8 +718,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.MachineApiService.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Returns(Task.FromResult(new PreTranslationDto()));
 
         // SUT
@@ -786,8 +737,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -807,8 +757,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -826,8 +775,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -845,8 +793,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new InvalidOperationException());
 
         // SUT
@@ -864,8 +811,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(new WordGraph()));
 
         // SUT
@@ -888,8 +834,7 @@ public class MachineApiControllerTests
         // SUT
         await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .StartBuildAsync(User01, Project01, includeAdditionalInfo: true, CancellationToken.None);
     }
 
@@ -898,8 +843,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -915,8 +859,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -930,8 +873,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -945,16 +887,14 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
     }
 
@@ -963,12 +903,11 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartPreTranslationBuildAsync(
-                User01,
-                Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
-                CancellationToken.None
-            )
+        env.MachineApiService.StartPreTranslationBuildAsync(
+            User01,
+            Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -987,12 +926,11 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartPreTranslationBuildAsync(
-                User01,
-                Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
-                CancellationToken.None
-            )
+        env.MachineApiService.StartPreTranslationBuildAsync(
+            User01,
+            Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
+            CancellationToken.None
+        )
             .Throws(new ForbiddenException());
 
         // SUT
@@ -1009,12 +947,11 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartPreTranslationBuildAsync(
-                User01,
-                Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
-                CancellationToken.None
-            )
+        env.MachineApiService.StartPreTranslationBuildAsync(
+            User01,
+            Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
+            CancellationToken.None
+        )
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -1031,8 +968,11 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartPreTranslationBuildAsync(User01, new BuildConfig { ProjectId = Project01 }, CancellationToken.None)
+        env.MachineApiService.StartPreTranslationBuildAsync(
+            User01,
+            new BuildConfig { ProjectId = Project01 },
+            CancellationToken.None
+        )
             .Returns(Task.CompletedTask);
 
         // SUT
@@ -1050,8 +990,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPair = new SegmentPair();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -1068,8 +1007,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPair = new SegmentPair();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -1084,8 +1022,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPair = new SegmentPair();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -1105,8 +1042,7 @@ public class MachineApiControllerTests
         ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
 
         Assert.IsInstanceOf<OkResult>(actual);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
     }
 
@@ -1115,8 +1051,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -1136,8 +1071,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -1155,8 +1089,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -1174,8 +1107,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(new TranslationResult()));
 
         // SUT
@@ -1194,8 +1126,7 @@ public class MachineApiControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -1217,8 +1148,7 @@ public class MachineApiControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -1238,8 +1168,7 @@ public class MachineApiControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -1259,8 +1188,7 @@ public class MachineApiControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(Array.Empty<TranslationResult>()));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
@@ -28,8 +28,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -48,8 +47,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -70,8 +68,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -90,8 +87,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -110,8 +106,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -130,8 +125,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -150,8 +144,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -170,8 +163,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -192,8 +184,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -212,8 +203,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -232,8 +222,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -252,8 +241,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -272,8 +260,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -289,8 +276,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -304,8 +290,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -319,8 +304,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetEngineAsync(User01, Project01, CancellationToken.None)
+        env.MachineApiService.GetEngineAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new EngineDto()));
 
         // SUT
@@ -334,8 +318,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -355,8 +338,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -374,8 +356,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -393,8 +374,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.GetWordGraphAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(new WordGraph()));
 
         // SUT
@@ -412,8 +392,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -429,8 +408,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -444,8 +422,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -459,8 +436,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -475,8 +451,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPairDto = new SegmentPairDto();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -493,8 +468,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPairDto = new SegmentPairDto();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -509,8 +483,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         var segmentPairDto = new SegmentPairDto();
-        env.MachineApiService
-            .TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.MachineApiService.TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -533,8 +506,7 @@ public class MachineApiV2ControllerTests
         );
 
         Assert.IsInstanceOf<OkResult>(actual);
-        await env.MachineApiService
-            .Received(1)
+        await env.MachineApiService.Received(1)
             .TrainSegmentAsync(User01, Project01, Arg.Any<SegmentPair>(), CancellationToken.None);
     }
 
@@ -543,8 +515,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -564,8 +535,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -583,8 +553,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -602,8 +571,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateAsync(User01, Project01, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(new TranslationResult()));
 
         // SUT
@@ -622,8 +590,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -645,8 +612,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -666,8 +632,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -687,8 +652,7 @@ public class MachineApiV2ControllerTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.MachineApiService
-            .TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
+        env.MachineApiService.TranslateNAsync(User01, Project01, n, string.Empty, CancellationToken.None)
             .Returns(Task.FromResult(Array.Empty<TranslationResult>()));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -56,8 +56,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -71,8 +70,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT
@@ -86,8 +84,7 @@ public class SFProjectsRpcControllerTests
     {
         var env = new TestEnvironment();
         const string servalConfig = "{ updatedConfig: true }";
-        env.SFProjectService
-            .SetServalConfigAsync(User01, Role, Project01, servalConfig)
+        env.SFProjectService.SetServalConfigAsync(User01, Role, Project01, servalConfig)
             .Throws(new ArgumentNullException());
 
         // SUT
@@ -124,8 +121,7 @@ public class SFProjectsRpcControllerTests
         var env = new TestEnvironment();
         var settings = new SFProjectSettings();
         const string errorMessage = "Not Found";
-        env.SFProjectService
-            .UpdateSettingsAsync(User01, Project01, settings)
+        env.SFProjectService.UpdateSettingsAsync(User01, Project01, settings)
             .Throws(new DataNotFoundException(errorMessage));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
@@ -27,8 +27,7 @@ public class AnonymousServiceTests
         ShareKey projectSecretShareKey = projectSecret.ShareKeys.FirstOrDefault(sk => sk.Key == shareKey);
         env.SFProjectService.GetProjectSecretByShareKey(shareKey).Returns(projectSecret);
         env.SFProjectService.GetProjectAsync(Project01).Returns(Task.FromResult(project));
-        env.SFProjectService
-            .CheckShareKeyValidity(shareKey)
+        env.SFProjectService.CheckShareKeyValidity(shareKey)
             .Returns(
                 Task.FromResult(
                     new ValidShareKey()
@@ -67,8 +66,7 @@ public class AnonymousServiceTests
         ShareKey projectSecretShareKey = projectSecret.ShareKeys.FirstOrDefault(sk => sk.Key == shareKey);
         env.SFProjectService.GetProjectSecretByShareKey(shareKey).Returns(projectSecret);
         env.SFProjectService.GetProjectAsync(Project01).Returns(Task.FromResult(project));
-        env.SFProjectService
-            .CheckShareKeyValidity(shareKey)
+        env.SFProjectService.CheckShareKeyValidity(shareKey)
             .Returns(
                 Task.FromResult(
                     new ValidShareKey()
@@ -142,8 +140,7 @@ public class AnonymousServiceTests
         ShareKey projectSecretShareKey = projectSecret.ShareKeys.FirstOrDefault(sk => sk.Key == shareKey);
         env.SFProjectService.GetProjectSecretByShareKey(shareKey).Returns(env.ProjectSecrets.Get(Project01));
         env.SFProjectService.GetProjectAsync(Project01).Returns(Task.FromResult(env.Projects.Get(Project01)));
-        env.SFProjectService
-            .CheckShareKeyValidity(shareKey)
+        env.SFProjectService.CheckShareKeyValidity(shareKey)
             .Returns(
                 Task.FromResult(
                     new ValidShareKey()

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -72,16 +72,14 @@ public class InternetSharedRepositorySourceProviderTests
             RegistryU.Implementation = new DotNetCoreRegistry();
             InternetAccess.RawStatus = InternetUse.Enabled;
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            siteOptions
-                .Value
-                .Returns(
-                    new SiteOptions
-                    {
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "xforge"
-                    }
-                );
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "xforge"
+                }
+            );
             Provider = new InternetSharedRepositorySourceProvider(
                 MockJwtTokenHelper,
                 siteOptions,

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -16,8 +16,7 @@ public class JwtInternetSharedRepositorySourceTests
     public void CanUserAuthenticateToPTArchives_Works()
     {
         var env = new TestEnvironment();
-        env.MockPTArchivesClient
-            .Configure()
+        env.MockPTArchivesClient.Configure()
             .Get(Arg.Any<string>())
             .Returns(
                 _ =>
@@ -29,8 +28,7 @@ public class JwtInternetSharedRepositorySourceTests
         // One SUT
         Assert.That(env.RepoSource.CanUserAuthenticateToPTArchives(), Is.False, "problem when using server");
 
-        env.MockPTArchivesClient
-            .Configure()
+        env.MockPTArchivesClient.Configure()
             .Get(Arg.Any<string>())
             .Returns(
                 "<repos><repo><proj>ABCD</proj><projid>4011111111111111111111111111111111111111"

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -104,8 +104,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .CancelBuildAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.CancelBuildAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.NotSupported);
 
         // SUT
@@ -147,8 +146,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Builds
-            .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
+        env.Builds.GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
             .Returns(Task.FromResult<Build>(null));
 
         // SUT
@@ -173,8 +171,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
 
         // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
-        env.Builds
-            .SubscribeAsync(Build01, CancellationToken.None)
+        env.Builds.SubscribeAsync(Build01, CancellationToken.None)
             .Returns(Task.FromResult(new Subscription<Build>(Build01, null, _ => { })));
 
         // SUT
@@ -199,8 +196,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         const int minRevision = 0;
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-        env.TranslationEnginesClient
-            .GetBuildAsync(TranslationEngine01, Build01, minRevision, CancellationToken.None)
+        env.TranslationEnginesClient.GetBuildAsync(TranslationEngine01, Build01, minRevision, CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
 
         // SUT
@@ -224,8 +220,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-        env.TranslationEnginesClient
-            .GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
+        env.TranslationEnginesClient.GetBuildAsync(TranslationEngine01, Build01, null, CancellationToken.None)
             .Throws(ServalApiExceptions.TimeOut);
 
         // SUT
@@ -339,8 +334,7 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.95;
         const int revision = 553;
         const string state = "ACTIVE";
-        env.Builds
-            .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
+        env.Builds.GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new Build
@@ -387,8 +381,12 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.95;
         const int revision = 553;
         const JobState state = JobState.Active;
-        env.TranslationEnginesClient
-            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -444,8 +442,12 @@ public class MachineApiServiceTests
         const string corpusId1 = "corpusId1";
         const string corpusId2 = "corpusId2";
         const int step = 123;
-        env.TranslationEnginesClient
-            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -513,8 +515,12 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetBuildAsync(
+            TranslationEngine01,
+            Build01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Returns(Task.FromResult(new TranslationBuild()));
 
         // SUT
@@ -528,11 +534,9 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.Builds
-            .DidNotReceiveWithAnyArgs()
+        await env.Builds.DidNotReceiveWithAnyArgs()
             .GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None);
     }
 
@@ -554,8 +558,7 @@ public class MachineApiServiceTests
         );
 
         await env.Builds.Received(1).GetByLocatorAsync(BuildLocatorType.Id, Build01, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .GetBuildAsync(TranslationEngine01, Build01, minRevision: null, CancellationToken.None);
     }
 
@@ -565,8 +568,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Builds
-            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
+        env.Builds.GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult<Build>(null));
 
         // SUT
@@ -590,8 +592,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
 
         // NOTE: It is not possible to test No Build Running, as the Subscription Change cannot be modified
-        env.Builds
-            .SubscribeByEngineIdAsync(TranslationEngine01, CancellationToken.None)
+        env.Builds.SubscribeByEngineIdAsync(TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult(new Subscription<Build>(TranslationEngine01, null, _ => { })));
 
         // SUT
@@ -615,8 +616,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         const int minRevision = 0;
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, minRevision, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(TranslationEngine01, minRevision, CancellationToken.None)
             .Throws(ServalApiExceptions.NoContent);
 
         // SUT
@@ -639,8 +639,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(TranslationEngine01, null, CancellationToken.None)
             .Throws(ServalApiExceptions.TimeOut);
 
         // SUT
@@ -724,8 +723,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -773,8 +771,7 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.95;
         const int revision = 553;
         const string state = "ACTIVE";
-        env.Builds
-            .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
+        env.Builds.GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new Build
@@ -820,8 +817,11 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.95;
         const int revision = 553;
         const JobState state = JobState.Active;
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -869,11 +869,13 @@ public class MachineApiServiceTests
         const double percentCompleted = 0;
         const int revision = 43;
         const JobState state = JobState.Completed;
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Throws(ServalApiExceptions.NoContent);
-        env.TranslationEnginesClient
-            .GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult<IList<TranslationBuild>>(
                     new List<TranslationBuild>
@@ -920,11 +922,13 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Throws(ServalApiExceptions.NoContent);
-        env.TranslationEnginesClient
-            .GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult<IList<TranslationBuild>>(new List<TranslationBuild>()));
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -947,8 +951,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None)
+        env.TranslationEnginesClient.GetCurrentBuildAsync(
+            TranslationEngine01,
+            minRevision: null,
+            CancellationToken.None
+        )
             .Returns(Task.FromResult(new TranslationBuild()));
 
         // SUT
@@ -961,11 +968,9 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.Builds
-            .DidNotReceiveWithAnyArgs()
+        await env.Builds.DidNotReceiveWithAnyArgs()
             .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
     }
 
@@ -985,11 +990,9 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.Builds
-            .Received(1)
+        await env.Builds.Received(1)
             .GetByLocatorAsync(BuildLocatorType.Engine, TranslationEngine01, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .GetCurrentBuildAsync(TranslationEngine01, minRevision: null, CancellationToken.None);
     }
 
@@ -1037,8 +1040,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -1052,11 +1054,9 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.InternalServerError);
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new Engine()));
 
         // SUT
@@ -1071,8 +1071,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.Forbidden);
 
         // SUT
@@ -1099,8 +1098,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -1115,11 +1113,9 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new Engine()));
 
         // SUT
@@ -1137,8 +1133,7 @@ public class MachineApiServiceTests
         const string targetLanguageTag = "en_NZ";
         const double confidence = 0.96;
         const int corpusSize = 472;
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new Engine
@@ -1178,8 +1173,7 @@ public class MachineApiServiceTests
         const string targetLanguageTag = "en_NZ";
         const double confidence = 96.0;
         const int corpusSize = 472;
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationEngine
@@ -1218,11 +1212,9 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult(new TranslationEngine()));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new Engine()));
 
         // SUT
@@ -1237,8 +1229,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult<IList<TranslationBuild>>(
                     new List<TranslationBuild>
@@ -1370,8 +1361,7 @@ public class MachineApiServiceTests
         const double percentCompleted = 0;
         const int revision = 43;
         const JobState state = JobState.Completed;
-        env.TranslationEnginesClient
-            .GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult<IList<TranslationBuild>>(
                     new List<TranslationBuild>
@@ -1415,8 +1405,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.PreTranslationService
-            .GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.PreTranslationService.GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(ServalApiExceptions.EngineNotBuilt);
 
         // SUT
@@ -1467,8 +1456,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.PreTranslationService
-            .GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.PreTranslationService.GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -1484,8 +1472,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         const string reference = "MAT 1:1";
         const string translation = "The book of the generations of Jesus Christ, the son of David, the son of Abraham.";
-        env.PreTranslationService
-            .GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
+        env.PreTranslationService.GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new PreTranslation[]
@@ -1552,8 +1539,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -1580,8 +1566,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -1596,11 +1581,12 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(ServalApiExceptions.EngineNotBuilt);
-        env.EngineService
-            .GetWordGraphAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.GetWordGraphAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(new MachineWordGraph(Array.Empty<MachineWordGraphArc>(), Array.Empty<int>())));
 
         // SUT
@@ -1614,11 +1600,12 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
-        env.EngineService
-            .GetWordGraphAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.GetWordGraphAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(new MachineWordGraph(Array.Empty<MachineWordGraphArc>(), Array.Empty<int>())));
 
         // SUT
@@ -1633,8 +1620,10 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         const float initialStateScore = -91.43696f;
-        env.EngineService
-            .GetWordGraphAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.GetWordGraphAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new MachineWordGraph(
@@ -1672,8 +1661,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         const float initialStateScore = -91.43696f;
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new WordGraph
@@ -1701,21 +1689,20 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment)
             .Returns(Task.FromResult(new WordGraph()));
-        env.EngineService
-            .GetWordGraphAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.GetWordGraphAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(new MachineWordGraph()));
 
         // SUT
         _ = await env.Service.GetWordGraphAsync(User01, Project01, Segment, CancellationToken.None);
 
-        await env.EngineService
-            .Received(1)
+        await env.EngineService.Received(1)
             .GetWordGraphAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment));
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .GetWordGraphAsync(TranslationEngine01, Segment, CancellationToken.None);
     }
 
@@ -1724,8 +1711,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetWordGraphAsync(TranslationEngine01, Segment)
+        env.TranslationEnginesClient.GetWordGraphAsync(TranslationEngine01, Segment)
             .Throws(ServalApiExceptions.EngineNotBuilt);
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -1856,8 +1842,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -1871,11 +1856,13 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineProjectService
-            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None)
+        env.MachineProjectService.AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine01));
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -1889,15 +1876,18 @@ public class MachineApiServiceTests
             );
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
         // The following substitution is Serval stating that a translation engine SF expects to exist has been removed
-        env.MachineProjectService
-            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
+        env.MachineProjectService.TranslationEngineExistsAsync(
+            Project01,
+            TranslationEngine01,
+            preTranslate: false,
+            CancellationToken.None
+        )
             .Returns(Task.FromResult(false));
 
         // SUT
         await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
-        await env.MachineProjectService
-            .Received(1)
+        await env.MachineProjectService.Received(1)
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
     }
 
@@ -1907,19 +1897,21 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
-        env.MachineProjectService
-            .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: false, CancellationToken.None)
+        env.MachineProjectService.TranslationEngineExistsAsync(
+            Project01,
+            TranslationEngine01,
+            preTranslate: false,
+            CancellationToken.None
+        )
             .Throws(ServalApiExceptions.InternalServerError);
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
         // SUT
         await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
-        await env.MachineProjectService
-            .DidNotReceiveWithAnyArgs()
+        await env.MachineProjectService.DidNotReceiveWithAnyArgs()
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
         await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
     }
@@ -1929,11 +1921,13 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineProjectService
-            .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None)
+        env.MachineProjectService.AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine01));
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -1950,8 +1944,7 @@ public class MachineApiServiceTests
         // SUT
         await env.Service.StartBuildAsync(User01, Project03, includeAdditionalInfo: false, CancellationToken.None);
 
-        await env.MachineProjectService
-            .Received(1)
+        await env.MachineProjectService.Received(1)
             .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None);
     }
 
@@ -1973,8 +1966,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -1989,8 +1985,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Throws(ServalApiExceptions.Forbidden);
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
@@ -2005,8 +2004,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
@@ -2026,8 +2028,7 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.01;
         const int revision = 2;
         const string state = "ACTIVE";
-        env.EngineService
-            .StartBuildAsync(TranslationEngine01)
+        env.EngineService.StartBuildAsync(TranslationEngine01)
             .Returns(
                 Task.FromResult(
                     new Build
@@ -2070,8 +2071,11 @@ public class MachineApiServiceTests
         const double percentCompleted = 0.01;
         const int revision = 2;
         const JobState state = JobState.Active;
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult(
                     new TranslationBuild
@@ -2096,8 +2100,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.MachineProjectService
-            .Received(1)
+        await env.MachineProjectService.Received(1)
             .SyncProjectCorporaAsync(
                 User01,
                 Arg.Is<BuildConfig>(b => b.ProjectId == Project01),
@@ -2119,8 +2122,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
             .Returns(Task.FromResult(new TranslationBuild()));
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
@@ -2128,16 +2134,14 @@ public class MachineApiServiceTests
         _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
 
         await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
-        await env.MachineProjectService
-            .Received(1)
+        await env.MachineProjectService.Received(1)
             .SyncProjectCorporaAsync(
                 User01,
                 Arg.Is<BuildConfig>(b => b.ProjectId == Project01),
                 preTranslate: false,
                 CancellationToken.None
             );
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -2154,8 +2158,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService
-            .Received(1)
+        await env.SyncService.Received(1)
             .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project03 && s.TargetOnly && s.UserId == User01));
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationJobId);
@@ -2189,11 +2192,9 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService
-            .Received(1)
+        await env.SyncService.Received(1)
             .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project03 && s.TargetOnly && s.UserId == User01));
-        await env.SyncService
-            .Received(1)
+        await env.SyncService.Received(1)
             .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.TargetOnly && s.UserId == User01));
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationJobId);
@@ -2357,8 +2358,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService
-            .Received(1)
+        await env.SyncService.Received(1)
             .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.TargetOnly && s.UserId == User01));
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationJobId);
@@ -2396,8 +2396,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -2424,8 +2423,11 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TrainSegmentAsync(TranslationEngine01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.TranslationEnginesClient.TrainSegmentAsync(
+            TranslationEngine01,
+            Arg.Any<SegmentPair>(),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -2446,16 +2448,18 @@ public class MachineApiServiceTests
             SourceSegment = Segment,
             TargetSegment = TargetSegment,
         };
-        env.TranslationEnginesClient
-            .TrainSegmentAsync(TranslationEngine01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.TranslationEnginesClient.TrainSegmentAsync(
+            TranslationEngine01,
+            Arg.Any<SegmentPair>(),
+            CancellationToken.None
+        )
             .Throws(ServalApiExceptions.InternalServerError);
-        env.EngineService
-            .TrainSegmentAsync(
-                TranslationEngine01,
-                Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
-                Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.TargetSegment),
-                segmentPair.SentenceStart
-            )
+        env.EngineService.TrainSegmentAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.TargetSegment),
+            segmentPair.SentenceStart
+        )
             .Returns(Task.FromResult(true));
 
         // SUT
@@ -2475,16 +2479,18 @@ public class MachineApiServiceTests
             SourceSegment = Segment,
             TargetSegment = TargetSegment,
         };
-        env.TranslationEnginesClient
-            .TrainSegmentAsync(TranslationEngine01, Arg.Any<SegmentPair>(), CancellationToken.None)
+        env.TranslationEnginesClient.TrainSegmentAsync(
+            TranslationEngine01,
+            Arg.Any<SegmentPair>(),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
-        env.EngineService
-            .TrainSegmentAsync(
-                TranslationEngine01,
-                Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
-                Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.TargetSegment),
-                segmentPair.SentenceStart
-            )
+        env.EngineService.TrainSegmentAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.TargetSegment),
+            segmentPair.SentenceStart
+        )
             .Returns(Task.FromResult(true));
 
         // SUT
@@ -2509,8 +2515,7 @@ public class MachineApiServiceTests
         // SUT
         await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
 
-        await env.EngineService
-            .Received(1)
+        await env.EngineService.Received(1)
             .TrainSegmentAsync(
                 TranslationEngine01,
                 Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
@@ -2529,8 +2534,7 @@ public class MachineApiServiceTests
         // SUT
         await env.Service.TrainSegmentAsync(User01, Project01, new SegmentPair(), CancellationToken.None);
 
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .TrainSegmentAsync(TranslationEngine01, Arg.Any<SegmentPair>(), CancellationToken.None);
     }
 
@@ -2549,16 +2553,14 @@ public class MachineApiServiceTests
         // SUT
         await env.Service.TrainSegmentAsync(User01, Project01, segmentPair, CancellationToken.None);
 
-        await env.EngineService
-            .Received(1)
+        await env.EngineService.Received(1)
             .TrainSegmentAsync(
                 TranslationEngine01,
                 Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.SourceSegment),
                 Arg.Is<string[]>(s => s.Length == 1 && s.First() == segmentPair.TargetSegment),
                 segmentPair.SentenceStart
             );
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .TrainSegmentAsync(TranslationEngine01, Arg.Any<SegmentPair>(), CancellationToken.None);
     }
 
@@ -2606,8 +2608,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -2634,8 +2635,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -2650,11 +2650,12 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(ServalApiExceptions.NoContent);
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new MachineTranslationResult(
@@ -2679,11 +2680,12 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new MachineTranslationResult(
@@ -2708,8 +2710,10 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new MachineTranslationResult(
@@ -2743,8 +2747,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationResult
@@ -2779,8 +2782,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateAsync(TranslationEngine01, Segment, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationResult
@@ -2795,8 +2797,10 @@ public class MachineApiServiceTests
                     }
                 )
             );
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new MachineTranslationResult(
@@ -2813,11 +2817,9 @@ public class MachineApiServiceTests
         // SUT
         _ = await env.Service.TranslateAsync(User01, Project01, Segment, CancellationToken.None);
 
-        await env.EngineService
-            .Received(1)
+        await env.EngineService.Received(1)
             .TranslateAsync(TranslationEngine01, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment));
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .TranslateAsync(TranslationEngine01, Segment, CancellationToken.None);
     }
 
@@ -2854,8 +2856,7 @@ public class MachineApiServiceTests
         const int n = 1;
         var env = new TestEnvironment();
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
-        env.Engines
-            .GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
+        env.Engines.GetByLocatorAsync(EngineLocatorType.Project, Project01, CancellationToken.None)
             .Returns(Task.FromResult<Engine>(null));
 
         // SUT
@@ -2884,8 +2885,7 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
@@ -2901,11 +2901,13 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
             .Throws(ServalApiExceptions.NotSupported);
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, n, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            n,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(Array.Empty<MachineTranslationResult>().AsEnumerable()));
 
         // SUT
@@ -2920,11 +2922,13 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
             .Throws(new BrokenCircuitException());
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, n, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            n,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(Array.Empty<MachineTranslationResult>().AsEnumerable()));
 
         // SUT
@@ -2939,8 +2943,11 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, n, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            n,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(
                 Task.FromResult(
                     new[]
@@ -2984,8 +2991,7 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
+        env.TranslationEnginesClient.TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None)
             .Returns(
                 Task.FromResult<IList<TranslationResult>>(
                     new[]
@@ -3031,18 +3037,19 @@ public class MachineApiServiceTests
         // Set up test environment
         const int n = 1;
         var env = new TestEnvironment();
-        env.EngineService
-            .TranslateAsync(TranslationEngine01, n, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment))
+        env.EngineService.TranslateAsync(
+            TranslationEngine01,
+            n,
+            Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment)
+        )
             .Returns(Task.FromResult(Array.Empty<MachineTranslationResult>().AsEnumerable()));
 
         // SUT
         _ = await env.Service.TranslateNAsync(User01, Project01, n, Segment, CancellationToken.None);
 
-        await env.EngineService
-            .Received(1)
+        await env.EngineService.Received(1)
             .TranslateAsync(TranslationEngine01, n, Arg.Is<string[]>(s => s.Length == 1 && s.First() == Segment));
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .TranslateNAsync(TranslationEngine01, n, Segment, CancellationToken.None);
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -94,8 +94,7 @@ public class MachineProjectServiceTests
         await env.Service.AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
 
         await env.EngineService.Received().AddProjectAsync(Arg.Any<MachineProject>());
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None);
     }
 
@@ -162,8 +161,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine02, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -181,8 +179,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -203,8 +200,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(
                 Arg.Is<TranslationEngineConfig>(
                     t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == targetLanguage
@@ -218,8 +214,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment(new TestEnvironmentOptions());
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine02, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine02, CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
         string sourceLanguage = env.Projects.Get(Project02).TranslateConfig.Source!.WritingSystem.Tag;
         string targetLanguage = env.Projects.Get(Project02).WritingSystem.Tag;
@@ -233,8 +228,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(
                 Arg.Is<TranslationEngineConfig>(
                     t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == targetLanguage
@@ -260,8 +254,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(
                 Arg.Is<TranslationEngineConfig>(
                     t => t.SourceLanguage == sourceLanguage && t.TargetLanguage == sourceLanguage
@@ -293,16 +286,13 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine02, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
 
         // Ensure no methods that update the corpus or files were called
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .UpdateCorpusAsync(
                 TranslationEngine02,
                 Corpus02,
@@ -310,11 +300,9 @@ public class MachineProjectServiceTests
                 CancellationToken.None
             );
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None);
         Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationJobId);
         Assert.IsNull(env.ProjectSecrets.Get(Project02).ServalData!.PreTranslationQueuedAt);
@@ -334,8 +322,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .StartBuildAsync(TranslationEngine02, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -373,8 +360,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .StartBuildAsync(TranslationEngine02, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -392,11 +378,9 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None);
     }
 
@@ -409,13 +393,11 @@ public class MachineProjectServiceTests
         );
 
         // Make the Serval API return the error code for a missing translation engine
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine02, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine02, CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
 
         // Return the correctly created corpus
-        env.TranslationEnginesClient
-            .GetCorpusAsync(TranslationEngine01, Arg.Any<string>(), CancellationToken.None)
+        env.TranslationEnginesClient.GetCorpusAsync(TranslationEngine01, Arg.Any<string>(), CancellationToken.None)
             .Returns(
                 args =>
                     Task.FromResult(
@@ -437,11 +419,9 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None);
     }
 
@@ -455,8 +435,7 @@ public class MachineProjectServiceTests
         await env.SetDataInSync(Project02, preTranslate: true, requiresUpdate: true);
 
         // Make the Serval API return the error code for a missing translation engine
-        env.DataFilesClient
-            .UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None)
+        env.DataFilesClient.UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
 
         // SUT
@@ -467,11 +446,9 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine02, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
-        await env.DataFilesClient
-            .Received()
+        await env.DataFilesClient.Received()
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
     }
 
@@ -511,8 +488,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
         project = env.Projects.Get(Project03);
         Assert.IsNotNull(project.WritingSystem.Tag);
@@ -528,8 +504,7 @@ public class MachineProjectServiceTests
         );
 
         // Make the Serval API return the error code for a missing translation engine
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine02, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine02, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationEngine
@@ -551,12 +526,10 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
         await env.TranslationEnginesClient.Received().DeleteAsync(TranslationEngine02, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None);
     }
 
@@ -574,8 +547,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
 
-        await env.TranslationEnginesClient
-            .Received()
+        await env.TranslationEnginesClient.Received()
             .StartBuildAsync(TranslationEngine01, Arg.Any<TranslationBuildConfig>(), CancellationToken.None);
     }
 
@@ -606,8 +578,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = false });
-        env.TranslationEnginesClient
-            .CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>(), CancellationToken.None)
             .Throws(new TaskCanceledException());
 
         // SUT
@@ -652,8 +623,7 @@ public class MachineProjectServiceTests
 
         // Ensure that the translation engine, corpus and any files are deleted
         await env.TranslationEnginesClient.Received(1).DeleteAsync(TranslationEngine02, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .DeleteCorpusAsync(TranslationEngine02, Corpus01, CancellationToken.None);
         await env.DataFilesClient.Received(1).DeleteAsync(File01, CancellationToken.None);
         await env.DataFilesClient.Received(1).DeleteAsync(File02, CancellationToken.None);
@@ -669,11 +639,9 @@ public class MachineProjectServiceTests
         await env.Service.RemoveProjectAsync(User01, Project02, preTranslate: false, CancellationToken.None);
 
         // Ensure that the translation engine, corpus and any files were not deleted
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .DeleteAsync(TranslationEngine02, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .DeleteCorpusAsync(TranslationEngine02, Corpus01, CancellationToken.None);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(File01, CancellationToken.None);
     }
@@ -688,11 +656,9 @@ public class MachineProjectServiceTests
         await env.Service.RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
 
         // Ensure that the translation engine, corpus and any files were not deleted
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .DeleteAsync(TranslationEngine01, CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .DeleteCorpusAsync(TranslationEngine01, Corpus01, CancellationToken.None);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(File01, CancellationToken.None);
     }
@@ -758,8 +724,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .AddCorpusAsync(
                 Arg.Any<string>(),
                 Arg.Is<TranslationCorpusConfig>(
@@ -768,8 +733,7 @@ public class MachineProjectServiceTests
                 CancellationToken.None
             );
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .Received(1)
+        await env.DataFilesClient.Received(1)
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
         Assert.AreEqual(1, env.ProjectSecrets.Get(Project01).ServalData?.Corpora[Corpus01].SourceFiles.Count);
     }
@@ -794,8 +758,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .AddCorpusAsync(
                 Arg.Any<string>(),
                 Arg.Is<TranslationCorpusConfig>(
@@ -804,8 +767,7 @@ public class MachineProjectServiceTests
                 CancellationToken.None
             );
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .Received(1)
+        await env.DataFilesClient.Received(1)
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
         Assert.AreEqual(1, env.ProjectSecrets.Get(Project01).ServalData?.Corpora[Corpus01].SourceFiles.Count);
     }
@@ -828,8 +790,7 @@ public class MachineProjectServiceTests
         );
         Assert.IsTrue(actual);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .ReceivedWithAnyArgs(1)
+        await env.DataFilesClient.ReceivedWithAnyArgs(1)
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, string.Empty, CancellationToken.None);
         Assert.AreEqual(1, env.ProjectSecrets.Get(Project02).ServalData?.Corpora[Corpus01].SourceFiles.Count);
         Assert.AreEqual(0, env.ProjectSecrets.Get(Project02).ServalData?.Corpora[Corpus01].TargetFiles.Count);
@@ -853,8 +814,7 @@ public class MachineProjectServiceTests
         );
         Assert.IsFalse(actual);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
     }
 
@@ -872,11 +832,9 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsFalse(actual);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .AddCorpusAsync(TranslationEngine02, Arg.Any<TranslationCorpusConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .UpdateCorpusAsync(
                 TranslationEngine02,
                 Corpus01,
@@ -901,11 +859,9 @@ public class MachineProjectServiceTests
         );
         Assert.IsFalse(actual);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .UpdateAsync(Arg.Any<string>(), Arg.Any<FileParameter>(), CancellationToken.None);
     }
 
@@ -917,8 +873,11 @@ public class MachineProjectServiceTests
         await env.BeforeFirstSync(Project01);
 
         // Make adding the corpus to fail due to an API issue
-        env.TranslationEnginesClient
-            .AddCorpusAsync(TranslationEngine01, Arg.Any<TranslationCorpusConfig>(), CancellationToken.None)
+        env.TranslationEnginesClient.AddCorpusAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationCorpusConfig>(),
+            CancellationToken.None
+        )
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -950,8 +909,7 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsFalse(actual);
-        await env.TextCorpusFactory
-            .Received(1)
+        await env.TextCorpusFactory.Received(1)
             .CreateAsync(
                 Arg.Is<string[]>(p => p.Length == 1 && p.First() == Project02),
                 TextCorpusType.Target,
@@ -961,8 +919,7 @@ public class MachineProjectServiceTests
                     b => b.TrainingBooks.Count == 2 && b.TrainingBooks.First() == 1 && b.TrainingBooks.Last() == 2
                 )
             );
-        await env.TextCorpusFactory
-            .Received(1)
+        await env.TextCorpusFactory.Received(1)
             .CreateAsync(
                 Arg.Is<string[]>(p => p.Length == 1 && p.First() == Project02),
                 TextCorpusType.Source,
@@ -1010,12 +967,10 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
-        await env.DataFilesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.DataFilesClient.DidNotReceiveWithAnyArgs()
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, Arg.Any<string>(), CancellationToken.None);
         await env.DataFilesClient.DidNotReceiveWithAnyArgs().DeleteAsync(string.Empty, CancellationToken.None);
-        await env.DataFilesClient
-            .ReceivedWithAnyArgs(1)
+        await env.DataFilesClient.ReceivedWithAnyArgs(1)
             .UpdateAsync("File03", Arg.Any<FileParameter>(), CancellationToken.None);
     }
 
@@ -1061,8 +1016,7 @@ public class MachineProjectServiceTests
         Assert.IsTrue(actual);
         await env.DataFilesClient.Received(1).DeleteAsync("File03", CancellationToken.None);
         await env.DataFilesClient.Received(1).DeleteAsync("File04", CancellationToken.None);
-        await env.DataFilesClient
-            .Received(2)
+        await env.DataFilesClient.Received(2)
             .CreateAsync(Arg.Any<FileParameter>(), FileFormat.Text, "textId", CancellationToken.None);
     }
 
@@ -1130,8 +1084,7 @@ public class MachineProjectServiceTests
         Assert.IsTrue(actual);
 
         // Check for the generation of the training source
-        await env.TextCorpusFactory
-            .Received(1)
+        await env.TextCorpusFactory.Received(1)
             .CreateAsync(
                 Arg.Any<IEnumerable<string>>(),
                 TextCorpusType.Source,
@@ -1141,8 +1094,7 @@ public class MachineProjectServiceTests
             );
 
         // Check for the generation of the alternate training source
-        await env.TextCorpusFactory
-            .Received(1)
+        await env.TextCorpusFactory.Received(1)
             .CreateAsync(
                 Arg.Any<IEnumerable<string>>(),
                 TextCorpusType.Source,
@@ -1152,8 +1104,7 @@ public class MachineProjectServiceTests
             );
 
         // The target is shared between the two corpora, so it will only be generated once
-        await env.TextCorpusFactory
-            .Received(1)
+        await env.TextCorpusFactory.Received(1)
             .CreateAsync(
                 Arg.Any<IEnumerable<string>>(),
                 TextCorpusType.Target,
@@ -1173,8 +1124,7 @@ public class MachineProjectServiceTests
         await env.SetDataInSync(Project02);
 
         // Make the Serval API return the error code for a missing translation engine
-        env.TranslationEnginesClient
-            .GetCorpusAsync(TranslationEngine02, Arg.Any<string>(), CancellationToken.None)
+        env.TranslationEnginesClient.GetCorpusAsync(TranslationEngine02, Arg.Any<string>(), CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
 
         // SUT
@@ -1185,14 +1135,11 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .AddCorpusAsync(Arg.Any<string>(), Arg.Any<TranslationCorpusConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .DeleteCorpusAsync(Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .UpdateCorpusAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -1211,8 +1158,7 @@ public class MachineProjectServiceTests
         await env.SetDataInSync(Project02);
 
         // Make the Serval API return the error code for a missing translation engine
-        env.TranslationEnginesClient
-            .GetCorpusAsync(TranslationEngine02, Arg.Any<string>(), CancellationToken.None)
+        env.TranslationEnginesClient.GetCorpusAsync(TranslationEngine02, Arg.Any<string>(), CancellationToken.None)
             .Returns(
                 args =>
                     Task.FromResult(
@@ -1233,14 +1179,11 @@ public class MachineProjectServiceTests
             CancellationToken.None
         );
         Assert.IsTrue(actual);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .AddCorpusAsync(Arg.Any<string>(), Arg.Any<TranslationCorpusConfig>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .Received(1)
+        await env.TranslationEnginesClient.Received(1)
             .DeleteCorpusAsync(Arg.Any<string>(), Arg.Any<string>(), CancellationToken.None);
-        await env.TranslationEnginesClient
-            .DidNotReceiveWithAnyArgs()
+        await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs()
             .UpdateCorpusAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -1254,8 +1197,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.Forbidden);
 
         // SUT
@@ -1273,8 +1215,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.NotFound);
 
         // SUT
@@ -1308,8 +1249,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationEngine
@@ -1336,8 +1276,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationEngine
@@ -1364,8 +1303,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Returns(
                 Task.FromResult(
                     new TranslationEngine
@@ -1392,8 +1330,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.TranslationEnginesClient
-            .GetAsync(TranslationEngine01, CancellationToken.None)
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
             .Throws(ServalApiExceptions.InternalServerError);
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -968,11 +968,9 @@ public class ParatextNotesMapperTests
                 .GetUsernameFromUserId(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(x => Task.FromResult(userIdToUsername[(string)x[1]]));
 
-            var options = Microsoft
-                .Extensions
-                .Options
-                .Options
-                .Create(new LocalizationOptions { ResourcesPath = "Resources" });
+            var options = Microsoft.Extensions.Options.Options.Create(
+                new LocalizationOptions { ResourcesPath = "Resources" }
+            );
             var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
             var localizer = new StringLocalizer<SharedResource>(factory);
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -229,19 +229,20 @@ public class ParatextServiceTests
                 Assert.That(
                     (await env.RealtimeService.GetRepository<SFProject>().GetAllAsync())
                         .Single(sfProject => sfProject.ParatextId == testCase.paratextProjectId)
-                        .UserRoles
-                        .ContainsKey(testCase.sfUserId),
+                        .UserRoles.ContainsKey(testCase.sfUserId),
                     Is.EqualTo(testCase.sfUserIsOnSfProject),
                     "not set up - whether user is on existing sf project or not"
                 );
             }
             Assert.That(
-                env.MockInternetSharedRepositorySourceProvider
-                    .GetSource(testCase.userSecret, string.Empty, string.Empty)
+                env.MockInternetSharedRepositorySourceProvider.GetSource(
+                    testCase.userSecret,
+                    string.Empty,
+                    string.Empty
+                )
                     .GetRepositories()
                     .FirstOrDefault(sharedRepository => sharedRepository.SendReceiveId.Id == testCase.paratextProjectId)
-                    .SourceUsers
-                    .GetRole(testCase.ptUsername) == UserRoles.Administrator,
+                    .SourceUsers.GetRole(testCase.ptUsername) == UserRoles.Administrator,
                 Is.EqualTo(testCase.ptUserIsAdminOnPtProject),
                 "not set up - whether pt user is an admin on pt project"
             );
@@ -290,8 +291,7 @@ public class ParatextServiceTests
         Assert.DoesNotThrowAsync(async () => resources = await env.Service.GetResourcesAsync(env.User02));
         // "Don't crash when permission problem");
         Assert.AreEqual(0, resources.Count(), "An empty set of resources should have been returned");
-        env.MockExceptionHandler
-            .Received()
+        env.MockExceptionHandler.Received()
             .ReportException(
                 Arg.Is<Exception>((Exception e) => e.Message.Contains("inquire about resources and is ignoring error"))
             );
@@ -386,13 +386,12 @@ public class ParatextServiceTests
     {
         // Set up environment
         var env = new TestEnvironment();
-        env.MockJwtTokenHelper
-            .RefreshAccessTokenAsync(
-                Arg.Any<ParatextOptions>(),
-                Arg.Any<Tokens>(),
-                Arg.Any<HttpClient>(),
-                CancellationToken.None
-            )
+        env.MockJwtTokenHelper.RefreshAccessTokenAsync(
+            Arg.Any<ParatextOptions>(),
+            Arg.Any<Tokens>(),
+            Arg.Any<HttpClient>(),
+            CancellationToken.None
+        )
             .Throws(new HttpRequestException("Bad Request", null, HttpStatusCode.BadRequest));
 
         // SUT
@@ -400,8 +399,7 @@ public class ParatextServiceTests
         var permission = await env.Service.GetResourcePermissionAsync(paratextId, env.User01, CancellationToken.None);
 
         Assert.That(permission, Is.EqualTo(TextInfoPermission.None));
-        await env.MockJwtTokenHelper
-            .Received()
+        await env.MockJwtTokenHelper.Received()
             .RefreshAccessTokenAsync(
                 Arg.Any<ParatextOptions>(),
                 Arg.Any<Tokens>(),
@@ -2396,8 +2394,14 @@ public class ParatextServiceTests
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected");
 
         // SUT
-        IList<NoteThreadChange> changes = env.Service
-            .GetNoteThreadChanges(userSecret, ptProjectId, 40, noteThreadDocs, chapterDeltas, ptProjectUsers)
+        IList<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            ptProjectUsers
+        )
             .ToList();
         // We fetched a single change, of one new note to create.
 
@@ -3480,13 +3484,12 @@ public class ParatextServiceTests
         env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
         env.SetupSuccessfulSendReceive();
         // Setup share changes to be unsuccessful
-        env.MockSharingLogicWrapper
-            .ShareChanges(
-                Arg.Any<List<SharedProject>>(),
-                Arg.Any<SharedRepositorySource>(),
-                out Arg.Any<List<SendReceiveResult>>(),
-                Arg.Any<List<SharedProject>>()
-            )
+        env.MockSharingLogicWrapper.ShareChanges(
+            Arg.Any<List<SharedProject>>(),
+            Arg.Any<SharedRepositorySource>(),
+            out Arg.Any<List<SendReceiveResult>>(),
+            Arg.Any<List<SharedProject>>()
+        )
             .Returns(false);
 
         InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(
@@ -3531,13 +3534,12 @@ public class ParatextServiceTests
         env.SetupSuccessfulSendReceive();
         // Setup share changes to be unsuccessful, but return true
         // This scenario occurs if a project is locked on the PT server
-        env.MockSharingLogicWrapper
-            .ShareChanges(
-                Arg.Any<List<SharedProject>>(),
-                Arg.Any<SharedRepositorySource>(),
-                out Arg.Any<List<SendReceiveResult>>(),
-                Arg.Any<List<SharedProject>>()
-            )
+        env.MockSharingLogicWrapper.ShareChanges(
+            Arg.Any<List<SharedProject>>(),
+            Arg.Any<SharedRepositorySource>(),
+            out Arg.Any<List<SendReceiveResult>>(),
+            Arg.Any<List<SharedProject>>()
+        )
             .Returns(x =>
             {
                 x[2] = new List<SendReceiveResult>
@@ -3575,8 +3577,7 @@ public class ParatextServiceTests
 
         // SUT 1
         await env.Service.SendReceiveAsync(user01Secret, ptProjectId, null, default, Substitute.For<SyncMetrics>());
-        env.MockSharingLogicWrapper
-            .Received(1)
+        env.MockSharingLogicWrapper.Received(1)
             .ShareChanges(
                 Arg.Is<List<SharedProject>>(list => list.Count == 1 && list[0].SendReceiveId.Id == ptProjectId),
                 Arg.Any<SharedRepositorySource>(),
@@ -3599,8 +3600,7 @@ public class ParatextServiceTests
                 )
         );
         Assert.That(resultingException.Message, Does.Contain("unknownPtProjectId8"));
-        env.MockSharingLogicWrapper
-            .DidNotReceive()
+        env.MockSharingLogicWrapper.DidNotReceive()
             .ShareChanges(default, Arg.Any<SharedRepositorySource>(), out Arg.Any<List<SendReceiveResult>>(), default);
     }
 
@@ -3675,8 +3675,7 @@ public class ParatextServiceTests
         // Better may be to assert that each SharedProject.Permissions.GetUser()
         // returns a desired PT username, if the test environment wasn't
         // mired in mock.
-        env.MockSharingLogicWrapper
-            .Received(2)
+        env.MockSharingLogicWrapper.Received(2)
             .ShareChanges(
                 Arg.Is<List<SharedProject>>(
                     list =>
@@ -3698,8 +3697,7 @@ public class ParatextServiceTests
         string sourcePath = Path.Combine(env.SyncDir, newSourceProjectId, "target");
 
         // Only set the the new source ScrText when it is "cloned" to the filesystem
-        env.MockFileSystemService
-            .When(fs => fs.CreateDirectory(sourcePath))
+        env.MockFileSystemService.When(fs => fs.CreateDirectory(sourcePath))
             .Do(_ =>
             {
                 ScrText newSourceScrText = env.GetScrText(associatedPtUser, newSourceProjectId);
@@ -4317,8 +4315,11 @@ public class ParatextServiceTests
 
         IInternetSharedRepositorySource mockSource = Substitute.For<IInternetSharedRepositorySource>();
 
-        env.MockInternetSharedRepositorySourceProvider
-            .GetSource(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>())
+        env.MockInternetSharedRepositorySourceProvider.GetSource(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<string>()
+        )
             .Returns(mockSource);
         mockSource.CanUserAuthenticateToPTArchives().Returns(false);
 
@@ -4552,10 +4553,9 @@ public class ParatextServiceTests
         var associatedPtUser = new SFParatextUser(env.Username01);
         string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
         string rev = "some-desired-revision";
-        env.MockHgWrapper
-            .GetRepoRevision(
-                Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Combine(projectPTId, "target")))
-            )
+        env.MockHgWrapper.GetRepoRevision(
+            Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Combine(projectPTId, "target")))
+        )
             .Returns(rev);
         // SUT
         env.Service.SetRepoToRevision(

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -97,8 +97,7 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .BuildProjectAsync(
                 Arg.Any<string>(),
                 Arg.Any<BuildConfig>(),
@@ -141,8 +140,7 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .BuildProjectAsync(
                 "user01",
                 Arg.Is<BuildConfig>(b => b.ProjectId == "project01"),
@@ -185,8 +183,7 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .BuildProjectAsync(
                 "user01",
                 Arg.Is<BuildConfig>(b => b.ProjectId == "project01"),
@@ -228,8 +225,7 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .BuildProjectAsync(
                 Arg.Any<string>(),
                 Arg.Any<BuildConfig>(),
@@ -262,8 +258,7 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
         Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .BuildProjectAsync(
                 Arg.Any<string>(),
                 Arg.Any<BuildConfig>(),
@@ -298,18 +293,14 @@ public class ParatextSyncRunnerTests
             1
         );
 
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>());
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>());
 
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>());
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>());
 
         var delta = Delta.New().InsertText("text");
@@ -342,18 +333,14 @@ public class ParatextSyncRunnerTests
         await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
 
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
 
         var delta = Delta.New().InsertText("text");
@@ -385,18 +372,14 @@ public class ParatextSyncRunnerTests
         await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "target", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "target", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
 
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "source", 40, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .PutBookText(Arg.Any<UserSecret>(), "source", 41, Arg.Any<XDocument>(), Arg.Any<Dictionary<int, string>>());
 
         env.ParatextService.DidNotReceive().PutNotes(Arg.Any<UserSecret>(), "target", Arg.Any<XElement>());
@@ -437,8 +420,7 @@ public class ParatextSyncRunnerTests
 
         await env.Runner.RunAsync("project02", "user01", "project02", false, CancellationToken.None);
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-        env.ParatextService
-            .Received()
+        env.ParatextService.Received()
             .GetNoteThreadChanges(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -566,12 +548,11 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -593,19 +574,17 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
         // SUT
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        await env.SFProjectService
-            .Received()
+        await env.SFProjectService.Received()
             .UpdatePermissionsAsync(
                 "user01",
                 Arg.Is<IDocument<SFProject>>(
@@ -626,16 +605,14 @@ public class ParatextSyncRunnerTests
         SFProject project = env.GetProject("project01");
         Assert.That(project.Editable, Is.True, "setup");
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(new ParatextSettings { Editable = false });
 
         // SUT
@@ -661,14 +638,12 @@ public class ParatextSyncRunnerTests
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
         env.VerifyProjectSync(true, null, "project01");
         // expect that we do not create a new note tag
-        env.ParatextService
-            .DidNotReceive()
+        env.ParatextService.DidNotReceive()
             .UpdateCommentTag(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<NoteTag>());
 
         // introduce an SF note thread
         env.AddParatextNoteThreadData(books, true);
-        env.ParatextService
-            .UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>())
+        env.ParatextService.UpdateCommentTag(Arg.Any<UserSecret>(), "target", Arg.Any<NoteTag>())
             .Returns(env.translateNoteTagId);
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
         project = env.VerifyProjectSync(true, null, "project01");
@@ -701,15 +676,14 @@ public class ParatextSyncRunnerTests
         var threadElem = new XElement("thread", new XAttribute("id", "thread01"));
         notesElem.Add(threadElem);
 
-        env.NotesMapper
-            .GetNotesChangelistAsync(
-                Arg.Any<XElement>(),
-                Arg.Any<IEnumerable<IDocument<Question>>>(),
-                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                Arg.Any<Dictionary<string, string>>(),
-                CheckingAnswerExport.MarkedForExport,
-                Arg.Any<int>()
-            )
+        env.NotesMapper.GetNotesChangelistAsync(
+            Arg.Any<XElement>(),
+            Arg.Any<IEnumerable<IDocument<Question>>>(),
+            Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+            Arg.Any<Dictionary<string, string>>(),
+            CheckingAnswerExport.MarkedForExport,
+            Arg.Any<int>()
+        )
             .Returns(Task.FromResult(notesElem));
         // project01 has questions but does not export any
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -768,8 +742,7 @@ public class ParatextSyncRunnerTests
                 Icon = "editedIcon"
             }
         };
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(new ParatextSettings { NoteTags = newNoteTags });
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -786,12 +759,11 @@ public class ParatextSyncRunnerTests
         env.SetupPTData(books);
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>(project => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>(project => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
         int fontSize = 10;
         string font = ProjectSettings.defaultFontName;
@@ -821,8 +793,7 @@ public class ParatextSyncRunnerTests
         string newBaseProjectShortName = "BPT";
         const string newCopyrightBanner = "Copyright Banner Goes Here";
         const string newCopyrightNotice = $"<p>Notification: {newCopyrightBanner}</p><p>Copyright Notice Goes Here</p>";
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(
                 new ParatextSettings
                 {
@@ -856,8 +827,7 @@ public class ParatextSyncRunnerTests
         newProjectType = ProjectType.Daughter.ToString();
         newBaseProjectParatextId = "daughter_pt";
         newBaseProjectShortName = "DPT";
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(
                 new ParatextSettings
                 {
@@ -880,8 +850,7 @@ public class ParatextSyncRunnerTests
         newProjectType = ProjectType.Standard.ToString();
         newBaseProjectParatextId = null;
         newBaseProjectShortName = string.Empty;
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(
                 new ParatextSettings
                 {
@@ -905,12 +874,11 @@ public class ParatextSyncRunnerTests
         env.SetupPTData(books);
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
 
@@ -931,12 +899,11 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService
-            .GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetProjectRolesAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
 
         await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
@@ -960,8 +927,7 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, false, false, false, books);
         env.SetupPTData(books);
 
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), "target")
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), "target")
             .Returns(new ParatextSettings { IsRightToLeft = true });
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
@@ -999,8 +965,7 @@ public class ParatextSyncRunnerTests
         env.SetupPTData(books);
 
         string newFullName = "New Full Name";
-        env.ParatextService
-            .GetParatextSettings(Arg.Any<UserSecret>(), "target")
+        env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), "target")
             .Returns(new ParatextSettings { FullName = newFullName });
 
         // SUT
@@ -1016,8 +981,7 @@ public class ParatextSyncRunnerTests
     {
         var env = new TestEnvironment();
         env.SetupSFData(false, false, false, false, new Book("MAT", 2), new Book("MRK", 2));
-        env.RealtimeService
-            .GetRepository<TextData>()
+        env.RealtimeService.GetRepository<TextData>()
             .Add(new TextData(Delta.New().InsertText("old text")) { Id = TextData.GetTextDocId("project01", 42, 1) });
         env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
 
@@ -1207,8 +1171,7 @@ public class ParatextSyncRunnerTests
         // SUT
         await env.RunAndAssertContinuesAsync(projectSFId, userId, expectedRepositoryVersion);
         // Shouldn't be setting repo rev.
-        env.ParatextService
-            .DidNotReceive()
+        env.ParatextService.DidNotReceive()
             .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -1235,8 +1198,7 @@ public class ParatextSyncRunnerTests
         // SUT
         await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: null);
         // Shouldn't be setting repo rev.
-        env.ParatextService
-            .DidNotReceive()
+        env.ParatextService.DidNotReceive()
             .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -1263,8 +1225,7 @@ public class ParatextSyncRunnerTests
         // SUT
         await env.RunAndAssertContinuesAsync(projectSFId, userId, finalDBSyncedToRepositoryVersion: "v1");
         // Shouldn't be setting repo rev.
-        env.ParatextService
-            .DidNotReceive()
+        env.ParatextService.DidNotReceive()
             .SetRepoToRevision(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -1318,16 +1279,15 @@ public class ParatextSyncRunnerTests
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Setup a trap to crash the task
-        env.NotesMapper
-            .When(
-                x =>
-                    x.InitAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<List<User>>(),
-                        Arg.Any<SFProject>(),
-                        Arg.Any<CancellationToken>()
-                    )
-            )
+        env.NotesMapper.When(
+            x =>
+                x.InitAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<List<User>>(),
+                    Arg.Any<SFProject>(),
+                    Arg.Any<CancellationToken>()
+                )
+        )
             .Do(_ => throw new ArgumentException());
 
         // Run the task
@@ -1356,16 +1316,13 @@ public class ParatextSyncRunnerTests
         // after a failed send/receive
         env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
         env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
-        env.ParatextService
-            .When(p => p.GetBookText(Arg.Any<UserSecret>(), "target", Arg.Any<int>()))
+        env.ParatextService.When(p => p.GetBookText(Arg.Any<UserSecret>(), "target", Arg.Any<int>()))
             .Do(_ => throw new ArgumentException());
 
-        env.ParatextService
-            .When(p => p.RestoreRepository(Arg.Any<UserSecret>(), "target"))
+        env.ParatextService.When(p => p.RestoreRepository(Arg.Any<UserSecret>(), "target"))
             .Do(
                 _ =>
-                    env.ParatextService
-                        .GetLatestSharedVersion(Arg.Any<UserSecret>(), "target")
+                    env.ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target")
                         .Returns("revNotMatchingVersion")
             );
 
@@ -1392,16 +1349,15 @@ public class ParatextSyncRunnerTests
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Setup a trap to cancel the task
-        env.NotesMapper
-            .When(
-                x =>
-                    x.InitAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<List<User>>(),
-                        Arg.Any<SFProject>(),
-                        Arg.Any<CancellationToken>()
-                    )
-            )
+        env.NotesMapper.When(
+            x =>
+                x.InitAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<List<User>>(),
+                    Arg.Any<SFProject>(),
+                    Arg.Any<CancellationToken>()
+                )
+        )
             .Do(_ =>
             {
                 cancellationTokenSource.Cancel();
@@ -1413,9 +1369,9 @@ public class ParatextSyncRunnerTests
 
         // The TaskCancelledException was not logged
         Assert.That(
-            env.MockLogger
-                .LogEvents
-                .Count((LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null),
+            env.MockLogger.LogEvents.Count(
+                (LogEvent logEvent) => logEvent.LogLevel == LogLevel.Error || logEvent.Exception != null
+            ),
             Is.EqualTo(0)
         );
 
@@ -1438,17 +1394,16 @@ public class ParatextSyncRunnerTests
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Setup a trap to cancel the task
-        env.ParatextService
-            .When(
-                x =>
-                    x.SendReceiveAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<string>(),
-                        Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>(),
-                        Arg.Any<SyncMetrics>()
-                    )
-            )
+        env.ParatextService.When(
+            x =>
+                x.SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                )
+        )
             .Do(_ => cancellationTokenSource.Cancel());
 
         // Run the task
@@ -1473,17 +1428,16 @@ public class ParatextSyncRunnerTests
         env.ParatextService.BackupExists(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(true);
         env.ParatextService.RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(false);
 
-        env.ParatextService
-            .When(
-                x =>
-                    x.SendReceiveAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<string>(),
-                        Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>(),
-                        Arg.Any<SyncMetrics>()
-                    )
-            )
+        env.ParatextService.When(
+            x =>
+                x.SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                )
+        )
             .Do(_ => cancellationTokenSource.Cancel());
         await env.Runner.RunAsync("project01", "user01", "project01", false, cancellationTokenSource.Token);
         env.ParatextService.Received(1).RestoreRepository(Arg.Any<UserSecret>(), Arg.Any<string>());
@@ -1537,17 +1491,16 @@ public class ParatextSyncRunnerTests
         env.Connection.Get<SFProject>("project01").Returns(project);
 
         // Setup a trap to cancel the task
-        env.ParatextService
-            .When(
-                x =>
-                    x.SendReceiveAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<string>(),
-                        Arg.Any<IProgress<ProgressState>>(),
-                        Arg.Any<CancellationToken>(),
-                        Arg.Any<SyncMetrics>()
-                    )
-            )
+        env.ParatextService.When(
+            x =>
+                x.SendReceiveAsync(
+                    Arg.Any<UserSecret>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IProgress<ProgressState>>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<SyncMetrics>()
+                )
+        )
             .Do(_ => cancellationTokenSource.Cancel());
 
         // Run the task
@@ -1580,15 +1533,13 @@ public class ParatextSyncRunnerTests
 
         // Only check for ExcludePropertyFromTransaction being executed,
         // as the substitute RealtimeService will not update documents.
-        env.Connection
-            .Received(1)
+        env.Connection.Received(1)
             .ExcludePropertyFromTransaction(
                 Arg.Is<Expression<Func<SFProject, object>>>(
                     ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.QueuedCount"
                 )
             );
-        env.Connection
-            .Received(1)
+        env.Connection.Received(1)
             .ExcludePropertyFromTransaction(
                 Arg.Is<Expression<Func<SFProject, object>>>(
                     ex => string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
@@ -1739,21 +1690,19 @@ public class ParatextSyncRunnerTests
         string dataId = "dataId01";
         env.SetupNoteChanges(dataId, "thread01", "MAT 1:1", false);
         SyncMetricInfo info = new SyncMetricInfo(0, 0, 1);
-        env.ParatextService
-            .UpdateParatextCommentsAsync(
-                Arg.Any<UserSecret>(),
-                "target",
-                40,
-                Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                Arg.Any<Dictionary<string, string>>(),
-                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                Arg.Any<int>()
-            )
+        env.ParatextService.UpdateParatextCommentsAsync(
+            Arg.Any<UserSecret>(),
+            "target",
+            40,
+            Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+            Arg.Any<Dictionary<string, string>>(),
+            Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+            Arg.Any<int>()
+        )
             .Returns(Task.FromResult(info));
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-        await env.ParatextService
-            .Received(1)
+        await env.ParatextService.Received(1)
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -1780,21 +1729,19 @@ public class ParatextSyncRunnerTests
         Book[] books = new[] { book };
         env.AddParatextNoteThreadData(books, true, true);
         SyncMetricInfo info = new SyncMetricInfo(1, 0, 0);
-        env.ParatextService
-            .UpdateParatextCommentsAsync(
-                Arg.Any<UserSecret>(),
-                "target",
-                40,
-                Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                Arg.Any<Dictionary<string, string>>(),
-                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                Arg.Any<int>()
-            )
+        env.ParatextService.UpdateParatextCommentsAsync(
+            Arg.Any<UserSecret>(),
+            "target",
+            40,
+            Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+            Arg.Any<Dictionary<string, string>>(),
+            Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+            Arg.Any<int>()
+        )
             .Returns(Task.FromResult(info));
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-        await env.ParatextService
-            .Received(1)
+        await env.ParatextService.Received(1)
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -1805,8 +1752,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<int>()
             );
 
-        env.ParatextService
-            .Received(1)
+        env.ParatextService.Received(1)
             .GetNoteThreadChanges(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -1934,8 +1880,7 @@ public class ParatextSyncRunnerTests
 
         SFProject project = env.GetProject();
         Assert.That(project.Sync.LastSyncSuccessful, Is.True);
-        env.ParatextService
-            .Received(1)
+        env.ParatextService.Received(1)
             .GetNoteThreadChanges(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -2264,14 +2209,13 @@ public class ParatextSyncRunnerTests
         // Setup the environment so the Paratext service will return that the resource has changed
         env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
         env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>()).Returns(true);
-        env.ParatextService
-            .SendReceiveAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Any<string>(),
-                Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<SyncMetrics>()
-            )
+        env.ParatextService.SendReceiveAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<IProgress<ProgressState>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<SyncMetrics>()
+        )
             .Returns(new ParatextResource());
 
         // SUT
@@ -2306,14 +2250,13 @@ public class ParatextSyncRunnerTests
         // Setup the environment so the Paratext service will return that the resource has not changed
         env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
         env.ParatextService.ResourceDocsNeedUpdating(Arg.Any<SFProject>(), Arg.Any<ParatextResource>()).Returns(false);
-        env.ParatextService
-            .SendReceiveAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Any<string>(),
-                Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<SyncMetrics>()
-            )
+        env.ParatextService.SendReceiveAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<IProgress<ProgressState>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<SyncMetrics>()
+        )
             .Returns(new ParatextResource());
 
         // SUT
@@ -2416,20 +2359,18 @@ public class ParatextSyncRunnerTests
         Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
-        env.ParatextService
-            .PutBookText(
-                Arg.Any<UserSecret>(),
-                Arg.Any<string>(),
-                Arg.Any<int>(),
-                Arg.Any<XDocument>(),
-                Arg.Any<Dictionary<int, string>>()
-            )
+        env.ParatextService.PutBookText(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<int>(),
+            Arg.Any<XDocument>(),
+            Arg.Any<Dictionary<int, string>>()
+        )
             .Returns(1);
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        await env.ParatextService
-            .Received(2)
+        await env.ParatextService.Received(2)
             .PutBookText(
                 Arg.Any<UserSecret>(),
                 Arg.Any<string>(),
@@ -2461,14 +2402,13 @@ public class ParatextSyncRunnerTests
 
         // Setup the environment so the Paratext service will return that source is a resource
         env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
-        env.ParatextService
-            .SendReceiveAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Any<string>(),
-                Arg.Any<IProgress<ProgressState>>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<SyncMetrics>()
-            )
+        env.ParatextService.SendReceiveAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<IProgress<ProgressState>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<SyncMetrics>()
+        )
             .Returns(new ParatextResource());
 
         // Ensure that the source is project02, and has no users with access
@@ -2502,8 +2442,7 @@ public class ParatextSyncRunnerTests
         env.SetupPTData(books);
 
         // This Biblical Term will be updated
-        env.RealtimeService
-            .GetRepository<BiblicalTerm>()
+        env.RealtimeService.GetRepository<BiblicalTerm>()
             .Add(
                 new BiblicalTerm
                 {
@@ -2539,8 +2478,7 @@ public class ParatextSyncRunnerTests
             );
 
         // This Biblical Term will be deleted
-        env.RealtimeService
-            .GetRepository<BiblicalTerm>()
+        env.RealtimeService.GetRepository<BiblicalTerm>()
             .Add(
                 new BiblicalTerm
                 {
@@ -2551,8 +2489,7 @@ public class ParatextSyncRunnerTests
                 }
             );
 
-        env.ParatextService
-            .GetBiblicalTermsAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IEnumerable<int>>())
+        env.ParatextService.GetBiblicalTermsAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IEnumerable<int>>())
             .Returns(
                 Task.FromResult(
                     new BiblicalTermsChanges
@@ -2599,8 +2536,7 @@ public class ParatextSyncRunnerTests
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        env.ParatextService
-            .Received(1)
+        env.ParatextService.Received(1)
             .UpdateBiblicalTerms(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<BiblicalTerm>>());
 
         SFProject project = env.GetProject();
@@ -2667,21 +2603,19 @@ public class ParatextSyncRunnerTests
         Book[] books = { book };
         env.AddParatextNoteThreadData(books, true, true, true);
         SyncMetricInfo info = new SyncMetricInfo(1, 0, 0);
-        env.ParatextService
-            .UpdateParatextCommentsAsync(
-                Arg.Any<UserSecret>(),
-                "target",
-                null,
-                Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
-                Arg.Any<Dictionary<string, string>>(),
-                Arg.Any<Dictionary<string, ParatextUserProfile>>(),
-                Arg.Any<int>()
-            )
+        env.ParatextService.UpdateParatextCommentsAsync(
+            Arg.Any<UserSecret>(),
+            "target",
+            null,
+            Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
+            Arg.Any<Dictionary<string, string>>(),
+            Arg.Any<Dictionary<string, ParatextUserProfile>>(),
+            Arg.Any<int>()
+        )
             .Returns(Task.FromResult(info));
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-        await env.ParatextService
-            .Received(1)
+        await env.ParatextService.Received(1)
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
@@ -2692,8 +2626,7 @@ public class ParatextSyncRunnerTests
                 Arg.Any<int>()
             );
 
-        env.ParatextService
-            .Received(1)
+        env.ParatextService.Received(1)
             .GetNoteThreadChanges(
                 Arg.Any<UserSecret>(),
                 "target",

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -28,8 +28,12 @@ public class PreTranslationServiceTests
         const int bookNum = 64;
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
-        env.TranslationEnginesClient
-            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult<IList<Pretranslation>>(
                     new List<Pretranslation>
@@ -110,8 +114,12 @@ public class PreTranslationServiceTests
         const int bookNum = 40;
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
-        env.TranslationEnginesClient
-            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
             .Returns(Task.FromResult<IList<Pretranslation>>(new List<Pretranslation>()));
 
         // SUT
@@ -133,8 +141,12 @@ public class PreTranslationServiceTests
         const int bookNum = 40;
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
-        env.TranslationEnginesClient
-            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None)
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
             .Returns(
                 Task.FromResult<IList<Pretranslation>>(
                     new List<Pretranslation>

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -53,8 +53,7 @@ public class SFProjectServiceTests
         const string role = SFProjectRole.CommunityChecker;
 
         await env.Service.InviteAsync(User01, Project01, email, "en", role);
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 email,
                 Arg.Any<string>(),
@@ -76,8 +75,7 @@ public class SFProjectServiceTests
         const string role = SFProjectRole.CommunityChecker;
 
         await env.Service.InviteAsync(User01, Project03, email, "en", role);
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 email,
                 Arg.Any<string>(),
@@ -104,13 +102,12 @@ public class SFProjectServiceTests
         await env.Service.InviteAsync(User02, Project04, observerEmail, "en", SFProjectRole.Viewer);
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project04);
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.Viewer),
+            projectSecret.ShareKeys.Any(
+                s => s.Email == observerEmail && s.Key == observerKey && s.ProjectRole == SFProjectRole.Viewer
+            ),
             Is.True
         );
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 observerEmail,
                 Arg.Any<string>(),
@@ -125,13 +122,12 @@ public class SFProjectServiceTests
         await env.Service.InviteAsync(User02, Project04, reviewerEmail, "en", SFProjectRole.Commenter);
         projectSecret = env.ProjectSecrets.Get(Project04);
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Commenter),
+            projectSecret.ShareKeys.Any(
+                s => s.Email == reviewerEmail && s.Key == reviewerKey && s.ProjectRole == SFProjectRole.Commenter
+            ),
             Is.True
         );
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 reviewerEmail,
                 Arg.Any<string>(),
@@ -167,8 +163,7 @@ public class SFProjectServiceTests
 
         await env.Service.InviteAsync(User01, Project03, email, "en", endingRole);
         // Invitation email was resent but with original code and updated time
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 Arg.Is(email),
                 Arg.Any<string>(),
@@ -215,8 +210,7 @@ public class SFProjectServiceTests
         env.SecurityService.GenerateKey().Returns("newkey");
         await env.Service.InviteAsync(User01, Project03, email, "en", role);
         // Invitation email was sent with a new code
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 Arg.Is(email),
                 Arg.Any<string>(),
@@ -244,8 +238,7 @@ public class SFProjectServiceTests
         const string role = SFProjectRole.CommunityChecker;
         // SUT
         await env.Service.InviteAsync(User02, Project02, email, "en", role);
-        await env.EmailService
-            .Received(1)
+        await env.EmailService.Received(1)
             .SendEmailAsync(
                 email,
                 Arg.Any<string>(),
@@ -310,15 +303,13 @@ public class SFProjectServiceTests
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project06);
 
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "maxUsersReached"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Viewer
-                        && sk.UsersGenerated == 250
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "maxUsersReached"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Viewer
+                    && sk.UsersGenerated == 250
+            ),
             Is.True,
             "setup"
         );
@@ -333,16 +324,14 @@ public class SFProjectServiceTests
         Assert.That(shareLink, Is.EqualTo("newKey"));
         projectSecret = env.ProjectSecrets.Get(Project06);
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "newKey"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Viewer
-                        && sk.Reserved == null
-                        && sk.UsersGenerated == 0
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "newKey"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Viewer
+                    && sk.Reserved == null
+                    && sk.UsersGenerated == 0
+            ),
             Is.True
         );
     }
@@ -354,14 +343,12 @@ public class SFProjectServiceTests
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project06);
 
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "reservedKey"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Viewer
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "reservedKey"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Viewer
+            ),
             Is.True,
             "setup"
         );
@@ -376,15 +363,13 @@ public class SFProjectServiceTests
         Assert.That(shareLink, Is.EqualTo("newKey"));
         projectSecret = env.ProjectSecrets.Get(Project06);
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "newKey"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Viewer
-                        && sk.Reserved == null
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "newKey"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Viewer
+                    && sk.Reserved == null
+            ),
             Is.True
         );
     }
@@ -580,8 +565,7 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
         SFProject project = env.GetProject(Project04);
         Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+        env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
             .Returns(Task.FromResult(new Attempt<string>(SFProjectRole.Translator)));
 
         await env.Service.JoinWithShareKeyAsync(User03, "linksharing04");
@@ -757,21 +741,21 @@ public class SFProjectServiceTests
             "setup. role should be different than community checker for purposes of part of what this test is testing."
         );
         string shareKeyCode = "key12345";
-        ShareKey shareKeyForUserInvitation = env.ProjectSecrets
-            .Get(project.Id)
-            .ShareKeys
-            .First((ShareKey shareKey) => shareKey.Key == shareKeyCode);
+        ShareKey shareKeyForUserInvitation = env.ProjectSecrets.Get(project.Id)
+            .ShareKeys.First((ShareKey shareKey) => shareKey.Key == shareKeyCode);
         Assert.That(
             shareKeyForUserInvitation.ProjectRole,
             Is.EqualTo(SFProjectRole.CommunityChecker),
             "setup. the user should be being invited as a community checker."
         );
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
         string userDBLPermissionForResource = TextInfoPermission.Read;
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
             .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
         Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
@@ -802,32 +786,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         // SUT
@@ -903,8 +884,7 @@ public class SFProjectServiceTests
         );
 
         // The get permission methods shouldn't have even been called.
-        await env.ParatextService
-            .DidNotReceiveWithAnyArgs()
+        await env.ParatextService.DidNotReceiveWithAnyArgs()
             .GetPermissionsAsync(
                 Arg.Any<UserSecret>(),
                 Arg.Any<SFProject>(),
@@ -912,8 +892,7 @@ public class SFProjectServiceTests
                 Arg.Any<int>(),
                 Arg.Any<int>()
             );
-        await env.ParatextService
-            .DidNotReceiveWithAnyArgs()
+        await env.ParatextService.DidNotReceiveWithAnyArgs()
             .GetResourcePermissionAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
@@ -964,27 +943,27 @@ public class SFProjectServiceTests
         // and in ParatextService.CallApiAsync() there originates a System.Net.Http.HttpRequestException or perhaps
         // EdjCase.JsonRpc.Common.RpcException. Our test should not end up doing down a path that causes this
         // exception.
-        env.ParatextService
-            .GetParatextUsernameMappingAsync(
-                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetParatextUsernameMappingAsync(
+            Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+            Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(
                 Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
             );
 
         string userRoleOnPTProject = null;
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
         string userDBLPermissionForResource = TextInfoPermission.None;
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
             .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
-        env.ParatextService
-            .GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>())
+        env.ParatextService.GetBookList(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(x => throw new Exception("Probably can not do this."));
 
         // PT could answer with these permissions.
@@ -1005,32 +984,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         // SUT
@@ -1082,8 +1058,7 @@ public class SFProjectServiceTests
         // getting called is a helpful indication of expected operation.
         // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
         // place in case they begin to be used.
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .GetPermissionsAsync(
                 Arg.Any<UserSecret>(),
                 Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
@@ -1091,8 +1066,7 @@ public class SFProjectServiceTests
                 Arg.Any<int>(),
                 Arg.Any<int>()
             );
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .GetPermissionsAsync(
                 Arg.Any<UserSecret>(),
                 Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
@@ -1149,23 +1123,24 @@ public class SFProjectServiceTests
         );
         Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
 
-        env.ParatextService
-            .GetParatextUsernameMappingAsync(
-                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<CancellationToken>()
-            )
+        env.ParatextService.GetParatextUsernameMappingAsync(
+            Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+            Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(
                 Task.FromException<IReadOnlyDictionary<string, string>>(new System.Net.Http.HttpRequestException())
             );
 
         string userRoleOnPTProject = null;
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Failure(userRoleOnPTProject)));
         string userDBLPermissionForResource = TextInfoPermission.Read;
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
             .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
         var bookList = new List<int>() { 40, 41 };
@@ -1190,32 +1165,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         // SUT
@@ -1244,8 +1216,7 @@ public class SFProjectServiceTests
 
         // User03 is not on project project05PTId, but they have access to the source resource. So
         // UpdatePermissionsAsync() should be inquiring about this and setting permissions as appropriate.
-        await env.ParatextService
-            .Received()
+        await env.ParatextService.Received()
             .GetResourcePermissionAsync(Resource01PTId, User03, Arg.Any<CancellationToken>());
         resource = env.GetProject(Resource01);
         Assert.That(
@@ -1272,8 +1243,7 @@ public class SFProjectServiceTests
         // don't get applied. But for now, not getting called is a helpful indication of expected operation.
         // The mocks above regarding env.ParatextService.GetPermissionsAsync(for the target project) are left in
         // place in case they begin to be used.
-        await env.ParatextService
-            .DidNotReceive()
+        await env.ParatextService.DidNotReceive()
             .GetPermissionsAsync(
                 Arg.Any<UserSecret>(),
                 Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Project05),
@@ -1281,8 +1251,7 @@ public class SFProjectServiceTests
                 Arg.Any<int>(),
                 Arg.Any<int>()
             );
-        await env.ParatextService
-            .Received(1)
+        await env.ParatextService.Received(1)
             .GetPermissionsAsync(
                 Arg.Any<UserSecret>(),
                 Arg.Is<SFProject>((SFProject sfProject) => sfProject.Id == Resource01),
@@ -1499,8 +1468,7 @@ public class SFProjectServiceTests
         Assert.IsTrue(env.GetProject(projectId).UserRoles.ContainsKey(userToRemove));
 
         // Delete the project user config
-        int deleted = await env.RealtimeService
-            .GetRepository<SFProjectUserConfig>()
+        int deleted = await env.RealtimeService.GetRepository<SFProjectUserConfig>()
             .DeleteAllAsync(p => p.Id == projectUserConfigId);
         Assert.AreEqual(1, deleted);
 
@@ -1610,8 +1578,11 @@ public class SFProjectServiceTests
 
         Assert.That(project.UserRoles.ContainsKey(User03), Is.False, "setup");
         Assert.That(projectSecret.ShareKeys.Any(sk => sk.Key == "key1234"), Is.True, "setup");
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
 
         await env.Service.AddUserAsync(User03, Project03, null);
@@ -1624,8 +1595,7 @@ public class SFProjectServiceTests
     public void AddUserAsync_SourceProjectUnavailable_SkipProject()
     {
         var env = new TestEnvironment();
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+        env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
         Assert.DoesNotThrowAsync(() => env.Service.AddUserAsync(User03, Project04, SFProjectRole.Translator));
         var project = env.GetProject(Project04);
@@ -1671,12 +1641,14 @@ public class SFProjectServiceTests
         Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
 
         string userRoleOnPTProject = SFProjectRole.Translator;
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
         string userDBLPermissionForResource = TextInfoPermission.Read;
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
             .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
         var bookList = new List<int>() { 40, 41 };
@@ -1700,32 +1672,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project05PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         string projectRoleSpecifiedFromConnectProjectPage = null;
@@ -1771,8 +1740,7 @@ public class SFProjectServiceTests
         Assert.That(source.UserRoles.ContainsKey(User03), Is.False, "setup");
         User user = env.GetUser(User03);
         Assert.That(user.Sites[SiteId].Projects, Is.Empty);
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+        env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
 
         await env.Service.AddUserAsync(User03, Project03, SFProjectRole.Translator);
@@ -1791,16 +1759,14 @@ public class SFProjectServiceTests
         SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project06);
 
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "toBeReservedKey"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Commenter
-                        && sk.ExpirationTime == null
-                        && sk.Reserved == null
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "toBeReservedKey"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Commenter
+                    && sk.ExpirationTime == null
+                    && sk.Reserved == null
+            ),
             Is.True,
             "setup"
         );
@@ -1810,16 +1776,14 @@ public class SFProjectServiceTests
         projectSecret = env.ProjectSecrets.Get(Project06);
 
         Assert.That(
-            projectSecret
-                .ShareKeys
-                .Any(
-                    sk =>
-                        sk.Key == "toBeReservedKey"
-                        && sk.ShareLinkType == ShareLinkType.Recipient
-                        && sk.ProjectRole == SFProjectRole.Commenter
-                        && sk.ExpirationTime > DateTime.Now
-                        && sk.Reserved == true
-                ),
+            projectSecret.ShareKeys.Any(
+                sk =>
+                    sk.Key == "toBeReservedKey"
+                    && sk.ShareLinkType == ShareLinkType.Recipient
+                    && sk.ProjectRole == SFProjectRole.Commenter
+                    && sk.ExpirationTime > DateTime.Now
+                    && sk.Reserved == true
+            ),
             Is.True
         );
     }
@@ -1860,23 +1824,21 @@ public class SFProjectServiceTests
             { User02, TextInfoPermission.Read },
         };
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
 
         sfProject = env.GetProject(Project01);
@@ -1936,23 +1898,21 @@ public class SFProjectServiceTests
             { User02, TextInfoPermission.Read },
         };
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
 
         SFProject sfProject = env.GetProject(Project01);
@@ -1991,23 +1951,21 @@ public class SFProjectServiceTests
             { User02, TextInfoPermission.None },
         };
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
 
         SFProject sfProject = env.GetProject(Project01);
@@ -2053,32 +2011,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == project01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == Resource01PTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         SFProject sfProject = env.GetProject(Project01);
@@ -2172,11 +2127,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.DraftConfig.AlternateSource?.ParatextId, Is.Null);
         Assert.That(project.TranslateConfig.DraftConfig.AlternateSource?.Name, Is.Null);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2211,11 +2164,9 @@ public class SFProjectServiceTests
         Assert.That(alternateSourceProject.ParatextId, Is.EqualTo(newProjectParatextId));
         Assert.That(alternateSourceProject.Name, Is.EqualTo("NewSource"));
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
 
@@ -2244,11 +2195,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.DraftConfig.AlternateTrainingSource?.ParatextId, Is.Null);
         Assert.That(project.TranslateConfig.DraftConfig.AlternateTrainingSource?.Name, Is.Null);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2282,11 +2231,9 @@ public class SFProjectServiceTests
         Assert.That(alternateTrainingSourceProject.ParatextId, Is.EqualTo("changedId"));
         Assert.That(alternateTrainingSourceProject.Name, Is.EqualTo("NewSource"));
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
 
@@ -2311,11 +2258,9 @@ public class SFProjectServiceTests
         SFProject project = env.GetProject(Project01);
         Assert.That(project.TranslateConfig.DraftConfig.AlternateTrainingSourceEnabled, Is.True);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2335,11 +2280,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
         Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
 
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2359,11 +2302,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.Source.ParatextId, Is.EqualTo("changedId"));
         Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("NewSource"));
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2382,11 +2323,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.True);
         Assert.That(project.TranslateConfig.Source.Name, Is.EqualTo("Source Only Project"));
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2409,11 +2348,9 @@ public class SFProjectServiceTests
         Assert.That(project.TranslateConfig.TranslationSuggestionsEnabled, Is.False);
         Assert.That(project.TranslateConfig.Source, Is.Null);
 
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2428,11 +2365,9 @@ public class SFProjectServiceTests
         SFProject project = env.GetProject(Project01);
         Assert.That(project.CheckingConfig.CheckingEnabled, Is.True);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2447,11 +2382,9 @@ public class SFProjectServiceTests
         SFProject project = env.GetProject(Project01);
         Assert.That(project.CheckingConfig.ShareEnabled, Is.True);
 
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env.MachineProjectService
-            .DidNotReceive()
+        await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
@@ -2469,8 +2402,7 @@ public class SFProjectServiceTests
         Assert.That(env.ContainsProject(Project01), Is.False);
         User user = env.GetUser(User01);
         Assert.That(user.Sites[SiteId].Projects, Does.Not.Contain(Project01));
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
         env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.False);
@@ -2481,8 +2413,7 @@ public class SFProjectServiceTests
         await env.Service.DeleteProjectAsync(User01, SourceOnly);
 
         await env.SyncService.Received().CancelSyncAsync(User01, SourceOnly);
-        await env.MachineProjectService
-            .Received()
+        await env.MachineProjectService.Received()
             .RemoveProjectAsync(User01, SourceOnly, preTranslate: false, CancellationToken.None);
         env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
         Assert.That(env.ContainsProject(SourceOnly), Is.False);
@@ -2495,8 +2426,11 @@ public class SFProjectServiceTests
     {
         var env = new TestEnvironment();
         int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
         // SUT
         string sfProjectId = await env.Service.CreateProjectAsync(
@@ -2518,11 +2452,13 @@ public class SFProjectServiceTests
     {
         var env = new TestEnvironment();
         int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(TextInfoPermission.Read));
         // SUT
         string sfProjectId = await env.Service.CreateProjectAsync(
@@ -2542,8 +2478,7 @@ public class SFProjectServiceTests
         );
 
         // The source should have a later ID than the target in the project repository
-        var projects = env.RealtimeService
-            .GetRepository<SFProject>()
+        var projects = env.RealtimeService.GetRepository<SFProject>()
             .Query()
             .Where(p => p.ParatextId == "ptProject123" || p.ParatextId == "resource_project")
             .OrderBy(p => p.Id);
@@ -2561,8 +2496,11 @@ public class SFProjectServiceTests
     {
         var env = new TestEnvironment();
         int projectCount = env.RealtimeService.GetRepository<SFProject>().Query().Count();
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
         SFProject existingSfProject = env.GetProject(Project01);
         // SUT
@@ -2606,12 +2544,14 @@ public class SFProjectServiceTests
         Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
 
         string userRoleOnPTProject = SFProjectRole.Administrator;
-        env.ParatextService
-            .TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        env.ParatextService.TryGetProjectRoleAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>()
+        )
             .Returns(Task.FromResult(Attempt.Success(userRoleOnPTProject)));
         string userDBLPermissionForResource = TextInfoPermission.Read;
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User03, Arg.Any<CancellationToken>())
             .Returns<Task<string>>(Task.FromResult(userDBLPermissionForResource));
 
         var bookList = new List<int>() { 40, 41 };
@@ -2638,32 +2578,29 @@ public class SFProjectServiceTests
         };
         const int bookValueToIndicateWholeResource = 0;
         const int chapterValueToIndicateWholeBook = 0;
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptBookPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                Arg.Any<int>(),
-                Arg.Is<int>((int arg) => arg > 0)
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == targetProjectPTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<int>(),
+            Arg.Is<int>((int arg) => arg > 0)
+        )
             .Returns(Task.FromResult(ptChapterPermissions));
-        env.ParatextService
-            .GetPermissionsAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>((SFProject project) => project.ParatextId == sourceProjectPTId),
-                Arg.Any<IReadOnlyDictionary<string, string>>(),
-                bookValueToIndicateWholeResource,
-                chapterValueToIndicateWholeBook
-            )
+        env.ParatextService.GetPermissionsAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>((SFProject project) => project.ParatextId == sourceProjectPTId),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            bookValueToIndicateWholeResource,
+            chapterValueToIndicateWholeBook
+        )
             .Returns(Task.FromResult(ptSourcePermissions));
 
         resource = env.GetProject(Resource01);
@@ -2697,8 +2634,7 @@ public class SFProjectServiceTests
 
         // Initially connecting a project should have called Sync, or SF is not going to fetch books and set
         // permissions on them.
-        await env.SyncService
-            .Received()
+        await env.SyncService.Received()
             .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == sfProjectId && s.TrainEngine && s.UserId == User03));
 
         // Don't check that permissions were added to the target project, because we mock the Sync functionality.
@@ -2756,8 +2692,7 @@ public class SFProjectServiceTests
     public async Task AddUserToResourceProjectAsync_UserResourcePermission()
     {
         var env = new TestEnvironment();
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(TextInfoPermission.Read));
 
         User user = env.GetUser(User01);
@@ -2773,8 +2708,7 @@ public class SFProjectServiceTests
     public void AddUserToResourceProjectAsync_UserResourceNoPermission()
     {
         var env = new TestEnvironment();
-        env.ParatextService
-            .GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
+        env.ParatextService.GetResourcePermissionAsync(Arg.Any<string>(), User01, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(TextInfoPermission.None));
 
         User user = env.GetUser(User01);
@@ -3681,17 +3615,15 @@ public class SFProjectServiceTests
                 )
             );
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            siteOptions
-                .Value
-                .Returns(
-                    new SiteOptions
-                    {
-                        Id = SiteId,
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "xforge"
-                    }
-                );
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Id = SiteId,
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "xforge"
+                }
+            );
             var audioService = Substitute.For<IAudioService>();
             EmailService = Substitute.For<IEmailService>();
             var currentTime = DateTime.Now;

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -237,8 +237,7 @@ public class SyncServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("jobid");
-        await env.RealtimeService
-            .GetRepository<SFProject>()
+        await env.RealtimeService.GetRepository<SFProject>()
             .UpdateAsync(
                 p => p.Id == "project03",
                 u => u.Set(pr => pr.TranslateConfig.TranslationSuggestionsEnabled, false)

--- a/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
@@ -17,8 +17,7 @@ public class TransceleratorServiceTests
     {
         var env = new TestEnvironment();
         env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
-        env.FileSystemService
-            .EnumerateFiles(Arg.Any<string>())
+        env.FileSystemService.EnumerateFiles(Arg.Any<string>())
             .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
         env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(TestEnvironment.XmlFileText("1.1"));
 
@@ -38,8 +37,7 @@ public class TransceleratorServiceTests
     {
         var env = new TestEnvironment();
         env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
-        env.FileSystemService
-            .EnumerateFiles(Arg.Any<string>())
+        env.FileSystemService.EnumerateFiles(Arg.Any<string>())
             .Returns(new string[] { "Translated Checking Questions for GEN.xml" });
         env.FileSystemService.FileReadText(Arg.Any<string>()).Returns(TestEnvironment.XmlFileText("1.0"));
         Assert.Throws<DataNotFoundException>(() => env.Service.Questions(Project01));
@@ -52,11 +50,9 @@ public class TransceleratorServiceTests
         public TestEnvironment()
         {
             FileSystemService = Substitute.For<IFileSystemService>();
-            IOptions<SiteOptions> siteOptions = Microsoft
-                .Extensions
-                .Options
-                .Options
-                .Create(new SiteOptions() { SiteDir = "scriptureforge" });
+            IOptions<SiteOptions> siteOptions = Microsoft.Extensions.Options.Options.Create(
+                new SiteOptions() { SiteDir = "scriptureforge" }
+            );
             Service = new TransceleratorService(FileSystemService, siteOptions);
         }
 

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -41,9 +41,7 @@ public class ConnectionTests
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
         // Verify that the call was passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -75,9 +73,7 @@ public class ConnectionTests
         List<Json0Op> op = builder.Op;
         var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
 
-        env.RealtimeService
-            .Server
-            .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+        env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
             .Returns(Task.FromResult(snapshot));
         env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op).Returns(Task.FromResult(updatedData));
 
@@ -96,17 +92,11 @@ public class ConnectionTests
         await env.Service.CommitTransactionAsync();
 
         // Verify Submit Operations
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .SubmitOpAsync<object>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
     }
 
@@ -138,9 +128,7 @@ public class ConnectionTests
         Assert.AreEqual(queuedOperation.OtTypeName, otTypeName);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(0)
+        await env.RealtimeService.Server.Received(0)
             .CreateDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<string>());
     }
 
@@ -161,9 +149,7 @@ public class ConnectionTests
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .CreateDocAsync(
                 Arg.Any<int>(),
                 Arg.Any<string>(),
@@ -193,9 +179,7 @@ public class ConnectionTests
         Assert.AreEqual(queuedOperation.Id, id);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(0)
+        await env.RealtimeService.Server.Received(0)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -214,9 +198,7 @@ public class ConnectionTests
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -269,9 +251,7 @@ public class ConnectionTests
         var env = new TestEnvironment();
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
         const string id = "id1";
-        env.RealtimeService
-            .Server
-            .FetchDocAsync<Project>(Arg.Any<int>(), collection, id)
+        env.RealtimeService.Server.FetchDocAsync<Project>(Arg.Any<int>(), collection, id)
             .Returns(
                 new Snapshot<Project>
                 {
@@ -304,9 +284,7 @@ public class ConnectionTests
         var env = new TestEnvironment(documentCacheDisabled: true);
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
         const string id = "id1";
-        env.RealtimeService
-            .Server
-            .FetchDocAsync<Project>(Arg.Any<int>(), collection, id)
+        env.RealtimeService.Server.FetchDocAsync<Project>(Arg.Any<int>(), collection, id)
             .Returns(
                 new Snapshot<Project>
                 {
@@ -339,9 +317,7 @@ public class ConnectionTests
         var env = new TestEnvironment();
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
         string[] ids = { "id1", "id2" };
-        env.RealtimeService
-            .Server
-            .FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
+        env.RealtimeService.Server.FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
             .Returns(
                 new Snapshot<Project>[]
                 {
@@ -377,9 +353,7 @@ public class ConnectionTests
         var env = new TestEnvironment(documentCacheDisabled: true);
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
         string[] ids = { "id1" };
-        env.RealtimeService
-            .Server
-            .FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
+        env.RealtimeService.Server.FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
             .Returns(
                 new Snapshot<Project>[]
                 {
@@ -427,9 +401,7 @@ public class ConnectionTests
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(0)
+        await env.RealtimeService.Server.Received(0)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -460,9 +432,7 @@ public class ConnectionTests
         var builder = new Json0OpBuilder<TestProject>(data);
         builder.Set(p => p.SyncDisabled, true);
         List<Json0Op> op = builder.Op;
-        env.RealtimeService
-            .Server
-            .ApplyOpAsync(Arg.Any<string>(), Arg.Any<TestProject>(), Arg.Any<object>())
+        env.RealtimeService.Server.ApplyOpAsync(Arg.Any<string>(), Arg.Any<TestProject>(), Arg.Any<object>())
             .Returns(Task.FromResult(snapshot.Data));
 
         // SUT
@@ -477,9 +447,7 @@ public class ConnectionTests
         Assert.Zero(env.Service.QueuedOperations.Count);
 
         // Verify that the call was passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
     }
 
@@ -501,9 +469,7 @@ public class ConnectionTests
         List<Json0Op> op = builder.Op;
         var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
 
-        env.RealtimeService
-            .Server
-            .FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
+        env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
             .Returns(Task.FromResult(snapshot));
         env.RealtimeService.Server.ApplyOpAsync(otTypeName, snapshot.Data, op).Returns(Task.FromResult(updatedData));
 
@@ -523,9 +489,7 @@ public class ConnectionTests
         Assert.AreEqual(queuedOperation.Op, op);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(0)
+        await env.RealtimeService.Server.Received(0)
             .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
     }
 
@@ -552,9 +516,7 @@ public class ConnectionTests
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
         // Verify that the call was not passed to the underlying realtime server
-        await env.RealtimeService
-            .Server
-            .Received(1)
+        await env.RealtimeService.Server.Received(1)
             .SubmitOpAsync<TestProject>(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>());
     }
 

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -121,8 +121,7 @@ public class RealtimeServiceTests
         var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
         cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
         cursorMock.Current.Returns(new[] { doc });
-        env.MongoDatabase
-            .GetCollection<BsonDocument>("o_users")
+        env.MongoDatabase.GetCollection<BsonDocument>("o_users")
             .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
             .Returns(Task.FromResult(cursorMock));
 
@@ -144,8 +143,7 @@ public class RealtimeServiceTests
         var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
         cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
         cursorMock.Current.Returns(new[] { doc });
-        env.MongoDatabase
-            .GetCollection<BsonDocument>("o_users")
+        env.MongoDatabase.GetCollection<BsonDocument>("o_users")
             .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
             .Returns(Task.FromResult(cursorMock));
 
@@ -167,8 +165,7 @@ public class RealtimeServiceTests
         var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
         cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
         cursorMock.Current.Returns(new[] { doc });
-        env.MongoDatabase
-            .GetCollection<BsonDocument>("o_users")
+        env.MongoDatabase.GetCollection<BsonDocument>("o_users")
             .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
             .Returns(Task.FromResult(cursorMock));
 
@@ -191,8 +188,7 @@ public class RealtimeServiceTests
         var cursorMock = Substitute.For<IAsyncCursor<BsonDocument>>();
         cursorMock.MoveNextAsync().Returns(Task.FromResult(true), Task.FromResult(false));
         cursorMock.Current.Returns(new[] { doc2, doc1 });
-        env.MongoDatabase
-            .GetCollection<BsonDocument>("o_users")
+        env.MongoDatabase.GetCollection<BsonDocument>("o_users")
             .FindAsync(Arg.Any<FilterDefinition<BsonDocument>>(), Arg.Any<FindOptions<BsonDocument, BsonDocument>>())
             .Returns(Task.FromResult(cursorMock));
 
@@ -210,28 +206,22 @@ public class RealtimeServiceTests
         {
             IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
             IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            IOptions<DataAccessOptions> dataAccessOptions = Microsoft
-                .Extensions
-                .Options
-                .Options
-                .Create(new DataAccessOptions { MongoDatabaseName = "mongoDatabaseName" });
-            IOptions<RealtimeOptions> realtimeOptions = Microsoft
-                .Extensions
-                .Options
-                .Options
-                .Create(
-                    new RealtimeOptions
+            IOptions<DataAccessOptions> dataAccessOptions = Microsoft.Extensions.Options.Options.Create(
+                new DataAccessOptions { MongoDatabaseName = "mongoDatabaseName" }
+            );
+            IOptions<RealtimeOptions> realtimeOptions = Microsoft.Extensions.Options.Options.Create(
+                new RealtimeOptions
+                {
+                    ProjectDoc = new DocConfig("some_projects", typeof(Project)),
+                    ProjectDataDocs = new List<DocConfig>
                     {
-                        ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                        ProjectDataDocs = new List<DocConfig>
-                        {
-                            new DocConfig("favorite_numbers", typeof(int)),
-                            new DocConfig("favorite_things", typeof(object)),
-                            new DocConfig("favorite_verses", typeof(string)),
-                        },
-                        UserDataDocs = new List<DocConfig> { new DocConfig("favorite_animals", typeof(object)) },
-                    }
-                );
+                        new DocConfig("favorite_numbers", typeof(int)),
+                        new DocConfig("favorite_things", typeof(object)),
+                        new DocConfig("favorite_verses", typeof(string)),
+                    },
+                    UserDataDocs = new List<DocConfig> { new DocConfig("favorite_animals", typeof(object)) },
+                }
+            );
             IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
 
             IMongoClient mongoClient = Substitute.For<IMongoClient>();

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -461,17 +461,15 @@ public class ProjectServiceTests
             );
 
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            siteOptions
-                .Value
-                .Returns(
-                    new SiteOptions
-                    {
-                        Id = SiteId,
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost"),
-                        SiteDir = "site"
-                    }
-                );
+            siteOptions.Value.Returns(
+                new SiteOptions
+                {
+                    Id = SiteId,
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost"),
+                    SiteDir = "site"
+                }
+            );
             AudioService = Substitute.For<IAudioService>();
 
             ProjectSecrets = new MemoryRepository<TestProjectSecret>(

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -429,16 +429,14 @@ public class UserServiceTests
             );
 
             var options = Substitute.For<IOptions<SiteOptions>>();
-            options
-                .Value
-                .Returns(
-                    new SiteOptions
-                    {
-                        Id = "xf",
-                        Name = "xForge",
-                        Origin = new Uri("http://localhost")
-                    }
-                );
+            options.Value.Returns(
+                new SiteOptions
+                {
+                    Id = "xf",
+                    Name = "xForge",
+                    Origin = new Uri("http://localhost")
+                }
+            );
 
             Service = new UserService(RealtimeService, options, UserSecrets, AuthService, ProjectService, Logger);
         }


### PR DESCRIPTION
This PR updates CSharpier from 0.26.3 to 0.26.7.

This version adds an change that doesn't break up long chains into new lines, reverting a change in 0.26.0 that split these into a new line for every field in the chain, which improves readability, and reverts most of the changes made by the previous CSharpier update PR.

See https://github.com/belav/csharpier/releases/tag/0.26.7 for details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2244)
<!-- Reviewable:end -->
