### PR TITLE
SF-2551 Throttle Syncs to one at a time

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -894,7 +894,7 @@ public class MachineApiService : IMachineApiService
         if (!string.IsNullOrWhiteSpace(jobId))
         {
             // Run the training after the sync has completed
-            jobId = _backgroundJobClient.ContinueJobWith<IMachineProjectService>(
+            jobId = _backgroundJobClient.ContinueJobWith<MachineProjectService>(
                 jobId,
                 r => r.BuildProjectForBackgroundJobAsync(curUserId, buildConfig, true, CancellationToken.None)
             );
@@ -902,7 +902,7 @@ public class MachineApiService : IMachineApiService
         else
         {
             // No sync required, just run the training
-            jobId = _backgroundJobClient.Enqueue<IMachineProjectService>(
+            jobId = _backgroundJobClient.Enqueue<MachineProjectService>(
                 r => r.BuildProjectForBackgroundJobAsync(curUserId, buildConfig, true, CancellationToken.None)
             );
         }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -391,6 +391,7 @@ public class MachineProjectService : IMachineProjectService
         return null;
     }
 
+    [Mutex]
     public async Task BuildProjectForBackgroundJobAsync(
         string curUserId,
         BuildConfig buildConfig,
@@ -847,6 +848,7 @@ public class MachineProjectService : IMachineProjectService
         }
     }
 
+    [Mutex]
     public async Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId)
     {
         // Get the user secret

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -144,10 +144,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
     /// <param name="trainEngine"><c>true</c> if we are to train the SMT translation engine; otherwise <c>false</c>.</param>
     /// <param name="token">The cancellation token.</param>
     /// <remarks>
-    /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex on the
-    /// <paramref name="projectSFId"/> parameter, i.e. "{0}".
+    /// Do not allow multiple sync jobs to run in parallel on the same project by creating a hangfire mutex that
+    /// restricts the execution of this method as a background job to one instance at a time.
     /// </remarks>
-    [Mutex("{0}")]
+    [Mutex]
     public async Task RunAsync(
         string projectSFId,
         string userId,

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1448,7 +1448,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
 
             // After syncing the source project (which will take some time), ensure that the writing system matches
             // what is in the project document
-            _backgroundJobClient.ContinueJobWith<IMachineProjectService>(
+            _backgroundJobClient.ContinueJobWith<MachineProjectService>(
                 jobId,
                 r => r.UpdateTranslationSourcesAsync(curUserId, sfProjectId)
             );


### PR DESCRIPTION
This PR throttles Hangfire jobs to run one at a time, per job type.

These job types are:

 * Syncs
 * Draft Builds
 * Updating of Translation Sources

This was achieved by modifying the Mutex to make the `resource` parameter optional. When `resource` is not configured, the method name is used as the mutex key.

It was determined to allow this approach rather than allow just one job at a time for any job type to stop any potential dependency deadlocks (i.e. when a sync triggers a build, and that build may require a sync, etc). In addition, the three job types are different enough that I do not that that a Resource conflict is likely due to concurrent access, as the shared surface is the MongoDB, the Realtime server, and Paratext Settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2347)
<!-- Reviewable:end -->
