### PR TITLE
SF-2462 Stop reporting pre-translation build in progress errors

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
@@ -10,6 +10,15 @@ namespace SIL.XForge.Scripture.Services;
 /// <remarks>These have been constructed based on the information in Swagger.</remarks>
 public static class ServalApiExceptions
 {
+    public static ServalApiException BuildInProgress =>
+        new ServalApiException(
+            "There is already an active or pending build or a build in the process of being canceled",
+            StatusCodes.Status409Conflict,
+            null,
+            new Dictionary<string, IEnumerable<string>>(),
+            null
+        );
+
     public static ServalApiException EngineNotBuilt =>
         new ServalApiException(
             "The engine needs to be built first",


### PR DESCRIPTION
When a build is already in progress, and the user triggers another (usually due to connectivity issues, multiple windows open, or multiple users attempting to start a build at the same time), an error was reported to the user.

This PR resolves that by not reporting that specific error to the user. This means that the progress of the already started build will be displayed to the user, and upon completion of that build, they will be able to access the draft when that build is complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2298)
<!-- Reviewable:end -->
