### PR TITLE
SF-2582 Improve recoverability when Serval client credentials change

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -67,7 +67,7 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
       );
       return this.createWordGraph(response.data as WordGraphDto);
     } catch (err: any) {
-      if (err.status === 404 || err.status === 409) {
+      if (err.status === 403 || err.status === 404 || err.status === 409) {
         this.noticeService.showError(
           translate('error_messages.suggestion_engine_requires_retrain'),
           translate('error_messages.go_to_retrain'),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -56,7 +56,7 @@ export class DraftGenerationService {
       map(res => res.data),
       catchError(err => {
         // If no build has ever been started, return undefined
-        if (err.status === 404) {
+        if (err.status === 403 || err.status === 404) {
           return of(undefined);
         }
         return throwError(err);
@@ -77,7 +77,7 @@ export class DraftGenerationService {
         map(res => res.data),
         catchError(err => {
           // If project doesn't exist on Serval, return undefined
-          if (err.status === 404) {
+          if (err.status === 403 || err.status === 404) {
             return of(undefined);
           }
           return throwError(err);
@@ -139,7 +139,7 @@ export class DraftGenerationService {
         map(res => (res.data && this.toDraftSegmentMap(res.data.preTranslations)) ?? {}),
         catchError(err => {
           // If no pretranslations exist, return empty dictionary
-          if (err.status === 404 || err.status === 409) {
+          if (err.status === 403 || err.status === 404 || err.status === 409) {
             return of({});
           }
           return throwError(err);

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -78,7 +78,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
     }
 
@@ -334,7 +335,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
         catch (InvalidOperationException)
         {
@@ -399,7 +401,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
     }
 
@@ -442,7 +445,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
     }
 
@@ -484,7 +488,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
     }
 
@@ -571,7 +576,8 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -51,7 +51,8 @@ public class MachineApiControllerTests
         // SUT
         ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<ForbidResult>(actual);
+        Assert.IsInstanceOf<StatusCodeResult>(actual);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -703,7 +704,8 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -824,7 +826,8 @@ public class MachineApiControllerTests
         // SUT
         ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -897,7 +900,8 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -971,7 +975,8 @@ public class MachineApiControllerTests
         // SUT
         ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
 
-        Assert.IsInstanceOf<ForbidResult>(actual);
+        Assert.IsInstanceOf<StatusCodeResult>(actual);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -1117,7 +1122,8 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
     }
 
     [Test]


### PR DESCRIPTION
When the Serval client credentials change, any actions for SMT or Pre-Translation engines return 403 errors. This PR allows the pre-translation projects to be recreated when this occurs, and provides better error help in the editor, prompting the user to rebuild the translation engine (which will fix these issues).

It was also discovered the HTTP POST methods in MVC Controllers return a 400 error when `Forbid()` is returned (which is supposed to return a 403 error). This bug has been fixed to ensure the frontend has an accurate error code.

As this bug currently affects QA, it should be deployed there for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2357)
<!-- Reviewable:end -->
