### PR TITLE
SF-2571 Stop overwriting the sync metrics from previous syncs

### DIFF
--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -7,7 +7,7 @@ namespace SIL.XForge.Scripture.Models;
 /// <summary>
 /// Information on each sync performed.
 /// </summary>
-public class SyncMetrics : IIdentifiable
+public record SyncMetrics : IIdentifiable
 {
     // Sync Details
     public DateTime? DateFinished { get; set; }
@@ -38,5 +38,10 @@ public class SyncMetrics : IIdentifiable
     /// <summary>
     /// The log messages from <see cref="Services.ParatextSyncRunner"/>.
     /// </summary>
-    public List<string> Log { get; set; } = new List<string>();
+    public List<string> Log { get; set; } = [];
+
+    /// <summary>
+    /// Any previous syncs from the same hangfire job.
+    /// </summary>
+    public List<SyncMetrics>? PreviousSyncs { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -976,6 +976,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
             return false;
         }
 
+        // If there was a sync prior to this one
+        if (_syncMetrics.DateStarted is not null)
+        {
+            // Record the previous sync in clean sync metrics record with the same id
+            _syncMetrics = new SyncMetrics
+            {
+                DateQueued = _syncMetrics.DateQueued,
+                Id = _syncMetrics.Id,
+                ProjectRef = _syncMetrics.ProjectRef,
+                Status = SyncStatus.Queued,
+                UserRef = _syncMetrics.UserRef,
+                PreviousSyncs = [.. _syncMetrics.PreviousSyncs ?? [], _syncMetrics with { PreviousSyncs = [] }],
+            };
+        }
+
+        // Set the sync metrics
         _syncMetrics.ProductVersion = Product.Version;
         _syncMetrics.DateStarted = DateTime.UtcNow;
         _syncMetrics.Status = SyncStatus.Running;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -78,6 +78,52 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
+    public async Task SyncAsync_KeepsErrorStateWhenRunningAgain()
+    {
+        var env = new TestEnvironment();
+        int count = 0;
+        env.SetupSFData(true, true, false, false);
+        env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2));
+        env.DeltaUsxMapper.When(d => d.ToChapterDeltas(Arg.Any<XDocument>()))
+            .Do(x =>
+            {
+                // Throw an exception for the first two times this is executed
+                if (count++ < 2)
+                {
+                    throw new Exception();
+                }
+            });
+
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false);
+        Assert.That(project.Sync.DataInSync, Is.False);
+
+        // Check that the failure was logged in the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+
+        // Run a second time, keeping the same sync metrics id
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // Check that the previous failure was logged in the previous sync metrics, and the current failure is recorded too
+        syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+        Assert.That(syncMetrics.PreviousSyncs.Count, Is.EqualTo(1));
+        Assert.That(syncMetrics.PreviousSyncs.First().Status, Is.EqualTo(SyncStatus.Failed));
+
+        // Run for a third time, keeping the same sync metrics id
+        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+
+        // Check that the previous failures were logged in the previous sync metrics, and the current success is recorded
+        syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(syncMetrics.PreviousSyncs.Count, Is.EqualTo(2));
+        Assert.That(syncMetrics.PreviousSyncs.First().Status, Is.EqualTo(SyncStatus.Failed));
+        Assert.That(syncMetrics.PreviousSyncs.Last().Status, Is.EqualTo(SyncStatus.Failed));
+    }
+
+    [Test]
     public async Task SyncAsync_NewProjectTranslationSuggestionsAndCheckingDisabled()
     {
         var env = new TestEnvironment();
@@ -1892,23 +1938,32 @@ public class ParatextSyncRunnerTests
         SFProject project = env.GetProject();
         Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
+        // Verify the sync metrics
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+
         // Add a conflict note
         env.SetupNewConflictNoteThreadChange("conflictthread01");
         env.GuidService.NewObjectId().Returns("conflict01");
-        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01_alt1", false, CancellationToken.None);
 
         Assert.That(env.ContainsNoteThread("project01", "conflict01"), Is.True);
         project = env.GetProject();
         Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
         // Verify the sync metrics
-        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        syncMetrics = env.GetSyncMetrics("project01_alt1");
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
-            Is.EqualTo(new NoteSyncMetricInfo(added: 2, deleted: 0, updated: 0, removed: 0))
+            Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
         );
-        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
     }
 
     [Test]
@@ -1962,14 +2017,14 @@ public class ParatextSyncRunnerTests
         env.SetupNoteRemovedChange(dataId, threadId, new[] { "n03" });
 
         // SUT 2
-        await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt", false, CancellationToken.None);
+        await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt1", false, CancellationToken.None);
 
         Assert.That(env.ContainsNoteThread(sfProjectId, dataId), Is.True);
         project = env.GetProject();
         Assert.That(project.Sync.LastSyncSuccessful, Is.True);
 
         // Verify the sync metrics
-        syncMetrics = env.GetSyncMetrics("project01_alt");
+        syncMetrics = env.GetSyncMetrics("project01_alt1");
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
@@ -2055,19 +2110,6 @@ public class ParatextSyncRunnerTests
         env.GuidService.NewObjectId().Returns(dataId);
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
-        // Default resolved status is false
-        NoteThread thread02 = env.GetNoteThread("project01", dataId);
-        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
-        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
-
-        // Change resolve status to true
-        env.SetupNoteStatusChange(dataId, threadId, NoteStatus.Resolved.InternalValue);
-        await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
-
-        thread02 = env.GetNoteThread("project01", dataId);
-        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
-        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
-
         // Verify the sync metrics
         SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
@@ -2075,18 +2117,40 @@ public class ParatextSyncRunnerTests
             syncMetrics.Notes,
             Is.EqualTo(new NoteSyncMetricInfo(added: 1, deleted: 0, updated: 0, removed: 0))
         );
-        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 1)));
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 0, updated: 0)));
+
+        // Default resolved status is false
+        NoteThread thread02 = env.GetNoteThread("project01", dataId);
+        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
+
+        // Change resolve status to true
+        env.SetupNoteStatusChange(dataId, threadId, NoteStatus.Resolved.InternalValue);
+        await env.Runner.RunAsync("project01", "user01", "project01_alt1", false, CancellationToken.None);
+
+        thread02 = env.GetNoteThread("project01", dataId);
+        Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
+        Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Resolved.InternalValue));
+
+        // Verify the sync metrics
+        syncMetrics = env.GetSyncMetrics("project01_alt1");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
+        Assert.That(
+            syncMetrics.Notes,
+            Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
+        );
+        Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 1)));
 
         // Change status back to false - happens if the note becomes unresolved again in Paratext
         env.SetupNoteStatusChange(dataId, threadId, NoteStatus.Todo.InternalValue);
-        await env.Runner.RunAsync("project01", "user01", "project01_alt", false, CancellationToken.None);
+        await env.Runner.RunAsync("project01", "user01", "project01_alt2", false, CancellationToken.None);
 
         thread02 = env.GetNoteThread("project01", dataId);
         Assert.That(thread02.VerseRef.ToString(), Is.EqualTo("MAT 1:1"));
         Assert.That(thread02.Status, Is.EqualTo(NoteStatus.Todo.InternalValue));
 
         // Verify the sync metrics
-        syncMetrics = env.GetSyncMetrics("project01_alt");
+        syncMetrics = env.GetSyncMetrics("project01_alt2");
         Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Successful));
         Assert.That(
             syncMetrics.Notes,
@@ -3201,7 +3265,8 @@ public class ParatextSyncRunnerTests
                 new[]
                 {
                     new SyncMetrics { Id = "project01" },
-                    new SyncMetrics { Id = "project01_alt" },
+                    new SyncMetrics { Id = "project01_alt1" },
+                    new SyncMetrics { Id = "project01_alt2" },
                     new SyncMetrics { Id = "project02" },
                     new SyncMetrics { Id = "project03" },
                     new SyncMetrics { Id = "project04" },


### PR DESCRIPTION
This PR stops sync metrics from being overwritten when a job is rerun from Hangfire.

This is achieved by taking the previous sync metrics (which this job is about to overwrite), and placing them in the PreviousSyncs collection.

This is achieved by utilizing the `record` feature of C# 10 (.NET 6.0) and the collection expressions added in C# 12 (.NET 8.0).

To test, I could only cause the erroneous case by killing the .NET process at the right time, and waiting for Hangfire to rerun, and then view the `sync_metrics` collection. For this reason, testing should be performed by a developer.

I chose to make `SyncMetrics.PreviousSyncs` nullable, as there are already `sync_metrics` documents, and it should be very few syncs that fail in such a way to trigger this feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2387)
<!-- Reviewable:end -->
