### PR TITLE
SF-2310 Add Paratext zip file support for Serval

### DIFF
--- a/scripts/db_tools/parse-version.ts
+++ b/scripts/db_tools/parse-version.ts
@@ -34,7 +34,8 @@ class ParseVersion {
     'Use In-Process Machine for Suggestions',
     'Use Serval for Suggestions',
     'Use Echo for Pre-Translation Drafting',
-    'Allow Fast Pre-Translation Training'
+    'Allow Fast Pre-Translation Training',
+    'Upload Paratext Zip Files for Pre-Translation Drafting'
   ];
 
   constructor() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -290,6 +290,13 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
+  private readonly uploadParatextZipForPreTranslation: FeatureFlag = new ServerOnlyFeatureFlag(
+    'UploadParatextZipForPreTranslation',
+    'Upload Paratext Zip Files for Pre-Translation Drafting',
+    12,
+    this.featureFlagStore
+  );
+
   get featureFlags(): FeatureFlag[] {
     return Object.values(this).filter(value => value instanceof FeatureFlagFromStorage);
   }

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -6,6 +6,7 @@ namespace SIL.XForge.Scripture.Models;
 public static class FeatureFlags
 {
     public const string Serval = "Serval";
+    public const string UploadParatextZipForPreTranslation = "UploadParatextZipForPreTranslation";
     public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
     public const string MachineInProcess = "MachineInProcess";
 }

--- a/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
@@ -25,6 +25,17 @@ public class ServalCorpus
     public bool AlternateTrainingSource { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to upload the project as a Paratext zip file.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if we are uploading a Paratext zip file; otherwise, <c>false</c> if this corpus is for translation.
+    /// </value>
+    /// <remarks>
+    /// This is only for use with Pre-translation - not with SMT.
+    /// </remarks>
+    public bool UploadParatextZipFile { get; set; }
+
+    /// <summary>
     /// Gets or sets the source files uploaded to Serval.
     /// </summary>
     /// <value>

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1,17 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Newtonsoft.Json.Linq;
 using Serval.Client;
 using SIL.Machine.Corpora;
 using SIL.Machine.WebApi.Services;
+using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
@@ -40,10 +44,12 @@ public class MachineProjectService : IMachineProjectService
     private readonly IEngineService _engineService;
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IFeatureManager _featureManager;
+    private readonly IFileSystemService _fileSystemService;
     private readonly ILogger<MachineProjectService> _logger;
     private readonly IParatextService _paratextService;
     private readonly IRepository<SFProjectSecret> _projectSecrets;
     private readonly IRealtimeService _realtimeService;
+    private readonly IOptions<SiteOptions> _siteOptions;
     private readonly ISFTextCorpusFactory _textCorpusFactory;
     private readonly ITranslationEnginesClient _translationEnginesClient;
     private readonly IRepository<UserSecret> _userSecrets;
@@ -53,10 +59,12 @@ public class MachineProjectService : IMachineProjectService
         IEngineService engineService,
         IExceptionHandler exceptionHandler,
         IFeatureManager featureManager,
+        IFileSystemService fileSystemService,
         ILogger<MachineProjectService> logger,
         IParatextService paratextService,
         IRepository<SFProjectSecret> projectSecrets,
         IRealtimeService realtimeService,
+        IOptions<SiteOptions> siteOptions,
         ISFTextCorpusFactory textCorpusFactory,
         ITranslationEnginesClient translationEnginesClient,
         IRepository<UserSecret> userSecrets
@@ -66,10 +74,12 @@ public class MachineProjectService : IMachineProjectService
         _engineService = engineService;
         _exceptionHandler = exceptionHandler;
         _featureManager = featureManager;
+        _fileSystemService = fileSystemService;
         _logger = logger;
         _paratextService = paratextService;
         _projectSecrets = projectSecrets;
         _realtimeService = realtimeService;
+        _siteOptions = siteOptions;
         _textCorpusFactory = textCorpusFactory;
         _translationEnginesClient = translationEnginesClient;
         _userSecrets = userSecrets;
@@ -603,6 +613,12 @@ public class MachineProjectService : IMachineProjectService
             )
             .Key;
 
+        // See if we are uploading a Paratext zip file
+        bool uploadParatextZipFile =
+            preTranslate
+            && await _featureManager.IsEnabledAsync(FeatureFlags.UploadParatextZipForPreTranslation)
+            && (corpusId == null || projectSecret.ServalData.Corpora[corpusId].UploadParatextZipFile);
+
         // See if there is a training corpus
         string? alternateTrainingSourceCorpusId = null;
         bool useAlternateTrainingSource =
@@ -624,17 +640,24 @@ public class MachineProjectService : IMachineProjectService
         }
 
         // Reuse the SFTextCorpusFactory implementation
-        IEnumerable<ISFText> texts = await _textCorpusFactory.CreateAsync(
-            new[] { project.Id },
-            TextCorpusType.Source,
-            preTranslate,
-            useAlternateTrainingSource: false,
-            buildConfig
-        );
+        // This is only necessary for SMT suggestions or pre-Paratext zip support NMT projects
+        IEnumerable<ISFText> texts = new List<ISFText>();
+        if (!uploadParatextZipFile)
+        {
+            texts = await _textCorpusFactory.CreateAsync(
+                new[] { project.Id },
+                TextCorpusType.Source,
+                preTranslate,
+                useAlternateTrainingSource: false,
+                buildConfig
+            );
+        }
+
         var newSourceCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
-            includeBlankSegments: true,
+            project.TranslateConfig.Source!.ParatextId,
+            uploadParatextZipFile,
             texts,
             oldSourceCorpusFiles,
             newSourceCorpusFiles,
@@ -648,17 +671,23 @@ public class MachineProjectService : IMachineProjectService
             oldTargetCorpusFiles = projectSecret.ServalData.Corpora[corpusId].TargetFiles;
         }
 
-        texts = await _textCorpusFactory.CreateAsync(
-            new[] { project.Id },
-            TextCorpusType.Target,
-            preTranslate,
-            useAlternateTrainingSource: false,
-            buildConfig
-        );
+        // Only specify the text corpus if we are not uploading to Paratext
+        if (!uploadParatextZipFile)
+        {
+            texts = await _textCorpusFactory.CreateAsync(
+                new[] { project.Id },
+                TextCorpusType.Target,
+                preTranslate,
+                useAlternateTrainingSource: false,
+                buildConfig
+            );
+        }
+
         List<ServalCorpusFile> newTargetCorpusFiles = new List<ServalCorpusFile>();
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
-            preTranslate,
+            project.ParatextId,
+            uploadParatextZipFile,
             texts,
             oldTargetCorpusFiles,
             newTargetCorpusFiles,
@@ -679,16 +708,22 @@ public class MachineProjectService : IMachineProjectService
                     .SourceFiles;
             }
 
-            texts = await _textCorpusFactory.CreateAsync(
-                new[] { project.Id },
-                TextCorpusType.Source,
-                preTranslate: true,
-                useAlternateTrainingSource: true,
-                buildConfig
-            );
+            // Only specify the text corpus if we are not uploading to Paratext
+            if (!uploadParatextZipFile)
+            {
+                texts = await _textCorpusFactory.CreateAsync(
+                    new[] { project.Id },
+                    TextCorpusType.Source,
+                    preTranslate,
+                    useAlternateTrainingSource: true,
+                    buildConfig
+                );
+            }
+
             corpusUpdated |= await UploadNewCorpusFilesAsync(
                 project.Id,
-                includeBlankSegments: true,
+                project.TranslateConfig.DraftConfig.AlternateTrainingSource.ParatextId,
+                uploadParatextZipFile,
                 texts,
                 oldAlternateTrainingSourceCorpusFiles,
                 newAlternateTrainingSourceCorpusFiles,
@@ -703,6 +738,7 @@ public class MachineProjectService : IMachineProjectService
             corpusId,
             preTranslate,
             useAlternateTrainingSource: false,
+            uploadParatextZipFile,
             corpusUpdated,
             newSourceCorpusFiles,
             newTargetCorpusFiles,
@@ -718,6 +754,7 @@ public class MachineProjectService : IMachineProjectService
                 corpusId: alternateTrainingSourceCorpusId,
                 preTranslate: true,
                 useAlternateTrainingSource: true,
+                uploadParatextZipFile,
                 corpusUpdated,
                 sourceCorpusFiles: newAlternateTrainingSourceCorpusFiles,
                 newTargetCorpusFiles,
@@ -967,6 +1004,114 @@ public class MachineProjectService : IMachineProjectService
         return translationEngineId;
     }
 
+    private async Task<bool> UploadFileAsync(
+        string textId,
+        string textFileData,
+        FileFormat fileFormat,
+        ICollection<ServalCorpusFile>? oldCorpusFiles,
+        ICollection<ServalCorpusFile> newCorpusFiles,
+        CancellationToken cancellationToken
+    )
+    {
+        byte[] buffer = Encoding.UTF8.GetBytes(textFileData);
+        await using Stream stream = new MemoryStream(buffer, false);
+        return await UploadFileAsync(textId, stream, fileFormat, oldCorpusFiles, newCorpusFiles, cancellationToken);
+    }
+
+    private async Task<bool> UploadFileAsync(
+        string textId,
+        Stream stream,
+        FileFormat fileFormat,
+        ICollection<ServalCorpusFile>? oldCorpusFiles,
+        ICollection<ServalCorpusFile> newCorpusFiles,
+        CancellationToken cancellationToken
+    )
+    {
+        // See if the corpus exists and update it if it is missing, or if the checksum has changed
+        bool uploadText = false;
+
+        // Reset the stream to the start
+        stream.Seek(0, SeekOrigin.Begin);
+
+        // Calculate the checksum from the stream
+        using MD5 md5 = MD5.Create();
+        StringBuilder sb = new StringBuilder();
+        foreach (var hashByte in await md5.ComputeHashAsync(stream, cancellationToken))
+        {
+            sb.Append(hashByte.ToString("X2").ToLower());
+        }
+
+        // Upload the file if it is not there or has changed
+        string checksum = sb.ToString();
+        ServalCorpusFile? previousCorpusFile = oldCorpusFiles?.FirstOrDefault(c => c.TextId == textId);
+        if (previousCorpusFile is null || previousCorpusFile.FileChecksum != checksum)
+        {
+            uploadText = true;
+        }
+
+        // No update, so do not upload
+        if (!uploadText)
+        {
+            newCorpusFiles.Add(previousCorpusFile);
+            return false;
+        }
+
+        // Reset the stream to the start
+        stream.Seek(0, SeekOrigin.Begin);
+
+        // Upload the file
+        DataFile dataFile;
+        if (previousCorpusFile is null)
+        {
+            dataFile = await _dataFilesClient.CreateAsync(
+                new FileParameter(stream),
+                fileFormat,
+                textId,
+                cancellationToken
+            );
+        }
+        else
+        {
+            // See if the file exists, and it is the same format
+            bool dataFileExists;
+            try
+            {
+                dataFile = await _dataFilesClient.GetAsync(previousCorpusFile.FileId, cancellationToken);
+                dataFileExists = dataFile.Format == fileFormat;
+            }
+            catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+            {
+                _logger.LogInformation($"File {previousCorpusFile.FileId} does not exist - creating.");
+                dataFileExists = false;
+            }
+
+            // Update the file if it exists, otherwise create it
+            dataFile = dataFileExists
+                ? await _dataFilesClient.UpdateAsync(
+                    previousCorpusFile.FileId,
+                    new FileParameter(stream),
+                    cancellationToken
+                )
+                : await _dataFilesClient.CreateAsync(
+                    new FileParameter(stream),
+                    fileFormat,
+                    textId,
+                    cancellationToken
+                );
+        }
+
+        newCorpusFiles.Add(
+            new ServalCorpusFile
+            {
+                FileChecksum = checksum,
+                FileId = dataFile.Id,
+                TextId = textId,
+            }
+        );
+
+        return true;
+    }
+
     /// <summary>
     /// Gets the target language for the project
     /// </summary>
@@ -1004,6 +1149,7 @@ public class MachineProjectService : IMachineProjectService
     /// <param name="corpusId">The corpus identifier. If <c>null</c>, a new corpus is created.</param>
     /// <param name="preTranslate">The project is for pre-translation.</param>
     /// <param name="useAlternateTrainingSource">If <c>true</c>, use the alternate training source.</param>
+    /// <param name="uploadParatextZipFile">A Paratext zip file was used for the upload.</param>
     /// <param name="corpusUpdated">The files in the corpus have been updated.</param>
     /// <param name="sourceCorpusFiles">The source corpus files.</param>
     /// <param name="targetCorpusFiles">The target corpus files.</param>
@@ -1015,6 +1161,7 @@ public class MachineProjectService : IMachineProjectService
         string? corpusId,
         bool preTranslate,
         bool useAlternateTrainingSource,
+        bool uploadParatextZipFile,
         bool corpusUpdated,
         List<ServalCorpusFile> sourceCorpusFiles,
         List<ServalCorpusFile> targetCorpusFiles,
@@ -1122,6 +1269,7 @@ public class MachineProjectService : IMachineProjectService
                         TargetFiles = targetCorpusFiles,
                         PreTranslate = preTranslate,
                         AlternateTrainingSource = useAlternateTrainingSource,
+                        UploadParatextZipFile = uploadParatextZipFile,
                     }
                 )
         );
@@ -1133,8 +1281,9 @@ public class MachineProjectService : IMachineProjectService
     /// Syncs a collection of <see cref="ISFText"/> to Serval, creating files on Serval as necessary.
     /// </summary>
     /// <param name="projectId">The project identifier.</param>
-    /// <param name="includeBlankSegments">
-    /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
+    /// <param name="paratextId">The Paratext identifier.</param>
+    /// <param name="uploadParatextZipFile">
+    /// <c>true</c> if we are uploading a Paratext zip file; otherwise <c>false</c>.
     /// </param>
     /// <param name="texts">The texts created by <see cref="SFTextCorpusFactory"/>.</param>
     /// <param name="oldCorpusFiles">The existing corpus files (optional).</param>
@@ -1146,7 +1295,8 @@ public class MachineProjectService : IMachineProjectService
     /// </remarks>
     private async Task<bool> UploadNewCorpusFilesAsync(
         string projectId,
-        bool includeBlankSegments,
+        string paratextId,
+        bool uploadParatextZipFile,
         IEnumerable<ISFText> texts,
         ICollection<ServalCorpusFile>? oldCorpusFiles,
         ICollection<ServalCorpusFile> newCorpusFiles,
@@ -1156,74 +1306,63 @@ public class MachineProjectService : IMachineProjectService
         // Used to return whether the corpus files were created or updated
         bool corpusUpdated = false;
 
-        // Sync each text
-        foreach (ISFText text in texts)
+        // Upload the Paratext zip file, if we are supposed to
+        if (uploadParatextZipFile)
         {
-            string textFileData = GetTextFileData(text, includeBlankSegments);
-            if (!string.IsNullOrWhiteSpace(textFileData))
+            // Get the path to the Paratext directory
+            string path = Path.Combine(_siteOptions.Value.SiteDir, "sync", paratextId, "target");
+
+            // Ensure that the path exists
+            if (!_fileSystemService.DirectoryExists(path))
             {
-                // Remove the project id from the start of the text id (if present)
-                string textId = text.Id.StartsWith($"{projectId}_") ? text.Id[(projectId.Length + 1)..] : text.Id;
+                throw new DirectoryNotFoundException($"The following directory could not be found: {path}");
+            }
 
-                // See if the corpus exists and update it if it is missing, or if the checksum has changed
-                bool uploadText = false;
-                string checksum = StringUtils.ComputeMd5Hash(textFileData);
-                ServalCorpusFile? previousCorpusFile = oldCorpusFiles?.FirstOrDefault(c => c.TextId == textId);
-                if (previousCorpusFile is null || previousCorpusFile.FileChecksum != checksum)
+            // Create the zip file from the directory in memory
+            await using var memoryStream = new MemoryStream();
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+            {
+                // Do not convert the ZipArchive using statement above into a using declaration,
+                // otherwise the ZipArchive disposal will crash after the MemoryStream disposal.
+                foreach (string filePath in _fileSystemService.EnumerateFiles(path))
                 {
-                    uploadText = true;
+                    await using Stream fileStream = _fileSystemService.OpenFile(filePath, FileMode.Open);
+                    ZipArchiveEntry entry = archive.CreateEntry(Path.GetFileName(filePath));
+                    await using Stream entryStream = entry.Open();
+                    await fileStream.CopyToAsync(entryStream, cancellationToken);
                 }
+            }
 
-                // Upload the file if it is not there or has changed
-                if (uploadText)
+            // Upload the zip file
+            corpusUpdated = await UploadFileAsync(
+                projectId,
+                memoryStream,
+                FileFormat.Paratext,
+                oldCorpusFiles,
+                newCorpusFiles,
+                cancellationToken
+            );
+        }
+        else
+        {
+            // Sync each text
+            foreach (ISFText text in texts)
+            {
+                string textFileData = GetTextFileData(text, includeBlankSegments: false);
+                if (!string.IsNullOrWhiteSpace(textFileData))
                 {
-                    await using MemoryStream data = new MemoryStream(Encoding.UTF8.GetBytes(textFileData));
-                    DataFile dataFile;
-                    if (previousCorpusFile is null)
-                    {
-                        dataFile = await _dataFilesClient.CreateAsync(
-                            new FileParameter(data),
-                            FileFormat.Text,
-                            textId,
-                            cancellationToken
-                        );
-                    }
-                    else
-                    {
-                        try
-                        {
-                            dataFile = await _dataFilesClient.UpdateAsync(
-                                previousCorpusFile.FileId,
-                                new FileParameter(data),
-                                cancellationToken
-                            );
-                        }
-                        catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
-                        {
-                            _logger.LogInformation($"File {previousCorpusFile.FileId} does not exist - creating.");
-                            dataFile = await _dataFilesClient.CreateAsync(
-                                new FileParameter(data),
-                                FileFormat.Text,
-                                textId,
-                                cancellationToken
-                            );
-                        }
-                    }
+                    // Remove the project id from the start of the text id (if present)
+                    string textId = text.Id.StartsWith($"{projectId}_") ? text.Id[(projectId.Length + 1)..] : text.Id;
 
-                    newCorpusFiles.Add(
-                        new ServalCorpusFile
-                        {
-                            FileChecksum = checksum,
-                            FileId = dataFile.Id,
-                            TextId = textId,
-                        }
+                    // Upload the text file
+                    corpusUpdated |= await UploadFileAsync(
+                        textId,
+                        textFileData,
+                        FileFormat.Text,
+                        oldCorpusFiles,
+                        newCorpusFiles,
+                        cancellationToken
                     );
-
-                    corpusUpdated = true;
-                }
-                else
-                {
-                    newCorpusFiles.Add(previousCorpusFile);
                 }
             }
         }

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -34,6 +34,8 @@ public class PreTranslationService : IPreTranslationService
 
     public static string GetTextId(int bookNum, int chapterNum) => $"{bookNum}_{chapterNum}";
 
+    public static string GetTextId(int bookNum) => Canon.BookNumberToId(bookNum);
+
     public async Task<PreTranslation[]> GetPreTranslationsAsync(
         string curUserId,
         string sfProjectId,
@@ -66,7 +68,8 @@ public class PreTranslationService : IPreTranslationService
         }
 
         // Get the pre-translation data from Serval
-        string textId = GetTextId(bookNum, chapterNum);
+        bool useParatextVerseRef = projectSecret.ServalData.Corpora[corpusId].UploadParatextZipFile;
+        string textId = useParatextVerseRef ? GetTextId(bookNum) : GetTextId(bookNum, chapterNum);
         foreach (
             Pretranslation preTranslation in await _translationEnginesClient.GetAllPretranslationsAsync(
                 translationEngineId,
@@ -76,69 +79,90 @@ public class PreTranslationService : IPreTranslationService
             )
         )
         {
-            // A reference will be in the format "40_1:verse_001_002"
+            // A reference will be in one of the formats:
+            // FileFormat.Text: "40_1:verse_001_002"
+            // FileFormat.Paratext: "MAT 1:2"
             string reference = preTranslation.Refs.FirstOrDefault();
             if (string.IsNullOrWhiteSpace(reference))
             {
                 continue;
             }
 
-            // Check for then remove the textId from the reference
-            string[] referenceParts;
-            if (reference.Contains(':'))
+            // Only return this chapter if we are using the Paratext verse ref format
+            if (useParatextVerseRef)
             {
-                referenceParts = reference.Split(':', StringSplitOptions.RemoveEmptyEntries);
-                if (referenceParts.Length != 2)
+                // The file format is FileFormat.Paratext
+
+                // Ensure we have a valid verse reference and it is for this chapter
+                if (!VerseRef.TryParse(reference, out VerseRef verseRef) || verseRef.ChapterNum != chapterNum)
                 {
                     continue;
                 }
 
-                // The first part must be the text id
-                if (referenceParts.First() != textId)
+                // Conform the reference to the format the frontend expects
+                reference = $"verse_{verseRef.ChapterNum}_{verseRef.Verse}";
+            }
+            else
+            {
+                // The file format is FileFormat.Text
+
+                // Check for then remove the textId from the reference
+                string[] referenceParts;
+                if (reference.Contains(':'))
+                {
+                    referenceParts = reference.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                    if (referenceParts.Length != 2)
+                    {
+                        continue;
+                    }
+
+                    // The first part must be the text id
+                    if (referenceParts.First() != textId)
+                    {
+                        continue;
+                    }
+
+                    // Remove the reference part
+                    reference = referenceParts.Last();
+                }
+
+                // Ensure this is for a verse - we do not support headings and metadata
+                referenceParts = reference.Split('_', StringSplitOptions.RemoveEmptyEntries);
+                if (reference.StartsWith("verse_"))
+                {
+                    // The reference is in the form verse_001_001 or verse_001_001_001
+                    if (
+                        referenceParts.Length < 3
+                        || !int.TryParse(referenceParts[1], out int refChapterNum)
+                        || refChapterNum != chapterNum
+                    )
+                    {
+                        continue;
+                    }
+
+                    // Get the reference in the form verse_1_1, if we did not send all segments
+                    // This will allow us to combine multiple paragraphs or poetry lines in the same verse
+                    if (!project.TranslateConfig.DraftConfig.SendAllSegments)
+                    {
+                        string verse = referenceParts[2];
+                        VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
+                        reference = $"verse_{verseRef.ChapterNum}_{verseRef.Verse}";
+                    }
+                }
+
+                // Parse the reference for non-verse segments, if we sent them for pre-translation
+                if (project.TranslateConfig.DraftConfig.SendAllSegments)
+                {
+                    // The reference is in the format abc_001, abc_001_001, etc. Convert it to the format abc_1 or abc_1_1
+                    reference = string.Join(
+                        '_',
+                        referenceParts.Select(part => int.TryParse(part, out int number) ? number.ToString() : part)
+                    );
+                }
+                else if (!reference.StartsWith("verse_"))
                 {
                     continue;
                 }
-
-                // Remove the reference part
-                reference = referenceParts.Last();
-            }
-
-            // Ensure this is for a verse - we do not support headings and metadata
-            referenceParts = reference.Split('_', StringSplitOptions.RemoveEmptyEntries);
-            if (reference.StartsWith("verse_"))
-            {
-                // The reference is in the form verse_001_001 or verse_001_001_001
-                if (
-                    referenceParts.Length < 3
-                    || !int.TryParse(referenceParts[1], out int refChapterNum)
-                    || refChapterNum != chapterNum
-                )
-                {
-                    continue;
-                }
-
-                // Get the reference in the form verse_1_1, if we did not send all segments
-                // This will allow us to combine multiple paragraphs or poetry lines in the same verse
-                if (!project.TranslateConfig.DraftConfig.SendAllSegments)
-                {
-                    string verse = referenceParts[2];
-                    VerseRef verseRef = new VerseRefData(bookNum, chapterNum, verse).ToVerseRef();
-                    reference = $"verse_{verseRef.ChapterNum}_{verseRef.Verse}";
-                }
-            }
-
-            // Parse the reference for non-verse segments, if we sent them for pre-translation
-            if (project.TranslateConfig.DraftConfig.SendAllSegments)
-            {
-                // The reference is in the format abc_001, abc_001_001, etc. Convert it to the format abc_1 or abc_1_1
-                reference = string.Join(
-                    '_',
-                    referenceParts.Select(part => int.TryParse(part, out int number) ? number.ToString() : part)
-                );
-            }
-            else if (!reference.StartsWith("verse_"))
-            {
-                continue;
             }
 
             // Build the translation string

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -61,6 +61,7 @@
   "FeatureManagement": {
     "Serval": true,
     "MachineInProcess": true,
+    "UploadParatextZipForPreTranslation": false,
     "UseEchoForPreTranslation": false
   }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -88,7 +88,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationsAsync_AllowsSegmentedVersesAndHeadingsWhenSendAllSegmentsTrue()
     {
         // Set up test environment
-        var env = new TestEnvironment(sendAllSegments: true);
+        var env = new TestEnvironment(new TestEnvironmentOptions { SendAllSegments = true });
         const int bookNum = 64;
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
@@ -174,7 +174,36 @@ public class PreTranslationServiceTests
     }
 
     [Test]
-    public async Task GetPreTranslationsAsync_ReturnsEmptyArrayIfNoPreTranslations()
+    public async Task GetPreTranslationsAsync_ReturnsEmptyArrayIfNoPreTranslations_Paratext()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { UseParatextZipFile = true });
+        const int bookNum = 40;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum);
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
+            .Returns(Task.FromResult<IList<Pretranslation>>(new List<Pretranslation>()));
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            bookNum,
+            chapterNum,
+            CancellationToken.None
+        );
+        Assert.Zero(actual.Length);
+        await env.TranslationEnginesClient.Received()
+            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetPreTranslationsAsync_ReturnsEmptyArrayIfNoPreTranslations_Text()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -198,10 +227,83 @@ public class PreTranslationServiceTests
             CancellationToken.None
         );
         Assert.Zero(actual.Length);
+        await env.TranslationEnginesClient.Received()
+            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None);
     }
 
     [Test]
-    public async Task GetPreTranslationsAsync_ReturnsUsablePreTranslations()
+    public async Task GetPreTranslationsAsync_ReturnsUsablePreTranslations_Paratext()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { UseParatextZipFile = true });
+        const int bookNum = 40;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum);
+        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+            TranslationEngine01,
+            Corpus01,
+            textId,
+            CancellationToken.None
+        )
+            .Returns(
+                Task.FromResult<IList<Pretranslation>>(
+                    new List<Pretranslation>
+                    {
+                        new Pretranslation { TextId = "40_1", Translation = "Matthew" },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "MAT 1:1" },
+                            Translation =
+                                "The book of the birth of Jesus Christ , the son of David , the son of Abraham .",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "MAT 1:2" },
+                            Translation =
+                                "Abraham was the father of Isaac , Isaac was the father of James , and James was the father of Jude and his brethren .",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "MAT 2:1" },
+                            Translation =
+                                "This will not be returned - Serval returns all of the book's pre-translations",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "invalid_ref" },
+                            Translation = "This will not be returned as it has an invalid ref",
+                        },
+                    }
+                )
+            );
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            User01,
+            Project01,
+            bookNum,
+            chapterNum,
+            CancellationToken.None
+        );
+        Assert.AreEqual(2, actual.Length);
+        Assert.AreEqual("verse_1_1", actual.First().Reference);
+        Assert.AreEqual(
+            "The book of the birth of Jesus Christ, the son of David, the son of Abraham. ",
+            actual.First().Translation
+        );
+        Assert.AreEqual("verse_1_2", actual.Last().Reference);
+        Assert.AreEqual(
+            "Abraham was the father of Isaac, Isaac was the father of James, and James was the father of Jude and his brethren. ",
+            actual.Last().Translation
+        );
+    }
+
+    [Test]
+    public async Task GetPreTranslationsAsync_ReturnsUsablePreTranslations_Text()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -233,6 +335,30 @@ public class PreTranslationServiceTests
                             Translation =
                                 "Abraham was the father of Isaac , Isaac was the father of James , and James was the father of Jude and his brethren .",
                         },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "invalid_ref" },
+                            Translation = "This ref does not have a colon, so is invalid and will not be returned",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "41_1:verse_001_002" },
+                            Translation = "This ref is for the wrong book, so will not be returned",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "40_1:verse_001" },
+                            Translation = "This ref has only a chapter number, so will not be returned",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "40_1",
+                            Refs = { "40_1:verse_001:001" },
+                            Translation = "This ref has too many colons, so will not be returned",
+                        },
                     }
                 )
             );
@@ -258,10 +384,17 @@ public class PreTranslationServiceTests
         );
     }
 
+    private class TestEnvironmentOptions
+    {
+        public bool SendAllSegments { get; init; }
+        public bool UseParatextZipFile { get; init; }
+    }
+
     private class TestEnvironment
     {
-        public TestEnvironment(bool sendAllSegments = false)
+        public TestEnvironment(TestEnvironmentOptions? options = null)
         {
+            options ??= new TestEnvironmentOptions();
             var projectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]
                 {
@@ -275,11 +408,15 @@ public class PreTranslationServiceTests
                             {
                                 {
                                     "another_corpus",
-                                    new ServalCorpus { PreTranslate = false, }
+                                    new ServalCorpus { PreTranslate = false }
                                 },
                                 {
                                     Corpus01,
-                                    new ServalCorpus { PreTranslate = true, }
+                                    new ServalCorpus
+                                    {
+                                        PreTranslate = true,
+                                        UploadParatextZipFile = options.UseParatextZipFile,
+                                    }
                                 },
                             },
                         },
@@ -294,7 +431,10 @@ public class PreTranslationServiceTests
                 new SFProject
                 {
                     Id = Project01,
-                    TranslateConfig = new TranslateConfig { DraftConfig = { SendAllSegments = sendAllSegments, }, },
+                    TranslateConfig = new TranslateConfig
+                    {
+                        DraftConfig = { SendAllSegments = options.SendAllSegments }
+                    },
                 },
             };
             realtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));


### PR DESCRIPTION
This PR adds support for uploading data to Serval as a Paratext zip file.

Since Serval support has already gone live, this format will only be used for draft generation if:

 * The **UploadParatextZipForPreTranslation** feature flag is enabled on the backend
 * A draft has not been previously generated for the project

*This is to ensure that any new drafts will not wildly vary from previous drafts, until the feature is stable and formally released across Serval and Scripture Forge.*

When these two conditions are met, and a pre-translation build is started:

1. A sync is performed for the source & target to ensure the disk contains the most up to date version of the project.
2. The contents of the Paratext project directory are zipped into a memory stream.
3. This stream is uploaded to Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2286)
<!-- Reviewable:end -->
