### PR TITLE
SF-2430 Make verse label consistent with highlighted verse

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -115,6 +115,35 @@ describe('ScriptureAudioComponent', () => {
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   }));
 
+  it('emits correct verse label when using timing data with gaps', fakeAsync(() => {
+    const env = new TestEnvironment({
+      timings: [
+        { textRef: '1', from: 0, to: 1 },
+        { textRef: '2', from: 2, to: 3 }
+      ]
+    });
+
+    env.audioPlayer.audio.currentTime = 1.5;
+    env.audioPlayer.audio.timeUpdated$.next();
+    env.wait();
+    expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
+  }));
+
+  it('emits correct verse label after timing data finishes', fakeAsync(() => {
+    const env = new TestEnvironment({
+      timings: [
+        { textRef: '1', from: 0, to: 1 },
+        { textRef: '2', from: 1, to: 2 },
+        { textRef: '', from: 2, to: 3 }
+      ]
+    });
+
+    env.audioPlayer.audio.currentTime = 3.5;
+    env.audioPlayer.audio.timeUpdated$.next();
+    env.wait();
+    expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
+  }));
+
   it('pauses and emits on close', fakeAsync(() => {
     const env = new TestEnvironment();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -115,7 +115,7 @@ describe('ScriptureAudioComponent', () => {
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   }));
 
-  it('emits correct verse label when using timing data with gaps', fakeAsync(() => {
+  it('emits the next verse label when in between verses', fakeAsync(() => {
     const env = new TestEnvironment({
       timings: [
         { textRef: '1', from: 0, to: 1 },
@@ -129,7 +129,7 @@ describe('ScriptureAudioComponent', () => {
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
   }));
 
-  it('emits correct verse label after timing data finishes', fakeAsync(() => {
+  it('emits the last verse label after timing data finishes', fakeAsync(() => {
     const env = new TestEnvironment({
       timings: [
         { textRef: '1', from: 0, to: 1 },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -239,7 +239,13 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
   }
 
   private getCurrentVerseStr(currentTime: number): string {
-    const index: number = this.getCurrentIndexInTimings(currentTime);
+    let index: number = this.getRefIndexInTimings(currentTime);
+
+    // If the index is -1 we are past the end of the timing data, in that case we should use the last valid entry
+    if (index === -1) {
+      index = this._timing.length - 1;
+    }
+
     for (let i = index; i >= 0; i--) {
       const audioRef: AudioTextRef | undefined = CheckingUtils.parseAudioRefByTime(this._timing, this._timing[i].from);
       if (audioRef != null) return audioRef.verseStr;


### PR DESCRIPTION
The ScriptureAudioPlayerComponent's verse label is inconsistent with the highlightActiveVerse functionality of the CheckingTextComponent in two scenarios:

1. If we are after the end of the timing data ScriptureAudioPlayerComponent will display that we are on verse 1 where CheckingTextComponent highlights the last verse in the timing data.
2. If we are in a gap between two entries in the timing data ScriptureAudioPlayerComponent will display that we are on verse 1 where CheckingTextComponent highlights the next verse.

This PR updates the ScriptureAudioPlayerComponent verse label to behave the same way as CheckingTextComponent's verse highlighting in those cases. 

Issue Replication Steps:

- Navigate to Community Checking > Manage Questions
- Add chapter audio using this audio file and this timing file
- Navigate to a question on the relevant chapter
- Note that between 2 and 5 seconds and after 6 seconds the verse label below the progress bar says that we are on verse 1

Acceptance Tests:

- Same as above but during the last step the verse should replicate the behavior of the verse highlighting i.e. verse 3 is displayed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2258)
<!-- Reviewable:end -->
