### PR TITLE
SF-2486 Show the correct username for notes created in Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -46,7 +46,10 @@
           </div>
         </div>
         <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
-        <app-owner [ownerRef]="noteInfo.note.ownerRef" [dateTime]="noteInfo.note.dateCreated"></app-owner>
+        <div class="note-user">
+          <div class="user-name">{{ noteInfo.userName }}</div>
+          <small class="date-created">{{ noteInfo.dateCreated }}</small>
+        </div>
       </div>
     </div>
     <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="outline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -59,6 +59,17 @@ h1 {
       display: block;
       margin: 5px;
     }
+    .note-user {
+      display: flex;
+      line-height: 1.14em;
+      margin: 5px;
+      .user-name {
+        margin-inline-end: 5px;
+      }
+      .date-created {
+        opacity: 0.5;
+      }
+    }
     img {
       align-self: center;
       opacity: 0.5;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -636,7 +636,7 @@ describe('NoteDialogComponent', () => {
     expect(env.notes[0].nativeElement.querySelector('.user-name').textContent).toContain('User 01');
   }));
 
-  it('shows the SF note owner name if the user is a checking user', fakeAsync(() => {
+  it('shows the SF note owner name if the user is a commenter', fakeAsync(() => {
     env = new TestEnvironment({
       noteThread: TestEnvironment.getNoteThread(),
       currentUserId: 'user03',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -433,8 +433,9 @@ export class NoteDialogComponent implements OnInit {
         ? this.paratextProjectUsers?.find(user => user.opaqueUserId === note.syncUserRef)
         : undefined;
 
+    // If the user is not a PT user, or the note was created in SF, or the user created the note
     if (
-      syncUser == null || // There is no sync user (not synced yet or the current user is a checking user)
+      syncUser == null || // There is no sync user, i.e. the note is not synced yet or the current user is not a PT user
       note.editable || // Only notes created in SF are editable, so display the SF owner, falling back to the sync user
       syncUser.sfUserId === ownerDoc.id // The note is not editable, but the sync user is the owner, so use the SF owner
     ) {
@@ -443,15 +444,15 @@ export class NoteDialogComponent implements OnInit {
         : ownerDoc.data?.displayName ?? // Another user
             syncUser?.username ?? // Fallback to the sync user
             translate('checking.unknown_author'); // An "unknown author" (there is no sync user)
-    } else {
-      // The note was created in Paratext, so see if we have a profile for the sync user
-      const syncUserProfile: UserProfileDoc | undefined =
-        syncUser.sfUserId == null ? undefined : await this.userService.getProfile(syncUser.sfUserId);
-      return this.userService.currentUserId === syncUserProfile?.id
-        ? translate('checking.me') // "Me", i.e. the current user
-        : ownerDoc.data?.displayName ?? // Another user
-            syncUser.username; // Fallback to the sync user
     }
+
+    // The note was created in Paratext, so see if we have a profile for the sync user
+    const syncUserProfile: UserProfileDoc | undefined =
+      syncUser.sfUserId == null ? undefined : await this.userService.getProfile(syncUser.sfUserId);
+    return this.userService.currentUserId === syncUserProfile?.id
+      ? translate('checking.me') // "Me", i.e. the current user
+      : ownerDoc.data?.displayName ?? // Another user
+          syncUser.username; // Fallback to the sync user
   }
 
   private isNoteEditable(note: Note): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,11 +1,12 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import {
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
-  MatLegacyDialogRef as MatDialogRef
+  MatLegacyDialogRef as MatDialogRef,
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
 } from '@angular/material/legacy-dialog';
 import { translate } from '@ngneat/transloco';
+import { VerseRef } from '@sillsdev/scripture';
 import { sortBy } from 'lodash-es';
-import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { Note, REATTACH_SEPARATOR } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import {
   BIBLICAL_TERM_TAG_ICON,
@@ -14,20 +15,20 @@ import {
   SF_TAG_ICON
 } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
 import { AssignedUsers, NoteStatus } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
-import { VerseRef } from '@sillsdev/scripture';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
-import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
-import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { UserService } from 'xforge-common/user.service';
-import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { BiblicalTermDoc } from '../../../core/models/biblical-term-doc';
 import { defaultNoteThreadIcon, NoteThreadDoc } from '../../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { SFProjectService } from '../../../core/sf-project.service';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
 import { canInsertNote, formatFontSizeToRems, XmlUtils } from '../../../shared/utils';
 
 export interface NoteDialogData {
@@ -51,6 +52,8 @@ interface NoteDisplayInfo {
   icon: string;
   title: string;
   editable: boolean;
+  dateCreated: string;
+  userName: string;
   assignment?: string;
   reattachedVerse?: string;
   reattachedText?: string;
@@ -116,7 +119,7 @@ export class NoteDialogComponent implements OnInit {
       }
     }
     // extract note info and content for display
-    this.updateNotesToDisplay();
+    await this.updateNotesToDisplayAsync();
   }
 
   get canViewAssignedUser(): boolean {
@@ -249,7 +252,7 @@ export class NoteDialogComponent implements OnInit {
       await this.threadDoc!.submitJson0Op(op => op.set(nt => nt.notes[index].deleted, true));
     }
 
-    this.updateNotesToDisplay();
+    await this.updateNotesToDisplayAsync();
     if (this.notesToDisplay.length === 0) {
       this.dialogRef.close({ deleted: true });
     }
@@ -341,7 +344,7 @@ export class NoteDialogComponent implements OnInit {
     this.dialogRef.close(content);
   }
 
-  private updateNotesToDisplay(): void {
+  private async updateNotesToDisplayAsync(): Promise<void> {
     if (this.threadDoc?.data == null) return;
     const sortedNotes: Note[] = sortBy(
       this.threadDoc.data.notes.filter(n => !n.deleted),
@@ -358,6 +361,8 @@ export class NoteDialogComponent implements OnInit {
         icon: this.noteIcon(note),
         title: this.noteTitle(note),
         editable: this.isNoteEditable(note) && note.dataId === lastNoteId,
+        dateCreated: this.getNoteDateCreated(note),
+        userName: await this.getNoteUserNameAsync(note),
         assignment: this.getAssignedUserString(note.assignment),
         reattachedVerse: this.reattachedVerse(note),
         reattachedText: this.reattachedText(note)
@@ -402,6 +407,51 @@ export class NoteDialogComponent implements OnInit {
         return translate('note_dialog.status_resolved');
     }
     return note.reattached != null ? translate('note_dialog.note_reattached') : '';
+  }
+
+  /**
+   * Returns the date created value of the note, formatted to the user's locale.
+   * @param note The note.
+   * @returns The formatted creation date as a string.
+   */
+  private getNoteDateCreated(note: Note): string {
+    return this.i18n.formatDate(new Date(note.dateCreated));
+  }
+
+  /**
+   * Gets the name of the user who created the note, in so far as we can calculate it.
+   * @param note The note.
+   * @returns A promise of the user's name as a string.
+   */
+  private async getNoteUserNameAsync(note: Note): Promise<string> {
+    // Get the owner. This is often the project admin if the sync user is not in SF
+    const ownerDoc: UserProfileDoc = await this.userService.getProfile(note.ownerRef);
+
+    // Get the sync user, if we have a syncUserRef for the note
+    const syncUser: ParatextUserProfile | undefined =
+      note.syncUserRef != null
+        ? this.paratextProjectUsers?.find(user => user.opaqueUserId === note.syncUserRef)
+        : undefined;
+
+    if (
+      syncUser == null || // There is no sync user (not synced yet or the current user is a checking user)
+      note.editable || // Only notes created in SF are editable, so display the SF owner, falling back to the sync user
+      syncUser.sfUserId === ownerDoc.id // The note is not editable, but the sync user is the owner, so use the SF owner
+    ) {
+      return this.userService.currentUserId === ownerDoc.id
+        ? translate('checking.me') // "Me", i.e. the current user
+        : ownerDoc.data?.displayName ?? // Another user
+            syncUser?.username ?? // Fallback to the sync user
+            translate('checking.unknown_author'); // An "unknown author" (there is no sync user)
+    } else {
+      // The note was created in Paratext, so see if we have a profile for the sync user
+      const syncUserProfile: UserProfileDoc | undefined =
+        syncUser.sfUserId == null ? undefined : await this.userService.getProfile(syncUser.sfUserId);
+      return this.userService.currentUserId === syncUserProfile?.id
+        ? translate('checking.me') // "Me", i.e. the current user
+        : ownerDoc.data?.displayName ?? // Another user
+            syncUser.username; // Fallback to the sync user
+    }
   }
 
   private isNoteEditable(note: Note): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -451,7 +451,7 @@ export class NoteDialogComponent implements OnInit {
       syncUser.sfUserId == null ? undefined : await this.userService.getProfile(syncUser.sfUserId);
     return this.userService.currentUserId === syncUserProfile?.id
       ? translate('checking.me') // "Me", i.e. the current user
-      : ownerDoc.data?.displayName ?? // Another user
+      : syncUserProfile?.data?.displayName ?? // Another user
           syncUser.username; // Fallback to the sync user
   }
 

--- a/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
@@ -12,5 +12,5 @@ public class ParatextUserProfile
     /// A unique id that can be used to associate a project component (e.g. a note) to this paratext user
     /// </summary>
     public string OpaqueUserId { get; set; }
-    public string SFUserId { get; set; }
+    public string? SFUserId { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -2047,8 +2047,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
             else
             {
-                // If we do not have the SF user id, replace the entity so that the saving in CompleteSync() will not
-                // read this modified object from projectDoc.Data, and think that there are no changes.
+                // If we do not have the SF user Id set, set the SF user Id to be stored when CompleteSync() is called.
+                // We create a new object to so that the logic in projectDoc.SubmitJson0OpAsync() will see the change.
                 if (profile.SFUserId is null)
                 {
                     paratextUsers[username] = new ParatextUserProfile

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -2046,7 +2046,19 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 paratextUsers.TryAdd(username, userProfile);
             }
             else
-                profile.SFUserId ??= sfUserId;
+            {
+                // If we do not have the SF user id, replace the entity so that the saving in CompleteSync() will not
+                // read this modified object from projectDoc.Data, and think that there are no changes.
+                if (profile.SFUserId is null)
+                {
+                    paratextUsers[username] = new ParatextUserProfile
+                    {
+                        Username = profile.Username,
+                        SFUserId = sfUserId,
+                        OpaqueUserId = profile.OpaqueUserId,
+                    };
+                }
+            }
         }
         return paratextUsers;
     }


### PR DESCRIPTION
**Problem Synopsis**
Currently, Scripture Forge shows a note's owner as the note author. This is problematic for notes created in Paratext, as `Note.OwnerRef` will be the user who synced the note, not the user who created the note.

**Solution**
Re-implement `<app-owner>` in the Note Dialog Component, and calculate the user name.

**User Name Calculation**
The name calculation logic in `NoteDialogComponent.getNoteUserNameAsync()` could be represented as these rules (matching the new unit tests):

1. **If** the note was created by the currently logged in user **Then** Show "Me"
2. **If** the note has not been synced **Then** Show the SF note owner's name
3. **If** the currently logged in user is a checking user **Then** Show the SF note owner's name
4. **If** the note was created in Scripture Forge **Then** Show the note owner's name
5. **If** the note was created in Scripture Forge **And** we do not have a matching user record **Then** Show the PT user's name
6. **If** the note was created in Scripture Forge **And** we do not have an SF user or PT user **Then** Show "Unknown author"
7. **If** the note was created in Paratext **And** we have a matching user record **Then** Show the SF user's name
8. **If** the note was created in Paratext **And** we do not have a matching user record **Then** Show the PT user's name

**Additional Bug Fixed**
While debugging this issue, it was noticed that the `ParatextUserProfile.SfUserId` property was not being updated on sync. This was occurring because the `ParatextUserProfile` object being modified in `ParatextSyncRunner.GetCurrentProjectPTUsers()` was a reference to the same object in `SFProject.ParatextUsers` loaded from ShareDB. This meant that the property changed checks for `ParatextUserProfile` in `ParatextSyncRunner.CompleteSync()` were checking against the same object that had been modified (and not updating ShareDB).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2320)
<!-- Reviewable:end -->
