### PR TITLE
SF-2434 Allow resolving note threads for biblical terms

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
@@ -272,6 +272,23 @@ describe('BiblicalTermsComponent', () => {
     const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc('project01', 'user01');
     expect(projectUserConfigDoc.data!.noteRefsRead).toContain(noteThread.notes[1].dataId);
   }));
+
+  it('can resolve a note for a biblical term', fakeAsync(() => {
+    const projectId = 'project01';
+    const env = new TestEnvironment(projectId, 1, 1);
+    env.setupProjectData('en');
+    env.wait();
+
+    env.biblicalTermsNotesButton.click();
+    env.wait();
+    env.mockNoteDialogRef.close({ status: NoteStatus.Resolved });
+    env.wait();
+
+    verify(mockedMatDialog.open(NoteDialogComponent, anything())).once();
+    const noteThread: NoteThread = env.getNoteThreadDoc(projectId, 'threadId01').data!;
+    expect(noteThread.status).toEqual(NoteStatus.Resolved);
+    expect(noteThread.notes[1].content).toBeUndefined();
+  }));
 });
 
 class TestEnvironment {


### PR DESCRIPTION
The logic to save a note thread was both in the editor component and the biblical terms component. This PR adds the logic to resolve threads in the biblical terms component. It is possible that the logic should be consolidated, but there are enough subtleties between the two components that it might not be a simple solution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2274)
<!-- Reviewable:end -->
