### PR TITLE
Update notices over editor to use app-notice component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -107,22 +107,32 @@
           <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
         </div>
       </app-notice>
-      <div *ngIf="!isUsfmValid && hasEditRight" class="formatting-invalid-warning">
-        <mat-icon>warning</mat-icon> {{ t("cannot_edit_chapter_formatting_invalid") }}
-      </div>
-      <div *ngIf="!dataInSync && hasEditRight" class="out-of-sync-warning">
-        <mat-icon>warning</mat-icon> {{ t("project_data_out_of_sync") }}
-      </div>
-      <div *ngIf="target.areOpsCorrupted && hasEditRight" class="doc-corrupted-warning">
-        <mat-icon>error</mat-icon> {{ t("text_doc_corrupted") }}
+      <app-notice *ngIf="!isUsfmValid && hasEditRight" type="warning" icon="warning" class="formatting-invalid-warning">
+        {{ t("cannot_edit_chapter_formatting_invalid") }}
+      </app-notice>
+      <app-notice *ngIf="!dataInSync && hasEditRight" type="warning" icon="warning" class="out-of-sync-warning">
+        {{ t("project_data_out_of_sync") }}
+      </app-notice>
+      <app-notice
+        *ngIf="target.areOpsCorrupted && hasEditRight"
+        type="error"
+        icon="error"
+        class="doc-corrupted-warning"
+      >
+        {{ t("text_doc_corrupted") }}
         <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
-      </div>
-      <div *ngIf="projectTextNotEditable && hasEditRight" class="project-text-not-editable">
-        <mat-icon>info</mat-icon> {{ t("project_text_not_editable") }}
-      </div>
-      <div *ngIf="showNoEditPermissionMessage" class="no-edit-permission-message">
-        <mat-icon>info</mat-icon> {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
-      </div>
+      </app-notice>
+      <app-notice
+        *ngIf="projectTextNotEditable && hasEditRight"
+        type="info"
+        icon="info"
+        class="project-text-not-editable"
+      >
+        {{ t("project_text_not_editable") }}
+      </app-notice>
+      <app-notice *ngIf="showNoEditPermissionMessage" type="info" icon="info" class="no-edit-permission-message">
+        {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
+      </app-notice>
       <div #targetSplitContainer class="container-for-split">
         <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
         <as-split direction="vertical" [style.height]="targetSplitHeight">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -71,24 +71,7 @@ app-text {
 .doc-corrupted-warning,
 .project-text-not-editable,
 .no-edit-permission-message {
-  color: #ff4118;
-  border: 1px solid $border-color;
-  padding: 5px 10px;
-  margin-bottom: 10px;
-
-  @include media-breakpoint-only(xs) {
-    margin-left: 10px;
-    margin-right: 10px;
-  }
-
-  mat-icon {
-    vertical-align: bottom;
-  }
-}
-
-.no-edit-permission-message,
-.project-text-not-editable {
-  color: $lighterTextColor;
+  margin-bottom: 4px;
 }
 
 .both-editors-wrapper {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -394,7 +394,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get userRoleStr(): string {
-    return this.i18n.localizeRole(this.userRole || '');
+    return this.userRole == null ? '' : this.i18n.localizeRole(this.userRole);
   }
 
   get hasSourceViewRight(): boolean {


### PR DESCRIPTION
Before | After
-------|------
![editor_notices_before](https://github.com/sillsdev/web-xforge/assets/6140710/0f21213a-82e3-4624-afb3-e74b065a4d11) | ![editor_notices_after](https://github.com/sillsdev/web-xforge/assets/6140710/14f26ec7-70a3-4d59-8f72-d16e395dc43d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2289)
<!-- Reviewable:end -->
