### PR TITLE
SF-2647 Run SMT engine builds in a separate job to the project sync

### DIFF
--- a/src/SIL.XForge.Scripture/Models/SyncConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncConfig.cs
@@ -3,9 +3,6 @@ namespace SIL.XForge.Scripture.Models;
 /// <summary>
 /// The configuration of the sync to schedule.
 /// </summary>
-/// <remarks>
-/// TODO: Make CurUserId and ProjectId required in .NET 8.0.
-/// </remarks>
 public class SyncConfig
 {
     /// <summary>
@@ -22,10 +19,10 @@ public class SyncConfig
     /// <value>
     /// Required. The project id.
     /// </value>
-    public string ProjectId { get; init; } = string.Empty;
+    public required string ProjectId { get; init; }
 
     /// <summary>
-    /// A value indicating whether or not we are to sync the target only.
+    /// A value indicating whether we are to sync the target only.
     /// </summary>
     /// <value>
     /// Required. <c>true</c> if we are to sync the target only; otherwise <c>false</c>.
@@ -33,11 +30,12 @@ public class SyncConfig
     public bool TargetOnly { get; init; }
 
     /// <summary>
-    /// A value indicating whether or not we are to train the SMT engine.
+    /// A value indicating whether we are to train the SMT engine.
     /// </summary>
     /// <value>
     /// Required. <c>true</c> if we are to train the SMT engine; otherwise <c>false</c>.
     /// </value>
+    /// <remarks>This value is not used if <see cref="TargetOnly"/> is <c>true</c>.</remarks>
     public bool TrainEngine { get; init; }
 
     /// <summary>
@@ -46,5 +44,5 @@ public class SyncConfig
     /// <value>
     /// Required. The user id.
     /// </value>
-    public string UserId { get; init; } = string.Empty;
+    public required string UserId { get; init; }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -684,16 +684,38 @@ public class MachineProjectService(
             // If there is an existing alternate training source
 
             // Remove the corpus from Serval
-            await translationEnginesClient.DeleteCorpusAsync(
-                translationEngineId,
-                alternateTrainingSourceCorpusId,
-                cancellationToken
-            );
+            try
+            {
+                await translationEnginesClient.DeleteCorpusAsync(
+                    translationEngineId,
+                    alternateTrainingSourceCorpusId,
+                    cancellationToken
+                );
+            }
+            catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+            {
+                // If the file was already deleted, just log a message
+                string message =
+                    $"Corpus {alternateTrainingSourceCorpusId} in project {buildConfig.ProjectId}"
+                    + " was missing or already deleted.";
+                logger.LogInformation(e, message);
+            }
 
             // Remove the files from Serval
-            foreach (ServalCorpusFile file in oldAlternateTrainingSourceCorpusFiles)
+            foreach (ServalCorpusFile corpusFile in oldAlternateTrainingSourceCorpusFiles)
             {
-                await dataFilesClient.DeleteAsync(file.FileId, cancellationToken);
+                try
+                {
+                    await dataFilesClient.DeleteAsync(corpusFile.FileId, cancellationToken);
+                }
+                catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+                {
+                    // If the file was already deleted, just log a message
+                    string message =
+                        $"Corpora file {corpusFile.FileId} for text {corpusFile.TextId} in project {buildConfig.ProjectId}"
+                        + " was missing or already deleted.";
+                    logger.LogInformation(e, message);
+                }
             }
 
             // Remove the reference to the corpus from the project secret

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -679,7 +679,7 @@ public class MachineProjectService(
                 cancellationToken
             );
         }
-        else if (!string.IsNullOrWhiteSpace(alternateTrainingSourceCorpusId))
+        else if (preTranslate && !string.IsNullOrWhiteSpace(alternateTrainingSourceCorpusId))
         {
             // If there is an existing alternate training source
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -111,6 +111,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             throw new ForbiddenException();
 
         string projectId = ObjectId.GenerateNewId().ToString();
+        bool trainEngine = false;
         await using (IConnection conn = await RealtimeService.ConnectAsync(curUserId))
         {
             if (
@@ -145,6 +146,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             {
                 await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
                 await _machineProjectService.AddProjectAsync(curUserId, projectDoc.Id, false, CancellationToken.None);
+                trainEngine = true;
             }
         }
 
@@ -152,7 +154,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             new SyncConfig
             {
                 ProjectId = projectId,
-                TrainEngine = true,
+                TrainEngine = trainEngine,
                 UserId = curUserId,
             }
         );

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -183,7 +183,7 @@ public class SyncService(
                 // If we are not training SMT suggestions
                 if (!syncConfig.TrainEngine)
                 {
-                    // Exit so we don't queue the target again, in the following block
+                    // Exit so we don't queue the target again, later in this method
                     return targetJobId;
                 }
 

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -18,32 +18,15 @@ namespace SIL.XForge.Scripture.Services;
 /// <summary>
 /// This class manages syncing SF with the Paratext web service APIs.
 /// </summary>
-public class SyncService : ISyncService
+public class SyncService(
+    IBackgroundJobClient backgroundJobClient,
+    IHubContext<NotificationHub, INotifier> hubContext,
+    IRepository<SFProjectSecret> projectSecrets,
+    IRepository<SyncMetrics> metrics,
+    IRealtimeService realtimeService,
+    ILogger<SyncService> logger
+) : ISyncService
 {
-    private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly IHubContext<NotificationHub, INotifier> _hubContext;
-    private readonly IRepository<SFProjectSecret> _projectSecrets;
-    private readonly IRepository<SyncMetrics> _syncMetrics;
-    private readonly IRealtimeService _realtimeService;
-    private readonly ILogger<SyncService> _logger;
-
-    public SyncService(
-        IBackgroundJobClient backgroundJobClient,
-        IHubContext<NotificationHub, INotifier> hubContext,
-        IRepository<SFProjectSecret> projectSecrets,
-        IRepository<SyncMetrics> syncMetrics,
-        IRealtimeService realtimeService,
-        ILogger<SyncService> logger
-    )
-    {
-        _backgroundJobClient = backgroundJobClient;
-        _hubContext = hubContext;
-        _projectSecrets = projectSecrets;
-        _syncMetrics = syncMetrics;
-        _realtimeService = realtimeService;
-        _logger = logger;
-    }
-
     /// <summary>
     /// Syncs a project and its source project (if applicable).
     /// </summary>
@@ -53,7 +36,7 @@ public class SyncService : ISyncService
     /// <exception cref="ArgumentException">The source or target project cannot be found.</exception>
     public async Task<string> SyncAsync(SyncConfig syncConfig)
     {
-        await using IConnection conn = await _realtimeService.ConnectAsync(syncConfig.UserId);
+        await using IConnection conn = await realtimeService.ConnectAsync(syncConfig.UserId);
         // Load the project document
         IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(syncConfig.ProjectId);
         if (projectDoc.Data.SyncDisabled)
@@ -62,7 +45,7 @@ public class SyncService : ISyncService
         }
 
         // Load the target project secrets, so we can store the job id
-        if (!(await _projectSecrets.TryGetAsync(syncConfig.ProjectId)).TryResult(out SFProjectSecret projectSecret))
+        if (!(await projectSecrets.TryGetAsync(syncConfig.ProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
             throw new ArgumentException("The target project secret cannot be found.");
         }
@@ -76,7 +59,7 @@ public class SyncService : ISyncService
             {
                 // Load the source project secrets, so we can store the job id
                 if (
-                    !(await _projectSecrets.TryGetAsync(sourceProjectId)).TryResult(
+                    !(await projectSecrets.TryGetAsync(sourceProjectId)).TryResult(
                         out SFProjectSecret sourceProjectSecret
                     )
                 )
@@ -93,7 +76,7 @@ public class SyncService : ISyncService
                     Status = SyncStatus.Queued,
                     UserRef = syncConfig.UserId,
                 };
-                await _syncMetrics.InsertAsync(sourceSyncMetrics);
+                await metrics.InsertAsync(sourceSyncMetrics);
                 var targetSyncMetrics = new SyncMetrics
                 {
                     DateQueued = DateTime.UtcNow,
@@ -103,7 +86,7 @@ public class SyncService : ISyncService
                     Status = SyncStatus.Queued,
                     UserRef = syncConfig.UserId,
                 };
-                await _syncMetrics.InsertAsync(targetSyncMetrics);
+                await metrics.InsertAsync(targetSyncMetrics);
 
                 // Schedule the sync for 5 minutes to give us enough time to update the project's sync object
                 // We do this because there is no "draft" status in hangfire - this is close enough
@@ -111,7 +94,7 @@ public class SyncService : ISyncService
                 // the job unless the queued count and job ids have been incremented appropriately.
                 // We need to sync the source first so that we can link the source texts and train the engine.
                 string sourceJobId = !string.IsNullOrWhiteSpace(syncConfig.ParentJobId)
-                    ? _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+                    ? backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
                         syncConfig.ParentJobId,
                         r =>
                             r.RunAsync(
@@ -124,7 +107,7 @@ public class SyncService : ISyncService
                         null,
                         JobContinuationOptions.OnAnyFinishedState
                     )
-                    : _backgroundJobClient.Schedule<ParatextSyncRunner>(
+                    : backgroundJobClient.Schedule<ParatextSyncRunner>(
                         r =>
                             r.RunAsync(
                                 sourceProjectId,
@@ -135,7 +118,7 @@ public class SyncService : ISyncService
                             ),
                         TimeSpan.FromMinutes(5)
                     );
-                string targetJobId = _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+                string targetJobId = backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
                     sourceJobId,
                     r =>
                         r.RunAsync(
@@ -148,10 +131,10 @@ public class SyncService : ISyncService
                     null,
                     JobContinuationOptions.OnAnyFinishedState
                 );
-                _logger.LogInformation(
+                logger.LogInformation(
                     $"Queueing sync for source project {sourceProjectId} with sync metrics id {sourceSyncMetrics.Id}"
                 );
-                _logger.LogInformation(
+                logger.LogInformation(
                     $"Queueing sync for target project {syncConfig.ProjectId} with sync metrics id {targetSyncMetrics.Id}"
                 );
                 try
@@ -167,8 +150,8 @@ public class SyncService : ISyncService
                         $"For daughter SF project id {projectDoc.Id} after inc."
                     );
 
-                    // Store the source job id so we can cancel the job later if needed
-                    await _projectSecrets.UpdateAsync(
+                    // Store the source job id, so we can cancel the job later if needed
+                    await projectSecrets.UpdateAsync(
                         sourceProjectSecret.Id,
                         u =>
                         {
@@ -177,8 +160,8 @@ public class SyncService : ISyncService
                         }
                     );
 
-                    // Store the target job id so we can cancel the job later if needed
-                    await _projectSecrets.UpdateAsync(
+                    // Store the target job id, so we can cancel the job later if needed
+                    await projectSecrets.UpdateAsync(
                         projectSecret.Id,
                         u =>
                         {
@@ -187,13 +170,13 @@ public class SyncService : ISyncService
                         }
                     );
 
-                    _backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
+                    backgroundJobClient.ChangeState(sourceJobId, new EnqueuedState());
                 }
                 catch (Exception)
                 {
                     // Delete the jobs on error, and notify the user
-                    _backgroundJobClient.Delete(targetJobId);
-                    _backgroundJobClient.Delete(sourceJobId);
+                    backgroundJobClient.Delete(targetJobId);
+                    backgroundJobClient.Delete(sourceJobId);
                     throw;
                 }
 
@@ -209,7 +192,7 @@ public class SyncService : ISyncService
                 try
                 {
                     // Build the SMT suggestions after the target has synced successfully
-                    buildJobId = _backgroundJobClient.ContinueJobWith<MachineProjectService>(
+                    buildJobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
                         targetJobId,
                         r =>
                             r.BuildProjectForBackgroundJobAsync(
@@ -223,7 +206,7 @@ public class SyncService : ISyncService
                     );
 
                     // Store the build job id, so we can cancel the job later if needed
-                    await _projectSecrets.UpdateAsync(projectSecret.Id, u => u.Add(p => p.JobIds, buildJobId));
+                    await projectSecrets.UpdateAsync(projectSecret.Id, u => u.Add(p => p.JobIds, buildJobId));
 
                     // Return the build job id as it is the last in the chain
                     return buildJobId;
@@ -234,7 +217,7 @@ public class SyncService : ISyncService
                     if (!string.IsNullOrWhiteSpace(buildJobId))
                     {
                         // We only need to delete the build job
-                        _backgroundJobClient.Delete(buildJobId);
+                        backgroundJobClient.Delete(buildJobId);
                     }
 
                     // Return the target job id, as the build job was not created
@@ -252,12 +235,12 @@ public class SyncService : ISyncService
             Status = SyncStatus.Queued,
             UserRef = syncConfig.UserId,
         };
-        await _syncMetrics.InsertAsync(syncMetrics);
+        await metrics.InsertAsync(syncMetrics);
 
         // Sync the target project only, as it does not have a source, or the source cannot be synced
         // See the comments in the block above regarding scheduling for rationale on the process
         string jobId = !string.IsNullOrWhiteSpace(syncConfig.ParentJobId)
-            ? _backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+            ? backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
                 syncConfig.ParentJobId,
                 r =>
                     r.RunAsync(
@@ -270,7 +253,7 @@ public class SyncService : ISyncService
                 null,
                 JobContinuationOptions.OnAnyFinishedState
             )
-            : _backgroundJobClient.Schedule<ParatextSyncRunner>(
+            : backgroundJobClient.Schedule<ParatextSyncRunner>(
                 r =>
                     r.RunAsync(
                         syncConfig.ProjectId,
@@ -281,7 +264,7 @@ public class SyncService : ISyncService
                     ),
                 TimeSpan.FromMinutes(5)
             );
-        _logger.LogInformation(
+        logger.LogInformation(
             $"Queueing sync for project {syncConfig.ProjectId} with sync metrics id {syncMetrics.Id}"
         );
         try
@@ -292,8 +275,8 @@ public class SyncService : ISyncService
                 $"For SF project id {projectDoc.Id} after inc."
             );
 
-            // Store the job id so we can cancel the job later if needed
-            await _projectSecrets.UpdateAsync(
+            // Store the job id, so we can cancel the job later if needed
+            await projectSecrets.UpdateAsync(
                 projectSecret.Id,
                 u =>
                 {
@@ -302,20 +285,20 @@ public class SyncService : ISyncService
                 }
             );
 
-            _backgroundJobClient.ChangeState(jobId, new EnqueuedState());
+            backgroundJobClient.ChangeState(jobId, new EnqueuedState());
             return jobId;
         }
         catch (Exception)
         {
             // Delete the job on error, and notify the user
-            _backgroundJobClient.Delete(jobId);
+            backgroundJobClient.Delete(jobId);
             throw;
         }
     }
 
     public async Task CancelSyncAsync(string curUserId, string projectId)
     {
-        await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
+        await using IConnection conn = await realtimeService.ConnectAsync(curUserId);
         IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(projectId);
         if (projectDoc.Data.Sync.QueuedCount > 0)
         {
@@ -351,31 +334,31 @@ public class SyncService : ISyncService
         {
             message += $" {details}";
         }
-        _logger.LogWarning(message);
+        logger.LogWarning(message);
     }
 
     private async Task CancelProjectDocumentSyncAsync(IDocument<SFProject> projectDoc)
     {
         // Load the project secrets, so we can get any job ids
-        if ((await _projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
+        if ((await projectSecrets.TryGetAsync(projectDoc.Data.Id)).TryResult(out SFProjectSecret projectSecret))
         {
             // Cancel all jobs for the project
             foreach (string jobId in projectSecret.JobIds)
             {
-                _backgroundJobClient.Delete(jobId);
+                backgroundJobClient.Delete(jobId);
             }
 
             // Mark all sync metrics as cancelled
             foreach (string syncMetricsId in projectSecret.SyncMetricsIds)
             {
-                _logger.LogInformation(
+                logger.LogInformation(
                     $"Cancelling sync for project {projectSecret.Id} with sync metrics id {syncMetricsId}"
                 );
-                await _syncMetrics.UpdateAsync(syncMetricsId, u => u.Set(s => s.Status, SyncStatus.Cancelled));
+                await metrics.UpdateAsync(syncMetricsId, u => u.Set(s => s.Status, SyncStatus.Cancelled));
             }
 
             // Remove all job ids and sync metrics ids from the project secrets
-            await _projectSecrets.UpdateAsync(
+            await projectSecrets.UpdateAsync(
                 projectSecret.Id,
                 u =>
                 {
@@ -389,7 +372,7 @@ public class SyncService : ISyncService
                 $"For SF project id {projectDoc.Id} before setting QueuedCount to 0 as part of cancelling."
             );
             // Mark sync as cancelled
-            await _hubContext.NotifySyncProgress(projectDoc.Id, ProgressState.Completed);
+            await hubContext.NotifySyncProgress(projectDoc.Id, ProgressState.Completed);
             await projectDoc.SubmitJson0OpAsync(op =>
             {
                 op.Set(pd => pd.Sync.QueuedCount, 0);

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -1458,6 +1458,103 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    public async Task BuildProjectAsync_DoesNotCrashWhenDeletingMissingAlternateTrainingSourceCorpora()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions
+            {
+                LocalSourceTextHasData = true,
+                LocalTargetTextHasData = true,
+                AlternateTrainingSourceEnabled = false,
+            }
+        );
+        await env.SetDataInSync(
+            Project02,
+            preTranslate: true,
+            requiresUpdate: false,
+            uploadParatextZipFile: false,
+            alternateTrainingSource: true
+        );
+        ServalApiException ex = ServalApiExceptions.NotFound;
+        env.TranslationEnginesClient.DeleteCorpusAsync(TranslationEngine02, Corpus02, CancellationToken.None)
+            .Throws(ex);
+
+        // Check that we have more than one pre-translate corpora
+        Assert.AreEqual(2, env.ProjectSecrets.Get(Project02).ServalData!.Corpora.Count(c => c.Value.PreTranslate));
+
+        // SUT
+        bool actual = await env.Service.SyncProjectCorporaAsync(
+            User01,
+            new BuildConfig { ProjectId = Project02 },
+            preTranslate: true,
+            CancellationToken.None
+        );
+        Assert.IsFalse(actual);
+
+        // The old corpus and its files should be deleted
+        await env.TranslationEnginesClient.Received()
+            .DeleteCorpusAsync(TranslationEngine02, Corpus02, CancellationToken.None);
+        await env.DataFilesClient.Received().DeleteAsync(File01, CancellationToken.None);
+
+        // Ensure we have just one pre-translate corpora
+        Assert.AreEqual(1, env.ProjectSecrets.Get(Project02).ServalData!.Corpora.Count(c => c.Value.PreTranslate));
+
+        // The 404 exception was logged
+        env.MockLogger.AssertHasEvent(
+            logEvent => logEvent.LogLevel == LogLevel.Information && logEvent.Exception is ServalApiException
+        );
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_DoesNotCrashWhenDeletingMissingAlternateTrainingSourceFiles()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions
+            {
+                LocalSourceTextHasData = true,
+                LocalTargetTextHasData = true,
+                AlternateTrainingSourceEnabled = false,
+            }
+        );
+        await env.SetDataInSync(
+            Project02,
+            preTranslate: true,
+            requiresUpdate: false,
+            uploadParatextZipFile: false,
+            alternateTrainingSource: true
+        );
+        ServalApiException ex = ServalApiExceptions.NotFound;
+        env.DataFilesClient.DeleteAsync(File01, CancellationToken.None).Throws(ex);
+
+        // Check that we have more than one pre-translate corpora
+        Assert.AreEqual(2, env.ProjectSecrets.Get(Project02).ServalData!.Corpora.Count(c => c.Value.PreTranslate));
+
+        // SUT
+        bool actual = await env.Service.SyncProjectCorporaAsync(
+            User01,
+            new BuildConfig { ProjectId = Project02 },
+            preTranslate: true,
+            CancellationToken.None
+        );
+        Assert.IsFalse(actual);
+
+        // The old corpus and its files should be deleted
+        await env.TranslationEnginesClient.Received()
+            .DeleteCorpusAsync(TranslationEngine02, Corpus02, CancellationToken.None);
+        await env.DataFilesClient.Received().DeleteAsync(File01, CancellationToken.None);
+
+        // Ensure we have just one pre-translate corpora
+        Assert.AreEqual(1, env.ProjectSecrets.Get(Project02).ServalData!.Corpora.Count(c => c.Value.PreTranslate));
+
+        // The 404 exception was logged
+        env.MockLogger.AssertHasEvent(
+            logEvent => logEvent.LogLevel == LogLevel.Information && logEvent.Exception is ServalApiException
+        );
+    }
+
+    [Test]
     public async Task SyncProjectCorporaAsync_SynchronizesTheTranslationAndAlternateTrainingSourceCorpora()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -101,13 +101,6 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.DidNotReceive()
-            .BuildProjectAsync(
-                Arg.Any<string>(),
-                Arg.Any<BuildConfig>(),
-                Arg.Any<bool>(),
-                Arg.Any<CancellationToken>()
-            );
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -144,13 +137,6 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.Received()
-            .BuildProjectAsync(
-                "user01",
-                Arg.Is<BuildConfig>(b => b.ProjectId == "project01"),
-                preTranslate: false,
-                CancellationToken.None
-            );
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -187,13 +173,6 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.Received()
-            .BuildProjectAsync(
-                "user01",
-                Arg.Is<BuildConfig>(b => b.ProjectId == "project01"),
-                preTranslate: false,
-                CancellationToken.None
-            );
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -229,13 +208,6 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
         Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
 
-        await env.MachineProjectService.DidNotReceive()
-            .BuildProjectAsync(
-                Arg.Any<string>(),
-                Arg.Any<BuildConfig>(),
-                Arg.Any<bool>(),
-                Arg.Any<CancellationToken>()
-            );
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -262,13 +234,6 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsText("project02", "MAT", 1), Is.False);
         Assert.That(env.ContainsText("project02", "MAT", 2), Is.False);
 
-        await env.MachineProjectService.DidNotReceive()
-            .BuildProjectAsync(
-                Arg.Any<string>(),
-                Arg.Any<BuildConfig>(),
-                Arg.Any<bool>(),
-                Arg.Any<CancellationToken>()
-            );
         env.VerifyProjectSync(true);
 
         // Verify the sync metrics
@@ -3245,7 +3210,6 @@ public class ParatextSyncRunnerTests
             );
             UserService = Substitute.For<IUserService>();
             SFProjectService = Substitute.For<ISFProjectService>();
-            MachineProjectService = Substitute.For<IMachineProjectService>();
             ParatextService = Substitute.For<IParatextService>();
 
             var ptUserRoles = new Dictionary<string, string>
@@ -3312,7 +3276,6 @@ public class ParatextSyncRunnerTests
                 _projectSecrets,
                 _syncMetrics,
                 SFProjectService,
-                MachineProjectService,
                 ParatextService,
                 substituteRealtimeService ? SubstituteRealtimeService : RealtimeService,
                 DeltaUsxMapper,
@@ -3326,7 +3289,6 @@ public class ParatextSyncRunnerTests
         public ParatextSyncRunner Runner { get; }
         public IUserService UserService { get; }
         public ISFProjectService SFProjectService { get; }
-        public IMachineProjectService MachineProjectService { get; }
         public IParatextNotesMapper NotesMapper { get; }
         public IParatextService ParatextService { get; }
         public SFMemoryRealtimeService RealtimeService { get; }


### PR DESCRIPTION
This PR:

* Stops alternate training sources from being deleted on SMT builds
* Fixes crashes caused by missing alternate training corpora and files
* Enqueues the SMT build job separately to the sync job

I also took the opportunity to update sync service and sync config to use .NET 8.0 features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2386)
<!-- Reviewable:end -->
