### PR TITLE
SF-2583 Improve Note Speed

### DIFF
--- a/src/RealtimeServer/common/services/doc-service.ts
+++ b/src/RealtimeServer/common/services/doc-service.ts
@@ -1,4 +1,4 @@
-import { Db } from 'mongodb';
+import { Db, IndexSpecification } from 'mongodb';
 import { ConnectSession } from '../connect-session';
 import { Migration, MigrationConstructor } from '../migration';
 import { ValidationSchema } from '../models/validation-schema';
@@ -54,7 +54,7 @@ export abstract class DocService<T = any> {
   }
 
   abstract get collection(): string;
-  protected abstract get indexPaths(): string[];
+  protected abstract get indexPaths(): (string | IndexSpecification)[];
   validationSchema: ValidationSchema | undefined = undefined;
 
   init(server: RealtimeServer): void {
@@ -78,7 +78,11 @@ export abstract class DocService<T = any> {
   async createIndexes(db: Db): Promise<void> {
     for (const path of this.indexPaths) {
       const collection = db.collection(this.collection);
-      await collection.createIndex({ [path]: 1 });
+      if (typeof path === 'string') {
+        await collection.createIndex({ [path]: 1 });
+      } else {
+        await collection.createIndex(path);
+      }
     }
   }
 

--- a/src/RealtimeServer/scriptureforge/models/note-thread.ts
+++ b/src/RealtimeServer/scriptureforge/models/note-thread.ts
@@ -1,11 +1,26 @@
 import { ProjectData, PROJECT_DATA_INDEX_PATHS } from '../../common/models/project-data';
+import { obj } from '../../common/utils/obj-path';
 import { BiblicalTermNoteHeadingInfo } from './biblical-term-note-heading-info';
 import { Note } from './note';
 import { TextAnchor } from './text-anchor';
 import { VerseRefData } from './verse-ref-data';
 
 export const NOTE_THREAD_COLLECTION = 'note_threads';
-export const NOTE_THREAD_INDEX_PATHS = PROJECT_DATA_INDEX_PATHS;
+export const NOTE_THREAD_INDEX_PATHS = [
+  ...PROJECT_DATA_INDEX_PATHS,
+  // Index for SFProjectService.queryNoteThreads()
+  {
+    [obj<NoteThread>().pathStr(n => n.projectRef)]: 1,
+    [obj<NoteThread>().pathStr(n => n.status)]: 1,
+    [obj<NoteThread>().pathStr(n => n.verseRef.bookNum)]: 1,
+    [obj<NoteThread>().pathStr(n => n.verseRef.chapterNum)]: 1
+  },
+  // Index for SFProjectService.queryBiblicalTermNoteThreads()
+  {
+    [obj<NoteThread>().pathStr(n => n.projectRef)]: 1,
+    [obj<NoteThread>().pathStr(n => n.biblicalTermId)]: 1
+  }
+];
 
 /**
  * Note status, mimicking PT CommentList.cs.

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -32,11 +32,22 @@ function getKeyRange(filter: PropertyFilter): IDBKeyRange | undefined {
   return IDBKeyRange.only(filter);
 }
 
-function createObjectStore(db: IDBDatabase, collection: string, indexPaths?: string[]): void {
+function createObjectStore(
+  db: IDBDatabase,
+  collection: string,
+  indexPaths?: (string | { [x: string]: number | string })[]
+): void {
   const objectStore = db.createObjectStore(collection, { keyPath: 'id' });
   if (indexPaths != null) {
     for (const path of indexPaths) {
-      objectStore.createIndex(path, `data.${path}`);
+      if (typeof path === 'string') {
+        objectStore.createIndex(path, `data.${path}`);
+      } else {
+        objectStore.createIndex(
+          Object.keys(path).join('_'),
+          Object.keys(path).map(key => `data.${key}`)
+        );
+      }
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -8,7 +8,9 @@ import { RealtimeOfflineData } from './realtime-offline-data';
 
 export interface RealtimeDocConstructor {
   readonly COLLECTION: string;
-  readonly INDEX_PATHS: string[];
+
+  // string is the legacy one column index format, the associative array corresponds to MongoDB's IndexSpecification
+  readonly INDEX_PATHS: (string | { [x: string]: number | string })[];
 
   new (realtimeService: RealtimeService, adapter: RealtimeDocAdapter): RealtimeDoc;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1796,7 +1796,7 @@ public class ParatextSyncRunnerTests
         string threadExpected = "Context before Scripture text in project context after-Start:0-Length:0-MAT 1:1";
         Assert.That(thread01.NoteThreadToString(), Is.EqualTo(threadExpected));
         Assert.That(thread01.Assignment, Is.EqualTo(CommentThread.teamUser));
-        env.DeltaUsxMapper.ReceivedWithAnyArgs(2).ToChapterDeltas(default);
+        env.DeltaUsxMapper.ReceivedWithAnyArgs(1).ToChapterDeltas(default);
         Assert.That(thread01.Notes.Count, Is.EqualTo(startingNoteCount + expectedNoteCountChange));
         Assert.That(thread01.Notes[0].Content, Is.EqualTo("thread01 updated."));
         Assert.That(thread01.Notes[0].Assignment, Is.EqualTo(CommentThread.teamUser));


### PR DESCRIPTION
This PR:

 * Adds indices that match the querying patterns of the `note_threads` collection by `sf-project.service.ts`. This will speed up the realtime server's access of notes.
  **Note:** Indexes cannot be created on existing object stores during a version change transaction, so the indexes will only be created locally on log out/log on.
 * Optimizes of `ParatextSyncRunner.GetAndUpdateParatextBooksAndNotes()` to only update notes that are editable. This can speed up the pre-PT sync phase for projects with little or no notes created in SF.
 * Optimizes retrieval of chapter deltas from the USFM on disk to only be loaded once per book (the conversion from USFM to USX to Deltas is expensive). This is a minor performance improvement, but one that results in a reasonable code clean up.
 * Optimizes use of `CommentManager.FindThreads()` in `ParatextService` to query the VerseRefString, rather than the VerseRef object which must be instantiated for every note if used in `CommentManager.FindThreads()`.

(Each of these optimizations have a corresponding commit).

These changes resulted in a modest speed increase for one particularly large project with a note on every verse, but this PR does not provide massive improvements.

**Caveat:** I was unable to find any multiple iteration type bugs that could be optimized. An optimization I tried was to update all of the notes in one go - which turned out to be slower than the current process. Perhaps only substantial optimization could be achieved by creating a new MongoDB structure for notes that perhaps mimics Paratext's structure for notes more closely to enable a much quicker "one pass" note change detection algorithm (the scope of that kind of change is too large for this issue, and requires careful consideration).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2358)
<!-- Reviewable:end -->
