### PR TITLE
SF-2459 Add additional non-Biblical source/target files for Serval training

### DIFF
--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -114,6 +114,7 @@
         - "/var/lib/scriptureforge"
         - "/var/lib/scriptureforge/sync"
         - "/var/lib/scriptureforge/audio"
+        - "/var/lib/scriptureforge/training-data"
         - "/var/lib/xforge"
         - "/var/lib/xforge/avatars"
         - "{{lookup('env','HOME')}}/.local/share/SIL/WritingSystemRepository/3"

--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -14,7 +14,8 @@ export enum SFProjectDomain {
   PTNoteThreads = 'pt_note_threads',
   SFNoteThreads = 'sf_note_threads',
   Notes = 'notes',
-  TextAudio = 'text_audio'
+  TextAudio = 'text_audio',
+  TrainingData = 'training_data'
 }
 
 // See https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
@@ -87,7 +88,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     pt_note_threads: ['view', 'create', 'edit', 'delete_own'],
     sf_note_threads: ['view', 'create', 'edit', 'delete_own'],
     notes: ['view', 'create', 'edit_own', 'delete_own'],
-    text_audio: ['view']
+    text_audio: ['view'],
+    training_data: ['view', 'create', 'edit_own', 'delete_own']
   },
   pt_administrator: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -102,7 +104,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     pt_note_threads: ['view', 'create', 'edit', 'delete'],
     sf_note_threads: ['view', 'create', 'edit', 'delete'],
     notes: ['view', 'create', 'edit_own', 'delete'],
-    text_audio: ['view', 'edit', 'create', 'delete']
+    text_audio: ['view', 'edit', 'create', 'delete'],
+    training_data: ['view', 'create', 'edit', 'delete']
   },
   none: {}
 };

--- a/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-test-data.ts
@@ -19,8 +19,10 @@ function testProjectProfile(ordinal: number): SFProjectProfile {
       preTranslate: false,
       defaultNoteTagId: 1,
       draftConfig: {
+        additionalTrainingData: false,
         alternateTrainingSourceEnabled: false,
         lastSelectedTrainingBooks: [],
+        lastSelectedTrainingDataFiles: [],
         lastSelectedTranslationBooks: [],
         sendAllSegments: false
       }

--- a/src/RealtimeServer/scriptureforge/models/training-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/training-data.ts
@@ -1,0 +1,16 @@
+import { ProjectData, PROJECT_DATA_INDEX_PATHS } from '../../common/models/project-data';
+
+export const TRAINING_DATA_COLLECTION = 'training_data';
+export const TRAINING_DATA_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
+
+export function getTrainingDataId(projectId: string, dataId: string): string {
+  return `${projectId}:${dataId}`;
+}
+
+export interface TrainingData extends ProjectData {
+  dataId: string;
+  fileUrl: string;
+  mimeType: string;
+  skipRows: number;
+  title: string;
+}

--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -27,10 +27,12 @@ export interface BaseProject {
 }
 
 export interface DraftConfig {
+  additionalTrainingData: boolean;
   alternateSource?: TranslateSource;
   alternateTrainingSourceEnabled: boolean;
   alternateTrainingSource?: TranslateSource;
   lastSelectedTrainingBooks: number[];
+  lastSelectedTrainingDataFiles: string[];
   lastSelectedTranslationBooks: number[];
   sendAllSegments: boolean;
   servalConfig?: string;

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -1,20 +1,21 @@
 import ShareDB from 'sharedb';
+import { Operation } from '../common/models/project-rights';
 import { RealtimeServer } from '../common/realtime-server';
 import { SchemaVersionRepository } from '../common/schema-version-repository';
 import { DocService } from '../common/services/doc-service';
 import { UserService } from '../common/services/user-service';
-import { Operation } from '../common/models/project-rights';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from './models/sf-project-rights';
 import { NOTE_THREAD_COLLECTION } from './models/note-thread';
 import { SF_PROJECTS_COLLECTION } from './models/sf-project';
+import { SFProjectDomain, SF_PROJECT_RIGHTS } from './models/sf-project-rights';
 import { BiblicalTermService } from './services/biblical-term-service';
 import { NoteThreadService } from './services/note-thread-service';
 import { QuestionService } from './services/question-service';
+import { SF_PROJECT_MIGRATIONS } from './services/sf-project-migrations';
 import { SFProjectService } from './services/sf-project-service';
 import { SFProjectUserConfigService } from './services/sf-project-user-config-service';
-import { TextService } from './services/text-service';
-import { SF_PROJECT_MIGRATIONS } from './services/sf-project-migrations';
 import { TextAudioService } from './services/text-audio-service';
+import { TextService } from './services/text-service';
+import { TrainingDataService } from './services/training-data-service';
 
 const SF_DOC_SERVICES: DocService[] = [
   new UserService(),
@@ -24,7 +25,8 @@ const SF_DOC_SERVICES: DocService[] = [
   new QuestionService(),
   new BiblicalTermService(),
   new NoteThreadService(),
-  new TextAudioService()
+  new TextAudioService(),
+  new TrainingDataService()
 ];
 
 /**

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -360,6 +360,35 @@ describe('version 12', () => {
       expect(projectDoc.data.translateConfig.draftConfig.sendAllSegments).toBe(false);
     });
   });
+
+  describe('version 17', () => {
+    it('adds lastSelectedTrainingDataFiles to draftConfig', async () => {
+      const env = new TestEnvironment(16);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', { translateConfig: { draftConfig: {} } });
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingDataFiles).not.toBeDefined();
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingDataFiles).toBeDefined();
+    });
+    it('adds additionalTrainingData to draftConfig', async () => {
+      const env = new TestEnvironment(16);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {
+        translateConfig: { draftConfig: {} }
+      });
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.additionalTrainingData).toBeUndefined();
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.additionalTrainingData).toBe(false);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -282,6 +282,21 @@ class SFProjectMigration16 extends DocMigration {
   }
 }
 
+class SFProjectMigration17 extends DocMigration {
+  static readonly VERSION = 17;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    if (doc.data.translateConfig.draftConfig.lastSelectedTrainingDataFiles == null) {
+      ops.push({ p: ['translateConfig', 'draftConfig', 'lastSelectedTrainingDataFiles'], oi: [] });
+    }
+    if (doc.data.translateConfig.draftConfig.additionalTrainingData == null) {
+      ops.push({ p: ['translateConfig', 'draftConfig', 'additionalTrainingData'], oi: false });
+    }
+    await submitMigrationOp(SFProjectMigration17.VERSION, doc, ops);
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration1,
   SFProjectMigration2,
@@ -298,5 +313,6 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration13,
   SFProjectMigration14,
   SFProjectMigration15,
-  SFProjectMigration16
+  SFProjectMigration16,
+  SFProjectMigration17
 ];

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -118,6 +118,9 @@ export class SFProjectService extends ProjectService<SFProject> {
           draftConfig: {
             bsonType: 'object',
             properties: {
+              additionalTrainingData: {
+                bsonType: 'bool'
+              },
               alternateSource: {
                 bsonType: 'object',
                 properties: {
@@ -187,6 +190,12 @@ export class SFProjectService extends ProjectService<SFProject> {
                 bsonType: 'array',
                 items: {
                   bsonType: 'int'
+                }
+              },
+              lastSelectedTrainingDataFiles: {
+                bsonType: 'array',
+                items: {
+                  bsonType: 'string'
                 }
               },
               lastSelectedTranslationBooks: {

--- a/src/RealtimeServer/scriptureforge/services/training-data-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-migrations.ts
@@ -1,0 +1,3 @@
+import { MigrationConstructor } from '../../common/migration';
+
+export const TRAINING_DATA_MIGRATIONS: MigrationConstructor[] = [];

--- a/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
@@ -1,0 +1,113 @@
+import ShareDB from 'sharedb';
+import ShareDBMingo from 'sharedb-mingo-memory';
+import { instance, mock } from 'ts-mockito';
+import { User, USERS_COLLECTION } from '../../common/models/user';
+import { createTestUser } from '../../common/models/user-test-data';
+import { RealtimeServer } from '../../common/realtime-server';
+import { SchemaVersionRepository } from '../../common/schema-version-repository';
+import { allowAll, clientConnect, createDoc, fetchDoc, submitJson0Op } from '../../common/utils/test-utils';
+import { SFProject, SF_PROJECTS_COLLECTION } from '../models/sf-project';
+import { SFProjectRole } from '../models/sf-project-role';
+import { createTestProject } from '../models/sf-project-test-data';
+import { getTrainingDataId, TrainingData, TRAINING_DATA_COLLECTION } from '../models/training-data';
+import { TrainingDataService } from './training-data-service';
+
+describe('TrainingDataService', () => {
+  it('allows translator to view training data', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'translator');
+    await expect(
+      fetchDoc(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'))
+    ).resolves.not.toThrow();
+  });
+
+  it('allows administrator to edit training data', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'administrator');
+    await expect(
+      submitJson0Op<TrainingData>(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'), op =>
+        op.set<number>(n => n.skipRows, 1)
+      )
+    ).resolves.not.toThrow();
+  });
+
+  it('does not allow consultant to view training data', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'consultant');
+    await expect(
+      fetchDoc(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'))
+    ).rejects.toThrow();
+  });
+
+  it('does not allow translator to edit another users training data', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'translator');
+    await expect(
+      submitJson0Op<TrainingData>(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'), op =>
+        op.set<number>(n => n.skipRows, 1)
+      )
+    ).rejects.toThrow();
+  });
+});
+
+class TestEnvironment {
+  readonly service: TrainingDataService;
+  readonly server: RealtimeServer;
+  readonly db: ShareDBMingo;
+  readonly mockedSchemaVersionRepository = mock(SchemaVersionRepository);
+
+  constructor() {
+    this.service = new TrainingDataService();
+    const ShareDBMingoType = ShareDBMingo.extendMemoryDB(ShareDB.MemoryDB);
+    this.db = new ShareDBMingoType();
+    this.server = new RealtimeServer(
+      'TEST',
+      false,
+      false,
+      [this.service],
+      SF_PROJECTS_COLLECTION,
+      this.db,
+      instance(this.mockedSchemaVersionRepository)
+    );
+    allowAll(this.server, USERS_COLLECTION);
+    allowAll(this.server, SF_PROJECTS_COLLECTION);
+  }
+
+  async createData(): Promise<void> {
+    const conn = this.server.connect();
+    await createDoc<User>(conn, USERS_COLLECTION, 'administrator', createTestUser({}, 1));
+    await createDoc<User>(conn, USERS_COLLECTION, 'translator', createTestUser({}, 2));
+    await createDoc<User>(conn, USERS_COLLECTION, 'consultant', createTestUser({}, 3));
+
+    await createDoc<SFProject>(
+      conn,
+      SF_PROJECTS_COLLECTION,
+      'project01',
+      createTestProject({
+        userRoles: {
+          administrator: SFProjectRole.ParatextAdministrator,
+          translator: SFProjectRole.ParatextTranslator,
+          consultant: SFProjectRole.ParatextConsultant
+        }
+      })
+    );
+
+    await createDoc<TrainingData>(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'), {
+      dataId: 'dataid01',
+      projectRef: 'project01',
+      ownerRef: 'user01',
+      fileUrl: 'project01/user01_file01.csv?t=123456789123456789',
+      mimeType: 'text/csv',
+      skipRows: 0,
+      title: 'Test File'
+    });
+  }
+}

--- a/src/RealtimeServer/scriptureforge/services/training-data-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-service.ts
@@ -1,0 +1,59 @@
+import { ValidationSchema } from '../../common/models/validation-schema';
+import { ProjectDomainConfig } from '../../common/services/project-data-service';
+import { SFProjectDomain } from '../models/sf-project-rights';
+import { TrainingData, TRAINING_DATA_COLLECTION, TRAINING_DATA_INDEX_PATHS } from '../models/training-data';
+import { SFProjectDataService } from './sf-project-data-service';
+import { TRAINING_DATA_MIGRATIONS } from './training-data-migrations';
+
+/**
+ * This class manages Serval training data docs.
+ */
+export class TrainingDataService extends SFProjectDataService<TrainingData> {
+  readonly collection = TRAINING_DATA_COLLECTION;
+
+  protected readonly indexPaths = TRAINING_DATA_INDEX_PATHS;
+  readonly validationSchema: ValidationSchema = {
+    bsonType: SFProjectDataService.validationSchema.bsonType,
+    required: SFProjectDataService.validationSchema.required,
+    properties: {
+      ...SFProjectDataService.validationSchema.properties,
+      _id: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+:[0-9a-f]+$'
+      },
+      dataId: {
+        bsonType: 'string',
+        pattern: '^[0-9a-f]+$'
+      },
+      fileUrl: {
+        bsonType: 'string'
+      },
+      mimeType: {
+        bsonType: 'string'
+      },
+      skipRows: {
+        bsonType: 'int'
+      },
+      title: {
+        bsonType: 'string'
+      }
+    },
+    additionalProperties: false
+  };
+
+  constructor() {
+    super(TRAINING_DATA_MIGRATIONS);
+
+    const immutableProps = [this.pathTemplate(t => t.dataId)];
+    this.immutableProps.push(...immutableProps);
+  }
+
+  protected setupDomains(): ProjectDomainConfig[] {
+    return [
+      {
+        projectDomain: SFProjectDomain.TrainingData,
+        pathTemplate: this.pathTemplate()
+      }
+    ];
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-settings.ts
@@ -9,6 +9,7 @@ export interface SFProjectSettings {
   biblicalTermsEnabled?: boolean | null;
   translateShareEnabled?: boolean | null;
 
+  additionalTrainingData?: boolean | null;
   alternateSourceParatextId?: string | null;
   alternateTrainingSourceEnabled?: boolean | null;
   alternateTrainingSourceParatextId?: string | null;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-type-registry.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-type-registry.ts
@@ -11,6 +11,7 @@ import { SFProjectProfileDoc } from './sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from './sf-project-user-config-doc';
 import { TextAudioDoc } from './text-audio-doc';
 import { TextDoc } from './text-doc';
+import { TrainingDataDoc } from './training-data-doc';
 
 export const SF_TYPE_REGISTRY = new TypeRegistry(
   [
@@ -23,8 +24,9 @@ export const SF_TYPE_REGISTRY = new TypeRegistry(
     QuestionDoc,
     TextDoc,
     NoteThreadDoc,
-    TextAudioDoc
+    TextAudioDoc,
+    TrainingDataDoc
   ],
-  [FileType.Audio],
+  [FileType.Audio, FileType.TrainingData],
   [EDITED_SEGMENTS]
 );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/training-data-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/training-data-doc.ts
@@ -1,0 +1,11 @@
+import {
+  TrainingData,
+  TRAINING_DATA_COLLECTION,
+  TRAINING_DATA_INDEX_PATHS
+} from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { ProjectDataDoc } from 'xforge-common/models/project-data-doc';
+
+export class TrainingDataDoc extends ProjectDataDoc<TrainingData> {
+  static readonly COLLECTION = TRAINING_DATA_COLLECTION;
+  static readonly INDEX_PATHS = TRAINING_DATA_INDEX_PATHS;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -169,6 +169,21 @@
                     ></app-write-status>
                   </div>
                 </div>
+                <div class="tool-setting">
+                  <div class="tool-setting-field checkbox-field">
+                    <mat-checkbox
+                      formControlName="additionalTrainingData"
+                      id="checkbox-pre-translation-additional-training-data"
+                      >{{ t("pre_translation_additional_training_data") }}</mat-checkbox
+                    >
+                    <app-info [text]="t('pre_translation_additional_training_data_info')"></app-info>
+                    <app-write-status
+                      [state]="getControlState('additionalTrainingData')"
+                      [formGroup]="form"
+                      id="pre-translation-additional-training-data-status"
+                    ></app-write-status>
+                  </div>
+                </div>
               </ng-container>
               <ng-container *ngIf="canUpdateServalConfig">
                 <p

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -222,9 +222,11 @@ describe('SettingsComponent', () => {
               }
             },
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: false,
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -266,8 +268,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -292,8 +296,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -318,8 +324,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           }
         });
         env.wait();
@@ -335,8 +343,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -366,9 +376,11 @@ describe('SettingsComponent', () => {
               }
             },
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: true,
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -401,8 +413,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: true,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -429,9 +443,11 @@ describe('SettingsComponent', () => {
               }
             },
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: true,
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -476,8 +492,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: true
+            sendAllSegments: true,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -489,6 +507,44 @@ describe('SettingsComponent', () => {
         env.wait();
 
         expect(env.statusDone(env.sendAllSegmentsStatus)).not.toBeNull();
+      }));
+    });
+
+    describe('Additional Training Data', () => {
+      it('should update when the additional training data checkbox is ticked', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        env.wait();
+        expect(env.statusDone(env.additionalTrainingDataStatus)).toBeNull();
+        expect(env.inputElement(env.additionalTrainingDataCheckbox).checked).toBe(false);
+        env.clickElement(env.inputElement(env.additionalTrainingDataCheckbox));
+        expect(env.inputElement(env.additionalTrainingDataCheckbox).checked).toBe(true);
+        env.wait();
+
+        expect(env.statusDone(env.additionalTrainingDataStatus)).not.toBeNull();
+      }));
+
+      it('should update when the additional training data checkbox is unticked', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          draftConfig: {
+            alternateTrainingSourceEnabled: false,
+            lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
+            lastSelectedTranslationBooks: [],
+            sendAllSegments: false,
+            additionalTrainingData: true
+          },
+          preTranslate: true
+        });
+        env.wait();
+        expect(env.statusDone(env.additionalTrainingDataStatus)).toBeNull();
+        expect(env.inputElement(env.additionalTrainingDataCheckbox).checked).toBe(true);
+        env.clickElement(env.inputElement(env.additionalTrainingDataCheckbox));
+        expect(env.inputElement(env.additionalTrainingDataCheckbox).checked).toBe(false);
+        env.wait();
+
+        expect(env.statusDone(env.additionalTrainingDataStatus)).not.toBeNull();
       }));
     });
 
@@ -508,8 +564,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           projectType: ProjectType.BackTranslation
         });
@@ -545,8 +603,10 @@ describe('SettingsComponent', () => {
           draftConfig: {
             alternateTrainingSourceEnabled: false,
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           }
         });
         when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
@@ -583,9 +643,11 @@ describe('SettingsComponent', () => {
           draftConfig: {
             servalConfig: '{}',
             lastSelectedTrainingBooks: [],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [],
             alternateTrainingSourceEnabled: false,
-            sendAllSegments: false
+            sendAllSegments: false,
+            additionalTrainingData: false
           },
           preTranslate: true
         });
@@ -1198,6 +1260,14 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#pre-translation-send-all-segments-status'));
   }
 
+  get additionalTrainingDataCheckbox(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#checkbox-pre-translation-additional-training-data'));
+  }
+
+  get additionalTrainingDataStatus(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#pre-translation-additional-training-data-status'));
+  }
+
   makeProjectHaveTextAudio(): void {
     this.realtimeService.addSnapshot<TextAudio>(TextAudioDoc.COLLECTION, {
       id: 'sAudio1',
@@ -1288,9 +1358,11 @@ class TestEnvironment {
       },
       draftConfig: {
         lastSelectedTrainingBooks: [],
+        lastSelectedTrainingDataFiles: [],
         lastSelectedTranslationBooks: [],
         alternateTrainingSourceEnabled: false,
-        sendAllSegments: false
+        sendAllSegments: false,
+        additionalTrainingData: false
       }
     },
     checkingConfig: Partial<CheckingConfig> = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -38,6 +38,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   alternateTrainingSourceEnabled = new FormControl(false);
   alternateTrainingSourceParatextId = new FormControl<string | undefined>(undefined);
   sendAllSegments = new FormControl(false);
+  additionalTrainingData = new FormControl(false);
   servalConfig = new FormControl<string | undefined>(undefined);
   translateShareEnabled = new FormControl(false);
   checkingEnabled = new FormControl(false);
@@ -56,6 +57,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     alternateTrainingSourceEnabled: this.alternateTrainingSourceEnabled,
     alternateTrainingSourceParatextId: this.alternateTrainingSourceParatextId,
     sendAllSegments: this.sendAllSegments,
+    additionalTrainingData: this.additionalTrainingData,
     servalConfig: this.servalConfig,
     translateShareEnabled: this.translateShareEnabled,
     checkingEnabled: this.checkingEnabled,
@@ -350,6 +352,10 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       this.updateSetting(newValue, 'sendAllSegments');
     }
 
+    if (this.settingChanged(newValue, 'additionalTrainingData')) {
+      this.updateSetting(newValue, 'additionalTrainingData');
+    }
+
     // Check if the pre-translation alternate training source project needs to be updated
     if (this.settingChanged(newValue, 'alternateTrainingSourceParatextId')) {
       const settings: SFProjectSettings = {
@@ -425,6 +431,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       alternateTrainingSourceParatextId:
         this.projectDoc.data.translateConfig.draftConfig?.alternateTrainingSource?.paratextId,
       sendAllSegments: this.projectDoc.data.translateConfig.draftConfig.sendAllSegments,
+      additionalTrainingData: this.projectDoc.data.translateConfig.draftConfig.additionalTrainingData,
       servalConfig: this.projectDoc.data.translateConfig.draftConfig.servalConfig,
       translateShareEnabled: !!this.projectDoc.data.translateConfig.shareEnabled,
       checkingEnabled: this.projectDoc.data.checkingConfig.checkingEnabled,
@@ -458,6 +465,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     this.controlStates.set('alternateTrainingSourceEnabled', ElementState.InSync);
     this.controlStates.set('alternateTrainingSourceParatextId', ElementState.InSync);
     this.controlStates.set('sendAllSegments', ElementState.InSync);
+    this.controlStates.set('additionalTrainingData', ElementState.InSync);
     this.controlStates.set('servalConfig', ElementState.InSync);
     this.controlStates.set('translateShareEnabled', ElementState.InSync);
     this.controlStates.set('checkingEnabled', ElementState.InSync);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -66,10 +66,34 @@
         <div class="button-strip">
           <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
           <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+            {{ featureFlags.allowFastTraining.enabled || trainingDataFilesAvailable ? t("next") : t("generate_draft") }}
+          </button>
+        </div>
+      </mat-step>
+
+      <mat-step *ngIf="trainingDataFilesAvailable" [completed]="true">
+        <ng-template matStepLabel>
+          <div class="stepper-multi-header">
+            <h2>{{ t("choose_additional_training_data_files") }}</h2>
+            <h3>{{ t("choose_additional_training_data_files_subheader") }}</h3>
+          </div>
+        </ng-template>
+
+        <app-training-data-multi-select
+          [availableTrainingData]="availableTrainingData"
+          [selectedTrainingDataIds]="selectedTrainingDataIds"
+          (trainingDataSelect)="onTrainingDataSelect($event)"
+          data-test-id="draft-stepper-training-data-files"
+        ></app-training-data-multi-select>
+
+        <div class="button-strip">
+          <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
+          <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
             {{ featureFlags.allowFastTraining.enabled ? t("next") : t("generate_draft") }}
           </button>
         </div>
       </mat-step>
+
       <mat-step *ngIf="featureFlags.allowFastTraining.enabled" [completed]="true">
         <ng-template matStepLabel>
           <div class="stepper-multi-header">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -3,18 +3,21 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { BehaviorSubject } from 'rxjs';
-import { environment } from 'src/environments/environment';
-import { anything, mock, when } from 'ts-mockito';
+import { BehaviorSubject, of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { environment } from '../../../../environments/environment';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { NllbLanguageService } from '../../nllb-language.service';
+import { TrainingDataService } from '../training-data/training-data.service';
 import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
 
 describe('DraftGenerationStepsComponent', () => {
@@ -25,6 +28,7 @@ describe('DraftGenerationStepsComponent', () => {
   const mockFeatureFlagService = mock(FeatureFlagService);
   const mockProjectService = mock(SFProjectService);
   const mockNllbLanguageService = mock(NllbLanguageService);
+  const mockTrainingDataService = mock(TrainingDataService);
   const mockUserService = mock(UserService);
 
   const mockTargetProjectDoc = {
@@ -64,6 +68,12 @@ describe('DraftGenerationStepsComponent', () => {
     })
   } as UserDoc;
 
+  const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
+  when(mockTrainingDataQuery.localChanges$).thenReturn(of());
+  when(mockTrainingDataQuery.ready$).thenReturn(of(true));
+  when(mockTrainingDataQuery.remoteChanges$).thenReturn(of());
+  when(mockTrainingDataQuery.remoteDocChanges$).thenReturn(of());
+
   const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
 
   configureTestingModule(() => ({
@@ -73,6 +83,7 @@ describe('DraftGenerationStepsComponent', () => {
       { provide: FeatureFlagService, useMock: mockFeatureFlagService },
       { provide: NllbLanguageService, useMock: mockNllbLanguageService },
       { provide: SFProjectService, useMock: mockProjectService },
+      { provide: TrainingDataService, useMock: mockTrainingDataService },
       { provide: UserService, useMock: mockUserService }
     ]
   }));
@@ -103,6 +114,8 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockProjectService.getProfile('alternateTrainingProject')).thenResolve(
         mockAlternateTrainingSourceProjectDoc
       );
+      when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
+      when(mockTrainingDataQuery.docs).thenReturn([]);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -132,6 +145,8 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockProjectService.getProfile(anything())).thenResolve(mockSourceNonNllbProjectDoc);
       when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
       when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
+      when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
+      when(mockTrainingDataQuery.docs).thenReturn([]);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -161,10 +176,12 @@ describe('DraftGenerationStepsComponent', () => {
 
     it('should emit the correct selected books when done', () => {
       const trainingBooks = [2, 3];
+      const trainingDataFiles: string[] = [];
       const translationBooks = [1, 2];
 
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
 
       spyOn(component.done, 'emit');
 
@@ -176,6 +193,7 @@ describe('DraftGenerationStepsComponent', () => {
 
       expect(component.done.emit).toHaveBeenCalledWith({
         translationBooks,
+        trainingDataFiles,
         trainingBooks: trainingBooks.filter(book => !translationBooks.includes(book)),
         fastTraining: false
       } as DraftGenerationStepsResult);
@@ -220,6 +238,8 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(true));
       when(mockProjectService.getProfile(anything())).thenResolve(mockSourceNonNllbProjectDoc);
+      when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
+      when(mockTrainingDataQuery.docs).thenReturn([]);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -229,10 +249,12 @@ describe('DraftGenerationStepsComponent', () => {
 
     it('should emit the fast training value if checked', () => {
       const trainingBooks = [1, 2];
+      const trainingDataFiles: string[] = [];
       const translationBooks = [3, 4];
 
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
 
       spyOn(component.done, 'emit');
 
@@ -252,6 +274,7 @@ describe('DraftGenerationStepsComponent', () => {
 
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingBooks,
+        trainingDataFiles,
         translationBooks,
         fastTraining: true
       } as DraftGenerationStepsResult);
@@ -266,6 +289,7 @@ describe('DraftGenerationStepsComponent', () => {
           source: { projectRef: 'test' },
           draftConfig: {
             lastSelectedTrainingBooks: [2, 3, 4],
+            lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationBooks: [2, 3, 4]
           }
         }
@@ -276,6 +300,8 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockProjectService.getProfile(anything())).thenResolve(mockSourceNonNllbProjectDoc);
+      when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
+      when(mockTrainingDataQuery.docs).thenReturn([]);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -4,18 +4,27 @@ import { MatStepper } from '@angular/material/stepper';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
-import { filter } from 'rxjs/operators';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { merge, Subscription } from 'rxjs';
+import { filter, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
 import { SharedModule } from '../../../shared/shared.module';
 import { NllbLanguageService } from '../../nllb-language.service';
 import { DraftSource, DraftSourcesService } from '../draft-sources.service';
+import { TrainingDataMultiSelectComponent } from '../training-data/training-data-multi-select.component';
+import { TrainingDataUploadDialogComponent } from '../training-data/training-data-upload-dialog.component';
+import { TrainingDataService } from '../training-data/training-data.service';
 
 export interface DraftGenerationStepsResult {
   trainingBooks: number[];
+  trainingDataFiles: string[];
   translationBooks: number[];
   fastTraining: boolean;
 }
@@ -31,7 +40,9 @@ export interface DraftGenerationStepsResult {
     UICommonModule,
     TranslocoModule,
     TranslocoMarkupModule,
-    BookMultiSelectComponent
+    BookMultiSelectComponent,
+    TrainingDataMultiSelectComponent,
+    TrainingDataUploadDialogComponent
   ]
 })
 export class DraftGenerationStepsComponent extends SubscriptionDisposable implements OnInit {
@@ -40,6 +51,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   availableTranslateBooks?: number[] = undefined;
   availableTrainingBooks: number[] = [];
+  availableTrainingData: Readonly<TrainingData>[] = [];
 
   // Unusable books do not exist in the corresponding drafting/training source project
   unusableTranslateBooks: number[] = [];
@@ -50,6 +62,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   userSelectedTrainingBooks: number[] = [];
   userSelectedTranslateBooks: number[] = [];
 
+  selectedTrainingDataIds: string[] = [];
+
   // When translate books are selected, they will be filtered out from this list
   initialAvailableTrainingBooks: number[] = [];
 
@@ -59,13 +73,18 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   showBookSelectionError = false;
   isTrainingOptional = false;
 
+  trainingDataFilesAvailable = false;
   fastTraining: boolean = false;
+
+  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
+  private trainingDataSub?: Subscription;
 
   constructor(
     private readonly activatedProject: ActivatedProjectService,
     private readonly draftSourcesService: DraftSourcesService,
     readonly featureFlags: FeatureFlagService,
-    private readonly nllbLanguageService: NllbLanguageService
+    private readonly nllbLanguageService: NllbLanguageService,
+    private readonly trainingDataService: TrainingDataService
   ) {
     super();
   }
@@ -141,10 +160,52 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         this.setInitialTranslateBooks(this.availableTranslateBooks);
       }
     );
+
+    // Get the training data files for the project
+    this.subscribe(
+      this.activatedProject.projectDoc$.pipe(
+        filterNullish(),
+        tap(async projectDoc => {
+          // Query for all training data files in the project
+          this.trainingDataQuery?.dispose();
+          this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id);
+
+          let projectChanged: boolean = true;
+
+          // Subscribe to this query, and show these
+          this.trainingDataSub?.unsubscribe();
+          this.trainingDataSub = this.subscribe(
+            merge(
+              this.trainingDataQuery.localChanges$,
+              this.trainingDataQuery.ready$,
+              this.trainingDataQuery.remoteChanges$,
+              this.trainingDataQuery.remoteDocChanges$
+            ),
+            () => {
+              this.availableTrainingData = [];
+              if (projectDoc.data?.translateConfig.draftConfig.additionalTrainingData) {
+                this.availableTrainingData =
+                  this.trainingDataQuery?.docs.filter(d => d.data != null).map(d => d.data!) ?? [];
+              }
+              if (projectChanged) {
+                // Set the selection based on previous builds
+                projectChanged = false;
+                this.setInitialTrainingDataFiles(this.availableTrainingData.map(d => d.dataId));
+              }
+            }
+          );
+        })
+      )
+    );
   }
 
   onTrainingBookSelect(selectedBooks: number[]): void {
     this.userSelectedTrainingBooks = selectedBooks;
+    this.clearErrorMessage();
+  }
+
+  onTrainingDataSelect(selectedTrainingDataIds: string[]): void {
+    this.selectedTrainingDataIds = selectedTrainingDataIds;
     this.clearErrorMessage();
   }
 
@@ -168,6 +229,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     } else {
       this.done.emit({
         trainingBooks: this.userSelectedTrainingBooks,
+        trainingDataFiles: this.selectedTrainingDataIds,
         translationBooks: this.userSelectedTranslateBooks,
         fastTraining: this.fastTraining
       });
@@ -210,6 +272,21 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     // Set the selected books to the intersection, or if the intersection is empty, do not select any
     this.initialSelectedTrainingBooks = intersection.length > 0 ? intersection : [];
     this.userSelectedTrainingBooks = this.initialSelectedTrainingBooks;
+  }
+
+  private setInitialTrainingDataFiles(availableDataFiles: string[]): void {
+    // Get the previously selected training data files from the target project
+    const previousTrainingDataFiles: string[] =
+      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingDataFiles ?? [];
+
+    // The intersection is all of the available training data files in the target project that match the target's
+    // previous training data files
+    const intersection: string[] = availableDataFiles.filter(dataId => previousTrainingDataFiles.includes(dataId));
+
+    // Set the selected data files to the intersection, or if the intersection is empty, do not select any
+    this.selectedTrainingDataIds = intersection.length > 0 ? intersection : [];
+    this.trainingDataFilesAvailable =
+      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.additionalTrainingData ?? false;
   }
 
   private setSourceProjectDisplayNames(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -33,6 +33,7 @@ import { DraftGenerationComponent } from './draft-generation.component';
 import { DraftGenerationService } from './draft-generation.service';
 import { DraftSource, DraftSourcesService } from './draft-sources.service';
 import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
+import { TrainingDataService } from './training-data/training-data.service';
 
 describe('DraftGenerationComponent', () => {
   let mockAuthService: jasmine.SpyObj<AuthService>;
@@ -46,6 +47,7 @@ describe('DraftGenerationComponent', () => {
   let mockI18nService: jasmine.SpyObj<I18nService>;
   let mockPreTranslationSignupUrlService: jasmine.SpyObj<PreTranslationSignupUrlService>;
   let mockNllbLanguageService: jasmine.SpyObj<NllbLanguageService>;
+  let mockTrainingDataService: jasmine.SpyObj<TrainingDataService>;
 
   const buildDto: BuildDto = {
     id: 'testId',
@@ -104,7 +106,8 @@ describe('DraftGenerationComponent', () => {
           { provide: I18nService, useValue: mockI18nService },
           { provide: PreTranslationSignupUrlService, useValue: mockPreTranslationSignupUrlService },
           { provide: NllbLanguageService, useValue: mockNllbLanguageService },
-          { provide: OnlineStatusService, useClass: TestOnlineStatusService }
+          { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+          { provide: TrainingDataService, useValue: mockTrainingDataService }
         ]
       });
 
@@ -1162,6 +1165,7 @@ describe('DraftGenerationComponent', () => {
 
       env.component.startBuild({
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false,
         projectId: projectId
@@ -1169,6 +1173,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false
       });
@@ -1186,6 +1191,7 @@ describe('DraftGenerationComponent', () => {
 
       env.component.startBuild({
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false,
         projectId: projectId
@@ -1193,6 +1199,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false
       });
@@ -1212,6 +1219,7 @@ describe('DraftGenerationComponent', () => {
 
       env.component.startBuild({
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false,
         projectId: projectId
@@ -1219,6 +1227,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false
       });
@@ -1238,6 +1247,7 @@ describe('DraftGenerationComponent', () => {
 
       env.component.startBuild({
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false,
         projectId: projectId
@@ -1245,6 +1255,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false
       });
@@ -1265,6 +1276,7 @@ describe('DraftGenerationComponent', () => {
 
       env.component.startBuild({
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false,
         projectId: projectId
@@ -1272,6 +1284,7 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
         trainingBooks: [],
+        trainingDataFiles: [],
         translationBooks: [],
         fastTraining: false
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -334,6 +334,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     this.startBuild({
       projectId: this.activatedProject.projectId!,
       trainingBooks: result.trainingBooks,
+      trainingDataFiles: result.trainingDataFiles,
       translationBooks: result.translationBooks,
       fastTraining: result.fastTraining
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -3,9 +3,10 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { first } from 'rxjs/operators';
-import { BuildDto } from 'src/app/machine-api/build-dto';
-import { BuildStates } from 'src/app/machine-api/build-states';
-import { HttpClient } from 'src/app/machine-api/http-client';
+import { BuildDto } from '../../machine-api/build-dto';
+import { BuildStates } from '../../machine-api/build-states';
+import { HttpClient } from '../../machine-api/http-client';
+import { BuildConfig } from './draft-generation';
 import { DraftGenerationService } from './draft-generation.service';
 
 describe('DraftGenerationService', () => {
@@ -106,7 +107,13 @@ describe('DraftGenerationService', () => {
     it('should start a pretranslation build job and return an observable of BuildDto', done => {
       const spyGetBuildProgress = spyOn(service, 'getBuildProgress').and.returnValue(of(undefined));
       const spyPollBuildProgress = spyOn(service, 'pollBuildProgress').and.returnValue(of(buildDto));
-      const buildConfig = { projectId, trainingBooks: [], translationBooks: [], fastTraining: false };
+      const buildConfig: BuildConfig = {
+        projectId,
+        trainingBooks: [],
+        trainingDataFiles: [],
+        translationBooks: [],
+        fastTraining: false
+      };
       httpClient.post = jasmine.createSpy().and.returnValue(of({ data: buildDto }));
       service
         .startBuildOrGetActiveBuild(buildConfig)
@@ -123,16 +130,21 @@ describe('DraftGenerationService', () => {
     it('should return already active build job', done => {
       const spyGetBuildProgress = spyOn(service, 'getBuildProgress').and.returnValue(of(buildDto));
       const spyPollBuildProgress = spyOn(service, 'pollBuildProgress').and.returnValue(of(buildDto));
+      const buildConfig: BuildConfig = {
+        projectId,
+        trainingBooks: [],
+        trainingDataFiles: [],
+        translationBooks: [],
+        fastTraining: false
+      };
       httpClient.post = jasmine.createSpy();
-      service
-        .startBuildOrGetActiveBuild({ projectId, trainingBooks: [], translationBooks: [], fastTraining: false })
-        .subscribe(result => {
-          expect(result).toEqual(buildDto);
-          expect(spyGetBuildProgress).toHaveBeenCalledWith(projectId);
-          expect(spyPollBuildProgress).toHaveBeenCalledWith(projectId);
-          expect(httpClient.post).not.toHaveBeenCalled();
-          done();
-        });
+      service.startBuildOrGetActiveBuild(buildConfig).subscribe(result => {
+        expect(result).toEqual(buildDto);
+        expect(spyGetBuildProgress).toHaveBeenCalledWith(projectId);
+        expect(spyPollBuildProgress).toHaveBeenCalledWith(projectId);
+        expect(httpClient.post).not.toHaveBeenCalled();
+        done();
+      });
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -7,6 +7,7 @@ import { BuildStates } from 'src/app/machine-api/build-states';
 export interface BuildConfig {
   projectId: string;
   trainingBooks: number[];
+  trainingDataFiles: string[];
   translationBooks: number[];
   fastTraining: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
@@ -3,14 +3,14 @@ import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { BehaviorSubject } from 'rxjs';
-import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
-import { SFProjectService } from 'src/app/core/sf-project.service';
-import { environment } from 'src/environments/environment';
 import { mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
+import { environment } from '../../../environments/environment';
+import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
+import { SFProjectService } from '../../core/sf-project.service';
 import { DraftSources, DraftSourcesService } from './draft-sources.service';
 
 describe('DraftSourcesService', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
@@ -4,10 +4,10 @@ import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-inf
 import { TranslateConfig, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { combineLatest, defer, from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { environment } from 'src/environments/environment';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
+import { environment } from '../../../environments/environment';
 import { SFProjectService } from '../../core/sf-project.service';
 
 interface DraftTextInfo {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -1,0 +1,23 @@
+<ng-container *transloco="let t; read: 'training_data_multi_select'">
+  <mat-chip-listbox [multiple]="true" class="training-data-multi-select" (change)="onChipListChange($event)">
+    <mat-chip-option
+      *ngFor="let trainingData of trainingDataOptions"
+      [value]="trainingData.value"
+      [selected]="trainingData.selected"
+    >
+      {{ trainingData.value.title }}
+      <button
+        *ngIf="canDeleteTrainingData(trainingData.value)"
+        matChipRemove
+        (click)="deleteTrainingData(trainingData.value)"
+      >
+        <mat-icon>cancel</mat-icon>
+      </button>
+    </mat-chip-option>
+    <button mat-flat-button (click)="openUploadDialog()" color="accent">
+      <mat-icon matChipAvatar>file_upload</mat-icon>
+      {{ t("upload_csv") }}
+    </button>
+    <app-info [text]="t('file_information', { sourceLanguage, targetLanguage })"></app-info>
+  </mat-chip-listbox>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.scss
@@ -12,3 +12,10 @@
     margin: 0 8px;
   }
 }
+
+/* Stop overflow of text inside the chips */
+:host ::ng-deep .mat-mdc-standard-chip .mdc-evolution-chip__cell--primary,
+:host ::ng-deep .mat-mdc-standard-chip .mdc-evolution-chip__action--primary,
+:host ::ng-deep .mat-mdc-standard-chip .mat-mdc-chip-action-label {
+  overflow: hidden;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.scss
@@ -1,0 +1,14 @@
+.training-data-multi-select {
+  margin-top: 20px;
+
+  .mat-mdc-standard-chip {
+    &.mat-mdc-chip-selected,
+    &.mat-mdc-chip-highlighted {
+      --mdc-chip-elevated-container-color: #4a79c9;
+    }
+  }
+
+  button {
+    margin: 0 8px;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatChipListboxChange } from '@angular/material/chips';
+import { MatDialogRef } from '@angular/material/dialog';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { BehaviorSubject, of } from 'rxjs';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { Locale } from 'xforge-common/models/i18n-locale';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UserService } from 'xforge-common/user.service';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { TrainingDataMultiSelectComponent, TrainingDataOption } from './training-data-multi-select.component';
+import { TrainingDataUploadDialogComponent } from './training-data-upload-dialog.component';
+import { TrainingDataService } from './training-data.service';
+
+const mockActivatedProjectService = mock(ActivatedProjectService);
+const mockDialogService = mock(DialogService);
+const mockI18nService = mock(I18nService);
+const mockTrainingDataService = mock(TrainingDataService);
+const mockTrainingDataUploadDialogComponent = mock<MatDialogRef<TrainingDataUploadDialogComponent>>(MatDialogRef);
+const mockUserService = mock(UserService);
+
+describe('TrainingDataMultiSelectComponent', () => {
+  let component: TrainingDataMultiSelectComponent;
+  let fixture: ComponentFixture<TrainingDataMultiSelectComponent>;
+
+  const locale: Locale = {
+    localName: 'English',
+    englishName: 'English',
+    canonicalTag: 'en',
+    direction: 'ltr',
+    tags: [],
+    production: false
+  };
+  const mockProjectId: string = 'project01';
+  const mockProjectId$ = new BehaviorSubject<string>(mockProjectId);
+  const mockProjectDoc: SFProjectProfileDoc = {
+    id: mockProjectId,
+    data: createTestProjectProfile({
+      userRoles: { user01: SFProjectRole.ParatextAdministrator }
+    })
+  } as SFProjectProfileDoc;
+  const mockProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockProjectDoc);
+  const mockTrainingData: TrainingData[] = [
+    { dataId: 'data01', fileUrl: '', mimeType: '', skipRows: 0, title: '', projectRef: '', ownerRef: '' },
+    { dataId: 'data02', fileUrl: '', mimeType: '', skipRows: 0, title: '', projectRef: '', ownerRef: '' },
+    { dataId: 'data03', fileUrl: '', mimeType: '', skipRows: 0, title: '', projectRef: '', ownerRef: '' }
+  ];
+  const mockSelectedTrainingDataIds: string[] = ['data01', 'data03'];
+
+  configureTestingModule(() => ({
+    imports: [TestTranslocoModule],
+    providers: [
+      { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
+      { provide: DialogService, useMock: mockDialogService },
+      { provide: I18nService, useMock: mockI18nService },
+      { provide: TrainingDataService, useMock: mockTrainingDataService },
+      { provide: TrainingDataUploadDialogComponent, useMock: mockTrainingDataUploadDialogComponent },
+      { provide: UserService, useMock: mockUserService }
+    ]
+  }));
+
+  beforeEach(fakeAsync(() => {
+    when(mockActivatedProjectService.projectId).thenReturn(mockProjectId);
+    when(mockActivatedProjectService.projectId$).thenReturn(mockProjectId$);
+    when(mockActivatedProjectService.projectDoc).thenReturn(mockProjectDoc);
+    when(mockActivatedProjectService.projectDoc$).thenReturn(mockProjectDoc$);
+    when(mockDialogService.openMatDialog(TrainingDataUploadDialogComponent, anything())).thenReturn(
+      instance(mockTrainingDataUploadDialogComponent)
+    );
+    when(
+      mockDialogService.confirm('training_data_multi_select.confirm_delete', 'training_data_multi_select.delete')
+    ).thenResolve(true);
+    when(mockI18nService.locale$).thenReturn(of(locale));
+    when(mockTrainingDataUploadDialogComponent.afterClosed()).thenReturn(of({ dataId: 'data04' }));
+    fixture = TestBed.createComponent(TrainingDataMultiSelectComponent);
+    component = fixture.componentInstance;
+    component.availableTrainingData = mockTrainingData;
+    component.selectedTrainingDataIds = mockSelectedTrainingDataIds;
+    fixture.detectChanges();
+    tick();
+  }));
+
+  it('can delete training data', fakeAsync(async () => {
+    when(mockUserService.currentUserId).thenReturn('user01');
+    let canDelete = await component.canDeleteTrainingData(mockTrainingData[0]);
+
+    expect(canDelete).toBeTruthy();
+  }));
+
+  it('can not delete training data', fakeAsync(async () => {
+    when(mockUserService.currentUserId).thenReturn('user02');
+    let canDelete = await component.canDeleteTrainingData(mockTrainingData[0]);
+
+    expect(canDelete).toBeFalsy();
+  }));
+
+  it('can emit chip list change events', fakeAsync(async () => {
+    let result: string[] = [];
+    component.trainingDataSelect.subscribe((_result: string[]) => {
+      result = _result;
+    });
+    component.onChipListChange({ value: [{ dataId: 'data01' }] } as MatChipListboxChange);
+    tick();
+
+    expect(result).toEqual(['data01']);
+  }));
+
+  it('should delete training data', fakeAsync(async () => {
+    await component.deleteTrainingData(mockTrainingData[0]);
+    tick();
+
+    verify(mockTrainingDataService.deleteTrainingDataAsync(mockTrainingData[0])).once();
+    expect().nothing();
+  }));
+
+  it('should initialize training data options on ngOnChanges', () => {
+    const mockTrainingDataOptions: TrainingDataOption[] = [
+      { value: mockTrainingData[0], selected: true },
+      { value: mockTrainingData[1], selected: false },
+      { value: mockTrainingData[2], selected: true }
+    ];
+
+    component.ngOnChanges();
+
+    expect(component.trainingDataOptions).toEqual(mockTrainingDataOptions);
+  });
+
+  it('should show the upload dialog', fakeAsync(() => {
+    let result: string[] = [];
+    component.trainingDataSelect.subscribe((_result: string[]) => {
+      result = _result;
+    });
+    component.openUploadDialog();
+    tick();
+
+    verify(mockDialogService.openMatDialog(TrainingDataUploadDialogComponent, anything())).once();
+    expect(result).toEqual([...mockSelectedTrainingDataIds, 'data04']);
+  }));
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -106,7 +106,7 @@ export class TrainingDataMultiSelectComponent extends SubscriptionDisposable imp
   openUploadDialog(): void {
     if (this.activatedProjectService.projectId == null) return;
     const dialogConfig: MatDialogConfig<TrainingDataUploadDialogData> = {
-      data: { projectId: this.activatedProjectService.projectId },
+      data: { projectId: this.activatedProjectService.projectId, availableTrainingData: this.availableTrainingData },
       width: '320px'
     };
     const dialogRef = this.dialogService.openMatDialog(TrainingDataUploadDialogComponent, dialogConfig);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { MatChipListboxChange, MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { TranslocoModule } from '@ngneat/transloco';
+import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { UserService } from 'xforge-common/user.service';
+import { SharedModule } from '../../../shared/shared.module';
+import {
+  TrainingDataUploadDialogComponent,
+  TrainingDataUploadDialogData
+} from './training-data-upload-dialog.component';
+import { TrainingDataService } from './training-data.service';
+
+export interface TrainingDataOption {
+  value: TrainingData;
+  selected: boolean;
+}
+
+@Component({
+  selector: 'app-training-data-multi-select',
+  templateUrl: './training-data-multi-select.component.html',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatChipsModule, MatIconModule, SharedModule, TranslocoModule],
+  styleUrls: ['./training-data-multi-select.component.scss']
+})
+export class TrainingDataMultiSelectComponent extends SubscriptionDisposable implements OnChanges, OnInit {
+  @Input() availableTrainingData: TrainingData[] = [];
+  @Input() selectedTrainingDataIds: string[] = [];
+  @Output() trainingDataSelect = new EventEmitter<string[]>();
+
+  sourceLanguage?: string;
+  targetLanguage?: string;
+  trainingDataOptions: TrainingDataOption[] = [];
+  constructor(
+    private readonly activatedProjectService: ActivatedProjectService,
+    private readonly dialogService: DialogService,
+    private readonly i18n: I18nService,
+    private readonly trainingDataService: TrainingDataService,
+    private readonly userService: UserService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.subscribe(this.i18n.locale$, () => {
+      this.sourceLanguage = this.getLanguageDisplayName('source');
+      this.targetLanguage = this.getLanguageDisplayName('target');
+    });
+  }
+
+  ngOnChanges(): void {
+    this.initBookOptions();
+  }
+
+  private getLanguageDisplayName(project: 'source' | 'target'): string | undefined {
+    const projectDoc: SFProjectProfile | undefined = this.activatedProjectService.projectDoc?.data;
+    if (projectDoc == null) {
+      return;
+    } else if (project === 'source') {
+      return this.i18n.getLanguageDisplayName(projectDoc.translateConfig.source?.writingSystem.tag);
+    } else {
+      return this.i18n.getLanguageDisplayName(projectDoc.writingSystem.tag);
+    }
+  }
+
+  async canDeleteTrainingData(trainingData: TrainingData): Promise<boolean> {
+    const userId: string = this.userService.currentUserId;
+    const project: SFProjectProfile | undefined = this.activatedProjectService.projectDoc?.data;
+    return (
+      project != null &&
+      SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.TrainingData, Operation.Delete, trainingData)
+    );
+  }
+
+  async deleteTrainingData(trainingData: TrainingData): Promise<void> {
+    const confirmation = await this.dialogService.confirm(
+      'training_data_multi_select.confirm_delete',
+      'training_data_multi_select.delete'
+    );
+    if (!confirmation) return;
+    await this.trainingDataService.deleteTrainingDataAsync(trainingData);
+  }
+
+  initBookOptions(): void {
+    this.trainingDataOptions = this.availableTrainingData.map((item: TrainingData) => ({
+      value: item,
+      selected: this.selectedTrainingDataIds.includes(item.dataId)
+    }));
+  }
+
+  onChipListChange(event: MatChipListboxChange): void {
+    this.selectedTrainingDataIds = event.value.map((item: TrainingData) => item.dataId);
+    this.trainingDataSelect.emit(this.selectedTrainingDataIds);
+  }
+
+  openUploadDialog(): void {
+    if (this.activatedProjectService.projectId == null) return;
+    const dialogConfig: MatDialogConfig<TrainingDataUploadDialogData> = {
+      data: { projectId: this.activatedProjectService.projectId },
+      width: '320px'
+    };
+    const dialogRef = this.dialogService.openMatDialog(TrainingDataUploadDialogComponent, dialogConfig);
+    dialogRef.afterClosed().subscribe(result => {
+      if (result == null || result === 'close') {
+        return;
+      }
+
+      // Emit the selection event
+      this.trainingDataSelect.emit([...this.selectedTrainingDataIds, result.dataId]);
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
@@ -1,0 +1,39 @@
+<ng-container *transloco="let t; read: 'training_data_upload_dialog'">
+  <h2 mat-dialog-title>{{ t("upload_training_data") }}</h2>
+  <mat-dialog-content class="mat-typography">
+    <div class="dropzone" #dropzone>
+      <input type="file" #fileDropzone accept=".csv,.tsv,.txt,.xls,.xlsx" (change)="uploadedFiles($event)" />
+      <label>{{ t("drag_and_drop_files") }}<br />- {{ t("drag_and_drop_or_browse") }} -</label>
+      <button mat-flat-button color="primary" type="submit">{{ t("browse_files") }}</button>
+    </div>
+    <div class="data-blocks">
+      <div class="wrapper valid">
+        <ng-container>
+          <mat-checkbox #skipFirstRow>{{ t("skip_first_row") }}</mat-checkbox>
+        </ng-container>
+      </div>
+      <div class="wrapper wrapper-training-data-file" [ngClass]="{ valid: hasBeenUploaded }">
+        <ng-container *ngIf="hasBeenUploaded">
+          <span *ngIf="hasBeenUploaded">{{ trainingDataFilename }}</span>
+          <mat-icon *ngIf="hasBeenUploaded" (click)="deleteTrainingData()" class="delete">delete</mat-icon>
+        </ng-container>
+        <ng-container *ngIf="!hasBeenUploaded">
+          <mat-icon>file_download_off</mat-icon>
+          <span>{{ t("no_training_data_file_uploaded") }}</span>
+        </ng-container>
+      </div>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <div class="uploading" *ngIf="isUploading">
+      <span>{{ t("uploading") }}</span>
+      <mat-spinner diameter="24"></mat-spinner>
+    </div>
+    <button mat-button [mat-dialog-close]="'close'" type="button" id="upload-cancel-btn">
+      {{ t("cancel") }}
+    </button>
+    <button mat-flat-button color="primary" type="submit" (click)="save()" id="upload-save-btn">
+      {{ t("save") }}
+    </button>
+  </mat-dialog-actions>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
@@ -14,8 +14,14 @@
       </div>
       <div class="wrapper wrapper-training-data-file" [ngClass]="{ valid: hasBeenUploaded }">
         <ng-container *ngIf="hasBeenUploaded">
-          <span *ngIf="hasBeenUploaded">{{ trainingDataFilename }}</span>
-          <mat-icon *ngIf="hasBeenUploaded" (click)="deleteTrainingData()" class="delete">delete</mat-icon>
+          <app-info
+            *ngIf="showFilenameExists"
+            [text]="t('filename_already_exists')"
+            icon="warning"
+            type="warning"
+          ></app-info>
+          <span>{{ trainingDataFilename }}</span>
+          <mat-icon (click)="deleteTrainingData()" class="delete">delete</mat-icon>
         </ng-container>
         <ng-container *ngIf="!hasBeenUploaded">
           <mat-icon>file_download_off</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.scss
@@ -1,0 +1,126 @@
+@use 'src/variables';
+
+@mixin wrapperState($borderColor, $textColor) {
+  border-color: $borderColor;
+  color: $textColor;
+
+  mat-icon {
+    color: $borderColor;
+  }
+
+  .delete {
+    color: variables.$border-color;
+    cursor: pointer;
+
+    &:hover {
+      color: $textColor;
+    }
+  }
+}
+
+.mat-dialog-content {
+  .warning {
+    font-size: 21px;
+    margin-inline-end: unset;
+    color: variables.$orange;
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}
+
+.dropzone {
+  position: relative;
+  padding: 15px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 2px dashed variables.$border-color;
+  border-radius: 4px;
+  margin-bottom: 24px;
+
+  &:hover {
+    button {
+      background-color: variables.$greenLight;
+      color: variables.$greyDark;
+    }
+  }
+
+  &.dragover {
+    background: variables.$border-color;
+  }
+
+  input {
+    opacity: 0;
+    position: absolute;
+    z-index: 2;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    cursor: pointer;
+  }
+
+  label {
+    text-align: center;
+    font-size: 1.25rem;
+    line-height: 1.25em;
+    margin-bottom: 1rem;
+  }
+}
+
+.mat-dialog-actions {
+  justify-content: end;
+
+  .uploading {
+    flex-grow: 1;
+    display: flex;
+    column-gap: 8px;
+    flex-direction: row;
+  }
+}
+.data-blocks {
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+
+  .wrapper {
+    display: flex;
+    align-items: center;
+    column-gap: 5px;
+    border: 1px solid variables.$border-color;
+    padding: 5px 10px;
+    border-radius: 4px;
+    color: variables.$greyLight;
+    flex-basis: 44px;
+
+    mat-icon {
+      color: variables.$border-color;
+    }
+
+    app-info,
+    mat-icon {
+      flex: 0 0 30px;
+      text-align: center;
+      justify-content: center;
+    }
+
+    span {
+      flex: 1;
+      line-height: 1em;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    .divider {
+      flex: 0 0 1px;
+      border-left: 1px solid variables.$border-color;
+      height: calc(100% + 10px);
+    }
+
+    &.valid {
+      @include wrapperState(variables.$purpleLight, variables.$greyDark);
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.spec.ts
@@ -1,0 +1,163 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NgModule, NgZone } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MatLegacyDialog as MatDialog,
+  MatLegacyDialogModule as MatDialogModule,
+  MatLegacyDialogRef as MatDialogRef
+} from '@angular/material/legacy-dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ngfModule } from 'angular-file';
+import { anything, mock, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
+import { FileService } from 'xforge-common/file.service';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { UserService } from 'xforge-common/user.service';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+import {
+  TrainingDataFileUpload,
+  TrainingDataUploadDialogComponent,
+  TrainingDataUploadDialogResult
+} from './training-data-upload-dialog.component';
+import { TrainingDataService } from './training-data.service';
+
+const mockedDialogService = mock(DialogService);
+const mockedFileService = mock(FileService);
+const mockedTrainingDataService = mock(TrainingDataService);
+const mockedUserService = mock(UserService);
+
+describe('TrainingDataUploadDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [DialogTestModule],
+    providers: [
+      { provide: DialogService, useMock: mockedDialogService },
+      { provide: FileService, useMock: mockedFileService },
+      { provide: TrainingDataService, useMock: mockedTrainingDataService },
+      { provide: UserService, useMock: mockedUserService }
+    ]
+  }));
+
+  let env: TestEnvironment;
+
+  let overlayContainer: OverlayContainer;
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+    env = new TestEnvironment();
+  });
+  afterEach(() => {
+    // Prevents 'Error: Test did not clean up its overlay container content.'
+    overlayContainer.ngOnDestroy();
+  });
+
+  it('should upload training data and return the object on save', async () => {
+    let result: TrainingDataUploadDialogResult = { dataId: '' };
+    env.dialogRef.afterClosed().subscribe((_result: TrainingDataUploadDialogResult) => {
+      result = _result;
+    });
+    env.component.updateTrainingData(env.trainingDataFile);
+    await env.component.save();
+    await env.wait();
+
+    expect(result.dataId).not.toEqual('');
+  });
+
+  it('can drag and drop to initiate an upload', async () => {
+    const dataTransfer = new DataTransfer();
+    for (const file of TestEnvironment.uploadFiles) {
+      dataTransfer.items.add(file);
+    }
+    const dropEvent = new DragEvent('drop', { dataTransfer });
+    env.dropzoneElement.dispatchEvent(dropEvent);
+    await env.wait();
+
+    expect(env.wrapperTrainingDataFile.classList.contains('valid')).toBe(true);
+  });
+
+  it('can browse to upload files', async () => {
+    const dataTransfer = new DataTransfer();
+    for (const file of TestEnvironment.uploadFiles) {
+      dataTransfer.items.add(file);
+    }
+    const event = new Event('change');
+    env.fileUploadElement.files = dataTransfer.files;
+    env.fileUploadElement.dispatchEvent(event);
+    await env.wait();
+
+    expect(env.wrapperTrainingDataFile.classList.contains('valid')).toBe(true);
+  });
+});
+
+@NgModule({
+  imports: [
+    HttpClientTestingModule,
+    MatDialogModule,
+    ngfModule,
+    NoopAnimationsModule,
+    TestTranslocoModule,
+    UICommonModule
+  ]
+})
+class DialogTestModule {}
+
+class TestEnvironment {
+  static uploadFiles: File[] = [new File([], 'test.csv')];
+
+  readonly fixture: ComponentFixture<ChildViewContainerComponent>;
+  readonly ngZone: NgZone = TestBed.inject(NgZone);
+  readonly component: TrainingDataUploadDialogComponent;
+  readonly dialogRef: MatDialogRef<TrainingDataUploadDialogComponent>;
+  readonly trainingDataFile: TrainingDataFileUpload;
+
+  constructor() {
+    when(
+      mockedFileService.onlineUploadFileOrFail(
+        FileType.TrainingData,
+        anything(),
+        TrainingDataDoc.COLLECTION,
+        anything(),
+        anything(),
+        anything(),
+        true
+      )
+    ).thenResolve('training data file url');
+    when(mockedUserService.currentUserId).thenReturn('user01');
+
+    let blob = new Blob(['source_1,target_2\nsource_2,target_2'], { type: 'text/csv' });
+    this.trainingDataFile = {
+      blob,
+      fileName: 'test.csv',
+      url: URL.createObjectURL(new File([blob], 'test.wav'))
+    };
+
+    this.fixture = TestBed.createComponent(ChildViewContainerComponent);
+    this.dialogRef = TestBed.inject(MatDialog).open(TrainingDataUploadDialogComponent, {
+      data: { projectId: 'project01' }
+    });
+    this.component = this.dialogRef.componentInstance;
+    this.fixture.detectChanges();
+  }
+
+  get fileUploadElement(): HTMLInputElement {
+    return this.dropzoneElement.querySelector('input[type=file]') as HTMLInputElement;
+  }
+
+  get dropzoneElement(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.dropzone') as HTMLElement;
+  }
+
+  get wrapperTrainingDataFile(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.wrapper-training-data-file') as HTMLElement;
+  }
+
+  private get overlayContainerElement(): HTMLElement {
+    return this.fixture.nativeElement.parentElement.querySelector('.cdk-overlay-container');
+  }
+
+  async wait(ms: number = 200): Promise<void> {
+    await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
@@ -2,10 +2,7 @@ import { CommonModule } from '@angular/common';
 import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import {
-  MatLegacyCheckbox as MatCheckbox,
-  MatLegacyCheckboxModule as MatCheckboxModule
-} from '@angular/material/legacy-checkbox';
+import { MatCheckbox, MatCheckboxModule } from '@angular/material/checkbox';
 import {
   MatLegacyDialogModule as MatDialogModule,
   MatLegacyDialogRef as MatDialogRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
@@ -1,0 +1,188 @@
+import { CommonModule } from '@angular/common';
+import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import {
+  MatLegacyCheckbox as MatCheckbox,
+  MatLegacyCheckboxModule as MatCheckboxModule
+} from '@angular/material/legacy-checkbox';
+import {
+  MatLegacyDialogModule as MatDialogModule,
+  MatLegacyDialogRef as MatDialogRef,
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
+} from '@angular/material/legacy-dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { TranslocoModule } from '@ngneat/transloco';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { DialogService } from 'xforge-common/dialog.service';
+import { FileService } from 'xforge-common/file.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { UserService } from 'xforge-common/user.service';
+import { objectId } from 'xforge-common/utils';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+import { TrainingDataService } from './training-data.service';
+
+export interface TrainingDataUploadDialogData {
+  projectId: string;
+}
+
+export interface TrainingDataUploadDialogResult {
+  dataId: string;
+}
+
+export interface TrainingDataFileUpload {
+  url?: string;
+  fileName?: string;
+  blob?: Blob;
+}
+
+@Component({
+  selector: 'app-training-data-upload-dialog',
+  templateUrl: './training-data-upload-dialog.component.html',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatDialogModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    TranslocoModule
+  ],
+  styleUrls: ['./training-data-upload-dialog.component.scss']
+})
+export class TrainingDataUploadDialogComponent extends SubscriptionDisposable implements AfterViewInit {
+  @ViewChild('dropzone') dropzone?: ElementRef<HTMLDivElement>;
+  @ViewChild('fileDropzone') fileDropzone?: ElementRef<HTMLInputElement>;
+  @ViewChild('skipFirstRow') skipFirstRow?: MatCheckbox;
+  private _isUploading: boolean = false;
+  private _showNotUploadedError: boolean = false;
+  private trainingDataFile?: TrainingDataFileUpload;
+
+  constructor(
+    readonly i18n: I18nService,
+    @Inject(MAT_DIALOG_DATA) public data: TrainingDataUploadDialogData,
+    private readonly dialogRef: MatDialogRef<
+      TrainingDataUploadDialogComponent,
+      TrainingDataUploadDialogResult | undefined
+    >,
+    private readonly dialogService: DialogService,
+    private readonly fileService: FileService,
+    private readonly trainingDataService: TrainingDataService,
+    private readonly userService: UserService
+  ) {
+    super();
+  }
+
+  get hasBeenUploaded(): boolean {
+    return this.trainingDataFile?.blob != null && this.trainingDataFile?.fileName != null;
+  }
+
+  get isUploading(): boolean {
+    return this._isUploading;
+  }
+
+  get showNotUploadedError(): boolean {
+    return this._showNotUploadedError;
+  }
+
+  get trainingDataFilename(): string {
+    return this.trainingDataFile?.fileName ?? '';
+  }
+
+  updateTrainingData(trainingDataFile: TrainingDataFileUpload): void {
+    this.trainingDataFile = trainingDataFile;
+  }
+
+  deleteTrainingData(): void {
+    this.trainingDataFile = undefined;
+    this.fileDropzone!.nativeElement.value = '';
+  }
+
+  ngAfterViewInit(): void {
+    this.dropzone?.nativeElement.addEventListener('dragover', _ => {
+      this.dropzone?.nativeElement.classList.add('dragover');
+    });
+    this.dropzone?.nativeElement.addEventListener('dragleave', _ => {
+      this.dropzone?.nativeElement.classList.remove('dragover');
+    });
+    this.dropzone?.nativeElement.addEventListener('drop', (e: DragEvent) => {
+      this.dropzone?.nativeElement.classList.remove('dragover');
+      if (e?.dataTransfer?.files == null) {
+        return;
+      }
+      this.processUploadedFiles(e.dataTransfer.files);
+    });
+  }
+
+  async save(): Promise<void> {
+    // We cannot save a file if it has not been uploaded, or if offline
+    if (!this.hasBeenUploaded) {
+      this._showNotUploadedError = true;
+      return;
+    }
+
+    this._showNotUploadedError = false;
+    this._isUploading = true;
+    const dataId: string = objectId();
+    const fileUrl: string | undefined = await this.fileService.onlineUploadFileOrFail(
+      FileType.TrainingData,
+      this.data.projectId,
+      TrainingDataDoc.COLLECTION,
+      dataId,
+      this.trainingDataFile!.blob!,
+      this.trainingDataFile!.fileName!,
+      true
+    );
+    this._isUploading = false;
+    if (fileUrl == null) {
+      this.dialogService.message('training_data_upload_dialog.upload_failed');
+      return;
+    }
+
+    // Create the training_data record
+    let trainingData: TrainingData = {
+      ownerRef: this.userService.currentUserId,
+      projectRef: this.data.projectId,
+      dataId,
+      fileUrl,
+      mimeType: 'text/csv',
+      skipRows: this.skipFirstRow?.checked ?? false ? 1 : 0,
+      title: this.trainingDataFile!.fileName!
+    };
+    await this.trainingDataService.createTrainingDataAsync(trainingData);
+
+    this.dialogRef.close({ dataId });
+  }
+
+  /**
+   * Handles the change event of the #fileDropzone.
+   * We only support uploading one file at a time.
+   * @param e The event
+   * @returns void
+   */
+  uploadedFiles(e: Event): void {
+    const el = e.target as HTMLInputElement;
+    if (el.files == null) {
+      return;
+    }
+    this.processUploadedFiles(el.files);
+  }
+
+  private processUploadedFiles(files: FileList): void {
+    for (let index = 0; index < files.length; index++) {
+      const file: File | null = files.item(index);
+      if (file == null) {
+        continue;
+      }
+      const trainingDataFileUpload: TrainingDataFileUpload = {
+        url: URL.createObjectURL(file),
+        blob: file,
+        fileName: file.name
+      };
+      this.updateTrainingData(trainingDataFileUpload);
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.spec.ts
@@ -1,0 +1,122 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { getTrainingDataId, TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { anything, mock, verify } from 'ts-mockito';
+import { FileService } from 'xforge-common/file.service';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { Snapshot } from 'xforge-common/models/snapshot';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { TypeRegistry } from 'xforge-common/type-registry';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+import { TrainingDataService } from './training-data.service';
+
+describe('TrainingDataService', () => {
+  const trainingData: Partial<Snapshot<TrainingData>>[] = [
+    {
+      id: getTrainingDataId('project01', 'data01'),
+      data: {
+        projectRef: 'project01',
+        dataId: 'data01',
+        fileUrl: 'project01/test.csv',
+        mimeType: 'text/csv',
+        skipRows: 0,
+        title: 'test.csv',
+        ownerRef: 'user01'
+      }
+    },
+    {
+      id: getTrainingDataId('project02', 'data02'),
+      data: {
+        projectRef: 'project02',
+        dataId: 'data02',
+        fileUrl: 'project02/test2.csv',
+        mimeType: 'text/csv',
+        skipRows: 0,
+        title: 'test2.csv',
+        ownerRef: 'user01'
+      }
+    }
+  ];
+  let trainingDataService: TrainingDataService;
+  let realtimeService: TestRealtimeService;
+  const mockedFileService = mock(FileService);
+
+  configureTestingModule(() => ({
+    imports: [TestRealtimeModule.forRoot(new TypeRegistry([TrainingDataDoc], [FileType.TrainingData], []))],
+    providers: [{ provide: FileService, useMock: mockedFileService }]
+  }));
+
+  beforeEach(() => {
+    realtimeService = TestBed.inject(TestRealtimeService);
+    realtimeService.addSnapshots<TrainingData>(TrainingDataDoc.COLLECTION, trainingData);
+    trainingDataService = TestBed.inject(TrainingDataService);
+  });
+
+  it('should create a training data doc', fakeAsync(async () => {
+    const newTrainingData = {
+      projectRef: 'project01',
+      dataId: 'data03',
+      fileUrl: 'project01/test3.csv',
+      mimeType: 'text/csv',
+      skipRows: 0,
+      title: 'test3.csv',
+      ownerRef: 'user01'
+    };
+    await trainingDataService.createTrainingDataAsync(newTrainingData);
+    tick();
+
+    const trainingDataDoc = realtimeService.get<TrainingDataDoc>(
+      TrainingDataDoc.COLLECTION,
+      getTrainingDataId('project01', 'data03')
+    );
+    expect(trainingDataDoc.data).toEqual(newTrainingData);
+  }));
+
+  it('should delete a training data doc', fakeAsync(async () => {
+    // Verify the document exists
+    const existingTrainingDataDoc = realtimeService.get<TrainingDataDoc>(
+      TrainingDataDoc.COLLECTION,
+      getTrainingDataId('project01', 'data01')
+    );
+    expect(existingTrainingDataDoc.data?.dataId).toBe('data01');
+    expect(existingTrainingDataDoc.data?.projectRef).toBe('project01');
+
+    // SUT
+    const trainingDataToDelete: TrainingData = {
+      projectRef: 'project01',
+      dataId: 'data01',
+      fileUrl: '',
+      mimeType: '',
+      skipRows: 0,
+      title: '',
+      ownerRef: 'user01'
+    };
+    await trainingDataService.deleteTrainingDataAsync(trainingDataToDelete);
+    tick();
+
+    const trainingDataDoc = realtimeService.get<TrainingDataDoc>(
+      TrainingDataDoc.COLLECTION,
+      getTrainingDataId('project01', 'data01')
+    );
+    expect(trainingDataDoc.data).toBeUndefined();
+    verify(
+      mockedFileService.deleteFile(
+        FileType.TrainingData,
+        'project01',
+        TrainingDataDoc.COLLECTION,
+        anything(),
+        anything()
+      )
+    ).once();
+  }));
+
+  it('should query training data docs', fakeAsync(async () => {
+    const query: RealtimeQuery<TrainingDataDoc> = await trainingDataService.queryTrainingDataAsync('project01');
+    tick();
+
+    expect(trainingData.length).toEqual(2);
+    expect(query.docs.length).toEqual(1);
+  }));
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
+import { getTrainingDataId, TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { QueryParameters } from 'xforge-common/query-parameters';
+import { RealtimeService } from 'xforge-common/realtime.service';
+import { TrainingDataDoc } from '../../../core/models/training-data-doc';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TrainingDataService {
+  constructor(private readonly realtimeService: RealtimeService) {}
+
+  async createTrainingDataAsync(trainingData: TrainingData): Promise<void> {
+    const docId: string = getTrainingDataId(trainingData.projectRef, trainingData.dataId);
+    await this.realtimeService.create<TrainingDataDoc>(TrainingDataDoc.COLLECTION, docId, trainingData);
+  }
+
+  async deleteTrainingDataAsync(trainingData: TrainingData): Promise<void> {
+    // Get the training data document
+    const docId: string = getTrainingDataId(trainingData.projectRef, trainingData.dataId);
+    const trainingDataDoc = this.realtimeService.get<TrainingDataDoc>(TrainingDataDoc.COLLECTION, docId);
+    if (!trainingDataDoc.isLoaded) return;
+
+    // Delete the training data file and document
+    await trainingDataDoc.deleteFile(FileType.TrainingData, trainingData.dataId, trainingData.ownerRef);
+    await trainingDataDoc.delete();
+  }
+
+  queryTrainingDataAsync(projectId: string): Promise<RealtimeQuery<TrainingDataDoc>> {
+    const queryParams: QueryParameters = {
+      [obj<TrainingData>().pathStr(t => t.projectRef)]: projectId
+    };
+    return this.realtimeService.subscribeQuery(TrainingDataDoc.COLLECTION, queryParams);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -185,6 +185,8 @@
   },
   "draft_generation_steps": {
     "back": "Back",
+    "choose_additional_training_data_files_subheader": "Select additional training files.",
+    "choose_additional_training_data_files": "Choose additional files for training the language model",
     "choose_books_for_training_error": "No books selected. Select training books to continue.",
     "choose_books_for_training_subheader": "Select books that have been proofed.",
     "choose_books_for_training": "Choose books for training the language model",
@@ -399,6 +401,8 @@
     "invite_others": "Administrators can always invite people from the {{ templateTagBoundary }}Users{{ templateTagBoundary }} page.",
     "log_in_with_paratext": "Log in to Paratext",
     "pre_translation_drafting": "Translation draft generation",
+    "pre_translation_additional_training_data": "Allow additional training data",
+    "pre_translation_additional_training_data_info": "These are two column CSV files specially crafted to provide training data pairs.",
     "pre_translation_alternate_training_source_info": "Selecting a separate translation for training, such as a back translation, can improve drafting quality.",
     "pre_translation_alternate_training_source_text_placeholder": "Alternate training source text (optional)",
     "pre_translation_drafting_description": "Configure options for generating translation drafts.",
@@ -457,6 +461,25 @@
     "cross_reference": "Cross-reference",
     "end_note": "End note",
     "footnote": "Footnote"
+  },
+  "training_data_multi_select": {
+    "confirm_delete": "Are you sure you want to permanently delete this training data?",
+    "delete": "Delete",
+    "file_information": "The file should be a spreadsheet that has two columns of text: the first column in {{ sourceLanguage }}, the second in {{ targetLanguage }}.",
+    "upload_csv": "Upload CSV"
+  },
+  "training_data_upload_dialog": {
+    "browse_files": "Browse Files",
+    "cancel": "Cancel",
+    "drag_and_drop_files": "Drag and drop training data file here",
+    "drag_and_drop_or_browse": "OR",
+    "skip_first_row": "Skip first row of data file",
+    "no_training_data_file_uploaded": "No training data file uploaded",
+    "no_upload_offline": "Training data cannot be uploaded without connecting to the internet.",
+    "save": "Save",
+    "upload_failed": "The training data file could not be uploaded. Please try again or use a different file.",
+    "upload_training_data": "Upload Training Data",
+    "uploading": "Uploading..."
   },
   "training_progress": {
     "completed_successfully": "Completed successfully",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -473,6 +473,7 @@
     "cancel": "Cancel",
     "drag_and_drop_files": "Drag and drop training data file here",
     "drag_and_drop_or_browse": "OR",
+    "filename_already_exists": "A file already exists with this name.",
     "skip_first_row": "Skip first row of data file",
     "no_training_data_file_uploaded": "No training data file uploaded",
     "no_upload_offline": "Training data cannot be uploaded without connecting to the internet.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.prod.ts
@@ -15,5 +15,5 @@ export const environment = {
   realtimeUrl: '/realtime-api/',
   authDomain: 'login.languagetechnology.org',
   authClientId: 'tY2wXn40fsL5VsPM4uIHNtU6ZUEXGeFn',
-  offlineDBVersion: 7
+  offlineDBVersion: 8
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.pwa-test.ts
@@ -15,5 +15,5 @@ export const environment = {
   realtimeUrl: '/',
   authDomain: 'sil-appbuilder.auth0.com',
   authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
-  offlineDBVersion: 7
+  offlineDBVersion: 8
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
@@ -15,5 +15,5 @@ export const environment = {
   realtimeUrl: '/realtime-api/',
   authDomain: 'dev-sillsdev.auth0.com',
   authClientId: '4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj',
-  offlineDBVersion: 7
+  offlineDBVersion: 8
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
@@ -22,5 +22,5 @@ export const environment = {
   realtimeUrl: '/',
   authDomain: 'sil-appbuilder.auth0.com',
   authClientId: 'aoAGb9Yx1H5WIsvCW6JJCteJhSa37ftH',
-  offlineDBVersion: 7
+  offlineDBVersion: 8
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -221,8 +221,17 @@ export class FileService extends SubscriptionDisposable {
     }
   }
 
+  private convertToPascalCase(input: string): string {
+    return input
+      .split('-')
+      .map(word => {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join('');
+  }
+
   private onlineDeleteFile(fileType: FileType, projectId: string, dataId: string, ownerId: string): Promise<void> {
-    const method = `delete${fileType.charAt(0).toUpperCase()}${fileType.substring(1)}`;
+    const method = `delete${this.convertToPascalCase(fileType)}`;
     return this.commandService.onlineInvoke(PROJECTS_URL, method, { projectId, ownerId, dataId });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/file-offline-data.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/file-offline-data.ts
@@ -1,7 +1,8 @@
 import { OfflineData } from '../offline-store';
 
 export enum FileType {
-  Audio = 'audio'
+  Audio = 'audio',
+  TrainingData = 'training-data'
 }
 
 export function createUploadFileData(

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -22,19 +22,22 @@ public class SFProjectsUploadController : ControllerBase
 {
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IFileSystemService _fileSystemService;
-    private readonly IUserAccessor _userAccessor;
     private readonly ISFProjectService _projectService;
+    private readonly ITrainingDataService _trainingDataService;
+    private readonly IUserAccessor _userAccessor;
 
     public SFProjectsUploadController(
-        IUserAccessor userAccessor,
-        ISFProjectService projectService,
+        IExceptionHandler exceptionHandler,
         IFileSystemService fileSystemService,
-        IExceptionHandler exceptionHandler
+        ISFProjectService projectService,
+        ITrainingDataService trainingDataService,
+        IUserAccessor userAccessor
     )
     {
-        _userAccessor = userAccessor;
-        _projectService = projectService;
         _fileSystemService = fileSystemService;
+        _projectService = projectService;
+        _trainingDataService = trainingDataService;
+        _userAccessor = userAccessor;
         _exceptionHandler = exceptionHandler;
         _exceptionHandler.RecordUserIdForException(_userAccessor.UserId);
     }
@@ -46,6 +49,9 @@ public class SFProjectsUploadController : ControllerBase
     /// <response code="400">The data or parameters were malformed.</response>
     /// <response code="403">Insufficient permission to upload a file to this project.</response>
     /// <response code="404">The project does not exist.</response>
+    /// <remarks>
+    /// To increase or decrease the file size limit, modify the RequestSizeLimit attribute for this method.
+    /// </remarks>
     [HttpPost("audio")]
     [RequestSizeLimit(100_000_000)]
     public async Task<IActionResult> UploadAudioAsync()
@@ -55,111 +61,10 @@ public class SFProjectsUploadController : ControllerBase
         string dataId = string.Empty;
         string path = string.Empty;
 
-        // The following code handles via upload via streaming to avoid request and form limits in ASP.NET Core
-        // To increase or decrease the file size limit, modify the RequestSizeLimit attribute for this method
         try
         {
-            // The Content-Type must be a form-data request, and a boundary should be found in it
-            if (
-                !Request.HasFormContentType
-                || !MediaTypeHeaderValue.TryParse(Request.ContentType, out var mediaTypeHeader)
-                || string.IsNullOrEmpty(mediaTypeHeader.Boundary.Value)
-            )
-            {
-                return BadRequest();
-            }
-
-            // Read the multipart data
-            MultipartReader reader = new MultipartReader(mediaTypeHeader.Boundary.Value, Request.Body);
-            MultipartSection section = await reader.ReadNextSectionAsync();
-
-            // Iterate over each multipart section
-            while (section is not null)
-            {
-                bool hasContentDisposition = ContentDispositionHeaderValue.TryParse(
-                    section.ContentDisposition,
-                    out var contentDisposition
-                );
-
-                if (
-                    hasContentDisposition
-                    && contentDisposition.DispositionType.Equals("form-data")
-                    && !string.IsNullOrEmpty(contentDisposition.FileName.Value)
-                )
-                {
-                    // If we have a filename, get the file being uploaded...
-
-                    // Get the filename so we can get the extension
-                    string fileName = contentDisposition.FileName.Value ?? string.Empty;
-
-                    // Strip invalid characters from the file name
-                    fileName = Path.GetInvalidFileNameChars()
-                        .Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
-
-                    // Get the path to the temporary file
-                    path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.GetExtension(fileName));
-
-                    // Write the incoming file data to the temporary file
-                    await using Stream fileStream = _fileSystemService.CreateFile(path);
-                    await section.Body.CopyToAsync(fileStream);
-                }
-                else if (
-                    hasContentDisposition
-                    && contentDisposition.DispositionType.Equals("form-data")
-                    && string.IsNullOrEmpty(contentDisposition.FileName.Value)
-                    && string.IsNullOrEmpty(contentDisposition.FileNameStar.Value)
-                )
-                {
-                    // If we do not have a filename, get the other form data...
-
-                    // Get the media type encoding
-                    bool hasMediaTypeHeader = MediaTypeHeaderValue.TryParse(section.ContentType, out var mediaType);
-                    // Disable the following warning: The UTF-7 encoding is insecure and should not be used.
-#pragma warning disable SYSLIB0001
-                    // As UTF-7 is insecure, substitute UTF-8. If no encoding is specified, default to UTF-8
-                    Encoding encoding =
-                        !hasMediaTypeHeader || Encoding.UTF7.Equals(mediaType.Encoding) || mediaType.Encoding is null
-                            ? Encoding.UTF8
-                            : mediaType.Encoding;
-#pragma warning restore SYSLIB0001
-
-                    using StreamReader streamReader = new StreamReader(
-                        section.Body,
-                        encoding,
-                        detectEncodingFromByteOrderMarks: true,
-                        bufferSize: 1024,
-                        leaveOpen: true
-                    );
-
-                    // The value length limit is enforced by MultipartBodyLengthLimit
-                    string value = await streamReader.ReadToEndAsync();
-                    if (string.Equals(value, "undefined", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    // Collect the required form values
-                    switch (HeaderUtilities.RemoveQuotes(contentDisposition.Name).Value)
-                    {
-                        case "projectId":
-                            projectId = value;
-                            break;
-                        case "dataId":
-                            dataId = value;
-                            break;
-                    }
-                }
-
-                section = await reader.ReadNextSectionAsync();
-            }
-
-            // Throw an error if we do not have the required data
-            if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(dataId) || string.IsNullOrWhiteSpace(path))
-            {
-                return BadRequest();
-            }
-
-            // Convert and save the audio file
+            // Upload, convert and save the audio file
+            (dataId, path, projectId) = await HandleFileUploadAsync();
             Uri uri = await _projectService.SaveAudioAsync(_userAccessor.UserId, projectId, dataId, path);
             return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
         }
@@ -195,5 +100,187 @@ public class SFProjectsUploadController : ControllerBase
                 _fileSystemService.DeleteFile(path);
             }
         }
+    }
+
+    /// <summary>
+    /// Uploads a training data file.
+    /// </summary>
+    /// <response code="200">The file was uploaded successfully.</response>
+    /// <response code="400">The data or parameters were malformed.</response>
+    /// <response code="403">Insufficient permission to upload a file to this project.</response>
+    /// <response code="404">The project does not exist.</response>
+    /// <remarks>
+    /// To increase or decrease the file size limit, modify the RequestSizeLimit attribute for this method.
+    /// </remarks>
+    [HttpPost("training-data")]
+    [RequestSizeLimit(100_000_000)]
+    public async Task<IActionResult> UploadTrainingDataAsync()
+    {
+        // Declare the form values
+        string projectId = string.Empty;
+        string dataId = string.Empty;
+        string path = string.Empty;
+
+        try
+        {
+            // Upload, convert and save the training data file
+            (dataId, path, projectId) = await HandleFileUploadAsync();
+            Uri uri = await _trainingDataService.SaveTrainingDataAsync(_userAccessor.UserId, projectId, dataId, path);
+            return Created(uri.PathAndQuery, Path.GetFileName(uri.AbsolutePath));
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (FormatException)
+        {
+            return BadRequest();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "UploadTrainingDataAsync" },
+                    { "projectId", projectId },
+                    { "dataId", dataId },
+                }
+            );
+            throw;
+        }
+        finally
+        {
+            // Delete the temporary file, if it still exists
+            if (!string.IsNullOrEmpty(path) && _fileSystemService.FileExists(path))
+            {
+                _fileSystemService.DeleteFile(path);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Handle the file upload via streaming to avoid request and form limits in ASP.NET Core
+    /// </summary>
+    /// <returns>A tuple with the dataId, path, and projectId.</returns>
+    /// <remarks>
+    /// Never use a cancellation token with this method - it will result in stream errors.
+    /// </remarks>
+    /// <exception cref="FormatException">The request is an invalid format.</exception>
+    private async Task<(string dataId, string path, string projectId)> HandleFileUploadAsync()
+    {
+        // Declare the form values
+        string projectId = string.Empty;
+        string dataId = string.Empty;
+        string path = string.Empty;
+
+        // The Content-Type must be a form-data request, and a boundary should be found in it
+        if (
+            !Request.HasFormContentType
+            || !MediaTypeHeaderValue.TryParse(Request.ContentType, out var mediaTypeHeader)
+            || string.IsNullOrEmpty(mediaTypeHeader.Boundary.Value)
+        )
+        {
+            throw new FormatException();
+        }
+
+        // Strip double quotes from boundary, if present
+        // See https://datatracker.ietf.org/doc/html/rfc2046#section-5.1.1
+        string boundary = HeaderUtilities.RemoveQuotes(mediaTypeHeader.Boundary).Value;
+
+        // Read the multipart data
+        MultipartReader reader = new MultipartReader(boundary, Request.Body);
+        MultipartSection section = await reader.ReadNextSectionAsync();
+
+        // Iterate over each multipart section
+        while (section is not null)
+        {
+            bool hasContentDisposition = ContentDispositionHeaderValue.TryParse(
+                section.ContentDisposition,
+                out var contentDisposition
+            );
+
+            if (
+                hasContentDisposition
+                && contentDisposition.DispositionType.Equals("form-data")
+                && !string.IsNullOrEmpty(contentDisposition.FileName.Value)
+            )
+            {
+                // If we have a filename, get the file being uploaded...
+
+                // Get the filename so we can get the extension
+                string fileName = contentDisposition.FileName.Value ?? string.Empty;
+
+                // Strip invalid characters from the file name
+                fileName = Path.GetInvalidFileNameChars()
+                    .Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
+
+                // Get the path to the temporary file
+                path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.GetExtension(fileName));
+
+                // Write the incoming file data to the temporary file
+                await using Stream fileStream = _fileSystemService.CreateFile(path);
+                await section.Body.CopyToAsync(fileStream);
+            }
+            else if (
+                hasContentDisposition
+                && contentDisposition.DispositionType.Equals("form-data")
+                && string.IsNullOrEmpty(contentDisposition.FileName.Value)
+                && string.IsNullOrEmpty(contentDisposition.FileNameStar.Value)
+            )
+            {
+                // If we do not have a filename, get the other form data...
+
+                // Get the media type encoding
+                bool hasMediaTypeHeader = MediaTypeHeaderValue.TryParse(section.ContentType, out var mediaType);
+                // Disable the following warning: The UTF-7 encoding is insecure and should not be used.
+#pragma warning disable SYSLIB0001
+                // As UTF-7 is insecure, substitute UTF-8. If no encoding is specified, default to UTF-8
+                Encoding encoding =
+                    !hasMediaTypeHeader || Encoding.UTF7.Equals(mediaType.Encoding) || mediaType.Encoding is null
+                        ? Encoding.UTF8
+                        : mediaType.Encoding;
+#pragma warning restore SYSLIB0001
+
+                using StreamReader streamReader = new StreamReader(
+                    section.Body,
+                    encoding,
+                    detectEncodingFromByteOrderMarks: true,
+                    bufferSize: 1024,
+                    leaveOpen: true
+                );
+
+                // The value length limit is enforced by MultipartBodyLengthLimit
+                string value = await streamReader.ReadToEndAsync();
+                if (string.Equals(value, "undefined", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Collect the required form values
+                switch (HeaderUtilities.RemoveQuotes(contentDisposition.Name).Value)
+                {
+                    case "projectId":
+                        projectId = value;
+                        break;
+                    case "dataId":
+                        dataId = value;
+                        break;
+                }
+            }
+
+            section = await reader.ReadNextSectionAsync();
+        }
+
+        // Throw an error if we do not have the required data
+        if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(dataId) || string.IsNullOrWhiteSpace(path))
+        {
+            throw new FormatException();
+        }
+
+        return (dataId, path, projectId);
     }
 }

--- a/src/SIL.XForge.Scripture/Dockerfile
+++ b/src/SIL.XForge.Scripture/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install -y \
 RUN ln -s /usr/bin/hg /usr/local/bin/hg \
     && mkdir -p /var/lib/scriptureforge/sync \
     && mkdir -p /var/lib/scriptureforge/audio \
+    && mkdir -p /var/lib/scriptureforge/training-data \
     && mkdir -p /var/lib/xforge/avatars \
     && mkdir -p ~/.local/share/Paratext95 \
     && mkdir -p ~/.local/share/SIL/WritingSystemRepository/3 \

--- a/src/SIL.XForge.Scripture/Models/BuildConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/BuildConfig.cs
@@ -17,13 +17,19 @@ public class BuildConfig
     /// <summary>
     /// Gets or sets the books to use for training the draft.
     /// </summary>
-    /// <value>The books numbers to use as the source texts for training.</value>
+    /// <value>The numbers of the books to use as the source texts for training.</value>
     public HashSet<int> TrainingBooks { get; set; } = new HashSet<int>();
+
+    /// <summary>
+    /// Gets or sets the DataIds of the files to use for training.
+    /// </summary>
+    /// <value>The DataIds of the files to use as for training.</value>
+    public HashSet<string> TrainingDataFiles { get; set; } = new HashSet<string>();
 
     /// <summary>
     /// Gets or sets the books to use for translation.
     /// </summary>
-    /// <value>The books numbers to use as the source texts for training.</value>
+    /// <value>The numbers of the books to use as the source texts for training.</value>
     public HashSet<int> TranslationBooks { get; set; } = new HashSet<int>();
 
     /// <summary>
@@ -39,5 +45,5 @@ public class BuildConfig
     /// <remarks>
     /// A fast training build will be very inaccurate. Only use this value if you are testing or debugging.
     /// </remarks>
-    public bool FastTraining { get; set; } = false;
+    public bool FastTraining { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/DraftConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftConfig.cs
@@ -4,10 +4,12 @@ namespace SIL.XForge.Scripture.Models;
 
 public class DraftConfig
 {
+    public bool AdditionalTrainingData { get; set; }
     public TranslateSource? AlternateSource { get; set; }
     public bool AlternateTrainingSourceEnabled { get; set; }
     public TranslateSource? AlternateTrainingSource { get; set; }
     public IList<int> LastSelectedTrainingBooks { get; set; } = new List<int>();
+    public IList<string> LastSelectedTrainingDataFiles { get; set; } = new List<string>();
     public IList<int> LastSelectedTranslationBooks { get; set; } = new List<int>();
     public bool SendAllSegments { get; set; }
     public string? ServalConfig { get; set; }

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -1,3 +1,6 @@
+using SIL.XForge.Models;
+using SIL.XForge.Services;
+
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>
@@ -22,6 +25,23 @@ public static class MachineApi
     public const string GetLastCompletedPreTranslationBuild =
         "translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild";
 
+    /// <summary>
+    /// Ensures that a user has permission to perform actions to the Serval/Machine API.
+    /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <param name="project">The project.</param>
+    /// <exception cref="ForbiddenException">
+    /// The user does not have permission to access the Serval/Machine API.
+    /// </exception>
+    public static void EnsureProjectPermission(string userId, Project project)
+    {
+        // Check for permission
+        if (!HasPermission(userId, project))
+        {
+            throw new ForbiddenException();
+        }
+    }
+
     public static string GetBuildHref(string sfProjectId, string buildId)
     {
         // The {locatorType} parameter is required to maintain compatibility with the v1 machine-api and machine.js
@@ -31,4 +51,15 @@ public static class MachineApi
 
     public static string GetEngineHref(string sfProjectId) =>
         $"{Namespace}/{GetEngine.Replace("{sfProjectId}", sfProjectId)}";
+
+    /// <summary>
+    /// Determines if a user has permission to perform actions to the Serval/Machine API.
+    /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <param name="project">The project.</param>
+    /// <returns><c>true</c> if the user has permission; otherwise, <c>false</c>.</returns>
+    public static bool HasPermission(string? userId, Project project) =>
+        !string.IsNullOrWhiteSpace(userId)
+        && project.UserRoles.TryGetValue(userId, out string role)
+        && role is SFProjectRole.Administrator or SFProjectRole.Translator;
 }

--- a/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSettings.cs
@@ -13,6 +13,7 @@ public class SFProjectSettings
     public bool? TranslateShareEnabled { get; set; }
 
     // pre-translation settings
+    public bool? AdditionalTrainingData { get; set; }
     public string? AlternateSourceParatextId { get; set; }
     public bool? AlternateTrainingSourceEnabled { get; set; }
     public string? AlternateTrainingSourceParatextId { get; set; }

--- a/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalCorpus.cs
@@ -8,7 +8,7 @@ namespace SIL.XForge.Scripture.Models;
 public class ServalCorpus
 {
     /// <summary>
-    /// Gets or sets a value indicating whether or not this corpus is for pre-translation.
+    /// Gets or sets a value indicating whether this corpus is for pre-translation.
     /// </summary>
     /// <value>
     /// <c>true</c> if this corpus is for pre-translation; otherwise, <c>false</c>.
@@ -16,7 +16,16 @@ public class ServalCorpus
     public bool PreTranslate { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not this corpus is to be used for Serval to train on.
+    /// Gets or sets a value indicating whether this corpus is to be used for Serval as additional training data.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if this corpus is additional training data; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>If this is set to <c>true</c>, there should be another corpus with this set to <c>false</c>.</remarks>
+    public bool AdditionalTrainingData { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this corpus is to be used for Serval to train on.
     /// </summary>
     /// <value>
     /// <c>true</c> if this corpus is for training; otherwise, <c>false</c> if this corpus is for translation.

--- a/src/SIL.XForge.Scripture/Models/TrainingData.cs
+++ b/src/SIL.XForge.Scripture/Models/TrainingData.cs
@@ -1,0 +1,14 @@
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class TrainingData : ProjectData
+{
+    public static string GetDocId(string sfProjectId, string dataId) => $"{sfProjectId}:{dataId}";
+
+    public string DataId { get; set; } = string.Empty;
+    public string FileUrl { get; set; } = string.Empty;
+    public string MimeType { get; set; } = string.Empty;
+    public int SkipRows { get; set; }
+    public string Title { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Realtime/SFRealtimeServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class SFRealtimeServiceCollectionExtensions
                         new DocConfig("note_threads", typeof(NoteThread)),
                         new DocConfig("text_audio", typeof(TextAudio)),
                         new DocConfig("biblical_terms", typeof(BiblicalTerm)),
+                        new DocConfig("training_data", typeof(TrainingData)),
                     }
                 );
                 o.UserDataDocs.AddRange(

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -26,12 +26,14 @@
     <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.2" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
+    <PackageReference Include="NPOI" Version="2.6.2" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />

--- a/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
+++ b/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
@@ -30,6 +30,12 @@ public class BuildConfigJsonConverter : JsonConverter<BuildConfig>
             serializer.Serialize(writer, value.TrainingBooks);
         }
 
+        if (value.TrainingDataFiles.Count > 0)
+        {
+            writer.WritePropertyName(nameof(value.TrainingDataFiles));
+            serializer.Serialize(writer, value.TrainingDataFiles);
+        }
+
         if (value.TranslationBooks.Count > 0)
         {
             writer.WritePropertyName(nameof(value.TranslationBooks));

--- a/src/SIL.XForge.Scripture/Services/ITrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/ITrainingDataService.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+public interface ITrainingDataService
+{
+    Task DeleteTrainingDataAsync(string userId, string projectId, string ownerId, string dataId);
+    Task GetTextsAsync(
+        string userId,
+        string projectId,
+        IEnumerable<string> dataIds,
+        IList<ISFText> sourceTexts,
+        IList<ISFText> targetTexts
+    );
+    Task<Uri> SaveTrainingDataAsync(string userId, string projectId, string dataId, string path);
+}

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ public static class MachineServiceCollectionExtensions
         services.AddSingleton<IMachineProjectService, MachineProjectService>();
         services.AddSingleton<IPreTranslationService, PreTranslationService>();
         services.AddSingleton<ISFTextCorpusFactory, SFTextCorpusFactory>();
+        services.AddSingleton<ITrainingDataService, TrainingDataService>();
         return services;
     }
 

--- a/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFBiblicalTermsText.cs
@@ -46,7 +46,7 @@ public class SFBiblicalTermsText : ISFText
         return rendering.Trim();
     }
 
-    private IEnumerable<SFTextSegment> GetSegments(IList<BiblicalTerm> biblicalTerms)
+    private static IEnumerable<SFTextSegment> GetSegments(IList<BiblicalTerm> biblicalTerms)
     {
         if (!biblicalTerms.Any())
         {
@@ -69,7 +69,7 @@ public class SFBiblicalTermsText : ISFText
         }
     }
 
-    private IEnumerable<SFTextSegment> GetSegments(XDocument termRenderingsDoc)
+    private static IEnumerable<SFTextSegment> GetSegments(XDocument termRenderingsDoc)
     {
         if (termRenderingsDoc.Root is null)
         {

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -258,6 +258,13 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string audioDir = GetAudioDir(projectId);
         if (FileSystemService.DirectoryExists(audioDir))
             FileSystemService.DeleteDirectory(audioDir);
+        string trainingDataDir = Path.Combine(
+            SiteOptions.Value.SiteDir,
+            TrainingDataService.DirectoryName,
+            ptProjectId
+        );
+        if (FileSystemService.DirectoryExists(trainingDataDir))
+            FileSystemService.DeleteDirectory(trainingDataDir);
     }
 
     public async Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings)
@@ -373,6 +380,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 p => p.TranslateConfig.DraftConfig.AlternateTrainingSource,
                 alternateTrainingSource,
                 unsetAlternateTrainingSourceProject
+            );
+            UpdateSetting(
+                op,
+                p => p.TranslateConfig.DraftConfig.AdditionalTrainingData,
+                settings.AdditionalTrainingData
             );
             UpdateSetting(op, p => p.TranslateConfig.DraftConfig.SendAllSegments, settings.SendAllSegments);
 

--- a/src/SIL.XForge.Scripture/Services/SFTrainingText.cs
+++ b/src/SIL.XForge.Scripture/Services/SFTrainingText.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// An implementation of <see cref="ISFText"/> specifically for non-scripture training texts.
+/// </summary>
+public class SFTrainingText : ISFText
+{
+    public string Id { get; init; } = string.Empty;
+    public IEnumerable<SFTextSegment> Segments { get; init; } = new List<SFTextSegment>();
+}

--- a/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.Extensions.Options;
+using NPOI.HSSF.UserModel;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using SIL.XForge.Configuration;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
+using SIL.XForge.Utils;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class TrainingDataService(
+    IFileSystemService fileSystemService,
+    IRealtimeService realtimeService,
+    IOptions<SiteOptions> siteOptions
+) : ITrainingDataService
+{
+    /// <summary>
+    /// The training directory name. This is not the full path to the directory.
+    /// </summary>
+    ///
+    public const string DirectoryName = "training-data";
+    private static readonly CsvConfiguration _csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
+    {
+        DetectColumnCountChanges = true,
+        DetectDelimiter = true,
+        HasHeaderRecord = false,
+    };
+
+    public async Task DeleteTrainingDataAsync(string userId, string projectId, string ownerId, string dataId)
+    {
+        // Validate input
+        if (!StringUtils.ValidateId(dataId))
+        {
+            throw new FormatException($"{nameof(dataId)} is not a valid id.");
+        }
+
+        // Load the project so we can check permissions
+        await using IConnection conn = await realtimeService.ConnectAsync(userId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        // Ensure permission to access the Machine API
+        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+
+        // Ensure the user is the owner of the file, or an administrator
+        if (
+            userId != ownerId
+            && !(projectDoc.Data.UserRoles.TryGetValue(userId, out string role) && role is SFProjectRole.Administrator)
+        )
+        {
+            throw new ForbiddenException();
+        }
+
+        // Delete the file, if it exists
+        string filePath = GetTrainingDataFilePath(userId, projectDoc.Id, dataId);
+        if (fileSystemService.FileExists(filePath))
+        {
+            fileSystemService.DeleteFile(filePath);
+        }
+    }
+
+    /// <summary>
+    /// Gets the source and target texts for the training data files.
+    /// </summary>
+    /// <param name="userId">The user identifier</param>
+    /// <param name="projectId">The project identifier.</param>
+    /// <param name="dataIds">The data identifiers to retrieve.</param>
+    /// <param name="sourceTexts">The source texts (output).</param>
+    /// <param name="targetTexts">The target texts (output).</param>
+    /// <returns>The asynchronous task.</returns>
+    public async Task GetTextsAsync(
+        string userId,
+        string projectId,
+        IEnumerable<string> dataIds,
+        IList<ISFText> sourceTexts,
+        IList<ISFText> targetTexts
+    )
+    {
+        await using IConnection conn = await realtimeService.ConnectAsync(userId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+
+        // Ensure that the training data directory exists
+        string trainingDataDir = Path.Combine(siteOptions.Value.SiteDir, DirectoryName, projectId);
+        if (!fileSystemService.DirectoryExists(trainingDataDir))
+        {
+            throw new DataNotFoundException("The training data directory does not exist");
+        }
+
+        // Load each training data file
+        foreach (string dataId in dataIds)
+        {
+            IDocument<TrainingData> trainingDataDoc = await conn.FetchAsync<TrainingData>(
+                TrainingData.GetDocId(projectId, dataId)
+            );
+            if (!trainingDataDoc.IsLoaded)
+            {
+                // Skip if the document does not exist
+                continue;
+            }
+
+            // Get the file URL as an absolute URL
+            if (!Uri.TryCreate(trainingDataDoc.Data.FileUrl, UriKind.Absolute, out Uri uri))
+            {
+                // The file URL is relative, so make it absolute with the site URL
+                uri = new Uri(siteOptions.Value.Origin, trainingDataDoc.Data.FileUrl);
+            }
+
+            // Get the filename
+            string fileName = Path.GetFileName(uri.LocalPath);
+            string path = Path.Combine(trainingDataDir, fileName);
+            if (!fileSystemService.FileExists(path))
+            {
+                // Skip if the file does not exist
+                continue;
+            }
+
+            // Load the CSV file
+            await using Stream fileStream = fileSystemService.OpenFile(path, FileMode.Open);
+            using StreamReader streamReader = new StreamReader(fileStream);
+            using CsvReader csvReader = new CsvReader(streamReader, _csvConfiguration);
+
+            // Generate the text segments
+            var sourceSegments = new List<SFTextSegment>();
+            var targetSegments = new List<SFTextSegment>();
+            int segRef = 0;
+            int skipRows = trainingDataDoc.Data.SkipRows;
+            while (await csvReader.ReadAsync())
+            {
+                // Do not send data if there are too few columns
+                if (csvReader.ColumnCount < 2)
+                {
+                    break;
+                }
+
+                // Skip rows, if we are supposed to
+                if (skipRows > 0)
+                {
+                    skipRows--;
+                    continue;
+                }
+
+                // Increment the segment reference counter
+                segRef++;
+
+                // Add the first column of this line to the source segments
+                string sourceSegmentText = csvReader.GetField<string>(0);
+                sourceSegments.Add(new SFTextSegment([segRef.ToString()], sourceSegmentText, false, false, false));
+
+                // Add the second column of this line to the target segments
+                string targetSegmentText = csvReader.GetField<string>(1);
+                targetSegments.Add(new SFTextSegment([segRef.ToString()], targetSegmentText, false, false, false));
+            }
+
+            // Generate the ISFText objects, and add to the appropriate collections
+            sourceTexts.Add(new SFTrainingText { Id = dataId, Segments = sourceSegments });
+            targetTexts.Add(new SFTrainingText { Id = dataId, Segments = targetSegments });
+        }
+    }
+
+    /// <summary>
+    /// Saves the training data to the file system, performing conversion if necessary
+    /// </summary>
+    /// <param name="userId">The user identifier</param>
+    /// <param name="projectId">The project identifier.</param>
+    /// <param name="dataId">The data identifier.</param>
+    /// <param name="path">The path to the temporary file.</param>
+    /// <returns>The URL to the file.</returns>
+    /// <exception cref="DataNotFoundException">The project does not exist.</exception>
+    /// <exception cref="ForbiddenException">The user does not have access to upload.</exception>
+    /// <exception cref="FormatException">The data id or CSV file were not in the correct format.</exception>
+    public async Task<Uri> SaveTrainingDataAsync(string userId, string projectId, string dataId, string path)
+    {
+        await using IConnection conn = await realtimeService.ConnectAsync(userId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
+        if (!projectDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+
+        if (!StringUtils.ValidateId(dataId))
+        {
+            throw new FormatException($"{nameof(dataId)} is not a valid id.");
+        }
+
+        string outputPath = GetTrainingDataFilePath(userId, projectDoc.Id, dataId);
+
+        // Delete the existing file, if it exists
+        if (fileSystemService.FileExists(outputPath))
+        {
+            fileSystemService.DeleteFile(outputPath);
+        }
+
+        // Validate the file, and convert to CSV if required
+        await ConvertToCsvAsync(path, outputPath);
+
+        // Return the URL to the file
+        string outputFileName = Path.GetFileName(outputPath);
+        var uri = new Uri(
+            siteOptions.Value.Origin,
+            $"assets/{DirectoryName}/{projectId}/{outputFileName}?t={DateTime.UtcNow.ToFileTime()}"
+        );
+        return uri;
+    }
+
+    /// <summary>
+    /// Converts a file to a CSV file
+    /// </summary>
+    /// <param name="path">The file to convert</param>
+    /// <param name="outputPath">The path to the output file</param>
+    /// <returns>An asynchronous task.</returns>
+    /// <exception cref="FormatException">
+    /// The file does not have a valid extension, or it does not have two columns.
+    /// </exception>
+    /// <remarks>If the file is tab delimited or a CSV file, it will just be relocated to the new path.</remarks>
+    private async Task ConvertToCsvAsync(string path, string outputPath)
+    {
+        string extension = Path.GetExtension(path).ToUpperInvariant();
+        switch (extension)
+        {
+            case ".CSV":
+            case ".TSV":
+            case ".TXT":
+
+                {
+                    // Ensure that there are only two columns
+                    await using (Stream fileStream = fileSystemService.OpenFile(path, FileMode.Open))
+                    {
+                        using StreamReader streamReader = new StreamReader(fileStream);
+                        using CsvReader csvReader = new CsvReader(streamReader, _csvConfiguration);
+                        await csvReader.ReadAsync();
+                        if (csvReader.ColumnCount != 2)
+                        {
+                            throw new FormatException("The CSV file does not contain two columns");
+                        }
+                    }
+
+                    // Relocate the temporary file to the new directory
+                    fileSystemService.MoveFile(path, outputPath);
+                }
+                break;
+            case ".XLS":
+
+                {
+                    // Load the Excel 97-2003 spreadsheet
+                    await using Stream fileStream = fileSystemService.OpenFile(path, FileMode.Open);
+                    using IWorkbook workbook = new HSSFWorkbook(fileStream);
+                    await ConvertExcelToCsvAsync(workbook, outputPath);
+                }
+                break;
+            case ".XLSX":
+
+                {
+                    // Load the Excel 2007+ spreadsheet
+                    await using Stream fileStream = fileSystemService.OpenFile(path, FileMode.Open);
+                    using IWorkbook workbook = new XSSFWorkbook(fileStream);
+                    await ConvertExcelToCsvAsync(workbook, outputPath);
+                }
+                break;
+            default:
+                throw new FormatException();
+        }
+    }
+
+    /// <summary>
+    /// Converts an Excel file to spreadsheet.
+    /// </summary>
+    /// <param name="workbook">The Excel workbook from NPOI.</param>
+    /// <param name="outputPath">The path to write the CSV file to</param>
+    /// <returns>An asynchronous task.</returns>
+    /// <exception cref="FormatException">The Excel file does not contain two columns of data</exception>
+    private async Task ConvertExcelToCsvAsync(IWorkbook workbook, string outputPath)
+    {
+        // Verify there is a worksheet
+        if (workbook.NumberOfSheets == 0)
+        {
+            throw new FormatException("The Excel file does not contain a worksheet");
+        }
+
+        // Load the Excel file
+        var data = new List<(string, string)>();
+        ISheet sheet = workbook.GetSheetAt(0);
+        for (int rowNum = sheet.FirstRowNum; rowNum <= sheet.LastRowNum; rowNum++)
+        {
+            IRow row = sheet.GetRow(rowNum);
+            if (row is null || row.FirstCellNum == -1 || row.LastCellNum - row.FirstCellNum < 2)
+            {
+                // Skip if there are not two columns of data in this row that are side-by-side
+                continue;
+            }
+
+            string firstColumn =
+                row.GetCell(row.FirstCellNum, MissingCellPolicy.CREATE_NULL_AS_BLANK).ToString() ?? string.Empty;
+            string secondColumn =
+                row.GetCell(row.FirstCellNum + 1, MissingCellPolicy.CREATE_NULL_AS_BLANK).ToString() ?? string.Empty;
+            data.Add((firstColumn, secondColumn));
+        }
+
+        if (data.Count == 0)
+        {
+            throw new FormatException("The Excel file does not contain two columns of data");
+        }
+
+        // Write the CSV file
+        await using Stream fileStream = fileSystemService.CreateFile(outputPath);
+        await using StreamWriter streamWriter = new StreamWriter(fileStream);
+        await using CsvWriter csvWriter = new CsvWriter(streamWriter, CultureInfo.InvariantCulture);
+        foreach ((string first, string second) in data)
+        {
+            csvWriter.WriteField(first);
+            csvWriter.WriteField(second);
+            await csvWriter.NextRecordAsync();
+        }
+    }
+
+    /// <summary>
+    /// Gets the path to the training data file
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="projectId">The SF project identifier.</param>
+    /// <param name="dataId">The Data identifier from the TrainingData document.</param>
+    /// <returns>The absolute path to the training data file.</returns>
+    private string GetTrainingDataFilePath(string userId, string projectId, string dataId)
+    {
+        // Sanitise input
+        userId = Path.GetInvalidFileNameChars()
+            .Aggregate(userId, (current, c) => current.Replace(c.ToString(), string.Empty));
+        projectId = Path.GetInvalidFileNameChars()
+            .Aggregate(projectId, (current, c) => current.Replace(c.ToString(), string.Empty));
+        dataId = Path.GetInvalidFileNameChars()
+            .Aggregate(dataId, (current, c) => current.Replace(c.ToString(), string.Empty));
+
+        // Ensure that the training data directory exists
+        string trainingDataDir = Path.Combine(siteOptions.Value.SiteDir, DirectoryName, projectId);
+        if (!fileSystemService.DirectoryExists(trainingDataDir))
+        {
+            fileSystemService.CreateDirectory(trainingDataDir);
+        }
+
+        // Return the full path
+        return Path.Combine(trainingDataDir, $"{userId}_{dataId}.csv");
+    }
+}

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -231,6 +231,15 @@ public class Startup
                 RequestPath = "/assets/audio"
             }
         );
+        app.UseStaticFiles(
+            new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(
+                    Path.Combine(siteOptions.Value.SiteDir, TrainingDataService.DirectoryName)
+                ),
+                RequestPath = $"/assets/{TrainingDataService.DirectoryName}",
+            }
+        );
 
         if (SpaDevServerStartup == SpaDevServerStartup.None)
             app.UseSpaStaticFiles();

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsUploadControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsUploadControllerTests.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using SIL.XForge.Models;
+using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Controllers;
+
+[TestFixture]
+public class SFProjectsUploadControllerTests
+{
+    private const string Data01 = "data01";
+    private const string Project01 = "project01";
+    private const string User01 = "user01";
+    private static readonly string[] Roles = [SystemRole.User];
+
+    [Test]
+    public async Task UploadAudioAsync_EmptyRequestFails()
+    {
+        await using var env = new TestEnvironment();
+        env.CreateEmptyRequest();
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadAudioAsync();
+        Assert.IsInstanceOf<BadRequestResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadAudioAsync_Forbidden()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.mp3";
+        const string data = "ID3";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the audio
+        env.SFProjectService.SaveAudioAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new ForbiddenException());
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadAudioAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<ForbidResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadAudioAsync_NotFound()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.mp3";
+        const string data = "ID3";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the audio
+        env.SFProjectService.SaveAudioAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new DataNotFoundException("The project does not exist."));
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadAudioAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<NotFoundResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadAudioAsync_UnexpectedException()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.mp3";
+        const string data = "ID3";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the audio
+        env.SFProjectService.SaveAudioAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(env.Controller.UploadAudioAsync);
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
+    }
+
+    [Test]
+    public async Task UploadAudioAsync_UploadFile()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.mp3";
+        const string data = "ID3";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Set up the URI to the uploaded file
+        Uri baseUri = new Uri("https://scriptureforge.org/", UriKind.Absolute);
+        Uri relativeUri = new Uri(
+            $"/assets/audio/{Project01}/{fileName}?t={DateTime.UtcNow.ToFileTime()}",
+            UriKind.Relative
+        );
+        env.SFProjectService.SaveAudioAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Returns(new Uri(baseUri, relativeUri));
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadAudioAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<CreatedResult>(actual);
+        Assert.AreEqual(relativeUri.ToString(), (actual as CreatedResult)?.Location);
+        Assert.AreEqual(fileName, (actual as CreatedResult)?.Value);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_EmptyRequestFails()
+    {
+        await using var env = new TestEnvironment();
+        env.CreateEmptyRequest();
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsInstanceOf<BadRequestResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_FileNotUploaded()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        using var request = await env.CreateFileUploadRequestAsync(Data01, Project01, fileName: null, fileStream: null);
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsInstanceOf<BadRequestResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_DataIdUndefined()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.csv";
+        const string data = "Test,Data";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(
+            "undefined",
+            Project01,
+            fileName,
+            data
+        );
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsInstanceOf<BadRequestResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_Forbidden()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.csv";
+        const string data = "Test,Data";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the training data
+        env.TrainingDataService.SaveTrainingDataAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new ForbiddenException());
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<ForbidResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_NotFound()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.csv";
+        const string data = "Test,Data";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the training data
+        env.TrainingDataService.SaveTrainingDataAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new DataNotFoundException("The project does not exist."));
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<NotFoundResult>(actual);
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_UnexpectedException()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.csv";
+        const string data = "Test,Data";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Throw the exception when saving the training data
+        env.TrainingDataService.SaveTrainingDataAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Throws(new ArgumentNullException());
+
+        // SUT
+        Assert.ThrowsAsync<ArgumentNullException>(env.Controller.UploadTrainingDataAsync);
+        env.ExceptionHandler.Received().RecordEndpointInfoForException(Arg.Any<Dictionary<string, string>>());
+    }
+
+    [Test]
+    public async Task UploadTrainingDataAsync_UploadFile()
+    {
+        await using var env = new TestEnvironment();
+
+        // Set up the file upload
+        const string fileName = "test.csv";
+        const string data = "Test,Data";
+        using HttpRequestMessage _ = await env.CreateSuccessfulFileUploadResultAsync(Data01, Project01, fileName, data);
+
+        // Set up the URI to the uploaded file
+        Uri baseUri = new Uri("https://scriptureforge.org/", UriKind.Absolute);
+        Uri relativeUri = new Uri(
+            $"/assets/{TrainingDataService.DirectoryName}/{Project01}/{fileName}?t={DateTime.UtcNow.ToFileTime()}",
+            UriKind.Relative
+        );
+        env.TrainingDataService.SaveTrainingDataAsync(User01, Project01, Data01, Arg.Any<string>())
+            .Returns(new Uri(baseUri, relativeUri));
+
+        // SUT
+        IActionResult actual = await env.Controller.UploadTrainingDataAsync();
+        Assert.IsNotNull(actual);
+        Assert.IsInstanceOf<CreatedResult>(actual);
+        Assert.AreEqual(relativeUri.ToString(), (actual as CreatedResult)?.Location);
+        Assert.AreEqual(fileName, (actual as CreatedResult)?.Value);
+
+        // Verify clean up
+        env.FileSystemService.Received(1).DeleteFile(Arg.Any<string>());
+    }
+
+    private class TestEnvironment : IAsyncDisposable
+    {
+        private readonly List<MemoryStream> _memoryStreams = [];
+
+        public TestEnvironment()
+        {
+            ExceptionHandler = Substitute.For<IExceptionHandler>();
+            FileSystemService = Substitute.For<IFileSystemService>();
+            SFProjectService = Substitute.For<ISFProjectService>();
+            TrainingDataService = Substitute.For<ITrainingDataService>();
+            var userAccessor = Substitute.For<IUserAccessor>();
+            userAccessor.UserId.Returns(User01);
+            userAccessor.SystemRoles.Returns(Roles);
+            Controller = new SFProjectsUploadController(
+                ExceptionHandler,
+                FileSystemService,
+                SFProjectService,
+                TrainingDataService,
+                userAccessor
+            );
+        }
+
+        public SFProjectsUploadController Controller { get; }
+        public IExceptionHandler ExceptionHandler { get; }
+        public IFileSystemService FileSystemService { get; }
+        public ITrainingDataService TrainingDataService { get; }
+        public ISFProjectService SFProjectService { get; }
+
+        public void CreateEmptyRequest()
+        {
+            var httpContext = new DefaultHttpContext();
+            Controller.ControllerContext.HttpContext = httpContext;
+        }
+
+        /// <summary>
+        /// Creates a file upload request, but not the temporary file on disk.
+        /// </summary>
+        /// <param name="dataId">The data identifier.</param>
+        /// <param name="projectId">The SF project identifier.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="fileStream">The file stream.</param>
+        /// <returns>The Http Request Message. This must be disposed.</returns>
+        public async Task<HttpRequestMessage> CreateFileUploadRequestAsync(
+            string dataId,
+            string projectId,
+            string? fileName,
+            Stream? fileStream
+        )
+        {
+            // Create the form content
+            var content = new MultipartFormDataContent
+            {
+                { new StringContent(dataId), "dataId" },
+                { new StringContent(projectId), "projectId" },
+            };
+
+            // Set the file stream if specified
+            if (fileStream is not null)
+            {
+                var streamContent = new StreamContent(fileStream);
+                streamContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                {
+                    Name = "file",
+                    FileName = fileName,
+                };
+                content = new MultipartFormDataContent
+                {
+                    { new StringContent(dataId), "dataId" },
+                    { streamContent, "file" },
+                    { new StringContent(projectId), "projectId" },
+                };
+            }
+
+            // Add form fields to a new request message
+            var request = new HttpRequestMessage { Content = content };
+
+            // Set up the HTTP context with this data
+            Controller.ControllerContext.HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    ContentLength = request.Content.Headers.ContentLength,
+                    ContentType = request.Content.Headers.ContentType?.ToString(),
+                    Body = await request.Content.ReadAsStreamAsync(),
+                    Method = request.Method.Method,
+                },
+            };
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a file upload request, and the temporary file on disk.
+        /// </summary>
+        /// <param name="dataId">The data identifier.</param>
+        /// <param name="projectId">The SF project identifier.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="data">The file data.</param>
+        /// <returns>The Http Request Message. This must be disposed.</returns>
+        public async Task<HttpRequestMessage> CreateSuccessfulFileUploadResultAsync(
+            string dataId,
+            string projectId,
+            string? fileName,
+            string data
+        )
+        {
+            // Set up the file upload
+            MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes(data));
+            HttpRequestMessage request = await CreateFileUploadRequestAsync(dataId, projectId, fileName, fileStream);
+
+            // Set up the moving of the file
+            MemoryStream outputStream = new MemoryStream();
+            FileSystemService.CreateFile(Arg.Any<string>()).Returns(outputStream);
+
+            // Trigger clean up of the temporary file
+            FileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+            // Record the memory streams to retain scope and facilitate later disposal
+            _memoryStreams.Add(fileStream);
+            _memoryStreams.Add(outputStream);
+
+            // Return the request so the outer scope can dispose it
+            return request;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (MemoryStream memoryStream in _memoryStreams)
+            {
+                await memoryStream.DisposeAsync();
+            }
+        }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -31,6 +31,7 @@ public class MachineApiServiceTests
     private const string Segment = "segment";
     private const string TargetSegment = "targetSegment";
     private const string JobId = "jobId";
+    private const string Data01 = "data01";
 
     [Test]
     public void CancelPreTranslationBuildAsync_NoPermission()
@@ -1431,6 +1432,8 @@ public class MachineApiServiceTests
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationQueuedAt);
         Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationErrorMessage);
         Assert.IsEmpty(env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTrainingBooks);
+        Assert.IsEmpty(env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTrainingDataFiles);
+        Assert.IsEmpty(env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks);
     }
 
     [Test]
@@ -1462,7 +1465,7 @@ public class MachineApiServiceTests
     }
 
     [Test]
-    public async Task StartPreTranslationBuildAsync_SuccessWithTrainingAndTranslationBooks()
+    public async Task StartPreTranslationBuildAsync_SuccessWithTrainingAndTranslationBooksAndDataFiles()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -1474,7 +1477,8 @@ public class MachineApiServiceTests
             {
                 ProjectId = Project01,
                 TrainingBooks = { 1, 2 },
-                TranslationBooks = { 3, 4 }
+                TranslationBooks = { 3, 4 },
+                TrainingDataFiles = { Data01 },
             },
             CancellationToken.None
         );
@@ -1494,6 +1498,11 @@ public class MachineApiServiceTests
             env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks.First()
         );
         Assert.AreEqual(4, env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks.Last());
+        Assert.AreEqual(1, env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTrainingDataFiles.Count);
+        Assert.AreEqual(
+            Data01,
+            env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTrainingDataFiles.First()
+        );
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -37,6 +37,8 @@ public class MachineProjectServiceTests
     private const string User01 = "user01";
     private const string Corpus01 = "corpus01";
     private const string Corpus02 = "corpus02";
+    private const string Corpus03 = "corpus03";
+    private const string Data01 = "data01";
     private const string File01 = "file01";
     private const string File02 = "file02";
     private const string TranslationEngine01 = "translationEngine01";
@@ -164,6 +166,122 @@ public class MachineProjectServiceTests
             .StartBuildAsync(
                 TranslationEngine01,
                 Arg.Is<TranslationBuildConfig>(b => b.TrainOn == null),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_SendsAdditionalTrainingData()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupTrainingDataAsync(Project01);
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig { ProjectId = Project01, TrainingDataFiles = { Data01 } },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        // Ensure that the additional texts were retrieved
+        await env.TrainingDataService.Received()
+            .GetTextsAsync(
+                User01,
+                Project01,
+                Arg.Is<IEnumerable<string>>(d => d.Contains(Data01)),
+                Arg.Any<IList<ISFText>>(),
+                Arg.Any<IList<ISFText>>()
+            );
+
+        // Ensure that the additional files corpus was synced, and the build started
+        await env.TranslationEnginesClient.Received()
+            .AddCorpusAsync(Arg.Any<string>(), Arg.Any<TranslationCorpusConfig>(), CancellationToken.None);
+        Assert.IsNotEmpty(
+            env.ProjectSecrets.Get(Project01)
+                .ServalData!.Corpora.First(c => c.Value.PreTranslate && c.Value.AdditionalTrainingData)
+                .Key
+        );
+        await env.TranslationEnginesClient.Received()
+            .StartBuildAsync(
+                Arg.Any<string>(),
+                Arg.Is<TranslationBuildConfig>(b => b.TrainOn == null),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_SendsAdditionalTrainingDataWhenFilesPreviouslyUploaded()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupTrainingDataAsync(Project02, existingData: true);
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig { ProjectId = Project02, TrainingDataFiles = { Data01 } },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        // Ensure that the additional texts were retrieved
+        await env.TrainingDataService.Received()
+            .GetTextsAsync(
+                User01,
+                Project02,
+                Arg.Is<IEnumerable<string>>(d => d.Contains(Data01)),
+                Arg.Any<IList<ISFText>>(),
+                Arg.Any<IList<ISFText>>()
+            );
+
+        // Ensure that the previous files with different IDs were deleted, and new ones added
+        await env.DataFilesClient.Received().DeleteAsync(File01);
+        await env.DataFilesClient.Received().DeleteAsync(File02);
+        await env.DataFilesClient.Received()
+            .CreateAsync(Arg.Any<FileParameter>(), Arg.Any<FileFormat>(), Data01, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_SendsAdditionalTrainingDataWithAlternateSource()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions
+            {
+                AlternateTrainingSourceEnabled = true,
+                AlternateTrainingSourceConfigured = true,
+            }
+        );
+        await env.SetupTrainingDataAsync(Project02);
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig { ProjectId = Project02, TrainingDataFiles = { Data01 } },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        // Ensure that the additional texts were retrieved
+        await env.TrainingDataService.Received()
+            .GetTextsAsync(
+                User01,
+                Project02,
+                Arg.Is<IEnumerable<string>>(d => d.Contains(Data01)),
+                Arg.Any<IList<ISFText>>(),
+                Arg.Any<IList<ISFText>>()
+            );
+
+        // Ensure that the build passed the additional files corpus in the train_on parameter
+        string corpusId = env.ProjectSecrets.Get(Project02)
+            .ServalData!.Corpora.First(c => c.Value.PreTranslate && c.Value.AdditionalTrainingData)
+            .Key;
+        await env.TranslationEnginesClient.Received()
+            .StartBuildAsync(
+                Arg.Any<string>(),
+                Arg.Is<TranslationBuildConfig>(b => b.TrainOn.Any(c => c.CorpusId == corpusId)),
                 CancellationToken.None
             );
     }
@@ -2037,8 +2155,12 @@ public class MachineProjectServiceTests
                 }
             );
 
+            TrainingDataService = Substitute.For<ITrainingDataService>();
+            TrainingData = new MemoryRepository<TrainingData>();
+
             var realtimeService = new SFMemoryRealtimeService();
             realtimeService.AddRepository("sf_projects", OTType.Json0, Projects);
+            realtimeService.AddRepository("training_data", OTType.Json0, TrainingData);
 
             Service = new MachineProjectService(
                 DataFilesClient,
@@ -2051,6 +2173,7 @@ public class MachineProjectServiceTests
                 realtimeService,
                 siteOptions,
                 TextCorpusFactory,
+                TrainingDataService,
                 TranslationEnginesClient,
                 userSecrets
             );
@@ -2084,6 +2207,8 @@ public class MachineProjectServiceTests
         public IParatextService ParatextService { get; }
         public ISFTextCorpusFactory TextCorpusFactory { get; }
         public ITranslationEnginesClient TranslationEnginesClient { get; }
+        public ITrainingDataService TrainingDataService { get; }
+        public MemoryRepository<TrainingData> TrainingData { get; }
         public MemoryRepository<SFProject> Projects { get; }
         public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
         public MockLogger<MachineProjectService> MockLogger { get; }
@@ -2208,5 +2333,96 @@ public class MachineProjectServiceTests
                 projectId,
                 u => u.Set(p => p.ServalData, new ServalData { TranslationEngineId = TranslationEngine01 })
             );
+
+        /// <summary>
+        /// Sets up the additional training data
+        /// </summary>
+        /// <param name="projectId">The project identifier.</param>
+        /// <param name="existingData">If the project is to have existing data, <c>true</c>. Default: <c>false</c>.</param>
+        public async Task SetupTrainingDataAsync(string projectId, bool existingData = false)
+        {
+            TrainingData.Add(
+                new TrainingData
+                {
+                    Id = $"{projectId}:{Data01}",
+                    ProjectRef = projectId,
+                    DataId = Data01,
+                    OwnerRef = User01,
+                    FileUrl = $"/{projectId}/{User01}_{Data01}.csv?t={DateTime.UtcNow.ToFileTime()}",
+                    MimeType = "text/csv",
+                    SkipRows = 0,
+                }
+            );
+            TrainingDataService
+                .GetTextsAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<IEnumerable<string>>(),
+                    Arg.Any<IList<ISFText>>(),
+                    Arg.Any<IList<ISFText>>()
+                )
+                .Returns(args =>
+                {
+                    ((List<ISFText>)args[3]).Add(GetMockTrainingData(TextCorpusType.Source));
+                    ((List<ISFText>)args[4]).Add(GetMockTrainingData(TextCorpusType.Target));
+                    return Task.CompletedTask;
+                });
+            if (existingData)
+            {
+                if (projectId != Project02)
+                {
+                    throw new ArgumentException(@"You can only set existing data for Project02", nameof(projectId));
+                }
+
+                TranslationEnginesClient
+                    .GetAsync(TranslationEngine02, CancellationToken.None)
+                    .Returns(
+                        Task.FromResult(
+                            new TranslationEngine
+                            {
+                                Id = TranslationEngine02,
+                                Name = Project02,
+                                SourceLanguage = "en",
+                                TargetLanguage = "en_US",
+                                Type = MachineProjectService.Nmt,
+                            }
+                        )
+                    );
+                await ProjectSecrets.UpdateAsync(
+                    Project02,
+                    u =>
+                    {
+                        u.Set(p => p.ServalData.PreTranslationEngineId, TranslationEngine02);
+                        u.Set(
+                            p => p.ServalData.Corpora[Corpus03],
+                            new ServalCorpus
+                            {
+                                PreTranslate = true,
+                                AdditionalTrainingData = true,
+                                SourceFiles = new List<ServalCorpusFile> { new ServalCorpusFile { FileId = File01 }, },
+                                TargetFiles = new List<ServalCorpusFile> { new ServalCorpusFile { FileId = File02 }, },
+                            }
+                        );
+                    }
+                );
+            }
+        }
+
+        private static ISFText GetMockTrainingData(TextCorpusType textCorpusType) =>
+            new MockText
+            {
+                Id = Data01,
+                Segments = new List<SFTextSegment>
+                {
+                    new SFTextSegment(
+                        ["1"],
+                        $"alternate {textCorpusType.ToString().ToLowerInvariant()}",
+                        false,
+                        false,
+                        false
+                    ),
+                    new SFTextSegment(["2"], string.Empty, false, false, false),
+                },
+            };
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
@@ -1,0 +1,571 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NPOI.HSSF.UserModel;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Realtime;
+using SIL.XForge.Scripture.Models;
+using SIL.XForge.Scripture.Realtime;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class TrainingDataServiceTests
+{
+    private const string Data01 = "107f1f77bcf86cd799439011";
+    private const string Data02 = "207f1f77bcf86cd799439012";
+    private const string FileCsv = "test.csv";
+    private const string FileExcel2003 = "test.xls";
+    private const string FileExcel2007 = "test.xlsx";
+    private const string FileTsv = "test.tsv";
+    private const string FileTxt = "test.txt";
+    private const string Project01 = "project01";
+    private const string User01 = "user01";
+    private const string User02 = "user02";
+    private const string User03 = "user03";
+
+    [Test]
+    public void DeleteTrainingDataAsync_InvalidDataId()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.DeleteTrainingDataAsync(User01, Project01, User01, "invalid_data_id")
+        );
+    }
+
+    [Test]
+    public void DeleteTrainingDataAsync_MissingProject()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.DeleteTrainingDataAsync(User01, "invalid_project_id", User01, Data01)
+        );
+    }
+
+    [Test]
+    public void DeleteTrainingDataAsync_NoPermission()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.DeleteTrainingDataAsync(User02, Project01, User01, Data01)
+        );
+    }
+
+    [Test]
+    public async Task DeleteTrainingDataAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.DeleteTrainingDataAsync(User01, Project01, User01, Data01);
+        env.FileSystemService.Received().DeleteFile(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task GetTextsAsync_DoesNotGenerateTextsIfTooFewColumns()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { Data01 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // Set up the training data files
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Line1\nLine2"));
+        env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data01)), FileMode.Open).Returns(fileStream);
+
+        // SUT
+        await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
+        Assert.AreEqual(1, sourceTexts.Count);
+        Assert.AreEqual(0, sourceTexts.First().Segments.Count());
+    }
+
+    [Test]
+    public async Task GetTextsAsync_GeneratesSourceAndTargetTexts()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { Data01, Data02 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // Set up the training data files
+        await using MemoryStream fileStream1 = new MemoryStream(
+            Encoding.UTF8.GetBytes("D1Source1,D1Target1\nD1Source2,D1Target2")
+        );
+        env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data01)), FileMode.Open).Returns(fileStream1);
+        await using MemoryStream fileStream2 = new MemoryStream(
+            Encoding.UTF8.GetBytes("Source_Heading\tTarget_Heading\n\"D2 Source 1\"\t\"D2 Target 1\"")
+        );
+        env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data02)), FileMode.Open).Returns(fileStream2);
+
+        // SUT
+        await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
+        Assert.AreEqual(2, sourceTexts.Count);
+        Assert.AreEqual(2, sourceTexts.First().Segments.Count());
+        Assert.AreEqual("001", sourceTexts.First().Segments.First().SegmentRef);
+        Assert.AreEqual("D1Source1", sourceTexts.First().Segments.First().SegmentText);
+        Assert.AreEqual("002", sourceTexts.First().Segments.Last().SegmentRef);
+        Assert.AreEqual("D1Source2", sourceTexts.First().Segments.Last().SegmentText);
+        Assert.AreEqual(1, sourceTexts.Last().Segments.Count());
+        Assert.AreEqual("001", sourceTexts.Last().Segments.First().SegmentRef);
+        Assert.AreEqual("D2 Source 1", sourceTexts.Last().Segments.First().SegmentText);
+        Assert.AreEqual(2, targetTexts.Count);
+        Assert.AreEqual(2, targetTexts.First().Segments.Count());
+        Assert.AreEqual("001", targetTexts.First().Segments.First().SegmentRef);
+        Assert.AreEqual("D1Target1", targetTexts.First().Segments.First().SegmentText);
+        Assert.AreEqual("002", targetTexts.First().Segments.Last().SegmentRef);
+        Assert.AreEqual("D1Target2", targetTexts.First().Segments.Last().SegmentText);
+        Assert.AreEqual(1, targetTexts.Last().Segments.Count());
+        Assert.AreEqual("001", targetTexts.Last().Segments.First().SegmentRef);
+        Assert.AreEqual("D2 Target 1", targetTexts.Last().Segments.First().SegmentText);
+    }
+
+    [Test]
+    public void GetTextsAsync_MissingProject()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { Data01 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetTextsAsync(User01, "invalid_project_id", dataIds, sourceTexts, targetTexts)
+        );
+    }
+
+    [Test]
+    public void GetTextsAsync_MissingTrainingDataDirectory()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { Data01 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts)
+        );
+    }
+
+    [Test]
+    public void GetTextsAsync_NoPermission()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { Data01 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.GetTextsAsync(User03, Project01, dataIds, sourceTexts, targetTexts)
+        );
+    }
+
+    [Test]
+    public async Task GetTextsAsync_SkipsMissingDataId()
+    {
+        var env = new TestEnvironment();
+        var dataIds = new string[] { "missing_data_id" };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // SUT
+        await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
+        env.FileSystemService.DidNotReceive().FileExists(Arg.Any<string>());
+        env.FileSystemService.DidNotReceive().OpenFile(Arg.Any<string>(), FileMode.Open);
+    }
+
+    [Test]
+    public async Task GetTextsAsync_SkipsWhenFileNotFound()
+    {
+        var env = new TestEnvironment();
+        env.FileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+        var dataIds = new string[] { Data01, Data02 };
+        var sourceTexts = new List<ISFText>();
+        var targetTexts = new List<ISFText>();
+
+        // SUT
+        await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
+        env.FileSystemService.Received().FileExists(Arg.Any<string>());
+        env.FileSystemService.DidNotReceive().OpenFile(Arg.Any<string>(), FileMode.Open);
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_CorruptSpreadsheet()
+    {
+        var env = new TestEnvironment();
+
+        // Create the input file
+        await using MemoryStream fileStream = new MemoryStream();
+        using IWorkbook workbook = new HSSFWorkbook();
+        workbook.Write(fileStream, leaveOpen: true);
+        fileStream.Seek(0, SeekOrigin.Begin);
+        env.FileSystemService.OpenFile(FileExcel2003, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileExcel2003)
+        );
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_EmptySpreadsheet()
+    {
+        var env = new TestEnvironment();
+
+        // Create the input file
+        await using MemoryStream fileStream = new MemoryStream();
+        using IWorkbook workbook = new HSSFWorkbook();
+        workbook.CreateSheet("Sheet1");
+        workbook.Write(fileStream, leaveOpen: true);
+        fileStream.Seek(0, SeekOrigin.Begin);
+        env.FileSystemService.OpenFile(FileExcel2003, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileExcel2003)
+        );
+    }
+
+    [Test]
+    public void SaveTrainingDataAsync_InvalidDataId()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, "invalid_data_id", FileCsv)
+        );
+    }
+
+    [Test]
+    public void SaveTrainingDataAsync_InvalidFileExtensions()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, Data01, "test.doc")
+        );
+    }
+
+    [Test]
+    public void SaveTrainingDataAsync_MissingProject()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.SaveTrainingDataAsync(User01, "invalid_project_id", Data01, FileCsv)
+        );
+    }
+
+    [Test]
+    public void SaveTrainingDataAsync_NoPermission()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.SaveTrainingDataAsync(User03, Project01, Data01, FileCsv)
+        );
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_NotEnoughColumns()
+    {
+        var env = new TestEnvironment();
+
+        // Set up the input file
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test"));
+        env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileCsv)
+        );
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_SupportsCsvFiles()
+    {
+        var env = new TestEnvironment();
+
+        // Set up the input file
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data"));
+        env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
+
+        // We will also check that the directory is created
+        env.FileSystemService.FileExists(Arg.Any<string>()).Returns(false);
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
+
+        // SUT
+        Uri actual = await env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileCsv);
+        Assert.That(
+            actual
+                .ToString()
+                .StartsWith(
+                    $"http://localhost/assets/{TrainingDataService.DirectoryName}/{Project01}/{User01}_{Data01}.csv?t="
+                ),
+            Is.True
+        );
+
+        env.FileSystemService.Received(1).CreateDirectory(Arg.Any<string>());
+        env.FileSystemService.DidNotReceive().DeleteFile(Arg.Any<string>());
+        env.FileSystemService.Received(1).MoveFile(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_SupportsTsvFiles()
+    {
+        var env = new TestEnvironment();
+
+        // Set up the input file
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test\tData"));
+        env.FileSystemService.OpenFile(FileTsv, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Uri actual = await env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileTsv);
+        Assert.That(
+            actual
+                .ToString()
+                .StartsWith(
+                    $"http://localhost/assets/{TrainingDataService.DirectoryName}/{Project01}/{User01}_{Data01}.csv?t="
+                ),
+            Is.True
+        );
+
+        env.FileSystemService.Received(1).DeleteFile(Arg.Any<string>());
+        env.FileSystemService.Received(1).MoveFile(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_SupportsTxtFiles()
+    {
+        var env = new TestEnvironment();
+
+        // Set up the input file
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test;Data"));
+        env.FileSystemService.OpenFile(FileTxt, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Uri actual = await env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileTxt);
+        Assert.That(
+            actual
+                .ToString()
+                .StartsWith(
+                    $"http://localhost/assets/{TrainingDataService.DirectoryName}/{Project01}/{User01}_{Data01}.csv?t="
+                ),
+            Is.True
+        );
+
+        env.FileSystemService.Received(1).MoveFile(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_SupportsXlsFiles()
+    {
+        var env = new TestEnvironment();
+
+        // Create the input file
+        await using MemoryStream fileStream = new MemoryStream();
+        using IWorkbook workbook = new HSSFWorkbook();
+        ISheet sheet = workbook.CreateSheet("Sheet1");
+        IRow row = sheet.CreateRow(0);
+        row.CreateCell(0).SetCellValue("Test"); // A1
+        row.CreateCell(1).SetCellValue("Data"); // A2
+        workbook.Write(fileStream, leaveOpen: true);
+        fileStream.Seek(0, SeekOrigin.Begin);
+        env.FileSystemService.OpenFile(FileExcel2003, FileMode.Open).Returns(fileStream);
+
+        // Create the output file
+        string path = Path.Combine(
+            env.SiteOptions.Value.SiteDir,
+            TrainingDataService.DirectoryName,
+            Project01,
+            $"{User01}_{Data01}.csv"
+        );
+        await using NonDisposingMemoryStream outputStream = new NonDisposingMemoryStream();
+        env.FileSystemService.CreateFile(path).Returns(outputStream);
+
+        // SUT
+        Uri actual = await env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileExcel2003);
+        Assert.That(
+            actual
+                .ToString()
+                .StartsWith(
+                    $"http://localhost/assets/{TrainingDataService.DirectoryName}/{Project01}/{User01}_{Data01}.csv?t="
+                ),
+            Is.True
+        );
+
+        using StreamReader reader = new StreamReader(outputStream);
+        string text = await reader.ReadToEndAsync();
+        text = text.TrimEnd(); // Remove trailing new lines
+        Assert.AreEqual("Test,Data", text);
+        outputStream.ForceDispose();
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_SupportsXlsxFiles()
+    {
+        var env = new TestEnvironment();
+
+        // Create the input file
+        await using MemoryStream fileStream = new MemoryStream();
+        using IWorkbook workbook = new XSSFWorkbook();
+        ISheet sheet = workbook.CreateSheet("Output");
+        IRow row = sheet.CreateRow(1);
+        row.CreateCell(1).SetCellValue("Test"); // B2
+        row.CreateCell(2).SetCellValue("Data"); // B3
+        workbook.Write(fileStream, leaveOpen: true);
+        fileStream.Seek(0, SeekOrigin.Begin);
+        env.FileSystemService.OpenFile(FileExcel2007, FileMode.Open).Returns(fileStream);
+
+        // Create the output file
+        string path = Path.Combine(
+            env.SiteOptions.Value.SiteDir,
+            TrainingDataService.DirectoryName,
+            Project01,
+            $"{User01}_{Data01}.csv"
+        );
+        await using NonDisposingMemoryStream outputStream = new NonDisposingMemoryStream();
+        env.FileSystemService.CreateFile(path).Returns(outputStream);
+
+        // SUT
+        Uri actual = await env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileExcel2007);
+        Assert.That(
+            actual
+                .ToString()
+                .StartsWith(
+                    $"http://localhost/assets/{TrainingDataService.DirectoryName}/{Project01}/{User01}_{Data01}.csv?t="
+                ),
+            Is.True
+        );
+
+        using StreamReader reader = new StreamReader(outputStream);
+        string text = await reader.ReadToEndAsync();
+        text = text.TrimEnd(); // Remove trailing new lines
+        Assert.AreEqual("Test,Data", text);
+        outputStream.ForceDispose();
+    }
+
+    [Test]
+    public async Task SaveTrainingDataAsync_TooManyColumns()
+    {
+        var env = new TestEnvironment();
+
+        // Set up the input file
+        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data,More"));
+        env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
+
+        // SUT
+        Assert.ThrowsAsync<FormatException>(
+            () => env.Service.SaveTrainingDataAsync(User01, Project01, Data01, FileCsv)
+        );
+    }
+
+    /// <summary>
+    /// A memory stream that must be manually disposed.
+    /// </summary>
+    /// <remarks>This is only for use if your memory stream will be closed by a stream writer.</remarks>
+    private sealed class NonDisposingMemoryStream : MemoryStream
+    {
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            // If the stream is open, reset it to the start
+            if (CanSeek)
+            {
+                Flush();
+                Seek(0, SeekOrigin.Begin);
+            }
+        }
+
+        /// <summary>
+        /// Force the disposal of this object.
+        /// </summary>
+        public void ForceDispose() => base.Dispose(true);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            SiteOptions = Substitute.For<IOptions<SiteOptions>>();
+            SiteOptions.Value.Returns(
+                new SiteOptions { Origin = new Uri("http://localhost/", UriKind.Absolute), SiteDir = "site-dir" }
+            );
+            FileSystemService = Substitute.For<IFileSystemService>();
+            FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+            FileSystemService.FileExists(Arg.Any<string>()).Returns(true);
+
+            var projects = new MemoryRepository<SFProject>(
+                new[]
+                {
+                    new SFProject
+                    {
+                        Id = Project01,
+                        UserRoles = new Dictionary<string, string>
+                        {
+                            { User01, SFProjectRole.Administrator },
+                            { User02, SFProjectRole.Translator },
+                            { User03, SFProjectRole.Consultant },
+                        },
+                    },
+                }
+            );
+            var trainingData = new MemoryRepository<TrainingData>(
+                new[]
+                {
+                    new TrainingData
+                    {
+                        Id = TrainingData.GetDocId(Project01, Data01),
+                        DataId = Data01,
+                        ProjectRef = Project01,
+                        OwnerRef = User01,
+                        FileUrl = $"/{Project01}/{User01}_{Data01}.csv?t={DateTime.UtcNow.ToFileTime()}",
+                        MimeType = "text/csv",
+                        SkipRows = 0,
+                    },
+                    new TrainingData
+                    {
+                        Id = TrainingData.GetDocId(Project01, Data02),
+                        DataId = Data02,
+                        ProjectRef = Project01,
+                        OwnerRef = User02,
+                        FileUrl =
+                            $"http://example.com/{Project01}/{User01}_{Data02}.csv?t={DateTime.UtcNow.ToFileTime()}",
+                        MimeType = "text/csv",
+                        SkipRows = 1,
+                    },
+                }
+            );
+            var realtimeService = new SFMemoryRealtimeService();
+            realtimeService.AddRepository("sf_projects", OTType.Json0, projects);
+            realtimeService.AddRepository("training_data", OTType.Json0, trainingData);
+            Service = new TrainingDataService(FileSystemService, realtimeService, SiteOptions);
+        }
+
+        public IFileSystemService FileSystemService { get; }
+        public TrainingDataService Service { get; }
+        public IOptions<SiteOptions> SiteOptions { get; }
+    }
+}


### PR DESCRIPTION
This PR adds support for uploading extra-biblical material in CSV format for Serval pre-translation training.

Sample files are included in the JIRA ticket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2308)
<!-- Reviewable:end -->
