### PR TITLE
SF-2370 Upgrade legacy mat-radio

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -133,7 +133,7 @@ mat-icon {
 
 mat-radio-group.tool-setting {
   mat-radio-button {
-    margin: 0.5em 1em;
+    margin-inline-start: 1em;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -121,7 +121,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-paginator-theme($material-app-theme);
 @include mat.legacy-progress-bar-theme($material-app-theme);
 @include mat.legacy-progress-spinner-theme($material-app-theme);
-@include mat.legacy-radio-theme($material-app-theme);
+@include mat.radio-theme($material-app-theme);
 @include mat.legacy-select-theme($material-app-theme);
 @include mat.select-theme($material-app-theme);
 @include mat.sidenav-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/material/legacy-paginator';
 import { MatLegacyProgressBarModule as MatProgressBarModule } from '@angular/material/legacy-progress-bar';
 import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
-import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
+import { MatRadioModule } from '@angular/material/radio';
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
 import { MatSnackBarModule } from '@angular/material/snack-bar';


### PR DESCRIPTION
This PR upgrades mat-radio-group from legacy to the Angular Material mdc version. Used `ng generate @angular/material:mdc-migration` as a starting point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2267)
<!-- Reviewable:end -->
