### PR TITLE
SF-2425 Show user pretranslation failure info

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -92,21 +92,38 @@
         <div *ngIf="isDraftJobFetched">
           <ng-container *ngIf="isGenerationSupported">
             <ng-container *ngIf="isDraftFaulted(draftJob)">
-              <section>
-                <h3><mat-icon color="warn">warning</mat-icon>{{ t("warning_generation_faulted_header") }}</h3>
-                <p>
-                  <transloco
-                    key="draft_generation.warning_generation_faulted_detail"
-                    [params]="{
-                      generateButtonText: hasAnyCompletedBuild
-                        ? t('generate_new_draft_button')
-                        : t('generate_draft_button')
-                    }"
-                  ></transloco>
-                </p>
+              <app-notice type="error" icon="error" data-test-id="warning-generation-failed">
+                <div class="draft-generation-failed-message">
+                  <span
+                    ><transloco
+                      key="draft_generation.warning_generation_faulted"
+                      [params]="{
+                        generateButtonText: hasAnyCompletedBuild
+                          ? t('generate_new_draft_button')
+                          : t('generate_draft_button')
+                      }"
+                    ></transloco
+                  ></span>
+                  <a mat-button target="_blank" [href]="issueMailTo">
+                    {{ t("report_problem") }}
+                  </a>
+                </div>
+              </app-notice>
+              <section data-test-id="technical-details">
+                <div>
+                  <p class="error-text">Technical details:</p>
+                  <div>
+                    <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+                    <div>
+                      <strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}
+                    </div>
+                    <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
+                    <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+                  </div>
+                </div>
               </section>
-              <mat-divider inset></mat-divider>
             </ng-container>
+            <mat-divider inset></mat-divider>
 
             <section *ngIf="!isDraftInProgress(draftJob) && !hasAnyCompletedBuild">
               <h3>{{ t("generate_draft_header") }}</h3>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -113,12 +113,15 @@
                 <div>
                   <p class="error-text">Technical details:</p>
                   <div>
-                    <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+                    <div><strong>Message:</strong> {{ draftJob?.message ?? "unknown" }}</div>
                     <div>
-                      <strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}
+                      <strong>Translation Engine Id:</strong>
+                      {{ draftJob?.additionalInfo?.translationEngineId ?? "unknown" }}
                     </div>
-                    <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
-                    <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+                    <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId ?? "unknown" }}</div>
+                    <div>
+                      <strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") ?? "unknown" }}
+                    </div>
                   </div>
                 </div>
               </section>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -152,6 +152,16 @@ mat-divider.mat-divider-inset {
   }
 }
 
+.draft-generation-failed-message {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.error-text {
+  color: variables.$errorColor;
+}
+
 section {
   padding: 10px 0;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -828,7 +828,11 @@ describe('DraftGenerationComponent', () => {
   describe('isDraftFaulted', () => {
     it('should return true if the draft build is faulted', () => {
       let env = new TestEnvironment();
+      env.component.draftJob = { ...buildDto, state: BuildStates.Faulted };
+      env.fixture.detectChanges();
       expect(env.component.isDraftFaulted({ state: BuildStates.Faulted } as BuildDto)).toBe(true);
+      expect(env.getElementByTestId('warning-generation-failed')).not.toBe(null);
+      expect(env.getElementByTestId('technical-details')).not.toBe(null);
     });
 
     it('should return false if the draft build is not faulted', () => {
@@ -838,6 +842,8 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isDraftFaulted({ state: BuildStates.Canceled } as BuildDto)).toBe(false);
       expect(env.component.isDraftFaulted({ state: BuildStates.Pending } as BuildDto)).toBe(false);
       expect(env.component.isDraftFaulted({ state: BuildStates.Queued } as BuildDto)).toBe(false);
+      expect(env.getElementByTestId('warning-generation-failed')).toBe(null);
+      expect(env.getElementByTestId('technical-details')).toBe(null);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -23,6 +23,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { issuesEmailTemplate } from 'xforge-common/utils';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { SharedModule } from '../../shared/shared.module';
@@ -138,6 +139,10 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
 
   get isForwardTranslationEnabled(): boolean {
     return this.featureFlags.allowForwardTranslationNmtDrafting.enabled;
+  }
+
+  get issueMailTo(): string {
+    return issuesEmailTemplate();
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -166,10 +166,10 @@
     "preview_last_draft_header": "Preview last draft",
     "preview_last_draft_while_active_build_button": "Preview last draft",
     "preview_last_draft_while_active_build": "While the new draft generation is in progress, you can continue working with the previously generated draft.",
+    "report_problem": "Report problem",
     "sign_up_for_drafting": "Sign up for drafting",
     "suggested_workflow": "A suggested workflow is to draft and edit one book before generating a draft for the next book.",
-    "warning_generation_faulted_detail": "Click [em]\"{{ generateButtonText }}\"[/em] below to try again.",
-    "warning_generation_faulted_header": "Last generation attempt failed"
+    "warning_generation_faulted": "Last generation attempt failed. Click [em]\"{{ generateButtonText }}\"[/em] below to try again."
   },
   "draft_generation_steps": {
     "back": "Back",

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc;
 using Polly.CircuitBreaker;
 using Serval.Client;
 using SIL.Machine.WebApi;
-using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
@@ -125,7 +124,6 @@ public class MachineApiController : ControllerBase
                     sfProjectId,
                     minRevision,
                     preTranslate,
-                    includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -134,7 +132,6 @@ public class MachineApiController : ControllerBase
                     buildId,
                     minRevision,
                     preTranslate,
-                    includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                     cancellationToken
                 );
 
@@ -218,7 +215,6 @@ public class MachineApiController : ControllerBase
             ServalBuildDto? build = await _machineApiService.GetLastCompletedPreTranslationBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
-                includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                 cancellationToken
             );
 
@@ -363,7 +359,6 @@ public class MachineApiController : ControllerBase
             ServalBuildDto build = await _machineApiService.StartBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
-                includeAdditionalInfo: _userAccessor.SystemRole == SystemRole.SystemAdmin,
                 cancellationToken
             );
             return Ok(build);

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiV2Controller.cs
@@ -60,7 +60,6 @@ public class MachineApiV2Controller : ControllerBase
                     sfProjectId,
                     minRevision,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     cancellationToken
                 )
                 : await _machineApiService.GetBuildAsync(
@@ -69,7 +68,6 @@ public class MachineApiV2Controller : ControllerBase
                     buildId,
                     minRevision,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     cancellationToken
                 );
 
@@ -166,7 +164,6 @@ public class MachineApiV2Controller : ControllerBase
             BuildDto build = await _machineApiService.StartBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
-                includeAdditionalInfo: false,
                 cancellationToken
             );
             return Ok(UpdateDto(build));

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -15,7 +15,6 @@ public interface IMachineApiService
         string buildId,
         long? minRevision,
         bool preTranslate,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<ServalBuildDto?> GetCurrentBuildAsync(
@@ -23,14 +22,12 @@ public interface IMachineApiService
         string sfProjectId,
         long? minRevision,
         bool preTranslate,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<EngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task<ServalBuildDto?> GetLastCompletedPreTranslationBuildAsync(
         string curUserId,
         string sfProjectId,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     );
     Task<PreTranslationDto> GetPreTranslationAsync(
@@ -51,12 +48,7 @@ public interface IMachineApiService
         string segment,
         CancellationToken cancellationToken
     );
-    Task<ServalBuildDto> StartBuildAsync(
-        string curUserId,
-        string sfProjectId,
-        bool includeAdditionalInfo,
-        CancellationToken cancellationToken
-    );
+    Task<ServalBuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task StartPreTranslationBuildAsync(string curUserId, BuildConfig buildConfig, CancellationToken cancellationToken);
     Task TrainSegmentAsync(
         string curUserId,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -180,7 +180,6 @@ public class MachineApiService : IMachineApiService
         string buildId,
         long? minRevision,
         bool preTranslate,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     )
     {
@@ -212,7 +211,7 @@ public class MachineApiService : IMachineApiService
                     minRevision,
                     cancellationToken
                 );
-                buildDto = CreateDto(translationBuild, includeAdditionalInfo);
+                buildDto = CreateDto(translationBuild);
             }
             catch (Exception e)
             {
@@ -237,7 +236,6 @@ public class MachineApiService : IMachineApiService
     public async Task<ServalBuildDto?> GetLastCompletedPreTranslationBuildAsync(
         string curUserId,
         string sfProjectId,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     )
     {
@@ -269,7 +267,7 @@ public class MachineApiService : IMachineApiService
                 .MaxBy(b => b.DateFinished);
             if (translationBuild is not null)
             {
-                buildDto = CreateDto(translationBuild, includeAdditionalInfo);
+                buildDto = CreateDto(translationBuild);
             }
         }
         catch (Exception e)
@@ -291,7 +289,6 @@ public class MachineApiService : IMachineApiService
         string sfProjectId,
         long? minRevision,
         bool preTranslate,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     )
     {
@@ -337,7 +334,7 @@ public class MachineApiService : IMachineApiService
                         ).MaxBy(b => b.DateFinished) ?? throw new DataNotFoundException("Entity Deleted");
                 }
 
-                buildDto = CreateDto(translationBuild, includeAdditionalInfo);
+                buildDto = CreateDto(translationBuild);
             }
             catch (Exception e)
             {
@@ -584,7 +581,6 @@ public class MachineApiService : IMachineApiService
     public async Task<ServalBuildDto> StartBuildAsync(
         string curUserId,
         string sfProjectId,
-        bool includeAdditionalInfo,
         CancellationToken cancellationToken
     )
     {
@@ -677,7 +673,7 @@ public class MachineApiService : IMachineApiService
                         new TranslationBuildConfig(),
                         cancellationToken
                     );
-                    buildDto = CreateDto(translationBuild, includeAdditionalInfo);
+                    buildDto = CreateDto(translationBuild);
                 }
                 catch (Exception e)
                 {
@@ -1039,9 +1035,8 @@ public class MachineApiService : IMachineApiService
     /// Creates the Build DTO for the front end.
     /// </summary>
     /// <param name="translationBuild">The translation build from Serval.</param>
-    /// <param name="includeAdditionalInfo">If <c>true</c>, include additional information for system admins.</param>
     /// <returns>The build DTO.</returns>
-    private static ServalBuildDto CreateDto(TranslationBuild translationBuild, bool includeAdditionalInfo) =>
+    private static ServalBuildDto CreateDto(TranslationBuild translationBuild) =>
         new ServalBuildDto
         {
             Id = translationBuild.Id,
@@ -1050,16 +1045,14 @@ public class MachineApiService : IMachineApiService
             Message = translationBuild.Message,
             QueueDepth = translationBuild.QueueDepth ?? 0,
             State = translationBuild.State.ToString().ToUpperInvariant(),
-            AdditionalInfo = includeAdditionalInfo
-                ? new ServalBuildAdditionalInfo
-                {
-                    BuildId = translationBuild.Id,
-                    CorporaIds = translationBuild.Pretranslate?.Select(p => p.Corpus.Id),
-                    DateFinished = translationBuild.DateFinished,
-                    Step = translationBuild.Step,
-                    TranslationEngineId = translationBuild.Engine.Id,
-                }
-                : null,
+            AdditionalInfo = new ServalBuildAdditionalInfo
+            {
+                BuildId = translationBuild.Id,
+                CorporaIds = translationBuild.Pretranslate?.Select(p => p.Corpus.Id),
+                DateFinished = translationBuild.DateFinished,
+                Step = translationBuild.Step,
+                TranslationEngineId = translationBuild.Engine.Id,
+            }
         };
 
     private static EngineDto CreateDto(Engine engine) =>

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -479,6 +479,10 @@ public class MachineApiService : IMachineApiService
                 {
                     State = BuildStateFaulted,
                     Message = projectSecret.ServalData.PreTranslationErrorMessage,
+                    AdditionalInfo = new ServalBuildAdditionalInfo
+                    {
+                        TranslationEngineId = projectSecret.ServalData.PreTranslationEngineId ?? string.Empty,
+                    },
                 };
             }
 
@@ -495,6 +499,10 @@ public class MachineApiService : IMachineApiService
                 {
                     State = BuildStateFaulted,
                     Message = "The build failed to upload to the server.",
+                    AdditionalInfo = new ServalBuildAdditionalInfo
+                    {
+                        TranslationEngineId = projectSecret.ServalData.PreTranslationEngineId ?? string.Empty,
+                    },
                 };
             }
 
@@ -503,6 +511,10 @@ public class MachineApiService : IMachineApiService
             {
                 State = BuildStateQueued,
                 Message = "The build is being uploaded to the server.",
+                AdditionalInfo = new ServalBuildAdditionalInfo
+                {
+                    TranslationEngineId = projectSecret.ServalData?.PreTranslationEngineId ?? string.Empty,
+                },
             };
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -294,7 +294,8 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService.Received(1).GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None);
+        await env.MachineApiService.Received(1)
+            .GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 using Polly.CircuitBreaker;
 using Serval.Client;
 using SIL.Machine.WebApi;
-using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
@@ -102,7 +101,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -118,31 +117,11 @@ public class MachineApiControllerTests
     }
 
     [Test]
-    public async Task GetBuildAsync_IncludesAdditionalInfoForSystemAdmin()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
-
-        // SUT
-        await env.Controller.GetBuildAsync(
-            Project01,
-            Build01,
-            minRevision: null,
-            preTranslate: false,
-            CancellationToken.None
-        );
-
-        await env.MachineApiService.Received(1)
-            .GetBuildAsync(User01, Project01, Build01, null, false, true, CancellationToken.None);
-    }
-
-    [Test]
     public async Task GetBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -164,7 +143,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -184,7 +163,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -204,7 +183,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -240,9 +219,9 @@ public class MachineApiControllerTests
         await env.MachineApiService.Received(1)
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService.DidNotReceiveWithAnyArgs()
-            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
         await env.MachineApiService.DidNotReceiveWithAnyArgs()
-            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
     }
 
     [Test]
@@ -250,7 +229,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -266,9 +245,9 @@ public class MachineApiControllerTests
         await env.MachineApiService.Received(1)
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService.Received(1)
-            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
         await env.MachineApiService.DidNotReceiveWithAnyArgs()
-            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
     }
 
     [Test]
@@ -276,7 +255,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -292,9 +271,9 @@ public class MachineApiControllerTests
         await env.MachineApiService.DidNotReceiveWithAnyArgs()
             .GetPreTranslationQueuedStateAsync(User01, Project01, CancellationToken.None);
         await env.MachineApiService.DidNotReceiveWithAnyArgs()
-            .GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, true, CancellationToken.None);
         await env.MachineApiService.Received(1)
-            .GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None);
+            .GetBuildAsync(User01, Project01, Build01, null, true, CancellationToken.None);
     }
 
     [Test]
@@ -302,7 +281,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -315,28 +294,7 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService.Received(1)
-            .GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None);
-    }
-
-    [Test]
-    public async Task GetBuildAsync_NoBuildIdIncludesAdditionalInfoForSystemAdmin()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
-
-        // SUT
-        await env.Controller.GetBuildAsync(
-            Project01,
-            buildId: null,
-            minRevision: null,
-            preTranslate: false,
-            CancellationToken.None
-        );
-
-        await env.MachineApiService.Received(1)
-            .GetCurrentBuildAsync(User01, Project01, null, false, true, CancellationToken.None);
+        await env.MachineApiService.Received(1).GetBuildAsync(User01, Project01, Build01, null, CancellationToken.None);
     }
 
     [Test]
@@ -344,7 +302,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -364,7 +322,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -386,7 +344,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -406,7 +364,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -426,7 +384,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -446,7 +404,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -460,7 +418,7 @@ public class MachineApiControllerTests
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
         await env.MachineApiService.Received(1)
-            .GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None);
+            .GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None);
     }
 
     [Test]
@@ -522,30 +480,11 @@ public class MachineApiControllerTests
     }
 
     [Test]
-    public async Task GetLastCompletedPreTranslationBuildAsync_IncludesAdditionalInfoForSystemAdmin()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
-
-        // SUT
-        await env.Controller.GetLastCompletedPreTranslationBuildAsync(Project01, CancellationToken.None);
-
-        await env.MachineApiService.Received(1)
-            .GetLastCompletedPreTranslationBuildAsync(
-                User01,
-                Project01,
-                includeAdditionalInfo: true,
-                CancellationToken.None
-            );
-    }
-
-    [Test]
     public async Task GetLastCompletedPreTranslationBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -564,7 +503,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -581,7 +520,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -598,7 +537,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -615,7 +554,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
@@ -627,12 +566,7 @@ public class MachineApiControllerTests
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
 
         await env.MachineApiService.Received(1)
-            .GetLastCompletedPreTranslationBuildAsync(
-                User01,
-                Project01,
-                includeAdditionalInfo: false,
-                CancellationToken.None
-            );
+            .GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
     }
 
     [Test]
@@ -825,25 +759,11 @@ public class MachineApiControllerTests
     }
 
     [Test]
-    public async Task StartBuildAsync_IncludesAdditionalInfoForSystemAdmin()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.UserAccessor.SystemRole.Returns(SystemRole.SystemAdmin);
-
-        // SUT
-        await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
-
-        await env.MachineApiService.Received(1)
-            .StartBuildAsync(User01, Project01, includeAdditionalInfo: true, CancellationToken.None);
-    }
-
-    [Test]
     public async Task StartBuildAsync_MachineApiDown()
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -859,7 +779,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -873,7 +793,7 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -887,15 +807,14 @@ public class MachineApiControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
-        await env.MachineApiService.Received(1)
-            .StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        await env.MachineApiService.Received(1).StartBuildAsync(User01, Project01, CancellationToken.None);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiV2ControllerTests.cs
@@ -28,7 +28,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -47,7 +47,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -68,7 +68,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -87,7 +87,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -106,7 +106,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -125,7 +125,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -144,7 +144,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException("Entity Deleted"));
 
         // SUT
@@ -163,7 +163,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -184,7 +184,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult<ServalBuildDto>(null));
 
         // SUT
@@ -203,7 +203,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -222,7 +222,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -241,7 +241,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
+        env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT
@@ -392,7 +392,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new BrokenCircuitException());
 
         // SUT
@@ -408,7 +408,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new ForbiddenException());
 
         // SUT
@@ -422,7 +422,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
@@ -436,7 +436,7 @@ public class MachineApiV2ControllerTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        env.MachineApiService.StartBuildAsync(User01, Project01, false, CancellationToken.None)
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
             .Returns(Task.FromResult(new ServalBuildDto { Engine = new ResourceDto() }));
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -156,7 +156,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -183,7 +182,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: 1,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -208,7 +206,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -230,7 +227,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -254,7 +250,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -275,7 +270,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -296,7 +290,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -318,7 +311,6 @@ public class MachineApiServiceTests
                     Build01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -356,7 +348,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -410,7 +401,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -423,7 +413,7 @@ public class MachineApiServiceTests
         Assert.AreEqual(MachineApi.GetBuildHref(Project01, Build01), actual.Href);
         Assert.AreEqual(Project01, actual.Engine.Id);
         Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
-        Assert.IsNull(actual.AdditionalInfo);
+        Assert.NotNull(actual.AdditionalInfo);
     }
 
     [Test]
@@ -485,7 +475,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: true,
             CancellationToken.None
         );
 
@@ -530,7 +519,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: true,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -553,7 +541,6 @@ public class MachineApiServiceTests
             Build01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -577,7 +564,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -603,7 +589,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: 1,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -627,7 +612,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -648,7 +632,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -671,7 +654,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -691,7 +673,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -711,7 +692,6 @@ public class MachineApiServiceTests
                     "invalid_project_id",
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -734,7 +714,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -755,7 +734,6 @@ public class MachineApiServiceTests
                     Project03,
                     minRevision: null,
                     preTranslate: false,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -792,7 +770,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -844,7 +821,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -902,7 +878,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: true,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -940,7 +915,6 @@ public class MachineApiServiceTests
                     Project01,
                     minRevision: null,
                     preTranslate: true,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -964,7 +938,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: true,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -986,7 +959,6 @@ public class MachineApiServiceTests
             Project01,
             minRevision: null,
             preTranslate: false,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1252,7 +1224,6 @@ public class MachineApiServiceTests
         ServalBuildDto? actual = await env.Service.GetLastCompletedPreTranslationBuildAsync(
             User01,
             Project01,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1271,7 +1242,6 @@ public class MachineApiServiceTests
                 env.Service.GetLastCompletedPreTranslationBuildAsync(
                     "invalid_user_id",
                     Project01,
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -1289,7 +1259,6 @@ public class MachineApiServiceTests
                 env.Service.GetLastCompletedPreTranslationBuildAsync(
                     User01,
                     "invalid_project_id",
-                    includeAdditionalInfo: false,
                     CancellationToken.None
                 )
         );
@@ -1304,13 +1273,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () =>
-                env.Service.GetLastCompletedPreTranslationBuildAsync(
-                    User01,
-                    Project01,
-                    includeAdditionalInfo: false,
-                    CancellationToken.None
-                )
+            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
         );
     }
 
@@ -1322,13 +1285,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () =>
-                env.Service.GetLastCompletedPreTranslationBuildAsync(
-                    User01,
-                    Project03,
-                    includeAdditionalInfo: false,
-                    CancellationToken.None
-                )
+            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project03, CancellationToken.None)
         );
     }
 
@@ -1341,13 +1298,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<BrokenCircuitException>(
-            () =>
-                env.Service.GetLastCompletedPreTranslationBuildAsync(
-                    User01,
-                    Project01,
-                    includeAdditionalInfo: false,
-                    CancellationToken.None
-                )
+            () => env.Service.GetLastCompletedPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
         );
     }
 
@@ -1385,7 +1336,6 @@ public class MachineApiServiceTests
         ServalBuildDto? actual = await env.Service.GetLastCompletedPreTranslationBuildAsync(
             User01,
             Project01,
-            includeAdditionalInfo: false,
             CancellationToken.None
         );
 
@@ -1796,7 +1746,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
         );
     }
 
@@ -1808,13 +1758,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(
-            () =>
-                env.Service.StartBuildAsync(
-                    "invalid_user_id",
-                    Project01,
-                    includeAdditionalInfo: false,
-                    CancellationToken.None
-                )
+            () => env.Service.StartBuildAsync("invalid_user_id", Project01, CancellationToken.None)
         );
     }
 
@@ -1826,13 +1770,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () =>
-                env.Service.StartBuildAsync(
-                    User01,
-                    "invalid_project_id",
-                    includeAdditionalInfo: false,
-                    CancellationToken.None
-                )
+            () => env.Service.StartBuildAsync(User01, "invalid_project_id", CancellationToken.None)
         );
     }
 
@@ -1847,7 +1785,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
         );
     }
 
@@ -1885,7 +1823,7 @@ public class MachineApiServiceTests
             .Returns(Task.FromResult(false));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         await env.MachineProjectService.Received(1)
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
@@ -1907,7 +1845,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(true));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         await env.MachineProjectService.DidNotReceiveWithAnyArgs()
             .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
@@ -1942,7 +1880,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
         // SUT
-        await env.Service.StartBuildAsync(User01, Project03, includeAdditionalInfo: false, CancellationToken.None);
+        await env.Service.StartBuildAsync(User01, Project03, CancellationToken.None);
 
         await env.MachineProjectService.Received(1)
             .AddProjectAsync(User01, Project03, preTranslate: false, CancellationToken.None);
@@ -1957,7 +1895,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.StartBuildAsync(User01, Project03, includeAdditionalInfo: false, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project03, CancellationToken.None)
         );
     }
 
@@ -1976,7 +1914,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<BrokenCircuitException>(
-            () => env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None)
+            () => env.Service.StartBuildAsync(User01, Project01, CancellationToken.None)
         );
     }
 
@@ -1994,7 +1932,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<ServalApiException>());
     }
@@ -2013,7 +1951,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
     }
@@ -2044,12 +1982,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.Serval).Returns(Task.FromResult(false));
 
         // SUT
-        ServalBuildDto actual = await env.Service.StartBuildAsync(
-            User01,
-            Project01,
-            includeAdditionalInfo: false,
-            CancellationToken.None
-        );
+        ServalBuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         Assert.AreEqual(message, actual.Message);
         Assert.AreEqual(percentCompleted, actual.PercentCompleted);
@@ -2093,12 +2026,7 @@ public class MachineApiServiceTests
         env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
 
         // SUT
-        ServalBuildDto actual = await env.Service.StartBuildAsync(
-            User01,
-            Project01,
-            includeAdditionalInfo: false,
-            CancellationToken.None
-        );
+        ServalBuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         await env.MachineProjectService.Received(1)
             .SyncProjectCorporaAsync(
@@ -2131,7 +2059,7 @@ public class MachineApiServiceTests
         env.EngineService.StartBuildAsync(TranslationEngine01).Returns(Task.FromResult(new Build()));
 
         // SUT
-        _ = await env.Service.StartBuildAsync(User01, Project01, includeAdditionalInfo: false, CancellationToken.None);
+        _ = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
         await env.EngineService.Received(1).StartBuildAsync(TranslationEngine01);
         await env.MachineProjectService.Received(1)


### PR DESCRIPTION
It was decided that when translation generation failed (which may be more often at the beginning) we should show minimal details of the failure to the user. When a user decides to contact our team, if they included a screenshot, the details of the build will be easily included and we will be able to more quickly troubleshoot the issue.

![Error translation generation](https://github.com/sillsdev/web-xforge/assets/17931130/4251dfc0-d6b3-4ba5-91b4-019e78403eb2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2249)
<!-- Reviewable:end -->
