### PR TITLE
Add query to find sync errors for a project

### DIFF
--- a/mongodb/Projects/SyncFailureCause.mongodb
+++ b/mongodb/Projects/SyncFailureCause.mongodb
@@ -1,0 +1,36 @@
+use("xforge");
+
+const shortName = "WOElai";
+
+const project = db.sf_projects.findOne({
+  shortName: shortName
+});
+
+const id = project._id;
+
+console.log(`Project short name: ${shortName}`);
+console.log(`Project Id: ${id}`);
+console.log(`Paratext project ID: ${project.paratextId}`);
+
+const metrics = db.sync_metrics.aggregate([
+  {
+    $match: {
+      projectRef: id,
+      errorDetails: { $exists: true }
+    }
+  },
+  {
+    $group: {
+      _id: "$errorDetails",
+      count: { $sum: 1 }
+    }
+  },
+  {
+    $sort: { count: -1 }
+  }
+]);
+
+for (const metric of metrics) {
+  console.log(`\nThe following error occurred ${metric.count} time(s):`);
+  console.log(metric._id);
+}


### PR DESCRIPTION
I fairly frequently need to find why a particular project failed to sync. This usually involves looking at the sync metrics to see what errors have happened, and then (sometimes) looking at the project on disk. This requires finding the Paratext project ID. I also want to get the stack trace. This script attempts to do all of this at once with just a project short name.

Here is some example output:
```
Project short name: <redacted>
Project Id: 65b1cd4b295ef91ee7b15fdb
Paratext project ID: a0fe9c0653f9f776081fc0d8856dd2a16631e0e8

The following error occurred 3 time(s):
System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at SIL.XForge.Scripture.Services.ParatextService.GetNoteThreadChanges(UserSecret userSecret, String paratextId, Nullable`1 bookNum, IEnumerable`1 noteThreadDocs, Dictionary`2 chapterDeltas, Dictionary`2 ptProjectUsers) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextService.cs:line 1275
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateNoteThreadDocsAsync(Nullable`1 bookNum, Dictionary`2 noteThreadDocs, Dictionary`2 chapterDeltas)
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateDocsAsync(SyncPhase syncPhase, String targetParatextId, Dictionary`2 targetTextDocsByBook, Dictionary`2 questionDocsByBook, Dictionary`2 noteThreadDocsByBook, HashSet`1 targetBooks, HashSet`1 sourceBooks) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs:line 936
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.RunAsync(String projectSFId, String userId, String syncMetricsId, Boolean trainEngine, CancellationToken token) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs:line 413
Error occurred while executing Paratext sync for project with SF id '65b1cd4b295ef91ee7b15fdb'. 

The following error occurred 1 time(s):
System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at SIL.XForge.Scripture.Services.ParatextService.GetNoteThreadChanges(UserSecret userSecret, String paratextId, Nullable`1 bookNum, IEnumerable`1 noteThreadDocs, Dictionary`2 chapterDeltas, Dictionary`2 ptProjectUsers) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextService.cs:line 1280
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateNoteThreadDocsAsync(Nullable`1 bookNum, Dictionary`2 noteThreadDocs, Dictionary`2 chapterDeltas) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 1323
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateDocsAsync(SyncPhase syncPhase, String targetParatextId, Dictionary`2 targetTextDocsByBook, Dictionary`2 questionDocsByBook, Dictionary`2 noteThreadDocsByBook, HashSet`1 targetBooks, HashSet`1 sourceBooks) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 936
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.RunAsync(String projectSFId, String userId, String syncMetricsId, Boolean trainEngine, CancellationToken token) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 413
Error occurred while executing Paratext sync for project with SF id '65b1cd4b295ef91ee7b15fdb'. 

The following error occurred 1 time(s):
System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at SIL.XForge.Scripture.Services.ParatextService.GetNoteThreadChanges(UserSecret userSecret, String paratextId, Nullable`1 bookNum, IEnumerable`1 noteThreadDocs, Dictionary`2 chapterDeltas, Dictionary`2 ptProjectUsers) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextService.cs:line 1277
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateNoteThreadDocsAsync(Nullable`1 bookNum, Dictionary`2 noteThreadDocs, Dictionary`2 chapterDeltas)
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateDocsAsync(SyncPhase syncPhase, String targetParatextId, Dictionary`2 targetTextDocsByBook, Dictionary`2 questionDocsByBook, Dictionary`2 noteThreadDocsByBook, HashSet`1 targetBooks, HashSet`1 sourceBooks) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs:line 936
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.RunAsync(String projectSFId, String userId, String syncMetricsId, Boolean trainEngine, CancellationToken token) in /opt/buildagent/work/243d95264b8fa2c7/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs:line 413
Error occurred while executing Paratext sync for project with SF id '65b1cd4b295ef91ee7b15fdb'. 

The following error occurred 1 time(s):
System.InvalidOperationException: Sequence contains more than one matching element
   at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at SIL.XForge.Scripture.Services.ParatextService.GetNoteThreadChanges(UserSecret userSecret, String paratextId, Nullable`1 bookNum, IEnumerable`1 noteThreadDocs, Dictionary`2 chapterDeltas, Dictionary`2 ptProjectUsers) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextService.cs:line 1277
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateNoteThreadDocsAsync(Nullable`1 bookNum, Dictionary`2 noteThreadDocs, Dictionary`2 chapterDeltas) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 1323
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.UpdateDocsAsync(SyncPhase syncPhase, String targetParatextId, Dictionary`2 targetTextDocsByBook, Dictionary`2 questionDocsByBook, Dictionary`2 noteThreadDocsByBook, HashSet`1 targetBooks, HashSet`1 sourceBooks) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 936
   at SIL.XForge.Scripture.Services.ParatextSyncRunner.RunAsync(String projectSFId, String userId, String syncMetricsId, Boolean trainEngine, CancellationToken token) in C:\xForge\web-xforge\src\SIL.XForge.Scripture\Services\ParatextSyncRunner.cs:line 413
Error occurred while executing Paratext sync for project with SF id '65b1cd4b295ef91ee7b15fdb'. 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2337)
<!-- Reviewable:end -->
