### PR TITLE
SF-2432 Style editor height with CSS instead of JS

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.scss
@@ -1,0 +1,3 @@
+quill-editor {
+  display: block;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -82,7 +82,8 @@ export interface EmbedsByVerse {
 /** View of an editable text document. Used for displaying Scripture. */
 @Component({
   selector: 'app-text',
-  templateUrl: './text.component.html'
+  templateUrl: './text.component.html',
+  styleUrls: ['./text.component.scss']
 })
 export class TextComponent extends SubscriptionDisposable implements AfterViewInit, OnDestroy {
   @ViewChild('quillEditor', { static: true, read: ElementRef }) quill!: ElementRef;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'editor'">
-  <div class="content" fxLayout="column">
+  <div class="content" [class.reverse-columns]="isTargetTextRight">
     <div class="toolbar" fxLayout="row" fxLayoutAlign="start center">
       <div fxFlex fxLayout="row wrap">
         <app-book-chapter-chooser
@@ -57,162 +57,160 @@
         </div>
       </ng-container>
     </div>
-    <div [fxLayout]="isTargetTextRight ? 'row' : 'row-reverse'" class="both-editors-wrapper">
-      <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
-        <div class="language-label">{{ sourceLabel }}</div>
-        <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
-          <div>
-            {{ sourceCopyrightBanner }}
-            <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
-          </div>
-        </app-notice>
-        <div #sourceSplitContainer>
-          <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-          <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
-            <as-split-area [size]="75" [minSize]="20">
-              <div #sourceContainer class="text-container">
-                <app-text
-                  #source
-                  [isReadOnly]="true"
-                  [highlightSegment]="targetFocused"
-                  (loaded)="onTextLoaded('source')"
-                  (updated)="onSourceUpdated($event.delta != null)"
-                  [isRightToLeft]="isSourceRightToLeft"
-                  [fontSize]="sourceFontSize"
-                ></app-text>
-              </div>
-            </as-split-area>
-            <as-split-area [size]="25" *ngIf="biblicalTermsEnabledForSource" [dir]="i18n.direction">
-              <app-biblical-terms
-                id="source-biblical-terms"
-                [bookNum]="bookNum"
-                [chapter]="chapter"
-                [verse]="verse"
-                [configProjectId]="projectId"
-                [projectId]="sourceProjectId"
-              ></app-biblical-terms>
-            </as-split-area>
-          </as-split>
+    <div id="source-text-area" [fxShow.gt-xs]="showSource" fxHide.xs class="text-area">
+      <div class="language-label">{{ sourceLabel }}</div>
+      <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
+        <div>
+          {{ sourceCopyrightBanner }}
+          <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
         </div>
+      </app-notice>
+      <div #sourceSplitContainer class="container-for-split">
+        <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+        <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
+          <as-split-area [size]="75" [minSize]="20">
+            <div #sourceContainer class="text-container">
+              <app-text
+                #source
+                [isReadOnly]="true"
+                [highlightSegment]="targetFocused"
+                (loaded)="onTextLoaded('source')"
+                (updated)="onSourceUpdated($event.delta != null)"
+                [isRightToLeft]="isSourceRightToLeft"
+                [fontSize]="sourceFontSize"
+              ></app-text>
+            </div>
+          </as-split-area>
+          <as-split-area [size]="25" *ngIf="biblicalTermsEnabledForSource" [dir]="i18n.direction">
+            <app-biblical-terms
+              id="source-biblical-terms"
+              [bookNum]="bookNum"
+              [chapter]="chapter"
+              [verse]="verse"
+              [configProjectId]="projectId"
+              [projectId]="sourceProjectId"
+            ></app-biblical-terms>
+          </as-split-area>
+        </as-split>
       </div>
-      <div
-        id="target-text-area"
-        class="text-area"
-        [ngClass.gt-xs]="{ 'text-area-full-width': !showSource }"
-        ngClass.xs="text-area-full-width"
-      >
-        <div class="language-label" [fxShow.gt-xs]="showSource" fxHide.xs>{{ targetLabel }}</div>
-        <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
-          <div>
-            {{ targetCopyrightBanner }}
-            <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
-          </div>
-        </app-notice>
-        <div *ngIf="!isUsfmValid && hasEditRight" class="formatting-invalid-warning">
-          <mat-icon>warning</mat-icon> {{ t("cannot_edit_chapter_formatting_invalid") }}
+    </div>
+    <div
+      id="target-text-area"
+      class="text-area"
+      [ngClass.gt-xs]="{ 'text-area-full-width': !showSource }"
+      ngClass.xs="text-area-full-width"
+    >
+      <div class="language-label" [fxShow.gt-xs]="showSource" fxHide.xs>{{ targetLabel }}</div>
+      <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
+        <div>
+          {{ targetCopyrightBanner }}
+          <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
         </div>
-        <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
-          <mat-icon>warning</mat-icon> {{ t("project_data_out_of_sync") }}
-        </div>
-        <div *ngIf="target.areOpsCorrupted && hasEditRight" class="doc-corrupted-warning">
-          <mat-icon>error</mat-icon> {{ t("text_doc_corrupted") }}
-          <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
-        </div>
-        <div *ngIf="projectTextNotEditable && hasEditRight" class="project-text-not-editable">
-          <mat-icon>info</mat-icon> {{ t("project_text_not_editable") }}
-        </div>
-        <div *ngIf="showNoEditPermissionMessage" class="no-edit-permission-message">
-          <mat-icon>info</mat-icon> {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
-        </div>
-        <div #targetSplitContainer>
-          <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-          <as-split direction="vertical" [style.height]="targetSplitHeight">
-            <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
-              <div
-                #targetContainer
-                class="text-container"
-                [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'"
-                [ngClass]="{ 'has-draft': showPreviewDraft }"
-              >
-                <app-text
-                  #target
-                  [isReadOnly]="!canEdit"
-                  (updated)="
-                    onTargetUpdated(
-                      $event.segment,
-                      $event.delta,
-                      $event.prevSegment,
-                      $event.affectedEmbeds,
-                      $event.isLocalUpdate
-                    )
-                  "
-                  (loaded)="onTextLoaded('target')"
-                  (focused)="targetFocused = $event"
-                  (segmentRefChange)="onSegmentRefChange($event)"
-                  (presenceChange)="onPresenceChange($event)"
-                  [highlightSegment]="targetFocused && canEdit"
-                  [enablePresence]="true"
-                  [markInvalid]="true"
-                  [isRightToLeft]="isTargetRightToLeft"
-                  [fontSize]="fontSize"
-                  [selectableVerses]="showAddCommentUI"
-                  [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
-                ></app-text>
-                <app-suggestions
-                  class="mat-elevation-z2"
-                  [show]="showSuggestions && translationSuggestionsEnabled"
-                  [suggestions]="suggestions"
-                  [text]="target"
-                  (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
-                  (showChange)="showSuggestions = $event"
-                ></app-suggestions>
-                <ng-template #fabBottomSheet>
-                  <div class="fab-bottom-sheet" [dir]="direction">
-                    <b>{{ currentSegmentReference }}</b>
-                    <button
-                      *ngIf="!addingMobileNote && !hasEditRight"
-                      mat-flat-button
-                      (click)="toggleAddingMobileNote()"
-                      color="accent"
-                    >
-                      <mat-icon>add_comment</mat-icon>
-                      {{ t("add_comment") }}
-                    </button>
-                    <form *ngIf="addingMobileNote">
-                      <mat-form-field class="full-width" appearance="outline">
-                        <mat-label>{{ t("your_comment") }}</mat-label>
-                        <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
-                      </mat-form-field>
-                      <div class="fab-action-buttons">
-                        <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
-                          {{ t("cancel") }}
-                        </button>
-                        <button mat-flat-button class="save-button" color="primary" (click)="saveMobileNote()">
-                          {{ t("save") }}
-                        </button>
-                      </div>
-                    </form>
-                  </div>
-                </ng-template>
-                <div *ngIf="canInsertNote" #fabButton class="insert-note-fab" [style.left]="insertNoteFabLeft">
-                  <button mat-mini-fab title="{{ t('add_comment') }}" (click)="insertNote()">
+      </app-notice>
+      <div *ngIf="!isUsfmValid && hasEditRight" class="formatting-invalid-warning">
+        <mat-icon>warning</mat-icon> {{ t("cannot_edit_chapter_formatting_invalid") }}
+      </div>
+      <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
+        <mat-icon>warning</mat-icon> {{ t("project_data_out_of_sync") }}
+      </div>
+      <div *ngIf="target.areOpsCorrupted && hasEditRight" class="doc-corrupted-warning">
+        <mat-icon>error</mat-icon> {{ t("text_doc_corrupted") }}
+        <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
+      </div>
+      <div *ngIf="projectTextNotEditable && hasEditRight" class="project-text-not-editable">
+        <mat-icon>info</mat-icon> {{ t("project_text_not_editable") }}
+      </div>
+      <div *ngIf="showNoEditPermissionMessage" class="no-edit-permission-message">
+        <mat-icon>info</mat-icon> {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
+      </div>
+      <div #targetSplitContainer class="container-for-split">
+        <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+        <as-split direction="vertical" [style.height]="targetSplitHeight">
+          <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
+            <div
+              #targetContainer
+              class="text-container"
+              [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'"
+              [ngClass]="{ 'has-draft': showPreviewDraft }"
+            >
+              <app-text
+                #target
+                [isReadOnly]="!canEdit"
+                (updated)="
+                  onTargetUpdated(
+                    $event.segment,
+                    $event.delta,
+                    $event.prevSegment,
+                    $event.affectedEmbeds,
+                    $event.isLocalUpdate
+                  )
+                "
+                (loaded)="onTextLoaded('target')"
+                (focused)="targetFocused = $event"
+                (segmentRefChange)="onSegmentRefChange($event)"
+                (presenceChange)="onPresenceChange($event)"
+                [highlightSegment]="targetFocused && canEdit"
+                [enablePresence]="true"
+                [markInvalid]="true"
+                [isRightToLeft]="isTargetRightToLeft"
+                [fontSize]="fontSize"
+                [selectableVerses]="showAddCommentUI"
+                [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
+              ></app-text>
+              <app-suggestions
+                class="mat-elevation-z2"
+                [show]="showSuggestions && translationSuggestionsEnabled"
+                [suggestions]="suggestions"
+                [text]="target"
+                (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
+                (showChange)="showSuggestions = $event"
+              ></app-suggestions>
+              <ng-template #fabBottomSheet>
+                <div class="fab-bottom-sheet" [dir]="direction">
+                  <b>{{ currentSegmentReference }}</b>
+                  <button
+                    *ngIf="!addingMobileNote && !hasEditRight"
+                    mat-flat-button
+                    (click)="toggleAddingMobileNote()"
+                    color="accent"
+                  >
                     <mat-icon>add_comment</mat-icon>
+                    {{ t("add_comment") }}
                   </button>
+                  <form *ngIf="addingMobileNote">
+                    <mat-form-field class="full-width" appearance="outline">
+                      <mat-label>{{ t("your_comment") }}</mat-label>
+                      <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
+                    </mat-form-field>
+                    <div class="fab-action-buttons">
+                      <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
+                        {{ t("cancel") }}
+                      </button>
+                      <button mat-flat-button class="save-button" color="primary" (click)="saveMobileNote()">
+                        {{ t("save") }}
+                      </button>
+                    </div>
+                  </form>
                 </div>
+              </ng-template>
+              <div *ngIf="canInsertNote" #fabButton class="insert-note-fab" [style.left]="insertNoteFabLeft">
+                <button mat-mini-fab title="{{ t('add_comment') }}" (click)="insertNote()">
+                  <mat-icon>add_comment</mat-icon>
+                </button>
               </div>
-            </as-split-area>
-            <as-split-area [size]="25" *ngIf="biblicalTermsEnabledForTarget" [dir]="i18n.direction">
-              <app-biblical-terms
-                id="target-biblical-terms"
-                [bookNum]="bookNum"
-                [chapter]="chapter"
-                [verse]="verse"
-                [configProjectId]="projectId"
-                [projectId]="projectId"
-              ></app-biblical-terms>
-            </as-split-area>
-          </as-split>
-        </div>
+            </div>
+          </as-split-area>
+          <as-split-area [size]="25" *ngIf="biblicalTermsEnabledForTarget" [dir]="i18n.direction">
+            <app-biblical-terms
+              id="target-biblical-terms"
+              [bookNum]="bookNum"
+              [chapter]="chapter"
+              [verse]="verse"
+              [configProjectId]="projectId"
+              [projectId]="projectId"
+            ></app-biblical-terms>
+          </as-split-area>
+        </as-split>
       </div>
     </div>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -51,19 +51,6 @@
   margin: 0 6px;
 }
 
-.text-area {
-  width: 50%;
-
-  &.text-area-full-width {
-    width: 100%;
-  }
-}
-
-.text-container {
-  position: relative;
-  height: 100%;
-}
-
 app-text {
   height: 100%;
 }
@@ -139,4 +126,60 @@ app-text {
   &:hover {
     text-decoration: underline;
   }
+}
+
+.content {
+  height: calc(100vh - 84px);
+  display: grid;
+  grid-template-areas:
+    'toolbar toolbar'
+    'source target';
+  column-gap: 10px;
+
+  grid-template-rows: 72px minmax(0, 1fr);
+  grid-template-columns: 1fr 1fr;
+
+  &.reverse-columns {
+    grid-template-areas:
+      'toolbar toolbar'
+      'target source';
+  }
+}
+
+@include media-breakpoint-only(xs) {
+  .content {
+    grid-template-columns: 1fr;
+    grid-template-areas: 'toolbar' 'target';
+  }
+}
+
+.toolbar {
+  grid-area: toolbar;
+}
+
+#source-text-area {
+  grid-area: source;
+}
+
+#target-text-area {
+  grid-area: target;
+}
+
+.text-container {
+  height: 100%;
+  position: relative;
+}
+
+.text-area.text-area-full-width {
+  grid-column: 1 / span 2;
+}
+
+.text-area {
+  display: flex;
+  flex-direction: column;
+}
+
+.container-for-split {
+  flex-grow: 1;
+  overflow: hidden;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -590,7 +590,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   ngAfterViewInit(): void {
     this.subscribe(fromEvent(window, 'resize'), () => {
-      this.setTextHeight();
       this.positionInsertNoteFab();
     });
     this.subscribe(
@@ -691,7 +690,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             if (this.translationEngine == null || !this.translationSuggestionsProjectEnabled || !this.hasEditRight) {
               this.setupTranslationEngine();
             }
-            setTimeout(() => this.setTextHeight());
           });
 
           if (this.metricsSession != null) {
@@ -727,8 +725,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.checkForPreTranslations();
       }
     );
-
-    setTimeout(() => this.setTextHeight());
   }
 
   ngOnDestroy(): void {
@@ -1358,28 +1354,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     );
   }
 
-  private setTextHeight(): void {
-    if (this.target == null || this.targetSplitContainer == null) {
-      return;
-    }
-    // this is a horrible hack to set the height of the text components
-    // we don't want to use flexbox because it makes editing very slow
-    let elem: HTMLElement = this.targetSplitContainer.nativeElement;
-    let bounds = elem.getBoundingClientRect();
-    // add bottom padding
-    let top = bounds.top + (this.mediaObserver.isActive('xs') ? 0 : 14);
-    this.targetSplitHeight = `calc(100vh - ${top}px)`;
-
-    // Do the same for the source, as it will not have warnings like the target
-    if (this.source == null || this.sourceSplitContainer == null) {
-      return;
-    }
-    elem = this.sourceSplitContainer.nativeElement;
-    bounds = elem.getBoundingClientRect();
-    top = bounds.top + (this.mediaObserver.isActive('xs') ? 0 : 14);
-    this.sourceSplitHeight = `calc(100vh - ${top}px)`;
-  }
-
   private async changeText(): Promise<void> {
     if (this.projectDoc == null || this.text == null || this._chapter == null) {
       this.source!.id = undefined;
@@ -1421,7 +1395,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     });
 
     await this.loadNoteThreadDocs(this.projectDoc.id, this.text.bookNum, this._chapter);
-    setTimeout(() => this.setTextHeight());
   }
 
   private onStartTranslating(): void {


### PR DESCRIPTION
I think there may still be some edge cases that aren't handled quite correctly, but I can't find any that I can consistently reproduce. And there were already some issues before this change (more pronounced, I think).

- Fixes editor width and height
- Removes JS calculation of editor height, instead using CSS for layout
- Removes some use of @angular/flex-layout in the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2273)
<!-- Reviewable:end -->
