### PR TITLE
SF-2412 Overwriting audio timing data doesn't parse correctly

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -12,7 +12,7 @@ import { QuestionDoc } from 'src/app/core/models/question-doc';
 import { TextAudioDoc } from 'src/app/core/models/text-audio-doc';
 import { CsvService } from 'xforge-common/csv-service.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FileService } from 'xforge-common/file.service';
+import { FileService, formatFileSource } from 'xforge-common/file.service';
 import { I18nKey, I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -401,7 +401,7 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
       audio.addEventListener('error', () => {
         reject(new Error(`Audio Load Failed Code ${audio.error?.code ?? 'Unknown'}: ${audio.error?.message}`));
       });
-      audio.src = url;
+      audio.src = formatFileSource(FileType.Audio, url);
     });
   }
 


### PR DESCRIPTION
* Format audio source file when retrieving the duration

### Acceptance Tests
1. Upload a valid scripture audio and timing data to a book/chapter
2. Save the data
3. Edit the book/chapter from the overview or community checking screen
4. Upload another timing data file (not audio)
5. Save the data
6. Play the chapter audio in the community checking app and observe it functions as normal

The bug caused the timing data not to get parsed because `getDuration` returned zero when fetching an already uploaded audio file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2245)
<!-- Reviewable:end -->
