### PR TITLE
Remove use of Material legacy form fields

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -19,6 +19,8 @@ import { InAppRootOverlayContainer } from 'xforge-common/overlay-container';
 import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
+import { MAT_LEGACY_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/legacy-form-field';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -88,7 +90,9 @@ import { NavigationComponent } from './navigation/navigation.component';
     translocoMarkupRouterLinkRenderer(),
     defaultTranslocoMarkupTranspilers(),
     { provide: ErrorHandler, useClass: ExceptionHandlingService },
-    { provide: OverlayContainer, useClass: InAppRootOverlayContainer }
+    { provide: OverlayContainer, useClass: InAppRootOverlayContainer },
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },
+    { provide: MAT_LEGACY_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
The legacy form field appearance is the default, but is no longer supported in newer versions of Material. This PR sets the new default to the "outline" style.

Here's what each appearance looks like, taken from https://v14.material.angular.io/components/form-field/examples
![](https://github.com/sillsdev/web-xforge/assets/6140710/67c55d4e-10ed-459d-93b5-a2f375820815)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2260)
<!-- Reviewable:end -->
