### PR TITLE
Emit 401 errors from Serval as 403 errors on the Machine API

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -778,6 +778,7 @@ public class MachineApiService(
         {
             case { StatusCode: StatusCodes.Status204NoContent }:
                 throw new DataNotFoundException("Entity Deleted");
+            case { StatusCode: StatusCodes.Status401Unauthorized }:
             case { StatusCode: StatusCodes.Status403Forbidden }:
                 throw new ForbiddenException();
             case { StatusCode: StatusCodes.Status404NotFound }:

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -830,6 +830,20 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void GetPreTranslationAsync_InvalidCredentials()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.PreTranslationService.GetPreTranslationsAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(ServalApiExceptions.NotAuthenticated);
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(
+            () => env.Service.GetPreTranslationAsync(User01, Project01, 40, 1, CancellationToken.None)
+        );
+    }
+
+    [Test]
     public void GetPreTranslationAsync_NoPermission()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ServalApiExceptions.cs
@@ -55,6 +55,15 @@ public static class ServalApiExceptions
             null
         );
 
+    public static ServalApiException NotAuthenticated =>
+        new ServalApiException(
+            "The client is not authenticated.",
+            StatusCodes.Status401Unauthorized,
+            null,
+            new Dictionary<string, IEnumerable<string>>(),
+            null
+        );
+
     public static ServalApiException NotFound =>
         new ServalApiException(
             "The build does not exist.",


### PR DESCRIPTION
With the rotation of the Serval QA credentials, it was noted that Serval returns 401 errors with the old credentials, which are displayed as 500 errors on the Angular frontend.

This PR causes these errors to be rethrown as `ForbiddenException`, which is emitted as a HTTP 403 error to the Angular frontend, and so handled in a more elegant way by the frontend.

This PR does not require full testing, but can be recreated by running this PR with the previous (now out of date) Serval QA credentials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2397)
<!-- Reviewable:end -->
