### PR TITLE
Fix density styles warnings when running the front end

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -115,6 +115,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.autocomplete-theme($material-app-theme);
 @include mat.badge-theme($material-app-theme);
 @include mat.bottom-sheet-theme($material-app-theme);
+@include mat.button-theme($material-app-theme);
 @include mat.legacy-button-theme($material-app-theme);
 @include mat.button-toggle-theme($material-app-theme);
 @include mat.legacy-card-theme($material-app-theme);
@@ -137,7 +138,6 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.slide-toggle-theme($material-app-theme);
 @include mat.slider-theme($material-app-theme);
 @include mat.snack-bar-theme($material-app-theme);
-@include mat.button-theme($material-app-theme);
 @include mat.stepper-theme($material-app-theme);
 @include mat.table-theme($material-app-theme);
 @include mat.tabs-theme($material-app-theme);


### PR DESCRIPTION
This PR fixes a warning that appears whenever the frontend is run (i.e. via `ng serve`) warning that the "The same color styles are generated multiple times."

This warning appears to be due to the order we are including the material styles. Although these are not supposed to overlap, the button and legacy-button themes appear to conflict over the density (which is not defined for the legacy button, but is defined for the button (see the description of this change in https://material.angular.io/guide/mdc-migration#theming)

Change the order of loading appears to fix this, but I am not entirely sure why (it appears to be a bug with the angular/material library rather than our code). No difference of display was noticed for buttons or legacy buttons after this change was made.

**Warning Message Details**
```
./src/material-styles.scss - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same color styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 352:7  private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3   theme()
src\material-styles.scss 119:1                                   root stylesheet


./src/material-styles.scss - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same density styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 376:9  private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3   theme()
src\material-styles.scss 119:1                                   root stylesheet


./src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss?ngResource - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same color styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 352:7              private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3               theme()
src\material-styles.scss 119:1                                               @use
src\app\shared\book-chapter-chooser\book-chapter-chooser.component.scss 1:1  root stylesheet


./src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss?ngResource - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same density styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 376:9              private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3               theme()
src\material-styles.scss 119:1                                               @use
src\app\shared\book-chapter-chooser\book-chapter-chooser.component.scss 1:1  root stylesheet


./src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss?ngResource - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same color styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 352:7                             private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3                              theme()
src\material-styles.scss 119:1                                                              @use
src\app\translate\editor\editor-history\history-chooser\history-chooser.component.scss 1:1  root stylesheet


./src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss?ngResource - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
The same density styles are generated multiple times. Read more about how style duplication can be avoided in a dedicated guide. https://github.com/angular/components/blob/main/guides/duplicate-theming-styles.md

node_modules\@angular\material\core\theming\_theming.scss 376:9                             private-check-duplicate-theme-styles()
node_modules\@angular\material\button\_button-theme.scss 210:3                              theme()
src\material-styles.scss 119:1                                                              @use
src\app\translate\editor\editor-history\history-chooser\history-chooser.component.scss 1:1  root stylesheet
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2381)
<!-- Reviewable:end -->
