### PR TITLE
SF-2643 Fix editor jump to top on paste

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -81,10 +81,10 @@
               <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
             </div>
           </app-notice>
-          <div #sourceSplitContainer class="container-for-split">
+          <div class="container-for-split">
             <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
             <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
-              <as-split-area #sourceScrollContainer [size]="75" [minSize]="20">
+              <as-split-area [size]="75" [minSize]="20">
                 <div class="text-container">
                   <app-text
                     #source
@@ -149,16 +149,10 @@
           <app-notice *ngIf="showNoEditPermissionMessage" type="info" icon="info" class="no-edit-permission-message">
             {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
           </app-notice>
-          <div #targetSplitContainer class="container-for-split">
+          <div class="container-for-split">
             <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
             <as-split direction="vertical" [style.height]="targetSplitHeight">
-              <as-split-area
-                #targetScrollContainer
-                [size]="75"
-                [minSize]="20"
-                [dir]="i18n.direction"
-                [class.has-draft]="showPreviewDraft"
-              >
+              <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction" [class.has-draft]="showPreviewDraft">
                 <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
                   <app-text
                     #target

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -114,7 +114,7 @@ app-text {
 .insert-note-fab {
   position: absolute;
   visibility: hidden;
-  inset-inline-end: 2px;
+  inset-inline-end: 10px;
 }
 
 .fab-bottom-sheet {
@@ -171,14 +171,18 @@ app-text {
   overflow: hidden;
 }
 
-as-split-area.has-draft {
-  border: 4px dashed vars.$draft-color;
+as-split-area {
+  overflow: hidden !important;
+
+  &.has-draft {
+    border: 4px dashed vars.$draft-color;
+  }
 }
 
 .text-container {
   display: flex;
   position: relative;
-  min-height: 100%;
+  height: 100%;
 }
 
 .text-area {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3200,6 +3200,108 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: originalPos.start, length: originalPos.length + 1 });
       env.dispose();
     }));
+
+    it('should position FAB beside selected segment', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      const segmentRef = 'verse_1_1';
+
+      env.clickSegmentRef(segmentRef);
+      env.wait();
+
+      const segmentElRect = env.getSegmentElement(segmentRef)!.getBoundingClientRect();
+      const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
+      expect(segmentElRect.top).toEqual(fabRect.top);
+
+      env.dispose();
+    }));
+
+    it('should position FAB beside selected segment when scrolling segment in view', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      // Set window size to be narrow to test scrolling
+      const contentContainer: HTMLElement = document.getElementsByClassName('content')[0] as HTMLElement;
+      Object.assign(contentContainer.style, { width: '360px', height: '300px' });
+
+      const segmentRef = 'verse_1_1';
+
+      // Select segment
+      env.clickSegmentRef(segmentRef);
+      env.wait();
+
+      // Scroll, keeping selected segment in view
+      const scrollContainer: Element = env.component['targetScrollContainer'] as Element;
+      scrollContainer.scrollTop = 20;
+      scrollContainer.dispatchEvent(new Event('scroll'));
+
+      const segmentElRect = env.getSegmentElement(segmentRef)!.getBoundingClientRect();
+      const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
+      expect(fabRect.top).toEqual(segmentElRect.top);
+
+      env.dispose();
+    }));
+
+    it('should position FAB within scroll container when scrolling segment above view', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      // Set window size to be narrow to test scrolling
+      const contentContainer: HTMLElement = document.getElementsByClassName('content')[0] as HTMLElement;
+      Object.assign(contentContainer.style, { width: '360px', height: '300px' });
+
+      // Verse near top of scroll container
+      const segmentRef = 'verse_1_1';
+
+      // Select segment
+      env.clickSegmentRef(segmentRef);
+      env.wait();
+
+      const scrollContainer: Element = env.component['targetScrollContainer'] as Element;
+      const scrollContainerRect: DOMRect = scrollContainer.getBoundingClientRect();
+
+      // Scroll segment above view
+      scrollContainer.scrollTop = 200;
+      scrollContainer.dispatchEvent(new Event('scroll'));
+
+      const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
+      expect(fabRect.top).toEqual(scrollContainerRect.top + env.component['fabCushion']);
+
+      env.dispose();
+    }));
+
+    it('should position FAB within scroll container when scrolling segment below view', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig();
+      env.wait();
+
+      // Set window size to be narrow to test scrolling
+      const contentContainer: HTMLElement = document.getElementsByClassName('content')[0] as HTMLElement;
+      Object.assign(contentContainer.style, { width: '360px', height: '300px' });
+
+      // Verse near bottom of scroll container
+      const segmentRef = 'verse_1_6';
+
+      // Select segment
+      env.clickSegmentRef(segmentRef);
+      env.wait();
+
+      const scrollContainer: Element = env.component['targetScrollContainer'] as Element;
+      const scrollContainerRect: DOMRect = scrollContainer.getBoundingClientRect();
+
+      // Scroll segment below view
+      scrollContainer.scrollTop = 0;
+      scrollContainer.dispatchEvent(new Event('scroll'));
+
+      const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
+      expect(fabRect.bottom).toEqual(scrollContainerRect.bottom - env.component['fabCushion']);
+
+      env.dispose();
+    }));
   });
 
   describe('Translation Suggestions disabled', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3269,7 +3269,7 @@ describe('EditorComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
 
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(fabRect.top).toEqual(scrollContainerRect.top + env.component['fabCushion']);
+      expect(fabRect.top).toEqual(scrollContainerRect.top + env.component.fabVerticalCushion);
 
       env.dispose();
     }));
@@ -3298,7 +3298,7 @@ describe('EditorComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
 
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(fabRect.bottom).toEqual(scrollContainerRect.bottom - env.component['fabCushion']);
+      expect(fabRect.bottom).toEqual(scrollContainerRect.bottom - env.component.fabVerticalCushion);
 
       env.dispose();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -54,7 +54,18 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DeltaOperation } from 'rich-text';
 import { BehaviorSubject, combineLatest, fromEvent, merge, of, Subject, Subscription, timer } from 'rxjs';
-import { debounceTime, delayWhen, filter, first, repeat, retryWhen, switchMap, take, tap } from 'rxjs/operators';
+import {
+  debounceTime,
+  delayWhen,
+  filter,
+  first,
+  repeat,
+  retryWhen,
+  switchMap,
+  take,
+  tap,
+  throttleTime
+} from 'rxjs/operators';
 import { TabFactoryService, TabInfo, TabMenuService, TabStateService } from 'src/app/shared/sf-tab-group';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
@@ -164,16 +175,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   multiCursorViewers: MultiCursorViewer[] = [];
   hasDraft = false;
 
-  @ViewChild('sourceSplitContainer') sourceSplitContainer?: ElementRef;
-  @ViewChild('targetSplitContainer') targetSplitContainer?: ElementRef;
-  @ViewChild('sourceScrollContainer') sourceScrollContainer?: ElementRef;
-  @ViewChild('targetScrollContainer') targetScrollContainer?: ElementRef;
   @ViewChild('source') source?: TextComponent;
   @ViewChild('target') target?: TextComponent;
   @ViewChild('fabButton', { read: ElementRef }) insertNoteFab?: ElementRef<HTMLElement>;
   @ViewChild('fabBottomSheet') TemplateBottomSheet?: TemplateRef<any>;
   @ViewChild('mobileNoteTextarea') mobileNoteTextarea?: ElementRef<HTMLTextAreaElement>;
 
+  private sourceScrollContainer: Element | undefined;
+  private targetScrollContainer: Element | undefined;
   private interactiveTranslatorFactory?: InteractiveTranslatorFactory;
   private translationEngine?: RemoteTranslationEngine;
   private isTranslating: boolean = false;
@@ -209,12 +218,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private noteThreadQuery?: RealtimeQuery<NoteThreadDoc>;
   private toggleNoteThreadVerseRefs$: BehaviorSubject<void> = new BehaviorSubject<void>(undefined);
   private targetEditorLoaded$: Subject<void> = new Subject<void>();
+  private syncScrollRequested$: Subject<void> = new Subject<void>();
   private toggleNoteThreadSub?: Subscription;
   private shouldNoteThreadsRespondToEdits: boolean = false;
   private commenterSelectedVerseRef?: VerseRef;
   private resizeObserver?: ResizeObserver;
   private scrollSubscription?: Subscription;
   private readonly fabDiameter = 40;
+  private readonly fabCushion = 5;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -754,6 +765,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         this.checkForPreTranslations();
       }
     );
+
+    // Throttle bursts of sync scroll requests
+    this.syncScrollRequested$.pipe(takeUntilDestroyed(this.destroyRef), throttleTime(200)).subscribe(() => {
+      this.syncScroll();
+    });
   }
 
   ngOnDestroy(): void {
@@ -783,7 +799,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.lastShownSuggestions = [];
       if (this.source != null) {
         this.source.setSegment(this.target.segmentRef);
-        this.syncScroll();
+        this.syncScrollRequested$.next();
       }
       if (segment == null || !VERSE_REGEX.test(segment.ref)) {
         this.resetCommenterVerseSelection();
@@ -861,7 +877,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }
       }
       this.segmentUpdated$.next();
-      this.syncScroll();
+      this.syncScrollRequested$.next();
     }
 
     if (delta != null && this.shouldNoteThreadsRespondToEdits) {
@@ -879,7 +895,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     if (!textChange) {
       return;
     }
-    this.syncScroll();
+
+    this.syncScrollRequested$.next();
+
     if (
       this.target != null &&
       this.target.segment != null &&
@@ -899,16 +917,18 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     switch (textType) {
       case 'source':
         this.sourceLoaded = true;
+        this.sourceScrollContainer = this.source?.editor?.scrollingContainer;
         break;
       case 'target':
         this.targetLoaded = true;
+        this.targetScrollContainer = this.target?.editor?.scrollingContainer;
         this.toggleNoteThreadVerseRefs$.next();
         this.shouldNoteThreadsRespondToEdits = true;
 
         if (this.target?.editor != null && this.targetScrollContainer != null) {
           this.positionInsertNoteFab();
-          this.observeResize(this.targetScrollContainer.nativeElement);
-          this.subscribeScroll(this.targetScrollContainer.nativeElement);
+          this.observeResize(this.targetScrollContainer);
+          this.subscribeScroll(this.targetScrollContainer);
           this.targetEditorLoaded$.next();
           this.checkForPreTranslations();
         }
@@ -1705,8 +1725,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     dialogConfig: MatDialogConfig<D>
   ): MatDialogRef<T, R> {
     const selection: RangeStatic | null | undefined = this.target?.editor?.getSelection();
-    const targetScrollContainer: HTMLElement | undefined = this.targetScrollContainer?.nativeElement;
-    const targetScrollTop: number | undefined = targetScrollContainer?.scrollTop;
+    const targetScrollTop: number | undefined = this.targetScrollContainer?.scrollTop;
     const dialogRef: MatDialogRef<T, R> = this.dialogService.openMatDialog(component, dialogConfig);
 
     if (selection == null || !this.canEdit) {
@@ -1720,8 +1739,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         if (currentSelection?.index !== selection.index) {
           this.target.editor.setSelection(selection.index, 0, 'user');
 
-          if (targetScrollContainer != null && targetScrollTop != null) {
-            targetScrollContainer.scrollTop = targetScrollTop;
+          if (this.targetScrollContainer != null && targetScrollTop != null) {
+            this.targetScrollContainer.scrollTop = targetScrollTop;
           }
         }
       }
@@ -2159,6 +2178,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.source == null ||
       this.source.segment == null ||
       this.source.editor == null ||
+      this.sourceScrollContainer == null ||
       this.target == null ||
       this.target.segment == null ||
       this.target.editor == null ||
@@ -2167,24 +2187,25 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
 
-    const sourceScrollContainer: HTMLElement | undefined = this.sourceScrollContainer?.nativeElement;
-    if (sourceScrollContainer == null) {
-      return;
-    }
+    const targetRange: RangeStatic = this.target.segment.range;
+    const targetSelectionBounds: DOMRect = this.target.editor.selection.getBounds(targetRange.index);
 
-    const targetRange = this.target.segment.range;
-    const targetSelectionBounds = this.target.editor.selection.getBounds(targetRange.index);
+    const sourceRange: RangeStatic = this.source.segment.range;
+    const sourceSelectionBounds: DOMRect = this.source.editor.selection.getBounds(
+      sourceRange.index,
+      sourceRange.length
+    );
 
-    const sourceRange = this.source.segment.range;
-    const sourceSelectionBounds = this.source.editor.selection.getBounds(sourceRange.index, sourceRange.length);
-
-    let newScrollTop: number = sourceScrollContainer.scrollTop + sourceSelectionBounds.top - targetSelectionBounds.top;
+    let newScrollTop: number =
+      this.sourceScrollContainer.scrollTop + sourceSelectionBounds.top - targetSelectionBounds.top;
 
     // Check to see if the top of source selection would be visible after the scroll adjustment
-    const sourceTopPosition = targetSelectionBounds.top - sourceScrollContainer.getBoundingClientRect().top;
+    const sourceTopPosition: number =
+      sourceSelectionBounds.top - this.sourceScrollContainer.getBoundingClientRect().top;
 
     // Check to see if the bottom of source selection would be visible after the scroll adjustment
-    const sourceBottomPosition = sourceTopPosition + sourceSelectionBounds.height - sourceScrollContainer.clientHeight;
+    const sourceBottomPosition: number =
+      sourceTopPosition + sourceSelectionBounds.height - this.sourceScrollContainer.clientHeight;
 
     // Adjust the scroll to ensure the selection fits within the container
     // Only adjust the bottom position so long as that doesn't hide the top position i.e. a long verse(s)
@@ -2194,10 +2215,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       newScrollTop += sourceBottomPosition;
     }
 
-    sourceScrollContainer.scrollTop = newScrollTop;
+    this.sourceScrollContainer.scrollTop = newScrollTop;
   }
 
-  private observeResize(scrollContainer: HTMLElement): void {
+  private observeResize(scrollContainer: Element): void {
     this.resizeObserver?.disconnect();
     this.resizeObserver = new ResizeObserver(entries => {
       entries.forEach(_ => {
@@ -2207,14 +2228,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.resizeObserver.observe(scrollContainer);
   }
 
-  private subscribeScroll(scrollContainer: HTMLElement): void {
+  private subscribeScroll(scrollContainer: Element): void {
     this.scrollSubscription?.unsubscribe();
     this.scrollSubscription = this.subscribe(fromEvent(scrollContainer, 'scroll'), () => {
       this.keepInsertNoteFabInView(scrollContainer);
     });
   }
 
-  private keepInsertNoteFabInView(scrollContainer: HTMLElement): void {
+  private keepInsertNoteFabInView(scrollContainer: Element): void {
     if (
       this.insertNoteFab == null ||
       this.target == null ||
@@ -2225,15 +2246,16 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const bounds: DOMRect = scrollContainer.getBoundingClientRect();
-    const fabCushion = 10;
-    const fabTop = this.target.selectionBoundsTop - fabCushion;
-    const fabBottom = this.target.selectionBoundsTop + this.fabDiameter + fabCushion;
+    const fabTop = this.target.selectionBoundsTop - this.fabCushion;
+    const fabBottom = this.target.selectionBoundsTop + this.fabDiameter + this.fabCushion;
 
-    // Adjust margin when selection goes outside scroll container (0 if within visible scroll area)
-    const fabTopAdjustment = Math.max(0, scrollContainer.scrollTop - fabTop);
-    const fabBottomAdjustment = Math.min(0, bounds.height - (fabBottom - scrollContainer.scrollTop));
+    // Editor top is FAB upper bound
+    const fabTopAdjustment = Math.min(fabTop, scrollContainer.scrollTop);
 
-    this.insertNoteFab.nativeElement.style.marginTop = `${fabTopAdjustment + fabBottomAdjustment}px`;
+    // Editor bottom is FAB lower bound
+    const minAdjustment: number = Math.max(fabBottom - bounds.height, 0);
+
+    this.insertNoteFab.nativeElement.style.marginTop = `-${Math.max(fabTopAdjustment, minAdjustment)}px`;
   }
 
   private checkForPreTranslations(): void {


### PR DESCRIPTION
When pasting text in the target editor in chrome (no issue in firefox), the editor would jump the scroll to the top.  This PR fixes this issue as well as adds tests to ensure the note FAB is tracking the selected verse while staying within the visible scroll area.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2390)
<!-- Reviewable:end -->
