### PR TITLE
SF-2476 Add CacheService on project activation

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.ts
@@ -1,0 +1,36 @@
+import { EventEmitter, Injectable } from '@angular/core';
+import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
+import { TextDocId } from 'src/app/core/models/text-doc';
+import { SFProjectService } from 'src/app/core/sf-project.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CacheService extends SubscriptionDisposable {
+  private abortCurrent: EventEmitter<void> = new EventEmitter();
+  constructor(private readonly projectService: SFProjectService) {
+    super();
+  }
+
+  async cache(project: SFProjectProfileDoc): Promise<void> {
+    this.abortCurrent.emit();
+    await this.loadAllChapters(project);
+  }
+
+  private async loadAllChapters(project: SFProjectProfileDoc): Promise<void> {
+    var abort = false;
+    this.abortCurrent.subscribe(() => (abort = true));
+
+    if (project?.data != null) {
+      for (const text of project.data.texts) {
+        for (const chapter of text.chapters) {
+          if (abort) return;
+
+          const textDocId = new TextDocId(project.id, text.bookNum, chapter.number, 'target');
+          await this.projectService.getText(textDocId);
+        }
+      }
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -1,11 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { ActivationEnd, Router } from '@angular/router';
+import ObjectID from 'bson-objectid';
 import { BehaviorSubject, Observable, of } from 'rxjs';
+import { filter, map, startWith, switchMap } from 'rxjs/operators';
 import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
 import { SFProjectService } from 'src/app/core/sf-project.service';
-import ObjectID from 'bson-objectid';
-import { filter, map, startWith, switchMap } from 'rxjs/operators';
-import { TestBed } from '@angular/core/testing';
+import { CacheService } from 'src/app/shared/cache-service/cache-service';
 import { SubscriptionDisposable } from './subscription-disposable';
 
 interface IActiveProjectIdService {
@@ -53,6 +54,7 @@ export class ActivatedProjectService extends SubscriptionDisposable {
 
   constructor(
     private readonly projectService: SFProjectService,
+    private readonly cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
     super();
@@ -80,6 +82,9 @@ export class ActivatedProjectService extends SubscriptionDisposable {
   private set projectDoc(projectDoc: SFProjectProfileDoc | undefined) {
     if (this.projectDoc !== projectDoc) {
       this._projectDoc$.next(projectDoc);
+      if (this.projectDoc !== undefined) {
+        this.cacheService.cache(this.projectDoc);
+      }
     }
   }
 
@@ -119,13 +124,18 @@ export class TestActiveProjectIdService implements IActiveProjectIdService {
 export class TestActivatedProjectService extends ActivatedProjectService {
   constructor(
     projectService: SFProjectService,
+    cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
-    super(projectService, activeProjectIdService);
+    super(projectService, cacheService, activeProjectIdService);
   }
 
   static withProjectId(projectId: string): TestActivatedProjectService {
     const projectService = TestBed.inject(SFProjectService);
-    return new TestActivatedProjectService(projectService, new TestActiveProjectIdService(projectId));
+    return new TestActivatedProjectService(
+      projectService,
+      new CacheService(projectService),
+      new TestActiveProjectIdService(projectId)
+    );
   }
 }


### PR DESCRIPTION
CacheService asynchronously loads all texts in the given project. Any current operation is aborted when another cache() call is made.

Not implemented yet is CPU/bandwidth throttling.