### PR TITLE
SF-2493 Fix training source language for back translations

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -43,4 +43,5 @@ public interface IMachineProjectService
         bool preTranslate,
         CancellationToken cancellationToken
     );
+    Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId);
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -827,6 +827,71 @@ public class MachineProjectService : IMachineProjectService
         }
     }
 
+    public async Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId)
+    {
+        // Get the user secret
+        if (!(await _userSecrets.TryGetAsync(curUserId)).TryResult(out UserSecret userSecret))
+        {
+            throw new DataNotFoundException("The user secret does not exist.");
+        }
+
+        // Load the project from the realtime service
+        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(sfProjectId);
+        if (!projectDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        // If there is an alternate source, ensure that writing system and RTL is correct
+        if (projectDoc.Data.TranslateConfig.DraftConfig.AlternateSource is not null)
+        {
+            ParatextSettings? alternateSourceSettings = _paratextService.GetParatextSettings(
+                userSecret,
+                projectDoc.Data.TranslateConfig.DraftConfig.AlternateSource.ParatextId
+            );
+            if (alternateSourceSettings is not null)
+            {
+                await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    op.Set(
+                        pd => pd.TranslateConfig.DraftConfig.AlternateSource.IsRightToLeft,
+                        alternateSourceSettings.IsRightToLeft
+                    );
+                    if (alternateSourceSettings.LanguageTag is not null)
+                        op.Set(
+                            pd => pd.TranslateConfig.DraftConfig.AlternateSource.WritingSystem.Tag,
+                            alternateSourceSettings.LanguageTag
+                        );
+                });
+            }
+        }
+
+        // If there is an alternate training source, ensure that writing system and RTL is correct
+        if (projectDoc.Data.TranslateConfig.DraftConfig.AlternateTrainingSource is not null)
+        {
+            ParatextSettings? alternateSourceSettings = _paratextService.GetParatextSettings(
+                userSecret,
+                projectDoc.Data.TranslateConfig.DraftConfig.AlternateTrainingSource.ParatextId
+            );
+            if (alternateSourceSettings is not null)
+            {
+                await projectDoc.SubmitJson0OpAsync(op =>
+                {
+                    op.Set(
+                        pd => pd.TranslateConfig.DraftConfig.AlternateTrainingSource.IsRightToLeft,
+                        alternateSourceSettings.IsRightToLeft
+                    );
+                    if (alternateSourceSettings.LanguageTag is not null)
+                        op.Set(
+                            pd => pd.TranslateConfig.DraftConfig.AlternateTrainingSource.WritingSystem.Tag,
+                            alternateSourceSettings.LanguageTag
+                        );
+                });
+            }
+        }
+    }
+
     /// <summary>
     /// Gets the source language for the project.
     /// </summary>

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -30,6 +31,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     internal const string ProjectSettingValueUnset = "unset";
     private static readonly IEqualityComparer<Dictionary<string, string>> _permissionDictionaryEqualityComparer =
         new DictionaryComparer<string, string>();
+    private readonly IBackgroundJobClient _backgroundJobClient;
     private readonly IMachineProjectService _machineProjectService;
     private readonly ISyncService _syncService;
     private readonly IParatextService _paratextService;
@@ -54,7 +56,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         IRepository<UserSecret> userSecrets,
         IRepository<TranslateMetrics> translateMetrics,
         IStringLocalizer<SharedResource> localizer,
-        ITransceleratorService transceleratorService
+        ITransceleratorService transceleratorService,
+        IBackgroundJobClient backgroundJobClient
     )
         : base(realtimeService, siteOptions, audioService, projectSecrets, fileSystemService)
     {
@@ -67,6 +70,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         _securityService = securityService;
         _localizer = localizer;
         _transceleratorService = transceleratorService;
+        _backgroundJobClient = backgroundJobClient;
     }
 
     protected override string ProjectAdminRole => SFProjectRole.Administrator;
@@ -128,6 +132,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             {
                 TranslateSource source = await GetTranslateSourceAsync(
                     curUserId,
+                    projectDoc.Id,
                     settings.SourceParatextId,
                     syncIfCreated: false,
                     ptProjects
@@ -290,6 +295,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         {
             source = await GetTranslateSourceAsync(
                 curUserId,
+                projectId,
                 settings.SourceParatextId,
                 syncIfCreated: false,
                 ptProjects,
@@ -308,6 +314,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         {
             alternateSource = await GetTranslateSourceAsync(
                 curUserId,
+                projectId,
                 settings.AlternateSourceParatextId,
                 syncIfCreated: true,
                 ptProjects,
@@ -326,6 +333,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         {
             alternateTrainingSource = await GetTranslateSourceAsync(
                 curUserId,
+                projectId,
                 settings.AlternateTrainingSourceParatextId,
                 syncIfCreated: true,
                 ptProjects,
@@ -1365,6 +1373,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// Gets the translate source asynchronously.
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="paratextId">The paratext identifier.</param>
     /// <param name="syncIfCreated">If <c>true</c> sync the project if it is created.</param>
     /// <param name="ptProjects">The paratext projects.</param>
@@ -1373,6 +1382,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
     private async Task<TranslateSource> GetTranslateSourceAsync(
         string curUserId,
+        string sfProjectId,
         string paratextId,
         bool syncIfCreated,
         IEnumerable<ParatextProject> ptProjects,
@@ -1432,7 +1442,16 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         // This is usually because this is an alternate source for drafting
         if (projectCreated && syncIfCreated)
         {
-            await _syncService.SyncAsync(new SyncConfig { ProjectId = sourceProjectRef, UserId = curUserId });
+            string jobId = await _syncService.SyncAsync(
+                new SyncConfig { ProjectId = sourceProjectRef, UserId = curUserId }
+            );
+
+            // After syncing the source project (which will take some time), ensure that the writing system matches
+            // what is in the project document
+            _backgroundJobClient.ContinueJobWith<IMachineProjectService>(
+                jobId,
+                r => r.UpdateTranslationSourcesAsync(curUserId, sfProjectId)
+            );
         }
 
         return new TranslateSource

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -4,6 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -2169,6 +2172,7 @@ public class SFProjectServiceTests
         await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
+        env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
 
         // Check that the project was created
         Assert.That(
@@ -2236,6 +2240,7 @@ public class SFProjectServiceTests
         await env.MachineProjectService.DidNotReceive()
             .AddProjectAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
+        env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
 
         // Check that the project was created
         Assert.That(
@@ -3854,6 +3859,7 @@ public class SFProjectServiceTests
             SecurityService = Substitute.For<ISecurityService>();
             SecurityService.GenerateKey().Returns("1234abc");
             var transceleratorService = Substitute.For<ITransceleratorService>();
+            BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
 
             ParatextService
                 .IsResource(Arg.Any<string>())
@@ -3875,7 +3881,8 @@ public class SFProjectServiceTests
                 UserSecrets,
                 translateMetrics,
                 Localizer,
-                transceleratorService
+                transceleratorService,
+                BackgroundJobClient
             );
         }
 
@@ -3890,6 +3897,7 @@ public class SFProjectServiceTests
         public IParatextService ParatextService { get; }
         public IStringLocalizer<SharedResource> Localizer { get; }
         public MemoryRepository<UserSecret> UserSecrets { get; }
+        public IBackgroundJobClient BackgroundJobClient { get; }
 
         public SFProject GetProject(string id) => RealtimeService.GetRepository<SFProject>().Get(id);
 


### PR DESCRIPTION
This PR fixes the language tags for alternate source and alternate training sources for back translations by updating these values after the initial sync of the alternate source or alternate training source.

This bug occurred because the Paratext API does not return the language tag for back translation projects, and so to retrieve this value the project must first be synced with Scripture Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2326)
<!-- Reviewable:end -->
