### PR TITLE
Fix error in TranslateOverview retrain unit test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -275,6 +275,7 @@ class TestEnvironment {
     when(mockedTranslationEngineService.checkHasSourceBooks(anything())).thenReturn(true);
     when(this.mockedRemoteTranslationEngine.getStats()).thenResolve({ confidence: 0.25, trainedSegmentCount: 100 });
     when(this.mockedRemoteTranslationEngine.listenForTrainingStatus()).thenReturn(defer(() => this.trainingProgress$));
+    when(this.mockedRemoteTranslationEngine.startTraining()).thenResolve();
     when(mockedSFProjectService.getText(anything())).thenCall(id =>
       this.realtimeService.subscribe(TextDoc.COLLECTION, id.toString())
     );


### PR DESCRIPTION
This PR fixes the following error in the unit tests that was being logged in the console:

```
'ERROR', [[TypeError: Cannot read properties of null (reading 'then')
TypeError: Cannot read properties of null (reading 'then')
    at TranslateOverviewComponent.startTraining (http://localhost:9876/_karma_webpack_/webpack:/src/app/translate/translate-overview/translate-overview.component.ts:168:43)
    at listenerFn (ng:///TranslateOverviewComponent.js:120:41)
    at executeListenerWithErrorHandling (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/fesm2020/core.mjs:13975:16)
    at eventHandler (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/fesm2020/core.mjs:14008:22)
    at HTMLButtonElement.apply (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/platform-browser/fesm2020/platform-browser.mjs:457:38)
    at _ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/fesm2015/zone.js:406:31)
    at ProxyZoneSpec.onInvokeTask (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/fesm2015/zone-testing.js:318:39)
    at _ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/fesm2015/zone.js:405:60)
    at AsyncStackTaggingZoneSpec.onInvokeTask (http://localhost:9876/_karma_webpack_/webpack:/node_modules/@angular/core/fesm2020/core.mjs:23899:28)
    at _ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/fesm2015/zone.js:405:60)]]
```

The error was cause by a mocked method that was expected to return a Promise, but was returning a void.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2246)
<!-- Reviewable:end -->
