### PR TITLE
ci: release-to-qa: run every day except Tuesday

### DIFF
--- a/.github/workflows/release-to-qa.yml
+++ b/.github/workflows/release-to-qa.yml
@@ -2,10 +2,10 @@ name: Release to QA
 
 on:
   schedule:
-    # Run on Tuesday-Sunday at 01:30 UTC, shortly before beginning of tester workday.
+    # Run every day except Tuesday, at 01:30 UTC, shortly before beginning of tester workday.
     # Note that this workflow can be disabled from the GitHub UI by going to
     # Actions > Workflows > Release to QA > "..." > Disable workflow
-    - cron: "30 1 * * 0,2-6"
+    - cron: "30 1 * * 0-1,3-6"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I want this to run every day, before the testers start working, except for Tuesday _in UTC_.

@Nateowami I think this will correct the schedule.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2382)
<!-- Reviewable:end -->
