### PR TITLE
SF-2485 Handle table followed by char formatting

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -617,9 +617,11 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                 // current op's character attributes.
                 while (curCharAttrs.Count > 0 && !CharAttributesMatch(curCharAttrs, charAttrs))
                     CharEnded(childNodes, curCharAttrs);
-                curCharAttrs = charAttrs;
-                while (childNodes.Count < curCharAttrs.Count + 1)
+                // If the current op is inserting text with formatting that is not already being tracked for the
+                // existing text, prepare places to isolate the new text that the new formatting will apply to.
+                for (int i = curCharAttrs.Count; i < charAttrs.Count; i++)
                     childNodes.Push(new List<XNode>());
+                curCharAttrs = charAttrs;
             }
 
             // If we are inserting a basic string, rather than a more complex object, like a chapter number.

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -578,10 +578,17 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         }
     }
 
+    /// <summary>
+    /// Make USX from a Delta's ops.
+    /// </summary>
     private static IEnumerable<XNode> ProcessDelta(Delta delta)
     {
+        // Output XML.
         var content = new List<XNode>();
+        // Outer-to-inner set of nested character formatting, which applies to top childNodes elements.
         var curCharAttrs = new List<JObject>();
+        // In-progress nested text and formatting, with the top of the stack representing the inner part of the nesting.
+        // Each element contains a first-to-last set of XML nodes.
         var childNodes = new Stack<List<XNode>>();
         childNodes.Push(new List<XNode>());
         JObject curTableAttrs = null;
@@ -592,6 +599,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                 throw new ArgumentException("The delta is not a document.", nameof(delta));
 
             var attrs = (JObject)op[Delta.Attributes];
+            // If we were tracking character attributes for childNodes, but the text being inserted by the current op
+            // does not have any character attributes, then record char XML elements for all tracked character
+            // attributes.
             if (curCharAttrs.Count > 0 && (attrs == null || attrs["char"] == null))
             {
                 while (curCharAttrs.Count > 0)
@@ -600,6 +610,11 @@ public class DeltaUsxMapper : IDeltaUsxMapper
             else if (attrs != null && attrs["char"] != null)
             {
                 List<JObject> charAttrs = GetCharAttributes(attrs["char"]);
+                // Record character formatting for existing text if it does not apply to the text being inserted in the
+                // current op. If the op's character attributes set doesn't start with the character attributes that
+                // were being tracked, start recording char XML elements for the tracked character attributes until
+                // either we run out of them, or the tracked character attributes set matches the beginning of the
+                // current op's character attributes.
                 while (curCharAttrs.Count > 0 && !CharAttributesMatch(curCharAttrs, charAttrs))
                     CharEnded(childNodes, curCharAttrs);
                 curCharAttrs = charAttrs;
@@ -607,15 +622,22 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     childNodes.Push(new List<XNode>());
             }
 
+            // If we are inserting a basic string, rather than a more complex object, like a chapter number.
             if (op[Delta.InsertType].Type == JTokenType.String)
             {
                 var text = (string)op[Delta.InsertType];
+                // If we were recently working with table information, but the current op doesn't describe the end of a
+                // table cell, and we seem to be done with the table, then end the table.
                 if (curTableAttrs != null && (attrs == null || attrs["table"] == null) && text == "\n")
                 {
                     List<XNode> nextBlockNodes = RowEnded(childNodes, ref curRowAttrs);
                     TableEnded(content, childNodes, ref curTableAttrs);
                     childNodes.Peek().AddRange(nextBlockNodes);
                 }
+                // If we just finished a table cell. Account for being in a new row or new table than last time we
+                // observed. Take the top childNodes node-set and put it into a cell XML element. Leave childNodes with
+                // an empty node-set at the top for upcoming content, followed by a node-set with the cell XML element appended,
+                // followed by at least one more node-set (possibly being existing content).
                 else if (attrs != null && attrs["table"] != null)
                 {
                     var cellAttrs = (JObject)attrs["cell"];
@@ -628,6 +650,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
 
                     var tableAttrs = (JObject)attrs["table"];
                     var rowAttrs = (JObject)attrs["row"];
+                    // If we were already processing table cells for this table.
                     if (curTableAttrs != null)
                     {
                         if ((string)rowAttrs["id"] != (string)curRowAttrs["id"])
@@ -739,6 +762,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         return content;
     }
 
+    /// <summary>
+    /// If <param name="charAttrs"/> is a subset of <param name="curCharAttrs"/>.
+    /// </summary>
     private static bool CharAttributesMatch(List<JObject> curCharAttrs, List<JObject> charAttrs)
     {
         if (curCharAttrs.Count > charAttrs.Count)
@@ -752,6 +778,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         return true;
     }
 
+    /// <summary>
+    /// Return a List JObject from the incoming charAttrs, dealing with different possible types.
+    /// </summary>
     private static List<JObject> GetCharAttributes(JToken charAttrs)
     {
         return charAttrs switch
@@ -762,6 +791,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         };
     }
 
+    /// <summary>
+    /// Create XML element of a given name, with attributes and optional children content.
+    /// </summary>
     private static XElement CreateContainerElement(string name, JToken attributes, object content = null)
     {
         var elem = new XElement(name);
@@ -771,6 +803,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         return elem;
     }
 
+    /// <summary>
+    /// Add XML attributes to elem.
+    /// </summary>
     private static void AddAttributes(XElement elem, JToken attributes)
     {
         var attrsObj = (JObject)attributes;
@@ -782,6 +817,13 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         }
     }
 
+    /// <summary>
+    /// Apply last `curCharAttrs` character formatting to the top`childNodes` element.
+    ///
+    /// Take off the last description from `curCharAttrs"`. Use it to describe the attributes of a new char
+    /// XML element. Take off and put the first `childNodes` node-set as the char XML element's content,
+    /// and then append the char element to the next `childNodes` node-set.
+    /// </summary>
     private static void CharEnded(Stack<List<XNode>> childNodes, List<JObject> curCharAttrs)
     {
         JObject charAttrs = curCharAttrs[^1];
@@ -796,6 +838,11 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         childNodes.Peek().Add(charElem);
     }
 
+    /// <summary>
+    /// Create an XML row element using the second-from the bottom `childNodes` node-set as content, and
+    /// append it to the bottom `childNodes` node-set. Return the top node-set if there were 3. Leave
+    /// childNodes as only the bottom node-set.
+    /// </summary>
     private static List<XNode> RowEnded(Stack<List<XNode>> childNodes, ref JObject curRowAttrs)
     {
         if (childNodes.Count > 3)
@@ -811,6 +858,10 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         return nextBlockNodes;
     }
 
+    /// <summary>
+    /// Create an XML table element using the top `childNodes` node-set as content, and append it to
+    /// `content`.
+    /// </summary>
     private static void TableEnded(List<XNode> content, Stack<List<XNode>> childNodes, ref JObject curTableAttrs)
     {
         content.Add(CreateContainerElement("table", curTableAttrs, childNodes.Peek()));

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -24,6 +24,10 @@ public class Delta
 
     public static Delta New() => new Delta();
 
+    /// <summary>
+    /// For a document, represents a sequence of content. Paragraph and table information describes the content that
+    /// came before, not after, in the sequence.
+    /// </summary>
     public Delta() => Ops = new List<JToken>();
 
     public Delta(IEnumerable<JToken> ops) => Ops = ops.ToList();

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -2742,6 +2742,72 @@ public class DeltaUsxMapperTests
         XDocument roundtrippedUsx = mapper.ToUsx(Usx("PHM", Chapter("1")), chapterDeltas);
         Assert.IsTrue(XNode.DeepEquals(roundtrippedUsx, usxDoc));
     }
+
+    [Test]
+    public void ToDelta_TableInMiddleFollowedByCharStyle()
+    {
+        string ndCharID = _testGuidService.Generate();
+
+        string bookUsfm = """
+\id PHM
+\c 1
+\p
+\v 1 B
+\tr \th1 C
+\tr \tc1 D
+\p E
+\v 2 F \nd ND\nd*
+""";
+        XmlDocument usfmToUsxLoading = Paratext.Data.UsfmToUsx.ConvertToXmlDocument(
+            new Paratext.Data.MockScrStylesheet("usfm.sty"),
+            bookUsfm
+        );
+        using XmlNodeReader nodeReader = new(usfmToUsxLoading);
+        nodeReader.MoveToContent();
+        XDocument usfmToUsx = XDocument.Load(nodeReader);
+
+        XDocument usxDoc = Usx(
+            "PHM",
+            null,
+            "3.0",
+            Chapter("1"),
+            Para("p", Verse("1"), "B"),
+            Table(Row(Cell("th1", "start", "C")), Row(Cell("tc1", "start", "D"))),
+            Para("p", "E ", Verse("2"), "F ", Char("nd", "ND"))
+        );
+
+        Assert.That(XNode.DeepEquals(usxDoc, usfmToUsx));
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+
+        // Note that these expected deltas are somewhat reverse engineered, rather than known to be what should really
+        // be expected.
+        var expected = Delta
+            .New()
+            .InsertChapter("1")
+            .InsertBlank("p_1")
+            .InsertVerse("1")
+            .InsertText("B", "verse_1_1")
+            .InsertPara("p")
+            .InsertText("C", "cell_1_1_1")
+            .InsertCell(1, 1, "th1", "start")
+            .InsertText("D", "cell_1_2_1")
+            .InsertCell(1, 2, "tc1", "start")
+            .InsertText("E ", "p_2")
+            .InsertVerse("2")
+            .InsertText("F ", "verse_1_2")
+            .InsertChar("ND", "nd", ndCharID, "verse_1_2")
+            .InsertPara("p");
+
+        Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
+        Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(2));
+        Assert.That(chapterDeltas[0].IsValid, Is.True);
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+
+        // And we should be able to roundtrip it back.
+        XDocument roundtrippedUsx = mapper.ToUsx(Usx("PHM", null, "3.0", Chapter("1")), chapterDeltas);
+        Assert.IsTrue(XNode.DeepEquals(roundtrippedUsx, usxDoc));
     }
 
     [Test]
@@ -3432,6 +3498,49 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
     }
 
+    [Test]
+    public void Roundtrip_TableFollowedByCharStyle()
+    {
+        AssertRoundtrips(
+            """
+\id PHM
+\c 1
+\p
+\v 1 B
+\tr \th1 C
+\tr \tc1 D
+\p
+\p E
+\v 2 F \nd ND\nd*
+"""
+        );
+
+        AssertRoundtrips(
+            """
+\id PHM
+\c 1
+\p
+\v 1 B
+\tr \th1 C
+\tr \tc1 D
+\p
+\v 2 F \nd ND\nd*
+"""
+        );
+
+        AssertRoundtrips(
+            """
+\id NUM - A
+\c 1
+\p
+\v 1 B
+\tr \th1 C
+\tr \tc1 D
+\p E
+\v 2 F \nd ND\nd*
+"""
+        );
+    }
 
     [Test]
     public void Roundtrip_NestedChars()
@@ -3445,6 +3554,37 @@ public class DeltaUsxMapperTests
 """
         );
     }
+
+    [Test]
+    public void Roundtrip_NestedCharsInTable()
+    {
+        AssertRoundtrips(
+            """
+\id NUM - A
+\c 1
+\p
+\v 1 B
+\tr \th1 H1 \th1 H2
+\tr \tc1 D \tc1 \bd \+sup 1\+sup* This is\+sup 2\+sup* bold text.\+sup 3\+sup* \bd*  This is normal text.
+\p E
+\v 2 F \nd ND\nd*
+"""
+        );
+
+        AssertRoundtrips(
+            """
+\id NUM - A
+\c 1
+\p
+\v 1 B
+\tr \th1 H1 \th1 H2
+\tr \tc1 D \tc1 \bd \+sup 1\+sup* This is\+sup 2\+sup* bold text.\+sup 3\+sup* \bd*
+\p E
+\v 2 F \nd ND\nd*
+"""
+        );
+    }
+
     [Test]
     public async Task RoundTrip_Hebrew() => await RoundTripTestHelper("heb_usfm", "heb");
 

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3412,21 +3412,24 @@ public class DeltaUsxMapperTests
     }
 
     [Test]
-    public async Task RoundTrip_Hebrew() => await RoundTripTestHelper("heb_usfm");
+    public async Task RoundTrip_Hebrew() => await RoundTripTestHelper("heb_usfm", "heb");
 
     [Test]
-    public async Task RoundTrip_Asv() => await RoundTripTestHelper("eng-asv_usfm-partial");
+    public async Task RoundTrip_Asv() => await RoundTripTestHelper("eng-asv_usfm-partial", "eng-asv");
 
-    private async Task RoundTripTestHelper(string project)
+    private async Task RoundTripTestHelper(string projectZipFilename, string projectShortName)
     {
-        string zipFilePath = Path.Combine(GetPathToTestProject(), "SampleData", $"{project}.zip");
+        string zipFilePath = Path.Combine(GetPathToTestProject(), "SampleData", $"{projectZipFilename}.zip");
         await using FileStream zipFileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
         using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
         Assert.That(archive.Entries.Any(), "setup. unexpected input size.");
         foreach (ZipArchiveEntry entry in archive.Entries)
         {
-            string bookCode = Regex.Match(entry.Name, @".*-([A-Z0-9]{3}).*\.usfm").Groups[1].Value;
-            if (entry.Name.EndsWith(".usfm", StringComparison.OrdinalIgnoreCase) && bookCode is not ("FRT" or "INT"))
+            string bookCode = Regex
+                .Match(entry.Name, @$".*([A-Z0-9][A-Z0-9][A-Z0-9]){projectShortName}\..*")
+                .Groups[1]
+                .Value;
+            if (entry.Name.EndsWith("sfm", StringComparison.OrdinalIgnoreCase) && bookCode is not ("FRT" or "INT"))
             {
                 await using Stream entryStream = entry.Open();
                 using StreamReader reader = new StreamReader(entryStream);

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -835,6 +835,10 @@ public class DeltaUsxMapperTests
             Para("p", Verse("4"), "This is verse 4.")
         );
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+
+        // And we should be able to roundtrip it back.
+        List<ChapterDelta> roundtrippedChapterDeltas = mapper.ToChapterDeltas(newUsxDoc).ToList();
+        Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
     }
 
     [Test]
@@ -2733,6 +2737,11 @@ public class DeltaUsxMapperTests
         Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(4));
         Assert.That(chapterDeltas[0].IsValid, Is.True);
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+
+        // And we should be able to roundtrip it back.
+        XDocument roundtrippedUsx = mapper.ToUsx(Usx("PHM", Chapter("1")), chapterDeltas);
+        Assert.IsTrue(XNode.DeepEquals(roundtrippedUsx, usxDoc));
+    }
     }
 
     [Test]
@@ -2806,6 +2815,10 @@ public class DeltaUsxMapperTests
         Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(8));
         Assert.That(chapterDeltas[0].IsValid, Is.True);
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+
+        // And we should be able to roundtrip it back.
+        XDocument roundtrippedUsx = mapper.ToUsx(Usx("PHM", Chapter("1")), chapterDeltas);
+        Assert.IsTrue(XNode.DeepEquals(roundtrippedUsx, usxDoc));
     }
 
     [Test]
@@ -3419,6 +3432,19 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
     }
 
+
+    [Test]
+    public void Roundtrip_NestedChars()
+    {
+        AssertRoundtrips(
+            """
+\id PHM
+\c 1
+\p
+\v 1 \bd \+sup 1\+sup* This is\+sup 2\+sup* bold text.\+sup 3\+sup* \bd*  This is normal text.
+"""
+        );
+    }
     [Test]
     public async Task RoundTrip_Hebrew() => await RoundTripTestHelper("heb_usfm", "heb");
 

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -789,22 +789,30 @@ public class DeltaUsxMapperTests
             Delta
                 .New()
                 .InsertChapter("1")
+                // Table 1 begins
+                // Row 1 begins
+                // Cell 1 begins
                 .InsertText("Before verse.", "cell_1_1_1")
                 .InsertVerse("1")
                 .InsertText("This is verse ", "verse_1_1")
                 .InsertChar("1", "it", _testGuidService.Generate(), "verse_1_1")
                 .InsertText(".", "verse_1_1")
                 .InsertCell(1, 1, "tc1", "start")
+                // Cell 2 begins
                 .InsertBlank("cell_1_1_2")
                 .InsertVerse("2")
                 .InsertText("This is verse 2.", "verse_1_2")
                 .InsertCell(1, 1, "tc2", "start")
+                // Row 2 begins
+                // Cell 1 begins
                 .InsertBlank("cell_1_2_1")
                 .InsertCell(1, 2, "tc1", "start")
+                // Cell 2 begins
                 .InsertBlank("cell_1_2_2")
                 .InsertVerse("3")
                 .InsertText("This is verse 3.", "verse_1_3")
                 .InsertCell(1, 2, "tc2", "start")
+                // Post-table content
                 .InsertBlank("p_1")
                 .InsertVerse("4")
                 .InsertText("This is verse 4.", "verse_1_4")

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3423,6 +3423,8 @@ public class DeltaUsxMapperTests
         await using FileStream zipFileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
         using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
         Assert.That(archive.Entries.Any(), "setup. unexpected input size.");
+        bool allBooksRoundtrip = true;
+        List<string> errorMessages = new();
         foreach (ZipArchiveEntry entry in archive.Entries)
         {
             string bookCode = Regex
@@ -3436,36 +3438,66 @@ public class DeltaUsxMapperTests
 
                 // Read and stream the contents of the text file
                 string bookUsfm = await reader.ReadToEndAsync();
-                XmlDocument bookUsxLoading = Paratext.Data.UsfmToUsx.ConvertToXmlDocument(
-                    new Paratext.Data.MockScrStylesheet("usfm.sty"),
-                    bookUsfm
-                );
-                using XmlNodeReader nodeReader = new(bookUsxLoading);
-                nodeReader.MoveToContent();
-                XDocument bookUsx = XDocument.Load(nodeReader);
-                // Record the usx version string to make it match when later compared.
-                string usxVersion = bookUsx.Elements("usx").First().Attribute("version")!.Value;
-                // Record any text in the book node, which some books have, like <book code="GEN">- American Standard
-                // Version</book>
-                string? bookDesc = bookUsx.Elements("usx").Elements("book").First().FirstNode?.ToString();
-                DeltaUsxMapper mapper = new(_mapperGuidService, _logger, _exceptionHandler);
-
-                // SUT part 1
-                List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(bookUsx).ToList();
-
-                IEnumerable<XElement> chaptersToProcess = bookUsx
-                    .Elements("usx")
-                    .Elements("chapter")
-                    .Select(x => Chapter(x.Attribute("number")!.Value));
-
-                // SUT part 2
-                XDocument roundTrippedUsx = mapper.ToUsx(
-                    Usx(bookCode, bookDesc, usxVersion, chaptersToProcess),
-                    chapterDeltas
-                );
-                Assert.IsTrue(XNode.DeepEquals(roundTrippedUsx, bookUsx), $"Trouble in {entry.Name}");
+                if (!DoesRoundtrip(bookUsfm, out string errorMessage))
+                {
+                    allBooksRoundtrip = false;
+                    errorMessages.Add(errorMessage);
+                }
             }
         }
+        Assert.That(allBooksRoundtrip, Is.True, string.Join(Environment.NewLine, errorMessages));
+    }
+
+    private void AssertRoundtrips(string bookUsfm) =>
+        Assert.That(DoesRoundtrip(bookUsfm, out string errorMessage), Is.True, errorMessage);
+
+    private static string ExtractBookCode(string bookUsfm)
+    {
+        string firstLine = bookUsfm.Split('\n').FirstOrDefault()?.Trim();
+        string bookCode = Regex.Match(firstLine, @"\\id\s+(\w+)").Groups[1].Value;
+        return bookCode;
+    }
+
+    private bool DoesRoundtrip(string bookUsfm, out string errorMessage)
+    {
+        string bookCode = ExtractBookCode(bookUsfm);
+
+        XmlDocument bookUsxLoading = Paratext.Data.UsfmToUsx.ConvertToXmlDocument(
+            new Paratext.Data.MockScrStylesheet("usfm.sty"),
+            bookUsfm
+        );
+        using XmlNodeReader nodeReader = new(bookUsxLoading);
+        nodeReader.MoveToContent();
+        XDocument bookUsx = XDocument.Load(nodeReader);
+        // Record the usx version string to make it match when later compared.
+        string usxVersion = bookUsx.Elements("usx").First().Attribute("version")!.Value;
+        // Record any text in the book node, which some books have, like <book code="GEN">- American Standard
+        // Version</book>
+        string? bookDesc = bookUsx.Elements("usx").Elements("book").First().FirstNode?.ToString();
+        DeltaUsxMapper mapper = new(_mapperGuidService, _logger, _exceptionHandler);
+
+        // SUT part 1
+        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(bookUsx).ToList();
+
+        IEnumerable<XElement> chaptersToProcess = bookUsx
+            .Elements("usx")
+            .Elements("chapter")
+            .Select(x => Chapter(x.Attribute("number")!.Value));
+
+        // SUT part 2
+        XDocument roundTrippedUsx = mapper.ToUsx(Usx(bookCode, bookDesc, usxVersion, chaptersToProcess), chapterDeltas);
+        bool didRoundtrip = XNode.DeepEquals(bookUsx, roundTrippedUsx);
+        errorMessage = null;
+        if (!didRoundtrip)
+        {
+            errorMessage = $"Trouble roundtripping {bookCode}.";
+            IEnumerable<int> invalidChapters = chapterDeltas
+                .Where((ChapterDelta cd) => !cd.IsValid)
+                .Select((ChapterDelta cd) => cd.Number);
+            if (invalidChapters.Any())
+                errorMessage += $" Note that the following chapters were invalid: {string.Join(" ", invalidChapters)}";
+        }
+        return didRoundtrip;
     }
 
     private static string GetPathToTestProject() =>

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
@@ -8,6 +8,9 @@ namespace SIL.XForge.Scripture.Services;
 
 public static class DeltaUsxTestExtensions
 {
+    /// <summary>
+    /// This method should be called when a paragraph _ends_, not begins.
+    /// </summary>
     public static Delta InsertPara(this Delta delta, string style, bool invalid = false)
     {
         var obj = new JObject(new JProperty("style", style));
@@ -168,6 +171,9 @@ public static class DeltaUsxTestExtensions
         return delta.InsertEmbed("ms", obj, segRef, attrs);
     }
 
+    /// <summary>
+    /// This is called _after_ a cell's contents, not before.
+    /// </summary>
     public static Delta InsertCell(
         this Delta delta,
         int table,


### PR DESCRIPTION
- test: DeltaUsxMapper: Broaden finding of sample sfm files
- test: DeltaUsxMapper: split out roundtrip tester
- doc: Add comments
- test: add more roundtrip tests
- SF-2485 Handle table followed by char formatting

I intend that these commits will all be squashed together when merged. But it may help to review them separately.

Some more problem explanation is in the commit message at the end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2339)
<!-- Reviewable:end -->
