### PR TITLE
SF-2550 Disable In-Process Machine across all environments

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -60,7 +60,7 @@
   },
   "FeatureManagement": {
     "Serval": true,
-    "MachineInProcess": true,
+    "MachineInProcess": false,
     "UploadParatextZipForPreTranslation": false,
     "UseEchoForPreTranslation": false
   }


### PR DESCRIPTION
This PR changes the default feature flag configuration to disable In-Process Machine support, to reflect that In-Process Machine should be off permanently now for every environment.

A PR will follow later that complete removes code that references in the In-Process machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2345)
<!-- Reviewable:end -->
