### PR TITLE
SF-2598 Stop unnecessary ops created on sync

### DIFF
--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -357,8 +357,10 @@ public class Delta
     /// <summary>
     /// Test for value equality of two JTokens while ignoring the cid object property in char nodes.
     /// </summary>
-    static bool JTokenDeepEqualsIgnoreCharId(JToken a, JToken b)
+    private static bool JTokenDeepEqualsIgnoreCharId(JToken? a, JToken? b)
     {
+        if (a == null && b == null)
+            return true;
         if (b == null)
             return false;
         // If the token is not an object, it will not have a char property


### PR DESCRIPTION
This PR fixes a bug where unnecessary ops that modify the `cid` are created when those ops are preceded by ops that have no properties.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2369)
<!-- Reviewable:end -->
