### PR TITLE
SF-2375 Upgrade legacy mat-tabs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -42,7 +42,7 @@
       </div>
       <div *ngIf="answerFormVisible">
         <form [formGroup]="answerForm" autocomplete="off" id="answer-form" appScrollIntoView>
-          <mat-tab-group #answerTabs animationDuration="0ms">
+          <mat-tab-group #answerTabs [mat-stretch-tabs]="false" animationDuration="0ms">
             <mat-tab>
               <ng-template matTabLabel>
                 <span class="tab-label">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -2,8 +2,7 @@
 @use '../checking-global-vars' as checking-vars;
 @use 'bootstrap/scss/mixins/breakpoints';
 
-:host ::ng-deep .mat-tab-label {
-  min-width: unset;
+:host ::ng-deep .mat-mdc-tab {
   padding-inline: 16px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2625,7 +2625,7 @@ class TestEnvironment {
   }
 
   get audioTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.mat-tab-label:nth-child(2)'));
+    return this.fixture.debugElement.query(By.css('.mat-mdc-tab:nth-child(2)'));
   }
 
   get removeAudioButton(): DebugElement {
@@ -2658,7 +2658,7 @@ class TestEnvironment {
   }
 
   get selectTextTab(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.mat-tab-label:nth-child(3)'));
+    return this.fixture.debugElement.query(By.css('.mat-mdc-tab:nth-child(3)'));
   }
 
   get selectVersesButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -61,7 +61,7 @@ app-notice {
 
 // Hide the tab headers
 mat-tab-group {
-  ::ng-deep .mat-tab-header {
+  ::ng-deep .mat-mdc-tab-header {
     display: none;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -4,7 +4,7 @@ import {
   MatLegacyDialogRef as MatDialogRef,
   MatLegacyDialogState as MatDialogState
 } from '@angular/material/legacy-dialog';
-import { MatLegacyTabGroup as MatTabGroup } from '@angular/material/legacy-tabs';
+import { MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { isEmpty } from 'lodash-es';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -15,7 +15,7 @@
       This is a non-standard way to use the component and causes a slight UI glitch where the
       tab text jumps a few pixels when navigating between tabs. -->
       <div class="tab-selector">
-        <mat-tab-group (selectedIndexChange)="currentTabIndex = $event">
+        <mat-tab-group [mat-stretch-tabs]="false" (selectedIndexChange)="currentTabIndex = $event">
           <mat-tab label="{{ t('all') }}"></mat-tab>
           <mat-tab label="{{ t('paratext_members') }}"></mat-tab>
           <mat-tab label="{{ t('project_guests') }}"></mat-tab>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -77,6 +77,6 @@ td.mat-cell:last-of-type {
 }
 
 // prevent undesirable flicker effect when changing tabs
-:host ::ng-deep .mat-tab-body-wrapper {
+:host ::ng-deep .mat-mdc-tab-body-wrapper {
   display: none;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -557,7 +557,7 @@ class TestEnvironment {
   }
 
   tabElementFromIndex(index: number): DebugElement {
-    return this.tabControl.queryAll(By.css('.mat-tab-label'))[index];
+    return this.tabControl.queryAll(By.css('.mat-mdc-tab'))[index];
   }
 
   clickElement(element: HTMLElement | DebugElement): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -142,6 +142,13 @@ $material-theme-accent-error: mat.define-light-theme(
 // @include mat.sort-theme($material-app-theme);
 // @include mat.tree-theme($material-app-theme);
 
+// Remove letter spacing (added by Material v15+) that may not work with some language scripts (e.g. Arabic).
+// TODO: Add to this list as needed as we migrate to Material v15+
+.mdc-tab,
+.mdc-button {
+  letter-spacing: initial;
+}
+
 .card-outline {
   @include mat.elevation(0);
   border: 1px solid #e0e0e0;
@@ -153,4 +160,9 @@ button.mat-icon-button {
   &:not([disabled]):hover {
     color: $greenLight !important;
   }
+}
+
+// Restore the tab header underline from Material pre-v15
+.mat-mdc-tab-header {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -130,7 +130,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-snack-bar-theme($material-app-theme);
 @include mat.stepper-theme($material-app-theme);
 @include mat.legacy-table-theme($material-app-theme);
-@include mat.legacy-tabs-theme($material-app-theme);
+@include mat.tabs-theme($material-app-theme);
 @include mat.toolbar-theme($material-app-theme);
 @include mat.tooltip-theme($material-app-theme);
 @include mat.option-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -34,7 +34,7 @@ import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/
 import { MatSortModule } from '@angular/material/sort';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatLegacyTableModule as MatTableModule } from '@angular/material/legacy-table';
-import { MatLegacyTabsModule as MatTabsModule } from '@angular/material/legacy-tabs';
+import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoService } from '@ngneat/transloco';


### PR DESCRIPTION
This PR upgrades mat-tabs from legacy to the Angular Material mdc version.  Used `ng generate @angular/material:mdc-migration` as a starting point.

Some differences:
- Header labels stretch by default to fill the container's width. This can be turned off by setting the `<mat-tab-group>` input `[mat-stretch-tabs]="false"` when desired.
  - I added this attribute in some places to retain the old look. 
- The border under the tab headers is gone.
  - I did not add it back. Should we custom style this to add back the header bottom border?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2259)
<!-- Reviewable:end -->
