### PR TITLE
SF-2432 Fix quill editor double scroll bar

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -4,6 +4,7 @@
 
 quill-editor {
   height: 100%;
+  display: unset !important;
   > .ql-container {
     letter-spacing: 0.03125em;
     > .ql-editor {


### PR DESCRIPTION
The angular host appears to be injecting a style that affects the quill editor, causing the display to be set to inline-block. This was causing the quill editor to overflow its flex container and creating a double scroll bar. This PR forces the quill editor element to have the display set to unset, keeping the entire quill editor within its flex container.
![image](https://github.com/sillsdev/web-xforge/assets/17931130/5b6cca4a-99c4-49c3-99a1-86bc920b3c5c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2272)
<!-- Reviewable:end -->
