### PR TITLE
SF-2466 Remove warnings against selecting training data for NLLB languages

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -42,37 +42,12 @@
           </div>
         </ng-template>
 
-        <app-notice *ngIf="isTrainingOptional" type="warning" icon="info" mode="fill-light">
-          {{ t("training_book_selection_discouraged_info_part1") }}
-          <p>
-            <transloco
-              *ngIf="userSelectedTrainingBooks.length === 0"
-              key="draft_generation_steps.training_book_selection_discouraged_info_part2_skip_step"
-            ></transloco>
-          </p>
-          <p>
-            <transloco
-              *ngIf="userSelectedTrainingBooks.length > 0"
-              key="draft_generation_steps.training_book_selection_discouraged_info_part2_clear_selection"
-            ></transloco>
-          </p>
-        </app-notice>
-
         <app-book-multi-select
           [availableBooks]="availableTrainingBooks"
           [selectedBooks]="initialSelectedTrainingBooks"
           (bookSelect)="onTrainingBookSelect($event)"
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
-
-        <app-notice
-          *ngIf="isTrainingOptional && userSelectedTrainingBooks.length > 0"
-          type="warning"
-          icon="warning"
-          mode="fill-extra-dark"
-        >
-          {{ t("training_book_selection_discouraged_warning") }}
-        </app-notice>
 
         <app-notice *ngIf="unusableTrainingBooks.length" type="light">
           <h4>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -33,17 +33,13 @@ app-book-multi-select {
 }
 
 app-notice {
-  margin: 20px 0 10px;
+  margin-top: 20px;
   display: inline-flex;
 
   h4 {
     font-style: italic;
     font-weight: 400;
     margin: 0 0 16px;
-  }
-
-  p {
-    margin: 8px 0 0;
   }
 
   &.warning {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -185,11 +185,7 @@
     "next": "Next",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
-    "training_book_selection_discouraged_info_part1": "Both your source and target languages are in the set of pre-trained language models.",
-    "training_book_selection_discouraged_info_part2_skip_step": "[em]We recommend that you skip this step and continue to \"{{ draft_generation_steps.generate_draft }}\".[/em]",
-    "training_book_selection_discouraged_info_part2_clear_selection": "[em]We recommend that you clear the selected training books and continue to \"{{ draft_generation_steps.generate_draft }}\".[/em]",
-    "training_book_selection_discouraged_warning": "Selecting training data for these languages will slow your build time and may reduce draft quality!"
+    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",


### PR DESCRIPTION
Remove these two notices as well as another variation of the text
![image](https://github.com/sillsdev/web-xforge/assets/17464863/c069582a-0dcf-49c7-a1fc-f245383734e1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2310)
<!-- Reviewable:end -->
