### PR TITLE
SF-2384 Fix flicker after project book is deleted

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -70,6 +70,18 @@ describe('ProjectComponent', () => {
     expect().nothing();
   }));
 
+  it('navigate to first text when last selected text missing', fakeAsync(() => {
+    const env = new TestEnvironment();
+    const missingBookNum = 44;
+    env.setProjectData({ selectedTask: 'translate', selectedBooknum: missingBookNum, memberProjectIdSuffixes: [1] });
+    env.fixture.detectChanges();
+    tick();
+
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'ACT']), anything())).never();
+    verify(mockedRouter.navigate(deepEqual(['projects', 'project1', 'translate', 'MAT']), anything())).once();
+    expect().nothing();
+  }));
+
   it('navigate to checking tool if a checker and no last selected task', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedPermissions.canAccessTranslate(anything())).thenReturn(false);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -113,7 +113,10 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     task: TaskType = 'translate'
   ): void {
     const routePath = ['projects', projectId, task];
-    const bookNum: number | undefined = projectUserConfig.selectedBookNum ?? project.texts[0]?.bookNum;
+    let bookNum: number | undefined = projectUserConfig.selectedBookNum;
+    if (bookNum == null || !project.texts.some(t => t.bookNum === bookNum)) {
+      bookNum = project.texts[0]?.bookNum;
+    }
 
     if (bookNum != null) {
       routePath.push(Canon.bookNumberToId(bookNum));


### PR DESCRIPTION
When a user deletes a book in PT, the project component is not made aware and tries to navigate to the delete book. This causes an infinite redirect when the editor component redirects back to the project component when it realizes that the book does not exist. This PR updates the project component to navigate to a book only if the book exists on the project.

To reproduce this issue easily, update the SFProjectUserConfig doc entry in mongo so the selectedBookNum is a book that does not exist on the project.

![Selected Book Num Flicker](https://github.com/sillsdev/web-xforge/assets/17931130/d0fed600-6e1b-4e8c-b7b5-132d8dad9718)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2293)
<!-- Reviewable:end -->
