### PR TITLE
SF-2335b Remove @bugsnag/plugin-angular to fix Angular prod build

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -23,7 +23,6 @@
         "@angular/service-worker": "^16.2.12",
         "@auth0/auth0-spa-js": "^2.0.4",
         "@bugsnag/js": "^7.21.0",
-        "@bugsnag/plugin-angular": "^7.16.5",
         "@microsoft/signalr": "^7.0.0",
         "@ngneat/transloco": "^4.3.0",
         "@ngneat/transloco-locale": "^4.1.0",
@@ -3347,14 +3346,6 @@
         "iserror": "^0.0.2",
         "pump": "^3.0.0",
         "stack-generator": "^2.0.3"
-      }
-    },
-    "node_modules/@bugsnag/plugin-angular": {
-      "version": "7.22.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-angular/-/plugin-angular-7.22.2.tgz",
-      "integrity": "sha512-MSUsFiPuUhux+GiR1yK8YuZ1tAHoGP2Q7jvIQlmFr2uRh3O6BgCnFA5NR/kxqGiI2KnmdfPgww9pCAoFjIsrXw==",
-      "peerDependencies": {
-        "@bugsnag/js": "^7.0.0"
       }
     },
     "node_modules/@bugsnag/safe-json-stringify": {

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -43,7 +43,6 @@
     "@angular/service-worker": "^16.2.12",
     "@auth0/auth0-spa-js": "^2.0.4",
     "@bugsnag/js": "^7.21.0",
-    "@bugsnag/plugin-angular": "^7.16.5",
     "@microsoft/signalr": "^7.0.0",
     "@ngneat/transloco": "^4.3.0",
     "@ngneat/transloco-locale": "^4.1.0",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, Injector, NgZone } from '@angular/core';
 import Bugsnag, { Breadcrumb, BrowserConfig } from '@bugsnag/js';
-import { BugsnagErrorHandler } from '@bugsnag/plugin-angular';
 import { translate } from '@ngneat/transloco';
 import versionData from '../../../version.json';
 import { MACHINE_API_BASE_URL } from '../app/machine-api/http-client';
@@ -30,7 +29,7 @@ export class AppError extends Error {
 }
 
 @Injectable()
-export class ExceptionHandlingService extends BugsnagErrorHandler {
+export class ExceptionHandlingService {
   static initBugsnag(): void {
     const config: BrowserConfig = {
       apiKey: environment.bugsnagApiKey,
@@ -135,9 +134,7 @@ export class ExceptionHandlingService extends BugsnagErrorHandler {
   private alertQueue: ErrorAlertData[] = [];
   private dialogOpen = false;
 
-  constructor(private readonly injector: Injector) {
-    super();
-  }
+  constructor(private readonly injector: Injector) {}
 
   async handleError(originalError: unknown, silently: boolean = false): Promise<void> {
     // Angular error handlers are instantiated before all other providers, so we cannot inject dependencies. Instead we


### PR DESCRIPTION
See QA to see what the current error is: https://qa.scriptureforge.org/projects

```
Uncaught TypeError: Cannot set property ɵfac of class extends Ws{constructor(i){super(),this.bugsnagClient=i||Lc()._client}handleError(i){const n=this.bugsnagC...<omitted>...}} which has only a getter
    at <static_initializer> (exception-handling-service.ts:279:4)
    at exception-handling-service.ts:33:47
    at 8227 (exception-handling-service.ts:33:39)
    at t (bootstrap:19:1)
    at index.js:55:1
    at f (jsonp chunk loading:34:1)
    at main.adfd930d5184b905.js:1:83
```

It only happens in Angular production builds. In my testing, error reporting still works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2276)
<!-- Reviewable:end -->
