### PR TITLE
Fix warnings thrown when running unit tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -672,6 +672,7 @@ describe('CheckingOverviewComponent', () => {
       verify(mockedProjectService.onlineDeleteAudioTimingData(anything(), anything(), anything())).never();
       verify(mockedNoticeService.showError(anything())).once();
       env.waitForProjectDocChanges();
+      expect().nothing();
     }));
 
     it('can open chapter audio to edit ', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.spec.ts
@@ -5,6 +5,7 @@ import { anything, mock, verify, when } from 'ts-mockito';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { MockConsole } from 'xforge-common/mock-console';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -26,6 +27,7 @@ const mockedNoticeService = mock(NoticeService);
 const mockedNavigator = mock(Navigator);
 const mockedDialog = mock(DialogService);
 const mockedI18nService = mock(I18nService);
+const mockedConsole: MockConsole = MockConsole.install();
 
 describe('CheckingAudioRecorderComponent', () => {
   configureTestingModule(() => ({
@@ -78,10 +80,13 @@ describe('CheckingAudioRecorderComponent', () => {
   });
 
   it('should display message if microphone not accessible', async () => {
+    mockedConsole.expectAndHide(/No microphone/);
     env.rejectUserMedia = true;
     env.clickButton(env.recordButton);
     await env.waitForRecorder(100);
     verify(mockedNoticeService.show(anything())).once();
+    mockedConsole.verify();
+    mockedConsole.reset();
     env.rejectUserMedia = false;
     env.clickButton(env.recordButton);
     await env.waitForRecorder(1000);
@@ -126,7 +131,7 @@ class TestEnvironment {
     });
     when(mockedNavigator.mediaDevices).thenReturn({
       getUserMedia: (mediaConstraints: MediaStreamConstraints) =>
-        this.rejectUserMedia ? Promise.reject({}) : navigator.mediaDevices.getUserMedia(mediaConstraints)
+        this.rejectUserMedia ? Promise.reject('No microphone') : navigator.mediaDevices.getUserMedia(mediaConstraints)
     } as MediaDevices);
     this.fixture.detectChanges();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -17,6 +17,7 @@
           <span class="question-verse">{{ questionVerseRef(questionDoc) }}</span>
           <a *ngIf="getUnreadAnswers(questionDoc) > 0" class="view-answers" title="{{ t('view_answers') }}">
             <mat-icon
+              aria-hidden="false"
               class="mirror-rtl"
               [matBadge]="getUnreadAnswers(questionDoc)"
               matBadgePosition="before"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -44,6 +44,7 @@
     <mat-divider></mat-divider>
     <a *ngIf="canSync$ | async" mat-list-item [appRouterLink]="getProjectLink('sync')">
       <mat-icon
+        aria-hidden="false"
         mat-list-icon
         matBadge="error"
         [matBadgeHidden]="!lastSyncFailed || syncInProgress"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { TabMenuService } from '../base-services/tab-menu.service';
 import { SFTabsModule } from '../sf-tabs.module';
 import { TabGroupHeaderComponent } from './tab-group-header.component';
@@ -12,7 +13,7 @@ describe('TabGroupHeaderComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TabGroupHeaderComponent],
-      imports: [SFTabsModule],
+      imports: [SFTabsModule, TestTranslocoModule],
       providers: [{ provide: TabMenuService, useValue: { getMenuItems: () => of([]) } }]
     });
     fixture = TestBed.createComponent(TabGroupHeaderComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -1,11 +1,12 @@
 import { QueryList } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { TabMenuService } from 'src/app/shared/sf-tab-group';
-import { TabStateService } from './tab-state/tab-state.service';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
+import { TabMenuService } from '../../shared/sf-tab-group';
 import { TabFactoryService } from './base-services/tab-factory.service';
 import { SFTabsModule } from './sf-tabs.module';
 import { TabGroupComponent } from './tab-group.component';
+import { TabStateService } from './tab-state/tab-state.service';
 import { TabComponent } from './tab/tab.component';
 
 describe('TabGroupComponent', () => {
@@ -14,7 +15,7 @@ describe('TabGroupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SFTabsModule],
+      imports: [SFTabsModule, TestTranslocoModule],
       declarations: [TabGroupComponent, TabComponent],
       providers: [
         { provide: TabFactoryService, useValue: { createTab: () => {} } },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1463,7 +1463,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
 
-    const start: number = performance.now();
     const translator: InteractiveTranslator | undefined = await this.interactiveTranslatorFactory?.create(
       sourceSegment
     );
@@ -1479,8 +1478,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
     if (sourceSegment === this.source.segmentText) {
       this.translator = translator;
-      const finish = performance.now();
-      this.console.log(`Translated segment, length: ${translator.segmentWordRanges.length}, time: ${finish - start}ms`);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
@@ -190,6 +190,7 @@ describe('RolesAndPermissionsComponent', () => {
     verify(
       mockedProjectService.onlineSetUserProjectPermissions('project01', 'ptTranslator', deepEqual(permissions))
     ).once();
+    expect().nothing();
   }));
 });
 


### PR DESCRIPTION
This PR cleans up the warnings that flood the console when running unit tests via `npm test`. Removing these warnings makes it easier to find faulty code when running unit tests.

The changes in this PR include:

* Resolved warning: 'Detected a matBadge on an "aria-hidden" "mat-icon". Consider setting aria-hidden="false" in order to surface the information assistive technology.'
* Resolved warning: '%c Missing translation for 'en.tab_group_header.no_tabs_available''
* Removed the no longer needed diagnostic message 'Translated segment, length: 8, time: 0ms'
* Fixed warning 'Spec 'CheckingOverviewComponent Chapter Audio does not try to delete chapter audio if offline' has no expectations.'
* Fixed warning 'Spec 'RolesAndPermissionsComponent saves correct permissions without changing unrelated ones' has no expectations.'
* Fixed console error: 'ERROR: Object{}, [[]]'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2385)
<!-- Reviewable:end -->
