### PR TITLE
SF-2347 Do not show error when getting project role times out

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -3,13 +3,14 @@ import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { mock, verify, when } from 'ts-mockito';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { anything, mock, verify, when } from 'ts-mockito';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { paratextUsersFromRoles } from '../../shared/test-utils';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
@@ -20,6 +21,7 @@ import { ProgressState, SyncProgressComponent } from './sync-progress.component'
 const mockedNoticeService = mock(NoticeService);
 const mockedProjectService = mock(SFProjectService);
 const mockedProjectNotificationService = mock(ProjectNotificationService);
+const mockedErrorReportingService = mock(ErrorReportingService);
 
 describe('SyncProgressComponent', () => {
   configureTestingModule(() => ({
@@ -33,7 +35,8 @@ describe('SyncProgressComponent', () => {
     providers: [
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: ProjectNotificationService, useMock: mockedProjectNotificationService },
-      { provide: SFProjectService, useMock: mockedProjectService }
+      { provide: SFProjectService, useMock: mockedProjectService },
+      { provide: ErrorReportingService, useMock: mockedErrorReportingService }
     ]
   }));
 
@@ -110,6 +113,7 @@ describe('SyncProgressComponent', () => {
     env.setupProjectDoc();
     verify(mockedProjectService.onlineGetProjectRole('sourceProject02')).once();
     verify(mockedProjectService.get('sourceProject02')).never();
+    verify(mockedErrorReportingService.silentError(anything(), anything())).once();
     expect(env.progressBar).not.toBeNull();
   }));
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -93,7 +93,7 @@ describe('SyncProgressComponent', () => {
   }));
 
   it('does not access source project if user does not have a paratext role', fakeAsync(() => {
-    const env = new TestEnvironment({ userId: 'user01' });
+    const env = new TestEnvironment({ userId: 'user02', sourceProject: 'sourceProject02' });
     env.setupProjectDoc();
     env.updateSyncProgress(0, 'testProject01');
     env.updateSyncProgress(0, 'sourceProject02');
@@ -102,6 +102,15 @@ describe('SyncProgressComponent', () => {
     env.updateSyncProgress(0.5, 'testProject01');
     expect(env.host.syncProgress.syncProgressPercent).toEqual(50);
     env.emitSyncComplete(true, 'testProject01');
+  }));
+
+  it('does not throw error if get project role times out', fakeAsync(() => {
+    const env = new TestEnvironment({ userId: 'user01', sourceProject: 'sourceProject02' });
+    when(mockedProjectService.onlineGetProjectRole('sourceProject02')).thenReject(new Error('504: Gateway Timeout'));
+    env.setupProjectDoc();
+    verify(mockedProjectService.onlineGetProjectRole('sourceProject02')).once();
+    verify(mockedProjectService.get('sourceProject02')).never();
+    expect(env.progressBar).not.toBeNull();
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -3,6 +3,7 @@ import { ProgressBarMode } from '@angular/material/progress-bar';
 import { OtJson0Op } from 'ot-json0';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { merge, Observable } from 'rxjs';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -27,7 +28,8 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   constructor(
     private readonly projectService: SFProjectService,
     private readonly projectNotificationService: ProjectNotificationService,
-    private readonly featureFlags: FeatureFlagService
+    private readonly featureFlags: FeatureFlagService,
+    private readonly errorReportingService: ErrorReportingService
   ) {
     super();
 
@@ -74,7 +76,10 @@ export class SyncProgressComponent extends SubscriptionDisposable {
           }
         } catch (error) {
           this.sourceProjectDoc = undefined;
-          console.log(error);
+          this.errorReportingService.silentError(
+            'Error while accessing source project',
+            ErrorReportingService.normalizeError(error)
+          );
         }
       } else {
         this.sourceProjectDoc = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -63,16 +63,21 @@ export class SyncProgressComponent extends SubscriptionDisposable {
     if (this._projectDoc?.data?.translateConfig.source != null) {
       const sourceProjectId: string | undefined = this._projectDoc.data.translateConfig.source?.projectRef;
       if (sourceProjectId != null) {
-        const role: string = await this.projectService.onlineGetProjectRole(sourceProjectId);
-        // Only show progress for the source project when the user has sync
-        if (isParatextRole(role)) {
-          this.sourceProjectDoc = await this.projectService.get(sourceProjectId);
+        try {
+          const role: string = await this.projectService.onlineGetProjectRole(sourceProjectId);
+          // Only show progress for the source project when the user has sync
+          if (isParatextRole(role)) {
+            this.sourceProjectDoc = await this.projectService.get(sourceProjectId);
 
-          // Subscribe to SignalR notifications for the source project
-          await this.projectNotificationService.subscribeToProject(this.sourceProjectDoc.id);
-        } else {
+            // Subscribe to SignalR notifications for the source project
+            await this.projectNotificationService.subscribeToProject(this.sourceProjectDoc.id);
+          }
+        } catch (error) {
           this.sourceProjectDoc = undefined;
+          console.log(error);
         }
+      } else {
+        this.sourceProjectDoc = undefined;
       }
     }
 


### PR DESCRIPTION
TC69 is run as part of a full regression test on QA, but unfortunately an error message would appear sometimes when going offline as part of the test steps. This was caused most likely from an error that was thrown in the sync progress component. Since the error is not helpful and the sync proceeds to completion anyway, I've chosen to swallow the error in the sync progress component.

I don't believe it will be beneficial to send this to testing. We will know if this works once we move this onto QA and TC69 is no longer flaky.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2285)
<!-- Reviewable:end -->
