### PR TITLE
SF-2586 Fix biblical terms dialog text overlap

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
@@ -1,3 +1,5 @@
+@use 'src/xforge-common/media-breakpoints/breakpoints' as *;
+
 mat-dialog-actions {
   display: flex;
   place-content: flex-end;
@@ -6,5 +8,8 @@ mat-dialog-actions {
 mat-dialog-content {
   display: flex;
   flex-direction: column;
-  row-gap: 2em;
+  row-gap: 1em;
+  @include media-breakpoint('<=', md) {
+    row-gap: 2em;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
@@ -6,5 +6,5 @@ mat-dialog-actions {
 mat-dialog-content {
   display: flex;
   flex-direction: column;
-  row-gap: 1em;
+  row-gap: 2em;
 }


### PR DESCRIPTION
Here is how it looks after the fix.
![image](https://github.com/sillsdev/web-xforge/assets/17931130/6f47ddf7-a547-4a5b-b61c-c31a1c3f4a77)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2362)
<!-- Reviewable:end -->
