### PR TITLE
SF-2470 Fix incorrect books sent to Serval for Pre-Translation

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -670,6 +670,7 @@ public class MachineProjectService : IMachineProjectService
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
             project.TranslateConfig.Source!.ParatextId,
+            includeBlankSegments: true,
             uploadParatextZipFile,
             texts,
             oldSourceCorpusFiles,
@@ -700,6 +701,7 @@ public class MachineProjectService : IMachineProjectService
         corpusUpdated |= await UploadNewCorpusFilesAsync(
             project.Id,
             project.ParatextId,
+            includeBlankSegments: preTranslate,
             uploadParatextZipFile,
             texts,
             oldTargetCorpusFiles,
@@ -736,6 +738,7 @@ public class MachineProjectService : IMachineProjectService
             corpusUpdated |= await UploadNewCorpusFilesAsync(
                 project.Id,
                 project.TranslateConfig.DraftConfig.AlternateTrainingSource.ParatextId,
+                includeBlankSegments: true,
                 uploadParatextZipFile,
                 texts,
                 oldAlternateTrainingSourceCorpusFiles,
@@ -1344,6 +1347,10 @@ public class MachineProjectService : IMachineProjectService
     /// </summary>
     /// <param name="projectId">The project identifier.</param>
     /// <param name="paratextId">The Paratext identifier.</param>
+    /// <param name="includeBlankSegments">
+    /// <c>true</c> if we are to include blank segments (usually for a pre-translation target); otherwise <c>false</c>.
+    /// This is not used if <paramref name="uploadParatextZipFile"/> is <c>true</c>.
+    /// </param>
     /// <param name="uploadParatextZipFile">
     /// <c>true</c> if we are uploading a Paratext zip file; otherwise <c>false</c>.
     /// </param>
@@ -1358,6 +1365,7 @@ public class MachineProjectService : IMachineProjectService
     private async Task<bool> UploadNewCorpusFilesAsync(
         string projectId,
         string paratextId,
+        bool includeBlankSegments,
         bool uploadParatextZipFile,
         IEnumerable<ISFText> texts,
         ICollection<ServalCorpusFile>? oldCorpusFiles,
@@ -1410,7 +1418,7 @@ public class MachineProjectService : IMachineProjectService
             // Sync each text
             foreach (ISFText text in texts)
             {
-                string textFileData = GetTextFileData(text, includeBlankSegments: false);
+                string textFileData = GetTextFileData(text, includeBlankSegments);
                 if (!string.IsNullOrWhiteSpace(textFileData))
                 {
                     // Remove the project id from the start of the text id (if present)

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -1940,7 +1940,11 @@ public class MachineProjectServiceTests
             );
         }
 
-        private static string MockTextCorpusChecksum => StringUtils.ComputeMd5Hash("segRef\tsegment01\n");
+        private static string MockTextCorpusWithoutEmptySegmentChecksum =>
+            StringUtils.ComputeMd5Hash("segRef\tsegment01\n");
+
+        private static string MockTextCorpusWithEmptySegmentChecksum =>
+            StringUtils.ComputeMd5Hash("segRef\tsegment01\nsegRef_2\t\n");
 
         private static Task<IEnumerable<ISFText>> MockTextCorpus =>
             Task.FromResult<IEnumerable<ISFText>>(
@@ -1960,6 +1964,16 @@ public class MachineProjectServiceTests
                                 false,
                                 false,
                                 false
+                            ),
+                            new SFTextSegment(
+                                "textId_2",
+                                "segRef_2",
+                                string.Empty,
+                                Array.Empty<string>(),
+                                false,
+                                false,
+                                false,
+                                true
                             ),
                         },
                     },
@@ -1996,7 +2010,9 @@ public class MachineProjectServiceTests
                             {
                                 new ServalCorpusFile
                                 {
-                                    FileChecksum = requiresUpdate ? "old_checksum" : MockTextCorpusChecksum,
+                                    FileChecksum = requiresUpdate
+                                        ? "old_checksum"
+                                        : MockTextCorpusWithEmptySegmentChecksum,
                                     FileId = File01,
                                     TextId = "textId",
                                 },
@@ -2005,7 +2021,12 @@ public class MachineProjectServiceTests
                             {
                                 new ServalCorpusFile
                                 {
-                                    FileChecksum = requiresUpdate ? "old_checksum" : MockTextCorpusChecksum,
+                                    FileChecksum = requiresUpdate switch
+                                    {
+                                        true => "old_checksum",
+                                        false when preTranslate => MockTextCorpusWithEmptySegmentChecksum,
+                                        false => MockTextCorpusWithoutEmptySegmentChecksum,
+                                    },
                                     FileId = File02,
                                     TextId = "textId",
                                 },
@@ -2026,7 +2047,9 @@ public class MachineProjectServiceTests
                                 {
                                     new ServalCorpusFile
                                     {
-                                        FileChecksum = requiresUpdate ? "old_checksum" : MockTextCorpusChecksum,
+                                        FileChecksum = requiresUpdate
+                                            ? "old_checksum"
+                                            : MockTextCorpusWithEmptySegmentChecksum,
                                         FileId = File01,
                                         TextId = "textId",
                                     },
@@ -2035,7 +2058,12 @@ public class MachineProjectServiceTests
                                 {
                                     new ServalCorpusFile
                                     {
-                                        FileChecksum = requiresUpdate ? "old_checksum" : MockTextCorpusChecksum,
+                                        FileChecksum = requiresUpdate switch
+                                        {
+                                            true => "old_checksum",
+                                            false when preTranslate => MockTextCorpusWithEmptySegmentChecksum,
+                                            false => MockTextCorpusWithoutEmptySegmentChecksum,
+                                        },
                                         FileId = File02,
                                         TextId = "textId",
                                     },


### PR DESCRIPTION
Two critical bugs have been found in SF-2310 (#2286):

 * When the `UploadParatextZipForPreTranslation` feature flag is `true`, books selected are not specified in the Serval Build Configuration (d047c5d7dca924f518130343697870d56785ffc7)
 * When the `UploadParatextZipForPreTranslation` feature flag is `false`, blanks segments in target texts are not sent to Serval - this results in no pre-translation being generated (31f154f944b89ad73771a663d1a86d0e563fac37)

As #2286 is currently in [SF-QAv418](https://github.com/sillsdev/web-xforge/releases/tag/SF-QAv418), this PR should be treated as a blocker to this version going to `sf-live`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2305)
<!-- Reviewable:end -->
