### PR TITLE
SF-2442 Add AI draft tabs when draft generation completes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map, Observable } from 'rxjs';
+import { EditorTabType } from '../../../translate/editor/tabs/editor-tabs.types';
 import { TabGroup } from './tab-group';
 
 export interface TabInfo<TType extends string> {
@@ -62,13 +63,24 @@ export class TabStateService<TKey extends string, T extends TabInfo<string>> imp
     this.tabGroupsSource$.next(this.groups);
   }
 
-  addTab(groupId: TKey, tab: T): void {
+  addTab(groupId: TKey, tab: T, selectTab: boolean = true): void {
     if (!this.groups.has(groupId)) {
       this.groups.set(groupId, new TabGroup<TKey, T>(groupId, []));
     }
 
-    this.groups.get(groupId)!.addTab(tab, true);
+    this.groups.get(groupId)!.addTab(tab, selectTab);
     this.tabGroupsSource$.next(this.groups);
+  }
+
+  getTab(groupId: TKey, type: EditorTabType): number | undefined {
+    return this.groups.get(groupId)?.tabs?.findIndex(t => t.type === type);
+  }
+
+  hasTab(groupId: TKey, type: EditorTabType): boolean {
+    if (!this.groups.has(groupId)) {
+      return false;
+    }
+    return (this.groups.get(groupId)?.tabs?.filter(t => t.type === type) ?? []).length > 0;
   }
 
   removeTab(groupId: TKey, index: number): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -39,19 +39,6 @@
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
         </ng-container>
         <div class="toolbar-separator" fxHide.lt-md>&nbsp;</div>
-
-        <ng-container *ngIf="showPreviewDraft">
-          <div class="toolbar-separator"></div>
-          <button
-            mat-stroked-button
-            [title]="t('preview_draft_button')"
-            class="preview-draft-button"
-            (click)="goToDraftPreview()"
-          >
-            <mat-icon>edit_note</mat-icon>
-            {{ t("preview_draft_button") }}
-          </button>
-        </ng-container>
       </div>
       <ng-container *ngIf="showMultiViewers">
         <div fxFlexAlign="end" class="avatar-padding">
@@ -152,13 +139,7 @@
           <div #targetSplitContainer class="container-for-split">
             <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
             <as-split direction="vertical" [style.height]="targetSplitHeight">
-              <as-split-area
-                #targetScrollContainer
-                [size]="75"
-                [minSize]="20"
-                [dir]="i18n.direction"
-                [class.has-draft]="showPreviewDraft"
-              >
+              <as-split-area #targetScrollContainer [size]="75" [minSize]="20" [dir]="i18n.direction">
                 <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
                   <app-text
                     #target

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -74,11 +74,6 @@
   width: 0;
 }
 
-.preview-draft-button {
-  // Border helps associate button with target editor that shows similar border when it has a draft
-  border: 3px dashed vars.$draft-color;
-}
-
 .ql-suggestions {
   margin: 0 6px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -104,6 +104,7 @@ import { SuggestionsComponent } from './suggestions.component';
 import { EditorTabFactoryService } from './tabs/editor-tab-factory.service';
 import { EditorTabMenuService } from './tabs/editor-tab-menu.service';
 import { ACTIVE_EDIT_TIMEOUT } from './translate-metrics-session';
+import { EditorDraftComponent } from './editor-draft/editor-draft.component';
 
 const mockedAuthService = mock(AuthService);
 const mockedSFProjectService = mock(SFProjectService);
@@ -147,7 +148,8 @@ describe('EditorComponent', () => {
       EditorComponent,
       HistoryChooserComponent,
       SuggestionsComponent,
-      TrainingProgressComponent
+      TrainingProgressComponent,
+      EditorDraftComponent
     ],
     imports: [
       AngularSplitModule,
@@ -3687,6 +3689,43 @@ describe('EditorComponent', () => {
 
       expect(spyCreateTab).toHaveBeenCalledWith('project', { headerText: targetLabel });
     });
+
+    it('should add auto draft tab when available', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(
+        of({
+          verse_1_2: 'Abraham was the father of Isaac'
+        })
+      );
+      env.wait();
+
+      const tabGroup = env.component.tabState.getTabGroup('target');
+      expect(tabGroup?.tabs[1].type).toEqual('draft');
+
+      env.dispose();
+    }));
+
+    it('should hide auto draft tab when switching to chapter with no draft', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(
+        of({
+          verse_1_2: 'Abraham was the father of Isaac'
+        })
+      );
+      env.wait();
+
+      const tabGroup = env.component.tabState.getTabGroup('target');
+      expect(tabGroup?.tabs[1].type).toEqual('draft');
+      expect(env.component.chapter).toBe(1);
+
+      env.updateParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
+      env.wait();
+
+      expect(tabGroup?.tabs[1]).toBeUndefined();
+      expect(env.component.chapter).toBe(2);
+
+      env.dispose();
+    }));
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -506,10 +506,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.onlineStatusService.isOnline && this.multiCursorViewers.length > 0;
   }
 
-  get showPreviewDraft(): boolean {
-    return this.onlineStatusService.isOnline && this.featureFlags.showNmtDrafting.enabled && this.hasDraft;
-  }
-
   /**
    * Determines whether the comment adding UI should be shown
    * This will be true any time the user has the right to add notes
@@ -2279,6 +2275,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       .getGeneratedDraft(this.activatedProject.projectId!, this.bookNum!, this.chapter!)
       .subscribe((draft: DraftSegmentMap) => {
         this.hasDraft = this.draftViewerService.hasDraftOps(draft, targetOps);
+        const hasDraftTab = this.tabState.hasTab('target', 'draft');
+        if (this.hasDraft && !hasDraftTab) {
+          this.tabState.addTab('target', this.editorTabFactory.createTab('draft'), false);
+        } else if (!this.hasDraft && hasDraftTab) {
+          this.tabState.removeTab('target', this.tabState.getTab('target', 'draft')!);
+        }
       });
   }
 
@@ -2301,6 +2303,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         headerText: this.targetLabel
       })
     ];
+    if (this.hasDraft) {
+      targetTabs.push(this.editorTabFactory.createTab('draft'));
+    }
 
     this.tabState.addTabGroup('target', targetTabs);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -23,7 +23,7 @@ describe('EditorTabFactoryService', () => {
     expect(tab.type).toEqual('draft');
     expect(tab.icon).toEqual('model_training');
     expect(tab.headerText).toEqual('Auto Draft');
-    expect(tab.closeable).toEqual(true);
+    expect(tab.closeable).toEqual(false);
     expect(tab.unique).toEqual(true);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -20,7 +20,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
           type: 'draft',
           icon: 'model_training',
           headerText: 'Auto Draft',
-          closeable: true,
+          closeable: false,
           unique: true
         };
       case 'project-source':


### PR DESCRIPTION
* Removed "Preview draft" button and highlighting from the editor
* Show/hide the "Auto Draft" tab automatically when a draft is available/not available
* Auto Draft tab is no longer closable