### PR TITLE
Enable Serval support across all environments

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -59,7 +59,7 @@
     "TokenUrl": "https://languagetechnology.auth0.com/oauth/token"
   },
   "FeatureManagement": {
-    "Serval": false,
+    "Serval": true,
     "MachineInProcess": true,
     "UseEchoForPreTranslation": false
   }


### PR DESCRIPTION
This PR changes the default feature flag configuration to enable Serval support, to reflect that Serval should be on permanently now for every environment.

There is no need to push this to QA or Production immediately, as these environments already have Serval support enabled in their respective environment variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2252)
<!-- Reviewable:end -->
