### PR TITLE
SF-2527 Support for invalid reattached notes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.spec.ts
@@ -209,6 +209,45 @@ describe('NoteThreadDoc', () => {
     const expected: VerseRef = new VerseRef('MAT 1:2');
     expect(verseRef.equals(expected)).toBe(true);
   });
+
+  it('allows invalid reattached verses', async () => {
+    const reattached: string = 'MAT 1:2 reattached selected text  invalid';
+    const type: NoteType = NoteType.Normal;
+    const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
+    const notes: Note[] = [
+      {
+        dataId: 'note01',
+        type,
+        conflictType,
+        threadId: 'thread01',
+        content: 'note content',
+        deleted: false,
+        tagId: 2,
+        status: NoteStatus.Todo,
+        ownerRef: 'user01',
+        dateCreated: '2021-11-10T12:00:00',
+        dateModified: '2021-11-10T12:00:00'
+      },
+      {
+        dataId: 'reattach01',
+        type,
+        conflictType,
+        threadId: 'thread01',
+        content: '',
+        deleted: false,
+        status: NoteStatus.Unspecified,
+        ownerRef: 'user01',
+        dateCreated: '2021-11-10T13:00:00',
+        dateModified: '2021-11-10T13:00:00',
+        reattached
+      }
+    ];
+
+    const noteThreadDoc: NoteThreadDoc = await env.setupDoc(notes);
+    const verseRef: VerseRef = noteThreadDoc.currentVerseRef()!;
+    const expected: VerseRef = new VerseRef('MAT 1:1');
+    expect(verseRef.equals(expected)).toBe(true);
+  });
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -76,8 +76,13 @@ export class NoteThreadDoc extends ProjectDataDoc<NoteThread> {
       return toVerseRef(this.data.verseRef);
     }
 
-    const verseStr: string = lastReattach.reattached.split(REATTACH_SEPARATOR)[0];
-    return new VerseRef(verseStr);
+    try {
+      const verseStr: string = lastReattach.reattached.split(REATTACH_SEPARATOR)[0];
+      return new VerseRef(verseStr);
+    } catch {
+      // Ignore any errors parsing the re-attached verse
+      return toVerseRef(this.data.verseRef);
+    }
   }
 
   canUserResolveThread(userId: string, userRole: string, noteTags: NoteTag[]): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1627,6 +1627,23 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
+    it('shows an invalid reattached note in original location', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      // invalid reattachment string
+      env.reattachNote('project01', 'dataid04', 'MAT 1:4  invalid note  error', undefined, true);
+
+      // SUT
+      env.wait();
+      const range: RangeStatic = env.component.target!.getSegmentRange('verse_1_3')!;
+      const note4Position: number = env.getNoteThreadEditorPosition('dataid04');
+      const note4Doc: NoteThreadDoc = env.getNoteThreadDoc('project01', 'dataid04')!;
+      expect(note4Position).toEqual(range.index + 1);
+      // The note thread is on verse 3
+      expect(note4Doc.data!.verseRef.verseNum).toEqual(3);
+      env.dispose();
+    }));
+
     it('does not display conflict notes', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
@@ -4597,13 +4614,30 @@ class TestEnvironment {
     });
   }
 
-  reattachNote(projectId: string, threadDataId: string, verseStr: string, position: TextAnchor): void {
+  reattachNote(
+    projectId: string,
+    threadDataId: string,
+    verseStr: string,
+    position?: TextAnchor,
+    doNotParseReattachedVerseStr: boolean = false
+  ): void {
     const noteThreadDoc: NoteThreadDoc = this.getNoteThreadDoc(projectId, threadDataId);
     const template: Note = noteThreadDoc.data!.notes[0];
-    const verseRef: VerseRef = new VerseRef(verseStr);
-    const contextAfter: string = ` ${verseRef.verseNum}.`;
-    const reattachParts: string[] = [verseStr, 'verse', position.start.toString(), 'target: chapter 1, ', contextAfter];
-    const reattached: string = reattachParts.join(REATTACH_SEPARATOR);
+    let reattached: string;
+    if (doNotParseReattachedVerseStr || position == null) {
+      reattached = verseStr;
+    } else {
+      const verseRef: VerseRef = new VerseRef(verseStr);
+      const contextAfter: string = ` ${verseRef.verseNum}.`;
+      const reattachParts: string[] = [
+        verseStr,
+        'verse',
+        position.start.toString(),
+        'target: chapter 1, ',
+        contextAfter
+      ];
+      reattached = reattachParts.join(REATTACH_SEPARATOR);
+    }
     const type: NoteType = NoteType.Normal;
     const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const note: Note = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -205,6 +205,31 @@ describe('NoteDialogComponent', () => {
     expect(reattachNote.querySelector('img')?.getAttribute('title')).toEqual('Note reattached');
   }));
 
+  it('invalid reattached note', fakeAsync(() => {
+    let reattachedContent: string = 'Reattached content text.';
+    env = new TestEnvironment({
+      noteThread: TestEnvironment.getNoteThread(reattachedContent, undefined, undefined, true)
+    });
+
+    // Check note with status set
+    let expectedSrc = '/assets/icons/TagIcons/flag01.png';
+    let reattachNote = env.notes[4].nativeElement as HTMLElement;
+    expect(reattachNote.querySelector('.content .text')?.textContent).toBeUndefined();
+    expect(reattachNote.querySelector('.content .verse-reattached')?.textContent).toBeUndefined();
+    expect(reattachNote.querySelector('.content .note-content')!.textContent).toContain(reattachedContent);
+    expect(reattachNote.querySelector('img')?.getAttribute('src')).toEqual(expectedSrc);
+    expect(reattachNote.querySelector('img')?.getAttribute('title')).toEqual('To do');
+
+    // Check note with no status set
+    reattachedContent = 'reattached02';
+    expectedSrc = '/assets/icons/TagIcons/flag01.png';
+    reattachNote = env.notes[5].nativeElement as HTMLElement;
+    expect(reattachNote.querySelector('.content .verse-reattached')?.textContent).toBeUndefined();
+    expect(reattachNote.querySelector('.content .note-content')?.textContent).toContain(reattachedContent);
+    expect(reattachNote.querySelector('img')?.getAttribute('src')).toEqual(expectedSrc);
+    expect(reattachNote.querySelector('img')?.getAttribute('title')).toEqual('Note reattached');
+  }));
+
   it('shows assigned user', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
     expect(env.threadAssignedUser.nativeElement.textContent).toContain('Team');
@@ -761,6 +786,7 @@ class TestEnvironment {
   static reattached: string = ['MAT 1:4', 'reattached text', '17', 'before selection ', ' after selection'].join(
     REATTACH_SEPARATOR
   );
+  static invalidReattached: string = 'MAT 1:4  invalid note  invalid selection';
   static get defaultBiblicalTerm(): BiblicalTerm {
     return {
       projectRef: 'project01',
@@ -826,7 +852,12 @@ class TestEnvironment {
       ]
     };
   }
-  static getNoteThread(reattachedContent?: string, isInitialSFNote?: boolean, editable?: boolean): NoteThread {
+  static getNoteThread(
+    reattachedContent?: string,
+    isInitialSFNote?: boolean,
+    editable?: boolean,
+    invalidReattachedNote?: boolean
+  ): NoteThread {
     const type: NoteType = NoteType.Normal;
     const conflictType: NoteConflictType = NoteConflictType.DefaultValue;
     const tagId: number | undefined = isInitialSFNote === true ? undefined : 1;
@@ -932,7 +963,7 @@ class TestEnvironment {
         tagId: reattachedContent === '' ? undefined : 1,
         dateCreated: '',
         dateModified: '',
-        reattached: TestEnvironment.reattached
+        reattached: invalidReattachedNote ? TestEnvironment.invalidReattached : TestEnvironment.reattached
       });
       noteThread.notes.push({
         dataId: 'reattached02',
@@ -947,7 +978,7 @@ class TestEnvironment {
         tagId: 1,
         dateCreated: '',
         dateModified: '',
-        reattached: TestEnvironment.reattached
+        reattached: invalidReattachedNote ? TestEnvironment.invalidReattached : TestEnvironment.reattached
       });
     }
     return noteThread;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -473,6 +473,8 @@ export class NoteDialogComponent implements OnInit {
   private reattachedText(note: Note): string | undefined {
     if (note.reattached == null) return;
     const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
+    // If there are less than 5 parts, then the reattached string is invalid. Likely it was corrupted via XML editing
+    if (reattachedParts.length < 5) return;
     const selectedText: string = reattachedParts[1];
     const contextBefore: string = reattachedParts[3];
     const contextAfter: string = reattachedParts[4];
@@ -481,11 +483,16 @@ export class NoteDialogComponent implements OnInit {
 
   private reattachedVerse(note: Note): string | undefined {
     if (note.reattached == null) return;
-    const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
-    const verseStr: string = reattachedParts[0];
-    const vref: VerseRef = new VerseRef(verseStr);
-    const verseRef: string = this.i18n.localizeReference(vref);
-    const reattached: string = translate('note_dialog.reattached');
-    return `${verseRef} ${reattached}`;
+    try {
+      const reattachedParts: string[] = note.reattached.split(REATTACH_SEPARATOR);
+      const verseStr: string = reattachedParts[0];
+      const vref: VerseRef = new VerseRef(verseStr);
+      const verseRef: string = this.i18n.localizeReference(vref);
+      const reattached: string = translate('note_dialog.reattached');
+      return `${verseRef} ${reattached}`;
+    } catch {
+      // Ignore any errors parsing the re-attached verse
+      return;
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -3148,14 +3148,13 @@ public class ParatextService : DisposableBase, IParatextService
         string selectedText = comment.SelectedText;
         string contextBefore = comment.ContextBefore;
         string contextAfter = comment.ContextAfter;
-        if (comment.Reattached != null)
+        if (comment.ReattachedLocation is not null)
         {
-            string[] reattachedParts = comment.Reattached.Split(PtxUtils.StringUtils.orcCharacter);
-            verseRef = new VerseRef(reattachedParts[0]);
-            selectedText = reattachedParts[1];
-            startPos = int.Parse(reattachedParts[2]);
-            contextBefore = reattachedParts[3];
-            contextAfter = reattachedParts[4];
+            verseRef = comment.ReattachedLocation.VerseRef;
+            selectedText = comment.ReattachedLocation.SelectedText;
+            startPos = comment.ReattachedLocation.StartPosition;
+            contextBefore = comment.ReattachedLocation.ContextBefore;
+            contextAfter = comment.ReattachedLocation.ContextAfter;
         }
 
         if (!chapterDeltas.TryGetValue(verseRef.ChapterNum, out ChapterDelta chapterDelta) || startPos == 0)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2145,6 +2145,130 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public async Task GetNoteThreadChanges_ReattachedNote_HandleInvalidValues()
+    {
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
+        // The text doc is set up so that verse 7 has unique text that we reattach to
+        string verseStr = "MAT 1:7 This is not a valid verse   It was badly reattached";
+
+        env.AddNoteThreadData(
+            new[]
+            {
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+                new ThreadComponents { threadNum = 4, noteCount = 1 },
+                new ThreadComponents
+                {
+                    threadNum = 5,
+                    noteCount = 1,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+            }
+        );
+        env.AddParatextComments(
+            new[]
+            {
+                new ThreadComponents
+                {
+                    threadNum = 1,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+                new ThreadComponents
+                {
+                    threadNum = 2,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+                new ThreadComponents
+                {
+                    threadNum = 3,
+                    noteCount = 1,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+                new ThreadComponents
+                {
+                    threadNum = 4,
+                    noteCount = 2,
+                    username = env.Username01,
+                    reattachedVerseStr = verseStr,
+                    doNotParseReattachedVerseStr = true,
+                },
+                new ThreadComponents
+                {
+                    threadNum = 5,
+                    noteCount = 1,
+                    username = env.Username01,
+                },
+            }
+        );
+
+        await using IConnection conn = await env.RealtimeService.ConnectAsync();
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
+            conn,
+            new[] { "dataId1", "dataId3", "dataId4", "dataId5" }
+        );
+        Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
+        Dictionary<string, ParatextUserProfile> syncUsers = new Dictionary<string, ParatextUserProfile>
+        {
+            {
+                env.Username01,
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            },
+        };
+        IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
+            userSecret,
+            ptProjectId,
+            40,
+            noteThreadDocs,
+            chapterDeltas,
+            syncUsers
+        );
+        Assert.That(changes.Count, Is.EqualTo(5));
+
+        // Existing thread reattached
+        NoteThreadChange change1 = changes.Single(c => c.ThreadId == "thread1");
+        Assert.That(change1.NotesAdded.Count, Is.EqualTo(1));
+        Assert.That(change1.NotesAdded.Single().Reattached, Is.Not.Null);
+
+        // New thread note reattached
+        NoteThreadChange change2 = changes.Single(c => c.ThreadId == "thread2");
+        Assert.That(change2.NotesAdded.Count, Is.EqualTo(2));
+        Assert.That(change2.NotesAdded[1].Reattached, Is.Not.Null);
+
+        // The reattach note in thread3 is existing and is just a position change
+        NoteThreadChange change3 = changes.Single(c => c.ThreadId == "thread2");
+        Assert.That(change3.Position, Is.Not.Null);
+
+        // Existing thread new comment and reattached
+        NoteThreadChange change4 = changes.Single(c => c.ThreadId == "thread4");
+        Assert.That(change4.NotesAdded.Count, Is.EqualTo(2));
+        Assert.That(change4.NotesAdded[1].Reattached, Is.Not.Null);
+
+        // Existing thread and reattach comment removed
+        NoteThreadChange change5 = changes.Single(c => c.ThreadId == "thread5");
+        Assert.That(change5.NoteIdsRemoved.Count, Is.EqualTo(1));
+        Assert.That(change5.NoteIdsRemoved[0], Is.EqualTo("reattachedthread5"));
+    }
+
+    [Test]
     public void GetNoteThreadChanges_DeletedThreadIgnored()
     {
         var env = new TestEnvironment();
@@ -4075,11 +4199,12 @@ public class ParatextServiceTests
         public bool isConflict;
         public bool appliesToVerse;
         public string reattachedVerseStr;
+        public bool doNotParseReattachedVerseStr;
         public bool editable;
         public int versionNumber;
     }
 
-    struct ReattachedThreadInfo
+    record ReattachedThreadInfo
     {
         public string verseStr;
         public string selectedText;
@@ -5400,7 +5525,18 @@ public class ParatextServiceTests
                 }
                 if (comp.reattachedVerseStr != null)
                 {
-                    ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
+                    ReattachedThreadInfo rti = default;
+                    string reattached;
+                    if (comp.doNotParseReattachedVerseStr)
+                    {
+                        reattached = comp.reattachedVerseStr;
+                    }
+                    else
+                    {
+                        rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
+                        reattached = ReattachedThreadInfoStr(rti);
+                    }
+
                     notes.Add(
                         new Note
                         {
@@ -5412,14 +5548,17 @@ public class ParatextServiceTests
                             SyncUserRef = "syncuser01",
                             DateCreated = new DateTime(2019, 1, 20, 8, 0, 0, DateTimeKind.Utc),
                             Status = NoteStatus.Unspecified.InternalValue,
-                            Reattached = ReattachedThreadInfoStr(rti)
+                            Reattached = reattached,
                         }
                     );
-                    noteThread.Position = new TextAnchor
+                    if (rti is not null)
                     {
-                        Start = rti.contextBefore.Length,
-                        Length = rti.selectedText.Length
-                    };
+                        noteThread.Position = new TextAnchor
+                        {
+                            Start = rti.contextBefore.Length,
+                            Length = rti.selectedText.Length,
+                        };
+                    }
                 }
                 noteThread.Notes = notes;
                 if (notes.Count > 0)
@@ -5614,11 +5753,19 @@ public class ParatextServiceTests
 
                 if (comp.reattachedVerseStr != null)
                 {
-                    ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
                     Paratext.Data.ProjectComments.Comment reattachedComment = getThreadComment();
                     reattachedComment.Status = NoteStatus.Unspecified;
                     reattachedComment.Date = "2019-01-20T08:00:00.0000000+00:00";
-                    reattachedComment.Reattached = ReattachedThreadInfoStr(rti);
+                    if (comp.doNotParseReattachedVerseStr)
+                    {
+                        reattachedComment.Reattached = comp.reattachedVerseStr;
+                    }
+                    else
+                    {
+                        ReattachedThreadInfo rti = GetReattachedThreadInfo(comp.reattachedVerseStr);
+                        reattachedComment.Reattached = ReattachedThreadInfoStr(rti);
+                    }
+
                     ProjectCommentManager.AddComment(reattachedComment);
                 }
             }


### PR DESCRIPTION
This PR allows proper error handling for invalid reattached notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2334)
<!-- Reviewable:end -->
