### PR TITLE
Downgrade Jering to 6.3.1

### DIFF
--- a/src/SIL.XForge/Realtime/ExistingNodeJSProcess.cs
+++ b/src/SIL.XForge/Realtime/ExistingNodeJSProcess.cs
@@ -9,12 +9,6 @@ public class ExistingNodeJSProcess : INodeJSProcess
 {
     public void Dispose() => GC.SuppressFinalize(this);
 
-    public ValueTask DisposeAsync()
-    {
-        GC.SuppressFinalize(this);
-        return ValueTask.CompletedTask;
-    }
-
     public void AddOutputReceivedHandler(MessageReceivedEventHandler messageReceivedHandler) =>
         Task.Run(async () =>
         {
@@ -28,8 +22,6 @@ public class ExistingNodeJSProcess : INodeJSProcess
         });
 
     public void AddErrorReceivedHandler(MessageReceivedEventHandler messageReceivedHandler) { }
-
-    public void BeginOutputAndErrorReading() { }
 
     public void AddOutputDataReceivedHandler(DataReceivedEventHandler dataReceivedEventHandler) { }
 

--- a/src/SIL.XForge/Realtime/ExistingNodeJSProcessFactory.cs
+++ b/src/SIL.XForge/Realtime/ExistingNodeJSProcessFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using Jering.Javascript.NodeJS;
 
 namespace SIL.XForge.Realtime;
@@ -6,6 +5,4 @@ namespace SIL.XForge.Realtime;
 public class ExistingNodeJSProcessFactory : INodeJSProcessFactory
 {
     public INodeJSProcess Create(string serverScript) => new ExistingNodeJSProcess();
-
-    public INodeJSProcess Create(string serverScript, EventHandler exitedEventHandler) => new ExistingNodeJSProcess();
 }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -15,7 +15,7 @@ public class RealtimeServer : IRealtimeServer
     public RealtimeServer(INodeJSService nodeJSService)
     {
         _nodeJSService = nodeJSService;
-        _modulePath = Path.Combine("RealtimeServer", "lib", "cjs", "common", "index.js");
+        _modulePath = Path.Combine("RealtimeServer", "lib", "cjs", "common", "index");
     }
 
     public void Start(object options)

--- a/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class RealtimeServiceCollectionExtensions
         // Disable invocation timeout so the debugger can be paused
         if (nodeOptions?.Contains("--inspect", StringComparison.OrdinalIgnoreCase) == true)
         {
-            services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.InvocationTimeoutMS = -1);
+            services.Configure<OutOfProcessNodeJSServiceOptions>(options => options.TimeoutMS = -1);
         }
 
         services.AddSingleton<IJsonService, RealtimeJsonService>();

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Hangfire" Version="1.7.32" />
     <PackageReference Include="Hangfire.Mongo" Version="1.9.1" />
     <PackageReference Include="IdentityModel" Version="6.2.0" />
-    <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
+    <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.2" />
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />


### PR DESCRIPTION
This PR downgrades Jering to 6.3.1, which was the previous stable version (prior to #2292).

QA is currently experiencing unusual instability with the Realtime server, so this PR is to help determine if that instability is caused by the Jering upgrade to 7.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2351)
<!-- Reviewable:end -->
