### PR TITLE
SF-2581 Add missing target books message when selecting drafting books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -65,7 +65,7 @@
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
 
-        <app-notice *ngIf="unusableTrainingSourceBooks.length || unusableTrainingTargetBooks.lastIndexOf" type="light">
+        <app-notice *ngIf="unusableTrainingSourceBooks.length || unusableTrainingTargetBooks.length" type="light">
           <h4>
             <transloco
               *ngIf="unusableTrainingSourceBooks.length"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -13,7 +13,11 @@
           data-test-id="draft-stepper-translate-books"
         ></app-book-multi-select>
 
-        <app-notice *ngIf="unusableTranslateSourceBooks.length || unusableTranslateTargetBooks.length" type="light">
+        <app-notice *ngIf="unusableTranslateTargetBooks.length">
+          <transloco key="draft_generation_steps.unusable_target_books"></transloco>
+        </app-notice>
+
+        <app-notice *ngIf="unusableTranslateSourceBooks.length">
           <h4 *ngIf="unusableTranslateSourceBooks.length">
             <transloco
               key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
@@ -23,18 +27,6 @@
           <app-book-multi-select
             *ngIf="unusableTranslateSourceBooks.length"
             [availableBooks]="unusableTranslateSourceBooks"
-            [readonly]="true"
-          ></app-book-multi-select>
-
-          <h4 *ngIf="unusableTranslateTargetBooks.length">
-            <transloco
-              key="draft_generation_steps.these_target_books_cannot_be_used_for_translating"
-              [params]="{ targetProjectName }"
-            ></transloco>
-          </h4>
-          <app-book-multi-select
-            *ngIf="unusableTranslateTargetBooks.length"
-            [availableBooks]="unusableTranslateTargetBooks"
             [readonly]="true"
           ></app-book-multi-select>
         </app-notice>
@@ -65,7 +57,11 @@
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
 
-        <app-notice *ngIf="unusableTrainingSourceBooks.length || unusableTrainingTargetBooks.length" type="light">
+        <app-notice *ngIf="unusableTranslateTargetBooks.length">
+          <transloco key="draft_generation_steps.unusable_target_books"></transloco>
+        </app-notice>
+
+        <app-notice *ngIf="unusableTrainingSourceBooks.length">
           <h4>
             <transloco
               *ngIf="unusableTrainingSourceBooks.length"
@@ -76,19 +72,6 @@
           <app-book-multi-select
             *ngIf="unusableTrainingSourceBooks.length"
             [availableBooks]="unusableTrainingSourceBooks"
-            [readonly]="true"
-          ></app-book-multi-select>
-
-          <h4>
-            <transloco
-              *ngIf="unusableTrainingTargetBooks.length"
-              key="draft_generation_steps.these_target_books_cannot_be_used_for_training"
-              [params]="{ targetProjectName }"
-            ></transloco>
-          </h4>
-          <app-book-multi-select
-            *ngIf="unusableTrainingTargetBooks.length"
-            [availableBooks]="unusableTrainingTargetBooks"
             [readonly]="true"
           ></app-book-multi-select>
         </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -13,14 +13,30 @@
           data-test-id="draft-stepper-translate-books"
         ></app-book-multi-select>
 
-        <app-notice *ngIf="unusableTranslateBooks.length" type="light">
-          <h4>
+        <app-notice *ngIf="unusableTranslateSourceBooks.length || unusableTranslateTargetBooks.length" type="light">
+          <h4 *ngIf="unusableTranslateSourceBooks.length">
             <transloco
-              key="draft_generation_steps.these_books_cannot_be_used_for_translating"
+              key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
               [params]="{ draftingSourceProjectName }"
             ></transloco>
           </h4>
-          <app-book-multi-select [availableBooks]="unusableTranslateBooks" [readonly]="true"></app-book-multi-select>
+          <app-book-multi-select
+            *ngIf="unusableTranslateSourceBooks.length"
+            [availableBooks]="unusableTranslateSourceBooks"
+            [readonly]="true"
+          ></app-book-multi-select>
+
+          <h4 *ngIf="unusableTranslateTargetBooks.length">
+            <transloco
+              key="draft_generation_steps.these_target_books_cannot_be_used_for_translating"
+              [params]="{ targetProjectName }"
+            ></transloco>
+          </h4>
+          <app-book-multi-select
+            *ngIf="unusableTranslateTargetBooks.length"
+            [availableBooks]="unusableTranslateTargetBooks"
+            [readonly]="true"
+          ></app-book-multi-select>
         </app-notice>
 
         <app-notice *ngIf="showBookSelectionError" type="error">
@@ -49,14 +65,32 @@
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
 
-        <app-notice *ngIf="unusableTrainingBooks.length" type="light">
+        <app-notice *ngIf="unusableTrainingSourceBooks.length || unusableTrainingTargetBooks.lastIndexOf" type="light">
           <h4>
             <transloco
-              key="draft_generation_steps.these_books_cannot_be_used_for_training"
+              *ngIf="unusableTrainingSourceBooks.length"
+              key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
               [params]="{ trainingSourceProjectName }"
             ></transloco>
           </h4>
-          <app-book-multi-select [availableBooks]="unusableTrainingBooks" [readonly]="true"></app-book-multi-select>
+          <app-book-multi-select
+            *ngIf="unusableTrainingSourceBooks.length"
+            [availableBooks]="unusableTrainingSourceBooks"
+            [readonly]="true"
+          ></app-book-multi-select>
+
+          <h4>
+            <transloco
+              *ngIf="unusableTrainingTargetBooks.length"
+              key="draft_generation_steps.these_target_books_cannot_be_used_for_training"
+              [params]="{ targetProjectName }"
+            ></transloco>
+          </h4>
+          <app-book-multi-select
+            *ngIf="unusableTrainingTargetBooks.length"
+            [availableBooks]="unusableTrainingTargetBooks"
+            [readonly]="true"
+          ></app-book-multi-select>
         </app-notice>
 
         <app-notice *ngIf="showBookSelectionError" type="error">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -34,7 +34,11 @@ app-notice {
   h4 {
     font-style: italic;
     font-weight: 400;
-    margin: 0 0 16px;
+    margin: 16px 0;
+    /* Remove the top margin for the first h4 */
+    &:first-of-type {
+      margin-top: 0;
+    }
   }
 
   &.warning {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -34,11 +34,7 @@ app-notice {
   h4 {
     font-style: italic;
     font-weight: 400;
-    margin: 16px 0;
-    /* Remove the top margin for the first h4 */
-    &:first-of-type {
-      margin-top: 0;
-    }
+    margin: 0 0 16px;
   }
 
   &.warning {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -131,9 +131,14 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.availableTrainingBooks).toEqual([2, 3]);
     }));
 
-    it('should set "unusableTranslateBooks" and "unusableTrainingBooks" correctly', fakeAsync(() => {
-      expect(component.unusableTranslateBooks).toEqual([6, 7]);
-      expect(component.unusableTrainingBooks).toEqual([1, 6, 7]);
+    it('should set "unusableTranslateSourceBooks" and "unusableTrainingSourceBooks" correctly', fakeAsync(() => {
+      expect(component.unusableTranslateSourceBooks).toEqual([6, 7]);
+      expect(component.unusableTrainingSourceBooks).toEqual([1, 6, 7]);
+    }));
+
+    it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
+      expect(component.unusableTranslateTargetBooks).toEqual([4, 5]);
+      expect(component.unusableTrainingTargetBooks).toEqual([4, 5, 8]);
     }));
   });
 
@@ -162,9 +167,14 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.availableTrainingBooks).toEqual([1, 2, 3]);
     }));
 
-    it('should set "unusableTranslateBooks" and "unusableTrainingBooks" correctly', fakeAsync(() => {
-      expect(component.unusableTranslateBooks).toEqual([6, 7]);
-      expect(component.unusableTrainingBooks).toEqual([6, 7]);
+    it('should set "unusableTranslateSourceBooks" and "unusableTrainingSourceBooks" correctly', fakeAsync(() => {
+      expect(component.unusableTranslateSourceBooks).toEqual([6, 7]);
+      expect(component.unusableTrainingSourceBooks).toEqual([6, 7]);
+    }));
+
+    it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
+      expect(component.unusableTranslateTargetBooks).toEqual([4, 5]);
+      expect(component.unusableTrainingTargetBooks).toEqual([4, 5]);
     }));
 
     it('should select no books initially', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ar.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ar.json
@@ -199,8 +199,8 @@
     "loading": "التحميل جارٍ...",
     "next": "التالي",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_az.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_az.json
@@ -199,8 +199,8 @@
     "loading": "Yüklənir...",
     "next": "Növbəti",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -202,8 +202,7 @@
     "no_available_books": "You have no books available for drafting.",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
-    "these_target_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the target text ({{ targetProjectName }}).",
-    "these_target_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the target text ({{ targetProjectName }})."
+    "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -200,8 +200,10 @@
     "loading": "Loading...",
     "next": "Next",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
+    "these_target_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the target text ({{ targetProjectName }}).",
+    "these_target_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the target text ({{ targetProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_es.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_es.json
@@ -199,8 +199,8 @@
     "loading": "Cargando...",
     "next": "Siguiente",
     "no_available_books": "No tiene libros disponibles para la redacción.",
-    "these_books_cannot_be_used_for_training": "Los siguientes libros no pueden utilizarse para la formación, ya que no se encuentran en el texto fuente de formación ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "Los siguientes libros no pueden traducirse porque no se encuentran en el texto fuente de redacción ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "Los siguientes libros no pueden utilizarse para la formación, ya que no se encuentran en el texto fuente de formación ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "Los siguientes libros no pueden traducirse porque no se encuentran en el texto fuente de redacción ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Aplicar al proyecto",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_fr.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_fr.json
@@ -199,8 +199,8 @@
     "loading": "Chargement...",
     "next": "Suivant",
     "no_available_books": "Vous n'avez pas de livres disponibles pour l'ébauchage.",
-    "these_books_cannot_be_used_for_training": "Les livres suivants ne peuvent pas être utilisés pour la formation car ils ne sont pas dans le texte source de la formation ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "Les livres suivants ne peuvent pas être traduits car ils ne sont pas dans le texte source ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "Les livres suivants ne peuvent pas être utilisés pour la formation car ils ne sont pas dans le texte source de la formation ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "Les livres suivants ne peuvent pas être traduits car ils ne sont pas dans le texte source ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Appliquer au projet",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_id.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_id.json
@@ -199,8 +199,8 @@
     "loading": "Memuat...",
     "next": "Berikutnya",
     "no_available_books": "Anda tidak memiliki kitab yang tersedia untuk menyusun konsep.",
-    "these_books_cannot_be_used_for_training": "Kitab-kitab berikut ini tidak dapat digunakan untuk pelatihan karena tidak ada dalam teks sumber pelatihan ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "Kitab-kitab berikut ini tidak dapat diterjemahkan karena tidak ada dalam teks sumber pelatihan ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "Kitab-kitab berikut ini tidak dapat digunakan untuk pelatihan karena tidak ada dalam teks sumber pelatihan ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "Kitab-kitab berikut ini tidak dapat diterjemahkan karena tidak ada dalam teks sumber pelatihan ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Terapkan ke proyek",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
@@ -199,8 +199,8 @@
     "loading": "Loading...",
     "next": "ꤘꤣꤋꤛꤢꤩ꤭ꤕꤟꤥ",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
@@ -199,8 +199,8 @@
     "loading": "Loading...",
     "next": "ຕໍ່ໄປ",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
@@ -199,8 +199,8 @@
     "loading": "Carregando...",
     "next": "Próximo",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
@@ -199,8 +199,8 @@
     "loading": "Se încarcă...",
     "next": "Următor",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
@@ -199,8 +199,8 @@
     "loading": "Загрузка...",
     "next": "Далее",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
@@ -199,8 +199,8 @@
     "loading": "Loading...",
     "next": "下一个",
     "no_available_books": "You have no books available for drafting.",
-    "these_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
-    "these_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
+    "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
+    "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }})."
   },
   "draft_viewer": {
     "apply_to_project": "Apply to project",


### PR DESCRIPTION
This PR adds a message to the draft generation steps that lists books not found in the target text, but which are in the source text (and so the user would expect to be able to translate them).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2370)
<!-- Reviewable:end -->
