### PR TITLE
Add tool to download all files from Serval

### DIFF
--- a/tools/ServalDownloader/Program.cs
+++ b/tools/ServalDownloader/Program.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using IdentityModel.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Serval.Client;
+
+// The first argument must be the translation engine id
+if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+{
+    Console.WriteLine("You must specify the translation engine id");
+    return;
+}
+
+// Setup services
+ServiceProvider services = SetupServices();
+IDataFilesClient dataFilesClient = services.GetService<IDataFilesClient>()!;
+ITranslationEnginesClient translationEnginesClient = services.GetService<ITranslationEnginesClient>()!;
+
+// Set up the translation engine directory and get the translation engine
+string translationEngineId = args[0];
+string translationEnginePath = Path.Combine(Path.GetTempPath(), translationEngineId);
+Directory.CreateDirectory(translationEnginePath);
+TranslationEngine translationEngine = await translationEnginesClient.GetAsync(translationEngineId);
+if (translationEngine.Type != "nmt")
+{
+    Console.WriteLine("You can only download an NMT project");
+    return;
+}
+
+// Download every file for every corpus
+foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorporaAsync(translationEngineId))
+{
+    string corpusPath = Path.Combine(translationEnginePath, corpus.Id);
+    Directory.CreateDirectory(corpusPath);
+    foreach (TranslationCorpusFile sourceFile in corpus.SourceFiles)
+    {
+        // Create the source directory
+        string sourcePath = Path.Combine(corpusPath, "source");
+        Directory.CreateDirectory(sourcePath);
+
+        // Download the file
+        var file = await dataFilesClient.DownloadAsync(sourceFile.File.Id);
+
+        // Write the file
+        string path = Path.Combine(sourcePath, (sourceFile.TextId ?? sourceFile.File.Id) + ".txt");
+        Console.WriteLine($"Writing {path}...");
+        await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        file.Stream.CopyTo(fileStream);
+    }
+
+    foreach (TranslationCorpusFile targetFile in corpus.TargetFiles)
+    {
+        string targetPath = Path.Combine(corpusPath, "target");
+        Directory.CreateDirectory(targetPath);
+
+        // Download the file
+        FileResponse file = await dataFilesClient.DownloadAsync(targetFile.File.Id);
+
+        // Write the file
+        string path = Path.Combine(targetPath, (targetFile.TextId ?? targetFile.File.Id) + ".txt");
+        Console.WriteLine($"Writing {path}...");
+        await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        file.Stream.CopyTo(fileStream);
+    }
+}
+
+// If we are on Windows, open the directory in Explorer
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    Process.Start("explorer.exe", translationEnginePath);
+}
+
+// Exit
+return;
+
+static ServiceProvider SetupServices()
+{
+    const string httpClientName = "serval-api";
+
+    ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+    IConfiguration configuration = configurationBuilder
+        .AddJsonFile("appsettings.json", false, true)
+        .AddUserSecrets<Program>()
+        .Build();
+    ServalOptions servalOptions = configuration.GetSection("Serval").Get<ServalOptions>()!;
+
+    var services = new ServiceCollection();
+    services.AddAccessTokenManagement(options =>
+    {
+        options.Client.Clients.Add(
+            httpClientName,
+            new ClientCredentialsTokenRequest
+            {
+                Address = servalOptions.TokenUrl,
+                ClientId = servalOptions.ClientId,
+                ClientSecret = servalOptions.ClientSecret,
+                Parameters = new Parameters { { "audience", servalOptions.Audience } },
+            }
+        );
+    });
+    services.AddClientAccessTokenHttpClient(
+        httpClientName,
+        configureClient: client => client.BaseAddress = new Uri(servalOptions.ApiServer)
+    );
+    services.AddHttpClient(httpClientName).SetHandlerLifetime(TimeSpan.FromMinutes(5));
+    services.AddSingleton<ITranslationEnginesClient, TranslationEnginesClient>(sp =>
+    {
+        // Instantiate the translation engines client with our named HTTP client
+        var factory = sp.GetService<IHttpClientFactory>();
+        var httpClient = factory!.CreateClient(httpClientName);
+        return new TranslationEnginesClient(httpClient);
+    });
+    services.AddSingleton<IDataFilesClient, DataFilesClient>(sp =>
+    {
+        // Instantiate the data files client with our named HTTP client
+        var factory = sp.GetService<IHttpClientFactory>();
+        var httpClient = factory!.CreateClient(httpClientName);
+        return new DataFilesClient(httpClient);
+    });
+    return services.BuildServiceProvider();
+}
+
+public class ServalOptions
+{
+    public string ApiServer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string ClientId { get; set; } = string.Empty;
+    public string ClientSecret { get; set; } = string.Empty;
+    public string TokenUrl { get; set; } = string.Empty;
+}

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>4d0606c3-0fc7-4d76-b43b-236485004e81</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Serval.Client" Version="1.2.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/tools/ServalDownloader/ServalDownloader.sln
+++ b/tools/ServalDownloader/ServalDownloader.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServalDownloader", "ServalDownloader.csproj", "{A316AA71-4CCD-41D7-800A-1FDD94A0868E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A316AA71-4CCD-41D7-800A-1FDD94A0868E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A316AA71-4CCD-41D7-800A-1FDD94A0868E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A316AA71-4CCD-41D7-800A-1FDD94A0868E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A316AA71-4CCD-41D7-800A-1FDD94A0868E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {19971D78-9FD4-4B0B-80E9-025A57C92D39}
+	EndGlobalSection
+EndGlobal

--- a/tools/ServalDownloader/appsettings.json
+++ b/tools/ServalDownloader/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Serval": {
+    "ApiServer": "https://qa.serval-api.org",
+    "Audience": "https://serval-api.org/",
+    "TokenUrl": "https://dev-sillsdev.auth0.com/oauth/token"
+  }
+}


### PR DESCRIPTION
I have created a small tool to download all files from Serval for a translation engine. This is useful in debugging what was sent to Serval.

To run: `dotnet run 65d5058f352b5d93e8a2ac7c` (substituting your translation engine id)

I have only tested this on Windows. It should load the Serval values used by Scripture Forge from the user secrets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2352)
<!-- Reviewable:end -->
