### PR TITLE
SF-2464 Use Serval to check whether a language code is supported

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'draft_generation_steps'">
-  <ng-container *ngIf="availableTranslateBooks.length; else noAvailableBooks">
+  <ng-container *ngIf="availableTranslateBooks && availableTranslateBooks.length > 0">
     <mat-stepper orientation="vertical" linear (selectionChange)="onStepChange()">
       <mat-step [completed]="userSelectedTranslateBooks.length > 0">
         <ng-template matStepLabel>
@@ -92,7 +92,14 @@
     </mat-stepper>
   </ng-container>
 
-  <ng-template #noAvailableBooks>
+  <ng-container *ngIf="availableTranslateBooks && availableTranslateBooks.length <= 0">
     <p>{{ t("no_available_books") }}</p>
-  </ng-template>
+  </ng-container>
+
+  <ng-container *ngIf="availableTranslateBooks == null">
+    <div class="loading">
+      <mat-spinner [diameter]="20" color="primary"></mat-spinner>
+      <div>{{ t("loading") }}</div>
+    </div>
+  </ng-container>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -41,3 +41,11 @@ app-notice {
     display: flex;
   }
 }
+
+.loading {
+  display: flex;
+  margin: 1em;
+  mat-spinner {
+    margin-right: 1em;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -14,6 +14,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { NllbLanguageService } from '../../nllb-language.service';
 import { DraftGenerationStepsComponent, DraftGenerationStepsResult } from './draft-generation-steps.component';
 
 describe('DraftGenerationStepsComponent', () => {
@@ -23,6 +24,7 @@ describe('DraftGenerationStepsComponent', () => {
   const mockActivatedProjectService = mock(ActivatedProjectService);
   const mockFeatureFlagService = mock(FeatureFlagService);
   const mockProjectService = mock(SFProjectService);
+  const mockNllbLanguageService = mock(NllbLanguageService);
   const mockUserService = mock(UserService);
 
   const mockTargetProjectDoc = {
@@ -69,6 +71,7 @@ describe('DraftGenerationStepsComponent', () => {
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: FeatureFlagService, useMock: mockFeatureFlagService },
+      { provide: NllbLanguageService, useMock: mockNllbLanguageService },
       { provide: SFProjectService, useMock: mockProjectService },
       { provide: UserService, useMock: mockUserService }
     ]
@@ -127,6 +130,8 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
       when(mockProjectService.getProfile(anything())).thenResolve(mockSourceNonNllbProjectDoc);
+      when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
+      when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -38,7 +38,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   @Output() done = new EventEmitter<DraftGenerationStepsResult>();
   @ViewChild(MatStepper) stepper!: MatStepper;
 
-  availableTranslateBooks: number[] = [];
+  availableTranslateBooks?: number[] = undefined;
   availableTrainingBooks: number[] = [];
 
   // Unusable books do not exist in the corresponding drafting/training source project
@@ -79,7 +79,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         })
       ),
       // Build book lists
-      ({ target, source, alternateSource, alternateTrainingSource }) => {
+      async ({ target, source, alternateSource, alternateTrainingSource }) => {
         // The null values will have been filtered above
         target = target!;
         // Use the alternate source if specified, otherwise use the source
@@ -87,8 +87,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         // If both source and target project languages are in the NLLB,
         // training book selection is optional (and discouraged).
         this.isTrainingOptional =
-          this.nllbLanguageService.isNllbLanguage(target.writingSystem.tag) &&
-          this.nllbLanguageService.isNllbLanguage(draftingSource.writingSystem.tag);
+          (await this.nllbLanguageService.isNllbLanguageAsync(target.writingSystem.tag)) &&
+          (await this.nllbLanguageService.isNllbLanguageAsync(draftingSource.writingSystem.tag));
 
         const draftingSourceBooks = new Set<number>();
         let trainingSourceBooks = new Set<number>();
@@ -105,6 +105,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
           // If no training source project, use drafting source project books
           trainingSourceBooks = draftingSourceBooks;
         }
+
+        this.availableTranslateBooks = [];
 
         // If book exists in both target and source, add to available books.
         // Otherwise, add to unusable books.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -28,6 +28,7 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
+import { NllbLanguageService } from '../nllb-language.service';
 import { DraftGenerationComponent } from './draft-generation.component';
 import { DraftGenerationService } from './draft-generation.service';
 import { DraftSource, DraftSourcesService } from './draft-sources.service';
@@ -44,6 +45,7 @@ describe('DraftGenerationComponent', () => {
   let mockUserService: jasmine.SpyObj<UserService>;
   let mockI18nService: jasmine.SpyObj<I18nService>;
   let mockPreTranslationSignupUrlService: jasmine.SpyObj<PreTranslationSignupUrlService>;
+  let mockNllbLanguageService: jasmine.SpyObj<NllbLanguageService>;
 
   const buildDto: BuildDto = {
     id: 'testId',
@@ -99,6 +101,7 @@ describe('DraftGenerationComponent', () => {
           { provide: DialogService, useValue: mockDialogService },
           { provide: I18nService, useValue: mockI18nService },
           { provide: PreTranslationSignupUrlService, useValue: mockPreTranslationSignupUrlService },
+          { provide: NllbLanguageService, useValue: mockNllbLanguageService },
           { provide: OnlineStatusService, useClass: TestOnlineStatusService }
         ]
       });
@@ -163,6 +166,8 @@ describe('DraftGenerationComponent', () => {
       mockDraftGenerationService.getLastCompletedBuild.and.returnValue(of(buildDto));
       mockDraftSourcesService = jasmine.createSpyObj<DraftSourcesService>(['getDraftProjectSources']);
       mockDraftSourcesService.getDraftProjectSources.and.returnValue(of({}));
+      mockNllbLanguageService = jasmine.createSpyObj<NllbLanguageService>(['isNllbLanguageAsync']);
+      mockNllbLanguageService.isNllbLanguageAsync.and.returnValue(Promise.resolve(false));
     }
 
     get offlineTextElement(): HTMLElement | null {
@@ -194,7 +199,7 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.targetLanguage).toBe('en');
     });
 
-    it('should detect project requirements', () => {
+    it('should detect project requirements', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
           projectId: 'testProjectId',
@@ -211,13 +216,15 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
 
       expect(env.component.isBackTranslation).toBe(false);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.component.isSourceProjectSet).toBe(false);
-    });
+    }));
 
-    it('should detect source language same as target language', () => {
+    it('should detect source language same as target language', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
           projectId: 'testProjectId',
@@ -243,15 +250,17 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
 
       expect(env.component.isBackTranslation).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.component.isSourceProjectSet).toBe(true);
       expect(env.component.isSourceAndTargetDifferent).toBe(false);
       expect(env.component.isSourceAndTrainingSourceLanguageIdentical).toBe(true);
-    });
+    }));
 
-    it('should detect alternate training source language when different to alternate source language', () => {
+    it('should detect alternate training source language when different to alternate source language', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
           projectId: 'testProjectId',
@@ -289,15 +298,17 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
 
       expect(env.component.isBackTranslation).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.component.isSourceProjectSet).toBe(true);
       expect(env.component.isSourceAndTargetDifferent).toBe(true);
       expect(env.component.isSourceAndTrainingSourceLanguageIdentical).toBe(false);
-    });
+    }));
 
-    it('should detect alternate training source language when different to source language', () => {
+    it('should detect alternate training source language when different to source language', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
           projectId: 'testProjectId',
@@ -329,15 +340,17 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
 
       expect(env.component.isBackTranslation).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.component.isSourceProjectSet).toBe(true);
       expect(env.component.isSourceAndTargetDifferent).toBe(true);
       expect(env.component.isSourceAndTrainingSourceLanguageIdentical).toBe(false);
-    });
+    }));
 
-    it('should not detect alternate training source language as different when enabled but null', () => {
+    it('should not detect alternate training source language as different when enabled but null', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
           projectId: 'testProjectId',
@@ -363,13 +376,15 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
 
       expect(env.component.isBackTranslation).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.component.isSourceProjectSet).toBe(true);
       expect(env.component.isSourceAndTargetDifferent).toBe(true);
       expect(env.component.isSourceAndTrainingSourceLanguageIdentical).toBe(true);
-    });
+    }));
   });
 
   describe('Online status', () => {
@@ -993,7 +1008,7 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isTargetLanguageSupported).toBe(true);
     });
 
-    it('should enforce supported language for back translations even when forward translation feature flag is set', () => {
+    it('should enforce supported language for back translations even when forward translation feature flag is set', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
           'FeatureFlagService',
@@ -1022,10 +1037,12 @@ describe('DraftGenerationComponent', () => {
           })
         });
       });
+      env.fixture.detectChanges();
+      tick();
       expect(env.component.isForwardTranslationEnabled).toBe(true);
       expect(env.component.isBackTranslationMode).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(false);
-    });
+    }));
   });
 
   describe('navigateToTab', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -223,7 +223,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
       ]),
       async () => {
         this.isTargetLanguageSupported =
-          !this.isBackTranslationMode || this.nllbService.isNllbLanguage(this.targetLanguage);
+          !this.isBackTranslationMode || (await this.nllbService.isNllbLanguageAsync(this.targetLanguage));
 
         if (!this.isBackTranslationMode && !this.isPreTranslationApproved) {
           this.signupFormUrl = await this.preTranslationSignupUrlService.generateSignupUrl();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.spec.ts
@@ -2,11 +2,11 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { HttpClient } from 'src/app/machine-api/http-client';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { HttpClient } from '../machine-api/http-client';
 import { NllbLanguageService } from './nllb-language.service';
 import { NLLB_LANGUAGES } from './nllb-languages';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.spec.ts
@@ -1,11 +1,26 @@
-import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { HttpClient } from 'src/app/machine-api/http-client';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { NllbLanguageService } from './nllb-language.service';
 import { NLLB_LANGUAGES } from './nllb-languages';
 
 describe('NllbLanguageService', () => {
   let service: NllbLanguageService;
+  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
+  let mockErrorReportingService: jasmine.SpyObj<ErrorReportingService>;
+  let testOnlineStatusService: TestOnlineStatusService;
+
   beforeEach(() => {
+    mockErrorReportingService = jasmine.createSpyObj<ErrorReportingService>(['silentError']);
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, TestOnlineStatusModule.forRoot()],
       providers: [
         NllbLanguageService,
         {
@@ -18,54 +33,103 @@ describe('NllbLanguageService', () => {
               iso639_2b: 'eng'
             }
           }
-        }
+        },
+        { provide: ErrorReportingService, useValue: mockErrorReportingService },
+        { provide: HttpClient, useValue: { get: () => of({}) } },
+        { provide: OnlineStatusService, useClass: TestOnlineStatusService }
       ]
     });
     service = TestBed.inject(NllbLanguageService);
+    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    testOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
   });
 
-  describe('isNllbLanguage', () => {
-    it('should return true for valid two-letter NLLB language code', () => {
-      expect(service.isNllbLanguage('en')).toBe(true);
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('isLanguageSupportedAsync', () => {
+    beforeEach(() => {
+      testOnlineStatusService.setIsOnline(true);
     });
 
-    it('should return true for valid three-letter NLLB language code', () => {
-      expect(service.isNllbLanguage('eng')).toBe(true);
+    afterEach(() => {
+      expect(httpClient.get).toHaveBeenCalled();
     });
 
-    it('should return false for invalid two-letter NLLB language code', () => {
-      expect(service.isNllbLanguage('xy')).toBe(false);
+    it('should call the API', async () => {
+      httpClient.get = jasmine.createSpy().and.returnValue(of({ data: { isSupported: true, languageCode: 'abc' } }));
+      expect(await service.isNllbLanguageAsync('not_in_local_database')).toBe(true);
     });
 
-    it('should return false for invalid three-letter NLLB language code', () => {
-      expect(service.isNllbLanguage('xyz')).toBe(false);
+    it('should fallback to isNllbLanguage on error', fakeAsync(async () => {
+      httpClient.get = jasmine.createSpy().and.returnValue(
+        throwError(() => {
+          new HttpErrorResponse({ status: 503 });
+        })
+      );
+      expect(await service.isNllbLanguageAsync('en')).toBe(true);
+      expect(mockErrorReportingService.silentError).toHaveBeenCalled();
+    }));
+
+    it('should fallback to isNllbLanguage on empty value', async () => {
+      httpClient.get = jasmine.createSpy().and.returnValue(of({ data: {} }));
+      expect(await service.isNllbLanguageAsync('en')).toBe(true);
+    });
+  });
+
+  describe('isNllbLanguage fallback', () => {
+    beforeEach(() => {
+      httpClient.get = jasmine.createSpy().and.returnValue(of({}));
+      testOnlineStatusService.setIsOnline(false);
     });
 
-    it('should return false for invalid length NLLB language code', () => {
-      expect(service.isNllbLanguage('engl')).toBe(false);
-      expect(service.isNllbLanguage('e')).toBe(false);
+    afterEach(() => {
+      expect(httpClient.get).not.toHaveBeenCalled();
     });
 
-    it('should return false for blank, null, or undefined language code', () => {
-      expect(service.isNllbLanguage('')).toBe(false);
-      expect(service.isNllbLanguage(null)).toBe(false);
-      expect(service.isNllbLanguage(undefined)).toBe(false);
+    it('should return true for valid two-letter NLLB language code', async () => {
+      expect(await service.isNllbLanguageAsync('en')).toBe(true);
     });
 
-    it('should return true for valid two-letter NLLB language code with culture (hyphen delimited)', () => {
-      expect(service.isNllbLanguage('en-Latn-GB')).toBe(true);
+    it('should return true for valid three-letter NLLB language code', async () => {
+      expect(await service.isNllbLanguageAsync('eng')).toBe(true);
     });
 
-    it('should return false for invalid two-letter NLLB language code with culture (hyphen delimited)', () => {
-      expect(service.isNllbLanguage('xy-Latn-GB')).toBe(false);
+    it('should return false for invalid two-letter NLLB language code', async () => {
+      expect(await service.isNllbLanguageAsync('xy')).toBe(false);
     });
 
-    it('should return true for valid two-letter NLLB language code with culture (underscore delimited)', () => {
-      expect(service.isNllbLanguage('en_Latn_GB')).toBe(true);
+    it('should return false for invalid three-letter NLLB language code', async () => {
+      expect(await service.isNllbLanguageAsync('xyz')).toBe(false);
     });
 
-    it('should return false for invalid two-letter NLLB language code with culture (underscore delimited)', () => {
-      expect(service.isNllbLanguage('xy_Latn_GB')).toBe(false);
+    it('should return false for invalid length NLLB language code', async () => {
+      expect(await service.isNllbLanguageAsync('engl')).toBe(false);
+      expect(await service.isNllbLanguageAsync('e')).toBe(false);
+    });
+
+    it('should return false for blank, null, or undefined language code', async () => {
+      expect(await service.isNllbLanguageAsync('')).toBe(false);
+      expect(await service.isNllbLanguageAsync(null)).toBe(false);
+      expect(await service.isNllbLanguageAsync(undefined)).toBe(false);
+    });
+
+    it('should return true for valid two-letter NLLB language code with culture (hyphen delimited)', async () => {
+      expect(await service.isNllbLanguageAsync('en-Latn-GB')).toBe(true);
+    });
+
+    it('should return false for invalid two-letter NLLB language code with culture (hyphen delimited)', async () => {
+      expect(await service.isNllbLanguageAsync('xy-Latn-GB')).toBe(false);
+    });
+
+    it('should return true for valid two-letter NLLB language code with culture (underscore delimited)', async () => {
+      expect(await service.isNllbLanguageAsync('en_Latn_GB')).toBe(true);
+    });
+
+    it('should return false for invalid two-letter NLLB language code with culture (underscore delimited)', async () => {
+      expect(await service.isNllbLanguageAsync('xy_Latn_GB')).toBe(false);
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/nllb-language.service.ts
@@ -1,5 +1,14 @@
 import { Inject, Injectable } from '@angular/core';
+import { catchError, lastValueFrom, map, of } from 'rxjs';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { HttpClient } from '../machine-api/http-client';
 import { NllbLanguage, NllbLanguageDict, NLLB_LANGUAGES } from './nllb-languages';
+
+interface LanguageDto {
+  isSupported: boolean;
+  languageCode: string;
+}
 
 /**
  * Methods for working with the No Language Left Behind (NLLB) language codes.
@@ -8,7 +17,41 @@ import { NllbLanguage, NllbLanguageDict, NLLB_LANGUAGES } from './nllb-languages
   providedIn: 'root'
 })
 export class NllbLanguageService {
-  constructor(@Inject(NLLB_LANGUAGES) private readonly nllbLanguages: NllbLanguageDict) {}
+  constructor(
+    private readonly errorReportingService: ErrorReportingService,
+    private readonly httpClient: HttpClient,
+    @Inject(NLLB_LANGUAGES) private readonly nllbLanguages: NllbLanguageDict,
+    private readonly onlineStatusService: OnlineStatusService
+  ) {}
+
+  async isNllbLanguageAsync(languageCode: string | null | undefined): Promise<boolean> {
+    if (languageCode != null && this.onlineStatusService.isOnline) {
+      return await this.isLanguageSupportedAsync(languageCode);
+    } else {
+      return this.isNllbLanguage(languageCode);
+    }
+  }
+
+  /**
+   * Queries Serval to see if the language code is supported, and falls back to the local language database.
+   * @param languageCode The language code.
+   * @returns `true` if the language code is supported; `false` if not; and `undefined` on error.
+   */
+  private async isLanguageSupportedAsync(languageCode: string): Promise<boolean> {
+    const response = await lastValueFrom(
+      this.httpClient.get<LanguageDto>(`translation/languages/${encodeURIComponent(languageCode)}`).pipe(
+        map(res => res.data),
+        catchError(err => {
+          this.errorReportingService.silentError(
+            'Error while determining if language is supported',
+            ErrorReportingService.normalizeError(err)
+          );
+          return of({ isSupported: this.isNllbLanguage(languageCode) } as LanguageDto);
+        })
+      )
+    );
+    return response?.isSupported ?? this.isNllbLanguage(languageCode);
+  }
 
   /**
    * Whether the supplied language code is either a ISO 369-1 (two-letter)
@@ -17,7 +60,7 @@ export class NllbLanguageService {
    * culture information attached with hyphens or underscores ('en-Latn-GB').
    * @returns `true` if language code is in the list of NLLB languages.
    */
-  isNllbLanguage(languageCode: string | null | undefined): boolean {
+  private isNllbLanguage(languageCode: string | null | undefined): boolean {
     if (languageCode == null || languageCode.length < 2) {
       return false;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -192,6 +192,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Loading...",
     "next": "Next",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_es.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_es.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generar borrador",
+    "loading": "Cargando...",
     "next": "Siguiente",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_fr.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_fr.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Activer ceci permettra de gagner du temps mais réduira considérablement la précision.",
     "fast_training": "Permettre une formation rapide",
     "generate_draft": "Générer un brouillon",
+    "loading": "Chargement...",
     "next": "Suivant",
     "no_available_books": "Vous n'avez pas de livres disponibles pour l'ébauchage.",
     "these_books_cannot_be_used_for_training": "Les livres suivants ne peuvent pas être utilisés pour la formation car ils ne sont pas dans le texte source de la formation ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_id.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_id.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Buat konsep",
+    "loading": "Memuat...",
     "next": "Berikutnya",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Loading...",
     "next": "ꤘꤣꤋꤛꤢꤩ꤭ꤕꤟꤥ",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Loading...",
     "next": "ຕໍ່ໄປ",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Carregando...",
     "next": "Próximo",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Se încarcă...",
     "next": "Următor",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Загрузка...",
     "next": "Далее",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
@@ -182,6 +182,7 @@
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
     "generate_draft": "Generate draft",
+    "loading": "Loading...",
     "next": "下一个",
     "no_available_books": "You have no books available for drafting.",
     "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -343,6 +343,31 @@ public class MachineApiController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves information on whether a language is supported by Serval.
+    /// </summary>
+    /// <param name="languageCode">The language code.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The language information was successfully retrieved.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
+    [HttpGet(MachineApi.IsLanguageSupported)]
+    public async Task<ActionResult<LanguageDto>> IsLanguageSupportedAsync(
+        string languageCode,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            LanguageDto language = await _machineApiService.IsLanguageSupportedAsync(languageCode, cancellationToken);
+            return Ok(language);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+    }
+
+    /// <summary>
     /// Starts a build job for a translation engine.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>

--- a/src/SIL.XForge.Scripture/Models/LanguageDto.cs
+++ b/src/SIL.XForge.Scripture/Models/LanguageDto.cs
@@ -1,0 +1,17 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A DTO for the Machine API returning whether a language is supported by Serval.
+/// </summary>
+public class LanguageDto
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the language is natively supported by Serval.
+    /// </summary>
+    public bool IsSupported { get; set; }
+
+    /// <summary>
+    /// Gets or sets the language code that Serval will use internally.
+    /// </summary>
+    public string LanguageCode { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -11,6 +11,7 @@ public static class MachineApi
     public const string GetBuild = "translation/builds/id:{sfProjectId}.{buildId?}";
     public const string GetEngine = "translation/engines/project:{sfProjectId}";
     public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";
+    public const string IsLanguageSupported = "translation/languages/{languageCode}";
     public const string TrainSegment = "translation/engines/project:{sfProjectId}/actions/trainSegment";
     public const string Translate = "translation/engines/project:{sfProjectId}/actions/translate";
     public const string TranslateN = "translation/engines/project:{sfProjectId}/actions/translate/{n}";

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -36,7 +36,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />
-    <PackageReference Include="Serval.Client" Version="1.2.0" />
+    <PackageReference Include="Serval.Client" Version="1.2.0.1" />
     <PackageReference Include="SIL.Machine.WebApi" Version="$(MachineVersion)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -48,6 +48,7 @@ public interface IMachineApiService
         string segment,
         CancellationToken cancellationToken
     );
+    Task<LanguageDto> IsLanguageSupportedAsync(string languageCode, CancellationToken cancellationToken);
     Task<ServalBuildDto> StartBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
     Task StartPreTranslationBuildAsync(string curUserId, BuildConfig buildConfig, CancellationToken cancellationToken);
     Task TrainSegmentAsync(

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -25,6 +25,7 @@ public interface IMachineProjectService
         bool preTranslate,
         CancellationToken cancellationToken
     );
+    Task<string> GetTranslationEngineTypeAsync(bool preTranslate);
     Task RemoveProjectAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -36,11 +36,11 @@ namespace SIL.XForge.Scripture.Services;
 /// </summary>
 public class MachineProjectService : IMachineProjectService
 {
-    // Supported translation engines (Serval 1.1 format)
+    // Supported translation engines (Serval 1.2 format)
     // Serval 1.2 accepts the translation engine type in 1.1 (PascalCase) and 1.2 (kebab-case) format
-    internal const string Echo = "Echo";
-    internal const string Nmt = "Nmt";
-    internal const string SmtTransfer = "SmtTransfer";
+    internal const string Echo = "echo";
+    internal const string Nmt = "nmt";
+    internal const string SmtTransfer = "smt-transfer";
 
     private readonly IDataFilesClient _dataFilesClient;
     private readonly IEngineService _engineService;
@@ -445,6 +445,22 @@ public class MachineProjectService : IMachineProjectService
                 }
             );
         }
+    }
+
+    /// <summary>
+    /// Gets the translation engine type string for Serval.
+    /// </summary>
+    /// <param name="preTranslate">If <c>true</c>, then the translation engine is for pre-translation.</param>
+    /// <returns>The translation engine type string for Serval.</returns>
+    public async Task<string> GetTranslationEngineTypeAsync(bool preTranslate)
+    {
+        bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
+        return preTranslate switch
+        {
+            true when useEcho => Echo,
+            true => Nmt,
+            false => SmtTransfer,
+        };
     }
 
     public async Task RemoveProjectAsync(
@@ -1289,22 +1305,6 @@ public class MachineProjectService : IMachineProjectService
         // Echo requires the target and source language to be the same, as it outputs your source texts
         bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
         return useEcho ? GetSourceLanguage(project, useAlternateTrainingSource: false) : project.WritingSystem.Tag;
-    }
-
-    /// <summary>
-    /// Gets the translation engine type string for Serval.
-    /// </summary>
-    /// <param name="preTranslate">If <c>true</c>, then the translation engine is for pre-translation.</param>
-    /// <returns>The translation engine type string for Serval.</returns>
-    private async Task<string> GetTranslationEngineTypeAsync(bool preTranslate)
-    {
-        bool useEcho = await _featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
-        return preTranslate switch
-        {
-            true when useEcho => Echo,
-            true => Nmt,
-            false => SmtTransfer,
-        };
     }
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -87,6 +87,13 @@ public static class MachineServiceCollectionExtensions
             var httpClient = factory.CreateClient(MachineApi.HttpClientName);
             return new TranslationEnginesClient(httpClient);
         });
+        services.AddSingleton<ITranslationEngineTypesClient, TranslationEngineTypesClient>(sp =>
+        {
+            // Instantiate the translation engines client with our named HTTP client
+            var factory = sp.GetService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient(MachineApi.HttpClientName);
+            return new TranslationEngineTypesClient(httpClient);
+        });
         services.AddSingleton<IDataFilesClient, DataFilesClient>(sp =>
         {
             // Instantiate the data files client with our named HTTP client

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -972,6 +972,36 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    public async Task GetTranslationEngineTypeAsync_Echo()
+    {
+        var env = new TestEnvironment(new TestEnvironmentOptions { UseEchoForPreTranslation = true });
+
+        // SUT
+        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: true);
+        Assert.AreEqual(MachineProjectService.Echo, actual);
+    }
+
+    [Test]
+    public async Task GetTranslationEngineTypeAsync_Nmt()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: true);
+        Assert.AreEqual(MachineProjectService.Nmt, actual);
+    }
+
+    [Test]
+    public async Task GetTranslationEngineTypeAsync_Smt()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: false);
+        Assert.AreEqual(MachineProjectService.SmtTransfer, actual);
+    }
+
+    [Test]
     public void RemoveProjectAsync_ThrowsExceptionWhenProjectSecretMissing()
     {
         // Set up test environment


### PR DESCRIPTION
This PR adds a new API endpoint that queries Serval to determine if a language is supported by Serval or not.

When there are connection issues, fallback to the NLLB database in SF occurs. This database has not been removed, because it is still used to display the list of supported languages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2342)
<!-- Reviewable:end -->
