### PR TITLE
Create overridable default SFProjectUserConfig for tests

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config-test-data.ts
@@ -1,0 +1,25 @@
+import merge from 'lodash/merge';
+import { RecursivePartial } from '../../common/utils/type-utils';
+import { SFProjectUserConfig } from './sf-project-user-config';
+
+export function createTestProjectUserConfig(overrides?: RecursivePartial<SFProjectUserConfig>): SFProjectUserConfig {
+  // Create new object for each test
+  const defaultSFProjectUserConfig: SFProjectUserConfig = {
+    projectRef: 'project01',
+    ownerRef: '',
+    isTargetTextRight: false,
+    confidenceThreshold: 0.2,
+    biblicalTermsEnabled: false,
+    transliterateBiblicalTerms: false,
+    translationSuggestionsEnabled: true,
+    numSuggestions: 1,
+    selectedSegment: '',
+    questionRefsRead: [],
+    answerRefsRead: [],
+    commentRefsRead: [],
+    noteRefsRead: [],
+    audioRefsPlayed: []
+  };
+
+  return merge(defaultSFProjectUserConfig, overrides);
+}

--- a/src/RealtimeServer/scriptureforge/services/biblical-term-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/biblical-term-service.spec.ts
@@ -1,22 +1,23 @@
 import { VerseRef } from '@sillsdev/scripture';
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
-import { instance, mock } from 'ts-mockito';
 import { Connection } from 'sharedb/lib/client';
+import { instance, mock } from 'ts-mockito';
 import { User, USERS_COLLECTION } from '../../common/models/user';
 import { createTestUser } from '../../common/models/user-test-data';
 import { RealtimeServer } from '../../common/realtime-server';
 import { SchemaVersionRepository } from '../../common/schema-version-repository';
 import { allowAll, clientConnect, createDoc, fetchDoc, submitJson0Op } from '../../common/utils/test-utils';
-import { BiblicalTerm, BIBLICAL_TERM_COLLECTION, getBiblicalTermDocId } from '../models/biblical-term';
+import { BIBLICAL_TERM_COLLECTION, BiblicalTerm, getBiblicalTermDocId } from '../models/biblical-term';
 import { SF_PROJECTS_COLLECTION, SFProjectProfile } from '../models/sf-project';
+import { SFProjectRole } from '../models/sf-project-role';
+import { createTestProjectProfile } from '../models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
   SF_PROJECT_USER_CONFIGS_COLLECTION,
   SFProjectUserConfig
 } from '../models/sf-project-user-config';
-import { SFProjectRole } from '../models/sf-project-role';
-import { createTestProjectProfile } from '../models/sf-project-test-data';
+import { createTestProjectUserConfig } from '../models/sf-project-user-config-test-data';
 import { BiblicalTermService } from './biblical-term-service';
 
 describe('BiblicalTermService', () => {
@@ -81,22 +82,13 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', this.projectAdminId),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: this.projectAdminId,
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: true,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     );
 
     await createDoc<SFProjectProfile>(

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.spec.ts
@@ -1,8 +1,9 @@
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
-import { instance, mock } from 'ts-mockito';
 import { Connection } from 'sharedb/lib/client';
+import { instance, mock } from 'ts-mockito';
 import { User, USERS_COLLECTION } from '../../common/models/user';
+import { createTestUser } from '../../common/models/user-test-data';
 import { RealtimeServer } from '../../common/realtime-server';
 import { SchemaVersionRepository } from '../../common/schema-version-repository';
 import {
@@ -15,26 +16,26 @@ import {
   hasDoc,
   submitJson0Op
 } from '../../common/utils/test-utils';
+import { Note } from '../models/note';
+import {
+  getNoteThreadDocId,
+  NOTE_THREAD_COLLECTION,
+  NoteConflictType,
+  NoteStatus,
+  NoteThread,
+  NoteType
+} from '../models/note-thread';
 import { SF_PROJECTS_COLLECTION, SFProject } from '../models/sf-project';
 import { SFProjectRole } from '../models/sf-project-role';
+import { createTestProject } from '../models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
   SF_PROJECT_USER_CONFIGS_COLLECTION,
   SFProjectUserConfig
 } from '../models/sf-project-user-config';
-import {
-  getNoteThreadDocId,
-  NOTE_THREAD_COLLECTION,
-  NoteStatus,
-  NoteThread,
-  NoteType,
-  NoteConflictType
-} from '../models/note-thread';
-import { Note } from '../models/note';
-import { VerseRefData } from '../models/verse-ref-data';
+import { createTestProjectUserConfig } from '../models/sf-project-user-config-test-data';
 import { TextAnchor } from '../models/text-anchor';
-import { createTestProject } from '../models/sf-project-test-data';
-import { createTestUser } from '../../common/models/user-test-data';
+import { VerseRefData } from '../models/verse-ref-data';
 import { NoteThreadService } from './note-thread-service';
 
 describe('NoteThreadService', () => {
@@ -333,22 +334,13 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', this.projectAdminId),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: this.projectAdminId,
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: true,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     );
 
     await createDoc<User>(conn, USERS_COLLECTION, this.checkerId, createTestUser({}, 2));
@@ -357,22 +349,13 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', this.checkerId),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: this.checkerId,
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: true,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     );
 
     await createDoc<User>(conn, USERS_COLLECTION, this.commenterId, createTestUser({}, 3));
@@ -381,22 +364,11 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', this.commenterId),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: this.commenterId,
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: false,
-        numSuggestions: 1,
-        selectedSegment: '',
-        questionRefsRead: [],
-        answerRefsRead: [],
-        commentRefsRead: [],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        translationSuggestionsEnabled: false
+      })
     );
 
     await createDoc<SFProject>(

--- a/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.spec.ts
@@ -1,20 +1,21 @@
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
 import { instance, mock } from 'ts-mockito';
-import { createTestUser } from '../../common/models/user-test-data';
 import { User, USERS_COLLECTION } from '../../common/models/user';
+import { createTestUser } from '../../common/models/user-test-data';
 import { RealtimeServer } from '../../common/realtime-server';
 import { SchemaVersionRepository } from '../../common/schema-version-repository';
 import { allowAll, clientConnect, createDoc, flushPromises, submitJson0Op } from '../../common/utils/test-utils';
 import { getQuestionDocId, Question, QUESTIONS_COLLECTION } from '../models/question';
 import { SF_PROJECTS_COLLECTION, SFProject } from '../models/sf-project';
 import { SFProjectRole } from '../models/sf-project-role';
+import { createTestProject } from '../models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
   SF_PROJECT_USER_CONFIGS_COLLECTION,
   SFProjectUserConfig
 } from '../models/sf-project-user-config';
-import { createTestProject } from '../models/sf-project-test-data';
+import { createTestProjectUserConfig } from '../models/sf-project-user-config-test-data';
 import { QuestionService } from './question-service';
 
 describe('QuestionService', () => {
@@ -95,22 +96,13 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', 'projectAdmin'),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: 'projectAdmin',
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: true,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     );
 
     await createDoc<User>(conn, USERS_COLLECTION, 'checker', createTestUser({}, 2));
@@ -119,22 +111,13 @@ class TestEnvironment {
       conn,
       SF_PROJECT_USER_CONFIGS_COLLECTION,
       getSFProjectUserConfigDocId('project01', 'checker'),
-      {
+      createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: 'checker',
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
-        biblicalTermsEnabled: false,
-        transliterateBiblicalTerms: false,
-        translationSuggestionsEnabled: true,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     );
 
     await createDoc<SFProject>(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -1,6 +1,6 @@
 import { Location } from '@angular/common';
 import { DebugElement, NgModule, NgZone } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatExpansionPanel } from '@angular/material/expansion';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { By } from '@angular/platform-browser';
@@ -13,32 +13,33 @@ import { Operation } from 'realtime-server/lib/esm/common/models/project-rights'
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import {
-  QUESTIONS_COLLECTION,
+  getQuestionDocId,
   Question,
-  getQuestionDocId
+  QUESTIONS_COLLECTION
 } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
-  SFProjectUserConfig,
-  getSFProjectUserConfigDocId
+  getSFProjectUserConfigDocId,
+  SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { TextInfo } from 'realtime-server/scriptureforge/models/text-info';
 import { of } from 'rxjs';
 import { anything, capture, instance, mock, reset, resetCalls, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService, createTestFeatureFlag } from 'xforge-common/feature-flags/feature-flag.service';
+import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../core/models/question-doc';
@@ -749,54 +750,25 @@ class TestEnvironment {
   checkerUser = this.createUser(2, SFProjectRole.CommunityChecker);
   translatorUser = this.createUser(3, SFProjectRole.ParatextTranslator);
 
-  private adminProjectUserConfig: SFProjectUserConfig = {
+  private adminProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
+    projectRef: 'project01',
     ownerRef: this.adminUser.id,
+    isTargetTextRight: true
+  });
+
+  private reviewerProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
     projectRef: 'project01',
-    isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
-  private reviewerProjectUserConfig: SFProjectUserConfig = {
     ownerRef: this.checkerUser.id,
-    projectRef: 'project01',
     isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
-    questionRefsRead: ['q1Id', 'q2Id', 'q3Id'],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
-  private translatorProjectUserConfig: SFProjectUserConfig = {
+    questionRefsRead: ['q1Id', 'q2Id', 'q3Id']
+  });
+
+  private translatorProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
+    projectRef: 'project01',
     ownerRef: this.translatorUser.id,
-    projectRef: 'project01',
-    isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
+    isTargetTextRight: true
+  });
+
   private testProject: SFProjectProfile = createTestProjectProfile({
     texts: [
       {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.stories.ts
@@ -3,41 +3,33 @@ import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { expect } from '@storybook/jest';
 import { cloneDeep } from 'mingo/util';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
+import {
+  getSFProjectUserConfigDocId,
+  SFProjectUserConfig
+} from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { getTextAudioId, TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { I18nStoryModule } from 'xforge-common/i18n-story.module';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
-import { getSFProjectUserConfigDocId } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { QuestionDoc } from '../../../../core/models/question-doc';
-import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
+import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../../../../core/models/sf-type-registry';
+import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { SingleButtonAudioPlayerComponent } from '../../single-button-audio-player/single-button-audio-player.component';
-import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
 import { CheckingQuestionComponent } from './checking-question.component';
 
 const mockedProjectService = mock(SFProjectService);
 const query: RealtimeQuery<TextAudioDoc> = mock(RealtimeQuery<TextAudioDoc>);
 const projectUserConfigDoc: SFProjectUserConfigDoc = mock(SFProjectUserConfigDoc);
-const projectUserConfig: SFProjectUserConfig = {
-  biblicalTermsEnabled: false,
-  confidenceThreshold: 0,
-  isTargetTextRight: false,
-  numSuggestions: 0,
-  ownerRef: 'user01',
+const projectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
   projectRef: 'project01',
-  selectedSegment: '',
-  translationSuggestionsEnabled: false,
-  transliterateBiblicalTerms: false,
-  commentRefsRead: [],
-  noteRefsRead: [],
-  questionRefsRead: [],
-  answerRefsRead: [],
-  audioRefsPlayed: []
-};
+  ownerRef: 'user01',
+  translationSuggestionsEnabled: false
+});
 const textAudioDoc: TextAudioDoc = mock(TextAudioDoc);
 const textAudio: TextAudio = {
   dataId: 'id123',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2,7 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Location } from '@angular/common';
 import { DebugElement, NgZone } from '@angular/core';
-import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
 import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
 import { MatLegacyMenuHarness as MatMenuHarness } from '@angular/material/legacy-menu/testing';
@@ -21,19 +21,20 @@ import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { AnswerStatus } from 'realtime-server/lib/esm/scriptureforge/models/answer';
 import { Comment } from 'realtime-server/lib/esm/scriptureforge/models/comment';
-import { Question, getQuestionDocId } from 'realtime-server/lib/esm/scriptureforge/models/question';
+import { getQuestionDocId, Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
-  SFProjectUserConfig,
-  getSFProjectUserConfigDocId
+  getSFProjectUserConfigDocId,
+  SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
-import { TextData, getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
+import { getTextDocId, TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { fromVerseRef, toVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
-import { BehaviorSubject, Subject, of } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
 import { anyString, anything, instance, mock, reset, resetCalls, spy, verify, when } from 'ts-mockito';
@@ -41,9 +42,9 @@ import { AuthService } from 'xforge-common/auth.service';
 import { AvatarComponent } from 'xforge-common/avatar/avatar.component';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService, createTestFeatureFlag } from 'xforge-common/feature-flags/feature-flag.service';
+import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FileService } from 'xforge-common/file.service';
-import { FileOfflineData, FileType, createStorageFileData } from 'xforge-common/models/file-offline-data';
+import { createStorageFileData, FileOfflineData, FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -55,7 +56,7 @@ import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module'
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { TestTranslocoModule, configureTestingModule, getAudioBlob } from 'xforge-common/test-utils';
+import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { objectId } from 'xforge-common/utils';
@@ -2341,75 +2342,32 @@ class TestEnvironment {
 
   private readonly params$: BehaviorSubject<Params>;
   private readonly queryParams$: BehaviorSubject<Params>;
-  private readonly adminProjectUserConfig: SFProjectUserConfig = {
+  private readonly adminProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
+    projectRef: 'project01',
     ownerRef: ADMIN_USER.id,
-    projectRef: 'project01',
-    isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
+    isTargetTextRight: true
+  });
 
-  private readonly checkerProjectUserConfig: SFProjectUserConfig = {
+  private readonly checkerProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
+    projectRef: 'project01',
     ownerRef: CHECKER_USER.id,
-    projectRef: 'project01',
     isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
     selectedQuestionRef: 'project01:q5Id',
-    questionRefsRead: [],
-    answerRefsRead: ['a0Id', 'a1Id'],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
+    answerRefsRead: ['a0Id', 'a1Id']
+  });
 
-  private readonly cleanCheckerProjectUserConfig: SFProjectUserConfig = {
+  private readonly cleanCheckerProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
+    projectRef: 'project01',
     ownerRef: CLEAN_CHECKER_USER.id,
-    projectRef: 'project01',
-    isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedSegment: '',
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
+    isTargetTextRight: true
+  });
 
-  private readonly observerProjectUserConfig: SFProjectUserConfig = {
-    ownerRef: OBSERVER_USER.id,
+  private readonly observerProjectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
     projectRef: 'project01',
+    ownerRef: OBSERVER_USER.id,
     isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: true,
-    numSuggestions: 1,
-    selectedQuestionRef: 'project01:q5Id',
-    selectedSegment: '',
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: []
-  };
+    selectedQuestionRef: 'project01:q5Id'
+  });
 
   private readonly testProject: SFProject = TestEnvironment.generateTestProject();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -11,6 +11,7 @@ import {
   getSFProjectUserConfigDocId,
   SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { of } from 'rxjs';
 import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -230,24 +231,13 @@ class TestEnvironment {
       const projectId = `project${projectIdSuffix}`;
       this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
         id: getSFProjectUserConfigDocId(projectId, 'user01'),
-        data: {
-          ownerRef: 'user01',
+        data: createTestProjectUserConfig({
           projectRef: projectId,
+          ownerRef: 'user01',
           selectedTask: args.selectedTask,
           selectedBookNum: args.selectedTask == null ? undefined : args.selectedBooknum,
-          isTargetTextRight: true,
-          confidenceThreshold: 0.2,
-          biblicalTermsEnabled: false,
-          transliterateBiblicalTerms: false,
-          translationSuggestionsEnabled: true,
-          numSuggestions: 1,
-          selectedSegment: '',
-          questionRefsRead: [],
-          answerRefsRead: [],
-          commentRefsRead: [],
-          noteRefsRead: [],
-          audioRefsPlayed: []
-        }
+          isTargetTextRight: true
+        })
       });
 
       this.realtimeService.addSnapshot<SFProjectProfile>(SFProjectProfileDoc.COLLECTION, {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
@@ -6,8 +6,6 @@ import {
 } from '@angular/material/legacy-dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';
-import { of } from 'rxjs';
-import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { BiblicalTerm, getBiblicalTermDocId } from 'realtime-server/lib/esm/scriptureforge/models/biblical-term';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
@@ -26,7 +24,10 @@ import {
   getSFProjectUserConfigDocId,
   SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { fromVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
+import { of } from 'rxjs';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { GenericDialogComponent, GenericDialogOptions } from 'xforge-common/generic-dialog/generic-dialog.component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
@@ -41,9 +42,9 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { SFProjectService } from '../../core/sf-project.service';
-import { NoteDialogComponent } from '../editor/note-dialog/note-dialog.component';
 import { MockNoteDialogRef } from '../editor/editor.component.spec';
-import { BiblicalTermsComponent, BiblicalTermNoteIcon, BiblicalTermDialogIcon } from './biblical-terms.component';
+import { NoteDialogComponent } from '../editor/note-dialog/note-dialog.component';
+import { BiblicalTermDialogIcon, BiblicalTermNoteIcon, BiblicalTermsComponent } from './biblical-terms.component';
 
 const mockedI18nService = mock(I18nService);
 const mockedMatDialog = mock(MatDialog);
@@ -463,41 +464,28 @@ class TestEnvironment {
     });
     this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
       id: 'project01:user01',
-      data: {
+      data: createTestProjectUserConfig({
         projectRef: 'project01',
         ownerRef: 'user01',
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
         biblicalTermsEnabled: true,
-        transliterateBiblicalTerms: false,
         translationSuggestionsEnabled: false,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     });
     this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
       id: 'project02:user01',
-      data: {
+      data: createTestProjectUserConfig({
         projectRef: 'project02',
         ownerRef: 'user01',
-        isTargetTextRight: false,
-        confidenceThreshold: 0.2,
         biblicalTermsEnabled: true,
         transliterateBiblicalTerms: true,
         translationSuggestionsEnabled: false,
-        numSuggestions: 1,
-        selectedSegment: '',
         questionRefsRead: ['question01'],
         answerRefsRead: ['answer01'],
-        commentRefsRead: ['comment01'],
-        noteRefsRead: [],
-        audioRefsPlayed: []
-      }
+        commentRefsRead: ['comment01']
+      })
     });
     if (noteThreads) {
       this.realtimeService.addSnapshot<NoteThread>(NoteThreadDoc.COLLECTION, {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -33,9 +33,9 @@ import {
   getSFProjectUserConfigDocId,
   SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-
 import * as RichText from 'rich-text';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
@@ -767,22 +767,14 @@ class TestEnvironment {
     ...TestEnvironment.testProjectProfile,
     paratextUsers: TestEnvironment.paratextUsers
   });
-  static projectUserConfig: SFProjectUserConfig = {
-    questionRefsRead: [],
-    answerRefsRead: [],
-    commentRefsRead: [],
-    noteRefsRead: [],
-    audioRefsPlayed: [],
-    biblicalTermsEnabled: false,
-    transliterateBiblicalTerms: false,
-    translationSuggestionsEnabled: false,
-    isTargetTextRight: true,
-    confidenceThreshold: 0.2,
-    numSuggestions: 1,
-    selectedSegment: 'verse_1_1',
+  static projectUserConfig: SFProjectUserConfig = createTestProjectUserConfig({
     projectRef: TestEnvironment.PROJECT01,
-    ownerRef: 'user01'
-  };
+    ownerRef: 'user01',
+    isTargetTextRight: true,
+    translationSuggestionsEnabled: false,
+    selectedSegment: 'verse_1_1'
+  });
+
   static reattached: string = ['MAT 1:4', 'reattached text', '17', 'before selection ', ' after selection'].join(
     REATTACH_SEPARATOR
   );


### PR DESCRIPTION
Currently, adding new properties to the `SFProjectUserConfig` interface causes existing tests to need to be updated in order to add the property to their object initializations.

This PR creates a function that tests can call to retrieve an `SFProjectUserConfig` object with optional overrides.  Tests that use this function will not need to be updated when new, unrelated, properties are added to the the `SFProjectUserConfig` interface.

Also, this PR updates existing tests to use this function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2379)
<!-- Reviewable:end -->
