### PR TITLE
SF-2574 Provide project data to NMT forward drafting approval team

### DIFF
--- a/src/RealtimeServer/common/models/system-role.ts
+++ b/src/RealtimeServer/common/models/system-role.ts
@@ -1,4 +1,5 @@
 export enum SystemRole {
+  ServalAdmin = 'serval_admin',
   SystemAdmin = 'system_admin',
   User = 'user',
   None = 'none'

--- a/src/RealtimeServer/common/services/project-service.spec.ts
+++ b/src/RealtimeServer/common/services/project-service.spec.ts
@@ -13,6 +13,14 @@ import { ProjectService } from './project-service';
 const PROJECTS_COLLECTION = 'projects';
 
 describe('ProjectService', () => {
+  it('allows serval admin to view any project', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'servalAdmin', SystemRole.ServalAdmin);
+    await expect(fetchDoc(conn, PROJECTS_COLLECTION, 'project01')).resolves.not.toThrow();
+  });
+
   it('allows system admin to view any project', async () => {
     const env = new TestEnvironment();
     await env.createData();

--- a/src/RealtimeServer/common/services/project-service.ts
+++ b/src/RealtimeServer/common/services/project-service.ts
@@ -53,7 +53,12 @@ export abstract class ProjectService<T extends Project = Project> extends JsonDo
   };
 
   protected allowRead(_docId: string, doc: T, session: ConnectSession): boolean {
-    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin) || Object.keys(doc).length === 0) {
+    if (
+      session.isServer ||
+      session.roles.includes(SystemRole.ServalAdmin) ||
+      session.roles.includes(SystemRole.SystemAdmin) ||
+      Object.keys(doc).length === 0
+    ) {
       return true;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/ngsw-config.json
+++ b/src/SIL.XForge.Scripture/ClientApp/ngsw-config.json
@@ -38,6 +38,8 @@
     "/login/",
     "/connect-project",
     "/connect-project/",
+    "/serval-administration",
+    "/serval-administration/",
     "/system-administration",
     "/system-administration/"
   ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -6,6 +6,9 @@ import { SystemAdministrationComponent } from 'xforge-common/system-administrati
 import { ConnectProjectComponent } from './connect-project/connect-project.component';
 import { JoinComponent } from './join/join.component';
 import { ProjectComponent } from './project/project.component';
+import { ServalAdminAuthGuard } from './serval-administration/serval-admin-auth.guard';
+import { ServalAdministrationComponent } from './serval-administration/serval-administration.component';
+import { ServalProjectComponent } from './serval-administration/serval-project.component';
 import { SettingsComponent } from './settings/settings.component';
 import { PageNotFoundComponent } from './shared/page-not-found/page-not-found.component';
 import { SettingsAuthGuard, SyncAuthGuard } from './shared/project-router.guard';
@@ -22,6 +25,8 @@ const routes: Routes = [
   { path: 'projects/:projectId/sync', component: SyncComponent, canActivate: [SyncAuthGuard] },
   { path: 'projects/:projectId', component: ProjectComponent, canActivate: [AuthGuard] },
   { path: 'projects', component: StartComponent, canActivate: [AuthGuard] },
+  { path: 'serval-administration/:projectId', component: ServalProjectComponent, canActivate: [ServalAdminAuthGuard] },
+  { path: 'serval-administration', component: ServalAdministrationComponent, canActivate: [ServalAdminAuthGuard] },
   { path: 'system-administration', component: SystemAdministrationComponent, canActivate: [SystemAdminAuthGuard] },
   { path: '**', component: PageNotFoundComponent }
 ];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -87,8 +87,23 @@
             </div>
           </div>
           <mat-divider></mat-divider>
-          <button mat-menu-item *ngIf="isSystemAdmin" [disabled]="!isAppOnline" appRouterLink="/system-administration">
+          <button
+            mat-menu-item
+            *ngIf="isSystemAdmin"
+            id="system-admin-btn"
+            [disabled]="!isAppOnline"
+            appRouterLink="/system-administration"
+          >
             {{ t("system_administration") }}
+          </button>
+          <button
+            mat-menu-item
+            *ngIf="isServalAdmin"
+            id="serval-admin-btn"
+            [disabled]="!isAppOnline"
+            appRouterLink="/serval-administration"
+          >
+            {{ t("serval_administration") }}
           </button>
           <button mat-menu-item appRouterLink="/projects" id="project-home-link">{{ t("project_home") }}</button>
           <button mat-menu-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -6,6 +6,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Route, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CookieService } from 'ngx-cookie-service';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -342,6 +343,86 @@ describe('AppComponent', () => {
       env.clickEditDisplayName();
       verify(mockedNoticeService.show(anything())).once();
       verify(mockedUserService.editDisplayName(anything())).never();
+    }));
+  });
+
+  describe('Serval Administrator', () => {
+    it('shows serval administration menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+
+      // Verify the menu item is visible
+      expect(env.component.isServalAdmin).toBeTruthy();
+      expect(env.userMenu).not.toBeNull();
+      expect(env.userMenu.query(By.css('#serval-admin-btn'))).not.toBeNull();
+
+      // Hide the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+    }));
+
+    it('does not show system administration menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+
+      // Verify the menu item is not visible
+      expect(env.component.isSystemAdmin).toBeFalsy();
+      expect(env.userMenu).not.toBeNull();
+      expect(env.userMenu.query(By.css('#system-admin-btn'))).toBeNull();
+
+      // Hide the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+    }));
+  });
+
+  describe('System Administrator', () => {
+    it('shows system administration menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+
+      // Verify the menu item is visible
+      expect(env.component.isSystemAdmin).toBeTruthy();
+      expect(env.userMenu).not.toBeNull();
+      expect(env.userMenu.query(By.css('#system-admin-btn'))).not.toBeNull();
+
+      // Hide the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+    }));
+
+    it('does not show serval administration menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
+
+      // Verify the menu item is not visible
+      expect(env.component.isServalAdmin).toBeFalsy();
+      expect(env.userMenu).not.toBeNull();
+      expect(env.userMenu.query(By.css('#serval-admin-btn'))).toBeNull();
+
+      // Hide the user menu
+      env.avatarIcon.nativeElement.click();
+      env.wait();
     }));
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -244,12 +244,10 @@ describe('AppComponent', () => {
     expect(env.installBadge).toBeNull();
     expect(env.installButton).toBeNull();
     env.canInstall$.next(true);
-    env.avatarIcon.nativeElement.click();
-    env.wait();
+    env.showHideUserMenu();
     expect(env.installBadge).not.toBeNull();
     expect(env.installButton).not.toBeNull();
-    env.avatarIcon.nativeElement.click();
-    env.wait();
+    env.showHideUserMenu();
   }));
 
   it('hide install badge after avatar menu click', fakeAsync(() => {
@@ -262,8 +260,7 @@ describe('AppComponent', () => {
     expect(env.installBadge).not.toBeNull();
 
     when(mockedPwaService.installPromptLastShownTime).thenReturn(Date.now());
-    env.avatarIcon.nativeElement.click();
-    env.wait();
+    env.showHideUserMenu();
     expect(env.installBadge).toBeNull();
 
     // The install badge should be visible again
@@ -271,8 +268,7 @@ describe('AppComponent', () => {
     env.wait();
     expect(env.installBadge).not.toBeNull();
 
-    env.avatarIcon.nativeElement.click();
-    env.wait();
+    env.showHideUserMenu();
   }));
 
   it('user added to project after init', fakeAsync(() => {
@@ -324,8 +320,7 @@ describe('AppComponent', () => {
       const env = new TestEnvironment('online');
       env.init();
 
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
       expect(env.userMenu).not.toBeNull();
       env.clickEditDisplayName();
       verify(mockedUserService.editDisplayName(false)).once();
@@ -336,8 +331,7 @@ describe('AppComponent', () => {
       env.setCurrentUser('user02');
       env.init();
 
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
       expect(env.userMenu).not.toBeNull();
       expect(env.editNameButton).not.toBeNull();
       env.clickEditDisplayName();
@@ -353,17 +347,15 @@ describe('AppComponent', () => {
       env.init();
 
       // Show the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
 
       // Verify the menu item is visible
-      expect(env.component.isServalAdmin).toBeTruthy();
+      expect(env.component.isServalAdmin).toBe(true);
       expect(env.userMenu).not.toBeNull();
-      expect(env.userMenu.query(By.css('#serval-admin-btn'))).not.toBeNull();
+      expect(env.servalAdminButton).not.toBeNull();
 
       // Hide the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
     }));
 
     it('does not show system administration menu item', fakeAsync(() => {
@@ -372,17 +364,15 @@ describe('AppComponent', () => {
       env.init();
 
       // Show the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
 
       // Verify the menu item is not visible
-      expect(env.component.isSystemAdmin).toBeFalsy();
+      expect(env.component.isSystemAdmin).toBe(false);
       expect(env.userMenu).not.toBeNull();
-      expect(env.userMenu.query(By.css('#system-admin-btn'))).toBeNull();
+      expect(env.systemAdminButton).toBeNull();
 
       // Hide the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
     }));
   });
 
@@ -393,17 +383,15 @@ describe('AppComponent', () => {
       env.init();
 
       // Show the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
 
       // Verify the menu item is visible
-      expect(env.component.isSystemAdmin).toBeTruthy();
+      expect(env.component.isSystemAdmin).toBe(true);
       expect(env.userMenu).not.toBeNull();
-      expect(env.userMenu.query(By.css('#system-admin-btn'))).not.toBeNull();
+      expect(env.systemAdminButton).not.toBeNull();
 
       // Hide the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
     }));
 
     it('does not show serval administration menu item', fakeAsync(() => {
@@ -412,17 +400,15 @@ describe('AppComponent', () => {
       env.init();
 
       // Show the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
 
       // Verify the menu item is not visible
-      expect(env.component.isServalAdmin).toBeFalsy();
+      expect(env.component.isServalAdmin).toBe(false);
       expect(env.userMenu).not.toBeNull();
-      expect(env.userMenu.query(By.css('#serval-admin-btn'))).toBeNull();
+      expect(env.servalAdminButton).toBeNull();
 
       // Hide the user menu
-      env.avatarIcon.nativeElement.click();
-      env.wait();
+      env.showHideUserMenu();
     }));
   });
 });
@@ -548,6 +534,14 @@ class TestEnvironment {
     return this.userMenu.query(By.css('#edit-name-btn'));
   }
 
+  get servalAdminButton(): DebugElement {
+    return this.userMenu.query(By.css('#serval-admin-btn'));
+  }
+
+  get systemAdminButton(): DebugElement {
+    return this.userMenu.query(By.css('#system-admin-btn'));
+  }
+
   get navBar(): DebugElement {
     return this.fixture.debugElement.query(By.css('mat-toolbar'));
   }
@@ -662,6 +656,11 @@ class TestEnvironment {
     const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(op => op.set<string>(p => p.userRoles['user01'], SFProjectRole.CommunityChecker), false);
     this.currentUserDoc.submitJson0Op(op => op.add<string>(u => u.sites['sf'].projects, 'project04'), false);
+    this.wait();
+  }
+
+  showHideUserMenu(): void {
+    this.avatarIcon.nativeElement.click();
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -179,6 +179,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     return this.noticeService.isAppLoading;
   }
 
+  get isServalAdmin(): boolean {
+    return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+  }
+
   get isSystemAdmin(): boolean {
     return this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
+import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
 import { ParatextProject } from './models/paratext-project';
 
 /**
@@ -35,17 +36,21 @@ export class ParatextService {
 
   getParatextUsername(): Observable<string | undefined> {
     return this.http
-      .get<string | null>('paratext-api/username', { headers: this.headers })
+      .get<string | null>(`${PARATEXT_API_NAMESPACE}/username`, { headers: this.headers })
       .pipe(map(r => r ?? undefined));
   }
 
   getProjects(): Promise<ParatextProject[] | undefined> {
-    return this.http.get<ParatextProject[] | undefined>('paratext-api/projects', { headers: this.headers }).toPromise();
+    return this.http
+      .get<ParatextProject[] | undefined>(`${PARATEXT_API_NAMESPACE}/projects`, { headers: this.headers })
+      .toPromise();
   }
 
   getResources(): Promise<SelectableProject[] | undefined> {
     return this.http
-      .get<{ [id: string]: [shortName: string, name: string] }>('paratext-api/resources', { headers: this.headers })
+      .get<{ [id: string]: [shortName: string, name: string] }>(`${PARATEXT_API_NAMESPACE}/resources`, {
+        headers: this.headers
+      })
       .toPromise()
       .then(result =>
         result == null
@@ -60,9 +65,12 @@ export class ParatextService {
 
   async getRevisions(projectId: string, book: string, chapter: number): Promise<Revision[] | undefined> {
     return await this.http
-      .get<Revision[] | undefined>(`paratext-api/history/revisions/${projectId}_${book}_${chapter}_target`, {
-        headers: this.headers
-      })
+      .get<Revision[] | undefined>(
+        `${PARATEXT_API_NAMESPACE}/history/revisions/${projectId}_${book}_${chapter}_target`,
+        {
+          headers: this.headers
+        }
+      )
       .toPromise();
   }
 
@@ -74,7 +82,7 @@ export class ParatextService {
   ): Promise<Snapshot<TextData> | undefined> {
     return await this.http
       .get<Snapshot<TextData>>(
-        `paratext-api/history/snapshot/${projectId}_${book}_${chapter}_target?timestamp=${timestamp}`,
+        `${PARATEXT_API_NAMESPACE}/history/snapshot/${projectId}_${book}_${chapter}_target?timestamp=${timestamp}`,
         {
           headers: this.headers
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { of } from 'rxjs';
+import { anything, mock, when } from 'ts-mockito';
+import { AuthGuard } from 'xforge-common/auth.guard';
+import { AuthService } from 'xforge-common/auth.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { ServalAdminAuthGuard } from './serval-admin-auth.guard';
+
+const mockedAuthGuard = mock(AuthGuard);
+const mockedAuthService = mock(AuthService);
+
+describe('ServalAdminAuthGuard', () => {
+  configureTestingModule(() => ({
+    providers: [
+      { provide: AuthGuard, useMock: mockedAuthGuard },
+      { provide: AuthService, useMock: mockedAuthService }
+    ]
+  }));
+
+  it('can activate if user is logged in and has ServalAdmin role', () => {
+    const env = new TestEnvironment(true, SystemRole.ServalAdmin);
+
+    env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
+      expect(result).toBeTruthy();
+    });
+  });
+
+  it('cannot activate if user is not logged in', () => {
+    const env = new TestEnvironment(false, SystemRole.None);
+
+    env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
+      expect(result).toBeFalsy();
+    });
+  });
+
+  it('cannot activate if user is logged in but does not have ServalAdmin role', () => {
+    const env = new TestEnvironment(true, SystemRole.SystemAdmin);
+
+    env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
+      expect(result).toBeFalsy();
+    });
+  });
+
+  class TestEnvironment {
+    readonly service: ServalAdminAuthGuard;
+
+    constructor(isLoggedIn: boolean, role: SystemRole) {
+      this.service = TestBed.inject(ServalAdminAuthGuard);
+      when(mockedAuthGuard.canActivate(anything(), anything())).thenReturn(of(isLoggedIn));
+      when(mockedAuthGuard.allowTransition()).thenReturn(of(isLoggedIn));
+      when(mockedAuthService.currentUserRoles).thenReturn([role]);
+    }
+  }
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.spec.ts
@@ -23,7 +23,7 @@ describe('ServalAdminAuthGuard', () => {
     const env = new TestEnvironment(true, SystemRole.ServalAdmin);
 
     env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
-      expect(result).toBeTruthy();
+      expect(result).toBe(true);
     });
   });
 
@@ -31,7 +31,7 @@ describe('ServalAdminAuthGuard', () => {
     const env = new TestEnvironment(false, SystemRole.None);
 
     env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
-      expect(result).toBeFalsy();
+      expect(result).toBe(false);
     });
   });
 
@@ -39,7 +39,7 @@ describe('ServalAdminAuthGuard', () => {
     const env = new TestEnvironment(true, SystemRole.SystemAdmin);
 
     env.service.canActivate({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot).subscribe(result => {
-      expect(result).toBeFalsy();
+      expect(result).toBe(false);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-admin-auth.guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { Observable } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { AuthGuard } from 'xforge-common/auth.guard';
+import { AuthService } from 'xforge-common/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServalAdminAuthGuard {
+  constructor(private readonly authGuard: AuthGuard, private readonly authService: AuthService) {}
+
+  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+    return this.authGuard.canActivate(next, state).pipe(switchMap(() => this.allowTransition()));
+  }
+
+  allowTransition(): Observable<boolean> {
+    return this.authGuard.allowTransition().pipe(
+      map(isLoggedIn => {
+        if (isLoggedIn) {
+          return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+        }
+        return false;
+      })
+    );
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
@@ -1,5 +1,3 @@
-<div fxLayout="column" fxLayoutAlign="center start" class="body-content">
-  <h1>Serval Administration</h1>
-</div>
+<h1>Serval Administration</h1>
 
 <app-serval-projects></app-serval-projects>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
@@ -1,0 +1,5 @@
+<div fxLayout="column" fxLayoutAlign="center start" class="body-content">
+  <h1>Serval Administration</h1>
+</div>
+
+<app-serval-projects></app-serval-projects>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.spec.ts
@@ -1,0 +1,37 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
+import { ServalAdministrationComponent } from './serval-administration.component';
+import { ServalProjectsComponent } from './serval-projects.component';
+
+describe('ServalAdministrationComponent', () => {
+  configureTestingModule(() => ({
+    imports: [
+      ServalAdministrationComponent,
+      ServalProjectsComponent,
+      NoopAnimationsModule,
+      TestTranslocoModule,
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
+      HttpClientTestingModule
+    ]
+  }));
+
+  it('should be created', () => {
+    const env = new TestEnvironment();
+    expect(env.component).toBeTruthy();
+  });
+
+  class TestEnvironment {
+    readonly component: ServalAdministrationComponent;
+    readonly fixture: ComponentFixture<ServalAdministrationComponent>;
+
+    constructor() {
+      this.fixture = TestBed.createComponent(ServalAdministrationComponent);
+      this.component = this.fixture.componentInstance;
+      this.fixture.detectChanges();
+    }
+  }
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { ServalProjectsComponent } from './serval-projects.component';
+
+@Component({
+  selector: 'app-serval-administration',
+  templateUrl: './serval-administration.component.html',
+  styleUrls: ['./serval-administration.component.scss'],
+  standalone: true,
+  imports: [ServalProjectsComponent]
+})
+export class ServalAdministrationComponent {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { mock } from 'ts-mockito';
 import { CommandService } from 'xforge-common/command.service';
@@ -12,6 +13,7 @@ const mockedRetryingRequestService = mock(RetryingRequestService);
 
 describe('ServalAdministrationService', () => {
   configureTestingModule(() => ({
+    imports: [HttpClientTestingModule],
     providers: [
       { provide: CommandService, useMock: mockedCommandService },
       { provide: RealtimeService, useMock: mockedRealtimeService },
@@ -19,15 +21,42 @@ describe('ServalAdministrationService', () => {
     ]
   }));
 
-  it('should be created', () => {
-    const env = new TestEnvironment();
-    expect(env.service).toBeTruthy();
+  describe('isResource', () => {
+    it('should return true for a resource id', () => {
+      const env = new TestEnvironment();
+      const id = '1234567890abcdef';
+      expect(env.service.isResource(id)).toBeTruthy();
+    });
+
+    it('should return true for a project id', () => {
+      const env = new TestEnvironment();
+      const id = '123456781234567890abcdef1234567890abcdef1234567890abcdef';
+      expect(env.service.isResource(id)).toBeFalsy();
+    });
+  });
+
+  describe('downloadProject', () => {
+    it('should return a blob', () => {
+      const env = new TestEnvironment();
+      const projectId = 'project01';
+      const mockBlob = new Blob();
+      env.service.downloadProject(projectId).subscribe(blob => {
+        expect(blob).toEqual(mockBlob);
+      });
+
+      const request = env.httpTestingController.expectOne(`paratext-api/projects/${projectId}/download`);
+      expect(request.request.method).toBe('GET');
+      request.flush(mockBlob);
+      env.httpTestingController.verify();
+    });
   });
 
   class TestEnvironment {
+    readonly httpTestingController: HttpTestingController;
     readonly service: ServalAdministrationService;
 
     constructor() {
+      this.httpTestingController = TestBed.inject(HttpTestingController);
       this.service = TestBed.inject(ServalAdministrationService);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { mock } from 'ts-mockito';
+import { CommandService } from 'xforge-common/command.service';
+import { RealtimeService } from 'xforge-common/realtime.service';
+import { RetryingRequestService } from 'xforge-common/retrying-request.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { ServalAdministrationService } from './serval-administration.service';
+
+const mockedCommandService = mock(CommandService);
+const mockedRealtimeService = mock(RealtimeService);
+const mockedRetryingRequestService = mock(RetryingRequestService);
+
+describe('ServalAdministrationService', () => {
+  configureTestingModule(() => ({
+    providers: [
+      { provide: CommandService, useMock: mockedCommandService },
+      { provide: RealtimeService, useMock: mockedRealtimeService },
+      { provide: RetryingRequestService, useMock: mockedRetryingRequestService }
+    ]
+  }));
+
+  it('should be created', () => {
+    const env = new TestEnvironment();
+    expect(env.service).toBeTruthy();
+  });
+
+  class TestEnvironment {
+    readonly service: ServalAdministrationService;
+
+    constructor() {
+      this.service = TestBed.inject(ServalAdministrationService);
+    }
+  }
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
@@ -5,6 +5,7 @@ import { CommandService } from 'xforge-common/command.service';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RetryingRequestService } from 'xforge-common/retrying-request.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
 import { ServalAdministrationService } from './serval-administration.service';
 
 const mockedCommandService = mock(CommandService);
@@ -25,13 +26,13 @@ describe('ServalAdministrationService', () => {
     it('should return true for a resource id', () => {
       const env = new TestEnvironment();
       const id = '1234567890abcdef';
-      expect(env.service.isResource(id)).toBeTruthy();
+      expect(env.service.isResource(id)).toBe(true);
     });
 
-    it('should return true for a project id', () => {
+    it('should return false for a project id', () => {
       const env = new TestEnvironment();
       const id = '123456781234567890abcdef1234567890abcdef1234567890abcdef';
-      expect(env.service.isResource(id)).toBeFalsy();
+      expect(env.service.isResource(id)).toBe(false);
     });
   });
 
@@ -44,7 +45,7 @@ describe('ServalAdministrationService', () => {
         expect(blob).toEqual(mockBlob);
       });
 
-      const request = env.httpTestingController.expectOne(`paratext-api/projects/${projectId}/download`);
+      const request = env.httpTestingController.expectOne(`${PARATEXT_API_NAMESPACE}/projects/${projectId}/download`);
       expect(request.request.method).toBe('GET');
       request.flush(mockBlob);
       env.httpTestingController.verify();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
@@ -1,5 +1,7 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { Observable } from 'rxjs';
 import { CommandService } from 'xforge-common/command.service';
 import { ProjectService } from 'xforge-common/project.service';
 import { RealtimeService } from 'xforge-common/realtime.service';
@@ -16,8 +18,29 @@ export class ServalAdministrationService extends ProjectService<SFProjectProfile
   constructor(
     realtimeService: RealtimeService,
     commandService: CommandService,
-    protected readonly retryingRequestService: RetryingRequestService
+    protected readonly retryingRequestService: RetryingRequestService,
+    private readonly httpClient: HttpClient
   ) {
     super(realtimeService, commandService, retryingRequestService, SF_PROJECT_ROLES);
+  }
+
+  /**
+   * Downloads a project zip file as a blob
+   * @param projectId The Scripture Forge project identifier.
+   * @returns An observable.
+   */
+  downloadProject(projectId: string): Observable<Blob> {
+    return this.httpClient.get(`paratext-api/projects/${projectId}/download`, {
+      responseType: 'blob' // Set responseType to 'blob' to handle binary data
+    });
+  }
+
+  /**
+   * Determines if a Paratext id refers to a resource.
+   * @param paratextId The Paratext identifier.
+   * @returns True if the Paratext identifier is a resource identifier.
+   */
+  isResource(paratextId?: string): boolean {
+    return (paratextId?.length ?? 0) === 16;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
@@ -6,6 +6,7 @@ import { CommandService } from 'xforge-common/command.service';
 import { ProjectService } from 'xforge-common/project.service';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RetryingRequestService } from 'xforge-common/retrying-request.service';
+import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SF_PROJECT_ROLES } from '../core/models/sf-project-role-info';
 
@@ -30,7 +31,7 @@ export class ServalAdministrationService extends ProjectService<SFProjectProfile
    * @returns An observable.
    */
   downloadProject(projectId: string): Observable<Blob> {
-    return this.httpClient.get(`paratext-api/projects/${projectId}/download`, {
+    return this.httpClient.get(`${PARATEXT_API_NAMESPACE}/projects/${projectId}/download`, {
       responseType: 'blob' // Set responseType to 'blob' to handle binary data
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { CommandService } from 'xforge-common/command.service';
+import { ProjectService } from 'xforge-common/project.service';
+import { RealtimeService } from 'xforge-common/realtime.service';
+import { RetryingRequestService } from 'xforge-common/retrying-request.service';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { SF_PROJECT_ROLES } from '../core/models/sf-project-role-info';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServalAdministrationService extends ProjectService<SFProjectProfile, SFProjectProfileDoc> {
+  protected readonly collection = SFProjectProfileDoc.COLLECTION;
+
+  constructor(
+    realtimeService: RealtimeService,
+    commandService: CommandService,
+    protected readonly retryingRequestService: RetryingRequestService
+  ) {
+    super(realtimeService, commandService, retryingRequestService, SF_PROJECT_ROLES);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -9,4 +9,31 @@
       Pre-Translation Drafting Enabled
     </mat-checkbox>
   </div>
+  <h2>Downloads</h2>
+  <app-notice icon="info">
+    The Zip archives contain the Paratext files for the project at the time of last sync.
+  </app-notice>
+  <div class="table-container">
+    <table mat-table [dataSource]="rows">
+      <ng-container
+        *ngFor="let column of columnsToDisplay | slice : 0 : columnsToDisplay.length - 1"
+        [matColumnDef]="column"
+      >
+        <th mat-header-cell *matHeaderCellDef>{{ headingsToDisplay[column] }}</th>
+        <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-raised-button color="primary" (click)="downloadProject(row['id'], row['fileName'])">
+            Download
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></tr>
+    </table>
+  </div>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -2,7 +2,7 @@
 <a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
 
 <h2>Pre-Translation Configuration</h2>
-<mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)">
+<mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)" [disabled]="!isOnline">
   Pre-Translation Drafting Enabled
 </mat-checkbox>
 
@@ -23,7 +23,12 @@
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let row">
-        <button mat-raised-button color="primary" (click)="downloadProject(row['id'], row['fileName'])">
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="downloadProject(row['id'], row['fileName'])"
+          [disabled]="!isOnline"
+        >
           Download
         </button>
       </td>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -1,0 +1,12 @@
+<div fxLayout="column" fxLayoutAlign="center start" class="body-content">
+  <h1>{{ projectName }}</h1>
+  <div>
+    <a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
+  </div>
+  <h2>Pre-Translation Configuration</h2>
+  <div>
+    <mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)">
+      Pre-Translation Drafting Enabled
+    </mat-checkbox>
+  </div>
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -1,39 +1,35 @@
-<div fxLayout="column" fxLayoutAlign="center start" class="body-content">
-  <h1>{{ projectName }}</h1>
-  <div>
-    <a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
-  </div>
-  <h2>Pre-Translation Configuration</h2>
-  <div>
-    <mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)">
-      Pre-Translation Drafting Enabled
-    </mat-checkbox>
-  </div>
-  <h2>Downloads</h2>
-  <app-notice icon="info">
-    The Zip archives contain the Paratext files for the project at the time of last sync.
-  </app-notice>
-  <div class="table-container">
-    <table mat-table [dataSource]="rows">
-      <ng-container
-        *ngFor="let column of columnsToDisplay | slice : 0 : columnsToDisplay.length - 1"
-        [matColumnDef]="column"
-      >
-        <th mat-header-cell *matHeaderCellDef>{{ headingsToDisplay[column] }}</th>
-        <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
-      </ng-container>
+<h1>{{ projectName }}</h1>
+<a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
 
-      <ng-container matColumnDef="id">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-raised-button color="primary" (click)="downloadProject(row['id'], row['fileName'])">
-            Download
-          </button>
-        </td>
-      </ng-container>
+<h2>Pre-Translation Configuration</h2>
+<mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)">
+  Pre-Translation Drafting Enabled
+</mat-checkbox>
 
-      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-      <tr mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></tr>
-    </table>
-  </div>
+<h2>Downloads</h2>
+<app-notice icon="info">
+  The Zip archives contain the Paratext files for the project at the time of last sync.
+</app-notice>
+<div class="table-container">
+  <table mat-table [dataSource]="rows">
+    <ng-container
+      *ngFor="let column of columnsToDisplay | slice : 0 : columnsToDisplay.length - 1"
+      [matColumnDef]="column"
+    >
+      <th mat-header-cell *matHeaderCellDef>{{ headingsToDisplay[column] }}</th>
+      <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="id">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let row">
+        <button mat-raised-button color="primary" (click)="downloadProject(row['id'], row['fileName'])">
+          Download
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+    <tr mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></tr>
+  </table>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -11,11 +11,13 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
 import { SFProjectService } from '../core/sf-project.service';
+import { ServalAdministrationService } from './serval-administration.service';
 import { ServalProjectComponent } from './serval-project.component';
 
 const mockActivatedProjectService = mock(ActivatedProjectService);
 const mockActivatedRoute = mock(ActivatedRoute);
 const mockSFProjectService = mock(SFProjectService);
+const mockServalAdministrationService = mock(ServalAdministrationService);
 
 describe('ServalProjectComponent', () => {
   configureTestingModule(() => ({
@@ -29,6 +31,7 @@ describe('ServalProjectComponent', () => {
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: ActivatedRoute, useMock: mockActivatedRoute },
+      { provide: ServalAdministrationService, useMock: mockServalAdministrationService },
       { provide: SFProjectService, useMock: mockSFProjectService }
     ]
   }));
@@ -60,8 +63,30 @@ describe('ServalProjectComponent', () => {
       const mockProjectDoc = {
         id: this.mockProjectId,
         data: createTestProjectProfile({
+          name: 'Project 01',
+          shortName: 'P1',
           translateConfig: {
-            preTranslate: preTranslate
+            draftConfig: {
+              alternateSource: {
+                paratextId: 'ptproject03',
+                projectRef: 'project03',
+                name: 'Project 03',
+                shortName: 'P3'
+              },
+              alternateTrainingSource: {
+                paratextId: 'ptproject04',
+                projectRef: 'project04',
+                name: 'Project 04',
+                shortName: 'P4'
+              }
+            },
+            preTranslate: preTranslate,
+            source: {
+              paratextId: 'ptproject02',
+              projectRef: 'project02',
+              name: 'Project 02',
+              shortName: 'P2'
+            }
           }
         })
       } as SFProjectProfileDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -1,0 +1,91 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { BehaviorSubject } from 'rxjs';
+import { mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
+import { SFProjectService } from '../core/sf-project.service';
+import { ServalProjectComponent } from './serval-project.component';
+
+const mockActivatedProjectService = mock(ActivatedProjectService);
+const mockActivatedRoute = mock(ActivatedRoute);
+const mockSFProjectService = mock(SFProjectService);
+
+describe('ServalProjectComponent', () => {
+  configureTestingModule(() => ({
+    imports: [
+      ServalProjectComponent,
+      NoopAnimationsModule,
+      TestTranslocoModule,
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
+      HttpClientTestingModule
+    ],
+    providers: [
+      { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
+      { provide: ActivatedRoute, useMock: mockActivatedRoute },
+      { provide: SFProjectService, useMock: mockSFProjectService }
+    ]
+  }));
+
+  it('should allow enabling pre-translation drafting', fakeAsync(() => {
+    const env = new TestEnvironment(false);
+    expect(env.preTranslateCheckbox.checked).toBeFalsy();
+    env.clickElement(env.preTranslateCheckbox);
+    expect(env.preTranslateCheckbox.checked).toBeTruthy();
+    verify(mockSFProjectService.onlineSetPreTranslate(env.mockProjectId, true)).once();
+  }));
+
+  it('should allow disabling pre-translation drafting', fakeAsync(() => {
+    const env = new TestEnvironment(true);
+    expect(env.preTranslateCheckbox.checked).toBeTruthy();
+    env.clickElement(env.preTranslateCheckbox);
+    expect(env.preTranslateCheckbox.checked).toBeFalsy();
+    verify(mockSFProjectService.onlineSetPreTranslate(env.mockProjectId, false)).once();
+  }));
+
+  class TestEnvironment {
+    readonly component: ServalProjectComponent;
+    readonly fixture: ComponentFixture<ServalProjectComponent>;
+
+    mockProjectId = 'project01';
+
+    constructor(preTranslate: boolean) {
+      const mockProjectId$ = new BehaviorSubject<string>(this.mockProjectId);
+      const mockProjectDoc = {
+        id: this.mockProjectId,
+        data: createTestProjectProfile({
+          translateConfig: {
+            preTranslate: preTranslate
+          }
+        })
+      } as SFProjectProfileDoc;
+      const mockProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockProjectDoc);
+
+      when(mockActivatedProjectService.projectId).thenReturn(this.mockProjectId);
+      when(mockActivatedProjectService.projectId$).thenReturn(mockProjectId$);
+      when(mockActivatedProjectService.projectDoc).thenReturn(mockProjectDoc);
+      when(mockActivatedProjectService.projectDoc$).thenReturn(mockProjectDoc$);
+
+      this.fixture = TestBed.createComponent(ServalProjectComponent);
+      this.component = this.fixture.componentInstance;
+      this.fixture.detectChanges();
+    }
+
+    get preTranslateCheckbox(): HTMLInputElement {
+      return this.fixture.nativeElement.querySelector('mat-checkbox input');
+    }
+
+    clickElement(button: HTMLElement): void {
+      button.click();
+      this.fixture.detectChanges();
+      tick();
+      this.fixture.detectChanges();
+    }
+  }
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,27 +1,45 @@
+import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { tap } from 'rxjs';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { catchError, lastValueFrom, tap, throwError } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { NoticeService } from 'xforge-common/notice.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectService } from '../core/sf-project.service';
+import { NoticeComponent } from '../shared/notice/notice.component';
+import { ServalAdministrationService } from './serval-administration.service';
+
+interface Row {
+  id: string;
+  name: string;
+  category: string;
+  fileName: string;
+}
 
 @Component({
   selector: 'app-serval-project',
   templateUrl: './serval-project.component.html',
   styleUrls: ['./serval-project.component.scss'],
-  imports: [UICommonModule],
+  imports: [CommonModule, NoticeComponent, UICommonModule],
   standalone: true
 })
-export class ServalProjectComponent extends SubscriptionDisposable implements OnInit {
+export class ServalProjectComponent extends DataLoadingComponent implements OnInit {
   preTranslate = false;
   projectName = '';
 
+  headingsToDisplay = { category: 'Category', name: 'Project', id: '' };
+  columnsToDisplay = ['category', 'name', 'id'];
+  rows: Row[] = [];
+
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly projectService: SFProjectService
+    noticeService: NoticeService,
+    private readonly projectService: SFProjectService,
+    private readonly servalAdministrationService: ServalAdministrationService
   ) {
-    super();
+    super(noticeService);
   }
 
   ngOnInit(): void {
@@ -30,11 +48,101 @@ export class ServalProjectComponent extends SubscriptionDisposable implements On
         filterNullish(),
         tap(projectDoc => {
           if (projectDoc.data == null) return;
-          this.preTranslate = projectDoc.data.translateConfig.preTranslate;
-          this.projectName = projectDoc.data.shortName + ' - ' + projectDoc.data.name;
+          const project: SFProjectProfile = projectDoc.data;
+          this.preTranslate = project.translateConfig.preTranslate;
+          this.projectName = project.shortName + ' - ' + project.name;
+
+          // Setup the downloads table
+          const rows: Row[] = [];
+
+          // Add the target
+          rows.push({
+            id: projectDoc.id,
+            name: this.projectName,
+            category: 'Target Project',
+            fileName: project.shortName + '.zip'
+          });
+
+          // Add the source
+          if (
+            project.translateConfig.source != null &&
+            !this.servalAdministrationService.isResource(project.translateConfig.source.paratextId)
+          ) {
+            rows.push({
+              id: project.translateConfig.source.projectRef,
+              name: project.translateConfig.source.shortName + ' - ' + project.translateConfig.source.name,
+              category: 'Source Project',
+              fileName: project.translateConfig.source.shortName + '.zip'
+            });
+          }
+
+          // Add the alternate source
+          if (
+            project.translateConfig.draftConfig.alternateSource != null &&
+            !this.servalAdministrationService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
+          ) {
+            rows.push({
+              id: project.translateConfig.draftConfig.alternateSource.projectRef,
+              name:
+                project.translateConfig.draftConfig.alternateSource.shortName +
+                ' - ' +
+                project.translateConfig.draftConfig.alternateSource.name,
+              category: 'Alternate Source',
+              fileName: project.translateConfig.draftConfig.alternateSource.shortName + '.zip'
+            });
+          }
+
+          // Add the alternate training source
+          if (
+            project.translateConfig.draftConfig.alternateTrainingSource != null &&
+            !this.servalAdministrationService.isResource(
+              project.translateConfig.draftConfig.alternateTrainingSource.paratextId
+            )
+          ) {
+            rows.push({
+              id: project.translateConfig.draftConfig.alternateTrainingSource.projectRef,
+              name:
+                project.translateConfig.draftConfig.alternateTrainingSource.shortName +
+                ' - ' +
+                project.translateConfig.draftConfig.alternateTrainingSource.name,
+              category: 'Alternate Training Source',
+              fileName: project.translateConfig.draftConfig.alternateTrainingSource.shortName + '.zip'
+            });
+          }
+
+          // We have to set the rows this way to trigger the update
+          this.rows = rows;
         })
       )
     );
+  }
+
+  async downloadProject(id: string, fileName: string): Promise<void> {
+    this.loadingStarted();
+
+    // Download the zip file as a blob - this ensures we set the authorization header.
+    const blob: Blob = await lastValueFrom(
+      this.servalAdministrationService.downloadProject(id).pipe(
+        catchError(err => {
+          // Stop the loading, and throw the error
+          this.loadingFinished();
+          return throwError(() => err);
+        })
+      )
+    );
+
+    // Trigger a click that downloads the blob
+    // NOTE: This code should not be unit tested, as it will trigger downloads in the test browser
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+
+    this.loadingFinished();
   }
 
   onUpdatePreTranslate(newValue: boolean): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -5,6 +5,7 @@ import { catchError, lastValueFrom, tap, throwError } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectService } from '../core/sf-project.service';
@@ -36,10 +37,15 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
     noticeService: NoticeService,
+    private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
     private readonly servalAdministrationService: ServalAdministrationService
   ) {
     super(noticeService);
+  }
+
+  get isOnline(): boolean {
+    return this.onlineStatusService.isOnline;
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit } from '@angular/core';
+import { tap } from 'rxjs';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { SFProjectService } from '../core/sf-project.service';
+
+@Component({
+  selector: 'app-serval-project',
+  templateUrl: './serval-project.component.html',
+  styleUrls: ['./serval-project.component.scss'],
+  imports: [UICommonModule],
+  standalone: true
+})
+export class ServalProjectComponent extends SubscriptionDisposable implements OnInit {
+  preTranslate = false;
+  projectName = '';
+
+  constructor(
+    private readonly activatedProjectService: ActivatedProjectService,
+    private readonly projectService: SFProjectService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.subscribe(
+      this.activatedProjectService.projectDoc$.pipe(
+        filterNullish(),
+        tap(projectDoc => {
+          if (projectDoc.data == null) return;
+          this.preTranslate = projectDoc.data.translateConfig.preTranslate;
+          this.projectName = projectDoc.data.shortName + ' - ' + projectDoc.data.name;
+        })
+      )
+    );
+  }
+
+  onUpdatePreTranslate(newValue: boolean): Promise<void> {
+    return this.projectService.onlineSetPreTranslate(this.activatedProjectService.projectId!, newValue);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -1,0 +1,68 @@
+<div class="projects-controls">
+  <mat-form-field appearance="fill">
+    <mat-label>Filter projects...</mat-label>
+    <input matInput (keyup)="updateSearchTerm($event.target)" id="project-filter" />
+  </mat-form-field>
+</div>
+<ng-container *ngIf="!isLoading">
+  <ng-container *ngIf="length > 0">
+    <table mat-table id="projects-table" ngClass.gt-xs="fixed-layout-table" [dataSource]="rows">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let row">
+          <a [appRouterLink]="['/serval-administration', row.id]">{{ row.name }}</a>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="preTranslate">
+        <th mat-header-cell *matHeaderCellDef>Pre-Translation</th>
+        <td mat-cell *matCellDef="let row">
+          <strong *ngIf="row.preTranslate">Enabled</strong>
+          <span *ngIf="!row.preTranslate">Disabled</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="source">
+        <th mat-header-cell *matHeaderCellDef>Source</th>
+        <td mat-cell *matCellDef="let row">
+          <a *ngIf="row.sourceId != null" [appRouterLink]="['/serval-administration', row.sourceId]">{{
+            row.source
+          }}</a>
+          <span *ngIf="row.sourceId == null">{{ row.source }}</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="alternateSource">
+        <th mat-header-cell *matHeaderCellDef>Alternate Source</th>
+        <td mat-cell *matCellDef="let row">
+          <a
+            *ngIf="row.alternateSourceId != null"
+            [appRouterLink]="['/serval-administration', row.alternateSourceId]"
+            >{{ row.alternateSource }}</a
+          >
+          <span *ngIf="row.alternateSourceId == null">{{ row.alternateSource }}</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="alternateTrainingSource">
+        <th mat-header-cell *matHeaderCellDef>Alternate Training Source</th>
+        <td mat-cell *matCellDef="let row">
+          <a
+            *ngIf="row.alternateTrainingSourceId != null"
+            [appRouterLink]="['/serval-administration', row.alternateTrainingSourceId]"
+            >{{ row.alternateTrainingSource }}</a
+          >
+          <span *ngIf="row.alternateTrainingSourceId == null">{{ row.alternateTrainingSource }}</span>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
+    </table>
+
+    <mat-paginator
+      [pageIndex]="pageIndex"
+      [length]="length"
+      [pageSize]="pageSize"
+      [pageSizeOptions]="[5, 10, 20, 50, 100]"
+      (page)="updatePage($event.pageIndex, $event.pageSize)"
+    >
+    </mat-paginator>
+  </ng-container>
+  <div *ngIf="length === 0" class="no-projects-label">No projects found</div>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.scss
@@ -1,0 +1,15 @@
+.projects-controls {
+  margin: 32px 0;
+}
+
+mat-form-field {
+  margin-top: 10px;
+}
+
+.no-projects-label {
+  padding-top: 14px;
+}
+
+.fixed-layout-table {
+  table-layout: fixed;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.scss
@@ -1,15 +1,7 @@
-.projects-controls {
-  margin: 32px 0;
-}
-
 mat-form-field {
   margin-top: 10px;
 }
 
 .no-projects-label {
   padding-top: 14px;
-}
-
-.fixed-layout-table {
-  table-layout: fixed;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
@@ -1,0 +1,212 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DebugElement, getDebugNode } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { escapeRegExp, merge } from 'lodash-es';
+import { Project } from 'realtime-server/lib/esm/common/models/project';
+import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
+import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { combineLatest, from, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { anything, mock, when } from 'ts-mockito';
+import { FileType } from 'xforge-common/models/file-offline-data';
+import { ProjectDoc } from 'xforge-common/models/project-doc';
+import { NoticeService } from 'xforge-common/notice.service';
+import { QueryFilter, QueryParameters } from 'xforge-common/query-parameters';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TypeRegistry } from 'xforge-common/type-registry';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { UserService } from 'xforge-common/user.service';
+import { ServalAdministrationService } from './serval-administration.service';
+import { ServalProjectsComponent } from './serval-projects.component';
+
+const mockedNoticeService = mock(NoticeService);
+const mockedServalAdministrationService = mock(ServalAdministrationService);
+const mockedUserService = mock(UserService);
+
+describe('ServalProjectsComponent', () => {
+  configureTestingModule(() => ({
+    imports: [
+      ServalProjectsComponent,
+      NoopAnimationsModule,
+      RouterTestingModule,
+      UICommonModule,
+      TestTranslocoModule,
+      TestRealtimeModule.forRoot(new TypeRegistry([TestProjectDoc], [FileType.Audio], [])),
+      HttpClientTestingModule
+    ],
+    providers: [
+      { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: ServalAdministrationService, useMock: mockedServalAdministrationService },
+      { provide: UserService, useMock: mockedUserService }
+    ]
+  }));
+
+  it('should display projects', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData();
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+    tick();
+
+    expect(env.rows.length).toEqual(3);
+    expect(env.cell(0, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P1 - Project 01');
+    expect(env.cell(0, 1).nativeElement.textContent).toEqual('Enabled');
+    expect(env.cell(1, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P2 - Project 02');
+    expect(env.cell(1, 1).nativeElement.textContent).toEqual('Disabled');
+  }));
+
+  it('should display message when there are no projects', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+
+    expect(env.fixture.debugElement.query(By.css('.no-projects-label'))).not.toBeNull();
+  }));
+
+  it('should filter projects', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData();
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+
+    env.setInputValue(env.filterInput, '02');
+
+    expect(env.rows.length).toEqual(1);
+  }));
+
+  it('should page', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData();
+    env.component.pageSize = 2;
+    env.fixture.detectChanges();
+    tick();
+    env.fixture.detectChanges();
+
+    env.clickButton(env.nextButton);
+
+    expect(env.rows.length).toEqual(1);
+  }));
+});
+
+class TestProjectDoc extends ProjectDoc {
+  static readonly COLLECTION = 'projects';
+  static readonly INDEX_PATHS = [];
+
+  readonly taskNames: string[] = ['Task1', 'Task2'];
+}
+
+class TestEnvironment {
+  readonly component: ServalProjectsComponent;
+  readonly fixture: ComponentFixture<ServalProjectsComponent>;
+
+  private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
+
+  constructor() {
+    when(mockedUserService.currentUserId).thenReturn('user01');
+    when(mockedServalAdministrationService.onlineQuery(anything(), anything(), anything())).thenCall(
+      (term$: Observable<string>, parameters$: Observable<QueryParameters>) =>
+        combineLatest([term$, parameters$]).pipe(
+          switchMap(([term, queryParameters]) => {
+            const filters: QueryFilter = {
+              [obj<Project>().pathStr(p => p.name)]: { $regex: `.*${escapeRegExp(term)}.*`, $options: 'i' }
+            };
+            return from(
+              this.realtimeService.onlineQuery<TestProjectDoc>(
+                TestProjectDoc.COLLECTION,
+                merge(filters, queryParameters)
+              )
+            );
+          })
+        )
+    );
+
+    this.fixture = TestBed.createComponent(ServalProjectsComponent);
+    this.component = this.fixture.componentInstance;
+  }
+
+  get table(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#projects-table'));
+  }
+
+  get rows(): DebugElement[] {
+    // querying the debug table element doesn't seem to work, so we query the native element instead and convert back
+    // to debug elements
+    return Array.from(this.table.nativeElement.querySelectorAll('tbody tr')).map(r => getDebugNode(r) as DebugElement);
+  }
+
+  get filterInput(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#project-filter'));
+  }
+
+  get paginator(): DebugElement {
+    return this.fixture.debugElement.query(By.css('mat-paginator'));
+  }
+
+  get nextButton(): DebugElement {
+    return this.paginator.query(By.css('.mat-paginator-navigation-next'));
+  }
+
+  cell(row: number, column: number): DebugElement {
+    return this.rows[row].children[column];
+  }
+
+  clickButton(button: DebugElement): void {
+    button.nativeElement.click();
+    this.fixture.detectChanges();
+    tick();
+    this.fixture.detectChanges();
+  }
+
+  setInputValue(input: DebugElement, value: string): void {
+    const inputElem = input.nativeElement as HTMLInputElement;
+    inputElem.value = value;
+    inputElem.dispatchEvent(new Event('keyup'));
+    this.fixture.detectChanges();
+    tick();
+    this.fixture.detectChanges();
+  }
+
+  setupProjectData(): void {
+    this.realtimeService.addSnapshots<SFProject>(TestProjectDoc.COLLECTION, [
+      {
+        id: 'project01',
+        data: createTestProject({
+          name: 'Project 01',
+          translateConfig: {
+            preTranslate: true
+          },
+          userRoles: { user01: 'pt_administrator' },
+          userPermissions: {}
+        })
+      },
+      {
+        id: 'project02',
+        data: createTestProject({
+          name: 'Project 02',
+          shortName: 'P2',
+          userRoles: {},
+          userPermissions: {},
+          syncDisabled: true
+        })
+      },
+      {
+        id: 'project03',
+        data: createTestProject({
+          name: 'Project 03',
+          shortName: 'P3',
+          userRoles: { user01: 'pt_translator' },
+          userPermissions: {}
+        })
+      }
+    ]);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
@@ -56,10 +56,27 @@ describe('ServalProjectsComponent', () => {
     tick();
 
     expect(env.rows.length).toEqual(3);
+
+    // First row - pre-translate enabled, projects as sources
     expect(env.cell(0, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P1 - Project 01');
     expect(env.cell(0, 1).nativeElement.textContent).toEqual('Enabled');
+    expect(env.cell(0, 2).query(By.css('a')).nativeElement.text.trim()).toEqual('P2 - Project 02');
+    expect(env.cell(0, 3).query(By.css('a')).nativeElement.text.trim()).toEqual('P3 - Project 03');
+    expect(env.cell(0, 4).query(By.css('a')).nativeElement.text.trim()).toEqual('P4 - Project 04');
+
+    // Second row - pre-translate undefined, no sources
     expect(env.cell(1, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P2 - Project 02');
     expect(env.cell(1, 1).nativeElement.textContent).toEqual('Disabled');
+    expect(env.cell(1, 2).nativeElement.textContent).toEqual('None');
+    expect(env.cell(1, 3).nativeElement.textContent).toEqual('None');
+    expect(env.cell(1, 4).nativeElement.textContent).toEqual('None');
+
+    // Third row - pre-translate disabled, resources as sources
+    expect(env.cell(2, 0).query(By.css('a')).nativeElement.text.trim()).toEqual('P3 - Project 03');
+    expect(env.cell(2, 1).nativeElement.textContent).toEqual('Disabled');
+    expect(env.cell(2, 2).nativeElement.textContent).toEqual('R1 - Resource 01');
+    expect(env.cell(2, 3).nativeElement.textContent).toEqual('R2 - Resource 02');
+    expect(env.cell(2, 4).nativeElement.textContent).toEqual('R3 - Resource 03');
   }));
 
   it('should display message when there are no projects', fakeAsync(() => {
@@ -128,6 +145,9 @@ class TestEnvironment {
           })
         )
     );
+    when(mockedServalAdministrationService.isResource(anything())).thenCall((paratextId: string) => {
+      return paratextId?.startsWith('ptresource') ?? false;
+    });
 
     this.fixture = TestBed.createComponent(ServalProjectsComponent);
     this.component = this.fixture.componentInstance;
@@ -138,8 +158,6 @@ class TestEnvironment {
   }
 
   get rows(): DebugElement[] {
-    // querying the debug table element doesn't seem to work, so we query the native element instead and convert back
-    // to debug elements
     return Array.from(this.table.nativeElement.querySelectorAll('tbody tr')).map(r => getDebugNode(r) as DebugElement);
   }
 
@@ -182,7 +200,27 @@ class TestEnvironment {
         data: createTestProject({
           name: 'Project 01',
           translateConfig: {
-            preTranslate: true
+            draftConfig: {
+              alternateSource: {
+                paratextId: 'ptproject03',
+                projectRef: 'project03',
+                name: 'Project 03',
+                shortName: 'P3'
+              },
+              alternateTrainingSource: {
+                paratextId: 'ptproject04',
+                projectRef: 'project04',
+                name: 'Project 04',
+                shortName: 'P4'
+              }
+            },
+            preTranslate: true,
+            source: {
+              paratextId: 'ptproject02',
+              projectRef: 'project02',
+              name: 'Project 02',
+              shortName: 'P2'
+            }
           },
           userRoles: { user01: 'pt_administrator' },
           userPermissions: {}
@@ -203,6 +241,29 @@ class TestEnvironment {
         data: createTestProject({
           name: 'Project 03',
           shortName: 'P3',
+          translateConfig: {
+            draftConfig: {
+              alternateSource: {
+                paratextId: 'ptresource02',
+                projectRef: 'resource02',
+                name: 'Resource 02',
+                shortName: 'R2'
+              },
+              alternateTrainingSource: {
+                paratextId: 'ptresource03',
+                projectRef: 'resource03',
+                name: 'Resource 03',
+                shortName: 'R3'
+              }
+            },
+            preTranslate: false,
+            source: {
+              paratextId: 'ptresource01',
+              projectRef: 'resource01',
+              name: 'Resource 01',
+              shortName: 'R1'
+            }
+          },
           userRoles: { user01: 'pt_translator' },
           userPermissions: {}
         })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -1,0 +1,166 @@
+import { CommonModule } from '@angular/common';
+import { Component, HostBinding, OnInit } from '@angular/core';
+import { Project } from 'realtime-server/lib/esm/common/models/project';
+import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
+import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { BehaviorSubject } from 'rxjs';
+import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { I18nService } from 'xforge-common/i18n.service';
+import { NoticeService } from 'xforge-common/notice.service';
+import { QueryParameters } from 'xforge-common/query-parameters';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { ServalAdministrationService } from './serval-administration.service';
+
+class Row {
+  constructor(public readonly projectDoc: SFProjectProfileDoc) {}
+
+  get alternateSource(): string {
+    return this.projectDoc.data?.translateConfig.draftConfig.alternateSource == null
+      ? 'None'
+      : this.projectDoc.data.translateConfig.draftConfig.alternateSource.shortName +
+          ' - ' +
+          this.projectDoc.data.translateConfig.draftConfig.alternateSource.name;
+  }
+
+  get alternateSourceId(): string | undefined {
+    if ((this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId?.length ?? 0) > 16) {
+      return this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.projectRef;
+    } else {
+      return undefined;
+    }
+  }
+
+  get alternateTrainingSource(): string {
+    return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource == null
+      ? 'None'
+      : this.projectDoc.data.translateConfig.draftConfig.alternateTrainingSource.shortName +
+          ' - ' +
+          this.projectDoc.data.translateConfig.draftConfig.alternateTrainingSource.name;
+  }
+
+  get alternateTrainingSourceId(): string | undefined {
+    if ((this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId?.length ?? 0) > 16) {
+      return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.projectRef;
+    } else {
+      return undefined;
+    }
+  }
+
+  get id(): string {
+    return this.projectDoc.id;
+  }
+
+  get name(): string {
+    return this.projectDoc.data == null ? 'N/A' : this.projectDoc.data.shortName + ' - ' + this.projectDoc.data.name;
+  }
+
+  get preTranslate(): boolean {
+    return this.projectDoc.data?.translateConfig.preTranslate ?? false;
+  }
+
+  get source(): string {
+    return this.projectDoc.data?.translateConfig.source == null
+      ? 'None'
+      : this.projectDoc.data.translateConfig.source.shortName +
+          ' - ' +
+          this.projectDoc.data.translateConfig.source.name;
+  }
+
+  get sourceId(): string | undefined {
+    if ((this.projectDoc.data?.translateConfig.source?.paratextId?.length ?? 0) > 16) {
+      return this.projectDoc.data?.translateConfig.source?.projectRef;
+    } else {
+      return undefined;
+    }
+  }
+}
+
+@Component({
+  selector: 'app-serval-projects',
+  templateUrl: './serval-projects.component.html',
+  styleUrls: ['./serval-projects.component.scss'],
+  standalone: true,
+  imports: [CommonModule, UICommonModule]
+})
+export class ServalProjectsComponent extends DataLoadingComponent implements OnInit {
+  @HostBinding('class') classes = 'flex-column';
+
+  columnsToDisplay: string[] = ['name', 'preTranslate', 'source', 'alternateSource', 'alternateTrainingSource'];
+  rows: Row[] = [];
+
+  length: number = 0;
+  pageIndex: number = 0;
+  pageSize: number = 50;
+
+  private projectDocs?: Readonly<SFProjectProfileDoc[]>;
+
+  private readonly searchTerm$: BehaviorSubject<string>;
+  private readonly queryParameters$: BehaviorSubject<QueryParameters>;
+
+  constructor(
+    noticeService: NoticeService,
+    readonly i18n: I18nService,
+    private readonly servalAdministrationService: ServalAdministrationService
+  ) {
+    super(noticeService);
+    this.searchTerm$ = new BehaviorSubject<string>('');
+    this.queryParameters$ = new BehaviorSubject<QueryParameters>(this.getQueryParameters());
+  }
+
+  get isLoading(): boolean {
+    return this.projectDocs == null;
+  }
+
+  ngOnInit(): void {
+    this.loadingStarted();
+    this.subscribe(
+      this.servalAdministrationService.onlineQuery(this.searchTerm$, this.queryParameters$, [
+        obj<Project>().pathStr(p => p.name),
+        obj<SFProjectProfile>().pathStr(p => p.shortName)
+      ]),
+      searchResults => {
+        this.loadingStarted();
+        this.projectDocs = searchResults.docs;
+        this.length = searchResults.unpagedCount;
+        this.generateRows();
+        this.loadingFinished();
+      }
+    );
+  }
+
+  updateSearchTerm(target: EventTarget | null): void {
+    const termTarget = target as HTMLInputElement;
+    if (termTarget?.value != null) {
+      this.searchTerm$.next(termTarget.value);
+    }
+  }
+
+  updatePage(pageIndex: number, pageSize: number): void {
+    this.pageIndex = pageIndex;
+    this.pageSize = pageSize;
+    this.queryParameters$.next(this.getQueryParameters());
+  }
+
+  private generateRows(): void {
+    if (this.projectDocs == null) {
+      return;
+    }
+
+    const rows: Row[] = [];
+    for (const projectDoc of this.projectDocs) {
+      rows.push(new Row(projectDoc));
+    }
+    this.rows = rows;
+  }
+
+  private getQueryParameters(): QueryParameters {
+    return {
+      // Do not return resources
+      [obj<SFProject>().pathStr(q => q.resourceConfig)]: null,
+      $sort: { [obj<Project>().pathStr(p => p.name)]: 1 },
+      $skip: this.pageIndex * this.pageSize,
+      $limit: this.pageSize
+    };
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, HostBinding, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -95,8 +95,6 @@ class Row {
   imports: [CommonModule, UICommonModule]
 })
 export class ServalProjectsComponent extends DataLoadingComponent implements OnInit {
-  @HostBinding('class') classes = 'flex-column';
-
   columnsToDisplay: string[] = ['name', 'preTranslate', 'source', 'alternateSource', 'alternateTrainingSource'];
   rows: Row[] = [];
 
@@ -131,7 +129,6 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
         obj<SFProjectProfile>().pathStr(p => p.shortName)
       ]),
       searchResults => {
-        this.loadingStarted();
         this.projectDocs = searchResults.docs;
         this.length = searchResults.unpagedCount;
         this.generateRows();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -13,7 +13,10 @@ import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { ServalAdministrationService } from './serval-administration.service';
 
 class Row {
-  constructor(public readonly projectDoc: SFProjectProfileDoc) {}
+  constructor(
+    public readonly projectDoc: SFProjectProfileDoc,
+    private readonly servalAdministrationService: ServalAdministrationService
+  ) {}
 
   get alternateSource(): string {
     return this.projectDoc.data?.translateConfig.draftConfig.alternateSource == null
@@ -24,7 +27,11 @@ class Row {
   }
 
   get alternateSourceId(): string | undefined {
-    if ((this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId?.length ?? 0) > 16) {
+    if (
+      !this.servalAdministrationService.isResource(
+        this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId
+      )
+    ) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.projectRef;
     } else {
       return undefined;
@@ -40,7 +47,11 @@ class Row {
   }
 
   get alternateTrainingSourceId(): string | undefined {
-    if ((this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId?.length ?? 0) > 16) {
+    if (
+      !this.servalAdministrationService.isResource(
+        this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId
+      )
+    ) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.projectRef;
     } else {
       return undefined;
@@ -68,7 +79,7 @@ class Row {
   }
 
   get sourceId(): string | undefined {
-    if ((this.projectDoc.data?.translateConfig.source?.paratextId?.length ?? 0) > 16) {
+    if (!this.servalAdministrationService.isResource(this.projectDoc.data?.translateConfig.source?.paratextId)) {
       return this.projectDoc.data?.translateConfig.source?.projectRef;
     } else {
       return undefined;
@@ -149,7 +160,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
 
     const rows: Row[] = [];
     for (const projectDoc of this.projectDocs) {
-      rows.push(new Row(projectDoc));
+      rows.push(new Row(projectDoc, this.servalAdministrationService));
     }
     this.rows = rows;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -5,6 +5,7 @@
     "manage_questions": "Manage questions",
     "settings": "Settings",
     "synchronize": "Synchronize",
+    "serval_administration": "Serval Administration",
     "system_administration": "System Administration",
     "translate": "Translate",
     "edit_review": "Edit & review",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import {
   MatLegacyDialog as MatDialog,
   MatLegacyDialogConfig as MatDialogConfig
@@ -52,6 +52,7 @@ describe('ErrorDialogComponent', () => {
     expect(env.stackTrace).toBeNull();
 
     env.closeButton.click();
+    flush();
   }));
 
   it('should not render "Show details" link when no stack trace', fakeAsync(() => {
@@ -64,6 +65,7 @@ describe('ErrorDialogComponent', () => {
     expect(env.stackTrace).toBeNull();
 
     env.closeButton.click();
+    flush();
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/url-constants.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/url-constants.ts
@@ -1,4 +1,5 @@
 export const ANONYMOUS_URL = 'anonymous';
 export const COMMAND_API_NAMESPACE = 'command-api';
+export const PARATEXT_API_NAMESPACE = 'paratext-api';
 export const USERS_URL = 'users';
 export const PROJECTS_URL = 'projects';

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Serval.Client;
@@ -25,6 +26,7 @@ public interface IMachineProjectService
         bool preTranslate,
         CancellationToken cancellationToken
     );
+    Task<string> GetProjectZipAsync(string sfProjectId, Stream outputStream, CancellationToken cancellationToken);
     Task<string> GetTranslationEngineTypeAsync(bool preTranslate);
     Task RemoveProjectAsync(
         string curUserId,

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -417,7 +417,7 @@ public class MachineProjectService(
         // Ensure that the path exists
         if (!fileSystemService.DirectoryExists(path))
         {
-            throw new DataNotFoundException($"The following directory could not be found: {path}");
+            throw new DataNotFoundException($"The directory could not be found for {project.ParatextId}");
         }
 
         // Create the zip file from the directory in memory
@@ -1624,7 +1624,7 @@ public class MachineProjectService(
             // Ensure that the path exists
             if (!fileSystemService.DirectoryExists(path))
             {
-                throw new DirectoryNotFoundException($"The following directory could not be found: {path}");
+                throw new DirectoryNotFoundException($"The directory could not be found for {paratextId}");
             }
 
             // Create the zip file from the directory in memory

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -385,6 +385,58 @@ public class MachineProjectService(
     }
 
     /// <summary>
+    /// Gets the project as a zip file, writing it to <paramref name="outputStream"/>.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="outputStream">The output stream.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The name of the zip file, e.g. <c>ABC.zip</c>.</returns>
+    /// <exception cref="DataNotFoundException">The project does not exist, is a resource, or could not be found on disk.</exception>
+    public async Task<string> GetProjectZipAsync(
+        string sfProjectId,
+        Stream outputStream,
+        CancellationToken cancellationToken
+    )
+    {
+        // Load the project from the realtime service
+        Attempt<SFProject> attempt = await realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
+        if (!attempt.TryResult(out SFProject project))
+        {
+            throw new DataNotFoundException("The project does not exist.");
+        }
+
+        // Ensure that the project is not a resource
+        if (paratextService.IsResource(project.ParatextId))
+        {
+            throw new DataNotFoundException("You cannot download a resource.");
+        }
+
+        // Get the path to the Paratext directory
+        string path = Path.Combine(siteOptions.Value.SiteDir, "sync", project.ParatextId, "target");
+
+        // Ensure that the path exists
+        if (!fileSystemService.DirectoryExists(path))
+        {
+            throw new DataNotFoundException($"The following directory could not be found: {path}");
+        }
+
+        // Create the zip file from the directory in memory
+        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create, true);
+        foreach (string filePath in fileSystemService.EnumerateFiles(path))
+        {
+            await using Stream fileStream = fileSystemService.OpenFile(filePath, FileMode.Open);
+            ZipArchiveEntry entry = archive.CreateEntry(Path.GetFileName(filePath));
+            await using Stream entryStream = entry.Open();
+            await fileStream.CopyToAsync(entryStream, cancellationToken);
+        }
+
+        // Strip invalid characters from the file name
+        string fileName = Path.GetInvalidFileNameChars()
+            .Aggregate(project.ShortName, (current, c) => current.Replace(c.ToString(), string.Empty));
+        return $"{fileName}.zip";
+    }
+
+    /// <summary>
     /// Gets the translation engine type string for Serval.
     /// </summary>
     /// <param name="preTranslate">If <c>true</c>, then the translation engine is for pre-translation.</param>

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1034,7 +1034,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
 
     public async Task SetPreTranslateAsync(string curUserId, string[] systemRoles, string projectId, bool preTranslate)
     {
-        if (!systemRoles.Contains(SystemRole.SystemAdmin))
+        if (!(systemRoles.Contains(SystemRole.SystemAdmin) || systemRoles.Contains(SystemRole.ServalAdmin)))
             throw new ForbiddenException();
 
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -68,6 +68,7 @@ public class Startup
         "login",
         "projects",
         "join",
+        "serval-administration",
         "system-administration",
         "favicon.ico",
         "assets"

--- a/src/SIL.XForge/Models/SystemRole.cs
+++ b/src/SIL.XForge/Models/SystemRole.cs
@@ -2,6 +2,7 @@ namespace SIL.XForge.Models;
 
 public static class SystemRole
 {
+    public const string ServalAdmin = "serval_admin";
     public const string SystemAdmin = "system_admin";
     public const string User = "user";
     public const string None = "none";

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -1056,6 +1057,64 @@ public class MachineProjectServiceTests
         // SUT
         var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: false);
         Assert.AreEqual(MachineProjectService.SmtTransfer, actual);
+    }
+
+    [Test]
+    public async Task GetProjectZipAsync_Success()
+    {
+        var env = new TestEnvironment();
+        MemoryStream outputStream = new MemoryStream();
+
+        // SUT
+        string actual = await env.Service.GetProjectZipAsync(Project01, outputStream, CancellationToken.None);
+        Assert.AreEqual("P01.zip", actual);
+
+        // Validate the zip file
+        outputStream.Seek(0, SeekOrigin.Begin);
+        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Read);
+        Assert.AreEqual(1, archive.Entries.Count);
+        Assert.AreEqual("file", archive.Entries[0].FullName);
+    }
+
+    [Test]
+    public void GetProjectZipAsync_ThrowsExceptionWhenProjectDirectoryMissing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
+        MemoryStream outputStream = new MemoryStream();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetProjectZipAsync(Project01, outputStream, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetProjectZipAsync_ThrowsExceptionWhenProjectDocumentMissing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        MemoryStream outputStream = new MemoryStream();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetProjectZipAsync("invalid_project_id", outputStream, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public void GetProjectZipAsync_ThrowsExceptionWhenProjectIsAResource()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
+        MemoryStream outputStream = new MemoryStream();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.GetProjectZipAsync(Project01, outputStream, CancellationToken.None)
+        );
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -3075,7 +3075,7 @@ public class SFProjectServiceTests
         Assert.DoesNotThrowAsync(
             () => env.Service.SetPreTranslateAsync(User03, [SystemRole.SystemAdmin], Project01, false)
         );
-        // SUT 3
+        // SUT 4
         Assert.DoesNotThrowAsync(
             () => env.Service.SetPreTranslateAsync(User03, [SystemRole.ServalAdmin], Project01, false)
         );

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -3060,28 +3060,24 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void SetPreTranslate_RequiresSysAdmin()
+    public void SetPreTranslate_RequiresSystemAdminOrServalAdmin()
     {
         var env = new TestEnvironment();
         // SUT 1
         Assert.ThrowsAsync<ForbiddenException>(
-            async () =>
-                await env.Service.SetPreTranslateAsync(User03, new string[] { SystemRole.User }, Project01, false)
+            () => env.Service.SetPreTranslateAsync(User03, [SystemRole.User], Project01, false)
         );
         // SUT 2
         Assert.ThrowsAsync<ForbiddenException>(
-            async () =>
-                await env.Service.SetPreTranslateAsync(User03, new string[] { SystemRole.None }, Project01, false)
+            () => env.Service.SetPreTranslateAsync(User03, [SystemRole.None], Project01, false)
         );
         // SUT 3
         Assert.DoesNotThrowAsync(
-            async () =>
-                await env.Service.SetPreTranslateAsync(
-                    User03,
-                    new string[] { SystemRole.SystemAdmin },
-                    Project01,
-                    false
-                )
+            () => env.Service.SetPreTranslateAsync(User03, [SystemRole.SystemAdmin], Project01, false)
+        );
+        // SUT 3
+        Assert.DoesNotThrowAsync(
+            () => env.Service.SetPreTranslateAsync(User03, [SystemRole.ServalAdmin], Project01, false)
         );
     }
 
@@ -3092,12 +3088,12 @@ public class SFProjectServiceTests
 
         Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(false));
         // SUT 1
-        await env.Service.SetPreTranslateAsync(User01, new string[] { SystemRole.SystemAdmin }, Project02, true);
+        await env.Service.SetPreTranslateAsync(User01, [SystemRole.SystemAdmin], Project02, true);
         Assert.That(env.GetProject(Project02).TranslateConfig.PreTranslate, Is.EqualTo(true));
 
         Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(true));
         // SUT 2
-        await env.Service.SetPreTranslateAsync(User01, new string[] { SystemRole.SystemAdmin }, Project01, false);
+        await env.Service.SetPreTranslateAsync(User01, [SystemRole.ServalAdmin], Project01, false);
         Assert.That(env.GetProject(Project01).TranslateConfig.PreTranslate, Is.EqualTo(false));
     }
 


### PR DESCRIPTION
This PR:
 * Adds a Serval Administration Panel where users with the role ServalAdmin can activate pre-translation drafting for projects.
 * Adds the ability to download Paratext projects as a zip file in the Serval Administration Area.

**Developer testing notes**
If you want to add the ability to view this panel, open your user in Auth0, and change `xf_role` in app meta data to be:
```json
"xf_role": "serval_admin"
```
Or: 
```json
"xf_role": [
    "serval_admin"
  ]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2373)
<!-- Reviewable:end -->
