### PR TITLE
SF-2469 Inform user when no mic is found

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -126,7 +126,7 @@ class TestEnvironment {
     });
     when(mockedNavigator.mediaDevices).thenReturn({
       getUserMedia: (mediaConstraints: MediaStreamConstraints) =>
-        this.rejectUserMedia ? Promise.reject() : navigator.mediaDevices.getUserMedia(mediaConstraints)
+        this.rejectUserMedia ? Promise.reject({}) : navigator.mediaDevices.getUserMedia(mediaConstraints)
     } as MediaDevices);
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -104,9 +104,15 @@ export class CheckingAudioRecorderComponent implements OnInit, OnDestroy {
     });
   }
 
-  private errorCallback(): void {
+  private errorCallback(error: any): void {
+    console.error(error);
     this.status.emit({ status: 'denied' });
-    this.noticeService.show(translate('checking_audio_recorder.mic_access_denied'));
+
+    if (error.code === DOMException.NOT_FOUND_ERR) {
+      this.noticeService.show(translate('checking_audio_recorder.mic_not_found'));
+    } else {
+      this.noticeService.show(translate('checking_audio_recorder.mic_access_denied'));
+    }
   }
 
   private successCallback(stream: MediaStream): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -245,8 +245,9 @@
     "audio_cannot_be_previewed": "The audio is in a format that cannot be previewed. Save any changes and connect to the internet to play."
   },
   "checking_audio_recorder": {
-    "not_available": "Your browser currently does not support audio recording. Please try using another supported browser.",
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
+    "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
+    "not_available": "Your browser currently does not support audio recording. Please try using another supported browser.",
     "record": "Record",
     "stop_recording": "Stop Recording",
     "try_again": "Try Again"


### PR DESCRIPTION
I couldn't figure out why my machine wouldn't let me record, despite having given permission. It just kept saying permission denied, which I figured was related to being on localhost (an insecure origin).

Actually I just didn't have a mic connected. Probably not a common situation, but even I couldn't figure that out without stepping through the debugger. :facepalm:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2304)
<!-- Reviewable:end -->
