### PR TITLE
Change QA to use Serval Production

### DIFF
--- a/src/SIL.XForge.Scripture/appsettings.Development.json
+++ b/src/SIL.XForge.Scripture/appsettings.Development.json
@@ -31,6 +31,7 @@
     "HgExe": "/usr/local/bin/hg"
   },
   "Serval": {
-    "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
+    "ApiServer": "https://qa.serval-api.org",
+    "TokenUrl": "https://dev-sillsdev.auth0.com/oauth/token"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Staging.json
+++ b/src/SIL.XForge.Scripture/appsettings.Staging.json
@@ -14,9 +14,5 @@
     "ManagementAudience": "https://dev-sillsdev.auth0.com/api/v2/",
     "FrontendClientId": "4eHLjo40mAEGFU6zUxdYjnpnC1K1Ydnj",
     "BackendClientId": "0je4EE9NauROSGjrR1SCryL74TpF2CVC"
-  },
-  "Serval": {
-    "ApiServer": "https://qa.serval-api.org",
-    "TokenUrl": "https://dev-sillsdev.auth0.com/oauth/token"
   }
 }

--- a/src/SIL.XForge.Scripture/appsettings.Testing.json
+++ b/src/SIL.XForge.Scripture/appsettings.Testing.json
@@ -29,6 +29,7 @@
     "HgExe": "/usr/local/bin/hg"
   },
   "Serval": {
-    "TokenUrl": "https://sil-appbuilder.auth0.com/oauth/token"
+    "ApiServer": "https://qa.serval-api.org",
+    "TokenUrl": "https://dev-sillsdev.auth0.com/oauth/token"
   }
 }


### PR DESCRIPTION
This PR updates SF QA to use the Serval Production server and authentication configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2396)
<!-- Reviewable:end -->
