### PR TITLE
SF-2433 Prevent error when joining a project with email specific link

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.spec.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Route, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Subscription } from 'rxjs';
+import { ActiveProjectIdService } from './activated-project.service';
+import { configureTestingModule } from './test-utils';
+
+@Component({
+  template: '<div></div>'
+})
+class MockComponent {}
+
+const ROUTES: Route[] = [{ path: 'projects/:projectId', component: MockComponent }];
+let env: TestEnvironment;
+
+describe('ActiveProjectIdService', () => {
+  configureTestingModule(() => ({
+    imports: [RouterTestingModule.withRoutes(ROUTES)],
+    declarations: [MockComponent]
+  }));
+
+  beforeEach(() => (env = new TestEnvironment()));
+  afterEach(() => env.dispose());
+
+  it('should emit the project ID from the route parameters', fakeAsync(() => {
+    const projectId = 'project01';
+    env.router.navigate(['projects', projectId]);
+    tick();
+    expect(env.currentProjectId).toBe(projectId);
+  }));
+
+  it('should not emit new project ID when query parameter sharing is set', fakeAsync(() => {
+    const projectId = 'project01';
+    env.router.navigate(['projects', projectId]);
+    tick();
+    expect(env.currentProjectId).toBe(projectId);
+    env.router.navigate(['projects', 'project02'], { queryParams: { sharing: 'true' } });
+    tick();
+    expect(env.currentProjectId).toBe('project01');
+  }));
+});
+
+class TestEnvironment {
+  readonly router: Router;
+  readonly service: ActiveProjectIdService;
+  currentProjectId?: string;
+
+  private subscription: Subscription;
+
+  constructor() {
+    this.router = TestBed.inject(Router);
+    this.service = TestBed.inject(ActiveProjectIdService);
+
+    this.subscription = this.service.projectId$.subscribe(projectId => (this.currentProjectId = projectId));
+  }
+
+  dispose(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -15,7 +15,9 @@ interface IActiveProjectIdService {
 @Injectable({ providedIn: 'root' })
 export class ActiveProjectIdService implements IActiveProjectIdService {
   projectId$: Observable<string | undefined> = this.router.events.pipe(
-    filter(event => event instanceof ActivationEnd),
+    // filter out router events that include the old style link with sharing query parameter
+    // to prevent a permission denied error that occurs before the user has successfully joined
+    filter(event => event instanceof ActivationEnd && event.snapshot.queryParams['sharing'] !== 'true'),
     map(event => (event as ActivationEnd).snapshot.params.projectId),
     startWith(this.getProjectIdFromUrl(this.router.routerState.snapshot.url))
   );


### PR DESCRIPTION
The ActivatedProjectService relies on the ActiveProjectIdService to emit the projectId from the router snapshot. When a new ID is available, it is emitted and the ActivatedProjectService will fetch the project and make it available. Unfortunately, this occurs when using the old style email specific share links, resulting in an error before the user can successfully join the project.

This PR accomplishes the following:

- detects the presence of the sharing query parameter in the URL and ignores the router change
- adds tests for the ActiveProjectIdService

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2271)
<!-- Reviewable:end -->
