### PR TITLE
SF-2594 Allow saving comments with the bottomsheet with XML symbols

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2774,7 +2774,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('bottom sheet can accept xml reserved symbols', fakeAsync(() => {
+    it('can accept xml reserved symbols as note content', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.setCommenterUser();
@@ -2795,6 +2795,32 @@ describe('EditorComponent', () => {
       const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
       expect(noteThread.verseRef).toEqual(fromVerseRef(new VerseRef('LUK 1:1')));
       expect(noteThread.notes[0].content).toEqual(XmlUtils.encodeForXml(content));
+      env.dispose();
+    }));
+
+    it('can edit a note with xml reserved symbols as note content', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const projectId: string = 'project01';
+      env.setSelectionAndInsertNote('verse_1_2');
+      const content: string = 'content in the thread';
+      env.mockNoteDialogRef.close({ noteContent: content });
+      env.wait();
+      verify(mockedSFProjectService.createNoteThread(projectId, anything())).once();
+      const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
+      let noteThreadDoc: NoteThreadDoc = env.getNoteThreadDoc(projectId, noteThread.dataId);
+      expect(noteThreadDoc.data!.notes[0].content).toEqual(content);
+
+      const iconElement: HTMLElement = env.getNoteThreadIconElementAtIndex('verse_1_2', 0)!;
+      iconElement.click();
+      const editedContent = 'edited content <xml> tags';
+      env.mockNoteDialogRef.close({ noteDataId: noteThread.notes[0].dataId, noteContent: editedContent });
+      env.wait();
+      verify(mockedMatDialog.open(NoteDialogComponent, anything())).twice();
+      noteThreadDoc = env.getNoteThreadDoc(projectId, noteThread.dataId);
+      expect(noteThreadDoc.data!.notes[0].content).toEqual(XmlUtils.encodeForXml(editedContent));
       env.dispose();
     }));
 
@@ -4791,6 +4817,8 @@ export class MockNoteDialogRef {
     this.onClose();
     this.close$.next(result);
     this.close$.complete();
+    // reset the subject so that the mocked note dialog can be reopened
+    this.close$ = new Subject<NoteDialogResult | void>();
   }
 
   afterClosed(): Observable<NoteDialogResult | void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -92,6 +92,7 @@ import { SFTabsModule, TabFactoryService, TabMenuService } from '../../shared/sf
 import { SharedModule } from '../../shared/shared.module';
 import { getCombinedVerseTextDoc, paratextUsersFromRoles } from '../../shared/test-utils';
 import { PRESENCE_EDITOR_ACTIVE_TIMEOUT } from '../../shared/text/text.component';
+import { XmlUtils } from '../../shared/utils';
 import { BiblicalTermsComponent } from '../biblical-terms/biblical-terms.component';
 import { DraftGenerationService } from '../draft-generation/draft-generation.service';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
@@ -2770,6 +2771,30 @@ describe('EditorComponent', () => {
       const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
       expect(noteThread.verseRef).toEqual(fromVerseRef(new VerseRef('LUK 1:1')));
       expect(noteThread.notes[0].content).toEqual(content);
+      env.dispose();
+    }));
+
+    it('bottom sheet can accept xml reserved symbols', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.setCommenterUser();
+      env.updateParams({ projectId: 'project01', bookId: 'LUK' });
+      env.wait();
+
+      // Allow check for mobile viewports to return TRUE
+      when(mockedMediaObserver.isActive(anything())).thenReturn(true);
+      env.clickSegmentRef('verse_1_1');
+      env.wait();
+      expect(env.insertNoteFabMobile).toBeTruthy();
+      env.insertNoteFabMobile!.click();
+      expect(env.bottomSheetVerseReference?.textContent).toEqual('Luke 1:1');
+      const content = 'mobile <note> with xml symbols';
+      env.component.mobileNoteControl.setValue(content);
+      env.saveMobileNoteButton!.click();
+      env.wait();
+      const [, noteThread] = capture(mockedSFProjectService.createNoteThread).last();
+      expect(noteThread.verseRef).toEqual(fromVerseRef(new VerseRef('LUK 1:1')));
+      expect(noteThread.notes[0].content).toEqual(XmlUtils.encodeForXml(content));
       env.dispose();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -2778,7 +2778,7 @@ describe('EditorComponent', () => {
       const env = new TestEnvironment();
       env.setProjectUserConfig();
       env.setCommenterUser();
-      env.updateParams({ projectId: 'project01', bookId: 'LUK' });
+      env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
       env.wait();
 
       // Allow check for mobile viewports to return TRUE
@@ -2815,7 +2815,7 @@ describe('EditorComponent', () => {
 
       const iconElement: HTMLElement = env.getNoteThreadIconElementAtIndex('verse_1_2', 0)!;
       iconElement.click();
-      const editedContent = 'edited content <xml> tags';
+      const editedContent = 'edited content & <xml> tags';
       env.mockNoteDialogRef.close({ noteDataId: noteThread.notes[0].dataId, noteContent: editedContent });
       env.wait();
       verify(mockedMatDialog.open(NoteDialogComponent, anything())).twice();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -119,7 +119,8 @@ import {
   getVerseRefFromSegmentRef,
   threadIdFromMouseEvent,
   VERSE_REGEX,
-  verseRefFromMouseEvent
+  verseRefFromMouseEvent,
+  XmlUtils
 } from '../../shared/utils';
 import { EditorHistoryService } from './editor-history/editor-history.service';
 import { MultiCursorViewer } from './multi-viewer/multi-viewer.component';
@@ -1242,6 +1243,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     // only set the tag id if it is the first note in the thread
     const tagId: number | undefined =
       params.threadDataId == null ? this.projectDoc?.data?.translateConfig.defaultNoteTagId : undefined;
+    const noteContent: string | undefined = params.content == null ? undefined : XmlUtils.encodeForXml(params.content);
     // Configure the note
     const note: Note = {
       dateCreated: currentDate,
@@ -1250,7 +1252,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       dataId: params.dataId ?? objectId(),
       tagId,
       ownerRef: this.userService.currentUserId,
-      content: params.content,
+      content: noteContent,
       conflictType: NoteConflictType.DefaultValue,
       type: NoteType.Normal,
       status: params.status ?? NoteStatus.Todo,
@@ -1285,7 +1287,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         // updated the existing note
         if (threadDoc.data?.notes[noteIndex].editable === true) {
           await threadDoc!.submitJson0Op(op => {
-            op.set(t => t.notes[noteIndex].content, params.content);
+            op.set(t => t.notes[noteIndex].content, noteContent);
             op.set(t => t.notes[noteIndex].dateModified, currentDate);
           });
         } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -340,22 +340,6 @@ describe('NoteDialogComponent', () => {
     expect(env.dialogResult).toEqual({ noteContent: 'Enter note content', noteDataId: undefined });
   }));
 
-  it('can insert a note and encode for xml', fakeAsync(() => {
-    const verseRef = new VerseRef('MAT 1:3');
-    env = new TestEnvironment({ verseRef, noteTagId: 2 });
-    expect(env.noteInputElement).toBeTruthy();
-    expect(env.verseRef).toEqual('Matthew 1:3');
-    env.enterNoteContent('Enter note & have <xml> invalid content');
-    expect(env.component.currentNoteContent).toEqual('Enter note & have <xml> invalid content');
-    expect(env.component.segmentText).toEqual('target: chapter 1, verse 3.');
-    env.submit();
-
-    expect(env.dialogResult).toEqual({
-      noteContent: 'Enter note &amp; have &lt;xml&gt; invalid content',
-      noteDataId: undefined
-    });
-  }));
-
   it('show sf note tag on notes with undefined tag id', fakeAsync(() => {
     const noteThread: NoteThread = TestEnvironment.getNoteThread(undefined, true);
     env = new TestEnvironment({ noteThread });
@@ -414,22 +398,6 @@ describe('NoteDialogComponent', () => {
     env.enterNoteContent(content);
     env.submit();
     expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05' });
-  }));
-
-  it('allows user to edit the content with xml reserved symbols', fakeAsync(() => {
-    const noteThread: NoteThread = TestEnvironment.getNoteThread(undefined, undefined, true);
-    // note03 is marked as deleted
-    const encodedContent = 'note05 &amp; &lt;content&gt; in note';
-    noteThread.notes[4].content = encodedContent;
-    env = new TestEnvironment({ noteThread });
-    expect(env.getNoteContent(4)).toEqual('note05 & <content> in note');
-    expect(env.noteHasEditActions(4)).toBe(true);
-    env.clickEditNote();
-    expect(env.component.currentNoteContent).toEqual('note05 & <content> in note');
-    const content = 'note05 & <content> in note (edited)';
-    env.enterNoteContent(content);
-    env.submit();
-    expect(env.dialogResult).toEqual({ noteContent: encodedContent + ' (edited)', noteDataId: 'note05' });
   }));
 
   it('does not allow user to edit the last note in the thread if it is not editable', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -323,7 +323,7 @@ export class NoteDialogComponent implements OnInit {
     }
 
     this.dialogRef.close({
-      noteContent: XmlUtils.encodeForXml(this.currentNoteContent),
+      noteContent: this.currentNoteContent,
       noteDataId: this.noteIdBeingEdited
     });
   }
@@ -339,7 +339,7 @@ export class NoteDialogComponent implements OnInit {
     }
     const content: NoteDialogResult = { status: NoteStatus.Resolved };
     if (this.currentNoteContent.trim().length > 0) {
-      content.noteContent = XmlUtils.encodeForXml(this.currentNoteContent);
+      content.noteContent = this.currentNoteContent;
     }
     this.dialogRef.close(content);
   }


### PR DESCRIPTION
The content for a note needs to have any xml related symbols such as `>` and `<` encoded to be stored in mongo. This was previously done when editing or adding a note to a thread in the note dialog, but adding notes through the bottom sheet was missed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2365)
<!-- Reviewable:end -->
