### PR TITLE
Force Chromatic Rebuild for Storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -69,6 +69,8 @@ jobs:
           onlyChanged: true
           externals: |
             - '*.scss'
+          # Force a rebuild even if Chromatic thinks there are no changes
+          forceRebuild: true
       - name: Run Storybook tests
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run test-storybook -- --no-index-json
         env:


### PR DESCRIPTION
As storybook tests require the `storybookUrl` value from Chromatic, this PR forces Chromatic to rebuild, even if it thinks there are no changes.

For the reason behind this change, please see the "Publish to Chromatic" and "Run Storybook tests" sections of https://github.com/sillsdev/web-xforge/actions/runs/7277973553/job/19836485161

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2255)
<!-- Reviewable:end -->
