### PR TITLE
Update font use query to make charting font use easier

### DIFF
--- a/mongodb/Projects/ProjectFontUsage.mongodb
+++ b/mongodb/Projects/ProjectFontUsage.mongodb
@@ -16,4 +16,4 @@ const fonts = db.sf_projects.aggregate([
   }}
 ]).toArray();
 
-console.log(fonts.map(font => `${font.count},${font._id}`).join('\n'));
+console.log(fonts.map(font => `${font._id}\t${font.count}`).join('\n'));


### PR DESCRIPTION
This font query is used to see what fonts are in use on live.

Analyzing the use of fonts is done in a spreadsheet, and it's a lot easier to move data from the query to a spreadsheet when cells are separated by tabs, rather than commas. Also, having the font name before the count makes it easier to process the data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2377)
<!-- Reviewable:end -->
