### PR TITLE
Remove all use of letter spacing

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -5,7 +5,6 @@
 quill-editor {
   height: 100%;
   > .ql-container {
-    letter-spacing: 0.03125em;
     > .ql-editor {
       font-family: Roboto, 'Noto Sans Kayah Li', sans-serif;
       line-height: 1.6;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -85,7 +85,6 @@
     padding-left: 15px;
     margin-bottom: 1em;
     font-weight: 400;
-    letter-spacing: 0.03333333em;
     text-align: center;
     &:not(.visible) {
       display: none;


### PR DESCRIPTION
Letter spacing should generally be avoided for some scripts: https://rtlstyling.com/posts/rtl-styling#1.-letter-spacing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2269)
<!-- Reviewable:end -->
