### PR TITLE
SF-2528 Editor tabs drag/drop reorder

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-menu.service.ts
@@ -1,12 +1,12 @@
 import { Observable } from 'rxjs';
 
-export interface NewTabMenuItem {
+export interface TabMenuItem {
   type: string;
   text: string;
   icon?: string;
   disabled?: boolean;
 }
 
-export abstract class TabMenuService {
-  abstract getMenuItems(tabGroup: string): Observable<NewTabMenuItem[]>;
+export abstract class TabMenuService<TGroupId extends string> {
+  abstract getMenuItems(groupId?: TGroupId): Observable<TabMenuItem[]>;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
@@ -1,3 +1,4 @@
+import { CdkDrag, CdkDropList, CdkDropListGroup } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -23,7 +24,17 @@ import { TabComponent } from './tab/tab.component';
     TabScrollButtonComponent,
     TabBodyComponent
   ],
-  imports: [CommonModule, MatTabsModule, MatButtonModule, MatIconModule, MatMenuModule, TranslocoModule],
+  imports: [
+    CommonModule,
+    MatTabsModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    CdkDrag,
+    CdkDropList,
+    CdkDropListGroup,
+    TranslocoModule
+  ],
   exports: [TabGroupComponent, TabComponent, TabHeaderDirective]
 })
 export class SFTabsModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
@@ -1,4 +1,4 @@
-import { CdkDrag, CdkDropList, CdkDropListGroup } from '@angular/cdk/drag-drop';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -30,9 +30,7 @@ import { TabComponent } from './tab/tab.component';
     MatButtonModule,
     MatIconModule,
     MatMenuModule,
-    CdkDrag,
-    CdkDropList,
-    CdkDropListGroup,
+    DragDropModule,
     TranslocoModule
   ],
   exports: [TabGroupComponent, TabComponent, TabHeaderDirective]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.types.ts
@@ -5,3 +5,13 @@ export interface TabEvent {
 export interface TabHeaderMouseEvent extends TabEvent {
   mouseEvent: MouseEvent;
 }
+
+export interface TabLocation<TGroupId> {
+  groupId: TGroupId;
+  index: number;
+}
+
+export interface TabMoveEvent<TGroupId> {
+  from: TabLocation<TGroupId>;
+  to: TabLocation<TGroupId>;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.types.ts
@@ -2,8 +2,8 @@ export interface TabEvent {
   index: number;
 }
 
-export interface TabHeaderMouseEvent extends TabEvent {
-  mouseEvent: MouseEvent;
+export interface TabHeaderPointerEvent extends TabEvent {
+  pointerEvent: MouseEvent | TouchEvent;
 }
 
 export interface TabLocation<TGroupId> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -21,7 +21,8 @@
     [closeable]="tab.closeable"
     [movable]="tab.movable"
     [active]="i === selectedIndex"
-    (tabClick)="tabClick.next({ index: i, mouseEvent: $event })"
+    (tabPress)="tabPress.next({ index: i, pointerEvent: $event })"
+    (tabClick)="tabClick.next({ index: i, pointerEvent: $event })"
     (closeClick)="closeClick.next(i)"
     cdkDrag
     [cdkDragDisabled]="!tab.movable"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -5,13 +5,27 @@
   (scrollStop)="stopButtonScroll()"
 ></app-tab-scroll-button>
 
-<div class="tabs">
+<div
+  [id]="groupId!"
+  class="tabs"
+  cdkDropList
+  cdkDropListLockAxis="x"
+  cdkDropListOrientation="horizontal"
+  [cdkDropListDisabled]="!allowDragDrop"
+  [cdkDropListConnectedTo]="connectedTo"
+  [cdkDropListSortPredicate]="movablePredicate"
+  (cdkDropListDropped)="onTabDrop($event)"
+>
   <app-tab-header
     *ngFor="let tab of tabs; let i = index"
     [closeable]="tab.closeable"
+    [movable]="tab.movable"
     [active]="i === selectedIndex"
     (tabClick)="tabClick.next({ index: i, mouseEvent: $event })"
     (closeClick)="closeClick.next(i)"
+    cdkDrag
+    [cdkDragDisabled]="!tab.movable"
+    [cdkDragData]="tab"
   >
     <ng-container *ngTemplateOutlet="tab.tabHeaderTemplate"></ng-container>
   </app-tab-header>
@@ -22,6 +36,9 @@
     [closeable]="false"
     class="add-tab"
     (click)="onAddTabClicked()"
+    cdkDrag
+    cdkDragDisabled
+    [cdkDragData]="{ isAddTab: true }"
   >
     <mat-icon>add</mat-icon>
   </app-tab-header>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -13,7 +13,7 @@
   cdkDropListOrientation="horizontal"
   [cdkDropListDisabled]="!allowDragDrop"
   [cdkDropListConnectedTo]="connectedTo"
-  [cdkDropListSortPredicate]="movablePredicate"
+  [cdkDropListSortPredicate]="movablePredicate.bind(this)"
   (cdkDropListDropped)="onTabDrop($event)"
 >
   <app-tab-header

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.scss
@@ -52,6 +52,7 @@ app-tab-scroll-button {
   align-items: flex-end;
   gap: 0.1em;
   border-radius: var(--sf-tab-header-border-radius) var(--sf-tab-header-border-radius) 0 0;
+  width: 100%;
 
   // Hide scroll bar
   scrollbar-width: none;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.scss
@@ -59,6 +59,11 @@ app-tab-scroll-button {
     width: 0;
     height: 0;
   }
+
+  // Transition the slide of the tab headers when making place for drop
+  &.cdk-drop-list-dragging :not(app-tab-header.cdk-drag-placeholder) {
+    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
+  }
 }
 
 .add-tab {
@@ -68,6 +73,23 @@ app-tab-scroll-button {
   &:hover {
     color: inherit !important;
     background-color: var(--sf-tab-header-button-hover-background-color);
+  }
+}
+
+app-tab-header {
+  // Shadow under the dragged tab
+  &.cdk-drag-preview {
+    box-shadow: 0 4px 4px -3px rgba(0, 0, 0, 0.2);
+  }
+
+  // Empty spot for drop target
+  &.cdk-drag-placeholder {
+    opacity: 0;
+  }
+
+  // Transition the drop of the dragged tab into its place
+  &.cdk-drag-animating {
+    transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
@@ -1,3 +1,4 @@
+import { CdkDrag, CdkDropList } from '@angular/cdk/drag-drop';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
@@ -250,5 +251,34 @@ describe('TabGroupHeaderComponent', () => {
       expect(scrollIntoViewSpy).toHaveBeenCalled();
       expect(scrollToEndSpy).not.toHaveBeenCalled();
     }));
+  });
+
+  describe('movablePredicate', () => {
+    let tab: any;
+    let cdkDrag = {} as CdkDrag;
+    let cdkDropList: CdkDropList;
+
+    beforeEach(() => {
+      tab = {};
+      cdkDropList = { getSortedItems: () => [{ data: tab } as CdkDrag] } as CdkDropList;
+    });
+
+    it('should return true if the tab at index is an "add" tab', () => {
+      const index = 0;
+      tab.isAddTab = true;
+      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(true);
+    });
+
+    it('should return true if the tab at index is movable', () => {
+      const index = 0;
+      tab.movable = true;
+      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(true);
+    });
+
+    it('should return false if the tab at index is not an "add" and not movable', () => {
+      const index = 0;
+      tab.movable = false;
+      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(false);
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
@@ -254,31 +254,112 @@ describe('TabGroupHeaderComponent', () => {
   });
 
   describe('movablePredicate', () => {
-    let tab: any;
-    let cdkDrag = {} as CdkDrag;
+    let tabToMove: any;
+    let cdkDraggingTab = {} as CdkDrag;
     let cdkDropList: CdkDropList;
 
-    beforeEach(() => {
-      tab = {};
-      cdkDropList = { getSortedItems: () => [{ data: tab } as CdkDrag] } as CdkDropList;
+    describe('move within same tab group', () => {
+      beforeEach(() => {
+        // Dragging tab is in the drop list (not group transfer)
+        cdkDropList = { getSortedItems: () => [{ data: tabToMove } as CdkDrag, cdkDraggingTab] } as CdkDropList;
+        tabToMove = {};
+      });
+
+      it('should return true when direction is ltr and the tab at index is an "add" tab', () => {
+        const index = 0;
+        tabToMove.isAddTab = true;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return true when direction is rtl and the tab at index is an "add" tab', () => {
+        const index = 1;
+        tabToMove.isAddTab = true;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return true when direction is ltr and the tab at index is movable', () => {
+        const index = 0;
+        tabToMove.movable = true;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return true when direction is rtl and the tab at index is movable', () => {
+        const index = 1;
+        tabToMove.movable = true;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return false when direction is ltr and the tab at index is not an "add" and not movable', () => {
+        const index = 0;
+        tabToMove.movable = false;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(false);
+      });
+
+      it('should return false when direction is rtl and the tab at index is not an "add" and not movable', () => {
+        const index = 1;
+        tabToMove.movable = false;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(false);
+      });
     });
 
-    it('should return true if the tab at index is an "add" tab', () => {
-      const index = 0;
-      tab.isAddTab = true;
-      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(true);
-    });
+    describe('transfer to another tab group', () => {
+      beforeEach(() => {
+        // Dragging tab is not in the drop list (meaning group transfer)
+        cdkDropList = {
+          getSortedItems: () => [{ data: tabToMove } as CdkDrag, { data: {} } as CdkDrag]
+        } as CdkDropList;
+        tabToMove = {};
+      });
 
-    it('should return true if the tab at index is movable', () => {
-      const index = 0;
-      tab.movable = true;
-      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(true);
-    });
+      it('should return true when direction is ltr and the tab at index is an "add" tab', () => {
+        const index = 0;
+        tabToMove.isAddTab = true;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
 
-    it('should return false if the tab at index is not an "add" and not movable', () => {
-      const index = 0;
-      tab.movable = false;
-      expect(component.movablePredicate(index, cdkDrag, cdkDropList)).toBe(false);
+      it('should return true when direction is rtl and the tab at index is an "add" tab', () => {
+        // As of (v16), CDK drag and drop seems to have some issues transferring horizontally-oriented items in RTL.
+        // The library passes an index that references the wrong item when transferring groups in RTL.
+        const index = 2;
+        tabToMove.isAddTab = true;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return true when direction is ltr and the tab at index is movable', () => {
+        const index = 0;
+        tabToMove.movable = true;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return true when direction is rtl and the tab at index is movable', () => {
+        const index = 2;
+        tabToMove.movable = true;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(true);
+      });
+
+      it('should return false when direction is ltr and the tab at index is not an "add" and not movable', () => {
+        const index = 0;
+        tabToMove.movable = false;
+        component.direction = 'ltr';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(false);
+      });
+
+      it('should return false when direction is rtl and the tab at index is not an "add" and not movable', () => {
+        const index = 2;
+        tabToMove.movable = false;
+        component.direction = 'rtl';
+        expect(component.movablePredicate(index, cdkDraggingTab, cdkDropList)).toBe(false);
+      });
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
@@ -26,7 +26,7 @@ import {
   Subscription
 } from 'rxjs';
 import { TabMenuItem, TabMenuService } from 'src/app/shared/sf-tab-group';
-import { TabHeaderMouseEvent, TabMoveEvent } from '../sf-tabs.types';
+import { TabHeaderPointerEvent, TabLocation, TabMoveEvent } from '../sf-tabs.types';
 import { TabHeaderComponent } from '../tab-header/tab-header.component';
 import { TabComponent } from '../tab/tab.component';
 
@@ -43,7 +43,8 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
   @Input() selectedIndex = 0;
   @Input() allowDragDrop = true;
   @Input() connectedTo: string[] = [];
-  @Output() tabClick = new EventEmitter<TabHeaderMouseEvent>();
+  @Output() tabPress = new EventEmitter<TabHeaderPointerEvent>();
+  @Output() tabClick = new EventEmitter<TabHeaderPointerEvent>();
   @Output() closeClick = new EventEmitter<number>();
   @Output() tabMove = new EventEmitter<TabMoveEvent<string>>();
 
@@ -117,7 +118,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
 
   movablePredicate(index: number, _draggingTab: CdkDrag<TabComponent>, dropList: CdkDropList): boolean {
     const tabToMove = dropList.getSortedItems()[index];
-    return tabToMove.data.isAddTab || (tabToMove.data as TabComponent).movable;
+    return tabToMove && (tabToMove.data.isAddTab || (tabToMove.data as TabComponent).movable);
   }
 
   onAddTabClicked(): void {
@@ -126,8 +127,8 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
 
   onTabDrop(event: CdkDragDrop<Iterable<TabComponent>>): void {
     // Convert CdkDragDrop event to TabMoveEvent
-    const from = { groupId: event.previousContainer.id, index: event.previousIndex };
-    const to = { groupId: event.container.id, index: event.currentIndex };
+    const from: TabLocation<string> = { groupId: event.previousContainer.id, index: event.previousIndex };
+    const to: TabLocation<string> = { groupId: event.container.id, index: event.currentIndex };
     this.tabMove.emit({ from, to });
   }
 
@@ -183,6 +184,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
     // Handle tab overflow
     this.overflowing$.pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged()).subscribe(isOverflowing => {
       const host = this.elementRef.nativeElement;
+
       if (isOverflowing) {
         host.classList.add('overflowing');
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
@@ -11,11 +11,9 @@ import {
   Output,
   QueryList,
   SimpleChanges,
-  ViewChild,
   ViewChildren
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MatMenuTrigger } from '@angular/material/menu';
 import {
   BehaviorSubject,
   debounceTime,
@@ -52,7 +50,6 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
   @Output() tabAddRequest = new EventEmitter<string>();
 
   @ViewChildren(TabHeaderComponent, { read: ElementRef }) private tabHeaders?: QueryList<ElementRef>;
-  @ViewChild('menuTrigger') private menuTrigger?: MatMenuTrigger;
 
   menuItems$?: Observable<TabMenuItem[]>;
 
@@ -117,8 +114,8 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   movablePredicate(index: number, _draggingTab: CdkDrag<TabComponent>, dropList: CdkDropList): boolean {
-    const tabToMove = dropList.getSortedItems()[index];
-    return tabToMove && (tabToMove.data.isAddTab || (tabToMove.data as TabComponent).movable);
+    const tabToMove: CdkDrag<any> = dropList.getSortedItems()[index];
+    return tabToMove != null && (tabToMove.data.isAddTab || (tabToMove.data as TabComponent).movable);
   }
 
   onAddTabClicked(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
@@ -2,9 +2,12 @@
   [tabs]="tabs"
   [selectedIndex]="selectedIndex"
   [groupId]="groupId"
+  [allowDragDrop]="allowDragDrop"
+  [connectedTo]="connectedTo"
   (tabClick)="onTabHeaderClick($event)"
   (closeClick)="removeTab($event)"
   (tabAddRequest)="addTab($event)"
+  (tabMove)="moveTab($event)"
 ></app-tab-group-header>
 
 <app-tab-body *ngFor="let tab of tabs; let i = index" [active]="selectedIndex === i">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
@@ -4,6 +4,7 @@
   [groupId]="groupId"
   [allowDragDrop]="allowDragDrop"
   [connectedTo]="connectedTo"
+  (tabPress)="onTabHeaderPress($event)"
   (tabClick)="onTabHeaderClick($event)"
   (closeClick)="removeTab($event)"
   (tabAddRequest)="addTab($event)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -31,8 +31,12 @@ describe('TabGroupComponent', () => {
     fixture.detectChanges();
 
     // Override with 2 tabs
+    const tab1 = new TabComponent();
+    const tab2 = new TabComponent();
+    tab1.closeable = true;
+    tab2.closeable = false;
     component.tabs = new QueryList<TabComponent>();
-    component.tabs.reset([new TabComponent(), new TabComponent()]);
+    component.tabs.reset([tab1, tab2]);
   });
 
   it('should add tab using TabFactory and TabStateService when addTab is called', () => {
@@ -40,7 +44,8 @@ describe('TabGroupComponent', () => {
     const tab = {
       type: 'test',
       headerText: 'Tab Header',
-      closeable: false
+      closeable: false,
+      movable: true
     };
 
     const tabFactory = TestBed.inject(TabFactoryService);
@@ -64,7 +69,7 @@ describe('TabGroupComponent', () => {
   });
 
   it('should remove tab using TabStateService when removeTab is called on a removable tab', () => {
-    const tabIndex = 1;
+    const tabIndex = 0;
     const tabStateService = TestBed.inject(TabStateService);
     spyOn(tabStateService, 'removeTab');
     component.tabs.reset([new TabComponent(), new TabComponent(), new TabComponent()]);
@@ -73,7 +78,7 @@ describe('TabGroupComponent', () => {
   });
 
   it('should not remove tab using TabStateService when removeTab is called on a non-removable tab', () => {
-    const tabIndex = 0;
+    const tabIndex = 1;
     const tabStateService = TestBed.inject(TabStateService);
     spyOn(tabStateService, 'removeTab');
     component.removeTab(tabIndex);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
@@ -43,7 +43,7 @@ export class TabGroupComponent implements OnChanges {
 
   onTabHeaderPress(e: TabHeaderPointerEvent): void {
     // Select tab on left mouse button press or mobile touch
-    if (e.pointerEvent instanceof TouchEvent || e.pointerEvent.button === 0) {
+    if (this.isTouchEvent(e.pointerEvent) || e.pointerEvent.button === 0) {
       if (e.index < this.tabs.length) {
         this.selectTab(e.index);
       }
@@ -80,5 +80,9 @@ export class TabGroupComponent implements OnChanges {
 
   isTabRemovable(tabIndex: number): boolean {
     return this.tabs.get(tabIndex)?.closeable ?? false;
+  }
+
+  private isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
+    return typeof TouchEvent !== 'undefined' && event instanceof TouchEvent;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
@@ -83,6 +83,6 @@ export class TabGroupComponent implements OnChanges {
   }
 
   private isTouchEvent(event: MouseEvent | TouchEvent): event is TouchEvent {
-    return typeof TouchEvent !== 'undefined' && event instanceof TouchEvent;
+    return window.TouchEvent != null && event instanceof TouchEvent;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChild
 } from '@angular/core';
 import { TabFactoryService } from './base-services/tab-factory.service';
-import { TabHeaderMouseEvent, TabMoveEvent } from './sf-tabs.types';
+import { TabHeaderPointerEvent, TabMoveEvent } from './sf-tabs.types';
 import { TabStateService } from './tab-state/tab-state.service';
 import { TabBodyComponent } from './tab/tab-body/tab-body.component';
 import { TabComponent } from './tab/tab.component';
@@ -41,15 +41,20 @@ export class TabGroupComponent implements OnChanges {
     }
   }
 
-  onTabHeaderClick(e: TabHeaderMouseEvent): void {
-    // Close tab on middle button click
-    if (e.mouseEvent.button === 1) {
+  onTabHeaderPress(e: TabHeaderPointerEvent): void {
+    // Select tab on left mouse button press or mobile touch
+    if (e.pointerEvent instanceof TouchEvent || e.pointerEvent.button === 0) {
+      if (e.index < this.tabs.length) {
+        this.selectTab(e.index);
+      }
+    }
+  }
+
+  onTabHeaderClick(e: TabHeaderPointerEvent): void {
+    // Close tab on middle mouse button click
+    if (e.pointerEvent instanceof MouseEvent && e.pointerEvent.button === 1) {
       this.removeTab(e.index);
       return;
-    }
-
-    if (e.index < this.tabs.length) {
-      this.selectTab(e.index);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
@@ -9,19 +9,21 @@ import {
   ViewChild
 } from '@angular/core';
 import { TabFactoryService } from './base-services/tab-factory.service';
-import { TabHeaderMouseEvent } from './sf-tabs.types';
+import { TabHeaderMouseEvent, TabMoveEvent } from './sf-tabs.types';
 import { TabStateService } from './tab-state/tab-state.service';
 import { TabBodyComponent } from './tab/tab-body/tab-body.component';
 import { TabComponent } from './tab/tab.component';
 
 @Component({
-  selector: 'app-tab-group',
+  selector: 'app-tab-group [groupId]',
   templateUrl: './tab-group.component.html',
   styleUrls: ['./tab-group.component.scss']
 })
 export class TabGroupComponent implements OnChanges {
   @Input() groupId: string = '';
   @Input() selectedIndex = 0;
+  @Input() allowDragDrop = true;
+  @Input() connectedTo: string[] = [];
 
   @ViewChild(TabBodyComponent, { read: ElementRef }) scrollContainer?: ElementRef<HTMLElement>;
   @ContentChildren(TabComponent) tabs!: QueryList<TabComponent>;
@@ -67,7 +69,11 @@ export class TabGroupComponent implements OnChanges {
     }
   }
 
+  moveTab(e: TabMoveEvent<string>): void {
+    this.tabState.moveTab(e.from, e.to);
+  }
+
   isTabRemovable(tabIndex: number): boolean {
-    return tabIndex > 0 && tabIndex < this.tabs.length;
+    return this.tabs.get(tabIndex)?.closeable ?? false;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -2,14 +2,14 @@ import { Component, Input, OnChanges } from '@angular/core';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { Observable, of } from 'rxjs';
 import {
-  TabMenuItem,
   SFTabsModule,
   TabFactoryService,
   TabGroup,
   TabInfo,
+  TabMenuItem,
   TabMenuService,
   TabStateService
-} from 'src/app/shared/sf-tab-group';
+} from '../sf-tab-group';
 
 @Component({
   selector: 'app-tab-group-stories',
@@ -33,11 +33,7 @@ import {
       [selectedIndex]="tabGroup.value.selectedIndex"
       [connectedTo]="tabState.groupIds$ | async"
     >
-      <app-tab
-        *ngFor="let tab of tabGroup.value.tabs; let i = index"
-        [closeable]="tab.closeable"
-        [movable]="tab.movable"
-      >
+      <app-tab *ngFor="let tab of tabGroup.value.tabs" [closeable]="tab.closeable" [movable]="tab.movable">
         <ng-template sf-tab-header><div [innerHTML]="tab.headerText"></div></ng-template>
         <p><span [innerHTML]="tab.headerText"></span> in {{ tabGroup.key }}</p>
       </app-tab>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.html
@@ -2,6 +2,13 @@
   <ng-content></ng-content>
 </div>
 
-<button *ngIf="closeable" mat-icon-button class="close-button" (click)="close($event)">
+<button
+  *ngIf="closeable"
+  mat-icon-button
+  class="close-button"
+  (click)="onCloseClick($event)"
+  (mousedown)="onClosePress($event)"
+  (touchstart)="onClosePress($event)"
+>
   <mat-icon>close</mat-icon>
 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.spec.ts
@@ -74,7 +74,7 @@ describe('TabHeaderComponent', () => {
   it('should emit closeClick event on close', () => {
     spyOn(component.closeClick, 'emit');
     const event = new MouseEvent('click');
-    component.close(event);
+    component.onCloseClick(event);
     expect(component.closeClick.emit).toHaveBeenCalled();
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SFTabsModule } from '../sf-tabs.module';
 import { TabHeaderComponent } from './tab-header.component';
 
-describe('SfTabHeaderComponent', () => {
+describe('TabHeaderComponent', () => {
   let component: TabHeaderComponent;
   let fixture: ComponentFixture<TabHeaderComponent>;
 
@@ -14,6 +14,54 @@ describe('SfTabHeaderComponent', () => {
     fixture = TestBed.createComponent(TabHeaderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  describe('closeable class binding', () => {
+    it('should have the "closeable" class when closeable is true', () => {
+      component.closeable = true;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('closeable')).toBe(true);
+    });
+
+    it('should not have the "closeable" class when closeable is false', () => {
+      component.closeable = false;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('closeable')).toBe(false);
+    });
+  });
+
+  describe('movable class binding', () => {
+    it('should have the "movable" class when movable is true', () => {
+      component.movable = true;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('movable')).toBe(true);
+    });
+
+    it('should not have the "movable" class when movable is false', () => {
+      component.movable = false;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('movable')).toBe(false);
+    });
+  });
+
+  describe('active class binding', () => {
+    it('should have the "active" class when active is true', () => {
+      component.active = true;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('active')).toBe(true);
+    });
+
+    it('should not have the "active" class when active is false', () => {
+      component.active = false;
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.classList.contains('active')).toBe(false);
+    });
   });
 
   it('should emit tabClick event on click', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.ts
@@ -9,9 +9,15 @@ export class TabHeaderComponent {
   @HostBinding('class.closeable')
   @Input()
   closeable = true;
+
+  @HostBinding('class.movable')
+  @Input()
+  movable = true;
+
   @HostBinding('class.active')
   @Input()
   active = false;
+
   @Output() tabClick = new EventEmitter<MouseEvent>();
   @Output() closeClick = new EventEmitter<void>();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.ts
@@ -18,19 +18,32 @@ export class TabHeaderComponent {
   @Input()
   active = false;
 
-  @Output() tabClick = new EventEmitter<MouseEvent>();
+  @Output() tabPress = new EventEmitter<MouseEvent | TouchEvent>();
+  @Output() tabClick = new EventEmitter<MouseEvent | TouchEvent>();
   @Output() closeClick = new EventEmitter<void>();
+
+  @HostListener('mousedown', ['$event'])
+  @HostListener('touchstart', ['$event'])
+  onPress(e: MouseEvent | TouchEvent): void {
+    this.tabPress.emit(e);
+  }
 
   // Listen for left and middle clicks on the tab header
   @HostListener('click', ['$event'])
   @HostListener('auxclick', ['$event'])
-  onClick(e: MouseEvent): void {
+  onClick(e: MouseEvent | TouchEvent): void {
     this.tabClick.emit(e);
   }
 
-  close(e: MouseEvent): void {
+  onCloseClick(e: Event): void {
     // Stop propagation so 'tabClick' does not fire
     e.stopPropagation();
+
     this.closeClick.emit();
+  }
+
+  onClosePress(e: Event): void {
+    // Stop propagation so 'tabPress' does not fire
+    e.stopPropagation();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -143,10 +143,23 @@ describe('TabStateService', () => {
           { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
         ];
         const group = new TabGroup<string, any>(groupId, tabs);
-        group.selectedIndex = 1;
         service['groups'].set(groupId, group);
+
+        group.selectedIndex = 0;
+        service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
+        expect(service['groups'].get(groupId)!.selectedIndex).toBe(2);
+
+        group.selectedIndex = 1;
         service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
         expect(service['groups'].get(groupId)!.selectedIndex).toBe(0);
+
+        group.selectedIndex = 1;
+        service.moveTab({ groupId, index: 1 }, { groupId, index: 2 });
+        expect(service['groups'].get(groupId)!.selectedIndex).toBe(2);
+
+        group.selectedIndex = 1;
+        service.moveTab({ groupId, index: 2 }, { groupId, index: 1 });
+        expect(service['groups'].get(groupId)!.selectedIndex).toBe(2);
       });
 
       it('should move a tab across groups', () => {
@@ -172,21 +185,31 @@ describe('TabStateService', () => {
         const toGroupId: string = 'target';
         const fromTabs: TabInfo<string>[] = [
           { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 3', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 4', closeable: true, movable: true }
         ];
         const toTabs: TabInfo<string>[] = [
           { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
           { type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
         ];
         const fromGroup = new TabGroup<string, any>(fromGroupId, fromTabs);
-        fromGroup.selectedIndex = 0;
         const toGroup = new TabGroup<string, any>(toGroupId, toTabs);
-        toGroup.selectedIndex = 1;
+
         service['groups'].set(fromGroupId, fromGroup);
         service['groups'].set(toGroupId, toGroup);
+
+        fromGroup.selectedIndex = 0;
+        toGroup.selectedIndex = 1;
         service.moveTab({ groupId: fromGroupId, index: 0 }, { groupId: toGroupId, index: 1 });
         expect(service['groups'].get(fromGroupId)!.selectedIndex).toBe(0);
-        expect(service['groups'].get(toGroupId)!.selectedIndex).toBe(2);
+        expect(service['groups'].get(toGroupId)!.selectedIndex).toBe(1);
+
+        fromGroup.selectedIndex = 2;
+        toGroup.selectedIndex = 2;
+        service.moveTab({ groupId: fromGroupId, index: 2 }, { groupId: toGroupId, index: 1 });
+        expect(service['groups'].get(fromGroupId)!.selectedIndex).toBe(1);
+        expect(service['groups'].get(toGroupId)!.selectedIndex).toBe(1);
       });
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { take } from 'rxjs';
 import { TabGroup } from './tab-group';
 import { TabInfo, TabStateService } from './tab-state.service';
 
@@ -41,7 +42,7 @@ describe('TabStateService', () => {
     });
 
     describe('clearAllTabGroups', () => {
-      it('should clear all tab groups', () => {
+      it('should clear all tab groups and emit an empty map after clearing all tab groups', done => {
         const groupId1: string = 'group1';
         const groupId2: string = 'group2';
         const tabs: TabInfo<string>[] = [
@@ -50,25 +51,15 @@ describe('TabStateService', () => {
         ];
         service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
         service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
-        service.clearAllTabGroups();
-        expect(service['groups'].size).toBe(0);
-      });
-
-      it('should emit an empty map after clearing all tab groups', done => {
-        const groupId1: string = 'group1';
-        const groupId2: string = 'group2';
-        const tabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
-        ];
-        service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
-        service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
-        service.tabGroups$.subscribe(groups => {
-          if (groups.size === 0) {
-            done();
-          }
+        service.tabGroups$.pipe(take(1)).subscribe(groups => {
+          expect(groups.size).toBe(2);
         });
         service.clearAllTabGroups();
+        expect(service['groups'].size).toBe(0);
+        service.tabGroups$.pipe(take(1)).subscribe(groups => {
+          expect(groups.size).toBe(0);
+          done();
+        });
       });
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -6,8 +6,8 @@ describe('TabStateService', () => {
   let service: TabStateService<string, TabInfo<string>>;
   const groupId = 'testGroup';
   const tabs: TabInfo<string>[] = [
-    { type: 'tab1', headerText: 'Tab 1', closeable: true },
-    { type: 'tab2', headerText: 'Tab 2', closeable: false }
+    { type: 'tab1', headerText: 'Tab 1', closeable: true, movable: true },
+    { type: 'tab2', headerText: 'Tab 2', closeable: false, movable: true }
   ];
 
   beforeEach(() => {
@@ -15,28 +15,62 @@ describe('TabStateService', () => {
     service = TestBed.inject(TabStateService);
   });
 
-  it('should add a new tab group', () => {
-    service.addTabGroup(groupId, tabs);
-    expect(service['groups'].get(groupId)).toEqual(new TabGroup(groupId, tabs));
-  });
-
-  it('should throw an error if the group already exists', () => {
-    service.addTabGroup(groupId, tabs);
-    expect(() => service.addTabGroup(groupId, tabs)).toThrowError(`Tab group '${groupId}' already exists.`);
-  });
-
-  it('should emit the updated groups', done => {
-    service.addTabGroup(groupId, tabs);
-    service.tabGroups$.subscribe(groups => {
-      expect(groups.get(groupId)).toEqual(new TabGroup(groupId, tabs));
-      done();
+  describe('group actions', () => {
+    it('should add a new tab group', () => {
+      service.addTabGroup(groupId, tabs);
+      expect(service['groups'].get(groupId)).toEqual(new TabGroup(groupId, tabs));
     });
-  });
 
-  it('should remove a tab group', () => {
-    service.addTabGroup(groupId, tabs);
-    service.removeTabGroup(groupId);
-    expect(service['groups'].get(groupId)).toBeUndefined();
+    it('should throw an error if the group already exists', () => {
+      service.addTabGroup(groupId, tabs);
+      expect(() => service.addTabGroup(groupId, tabs)).toThrowError(`Tab group '${groupId}' already exists.`);
+    });
+
+    it('should emit the updated groups', done => {
+      service.addTabGroup(groupId, tabs);
+      service.tabGroups$.subscribe(groups => {
+        expect(groups.get(groupId)).toEqual(new TabGroup(groupId, tabs));
+        done();
+      });
+    });
+
+    it('should remove a tab group', () => {
+      service.addTabGroup(groupId, tabs);
+      service.removeTabGroup(groupId);
+      expect(service['groups'].get(groupId)).toBeUndefined();
+    });
+
+    describe('clearAllTabGroups', () => {
+      it('should clear all tab groups', () => {
+        const groupId1: string = 'group1';
+        const groupId2: string = 'group2';
+        const tabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        ];
+        service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
+        service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
+        service.clearAllTabGroups();
+        expect(service['groups'].size).toBe(0);
+      });
+
+      it('should emit an empty map after clearing all tab groups', done => {
+        const groupId1: string = 'group1';
+        const groupId2: string = 'group2';
+        const tabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        ];
+        service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
+        service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
+        service.tabGroups$.subscribe(groups => {
+          if (groups.size === 0) {
+            done();
+          }
+        });
+        service.clearAllTabGroups();
+      });
+    });
   });
 
   describe('tab actions', () => {
@@ -45,7 +79,8 @@ describe('TabStateService', () => {
       const tab: TabInfo<string> = {
         type: 'type-a',
         headerText: 'Header',
-        closeable: true
+        closeable: true,
+        movable: true
       };
       service.addTab(groupId, tab);
       expect(service['groups'].get(groupId)!.tabs.length).toBe(1);
@@ -57,7 +92,8 @@ describe('TabStateService', () => {
       const tab: TabInfo<string> = {
         type: 'type-a',
         headerText: 'Header',
-        closeable: true
+        closeable: true,
+        movable: true
       };
       service['groups'].set(groupId, new TabGroup<string, any>(groupId, [tab]));
       expect(service['groups'].get(groupId)!.tabs.length).toBe(1);
@@ -71,17 +107,87 @@ describe('TabStateService', () => {
         {
           type: 'type-a',
           headerText: 'Header 1',
-          closeable: true
+          closeable: true,
+          movable: true
         },
         {
           type: 'type-a',
           headerText: 'Header 2',
-          closeable: true
+          closeable: true,
+          movable: true
         }
       ];
       service['groups'].set(groupId, new TabGroup<string, any>(groupId, tabs));
       service.selectTab(groupId, 1);
       expect(service['groups'].get(groupId)!.selectedIndex).toBe(1);
+    });
+
+    describe('moveTab', () => {
+      it('should move a tab within the same group', () => {
+        const groupId: string = 'source';
+        const tabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+        ];
+        service['groups'].set(groupId, new TabGroup<string, any>(groupId, tabs));
+        service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
+        expect(service['groups'].get(groupId)!.tabs.map(tab => tab.type)).toEqual(['type-b', 'type-c', 'type-a']);
+      });
+
+      it('should update selected index when moving a tab within the same group', () => {
+        const groupId: string = 'source';
+        const tabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+        ];
+        const group = new TabGroup<string, any>(groupId, tabs);
+        group.selectedIndex = 1;
+        service['groups'].set(groupId, group);
+        service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
+        expect(service['groups'].get(groupId)!.selectedIndex).toBe(0);
+      });
+
+      it('should move a tab across groups', () => {
+        const fromGroupId: string = 'source';
+        const toGroupId: string = 'target';
+        const fromTabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        ];
+        const toTabs: TabInfo<string>[] = [
+          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
+          { type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+        ];
+        service['groups'].set(fromGroupId, new TabGroup<string, any>(fromGroupId, fromTabs));
+        service['groups'].set(toGroupId, new TabGroup<string, any>(toGroupId, toTabs));
+        service.moveTab({ groupId: fromGroupId, index: 0 }, { groupId: toGroupId, index: 1 });
+        expect(service['groups'].get(fromGroupId)!.tabs.map(tab => tab.type)).toEqual(['type-b']);
+        expect(service['groups'].get(toGroupId)!.tabs.map(tab => tab.type)).toEqual(['type-c', 'type-a', 'type-d']);
+      });
+
+      it('should update selected index when moving a tab across groups', () => {
+        const fromGroupId: string = 'source';
+        const toGroupId: string = 'target';
+        const fromTabs: TabInfo<string>[] = [
+          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        ];
+        const toTabs: TabInfo<string>[] = [
+          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
+          { type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+        ];
+        const fromGroup = new TabGroup<string, any>(fromGroupId, fromTabs);
+        fromGroup.selectedIndex = 0;
+        const toGroup = new TabGroup<string, any>(toGroupId, toTabs);
+        toGroup.selectedIndex = 1;
+        service['groups'].set(fromGroupId, fromGroup);
+        service['groups'].set(toGroupId, toGroup);
+        service.moveTab({ groupId: fromGroupId, index: 0 }, { groupId: toGroupId, index: 1 });
+        expect(service['groups'].get(fromGroupId)!.selectedIndex).toBe(0);
+        expect(service['groups'].get(toGroupId)!.selectedIndex).toBe(2);
+      });
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -1,31 +1,41 @@
+import { moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map, Observable } from 'rxjs';
+import { TabLocation } from '../sf-tabs.types';
 import { TabGroup } from './tab-group';
 
 export interface TabInfo<TType extends string> {
   type: TType;
   headerText: string;
+
+  /** Optional material icon to place alongside tab header text. */
   icon?: string;
+
+  /** Whether the tab can be removed from the tab group. */
   closeable: boolean;
+
+  /** Whether the tab can be dragged or reordered. */
+  movable: boolean;
 }
 
-interface TabState<TKey extends string, T> {
-  tabGroups$: Observable<Map<TKey, TabGroup<TKey, T>>>;
+interface TabState<TGroupId extends string, T> {
+  tabGroups$: Observable<Map<TGroupId, TabGroup<TGroupId, T>>>;
 
-  addTabGroup(groupId: TKey, tabs: Iterable<T>): void;
-  getTabGroup(groupId: TKey): TabGroup<TKey, T> | undefined;
-  removeTabGroup(groupId: TKey): boolean;
+  addTabGroup(groupId: TGroupId, tabs: Iterable<T>): void;
+  getTabGroup(groupId: TGroupId): TabGroup<TGroupId, T> | undefined;
+  removeTabGroup(groupId: TGroupId): boolean;
   clearAllTabGroups(): void;
 }
 
 @Injectable({
   providedIn: 'root'
 })
-export class TabStateService<TKey extends string, T extends TabInfo<string>> implements TabState<TKey, T> {
-  protected readonly groups = new Map<TKey, TabGroup<TKey, T>>();
+export class TabStateService<TGroupId extends string, T extends TabInfo<string>> implements TabState<TGroupId, T> {
+  protected readonly groups = new Map<TGroupId, TabGroup<TGroupId, T>>();
 
-  protected tabGroupsSource$ = new BehaviorSubject<Map<TKey, TabGroup<TKey, T>>>(this.groups);
-  tabGroups$: Observable<Map<TKey, TabGroup<TKey, T>>> = this.tabGroupsSource$.asObservable();
+  protected tabGroupsSource$ = new BehaviorSubject<Map<TGroupId, TabGroup<TGroupId, T>>>(this.groups);
+  tabGroups$: Observable<Map<TGroupId, TabGroup<TGroupId, T>>> = this.tabGroupsSource$.asObservable();
+
   tabs$: Observable<T[]> = this.tabGroupsSource$.pipe(
     map(tabGroups => {
       const tabs: T[] = [];
@@ -36,9 +46,21 @@ export class TabStateService<TKey extends string, T extends TabInfo<string>> imp
     })
   );
 
+  groupIds$: Observable<TGroupId[]> = this.tabGroupsSource$.pipe(map(groups => Array.from(groups.keys())));
+
   constructor() {}
 
-  addTabGroup(groupId: TKey, tabs: T[]): void {
+  addTabGroup(groupId: TGroupId, tabs: T[]): void;
+  addTabGroup(tabGroup: TabGroup<TGroupId, T>): void;
+  addTabGroup(groupIdOrGroup: TGroupId | TabGroup<TGroupId, T>, tabs?: T[]): void {
+    if (groupIdOrGroup instanceof TabGroup) {
+      const tabGroup: TabGroup<TGroupId, T> = groupIdOrGroup;
+      this.groups.set(tabGroup.groupId, tabGroup);
+      return;
+    }
+
+    const groupId = groupIdOrGroup;
+
     if (this.groups.has(groupId)) {
       throw new Error(`Tab group '${groupId}' already exists.`);
     }
@@ -47,11 +69,11 @@ export class TabStateService<TKey extends string, T extends TabInfo<string>> imp
     this.tabGroupsSource$.next(this.groups);
   }
 
-  getTabGroup(groupId: TKey): TabGroup<TKey, T> | undefined {
+  getTabGroup(groupId: TGroupId): TabGroup<TGroupId, T> | undefined {
     return this.groups.get(groupId)!;
   }
 
-  removeTabGroup(groupId: TKey): boolean {
+  removeTabGroup(groupId: TGroupId): boolean {
     const itemExisted = this.groups.delete(groupId);
     this.tabGroupsSource$.next(this.groups);
     return itemExisted;
@@ -62,22 +84,81 @@ export class TabStateService<TKey extends string, T extends TabInfo<string>> imp
     this.tabGroupsSource$.next(this.groups);
   }
 
-  addTab(groupId: TKey, tab: T): void {
+  addTab(groupId: TGroupId, tab: T): void {
     if (!this.groups.has(groupId)) {
-      this.groups.set(groupId, new TabGroup<TKey, T>(groupId, []));
+      this.groups.set(groupId, new TabGroup<TGroupId, T>(groupId, []));
     }
 
     this.groups.get(groupId)!.addTab(tab, true);
     this.tabGroupsSource$.next(this.groups);
   }
 
-  removeTab(groupId: TKey, index: number): void {
+  removeTab(groupId: TGroupId, index: number): void {
     this.groups.get(groupId)!.removeTab(index);
     this.tabGroupsSource$.next(this.groups);
   }
 
-  selectTab(groupId: TKey, index: number): void {
+  selectTab(groupId: TGroupId, index: number): void {
     this.groups.get(groupId)!.selectedIndex = index;
+    this.tabGroupsSource$.next(this.groups);
+  }
+
+  moveTab(from: TabLocation<TGroupId>, to: TabLocation<TGroupId>): void {
+    const fromGroup = this.groups.get(from.groupId);
+
+    if (fromGroup) {
+      // Tab move within same group
+      if (from.groupId === to.groupId) {
+        // Add bounds in case tab is dropped after 'add tab'
+        to.index = Math.min(fromGroup.tabs.length - 1, to.index);
+
+        moveItemInArray(fromGroup.tabs, from.index, to.index);
+
+        // Update selected tab index if necessary
+        switch (true) {
+          // Selected tab moved
+          case from.index === fromGroup.selectedIndex:
+            fromGroup.selectedIndex = to.index;
+            break;
+          // Tab before selected tab moved after selected tab
+          case from.index < fromGroup.selectedIndex && to.index >= fromGroup.selectedIndex:
+            fromGroup.selectedIndex--;
+            break;
+          // Tab after selected tab moved before selected tab
+          case from.index > fromGroup.selectedIndex && to.index <= fromGroup.selectedIndex:
+            fromGroup.selectedIndex++;
+            break;
+        }
+      } else {
+        // Tab move across groups
+        const toGroup = this.groups.get(to.groupId);
+
+        if (toGroup) {
+          // Add bounds in case tab is dropped after 'add tab'
+          to.index = Math.min(toGroup.tabs.length, to.index);
+
+          transferArrayItem(fromGroup.tabs, toGroup.tabs, from.index, to.index);
+
+          // Update 'from group' selected tab index if necessary
+          switch (true) {
+            // Selected tab moved to another group
+            case from.index === fromGroup.selectedIndex:
+              fromGroup.selectedIndex = 0;
+              break;
+            // Tab before selected tab moved to another group
+            case from.index < fromGroup.selectedIndex:
+              fromGroup.selectedIndex--;
+              break;
+          }
+
+          // Update 'to group' selected tab index if necessary
+          if (to.index <= toGroup.selectedIndex) {
+            toGroup.selectedIndex++;
+          }
+        }
+      }
+    }
+
     this.tabGroupsSource$.next(this.groups);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab.component.ts
@@ -8,6 +8,7 @@ import { TabHeaderDirective } from '../tab-header/tab-header.directive';
 })
 export class TabComponent {
   @Input() closeable: boolean = true;
+  @Input() movable: boolean = true;
   @ViewChild(TemplateRef) contentTemplate!: TemplateRef<any>;
   @ContentChild(TabHeaderDirective, { read: TemplateRef }) tabHeaderTemplate?: any;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
@@ -1,6 +1,8 @@
 :host {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  overflow: hidden;
 }
 
 mat-progress-bar {
@@ -15,6 +17,10 @@ app-history-chooser {
   top: 0;
   background: #fff;
   z-index: 1;
+}
+
+app-text {
+  overflow-y: auto;
 }
 
 app-notice {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.spec.ts
@@ -47,6 +47,28 @@ describe('EditorHistoryComponent', () => {
     mockHistoryChooserComponent.showDiffChange = showDiffChange$ as EventEmitter<boolean>;
   });
 
+  it('should clear loadedRevision and emit revisionSelect on ngOnChanges', () => {
+    component.loadedRevision = {} as Revision;
+    component.isViewInitialized = true;
+    spyOn(component.revisionSelect, 'emit');
+
+    component.ngOnChanges();
+
+    expect(component.loadedRevision).toBeUndefined();
+    expect(component.revisionSelect.emit).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should not emit revisionSelect on ngOnChanges when isViewInitialized is false', () => {
+    component.loadedRevision = {} as Revision;
+    component.isViewInitialized = false;
+    spyOn(component.revisionSelect, 'emit');
+
+    component.ngOnChanges();
+
+    expect(component.loadedRevision).toBeUndefined();
+    expect(component.revisionSelect.emit).not.toHaveBeenCalled();
+  });
+
   it('should load history after view init', fakeAsync(() => {
     const diff = new Delta();
     const revision: Revision = { key: 'date_here', value: 'description_here' };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -61,13 +61,14 @@
     </div>
 
     <app-tab-group
-      *ngFor="let tabGroup of this.tabState.tabGroups$ | async | keyvalue"
+      *ngFor="let tabGroup of tabState.tabGroups$ | async | keyvalue"
       id="{{ tabGroup.key }}-text-area"
       class="text-area"
       [groupId]="tabGroup.key"
       [selectedIndex]="tabGroup.value.selectedIndex"
+      [connectedTo]="(tabState.groupIds$ | async) ?? []"
     >
-      <app-tab *ngFor="let tab of tabGroup.value.tabs" [closeable]="tab.closeable">
+      <app-tab *ngFor="let tab of tabGroup.value.tabs" [closeable]="tab.closeable" [movable]="tab.movable">
         <!-- TODO: Localize tab header text -->
         <ng-template sf-tab-header>
           <mat-icon *ngIf="tab.icon">{{ tab.icon }}</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3213,7 +3213,7 @@ describe('EditorComponent', () => {
 
       const segmentElRect = env.getSegmentElement(segmentRef)!.getBoundingClientRect();
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(segmentElRect.top).toEqual(fabRect.top);
+      expect(segmentElRect.top).toBeCloseTo(fabRect.top, 0);
 
       env.dispose();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -16,6 +16,7 @@ describe('EditorTabFactoryService', () => {
     expect(tab.icon).toEqual('history');
     expect(tab.headerText).toEqual('History');
     expect(tab.closeable).toEqual(true);
+    expect(tab.movable).toEqual(true);
   });
 
   it('should create a "draft" tab', () => {
@@ -24,6 +25,7 @@ describe('EditorTabFactoryService', () => {
     expect(tab.icon).toEqual('model_training');
     expect(tab.headerText).toEqual('Auto Draft');
     expect(tab.closeable).toEqual(true);
+    expect(tab.movable).toEqual(true);
     expect(tab.unique).toEqual(true);
   });
 
@@ -33,6 +35,7 @@ describe('EditorTabFactoryService', () => {
     expect(tab.icon).toEqual('book');
     expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(false);
+    expect(tab.movable).toEqual(false);
     expect(tab.unique).toEqual(true);
   });
 
@@ -42,6 +45,7 @@ describe('EditorTabFactoryService', () => {
     expect(tab.icon).toEqual('book');
     expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(false);
+    expect(tab.movable).toEqual(false);
     expect(tab.unique).toEqual(true);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -13,7 +13,8 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
           type: 'history',
           icon: 'history',
           headerText: 'History',
-          closeable: true
+          closeable: true,
+          movable: true
         };
       case 'draft':
         return {
@@ -21,6 +22,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
           icon: 'model_training',
           headerText: 'Auto Draft',
           closeable: true,
+          movable: true,
           unique: true
         };
       case 'project-source':
@@ -34,6 +36,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
           icon: 'book',
           headerText: tabOptions.headerText,
           closeable: false,
+          movable: false,
           unique: true
         };
       default:

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -41,11 +41,11 @@ describe('EditorTabsMenuService', () => {
 
   it('should get "history" and "draft" menu items', done => {
     const env = new TestEnvironment();
-    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true }]);
+    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
     env.setLastCompletedBuildExists(true);
     service['canShowHistory'] = () => true;
 
-    service.getMenuItems('source').subscribe(items => {
+    service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('history');
       expect(items[0].disabled).toBeFalsy();
@@ -58,13 +58,13 @@ describe('EditorTabsMenuService', () => {
   it('should get "history" and not "draft" (tab already exists) menu items', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([
-      { type: 'history', headerText: 'History', closeable: true },
-      { type: 'draft', headerText: 'Draft', closeable: true, unique: true }
+      { type: 'history', headerText: 'History', closeable: true, movable: true },
+      { type: 'draft', headerText: 'Draft', closeable: true, movable: true, unique: true }
     ]);
     env.setLastCompletedBuildExists(true);
     service['canShowHistory'] = () => true;
 
-    service.getMenuItems('source').subscribe(items => {
+    service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(1);
       expect(items[0].type).toBe('history');
       expect(items[0].disabled).toBeFalsy();
@@ -74,11 +74,11 @@ describe('EditorTabsMenuService', () => {
 
   it('should get "history" (enabled) and not "draft" (no draft build) menu items', done => {
     const env = new TestEnvironment();
-    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true }]);
+    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
     env.setLastCompletedBuildExists(false);
     service['canShowHistory'] = () => true;
 
-    service.getMenuItems('source').subscribe(items => {
+    service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(1);
       expect(items[0].type).toBe('history');
       expect(items[0].disabled).toBeFalsy();
@@ -92,7 +92,7 @@ describe('EditorTabsMenuService', () => {
     env.setLastCompletedBuildExists(true);
     service['canShowHistory'] = () => false;
 
-    service.getMenuItems('source').subscribe(items => {
+    service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(1);
       expect(items[0].type).toBe('draft');
       expect(items[0].disabled).toBeFalsy();
@@ -106,7 +106,7 @@ describe('EditorTabsMenuService', () => {
     env.setLastCompletedBuildExists(false);
     service['canShowHistory'] = () => false;
 
-    service.getMenuItems('source').subscribe(items => {
+    service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(0);
       done();
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { combineLatest, forkJoin, map, Observable, of } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
-import { NewTabMenuItem, TabMenuService, TabStateService } from 'src/app/shared/sf-tab-group';
+import { TabMenuItem, TabMenuService, TabStateService } from 'src/app/shared/sf-tab-group';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
@@ -14,7 +14,7 @@ import { EditorTabGroupType, EditorTabInfo, EditorTabType, editorTabTypes } from
 @Injectable({
   providedIn: 'root'
 })
-export class EditorTabMenuService implements TabMenuService {
+export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> {
   constructor(
     private readonly userService: UserService,
     private readonly activatedProject: ActivatedProjectService,
@@ -23,7 +23,7 @@ export class EditorTabMenuService implements TabMenuService {
     private readonly i18n: I18nService
   ) {}
 
-  getMenuItems(_groupId: EditorTabGroupType): Observable<NewTabMenuItem[]> {
+  getMenuItems(): Observable<TabMenuItem[]> {
     return this.activatedProject.projectDoc$.pipe(
       filterNullish(),
       switchMap(projectDoc => {
@@ -35,7 +35,7 @@ export class EditorTabMenuService implements TabMenuService {
       }),
       switchMap(([projectDoc, buildDto, existingTabs]) => {
         const showDraft = buildDto != null;
-        const items: Observable<NewTabMenuItem>[] = [];
+        const items: Observable<TabMenuItem>[] = [];
 
         for (const tabType of editorTabTypes) {
           switch (tabType) {
@@ -67,7 +67,7 @@ export class EditorTabMenuService implements TabMenuService {
     );
   }
 
-  private createMenuItem(tabType: EditorTabType): Observable<NewTabMenuItem> {
+  private createMenuItem(tabType: EditorTabType): Observable<TabMenuItem> {
     switch (tabType) {
       case 'history':
         return this.i18n.translate('editor_tabs_menu.history_tab_header').pipe(


### PR DESCRIPTION
Add drag/drop reordering and moving of tabs between source/target tab groups.  Main source and target project tabs should remain fixed in place as first item in their respective groups.

This PR is currently based off `feature/sf-2439-editor-tabs`, which is not yet merged into master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2363)
<!-- Reviewable:end -->
