### PR TITLE
SF-2524 Prevent applying drafts when editing is not permitted

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.html
@@ -6,7 +6,7 @@
   </section>
 
   <div [class.offline]="!isOnline">
-    <p><transloco key="draft_viewer.select_apply_to_project"></transloco></p>
+    <p *ngIf="canEdit"><transloco key="draft_viewer.select_apply_to_project"></transloco></p>
     <p><transloco key="draft_viewer.select_edit"></transloco></p>
 
     <div class="draft-viewer-body" [ngClass]="{ 'no-source': !bookHasSource }">
@@ -56,7 +56,7 @@
             {{ isDraftApplied ? t("draft_indicator_applied") : t("draft_indicator_not_applied") }}
             <mat-icon *ngIf="isDraftApplied" class="check-icon">check</mat-icon>
           </span>
-          <div *ngIf="!isDraftApplied && hasDraft" class="apply-draft-button-container">
+          <div *ngIf="!isDraftApplied && hasDraft && canEdit" class="apply-draft-button-container">
             <button mat-flat-button color="primary" (click)="applyDraft()">
               <mat-icon>auto_awesome</mat-icon>
               {{ t("apply_to_project") }}


### PR DESCRIPTION
The SF editor interface prevents editing a chapter if:

 * The USFM is invalid
 * Editing the project is disabled
 * The ops are corrupted
 * The project is not in sync
 * The user does not have project level edit permission
 * The user does not have chapter level edit permission

This PR updates the draft preview screen to use these same checks.

As the draft viewer will be removed in the next few months, this PR does not display any warning messages about why the user cannot see the apply draft button (they could view these on the editor).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2338)
<!-- Reviewable:end -->
