### PR TITLE
SF-1622 Restart Realtime Server

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -140,6 +140,10 @@ export = {
     callback(undefined, {});
   },
 
+  isServerRunning: (callback: InteropCallback): void => {
+    callback(undefined, !(server == null));
+  },
+
   connect: (callback: InteropCallback, userId?: string): void => {
     if (server == null) {
       callback(new Error('Server not started.'));

--- a/src/SIL.XForge/Realtime/DeleteOnSuccessAttribute.cs
+++ b/src/SIL.XForge/Realtime/DeleteOnSuccessAttribute.cs
@@ -1,0 +1,18 @@
+using Hangfire.Common;
+using Hangfire.States;
+
+namespace SIL.XForge.Realtime;
+
+/// <summary>
+/// Clear out ping checks for the Realtime Server from the Hangfire jobs list
+/// </summary>
+public class DeleteOnSuccess : JobFilterAttribute, IElectStateFilter
+{
+    public void OnStateElection(ElectStateContext context)
+    {
+        if (context.CandidateState.Name == SucceededState.StateName)
+        {
+            context.CandidateState = new DeletedState { Reason = "Deleted automatically when succeeded.", };
+        }
+    }
+}

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -18,5 +18,7 @@ public interface IRealtimeServer
     Task<Op[]> GetOpsAsync(string collection, string id);
     void Start(object options);
     void Stop();
+    bool IsServerRunning();
+    bool Restart(object options);
     Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op);
 }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -34,6 +34,21 @@ public class RealtimeServer : IRealtimeServer
         _started = false;
     }
 
+    public bool IsServerRunning()
+    {
+        if (!_started)
+            return false;
+
+        return InvokeExportAsync<bool>("isServerRunning").GetAwaiter().GetResult();
+    }
+
+    public bool Restart(object options)
+    {
+        _started = false;
+        Start(options);
+        return IsServerRunning();
+    }
+
     public Task<int> ConnectAsync(string? userId = null)
     {
         if (userId != null)

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -87,6 +87,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
         }
     }
 
+    [DeleteOnSuccess]
     public void CheckIfRunning()
     {
         if (!Server.IsServerRunning())

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -266,7 +266,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
 
     private void RestartServer()
     {
-        Console.WriteLine("Attempting to restart Realtime Server");
+        Console.WriteLine("Attempting to restart the Realtime Server");
         string restartResponse;
         if (Server.Restart(CreateOptions()))
         {

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -19,6 +20,7 @@ namespace SIL.XForge.Realtime;
 public class RealtimeService : DisposableBase, IRealtimeService
 {
     private readonly IOptions<SiteOptions> _siteOptions;
+    private readonly IRecurringJobManager _recurringJobManager;
     private readonly IOptions<DataAccessOptions> _dataAccessOptions;
     private readonly IOptions<RealtimeOptions> _realtimeOptions;
     private readonly IOptions<AuthOptions> _authOptions;
@@ -28,6 +30,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
 
     public RealtimeService(
         IRealtimeServer server,
+        IRecurringJobManager recurringJobManager,
         IOptions<SiteOptions> siteOptions,
         IOptions<DataAccessOptions> dataAccessOptions,
         IOptions<RealtimeOptions> realtimeOptions,
@@ -37,6 +40,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
     )
     {
         Server = server;
+        _recurringJobManager = recurringJobManager;
         _siteOptions = siteOptions;
         _dataAccessOptions = dataAccessOptions;
         _realtimeOptions = realtimeOptions;
@@ -66,6 +70,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
         {
             object options = CreateOptions();
             Server.Start(options);
+            _recurringJobManager.AddOrUpdate("ping_service", () => CheckIfRunning(), Cron.Minutely);
         }
     }
 
@@ -74,7 +79,14 @@ public class RealtimeService : DisposableBase, IRealtimeService
         if (!_realtimeOptions.Value.UseExistingRealtimeServer)
         {
             Server.Stop();
+            _recurringJobManager.RemoveIfExists("ping_service");
         }
+    }
+
+    public void CheckIfRunning()
+    {
+        if (!Server.IsServerRunning())
+            RestartServer();
     }
 
     public async Task<IConnection> ConnectAsync(string userId = null)
@@ -248,6 +260,15 @@ public class RealtimeService : DisposableBase, IRealtimeService
         await milestonesCollection.DeleteManyAsync(dFilter);
     }
 
+    private void RestartServer()
+    {
+        Console.WriteLine("Attempting to restart Realtime Server");
+        if (Server.Restart(CreateOptions()))
+            Console.WriteLine("Successfully restarted the Realtime Server");
+        else
+            Console.WriteLine("Failed to restart the Realtime Server");
+    }
+
     private object CreateOptions()
     {
         string mongo = $"{_dataAccessOptions.Value.ConnectionString}/{_dataAccessOptions.Value.MongoDatabaseName}";
@@ -259,12 +280,12 @@ public class RealtimeService : DisposableBase, IRealtimeService
             Authority = $"https://{_authOptions.Value.Domain}/",
             _authOptions.Value.Audience,
             _authOptions.Value.Scope,
-            Origin = this._configuration.GetValue<string>("Site:Origin"),
-            BugsnagApiKey = this._configuration.GetValue<string>("Bugsnag:ApiKey"),
-            ReleaseStage = this._configuration.GetValue<string>("Bugsnag:ReleaseStage"),
-            this._realtimeOptions.Value.MigrationsDisabled,
-            this._realtimeOptions.Value.DataValidationDisabled,
-            SiteId = this._siteOptions.Value.Id,
+            Origin = _configuration.GetValue<string>("Site:Origin"),
+            BugsnagApiKey = _configuration.GetValue<string>("Bugsnag:ApiKey"),
+            ReleaseStage = _configuration.GetValue<string>("Bugsnag:ReleaseStage"),
+            _realtimeOptions.Value.MigrationsDisabled,
+            _realtimeOptions.Value.DataValidationDisabled,
+            SiteId = _siteOptions.Value.Id,
             Product.Version,
         };
     }

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -575,7 +575,7 @@ public class ConnectionTests
         public TestEnvironment(bool documentCacheDisabled = false)
         {
             var realtimeServer = Substitute.For<IRealtimeServer>();
-            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
+            IExceptionHandler exceptionHandler = Substitute.For<IExceptionHandler>();
             var siteOptions = Options.Create(Substitute.For<SiteOptions>());
             var dataAccessOptions = Options.Create(Substitute.For<DataAccessOptions>());
             var realtimeOptions = Options.Create(
@@ -588,15 +588,17 @@ public class ConnectionTests
             );
             var authOptions = Options.Create(Substitute.For<AuthOptions>());
             var mongoClient = Substitute.For<IMongoClient>();
+            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
             var configuration = Substitute.For<IConfiguration>();
             RealtimeService = new RealtimeService(
                 realtimeServer,
-                recurringJobManager,
+                exceptionHandler,
                 siteOptions,
                 dataAccessOptions,
                 realtimeOptions,
                 authOptions,
                 mongoClient,
+                recurringJobManager,
                 configuration
             );
             Service = new Connection(RealtimeService, documentCacheDisabled);

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.Extensions.Configuration;
 using MongoDB.Driver;
 using NSubstitute;
@@ -574,6 +575,7 @@ public class ConnectionTests
         public TestEnvironment(bool documentCacheDisabled = false)
         {
             var realtimeServer = Substitute.For<IRealtimeServer>();
+            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
             var siteOptions = Options.Create(Substitute.For<SiteOptions>());
             var dataAccessOptions = Options.Create(Substitute.For<DataAccessOptions>());
             var realtimeOptions = Options.Create(
@@ -589,6 +591,7 @@ public class ConnectionTests
             var configuration = Substitute.For<IConfiguration>();
             RealtimeService = new RealtimeService(
                 realtimeServer,
+                recurringJobManager,
                 siteOptions,
                 dataAccessOptions,
                 realtimeOptions,

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -206,7 +206,7 @@ public class RealtimeServiceTests
         public TestEnvironment()
         {
             IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
-            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
+            IExceptionHandler exceptionHandler = Substitute.For<IExceptionHandler>();
             IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
             IOptions<DataAccessOptions> dataAccessOptions = Microsoft.Extensions.Options.Options.Create(
                 new DataAccessOptions { MongoDatabaseName = "mongoDatabaseName" }
@@ -227,17 +227,19 @@ public class RealtimeServiceTests
             IOptions<AuthOptions> authOptions = Substitute.For<IOptions<AuthOptions>>();
 
             IMongoClient mongoClient = Substitute.For<IMongoClient>();
+            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
             mongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
             IConfiguration configuration = Substitute.For<IConfiguration>();
 
             Service = new RealtimeService(
                 realtimeServer,
-                recurringJobManager,
+                exceptionHandler,
                 siteOptions,
                 dataAccessOptions,
                 realtimeOptions,
                 authOptions,
                 mongoClient,
+                recurringJobManager,
                 configuration
             );
         }

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -205,6 +206,7 @@ public class RealtimeServiceTests
         public TestEnvironment()
         {
             IRealtimeServer realtimeServer = Substitute.For<IRealtimeServer>();
+            IRecurringJobManager recurringJobManager = Substitute.For<IRecurringJobManager>();
             IOptions<SiteOptions> siteOptions = Substitute.For<IOptions<SiteOptions>>();
             IOptions<DataAccessOptions> dataAccessOptions = Microsoft.Extensions.Options.Options.Create(
                 new DataAccessOptions { MongoDatabaseName = "mongoDatabaseName" }
@@ -230,6 +232,7 @@ public class RealtimeServiceTests
 
             Service = new RealtimeService(
                 realtimeServer,
+                recurringJobManager,
                 siteOptions,
                 dataAccessOptions,
                 realtimeOptions,

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -286,7 +286,7 @@ public class RealtimeServiceTests
 
     private class TestEnvironment
     {
-        public IExceptionHandler ExceptionHandler;
+        public readonly IExceptionHandler ExceptionHandler;
         public readonly RealtimeService Service;
         public readonly IMongoDatabase MongoDatabase = Substitute.For<IMongoDatabase>();
 


### PR DESCRIPTION
Implements a simple scheduled check to the realtime server to see if the server is not null and attempts to restart it if required.

**Acceptance tests**
1. Start a sync
2. Kill the realtime server node process
3. Observe SF displays the broken offline icon on the avatar
4. Wait for one minute
5. Observe SF has come back online

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2343)
<!-- Reviewable:end -->
