### PR TITLE
Fix broken draft generation step tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -72,6 +72,7 @@ describe('DraftGenerationStepsComponent', () => {
           }
         })
       } as SFProjectProfileDoc;
+      const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
 
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
@@ -178,7 +179,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.isTrainingOptional).toBe(false);
     }));
 
-    fit('should set "isTrainingOptional == true" when target and source are both in NLLB', fakeAsync(() => {
+    it('should set "isTrainingOptional == true" when target and source are both in NLLB', fakeAsync(() => {
       when(mockProjectService.getProfile(anything())).thenResolve(mockSourceNllbProjectDoc);
       targetProjectDoc$.next(mockTargetProjectDoc); // Trigger re-init on project changes
       tick();


### PR DESCRIPTION
A commit was made which accidentally focused the frontend tests to just run one test.

This PR changes the `fit` to `it`, and fixes three broken tests that the `fit` skipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2279)
<!-- Reviewable:end -->
