### PR TITLE
SF-2480 Remove revision number from product version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
I couldn't find a way to drop the revision number from the product version in our build steps, so I do a split on the product version. If there is a better way, I am happy to learn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2361)
<!-- Reviewable:end -->
