### PR TITLE
Attempt to fix project selector height on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation-project-selector/navigation-project-selector.component.scss
@@ -2,7 +2,7 @@
 ::ng-deep .app-navigation-project-selector-panel.mdc-menu-surface.mat-mdc-select-panel {
   // Top app bar height is 56px, this project selector's height is 56px, and we want 32px of space at the bottom.
   // 56 + 56 + 32 = 144
-  max-height: calc(100vh - 144px);
+  max-height: calc(100dvh - 144px);
 
   // .project-option added to increase CSS rule specificity
   mat-option.project-option {


### PR DESCRIPTION
When the user has a lot of projects, it's not possible to scroll down to the connect project option.

See this screenshot, where I can't scroll down to the connect project option.

This change has not been tested, and was made from my phone during the conference. If you are going to review the change, please test it and make sure it actually fixes the problem.

![](https://github.com/sillsdev/web-xforge/assets/6140710/c1800228-ca36-490d-860f-ddd5031aed4b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2371)
<!-- Reviewable:end -->
