### PR TITLE
Show project short name on system admin projects page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -9,7 +9,9 @@
     <table mat-table id="projects-table" ngClass.gt-xs="fixed-layout-table" [dataSource]="rows">
       <ng-container matColumnDef="name">
         <td mat-cell *matCellDef="let row">
-          <a *ngIf="row.isMember; else nonmember" [appRouterLink]="['/projects', row.id]">{{ row.name }}</a>
+          <a *ngIf="row.isMember; else nonmember" [appRouterLink]="['/projects', row.id]">
+            {{ row.shortName }} - {{ row.name }}
+          </a>
           <ng-template #nonmember>{{ row.name }}</ng-template>
         </td>
       </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.spec.ts
@@ -60,7 +60,7 @@ describe('SaProjectsComponent', () => {
     tick();
 
     expect(env.rows.length).toEqual(3);
-    expect(env.cell(0, 0).query(By.css('a')).nativeElement.text).toEqual('Project 01');
+    expect(env.cell(0, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P1 - Project 01');
     expect(env.cell(0, 1).nativeElement.textContent).toEqual('Task1, Task2');
     expect(env.selectValue(env.roleSelect(0))).toEqual('Administrator');
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -26,7 +26,11 @@ class Row {
   }
 
   get name(): string {
-    return this.projectDoc == null || this.projectDoc.data == null ? '' : this.projectDoc.data.name;
+    return this.projectDoc.data?.name ?? '';
+  }
+
+  get shortName(): string {
+    return this.projectDoc.data?.shortName ?? '';
   }
 
   get tasks(): string {


### PR DESCRIPTION
When searching for projects by short name, there are often multiple results, and you can't tell which one is the correct one because the short name isn't shown.

Before | After
-------|------
![](https://github.com/sillsdev/web-xforge/assets/6140710/3e7c427d-1ac0-415a-ba0f-7dbc273c8548) | ![](https://github.com/sillsdev/web-xforge/assets/6140710/14849367-eb6f-45b5-b9b6-b7845b603e96)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2318)
<!-- Reviewable:end -->
