### PR TITLE
SF-2457 Avoid incorrect plurals in checking overview labels

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -416,7 +416,7 @@ describe('CheckingOverviewComponent', () => {
       env.waitForQuestions();
       expect(env.textRows.length).toEqual(2);
       expect(env.textArchivedRows.length).toEqual(1);
-      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 questions');
+      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 question');
       env.clickExpanderAtRow(0);
       env.clickExpanderAtRow(1);
       expect(env.textRows.length).toEqual(9);
@@ -433,7 +433,7 @@ describe('CheckingOverviewComponent', () => {
       expect(archivedQuestion.textContent).toContain('Archived on');
       env.clickElement(env.questionPublishButtons[2]);
       expect(env.textArchivedRows.length).toEqual(3);
-      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 questions');
+      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 question');
       expect(env.textRows.length).toEqual(9);
     }));
 
@@ -454,7 +454,7 @@ describe('CheckingOverviewComponent', () => {
       // that chapter should have 6 questions
       expect(env.getPublishedQuestionsCountTextByRow(1)).toContain('6 questions');
       // and one question has been archived already
-      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 questions');
+      expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('1 question');
 
       // ARCHIVE QUESTIONS IN A CHAPTER
 
@@ -494,7 +494,7 @@ describe('CheckingOverviewComponent', () => {
       // Expect two books with archived questions
       expect(env.textArchivedRows.length).toEqual(2);
       expect(env.getArchivedQuestionsCountTextByRow(0)).toContain('7 questions');
-      expect(env.getArchivedQuestionsCountTextByRow(1)).toContain('1 questions');
+      expect(env.getArchivedQuestionsCountTextByRow(1)).toContain('1 question');
 
       // REPUBLISH QUESTIONS ONE BOOK AT A TIME
 
@@ -508,7 +508,7 @@ describe('CheckingOverviewComponent', () => {
       // and two books with published questions
       expect(env.textRows.length).toEqual(2);
       expect(env.getPublishedQuestionsCountTextByRow(0)).toContain('7 questions');
-      expect(env.getPublishedQuestionsCountTextByRow(1)).toContain('1 questions');
+      expect(env.getPublishedQuestionsCountTextByRow(1)).toContain('1 question');
     }));
   });
 
@@ -696,6 +696,16 @@ describe('CheckingOverviewComponent', () => {
     env.waitForQuestions();
     expect(env.component.questionCount(41, 1)).toEqual(0);
   }));
+
+  it('should get the correct question and answer labels depending on count', () => {
+    const env = new TestEnvironment();
+    expect(env.component.questionCountLabel(1)).toEqual('checking_overview.single_question_count_label');
+    expect(env.component.questionCountLabel(2)).toEqual('checking_overview.question_count_label');
+
+    expect(env.component.answerCountLabel(0)).toEqual('');
+    expect(env.component.answerCountLabel(1)).toEqual('checking_overview.single_answer_count_label');
+    expect(env.component.answerCountLabel(2)).toEqual('checking_overview.answer_count_label');
+  });
 });
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -337,7 +337,9 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   questionCountLabel(count: number): string {
-    return translate('checking_overview.question_count_label', { count: count });
+    return count === 1
+      ? translate('checking_overview.single_question_count_label')
+      : translate('checking_overview.question_count_label', { count: count });
   }
 
   timeArchivedStamp(date: string | undefined): string {
@@ -385,7 +387,13 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   answerCountLabel(count?: number): string {
-    return count != null && count > 0 ? translate('checking_overview.answer_count_label', { count: count }) : '';
+    if (count === undefined || count === 0) {
+      return '';
+    } else if (count === 1) {
+      return translate('checking_overview.single_answer_count_label');
+    } else {
+      return translate('checking_overview.answer_count_label', { count: count });
+    }
   }
 
   async setArchiveStatusForQuestionsInBook(text: TextInfo, archive: boolean): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -62,6 +62,8 @@
     "question_count_label": "{{ count }} questions",
     "republish_multiple": "Republish all questions in {{ location }}",
     "republish": "Republish",
+    "single_answer_count_label": "1 answer",
+    "single_question_count_label": "1 question",
     "time_archived_stamp": "Archived on {{ timeStamp }}"
   },
   "collaborators": {


### PR DESCRIPTION
Under the manage questions section each book/verse has a question count label and each book/verse/question has an answer count label.

In the case that there is only one question or answer we are still using the plural e.g. "1 questions" where we should be using the non-plural e.g. "1 question"

This PR adds two new translations to use when there is only one question/answer and uses them when applicable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2291)
<!-- Reviewable:end -->
