### PR TITLE
SF-2410 Allow user selection of sending just verse segments or all segments

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
@@ -21,7 +21,8 @@ function testProjectProfile(ordinal: number): SFProjectProfile {
       draftConfig: {
         alternateTrainingSourceEnabled: false,
         lastSelectedTrainingBooks: [],
-        lastSelectedTranslationBooks: []
+        lastSelectedTranslationBooks: [],
+        sendAllSegments: false
       }
     },
     checkingConfig: {

--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -32,6 +32,7 @@ export interface DraftConfig {
   alternateTrainingSource?: TranslateSource;
   lastSelectedTrainingBooks: number[];
   lastSelectedTranslationBooks: number[];
+  sendAllSegments: boolean;
   servalConfig?: string;
 }
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -352,7 +352,7 @@ describe('version 12', () => {
         translateConfig: { draftConfig: {} }
       });
       let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
-      expect(projectDoc.data.translateConfig.draftConfig.sendAllSegments).not.toBeDefined();
+      expect(projectDoc.data.translateConfig.draftConfig.sendAllSegments).toBeUndefined();
 
       await env.server.migrateIfNecessary();
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -343,6 +343,23 @@ describe('version 12', () => {
       expect(projectDoc.data.noteTags[0].creatorResolve).toBe(true);
     });
   });
+
+  describe('version 16', () => {
+    it('adds sendAllSegments to draftConfig', async () => {
+      const env = new TestEnvironment(15);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {
+        translateConfig: { draftConfig: {} }
+      });
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.sendAllSegments).not.toBeDefined();
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.sendAllSegments).toBe(false);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -269,6 +269,19 @@ class SFProjectMigration15 extends DocMigration {
   }
 }
 
+class SFProjectMigration16 extends DocMigration {
+  static readonly VERSION = 16;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    if (doc.data.translateConfig.draftConfig.sendAllSegments == null) {
+      ops.push({ p: ['translateConfig', 'draftConfig', 'sendAllSegments'], oi: false });
+    }
+
+    await submitMigrationOp(SFProjectMigration16.VERSION, doc, ops);
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration1,
   SFProjectMigration2,
@@ -284,5 +297,6 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration12,
   SFProjectMigration13,
   SFProjectMigration14,
-  SFProjectMigration15
+  SFProjectMigration15,
+  SFProjectMigration16
 ];

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -195,6 +195,9 @@ export class SFProjectService extends ProjectService<SFProject> {
                   bsonType: 'int'
                 }
               },
+              sendAllSegments: {
+                bsonType: 'bool'
+              },
               servalConfig: {
                 bsonType: 'string'
               }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
@@ -12,6 +12,7 @@ export interface SFProjectSettings {
   alternateSourceParatextId?: string | null;
   alternateTrainingSourceEnabled?: boolean | null;
   alternateTrainingSourceParatextId?: string | null;
+  sendAllSegments?: boolean | null;
   servalConfig?: string | null;
 
   checkingEnabled?: boolean | null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -156,6 +156,19 @@
                     id="alternate-training-source-status"
                   ></app-write-status>
                 </div>
+                <div class="tool-setting">
+                  <div class="tool-setting-field checkbox-field">
+                    <mat-checkbox formControlName="sendAllSegments" id="checkbox-pre-translation-send-all-segments">{{
+                      t("pre_translation_send_all_segments")
+                    }}</mat-checkbox>
+                    <app-info [text]="t('pre_translation_send_all_segments_info')"></app-info>
+                    <app-write-status
+                      [state]="getControlState('sendAllSegments')"
+                      [formGroup]="form"
+                      id="pre-translation-send-all-segments-status"
+                    ></app-write-status>
+                  </div>
+                </div>
               </ng-container>
               <ng-container *ngIf="canUpdateServalConfig">
                 <p

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -456,6 +456,42 @@ describe('SettingsComponent', () => {
       }));
     });
 
+    describe('Send All Segments', () => {
+      it('should update when the send all segments checkbox is ticked', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        env.wait();
+        expect(env.statusDone(env.sendAllSegmentsStatus)).toBeNull();
+        expect(env.inputElement(env.sendAllSegmentsCheckbox).checked).toBe(false);
+        env.clickElement(env.inputElement(env.sendAllSegmentsCheckbox));
+        expect(env.inputElement(env.sendAllSegmentsCheckbox).checked).toBe(true);
+        env.wait();
+
+        expect(env.statusDone(env.sendAllSegmentsStatus)).not.toBeNull();
+      }));
+
+      it('should update when the send all segments checkbox is unticked', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: true
+          },
+          preTranslate: true
+        });
+        env.wait();
+        expect(env.statusDone(env.sendAllSegmentsStatus)).toBeNull();
+        expect(env.inputElement(env.sendAllSegmentsCheckbox).checked).toBe(true);
+        env.clickElement(env.inputElement(env.sendAllSegmentsCheckbox));
+        expect(env.inputElement(env.sendAllSegmentsCheckbox).checked).toBe(false);
+        env.wait();
+
+        expect(env.statusDone(env.sendAllSegmentsStatus)).not.toBeNull();
+      }));
+    });
+
     describe('Serval Config TextArea', () => {
       it('should not display for non-system administrators', fakeAsync(() => {
         const env = new TestEnvironment();
@@ -1151,6 +1187,14 @@ class TestEnvironment {
     return (this.alternateTrainingSourceSelectComponent.projects || []).concat(
       this.alternateTrainingSourceSelectComponent.resources || []
     );
+  }
+
+  get sendAllSegmentsCheckbox(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#checkbox-pre-translation-send-all-segments'));
+  }
+
+  get sendAllSegmentsStatus(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#pre-translation-send-all-segments-status'));
   }
 
   makeProjectHaveTextAudio(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -223,7 +223,8 @@ describe('SettingsComponent', () => {
             },
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
-            alternateTrainingSourceEnabled: false
+            alternateTrainingSourceEnabled: false,
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -265,7 +266,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -290,7 +292,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -315,7 +318,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           }
         });
         env.wait();
@@ -331,7 +335,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -362,7 +367,8 @@ describe('SettingsComponent', () => {
             },
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
-            alternateTrainingSourceEnabled: true
+            alternateTrainingSourceEnabled: true,
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -395,7 +401,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -423,7 +430,8 @@ describe('SettingsComponent', () => {
             },
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
-            alternateTrainingSourceEnabled: true
+            alternateTrainingSourceEnabled: true,
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -464,7 +472,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -500,7 +509,8 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
-            lastSelectedTranslationBooks: []
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false
           }
         });
         when(mockedAuthService.currentUserRole).thenReturn(SystemRole.SystemAdmin);
@@ -538,7 +548,8 @@ describe('SettingsComponent', () => {
             servalConfig: '{}',
             lastSelectedTrainingBooks: [],
             lastSelectedTranslationBooks: [],
-            alternateTrainingSourceEnabled: false
+            alternateTrainingSourceEnabled: false,
+            sendAllSegments: false
           },
           preTranslate: true
         });
@@ -1233,7 +1244,8 @@ class TestEnvironment {
       draftConfig: {
         lastSelectedTrainingBooks: [],
         lastSelectedTranslationBooks: [],
-        alternateTrainingSourceEnabled: false
+        alternateTrainingSourceEnabled: false,
+        sendAllSegments: false
       }
     },
     checkingConfig: Partial<CheckingConfig> = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -37,6 +37,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   alternateSourceParatextId = new FormControl<string | undefined>(undefined);
   alternateTrainingSourceEnabled = new FormControl(false);
   alternateTrainingSourceParatextId = new FormControl<string | undefined>(undefined);
+  sendAllSegments = new FormControl(false);
   servalConfig = new FormControl<string | undefined>(undefined);
   translateShareEnabled = new FormControl(false);
   checkingEnabled = new FormControl(false);
@@ -54,6 +55,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     alternateSourceParatextId: this.alternateSourceParatextId,
     alternateTrainingSourceEnabled: this.alternateTrainingSourceEnabled,
     alternateTrainingSourceParatextId: this.alternateTrainingSourceParatextId,
+    sendAllSegments: this.sendAllSegments,
     servalConfig: this.servalConfig,
     translateShareEnabled: this.translateShareEnabled,
     checkingEnabled: this.checkingEnabled,
@@ -344,6 +346,10 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       this.updateSetting(newValue, 'alternateTrainingSourceEnabled');
     }
 
+    if (this.settingChanged(newValue, 'sendAllSegments')) {
+      this.updateSetting(newValue, 'sendAllSegments');
+    }
+
     // Check if the pre-translation alternate training source project needs to be updated
     if (this.settingChanged(newValue, 'alternateTrainingSourceParatextId')) {
       const settings: SFProjectSettings = {
@@ -418,6 +424,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       alternateTrainingSourceEnabled: this.projectDoc.data.translateConfig.draftConfig.alternateTrainingSourceEnabled,
       alternateTrainingSourceParatextId:
         this.projectDoc.data.translateConfig.draftConfig?.alternateTrainingSource?.paratextId,
+      sendAllSegments: this.projectDoc.data.translateConfig.draftConfig.sendAllSegments,
       servalConfig: this.projectDoc.data.translateConfig.draftConfig.servalConfig,
       translateShareEnabled: !!this.projectDoc.data.translateConfig.shareEnabled,
       checkingEnabled: this.projectDoc.data.checkingConfig.checkingEnabled,
@@ -450,6 +457,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     this.controlStates.set('alternateSourceParatextId', ElementState.InSync);
     this.controlStates.set('alternateTrainingSourceEnabled', ElementState.InSync);
     this.controlStates.set('alternateTrainingSourceParatextId', ElementState.InSync);
+    this.controlStates.set('sendAllSegments', ElementState.InSync);
     this.controlStates.set('servalConfig', ElementState.InSync);
     this.controlStates.set('translateShareEnabled', ElementState.InSync);
     this.controlStates.set('checkingEnabled', ElementState.InSync);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -151,8 +151,8 @@ describe('DraftGenerationService', () => {
       const preTranslationData = {
         data: {
           preTranslations: [
-            { reference: 'JHN 3:16', translation: 'For God so loved the world' },
-            { reference: 'JHN 1:1', translation: 'In the beginning was the Word' }
+            { reference: 'verse_3_16', translation: 'For God so loved the world' },
+            { reference: 'verse_1_1', translation: 'In the beginning was the Word' }
           ]
         }
       };
@@ -182,30 +182,6 @@ describe('DraftGenerationService', () => {
       httpClient.get = jasmine.createSpy().and.returnValue(of(preTranslationData));
       service.getGeneratedDraft(projectId, book, chapter).subscribe(result => {
         expect(result).toEqual({});
-        expect(httpClient.get).toHaveBeenCalledWith(
-          `translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}`
-        );
-        done();
-      });
-    });
-
-    it('should handle invalid verse references', done => {
-      const book = 43;
-      const chapter = 3;
-      const preTranslationData = {
-        data: {
-          preTranslations: [
-            { reference: 'Invalid Reference', translation: 'This should be ignored' },
-            { reference: 'JHN 3:16', translation: 'For God so loved the world' }
-          ]
-        }
-      };
-
-      httpClient.get = jasmine.createSpy().and.returnValue(of(preTranslationData));
-      service.getGeneratedDraft(projectId, book, chapter).subscribe(result => {
-        expect(result).toEqual({
-          verse_3_16: 'For God so loved the world '
-        });
         expect(httpClient.get).toHaveBeenCalledWith(
           `translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}`
         );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@angular/core';
-import { VerseRef } from '@sillsdev/scripture';
 import { Observable, of, throwError, timer, EMPTY } from 'rxjs';
 import { catchError, distinct, map, shareReplay, switchMap, takeWhile } from 'rxjs/operators';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -166,17 +165,11 @@ export class DraftGenerationService {
     const draftSegmentMap: DraftSegmentMap = {};
 
     for (let preTranslation of preTranslations) {
-      const { success, verseRef } = VerseRef.tryParse(preTranslation.reference);
-
-      if (success) {
-        const segmentRef: string = `verse_${verseRef.chapter}_${verseRef.verse}`;
-
-        // Ensure single space at end to not crowd a following verse number.
-        // TODO: Make this more sophisticated to check next segment for `{ insert: { verse: {} } }` before adding space?
-        // TODO: ... and investigate if there is a better way to display a space before the next verse marker
-        // TODO: ... without counting the space as part of the verse text.
-        draftSegmentMap[segmentRef] = preTranslation.translation.trimEnd() + ' ';
-      }
+      // Ensure single space at end to not crowd a following verse number.
+      // TODO: Make this more sophisticated to check next segment for `{ insert: { verse: {} } }` before adding space?
+      // TODO: ... and investigate if there is a better way to display a space before the next verse marker
+      // TODO: ... without counting the space as part of the verse text.
+      draftSegmentMap[preTranslation.reference] = preTranslation.translation.trimEnd() + ' ';
     }
 
     return draftSegmentMap;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -382,6 +382,8 @@
     "pre_translation_alternate_training_source_info": "Selecting a separate translation for training, such as a back translation, can improve drafting quality.",
     "pre_translation_alternate_training_source_text_placeholder": "Alternate training source text (optional)",
     "pre_translation_drafting_description": "Configure options for generating translation drafts.",
+    "pre_translation_send_all_segments": "Pre-translate headings and non-verse material",
+    "pre_translation_send_all_segments_info": "For these to be pre-translated, your translation structure must match your source exactly.",
     "pre_translation_source_text_placeholder": "Alternate drafting source text (optional)",
     "see_others_answers_and_comments": "Allow checkers to see each other's answers and comments",
     "select_project_or_resource": "Select the Paratext project or Digital Bible Library resource that your project is based on. If your project is based on a Paratext project, it's best to set it up as a daughter project in Paratext.",

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -122,6 +122,7 @@ public class SFProjectsRpcController : RpcControllerBase
                     { "AlternateSourceParatextId", settings?.AlternateSourceParatextId },
                     { "AlternateTrainingSourceEnabled", settings?.AlternateTrainingSourceEnabled?.ToString() },
                     { "AlternateTrainingSourceParatextId", settings?.AlternateTrainingSourceParatextId },
+                    { "SendAllSegments", settings?.SendAllSegments?.ToString() },
                     { "CheckingEnabled", settings?.CheckingEnabled?.ToString() },
                     { "CheckingShareEnabled", settings?.CheckingShareEnabled?.ToString() },
                     { "TranslateShareEnabled", settings?.TranslateShareEnabled?.ToString() },

--- a/src/SIL.XForge.Scripture/Models/DraftConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftConfig.cs
@@ -9,5 +9,6 @@ public class DraftConfig
     public TranslateSource? AlternateTrainingSource { get; set; }
     public IList<int> LastSelectedTrainingBooks { get; set; } = new List<int>();
     public IList<int> LastSelectedTranslationBooks { get; set; } = new List<int>();
+    public bool SendAllSegments { get; set; }
     public string? ServalConfig { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
@@ -16,6 +16,7 @@ public class SFProjectSettings
     public string? AlternateSourceParatextId { get; set; }
     public bool? AlternateTrainingSourceEnabled { get; set; }
     public string? AlternateTrainingSourceParatextId { get; set; }
+    public bool? SendAllSegments { get; set; }
 
     // checking settings
     public bool? CheckingEnabled { get; set; }

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -130,7 +130,7 @@ public class PreTranslationService : IPreTranslationService
             // Parse the reference for non-verse segments, if we sent them for pre-translation
             if (project.TranslateConfig.DraftConfig.SendAllSegments)
             {
-                // The reference is in the format abc_001 or abc_001_001. Convert it to the format abc_1 or abc_1_1
+                // The reference is in the format abc_001, abc_001_001, etc. Convert it to the format abc_1 or abc_1_1
                 reference = string.Join(
                     '_',
                     referenceParts.Select(part => int.TryParse(part, out int number) ? number.ToString() : part)

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -8,22 +8,27 @@ using Serval.Client;
 using SIL.Machine.Corpora;
 using SIL.Scripture;
 using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
+using SIL.XForge.Utils;
 
 namespace SIL.XForge.Scripture.Services;
 
 public class PreTranslationService : IPreTranslationService
 {
     private readonly IRepository<SFProjectSecret> _projectSecrets;
+    private readonly IRealtimeService _realtimeService;
     private readonly ITranslationEnginesClient _translationEnginesClient;
 
     public PreTranslationService(
         IRepository<SFProjectSecret> projectSecrets,
+        IRealtimeService realtimeService,
         ITranslationEnginesClient translationEnginesClient
     )
     {
         _projectSecrets = projectSecrets;
+        _realtimeService = realtimeService;
         _translationEnginesClient = translationEnginesClient;
     }
 
@@ -43,6 +48,13 @@ public class PreTranslationService : IPreTranslationService
         if (!(await _projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
             throw new DataNotFoundException("The project secret cannot be found.");
+        }
+
+        // Load the project from the realtime service
+        Attempt<SFProject> attempt = await _realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
+        if (!attempt.TryResult(out SFProject project))
+        {
+            throw new DataNotFoundException("The project does not exist.");
         }
 
         // Ensure we have the parameters to retrieve the pre-translation
@@ -92,25 +104,42 @@ public class PreTranslationService : IPreTranslationService
             }
 
             // Ensure this is for a verse - we do not support headings and metadata
-            if (!reference.StartsWith("verse_"))
-            {
-                continue;
-            }
-
             referenceParts = reference.Split('_', StringSplitOptions.RemoveEmptyEntries);
-            if (
-                referenceParts.Length < 3
-                || !int.TryParse(referenceParts[1], out int refChapterNum)
-                || refChapterNum != chapterNum
-            )
+            if (reference.StartsWith("verse_"))
+            {
+                // The reference is in the form verse_001_001 or verse_001_001_001
+                if (
+                    referenceParts.Length < 3
+                    || !int.TryParse(referenceParts[1], out int refChapterNum)
+                    || refChapterNum != chapterNum
+                )
+                {
+                    continue;
+                }
+
+                // Get the reference in the form verse_1_1, if we did not send all segments
+                // This will allow us to combine multiple paragraphs or poetry lines in the same verse
+                if (!project.TranslateConfig.DraftConfig.SendAllSegments)
+                {
+                    string verse = referenceParts[2];
+                    VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
+                    reference = $"verse_{verseRef.ChapterNum}_{verseRef.Verse}";
+                }
+            }
+
+            // Parse the reference for non-verse segments, if we sent them for pre-translation
+            if (project.TranslateConfig.DraftConfig.SendAllSegments)
+            {
+                // The reference is in the format abc_001 or abc_001_001. Convert it to the format abc_1 or abc_1_1
+                reference = string.Join(
+                    '_',
+                    referenceParts.Select(part => int.TryParse(part, out int number) ? number.ToString() : part)
+                );
+            }
+            else if (!reference.StartsWith("verse_"))
             {
                 continue;
             }
-
-            // Get the reference in the form MAT 1:2
-            string verse = referenceParts[2];
-            VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
-            reference = verseRef.Text;
 
             // Build the translation string
             StringBuilder sb = new StringBuilder();
@@ -135,11 +164,13 @@ public class PreTranslationService : IPreTranslationService
             // Add the pre-translation, or update if this is a segment of it
             if (preTranslations.Any(p => p.Reference == reference))
             {
-                preTranslations.First(p => p.Reference == reference).Translation += " " + translation;
+                preTranslations.First(p => p.Reference == reference).Translation += translation.TrimEnd() + " ";
             }
             else
             {
-                preTranslations.Add(new PreTranslation { Reference = reference, Translation = translation });
+                preTranslations.Add(
+                    new PreTranslation { Reference = reference, Translation = translation.TrimEnd() + " " }
+                );
             }
         }
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -366,6 +366,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 alternateTrainingSource,
                 unsetAlternateTrainingSourceProject
             );
+            UpdateSetting(op, p => p.TranslateConfig.DraftConfig.SendAllSegments, settings.SendAllSegments);
 
             UpdateSetting(op, p => p.CheckingConfig.CheckingEnabled, settings.CheckingEnabled);
             UpdateSetting(op, p => p.CheckingConfig.UsersSeeEachOthersResponses, settings.UsersSeeEachOthersResponses);

--- a/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTextCorpusFactory.cs
@@ -145,6 +145,7 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
                 // If we are not training a book, the segments in it must be empty
                 bool doNotSendSegmentText =
                     preTranslate && type == TextCorpusType.Target && !buildConfig.TrainingBooks.Contains(text.BookNum);
+                bool sendAllSegments = preTranslate && project.TranslateConfig.DraftConfig.SendAllSegments;
                 foreach (Chapter chapter in text.Chapters)
                 {
                     string id = TextData.GetTextDocId(textCorpusProjectId, text.BookNum, chapter.Number);
@@ -157,8 +158,9 @@ public class SFTextCorpusFactory : ISFTextCorpusFactory, ITextCorpusFactory
                                 projectId,
                                 text.BookNum,
                                 chapter.Number,
-                                preTranslate,
+                                includeBlankSegments: preTranslate,
                                 doNotSendSegmentText,
+                                sendAllSegments,
                                 doc
                             )
                         );

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -6,7 +6,9 @@ using NSubstitute;
 using NUnit.Framework;
 using Serval.Client;
 using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Realtime;
 using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services;
@@ -41,7 +43,7 @@ public class PreTranslationServiceTests
                         new Pretranslation
                         {
                             TextId = "64_1",
-                            Refs = { "64_1:h_001" },
+                            Refs = { "64_1:mt1_001" },
                             Translation = "3 John",
                         },
                         new Pretranslation
@@ -75,11 +77,76 @@ public class PreTranslationServiceTests
             CancellationToken.None
         );
         Assert.AreEqual(1, actual.Length);
-        Assert.AreEqual("3JN 1:1", actual.First().Reference);
+        Assert.AreEqual("verse_1_1", actual.First().Reference);
         Assert.AreEqual(
-            "By the old man, To my dear friend Gaius, whom I love in the truth:",
+            "By the old man, To my dear friend Gaius, whom I love in the truth: ",
             actual.First().Translation
         );
+    }
+
+    [Test]
+    public async Task GetPreTranslationsAsync_AllowsSegmentedVersesAndHeadingsWhenSendAllSegmentsTrue()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(sendAllSegments: true);
+        const int bookNum = 64;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
+            .Returns(
+                Task.FromResult<IList<Pretranslation>>(
+                    new List<Pretranslation>
+                    {
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:mt1_001" },
+                            Translation = "3 John",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001" },
+                            Translation = "By the old man,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_001" },
+                            Translation = "To my dear friend Gaius,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_002" },
+                            Translation = "whom I love in the truth:",
+                        },
+                    }
+                )
+            );
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            bookNum,
+            chapterNum,
+            CancellationToken.None
+        );
+        Assert.AreEqual(4, actual.Length);
+        Assert.AreEqual("mt1_1", actual[0].Reference);
+        Assert.AreEqual("3 John ", actual[0].Translation);
+        Assert.AreEqual("verse_1_1", actual[1].Reference);
+        Assert.AreEqual("By the old man, ", actual[1].Translation);
+        Assert.AreEqual("verse_1_1_1", actual[2].Reference);
+        Assert.AreEqual("To my dear friend Gaius, ", actual[2].Translation);
+        Assert.AreEqual("verse_1_1_2", actual[3].Reference);
+        Assert.AreEqual("whom I love in the truth: ", actual[3].Translation);
     }
 
     [Test]
@@ -179,21 +246,21 @@ public class PreTranslationServiceTests
             CancellationToken.None
         );
         Assert.AreEqual(2, actual.Length);
-        Assert.AreEqual("MAT 1:1", actual.First().Reference);
+        Assert.AreEqual("verse_1_1", actual.First().Reference);
         Assert.AreEqual(
-            "The book of the birth of Jesus Christ, the son of David, the son of Abraham.",
+            "The book of the birth of Jesus Christ, the son of David, the son of Abraham. ",
             actual.First().Translation
         );
-        Assert.AreEqual("MAT 1:2", actual.Last().Reference);
+        Assert.AreEqual("verse_1_2", actual.Last().Reference);
         Assert.AreEqual(
-            "Abraham was the father of Isaac, Isaac was the father of James, and James was the father of Jude and his brethren.",
+            "Abraham was the father of Isaac, Isaac was the father of James, and James was the father of Jude and his brethren. ",
             actual.Last().Translation
         );
     }
 
     private class TestEnvironment
     {
-        public TestEnvironment()
+        public TestEnvironment(bool sendAllSegments = false)
         {
             var projectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]
@@ -220,8 +287,19 @@ public class PreTranslationServiceTests
                     new SFProjectSecret { Id = Project02 },
                 }
             );
+
+            var realtimeService = new SFMemoryRealtimeService();
+            SFProject[] sfProjects =
+            {
+                new SFProject
+                {
+                    Id = Project01,
+                    TranslateConfig = new TranslateConfig { DraftConfig = { SendAllSegments = sendAllSegments, }, },
+                },
+            };
+            realtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
-            Service = new PreTranslationService(projectSecrets, TranslationEnginesClient);
+            Service = new PreTranslationService(projectSecrets, realtimeService, TranslationEnginesClient);
         }
 
         public PreTranslationService Service { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFScriptureTextTests.cs
@@ -38,8 +38,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: false,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -77,8 +78,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: false,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -114,8 +116,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: false,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -139,8 +142,9 @@ public class SFScriptureTextTests
                     projectId,
                     bookNumber,
                     chapterNumber,
-                    preTranslate: false,
+                    includeBlankSegments: false,
                     doNotSendSegmentText: false,
+                    sendAllSegments: false,
                     doc: null
                 )
         );
@@ -168,15 +172,16 @@ public class SFScriptureTextTests
                     projectId,
                     bookNumber,
                     chapterNumber,
-                    preTranslate: false,
+                    includeBlankSegments: false,
                     doNotSendSegmentText: false,
+                    sendAllSegments: false,
                     doc
                 )
         );
     }
 
     [Test]
-    public void Create_ExcludeBlankSegmentsIfPreTranslateFalse()
+    public void Create_ExcludeBlankSegmentsIfIncludeBlankSegmentsFalse()
     {
         var doc = new BsonDocument
         {
@@ -200,8 +205,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: false,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -210,7 +216,7 @@ public class SFScriptureTextTests
     }
 
     [Test]
-    public void Create_IncludeBlankSegmentsIfPreTranslateTrue()
+    public void Create_IncludeBlankSegmentsIfIncludeBlankSegmentsTrue()
     {
         var doc = new BsonDocument
         {
@@ -234,8 +240,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: true,
+            includeBlankSegments: true,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -244,7 +251,7 @@ public class SFScriptureTextTests
     }
 
     [Test]
-    public void Create_IncludeNonScriptureSegmentsIfPreTranslateFalse()
+    public void Create_IncludeNonScriptureSegmentsIfSendAllSegmentsTrue()
     {
         var doc = new BsonDocument
         {
@@ -268,8 +275,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: false,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: true,
             doc
         );
 
@@ -278,7 +286,7 @@ public class SFScriptureTextTests
     }
 
     [Test]
-    public void Create_ExcludeNonScriptureSegmentsIfPreTranslateTrue()
+    public void Create_ExcludeNonScriptureSegmentsIfSendAllSegmentsFalse()
     {
         var doc = new BsonDocument
         {
@@ -302,8 +310,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: true,
+            includeBlankSegments: false,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -336,8 +345,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: true,
+            includeBlankSegments: true,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 
@@ -370,8 +380,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: true,
+            includeBlankSegments: true,
             doNotSendSegmentText: true,
+            sendAllSegments: false,
             doc
         );
 
@@ -405,8 +416,9 @@ public class SFScriptureTextTests
             projectId,
             bookNumber,
             chapterNumber,
-            preTranslate: true,
+            includeBlankSegments: true,
             doNotSendSegmentText: false,
+            sendAllSegments: false,
             doc
         );
 


### PR DESCRIPTION
We currently only send verse data to Serval. We have been requested to add support for translating headings as well, but given Serval's current constraints, we can only provide this when the source and target structure matches exactly.

This PR adds a checkbox to Settings that allows sending all segments to Serval, and when the pre-translation is complete, will provide pre-translation drafting of those headings and verse paragraphs and prose sections.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2251)
<!-- Reviewable:end -->
