### PR TITLE
SF-2568 Allow all PT users to view chapter history

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3541,7 +3541,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('shows the history selector only if the user is an administrator or translator', fakeAsync(() => {
+    it('shows the history selector only if the user is a Paratext user', fakeAsync(() => {
       const projectConfig = {
         translateConfig: { ...defaultTranslateConfig, translationSuggestionsEnabled: false }
       };
@@ -3555,7 +3555,7 @@ describe('EditorComponent', () => {
 
       // Paratext Consultant
       env.setCurrentUser('user02');
-      expect(env.component.showHistoryChooser).toBeFalsy();
+      expect(env.component.showHistoryChooser).toBeTruthy();
 
       // Paratext Translator
       env.setCurrentUser('user03');
@@ -3571,9 +3571,9 @@ describe('EditorComponent', () => {
 
       // Paratext Observer
       env.setCurrentUser('user06');
-      expect(env.component.showHistoryChooser).toBeFalsy();
+      expect(env.component.showHistoryChooser).toBeTruthy();
 
-      // Paratext Viewer
+      // SF Viewer
       env.setCurrentUser('user07');
       expect(env.component.showHistoryChooser).toBeFalsy();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -43,7 +43,7 @@ import {
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { TextData, TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
@@ -536,8 +536,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get showHistoryChooser(): boolean {
-    // The user must be an administrator or translator. No specific edit permission for the chapter is required
-    return this.userHasGeneralEditRight;
+    // The user must be a Paratext user. No specific edit permission for the chapter is required
+    return isParatextRole(this.userRole);
   }
 
   get showSnapshot(): boolean {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1911,7 +1911,7 @@ public class ParatextService : DisposableBase, IParatextService
 
         if (
             !projectDoc.Data.UserRoles.TryGetValue(userSecret.Id, out string role)
-            || role is not (SFProjectRole.Translator or SFProjectRole.Administrator)
+            || !SFProjectRole.IsParatextRole(role)
         )
         {
             throw new ForbiddenException();
@@ -1982,7 +1982,7 @@ public class ParatextService : DisposableBase, IParatextService
 
         if (
             !projectDoc.Data.UserRoles.TryGetValue(userSecret.Id, out string role)
-            || role is not (SFProjectRole.Translator or SFProjectRole.Administrator)
+            || !SFProjectRole.IsParatextRole(role)
         )
         {
             throw new ForbiddenException();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4702,7 +4702,7 @@ public class ParatextServiceTests
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         SFProject project = env.NewSFProject();
-        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.PTObserver } };
+        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.Commenter } };
         env.AddProjectRepository(project);
 
         // SUT
@@ -4749,6 +4749,8 @@ public class ParatextServiceTests
         var associatedPtUser = new SFParatextUser(env.Username01);
         env.SetupProject(env.Project01, associatedPtUser);
         SFProject project = env.NewSFProject();
+        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.PTObserver } };
+        env.AddProjectRepository(project);
 
         // SUT
         bool historyExists = false;
@@ -4776,6 +4778,7 @@ public class ParatextServiceTests
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         SFProject project = env.NewSFProject();
+        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.PTObserver } };
         env.AddProjectRepository(project);
         const string book = "MAT";
         const int chapter = 1;
@@ -4794,7 +4797,7 @@ public class ParatextServiceTests
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         SFProject project = env.NewSFProject();
-        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.PTObserver } };
+        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.Commenter } };
         env.AddProjectRepository(project);
 
         // SUT


### PR DESCRIPTION
This PR enables support for all Paratext users to view chapter history, matching the behavior of Paratext.

SF Users (Commenters and Viewers) still do not have access to view the chapter history.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2349)
<!-- Reviewable:end -->
