### PR TITLE
SF-2463 Fix Paratext 7 Resources being marked as English

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1834,7 +1834,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             // The source can be null if there was an error getting a resource from the DBL
-            if (TranslationSuggestionsEnabled && _projectDoc.Data.TranslateConfig.Source != null)
+            if (_projectDoc.Data.TranslateConfig.Source != null)
             {
                 ParatextSettings? sourceSettings = _paratextService.GetParatextSettings(
                     _userSecret,


### PR DESCRIPTION
**Problem Overview**
Paratext 7 Resources store the language definition in the file ldml.xml, while Paratext 8+ store this data in the file [lang_id].ldml. One such project on prod and dev is DYU, or just in dev (i.e. is correct in prod), NNRV.

When ParatextData reads the installed resource in Scripture Forge, it shows the Resources language as being the default, English.

This was previously not much of a problem for Resources in Scripture Forge, but as we send this language code to Serval, we need to ensure that this code is correct so that pre-translation drafting can occur.

**Solution Overview**
The Paratext migrators are quite complex, and locked in the Paratext source code (i.e. they are not in ParatextData.dll). Because of this, I have implemented the minimum required migrator to move the shipped LDML file to a location where ParatextData can read the correct language code.

**Migration Notes**
To fix any existing installed resources, run the script `trigger-resources-need-sync.ts` in PR #1764.

**Testing Notes**
This PR should be tested by a developer as its changes are predominantly under the hood.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2300)
<!-- Reviewable:end -->
