### PR TITLE
SF-2635 Fix editor and biblical terms container height UI glitches

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab-body/tab-body.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab-body/tab-body.component.scss
@@ -1,6 +1,7 @@
 :host {
   border: var(--sf-tab-group-border-width) solid var(--sf-tab-group-border-color);
   overflow-y: auto;
+  height: 100%;
 
   &:not(.active) {
     display: none;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -74,7 +74,7 @@
           {{ tab.headerText }}
         </ng-template>
 
-        <ng-container *ngIf="tab.type === 'project-source'">
+        <div *ngIf="tab.type === 'project-source'" class="project-tab-container">
           <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
             <div>
               {{ sourceCopyrightBanner }}
@@ -109,9 +109,9 @@
               </as-split-area>
             </as-split>
           </div>
-        </ng-container>
+        </div>
 
-        <ng-container *ngIf="tab.type === 'project'">
+        <div *ngIf="tab.type === 'project'" class="project-tab-container">
           <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
             <div>
               {{ targetCopyrightBanner }}
@@ -152,12 +152,14 @@
           <div #targetSplitContainer class="container-for-split">
             <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
             <as-split direction="vertical" [style.height]="targetSplitHeight">
-              <as-split-area #targetScrollContainer [size]="75" [minSize]="20" [dir]="i18n.direction">
-                <div
-                  class="text-container"
-                  [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'"
-                  [ngClass]="{ 'has-draft': showPreviewDraft }"
-                >
+              <as-split-area
+                #targetScrollContainer
+                [size]="75"
+                [minSize]="20"
+                [dir]="i18n.direction"
+                [class.has-draft]="showPreviewDraft"
+              >
+                <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
                   <app-text
                     #target
                     [isReadOnly]="!canEdit"
@@ -242,7 +244,7 @@
               </as-split-area>
             </as-split>
           </div>
-        </ng-container>
+        </div>
 
         <app-editor-history
           *ngIf="tab.type === 'history'"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -84,7 +84,7 @@
 }
 
 app-text {
-  height: 100%;
+  min-height: 100%;
   width: 100%;
 }
 
@@ -154,21 +154,33 @@ app-text {
   }
 }
 
-.text-container {
+.project-tab-container {
   display: flex;
-  position: relative;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
 
-  &.has-draft {
-    border: 4px dashed vars.$draft-color;
+  app-notice {
+    margin: 1em;
   }
-}
-
-.text-area {
-  grid-row-start: 2;
 }
 
 .container-for-split {
   flex-grow: 1;
   height: 100%;
   overflow: hidden;
+}
+
+as-split-area.has-draft {
+  border: 4px dashed vars.$draft-color;
+}
+
+.text-container {
+  display: flex;
+  position: relative;
+  min-height: 100%;
+}
+
+.text-area {
+  grid-row-start: 2;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -2219,7 +2219,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const bounds: DOMRect = scrollContainer.getBoundingClientRect();
-    const fabCushion = 5;
+    const fabCushion = 10;
     const fabTop = this.target.selectionBoundsTop - fabCushion;
     const fabBottom = this.target.selectionBoundsTop + this.fabDiameter + fabCushion;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1708,20 +1708,29 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     dialogConfig: MatDialogConfig<D>
   ): MatDialogRef<T, R> {
     const selection: RangeStatic | null | undefined = this.target?.editor?.getSelection();
-    const scrollTop: number | undefined = this.target?.editor?.root.scrollTop;
+    const targetScrollContainer: HTMLElement | undefined = this.targetScrollContainer?.nativeElement;
+    const targetScrollTop: number | undefined = targetScrollContainer?.scrollTop;
     const dialogRef: MatDialogRef<T, R> = this.dialogService.openMatDialog(component, dialogConfig);
-    if (selection == null || !this.canEdit) return dialogRef;
+
+    if (selection == null || !this.canEdit) {
+      return dialogRef;
+    }
 
     const subscription: Subscription = dialogRef.afterClosed().subscribe(() => {
       if (this.target?.editor != null && this.dialogService.openDialogCount === 0) {
         const currentSelection: RangeStatic | null | undefined = this.target.editor.getSelection();
+
         if (currentSelection?.index !== selection.index) {
           this.target.editor.setSelection(selection.index, 0, 'user');
-          if (scrollTop != null) this.target.editor.root.scrollTop = scrollTop;
+
+          if (targetScrollContainer != null && targetScrollTop != null) {
+            targetScrollContainer.scrollTop = targetScrollTop;
+          }
         }
       }
       subscription.unsubscribe();
     });
+
     return dialogRef;
   }
 


### PR DESCRIPTION
Fixed issues:
- Tab body was not always full screen height.
- For short chapters, the editor did not extend all the way down to the biblical terms splitter.
- Editor was scrolling to top after saving a note.
- Fixed editor notices to remain visible at top of tab.


Source editor should scroll sync to target verse containing the cursor, and note fab button should still track and stay within editor bounds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2380)
<!-- Reviewable:end -->
