### PR TITLE
FIX: Revert Target and Source flipped in SF-2432

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'editor'">
-  <div class="content" [class.reverse-columns]="isTargetTextRight">
+  <div class="content" [class.reverse-columns]="!isTargetTextRight">
     <div class="toolbar" fxLayout="row" fxLayoutAlign="start center">
       <div fxFlex fxLayout="row wrap">
         <app-book-chapter-chooser


### PR DESCRIPTION
The PR #2273 changed the target to be on the left by default instead of the right. This PR reverses this by mapping the inverse of `isTargetTextRight` to the CSS class reverse-columns.

**Note:** The property `sf_project_user_config.isTargetTextRight` is set to `true` by default when this document is created (see SFProjectUserConfig.cs).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2295)
<!-- Reviewable:end -->
