### PR TITLE
SF-2563 Fix issues with Serval Alternate Training Sources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1025,6 +1025,10 @@ public class MachineProjectService : IMachineProjectService
             FeatureFlags.UploadParatextZipForPreTranslation
         );
 
+        // See if there is an alternate training source corpus
+        bool useAlternateTrainingSource =
+            draftConfig.AlternateTrainingSourceEnabled && draftConfig.AlternateTrainingSource is not null;
+
         // Set up the pre-translation and training corpora
         List<PretranslateCorpusConfig> preTranslate = new List<PretranslateCorpusConfig>();
         List<TrainingCorpusConfig>? trainOn = null;
@@ -1044,7 +1048,7 @@ public class MachineProjectService : IMachineProjectService
                 // Since all books are uploaded via the zip file, we need to specify the target books to translate
                 preTranslateCorpusConfig.TextIds = buildConfig.TranslationBooks.Select(Canon.BookNumberToId).ToList();
 
-                if (!draftConfig.AlternateTrainingSourceEnabled)
+                if (!useAlternateTrainingSource)
                 {
                     // As we do not have an alternate train on source specified, use the source texts to train on
                     trainOn ??= new List<TrainingCorpusConfig>();
@@ -1062,9 +1066,9 @@ public class MachineProjectService : IMachineProjectService
         }
 
         // Add the alternate training source, if enabled
-        if (draftConfig.AlternateTrainingSourceEnabled)
+        if (useAlternateTrainingSource)
         {
-            trainOn = new List<TrainingCorpusConfig>();
+            trainOn = [];
             foreach (
                 KeyValuePair<string, ServalCorpus> corpus in servalData.Corpora.Where(
                     s => s.Value.PreTranslate && s.Value.AlternateTrainingSource


### PR DESCRIPTION
This PR fixes two issues discovered with SF's sending and specifying of alternate training sources to Serval:

- When the "use alternate training source" checkbox is checked but no source is selected, the `train_on` parameter is misconfigured, resulting in an error on Serval.
- When an alternate training source is configured, then disabled, the corpus remains on Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2344)
<!-- Reviewable:end -->
