### PR TITLE
SF-2456 Allow projects with Serval SMT suggestions to change language

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1995,6 +1995,40 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public async Task StartBuildAsync_ServalRecreatesWhenLanguageChanges()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineProjectService.AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None)
+            .Returns(Task.FromResult(TranslationEngine01));
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(Task.FromResult(new TranslationEngine { SourceLanguage = "fr", TargetLanguage = "de" }));
+        env.TranslationEnginesClient.StartBuildAsync(
+            TranslationEngine01,
+            Arg.Any<TranslationBuildConfig>(),
+            CancellationToken.None
+        )
+            .Returns(Task.FromResult(new TranslationBuild()));
+        env.FeatureManager.IsEnabledAsync(FeatureFlags.MachineInProcess).Returns(Task.FromResult(false));
+
+        // SUT
+        ServalBuildDto actual = await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
+
+        Assert.IsNotNull(actual);
+        await env.MachineProjectService.Received(1)
+            .AddProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
+        await env.MachineProjectService.Received(1)
+            .RemoveProjectAsync(User01, Project01, preTranslate: false, CancellationToken.None);
+        await env.MachineProjectService.Received(1)
+            .SyncProjectCorporaAsync(
+                User01,
+                Arg.Is<BuildConfig>(b => b.ProjectId == Project01),
+                preTranslate: false,
+                CancellationToken.None
+            );
+    }
+
+    [Test]
     public async Task StartBuildAsync_ServalSuccess()
     {
         // Set up test environment
@@ -3019,6 +3053,7 @@ public class MachineApiServiceTests
                     CancellationToken.None
                 )
                 .Returns(Task.FromResult(true));
+            var mockLogger = new MockLogger<MachineApiService>();
             PreTranslationService = Substitute.For<IPreTranslationService>();
             ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]
@@ -3072,6 +3107,9 @@ public class MachineApiServiceTests
             SyncService = Substitute.For<ISyncService>();
             SyncService.SyncAsync(Arg.Any<SyncConfig>()).Returns(Task.FromResult("jobId"));
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
+            TranslationEnginesClient
+                .GetAsync(TranslationEngine01, CancellationToken.None)
+                .Returns(Task.FromResult(new TranslationEngine()));
 
             Service = new MachineApiService(
                 BackgroundJobClient,
@@ -3081,6 +3119,7 @@ public class MachineApiServiceTests
                 EngineService,
                 ExceptionHandler,
                 FeatureManager,
+                mockLogger,
                 MachineProjectService,
                 PreTranslationService,
                 ProjectSecrets,


### PR DESCRIPTION
This PR fixes a crash that can occur when training SMT suggestions using Serval where the project's source or target language has changed.

The Acceptance Test on the JIRA ticket details how to recreate this error.

Stack trace of the error from QA (also in bugsnag; this error has occurred on live too):
```
Serval.Client.ServalApiException The engine was specified incorrectly.  Did you use the same language for the source and target?

Status: 422
Response: 
"Source and target languages, swk & hi, do not match engine source and target languages, swk & hi-Latn" 
    /opt/buildagent/work/ee130f1d7ff31933/src/SIL.XForge.Scripture/Services/MachineApiService.cs:1218 SIL.XForge.Scripture.Services.MachineApiService+<ProcessServalApiExceptionAsync>d__41.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    /opt/buildagent/work/ee130f1d7ff31933/src/SIL.XForge.Scripture/Services/MachineApiService.cs:693 SIL.XForge.Scripture.Services.MachineApiService+<StartBuildAsync>d__26.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter<TResult>.GetResult()
    /opt/buildagent/work/ee130f1d7ff31933/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs:359 SIL.XForge.Scripture.Controllers.MachineApiController+<StartBuildAsync>d__11.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown lambda_method396680(Closure , object )
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor+TaskOfActionResultExecutor+<Execute>d__0.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker+<<InvokeActionMethodAsync>g__Logged|12_1>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker+<<InvokeNextActionFilterAsync>g__Awaited|10_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker+<<InvokeInnerFilterAsync>g__Awaited|13_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+<<InvokeNextExceptionFilterAsync>g__Awaited|26_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ExceptionContextSealed context)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+<<InvokeNextResourceFilter>g__Awaited|25_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+<<InvokeFilterPipelineAsync>g__Awaited|20_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+<<InvokeAsync>g__Logged|17_1>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+<<InvokeAsync>g__Logged|17_1>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Routing.EndpointMiddleware+<<Invoke>g__AwaitRequestTask|6_0>d.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler+<HandleAsync>d__0.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Authorization.AuthorizationMiddleware+<Invoke>d__6.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Authentication.AuthenticationMiddleware+<Invoke>d__6.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware+<Invoke>d__5.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Diagnostics.StatusCodePagesMiddleware+<Invoke>d__3.MoveNext()
    unknown System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    unknown System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
    unknown System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    unknown Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware+<<Invoke>g__Awaited|6_0>d.MoveNext()
```