### PR TITLE
SF-1581 No error on empty email field when sending invite

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -11,7 +11,7 @@
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>
             <input matInput type="email" formControlName="email" (input)="onEmailInput()" />
-            <mat-error *ngIf="email.hasError('pattern') || email.hasError('email') || email.hasError('required')">
+            <mat-error *ngIf="email.hasError('pattern') || email.hasError('required')">
               {{ t("email_invalid") }}
             </mat-error>
           </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -7,7 +7,7 @@
     <div class="invite-by-email">
       <h3>{{ t("send_a_link") }}</h3>
       <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
-        <form id="email-form" [formGroup]="sendInviteForm">
+        <form id="email-form" [formGroup]="sendInviteForm" #form="ngForm">
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>
             <input matInput type="email" formControlName="email" (input)="onEmailInput()" />
@@ -43,7 +43,7 @@
             color="primary"
             form="email-form"
             type="submit"
-            (click)="sendEmail()"
+            (click)="sendEmail(form)"
             [disabled]="isSubmitted"
           >
             {{ isAlreadyInvited ? t("resend") : t("send") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -11,7 +11,7 @@
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>
             <input matInput type="email" formControlName="email" (input)="onEmailInput()" />
-            <mat-error *ngIf="email.hasError('pattern') || email.hasError('email')">
+            <mat-error *ngIf="email.hasError('pattern') || email.hasError('email') || email.hasError('required')">
               {{ t("email_invalid") }}
             </mat-error>
           </mat-form-field>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -274,6 +274,17 @@ describe('ShareControlComponent', () => {
     env.wait();
     expect(env.shareLink).not.toBeNull();
   }));
+
+  it('should require setting the email before sending an invite', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setInvitationLanguage('en');
+    env.click(env.sendButton);
+    verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).never();
+    expect(env.fetchElement('#email mat-error').nativeElement.textContent).toContain('Email address is invalid');
+    env.setTextFieldValue(env.emailTextField, 'already@example.com');
+    env.click(env.sendButton);
+    verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).once();
+  }));
 });
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -294,6 +294,15 @@ describe('ShareControlComponent', () => {
     verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).never();
     expect(env.fetchElement('#email mat-error').nativeElement.textContent).toContain('Email address is invalid');
   }));
+
+  it('should not show required errors immediately after submitting', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setTextFieldValue(env.emailTextField, 'already@example.com');
+    env.setInvitationLanguage('en');
+    env.click(env.sendButton);
+    verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).once();
+    expect(env.fetchElement('#email mat-error')).toBeNull();
+  }));
 });
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -285,6 +285,15 @@ describe('ShareControlComponent', () => {
     env.click(env.sendButton);
     verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).once();
   }));
+
+  it('should require that the entered email is valid', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setInvitationLanguage('en');
+    env.setTextFieldValue(env.emailTextField, 'abc');
+    env.click(env.sendButton);
+    verify(mockedProjectService.onlineInvite(anything(), anything(), anything(), anything())).never();
+    expect(env.fetchElement('#email mat-error').nativeElement.textContent).toContain('Email address is invalid');
+  }));
 });
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -33,7 +33,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
   @Input() defaultRole: SFProjectRole = SF_DEFAULT_SHARE_ROLE;
   @ViewChild('shareLinkField') shareLinkField?: ElementRef<HTMLInputElement>;
 
-  email = new UntypedFormControl('', [XFValidators.email]);
+  email = new UntypedFormControl('', [XFValidators.email, Validators.required]);
   localeControl = new UntypedFormControl('', [Validators.required]);
   roleControl = new UntypedFormControl('', [Validators.required]);
   sendInviteForm: UntypedFormGroup = new UntypedFormGroup({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormGroupDirective, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
@@ -171,7 +171,7 @@ export class ShareControlComponent extends SubscriptionDisposable {
     this.isAlreadyInvited = await this.projectService.onlineIsAlreadyInvited(this._projectId, this.email.value);
   }
 
-  async sendEmail(): Promise<void> {
+  async sendEmail(form: FormGroupDirective): Promise<void> {
     if (this._projectId == null || this.email.value === '' || this.email.value == null || !this.sendInviteForm.valid) {
       return;
     }
@@ -194,7 +194,13 @@ export class ShareControlComponent extends SubscriptionDisposable {
     }
 
     this.noticeService.show(message);
-    this.email.reset();
+
+    const roleValue = this.shareRole;
+    const localeValue = this.localeControl.value;
+
+    form.resetForm();
+    this.roleControl.setValue(roleValue);
+    this.localeControl.setValue(localeValue);
   }
 
   private async updateFormEnabledStateAndLinkSharingKey(): Promise<void> {


### PR DESCRIPTION
No error is shown for the user invite email field if the send button is clicked while the email field is empty.

This PR marks the field as required.

Replication Steps:

- Navigate to users screen after logged In as project admin
- Click on the Send button under "Send a link"
- Note an error displayed only for the Invitation language field not for email field

Acceptance Tests

- Navigate to users screen after logged In as project admin
- Click on the Send button under "Send a link"
- Note an error under both the email and the invitation language fields

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2322)
<!-- Reviewable:end -->
