### PR TITLE
SF-2550 Disable In-Process Machine across all environments (#2345)

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -60,7 +60,7 @@
   },
   "FeatureManagement": {
     "Serval": true,
-    "MachineInProcess": true,
+    "MachineInProcess": false,
     "UploadParatextZipForPreTranslation": false,
     "UseEchoForPreTranslation": false
   }


### PR DESCRIPTION
This is a hotfix against sf-live.

(cherry picked from commit db1dea23e15e14893c82183f6c545790ed5f42f9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2348)
<!-- Reviewable:end -->
