### PR TITLE
Fix editor text-area-full-width precedence

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -171,7 +171,7 @@ app-text {
 }
 
 .text-area.text-area-full-width {
-  grid-column: 1 / span 2;
+  grid-column: 1 / span 2 !important;
 }
 
 .text-area {


### PR DESCRIPTION
When viewing a resource, or a project without a source, the editor does not stretch across the full width of the screen.

This occurs because the `#target-text-area` CSS rule takes precedence over the `.text-area.text-area-full-width` CSS rule.

See the screenshot below for details:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/5acea13b-b52f-4f60-8dad-374ee3ab6471)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2280)
<!-- Reviewable:end -->
