### PR TITLE
SF-2371 Update from Material legacy form related controls

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -65,7 +65,7 @@ $toolbar-height: 56px;
 
 header {
   width: 100%;
-  z-index: 7;
+  z-index: 1001; // Needs to be larger than overlay containers
 
   .title {
     cursor: pointer;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -24,14 +24,6 @@ $toolbar-height: 56px;
     z-index: 8;
   }
 
-  > header {
-    position: absolute;
-
-    &.overlay-drawer {
-      z-index: 6;
-    }
-  }
-
   .top-app-bar-adjust {
     margin-top: $toolbar-height;
   }
@@ -64,6 +56,7 @@ $toolbar-height: 56px;
 }
 
 header {
+  position: absolute;
   width: 100%;
   z-index: 1001; // Needs to be larger than overlay containers
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -20,7 +20,6 @@ import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browse
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
-import { MAT_LEGACY_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/legacy-form-field';
 import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -91,8 +90,7 @@ import { NavigationComponent } from './navigation/navigation.component';
     defaultTranslocoMarkupTranspilers(),
     { provide: ErrorHandler, useClass: ExceptionHandlingService },
     { provide: OverlayContainer, useClass: InAppRootOverlayContainer },
-    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },
-    { provide: MAT_LEGACY_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -15,11 +15,22 @@
           icon="warning"
           type="warning"
         ></app-info>
-        <mat-select [(value)]="book" [disabled]="inEditState" class="book-select-menu">
+        <mat-select
+          [(value)]="book"
+          [disabled]="inEditState"
+          class="book-select-menu"
+          [hideSingleSelectionIndicator]="true"
+        >
           <mat-option *ngFor="let b of books" [value]="b">{{ bookName(b) }}</mat-option>
         </mat-select>
         <div class="divider"></div>
-        <mat-select [(value)]="chapter" [disabled]="inEditState" class="chapter-select-menu">
+        <mat-select
+          [(value)]="chapter"
+          [disabled]="inEditState"
+          class="chapter-select-menu"
+          [hideSingleSelectionIndicator]="true"
+          [panelWidth]="80"
+        >
           <mat-option *ngFor="let c of chapters" [value]="c">{{ c }}</mat-option>
         </mat-select>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
@@ -72,6 +72,11 @@
     margin-bottom: 1rem;
   }
 }
+mat-select.book-select-menu ::ng-deep {
+  .mat-mdc-select-arrow-wrapper {
+    margin-right: 5px;
+  }
+}
 
 .mat-dialog-actions {
   justify-content: end;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
@@ -74,7 +74,7 @@
 }
 mat-select.book-select-menu ::ng-deep {
   .mat-mdc-select-arrow-wrapper {
-    margin-right: 5px;
+    margin-inline-end: 5px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -556,8 +556,8 @@ describe('ChapterAudioDialogComponent', () => {
     expect(env.component.book).toEqual(expectedBook);
     expect(env.component.chapter).toEqual(expectedChapter);
     expect(env.component.audioFilename).toEqual('Genesis 3');
-    expect(env.bookSelect.classList.contains('mat-select-disabled')).toBe(true);
-    expect(env.chapterSelect.classList.contains('mat-select-disabled')).toBe(true);
+    expect(env.bookSelect.classList.contains('mat-mdc-select-disabled')).toBe(true);
+    expect(env.chapterSelect.classList.contains('mat-mdc-select-disabled')).toBe(true);
     expect(env.wrapperAudio.classList.contains('valid')).toBe(true);
     expect(env.wrapperTiming.classList.contains('valid')).toBe(true);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -52,7 +52,7 @@
               </ng-template>
               <ng-template matTabContent>
                 <div class="answer-tab answer-text">
-                  <mat-form-field appearance="outline">
+                  <mat-form-field appearance="outline" subscriptSizing="dynamic">
                     <mat-label>{{ t("your_answer") }}</mat-label>
                     <textarea appAutofocus matInput formControlName="answerText"></textarea>
                   </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -90,9 +90,6 @@
       display: none;
     }
   }
-  ::ng-deep .mat-form-field-wrapper {
-    padding-bottom: 0px;
-  }
   .form-actions {
     display: flex;
     justify-content: flex-end;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.scss
@@ -4,6 +4,6 @@
   gap: 10px;
 }
 
-.mat-form-field {
+.mat-mdc-form-field {
   width: 100%;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -6,7 +6,7 @@ import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, flush, tick
 import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
 import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { MatLegacyMenuHarness as MatMenuHarness } from '@angular/material/legacy-menu/testing';
-import { MatLegacySelectHarness as MatSelectHarness } from '@angular/material/legacy-select/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, ActivatedRouteSnapshot, Params, Route, Router } from '@angular/router';
@@ -2651,7 +2651,7 @@ class TestEnvironment {
   }
 
   get yourAnswerContainer(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#answer-form .mat-form-field'));
+    return this.fixture.debugElement.query(By.css('#answer-form .mat-mdc-form-field'));
   }
 
   get yourAnswerField(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -128,7 +128,7 @@
         </div>
         <div colspan="2" class="filter-text">
           <div>
-            <mat-form-field appearance="fill">
+            <mat-form-field appearance="fill" subscriptSizing="dynamic">
               <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
             </mat-form-field>
             <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -103,25 +103,18 @@
   div {
     display: flex;
     align-items: center;
-    mat-form-field {
+    mat-form-field:not(.mdc-text-field--textarea) {
+      height: 36px;
       flex: 1;
       @include media-breakpoint-up(sm) {
         max-width: unset;
       }
       max-width: 70%;
       // below is to make denser
-      .mat-form-field-wrapper {
-        padding-bottom: 0;
-        .mat-form-field-infix {
-          border: 0;
-          padding: 0 0 0.75em 0;
+      .mat-mdc-text-field-wrapper {
+        div.mat-mdc-form-field-infix {
+          padding: 10px 0;
         }
-      }
-      .mat-form-field-underline {
-        bottom: 0;
-      }
-      .mat-form-field-subscript-wrapper {
-        display: none;
       }
     }
   }
@@ -129,19 +122,15 @@
 
 // below is to make denser
 :host ::ng-deep {
-  mat-form-field.mat-form-field.mat-form-field-appearance-outline
-    > div.mat-form-field-wrapper
-    > div.mat-form-field-flex
-    > div.mat-form-field-infix {
-    padding: 0.4em 0px;
-    top: -0.2em;
-    > span.mat-form-field-label-wrapper {
-      top: -1.2em;
+  mat-form-field.mat-mdc-form-field.mat-form-field-appearance-outline {
+    .mat-mdc-form-field-infix {
+      min-height: initial;
+      padding: 10px 0 5px;
     }
-  }
-  .mat-form-field-appearance-outline.mat-form-field-can-float.mat-form-field-should-float .mat-form-field-label {
-    transform: translateY(-1.1em) scale(0.75);
-    width: 133.33333%;
+
+    label.mat-mdc-floating-label:not(.mdc-floating-label--float-above) {
+      transform: translateY(-100%);
+    }
   }
 }
 
@@ -150,10 +139,8 @@
   @include media-breakpoint-up(sm) {
     display: flex;
     ::ng-deep {
-      mat-form-field:first-child .mat-form-field-outline-end {
-        border-radius: 0;
-      }
-      mat-form-field:last-child .mat-form-field-outline-start {
+      mat-form-field:first-child .mdc-notched-outline__trailing,
+      mat-form-field:last-child .mdc-notched-outline__leading {
         border-radius: 0;
       }
     }
@@ -164,7 +151,7 @@
   white-space: initial;
 }
 
-:not(mat-form-field) > .mat-error {
+:not(mat-form-field) > .mat-mdc-form-field-error {
   margin-top: 10px;
   font-size: 14px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -4,12 +4,6 @@
 
 mat-form-field {
   margin-bottom: 1em;
-  .scripture-helper-text .scripture-reference {
-    max-width: 248px;
-    .mat-form-field-suffix {
-      top: 0.5em;
-    }
-  }
   &.question-container {
     width: 100%;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, ErrorHandler } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { AbstractControl } from '@angular/forms';
-import { MatLegacySelect as MatSelect } from '@angular/material/legacy-select';
+import { MatSelect } from '@angular/material/select';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
@@ -535,7 +535,7 @@ class TestEnvironment {
   }
 
   isMenuItemDisabled(menu: DebugElement, index: number): boolean {
-    return this.getMenuItems(menu)[index].nativeElement.classList.contains('mat-option-disabled');
+    return this.getMenuItems(menu)[index].nativeElement.classList.contains('mdc-list-item--disabled');
   }
 
   getMenuItemText(menu: DebugElement, index: number): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.scss
@@ -2,12 +2,3 @@
 mat-form-field {
   width: 100%;
 }
-
-::ng-deep .mat-autocomplete-panel.project-select mat-option {
-  height: unset;
-  white-space: initial;
-  min-height: 48px;
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  line-height: 1.5em;
-}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
@@ -1,8 +1,8 @@
 import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
-import { MatLegacyAutocomplete as MatAutocomplete } from '@angular/material/legacy-autocomplete';
-import { MatLegacyFormField as MatFormField } from '@angular/material/legacy-form-field';
+import { MatAutocomplete } from '@angular/material/autocomplete';
+import { MatFormField } from '@angular/material/form-field';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
@@ -223,7 +223,7 @@ class TestEnvironment {
   }
 
   get groupLabels(): string[] {
-    return Array.from(this.panel.querySelectorAll('.mat-optgroup-label')).map(e => e.textContent?.trim() || '');
+    return Array.from(this.panel.querySelectorAll('.mat-mdc-optgroup-label')).map(e => e.textContent?.trim() || '');
   }
 
   get autoCompleteShowing(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -1,9 +1,6 @@
 import { Component, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, UntypedFormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
-import {
-  MatLegacyAutocomplete as MatAutocomplete,
-  MatLegacyAutocompleteTrigger as MatAutocompleteTrigger
-} from '@angular/material/legacy-autocomplete';
+import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { BehaviorSubject, combineLatest, fromEvent, Observable } from 'rxjs';
 import { filter, map, startWith, takeUntil, tap } from 'rxjs/operators';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -44,7 +44,7 @@
       margin: 0 0 0 24px;
     }
   }
-  .mat-error {
+  .mat-mdc-form-field-error {
     margin-top: 10px;
     font-size: 14px;
     display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
@@ -3,7 +3,9 @@
     <mat-select
       [value]="book"
       (valueChange)="bookChanged($event)"
-      [disabled]="bookSelectDisabled"
+      [disabled]="!!bookSelectDisabled"
+      [hideSingleSelectionIndicator]="true"
+      panelWidth="200"
       panelClass="book-select-menu"
     >
       <mat-option *ngFor="let b of books" [value]="b">{{ bookName(b) }}</mat-option>
@@ -13,7 +15,8 @@
     <mat-select
       [value]="chapter"
       (valueChange)="chapterChanged($event)"
-      [disabled]="chapterSelectDisabled"
+      [disabled]="!!chapterSelectDisabled"
+      [hideSingleSelectionIndicator]="true"
       panelClass="chapter-select-menu"
     >
       <mat-option *ngFor="let c of chapters" [value]="c">{{ c }}</mat-option>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -7,34 +7,23 @@
 // These styles were written by inspecting the elements using developer and then adding rules until it looked right
 #chapter-select ::ng-deep,
 #book-select ::ng-deep {
-  .mat-form-field-wrapper {
-    margin: 0;
-    padding-bottom: 0;
-    .mat-form-field-flex {
-      padding-top: 0;
-    }
-    .mat-form-field-flex:not(:hover) {
-      background-color: transparent;
-    }
+  height: 36px;
+  .mat-mdc-text-field-wrapper {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
-  .mat-form-field-underline {
-    display: none;
+  .mat-mdc-select-arrow-wrapper {
+    margin-left: 5px;
   }
-  .mat-select-arrow-wrapper {
-    transform: unset;
-  }
-  .mat-form-field-infix {
-    // It appeared there was a transparent border being used as padding
-    border-top-width: 0;
-    padding-top: 12px;
-    padding-bottom: 10px;
-  }
-  .mat-form-field-infix {
+  .mat-mdc-form-field-infix {
+    min-height: initial;
+    padding-top: 7px;
+    padding-bottom: 5px;
     width: initial;
   }
 }
 
-::ng-deep .mat-select-panel {
+::ng-deep .mat-mdc-select-panel {
   &.book-select-menu,
   &.chapter-select-menu {
     max-height: 85vh;
@@ -42,8 +31,8 @@
 }
 
 ::ng-deep {
-  #book-select .mat-form-field-outline-end,
-  #chapter-select .mat-form-field-outline-start {
+  #book-select .mdc-notched-outline__trailing,
+  #chapter-select .mdc-notched-outline__leading {
     border-radius: 0;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -8,10 +8,6 @@
 #chapter-select ::ng-deep,
 #book-select ::ng-deep {
   height: 36px;
-  .mat-mdc-text-field-wrapper {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
   .mat-mdc-select-arrow-wrapper {
     margin-left: 5px;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -1,3 +1,5 @@
+@use 'src/material-styles';
+
 :host {
   display: flex;
   align-items: center;
@@ -5,18 +7,9 @@
 
 // Unfortunately there doesn't appear to be a good way to style a mat-select
 // These styles were written by inspecting the elements using developer and then adding rules until it looked right
-#chapter-select ::ng-deep,
-#book-select ::ng-deep {
-  height: 36px;
-  .mat-mdc-select-arrow-wrapper {
-    margin-left: 5px;
-  }
-  .mat-mdc-form-field-infix {
-    min-height: initial;
-    padding-top: 7px;
-    padding-bottom: 5px;
-    width: initial;
-  }
+#chapter-select,
+#book-select {
+  @include material-styles.dense_mat_select();
 }
 
 ::ng-deep .mat-mdc-select-panel {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -17,7 +17,7 @@
           </mat-form-field>
           <mat-form-field id="invitation-role">
             <mat-label>{{ t("invitation_role") }}</mat-label>
-            <mat-select formControlName="role" panelClass="invitation-role-panel">
+            <mat-select formControlName="role" panelClass="invitation-role-panel" [hideSingleSelectionIndicator]="true">
               <mat-select-trigger>
                 {{ roleControl.value ? i18n.localizeRole(roleControl.value) : "" }}
               </mat-select-trigger>
@@ -30,7 +30,7 @@
           </mat-form-field>
           <mat-form-field id="invitation-language">
             <mat-label>{{ t("invitation_language") }}</mat-label>
-            <mat-select formControlName="locale" panelClass="locale-fonts">
+            <mat-select formControlName="locale" panelClass="locale-fonts" [hideSingleSelectionIndicator]="true">
               <mat-option *ngFor="let locale of i18n.locales" [value]="locale.canonicalTag">
                 {{ locale.localName }}
               </mat-option>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -42,7 +42,7 @@ form {
   }
 }
 
-::ng-deep .invitation-role-panel .mat-option {
+::ng-deep .invitation-role-panel .mat-mdc-option {
   height: 4em !important;
 
   .role-name,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.scss
@@ -166,7 +166,7 @@ app-text {
 }
 
 // Keep the options on the screen
-::ng-deep .mat-select-panel {
+::ng-deep .mat-mdc-select-panel {
   &.book-select-menu,
   &.chapter-select-menu {
     max-height: 65vh !important;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/history-chooser/history-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/history-chooser/history-chooser.component.scss
@@ -1,24 +1,5 @@
-// This is based on the chapter-select SCSS
-#history-select ::ng-deep {
-  .mat-form-field-wrapper {
-    padding-bottom: 0;
-    .mat-form-field-flex {
-      padding-top: 0;
-    }
-    .mat-form-field-flex:not(:hover) {
-      background-color: transparent;
-    }
-  }
-  .mat-form-field-underline {
-    display: none;
-  }
-  .mat-select-arrow-wrapper {
-    transform: unset;
-  }
-  .mat-form-field-infix {
-    border-top-width: 0;
-    max-width: 120px;
-    padding-top: 10px;
-    padding-bottom: 8px;
-  }
+@use 'src/material-styles';
+
+#history-select {
+  @include material-styles.dense_mat_select();
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -68,9 +68,6 @@ h1 {
 .full-width {
   width: 100%;
   margin-top: 1em;
-  .mat-form-field-flex {
-    padding: 0 0.75em;
-  }
 }
 .assigned-user {
   opacity: 0.5;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -43,10 +43,6 @@ mat-dialog-content {
   flex-direction: column;
 }
 
-mat-option {
-  height: 2.5em !important;
-}
-
 .minor-header {
   font-size: 0.875rem;
   line-height: 1.375rem;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -5,7 +5,7 @@ import {
   MatLegacyDialog as MatDialog,
   MatLegacyDialogConfig as MatDialogConfig
 } from '@angular/material/legacy-dialog';
-import { MatLegacySelect as MatSelect } from '@angular/material/legacy-select';
+import { MatSelect } from '@angular/material/select';
 import { MatSlider } from '@angular/material/slider';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -165,3 +165,19 @@ button.mat-icon-button {
 .mat-mdc-tab-header {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }
+
+@mixin dense_mat_select() {
+  ::ng-deep {
+    height: 36px;
+    .mat-mdc-form-field-infix {
+      min-height: initial;
+      padding-top: 7px;
+      padding-bottom: 5px;
+      width: initial;
+      min-width: 25px; // prevent weird transparent gap between content and scrollbar in Chromium
+    }
+    .mat-mdc-select-arrow-wrapper {
+      margin-inline-start: 5px;
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -100,8 +100,8 @@ $material-theme-accent-error: mat.define-light-theme(
   )
 );
 
-@include mat.legacy-core-theme($material-app-theme);
-@include mat.legacy-autocomplete-theme($material-app-theme);
+@include mat.core-theme($material-app-theme);
+@include mat.autocomplete-theme($material-app-theme);
 @include mat.badge-theme($material-app-theme);
 @include mat.bottom-sheet-theme($material-app-theme);
 @include mat.legacy-button-theme($material-app-theme);
@@ -112,17 +112,15 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-dialog-theme($material-app-theme);
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);
-@include mat.legacy-form-field-theme($material-theme-accent-error);
 @include mat.form-field-theme($material-theme-accent-error);
 @include mat.icon-theme($material-app-theme);
-@include mat.legacy-input-theme($material-app-theme);
+@include mat.input-theme($material-app-theme);
 @include mat.legacy-list-theme($material-app-theme);
 @include mat.legacy-menu-theme($material-app-theme);
 @include mat.legacy-paginator-theme($material-app-theme);
 @include mat.progress-bar-theme($material-app-theme);
 @include mat.legacy-progress-spinner-theme($material-app-theme);
 @include mat.radio-theme($material-app-theme);
-@include mat.legacy-select-theme($material-app-theme);
 @include mat.select-theme($material-app-theme);
 @include mat.sidenav-theme($material-app-theme);
 @include mat.legacy-slide-toggle-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,3 +1,3 @@
-.mat-dialog-content .mat-form-field {
+.mat-dialog-content .mat-mdc-form-field {
   width: 100%;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -26,6 +26,7 @@
               [value]="row.projectRole"
               [disabled]="row.isUpdatingRole"
               (selectionChange)="updateRole(row, $event.value)"
+              [hideSingleSelectionIndicator]="true"
             >
               <mat-option *ngFor="let projectRole of projectRoles" [value]="projectRole">
                 {{ i18n.localizeRole(projectRole.role) }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.scss
@@ -29,6 +29,7 @@ table {
 
 .connect-cell {
   text-align: right;
+  text-overflow: initial;
 }
 
 .task-label {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -292,7 +292,7 @@ class TestEnvironment {
   }
 
   selectValue(select: DebugElement): string {
-    const trigger = select.query(By.css('.mat-select-trigger'));
+    const trigger = select.query(By.css('.mat-mdc-select-trigger'));
     this.fixture.detectChanges();
     return trigger.nativeElement.textContent;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -9,14 +9,14 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
-import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { MatLegacyCheckboxModule as MatCheckboxModule } from '@angular/material/legacy-checkbox';
-import { MatLegacyOptionModule as MatOptionModule } from '@angular/material/legacy-core';
+import { MatOptionModule } from '@angular/material/core';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
-import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
-import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
 import {
@@ -24,7 +24,7 @@ import {
   MatLegacyPaginatorModule as MatPaginatorModule
 } from '@angular/material/legacy-paginator';
 import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
-import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
+import { MatSelectModule } from '@angular/material/select';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatRadioModule } from '@angular/material/radio';


### PR DESCRIPTION
* Upgrade material legacy select, form, input, option, autocomplete
* Removed ellipsis from role select cell in system administrator table

This PR upgrades `mat-select`, `mat-option`, `mat-form-field` and `mat-autocomplete` from legacy to the Angular Material mdc version. Used ng generate @angular/material:mdc-migration as a starting point.

I left most style changes as per the new version of material except where we intentionally changed the styling i.e. to make it denser.

Some styles were no longer required as they are part of the latest version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2296)
<!-- Reviewable:end -->
