### PR TITLE
SF-2437 Restrict audio upload to 95MB

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -44,12 +44,12 @@
           >
             <mat-icon>{{ chapterAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
           </app-single-button-audio-player>
-          <span *ngIf="hasAudioBeenUploaded">{{ audioFilename }}</span>
+          <span *ngIf="hasAudioBeenUploaded && !hasAudioDataError">{{ audioFilename }}</span>
           <mat-icon *ngIf="hasAudioBeenUploaded" (click)="deleteAudioData()" class="delete">delete</mat-icon>
         </ng-container>
         <ng-container *ngIf="!hasAudioBeenUploaded">
           <mat-icon>play_disabled</mat-icon>
-          <span *ngIf="!hasAudioBeenUploaded">{{ t("no_audio_file_uploaded") }}</span>
+          <span *ngIf="hasAudioDataError">{{ t(audioErrorMessageKey) }}</span>
         </ng-container>
       </div>
       <div

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -49,6 +49,7 @@
         </ng-container>
         <ng-container *ngIf="!hasAudioBeenUploaded">
           <mat-icon>play_disabled</mat-icon>
+          <span *ngIf="!hasAudioDataError">{{ t("no_audio_file_uploaded") }}</span>
           <span *ngIf="hasAudioDataError">{{ t(audioErrorMessageKey) }}</span>
         </ng-container>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -648,11 +648,10 @@ class TestEnvironment {
       ['1', '0', 'v2']
     ]);
     when(
-      mockedFileService.uploadFile(
+      mockedFileService.onlineUploadFileOrFail(
         FileType.Audio,
         anything(),
         TextAudioDoc.COLLECTION,
-        anything(),
         anything(),
         anything(),
         anything(),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -527,6 +527,7 @@ export class ChapterAudioDialogComponent extends SubscriptionDisposable implemen
         // if file is larger than 100MB, show an error
         if (file.size > 100_000_000) {
           this._audioErrorKey = 'audio_file_less_than_one_hundred_mb';
+          this.deleteAudioData();
           continue;
         }
         const audioAttachment: AudioAttachment = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.service.ts
@@ -1,6 +1,7 @@
 import { DialogService } from 'xforge-common/dialog.service';
 import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
 import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { SFProjectService } from '../../core/sf-project.service';
 import {
   ChapterAudioDialogComponent,
@@ -20,7 +21,7 @@ export class ChapterAudioDialogService {
       width: '320px'
     };
     const dialogRef = this.dialogService.openMatDialog(ChapterAudioDialogComponent, dialogConfig);
-    const result: ChapterAudioDialogResult | 'close' | undefined = await dialogRef.afterClosed().toPromise();
+    const result: ChapterAudioDialogResult | 'close' | undefined = await firstValueFrom(dialogRef.afterClosed());
     if (result == null || result === 'close') {
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -212,6 +212,7 @@
   "chapter_audio_dialog": {
     "audio": "Audio",
     "audio_already_exists": "Audio already exists for this selection.",
+    "audio_file_less_than_one_hundred_mb": "Audio files under 100MB only",
     "browse_files": "Browse Files",
     "cancel": "Cancel",
     "chapter_audio": "Chapter Audio",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -212,7 +212,7 @@
   "chapter_audio_dialog": {
     "audio": "Audio",
     "audio_already_exists": "Audio already exists for this selection.",
-    "audio_file_less_than_one_hundred_mb": "Audio files under 100MB only",
+    "audio_file_less_than_one_hundred_mb": "Audio files under 95MB only",
     "browse_files": "Browse Files",
     "cancel": "Cancel",
     "chapter_audio": "Chapter Audio",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/project-data-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/project-data-doc.ts
@@ -21,16 +21,34 @@ export abstract class ProjectDataDoc<T extends ProjectData = ProjectData> extend
     return fileData != null ? fileData.blob : undefined;
   }
 
-  async uploadFile(fileType: FileType, dataId: string, blob: Blob, filename: string): Promise<string | undefined> {
+  async uploadFile(
+    fileType: FileType,
+    dataId: string,
+    blob: Blob,
+    filename: string,
+    retryWhenOnline: boolean = true
+  ): Promise<string | undefined> {
     if (this.realtimeService.fileService == null || this.data == null) {
       return undefined;
     }
-    return await this.realtimeService.fileService.uploadFile(
+    if (retryWhenOnline) {
+      return await this.realtimeService.fileService.uploadFile(
+        fileType,
+        this.data.projectRef,
+        this.collection,
+        dataId,
+        this.id,
+        blob,
+        filename,
+        this.alwaysKeepFileOffline(fileType, dataId)
+      );
+    }
+
+    return await this.realtimeService.fileService.onlineUploadFileOrFail(
       fileType,
       this.data.projectRef,
       this.collection,
       dataId,
-      this.id,
       blob,
       filename,
       this.alwaysKeepFileOffline(fileType, dataId)

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -47,7 +47,7 @@ public class SFProjectsUploadController : ControllerBase
     /// <response code="403">Insufficient permission to upload a file to this project.</response>
     /// <response code="404">The project does not exist.</response>
     [HttpPost("audio")]
-    [RequestSizeLimit(300_000_000)]
+    [RequestSizeLimit(100_000_000)]
     public async Task<IActionResult> UploadAudioAsync()
     {
         // Declare the form values


### PR DESCRIPTION
When uploading an audio file that was greater than 100mb, there was a failure on QA and live because cloudflare has a restriction of 100mb for file uploads. This PR changes the file size limit from 300mb to 100mb and shows an error in the audio upload dialog when a user tries to upload a file greater than 100mb.
In addition, this PR changes the behaviour of the audio upload dialog to show a failure when uploading is unsuccessful, whereas previously a failure was caught silently and the user was not made aware.

<img width="327" alt="Audio file under 100MB" src="https://github.com/sillsdev/web-xforge/assets/17931130/38041dc6-24fe-4185-be59-d7367a773fd4">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2325)
<!-- Reviewable:end -->
