### PR TITLE
SF-2373 Upgrade legacy mat-snackbar

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -127,7 +127,8 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.sidenav-theme($material-app-theme);
 @include mat.legacy-slide-toggle-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
-@include mat.legacy-snack-bar-theme($material-app-theme);
+@include mat.snack-bar-theme($material-app-theme);
+@include mat.button-theme($material-app-theme);
 @include mat.stepper-theme($material-app-theme);
 @include mat.table-theme($material-app-theme);
 @include mat.tabs-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -3,7 +3,6 @@
 // This creates css variables for common breakpoints (needed when using MediaBreakpointService with BreakpointObserver)
 @use 'src/xforge-common/media-breakpoints/css-vars';
 
-@import 'variables';
 @import 'fonts';
 /* Only import relevant Bootstrap 4.x styles */
 @import 'bootstrap/scss/bootstrap-grid';
@@ -43,8 +42,8 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   padding-top: 5px !important;
 }
 
-.snackbar-error {
-  background-color: variables.$errorColor !important;
+.mdc-snackbar.snackbar-error {
+  --mdc-snackbar-container-color: #{variables.$errorColor};
 }
 
 .mat-flat-button,
@@ -61,7 +60,7 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
 }
 
 .locale-fonts mat-option {
-  font-family: $languageFonts;
+  font-family: variables.$languageFonts;
 }
 
 // Allows checkbox label word-wrap

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -1,8 +1,6 @@
-import {
-  MatLegacySnackBarConfig as MatSnackBarConfig,
-  MatLegacySnackBar as MatSnackBar
-} from '@angular/material/legacy-snack-bar';
 import { Injectable } from '@angular/core';
+import { MatSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { firstValueFrom } from 'rxjs';
 import { I18nService } from './i18n.service';
 
 /** Manages and provides access to notices shown to user on the web site. */
@@ -69,9 +67,6 @@ export class NoticeService {
 
     this.messageOnDisplay = message;
 
-    snackBarRef
-      .afterDismissed()
-      .toPromise()
-      .then(() => (this.messageOnDisplay = undefined));
+    firstValueFrom(snackBarRef.afterDismissed()).then(() => (this.messageOnDisplay = undefined));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -28,7 +28,7 @@ import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@ang
 import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
-import { MatLegacySnackBarModule as MatSnackBarModule } from '@angular/material/legacy-snack-bar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatSortModule } from '@angular/material/sort';


### PR DESCRIPTION
This PR upgrades mat-snackbar from legacy to the Angular Material mdc version. Used `ng generate @angular/material:mdc-migration` as a starting point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2265)
<!-- Reviewable:end -->
