### PR TITLE
SF-2636 Add preliminary font support

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -6,7 +6,7 @@ quill-editor {
   height: 100%;
   > .ql-container {
     > .ql-editor {
-      font-family: Roboto, 'Noto Sans Kayah Li', sans-serif;
+      font-family: Roboto, sans-serif;
       line-height: 1.6;
       width: 100%;
       word-break: break-word;
@@ -33,7 +33,7 @@ quill-editor {
 .read-only-editor > .ql-container {
   > .ql-editor {
     usx-segment {
-      padding: 0.2em 0;
+      line-height: 1.8;
     }
 
     .highlight-segment {
@@ -278,4 +278,12 @@ quill-editor.rtl .highlight-para usx-segment:first-child:before {
 usx-segment.draft {
   color: $draft-color;
   font-style: italic;
+}
+
+usx-segment {
+  font-family: var(--project-font);
+  &::before,
+  &::after {
+    font-family: Roboto, sans-serif;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.html
@@ -6,4 +6,5 @@
   (loaded)="onLoaded()"
   [isRightToLeft]="isRightToLeft"
   [fontSize]="fontSize"
+  [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
 ></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -5,6 +5,8 @@ import isEqual from 'lodash-es/isEqual';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { fromEvent, Subscription } from 'rxjs';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
+import { FontService } from 'xforge-common/font.service';
 import { TextDocId } from '../../../core/models/text-doc';
 import { TextComponent } from '../../../shared/text/text.component';
 import { getVerseStrFromSegmentRef, verseRefFromMouseEvent } from '../../../shared/utils';
@@ -19,6 +21,7 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   @Output() questionVerseSelected = new EventEmitter<VerseRef>();
   @Input() isRightToLeft: boolean = false;
   @Input() fontSize?: string;
+  @Input() projectDoc?: SFProjectProfileDoc;
 
   private clickSubs: Subscription[] = [];
   private _activeVerse?: VerseRef;
@@ -26,6 +29,10 @@ export class CheckingTextComponent extends SubscriptionDisposable {
   private _id?: TextDocId;
   private _questionVerses?: VerseRef[];
   private _placeholder?: string;
+
+  constructor(readonly fontService: FontService) {
+    super();
+  }
 
   @Input() set placeholder(value: string) {
     this._placeholder = value;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -145,6 +145,7 @@
                     (questionVerseSelected)="verseRefClicked($event)"
                     [isRightToLeft]="isRightToLeft"
                     [class.hidden]="hideChapterText"
+                    [projectDoc]="projectDoc"
                   ></app-checking-text>
                 </div>
                 <div class="scripture-audio-player-wrapper" *ngIf="showScriptureAudioPlayer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -94,6 +94,7 @@
                     (updated)="onSourceUpdated($event.delta != null)"
                     [isRightToLeft]="isSourceRightToLeft"
                     [fontSize]="sourceFontSize"
+                    [style.--project-font]="fontService.getFontFamilyFromProject(sourceProjectDoc)"
                   ></app-text>
                 </div>
               </as-split-area>
@@ -177,6 +178,7 @@
                     [fontSize]="fontSize"
                     [selectableVerses]="showAddCommentUI"
                     [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
+                    [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
                   ></app-text>
                   <app-suggestions
                     class="mat-elevation-z2"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -91,6 +91,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { getLinkHTML, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
+import { FontService } from 'xforge-common/font.service';
 import { environment } from '../../../environments/environment';
 import { isString } from '../../../type-utils';
 import { defaultNoteThreadIcon, NoteThreadDoc, NoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -204,7 +205,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private insertSuggestionEnd: number = -1;
   private bottomSheetRef?: MatBottomSheetRef;
   private currentUserDoc?: UserDoc;
-  private projectDoc?: SFProjectProfileDoc;
+  projectDoc?: SFProjectProfileDoc;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private paratextUsers: ParatextUserProfile[] = [];
   private projectUserConfigChangesSub?: Subscription;
@@ -212,7 +213,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private targetLabel?: string;
   private text?: TextInfo;
   private sourceText?: TextInfo;
-  private sourceProjectDoc?: SFProjectProfileDoc;
+  sourceProjectDoc?: SFProjectProfileDoc;
   private sourceLoaded: boolean = false;
   private targetLoaded: boolean = false;
   private _targetFocused: boolean = false;
@@ -248,6 +249,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly onlineStatusService: OnlineStatusService,
     private readonly translationEngineService: TranslationEngineService,
     readonly i18n: I18nService,
+    readonly fontService: FontService,
     readonly featureFlags: FeatureFlagService,
     private readonly reportingService: ErrorReportingService,
     private readonly activatedProject: ActivatedProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/index.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/index.html
@@ -12,10 +12,7 @@
     </script>
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+Kayah+Li&family=Roboto:wght@300;400;500&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
     <meta charset="utf-8" />
     <title>Scripture Forge</title>
     <base href="/" />

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.spec.ts
@@ -1,0 +1,58 @@
+import { FontService, FONT_FACE_DEFINITIONS, FONT_FACE_FALLBACKS } from './font.service';
+
+// Mocking the document with ts-mockito does not work because the type definitions for document.fonts does not include
+// the add method
+class FakeDocument {
+  addCount = 0;
+  fonts = {
+    add: (_: any) => {
+      this.addCount++;
+    }
+  };
+}
+
+describe('FontService', () => {
+  let fontService: FontService;
+
+  beforeEach(() => {
+    fontService = new FontService(new FakeDocument() as any);
+  });
+
+  it('should default to Charis SIL when font is not specified', () => {
+    expect(fontService.getCSSFontName(undefined)).toEqual('Charis SIL');
+    expect(fontService.getCSSFontName('')).toEqual('Charis SIL');
+  });
+
+  it('should default to Charis SIL when font is not recognized', () => {
+    expect(fontService.getCSSFontName('zyz123')).toEqual('Charis SIL');
+  });
+
+  it('should default to Charis SIL for proprietary serif fonts', () => {
+    expect(fontService.getCSSFontName('Times New Roman')).toEqual('Charis SIL');
+    expect(fontService.getCSSFontName('Cambria')).toEqual('Charis SIL');
+    expect(fontService.getCSSFontName('Sylfaen')).toEqual('Charis SIL');
+  });
+
+  it('should default to Andika for proprietary sans-serif fonts', () => {
+    expect(fontService.getCSSFontName('Arial')).toEqual('Andika');
+    expect(fontService.getCSSFontName('Verdana')).toEqual('Andika');
+    expect(fontService.getCSSFontName('Tahoma')).toEqual('Andika');
+  });
+
+  it('should fall back from Annapurna SIL Nepal to Annapurna SIL', () => {
+    expect(fontService.getCSSFontName('Annapurna SIL Nepal')).toEqual('Annapurna SIL');
+  });
+
+  it('should not have any broken font fallbacks', () => {
+    // make sure all fallbacks are actually defined
+    expect(Object.values(FONT_FACE_FALLBACKS).filter(fallback => FONT_FACE_DEFINITIONS[fallback] == null)).toEqual([]);
+  });
+
+  it('should only load each font once', () => {
+    fontService.getCSSFontName('Charis SIL');
+    fontService.getCSSFontName('Charis SIL');
+    fontService.getCSSFontName('Charis SIL');
+
+    expect(((fontService as any).document as FakeDocument).addCount).toEqual(1);
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
@@ -1,0 +1,135 @@
+import { Inject, Injectable } from '@angular/core';
+import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
+import { DOCUMENT } from './browser-globals';
+
+const DEFAULT_SERIF_FONT_FAMILY = 'Charis SIL';
+const DEFAULT_SANS_SERIF_FONT_FAMILY = 'Andika';
+const DEFAULT_FONT_FAMILY = DEFAULT_SERIF_FONT_FAMILY;
+
+export const FONT_FACE_FALLBACKS: { [key: string]: string } = {
+  // Proprietary fonts typically used for English (where we suspect the specified font isn't that critical)
+  Arial: DEFAULT_SANS_SERIF_FONT_FAMILY,
+  'Times New Roman': DEFAULT_SERIF_FONT_FAMILY,
+  Verdana: DEFAULT_SANS_SERIF_FONT_FAMILY,
+  'Arial Unicode MS': DEFAULT_SANS_SERIF_FONT_FAMILY,
+  Cambria: DEFAULT_SERIF_FONT_FAMILY,
+  Sylfaen: DEFAULT_SERIF_FONT_FAMILY,
+  Tahoma: DEFAULT_SANS_SERIF_FONT_FAMILY,
+  Calibri: DEFAULT_SANS_SERIF_FONT_FAMILY,
+  'Maiandra GD': DEFAULT_SANS_SERIF_FONT_FAMILY,
+
+  // Freely available fonts we have yet to properly support (temporary fallbacks)
+  'Suranna UI': DEFAULT_SERIF_FONT_FAMILY, // Suranna is available via Google Fonts
+  'Andika New Basic': 'Andika',
+  'Andika New Basic Compact': 'Andika',
+  'Andika Eng-Lit': 'Andika',
+  'Andika SEB': 'Andika',
+  'Annapurna SIL Nepal': 'Annapurna SIL',
+  'Annapurna SIL Thami': 'Annapurna SIL',
+  Gentium: 'Gentium Plus',
+  'Gentium Basic': 'Gentium Plus',
+  'Gentium Book Basic': 'Gentium Book Plus',
+  'Lateef Haz Kas Low': 'Lateef',
+  'Lateef Sindhi': 'Lateef',
+  'Scheherazade New Persian': 'Scheherazade New',
+
+  // Unclear category
+  'Karenni Unicode': 'Kay Pho Du',
+  'Adobe Arabic': 'Scheherazade New',
+  'Simplified Arabic': 'Scheherazade New'
+};
+
+export const FONT_FACE_DEFINITIONS: { [key: string]: string } = {
+  'Abyssinica SIL': 'https://fonts.languagetechnology.org/fonts/sil/abyssinicasil/web/AbyssinicaSIL-Regular.woff2',
+  Akatab: 'https://fonts.languagetechnology.org/fonts/sil/akatab/web/Akatab-Regular.woff2',
+  Alkalami: 'https://fonts.languagetechnology.org/fonts/sil/alkalami/web/Alkalami-Regular.woff2',
+  Andika: 'https://fonts.languagetechnology.org/fonts/sil/andika/web/Andika-Regular.woff2',
+  'Annapurna SIL': 'https://fonts.languagetechnology.org/fonts/sil/annapurnasil/web/AnnapurnaSIL-Regular.woff2',
+  'Awami Nastaliq': 'https://fonts.languagetechnology.org/fonts/sil/awaminastaliq/web/AwamiNastaliq-Regular.woff2',
+  Badami: 'https://fonts.languagetechnology.org/fonts/other/badami/woff/Badami-Regular.woff2',
+  Bailey: 'https://fonts.languagetechnology.org/fonts/other/bailey/web/Bailey-Regular.woff2',
+  'Charis SIL': 'https://fonts.languagetechnology.org/fonts/sil/charissil/web/CharisSIL-Regular.woff2',
+  'Dai Banna SIL': 'https://fonts.languagetechnology.org/fonts/sil/daibannasil/web/DaiBannaSIL-Regular.woff2',
+  'Doulos SIL': 'https://fonts.languagetechnology.org/fonts/sil/doulossil/web/DoulosSIL-Regular.woff2',
+  Eeyek: 'https://fonts.languagetechnology.org/fonts/sil/eeyek/web/Eeyek-Regular.woff',
+  'Ezra SIL': 'https://fonts.languagetechnology.org/fonts/sil/ezrasil/web/SILEOT.woff',
+  'Ezra SIL SR': 'https://fonts.languagetechnology.org/fonts/sil/ezrasilsr/web/SILEOTSR.woff',
+  'Galatia SIL': 'https://fonts.languagetechnology.org/fonts/sil/galatiasil/web/GalSILR.woff',
+  'Gentium Book Plus':
+    'https://fonts.languagetechnology.org/fonts/sil/gentiumbookplus/web/GentiumBookPlus-Regular.woff2',
+  'Gentium Plus': 'https://fonts.languagetechnology.org/fonts/sil/gentiumplus/web/GentiumPlus-Regular.woff2',
+  Harmattan: 'https://fonts.languagetechnology.org/fonts/sil/harmattan/web/Harmattan-Regular.woff2',
+  'Japa Sans Oriya': 'https://fonts.languagetechnology.org/fonts/sil/japasansoriya/woff/JapaSansOriya-Regular.woff2',
+  Kanchenjunga: 'https://fonts.languagetechnology.org/fonts/sil/kanchenjunga/web/Kanchenjunga-Regular.woff2',
+  'Kay Pho Du': 'https://fonts.languagetechnology.org/fonts/sil/kayphodu/web/KayPhoDu-Regular.woff2',
+  Lateef: 'https://fonts.languagetechnology.org/fonts/sil/lateef/web/Lateef-Regular.woff2',
+  'Lisu Bosa': 'https://fonts.languagetechnology.org/fonts/sil/lisubosa/web/LisuBosa-Regular.woff2',
+  Mingzat: 'https://fonts.languagetechnology.org/fonts/sil/mingzat/web/Mingzat-Regular.woff2',
+  Namdhinggo: 'https://fonts.languagetechnology.org/fonts/sil/namdhinggo/web/Namdhinggo-Regular.woff2',
+  Narnoor: 'https://fonts.languagetechnology.org/fonts/sil/narnoor/web/Narnoor-Regular.woff2',
+  Nokyung: 'https://fonts.languagetechnology.org/fonts/sil/nokyung/web/Nokyung-Regular.woff',
+  'Nuosu SIL': 'https://fonts.languagetechnology.org/fonts/sil/nuosusil/web/NuosuSIL-Regular.woff2',
+  Padauk: 'https://fonts.languagetechnology.org/fonts/sil/padauk/web/Padauk-Regular.woff2',
+  'Padauk Book': 'https://fonts.languagetechnology.org/fonts/sil/padaukbook/web/PadaukBook-Regular.woff2',
+  'Payap Lanna': 'https://fonts.languagetechnology.org/fonts/sil/payaplanna/web/PayapLanna-Regular.woff2',
+  Ruwudu: 'https://fonts.languagetechnology.org/fonts/sil/ruwudu/web/Ruwudu-Regular.woff2',
+  Scheherazade: 'https://fonts.languagetechnology.org/fonts/sil/scheherazade/web/Scheherazade-Regular.woff',
+  'Scheherazade New':
+    'https://fonts.languagetechnology.org/fonts/sil/scheherazadenew/web/ScheherazadeNew-Regular.woff2',
+  Surma: 'https://fonts.languagetechnology.org/fonts/other/surma/Surma-Regular.woff2',
+  Tagmukay: 'https://fonts.languagetechnology.org/fonts/sil/tagmukay/web/Tagmukay-Regular.woff',
+  'Tai Heritage Pro': 'https://fonts.languagetechnology.org/fonts/sil/taiheritagepro/web/TaiHeritagePro-Regular.woff',
+  ThiruValluvar: 'https://fonts.languagetechnology.org/fonts/other/thiruvalluvar/woff/ThiruValluvar-Regular.woff2'
+};
+
+@Injectable({ providedIn: 'root' })
+export class FontService {
+  // Map of project font names to CSS font families
+  private loadedFontFamilies: Map<string, string> = new Map();
+  // Requested font families that are unsupported (so we can log the warning only the first time they are encountered)
+  private unsupportedFontFamilies = new Set<string>();
+
+  constructor(@Inject(DOCUMENT) private readonly document: Document) {}
+
+  getFontFamilyFromProject(projectDoc: SFProjectProfileDoc | undefined): string {
+    return this.getCSSFontName(projectDoc?.data?.defaultFont);
+  }
+
+  /**
+   * Gets a CSS font family name for a given project's specified font. These may or may not be the same. If the
+   * specified font has not yet been loaded, it is loaded.
+   * @param projectFont The font specified in the project settings.
+   * @returns A font family that can be used in CSS to specify the font.
+   */
+  getCSSFontName(projectFont: string | undefined): string {
+    if (projectFont == null || projectFont === '') {
+      projectFont = DEFAULT_FONT_FAMILY;
+    } else if (FONT_FACE_DEFINITIONS[projectFont] == null && FONT_FACE_FALLBACKS[projectFont] != null) {
+      projectFont = FONT_FACE_FALLBACKS[projectFont];
+    } else if (FONT_FACE_DEFINITIONS[projectFont] == null) {
+      this.warnUnsupportedFont(projectFont);
+      projectFont = DEFAULT_FONT_FAMILY;
+    }
+
+    if (this.loadedFontFamilies.has(projectFont)) {
+      return this.loadedFontFamilies.get(projectFont)!;
+    }
+
+    let fontUrl = FONT_FACE_DEFINITIONS[projectFont];
+    this.addFontFamilyToDocument(projectFont, fontUrl);
+    this.loadedFontFamilies.set(projectFont, projectFont);
+    return projectFont;
+  }
+
+  private warnUnsupportedFont(font: string): void {
+    if (!this.unsupportedFontFamilies.has(font)) {
+      this.unsupportedFontFamilies.add(font);
+      console.warn(`No font definition for ${font}`);
+    }
+  }
+
+  private addFontFamilyToDocument(fontFamily: string, fontUrl: string): void {
+    const fontDefinition = new FontFace(fontFamily, `url(${fontUrl})`);
+    (this.document.fonts as any).add(fontDefinition);
+  }
+}


### PR DESCRIPTION
This loads fonts from fonts.languagetechnology.org, based on the font specified on the Paratext project. I only added support for the most used fonts on Scripture Forge, as I want to keep this change small and make sure it works well before expanding the list too much.

Things I did not address:
- Preview draft page
- Question dialog
- Text chooser dialog

Initially I was going to add support for them, but they were going to take slightly more work, and I wanted to keep this change as small as possible, so I can easily address any changes that need to be made, without it being held up. We can follow up this PR with fixing those other components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2346)
<!-- Reviewable:end -->
