### PR TITLE
SF-2662 Use project-specified font in question dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -466,6 +466,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
 
     const data: QuestionDialogData = {
       questionDoc,
+      projectDoc: this.projectDoc,
       textsByBookId: this.textsByBookId,
       projectId: this.projectDoc.id,
       isRightToLeft: this.projectDoc.data?.isRightToLeft

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -348,7 +348,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
   }
 
   async questionDialog(): Promise<void> {
-    if (this._questionDoc == null || this._questionDoc.data == null) {
+    if (this._questionDoc?.data == null || this._projectProfileDoc == null) {
       return;
     }
     const projectId = this._questionDoc.data.projectRef;
@@ -366,6 +366,7 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
 
     const data: QuestionDialogData = {
       questionDoc: this._questionDoc,
+      projectDoc: this._projectProfileDoc,
       textsByBookId: this.textsByBookId!,
       projectId,
       isRightToLeft: this.project?.isRightToLeft

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -986,6 +986,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
     const data: QuestionDialogData = {
       questionDoc: undefined,
+      projectDoc: this.projectDoc,
       textsByBookId: this.textsByBookId,
       projectId: this.projectDoc.id,
       defaultVerse: new VerseRef(this.book ?? 0, this.chapter ?? 1, 1),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -41,6 +41,7 @@
           placeholder="{{ t('enter_a_reference_to_load_text') }}"
           [activeVerse]="selection"
           [isRightToLeft]="isTextRightToLeft"
+          [projectDoc]="projectDoc"
         ></app-checking-text>
       </div>
       <mat-form-field class="question-container" id="question-text" appearance="outline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -14,6 +14,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { getQuestionDocId, Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
@@ -581,9 +582,15 @@ class TestEnvironment {
       questionDoc = this.realtimeService.get<QuestionDoc>(QuestionDoc.COLLECTION, questionId);
       questionDoc.onlineFetch();
     }
+    this.realtimeService.addSnapshot(SFProjectProfileDoc.COLLECTION, {
+      id: 'project01',
+      data: createTestProjectProfile()
+    });
+    const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, 'project01');
     const config: MatDialogConfig<QuestionDialogData> = {
       data: {
         questionDoc,
+        projectDoc,
         textsByBookId: {
           MAT: {
             bookNum: 40,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -15,6 +15,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { QuestionDoc } from '../../core/models/question-doc';
+import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
 import {
@@ -28,6 +29,7 @@ import { AudioAttachment } from '../checking/checking-audio-recorder/checking-au
 
 export interface QuestionDialogData {
   questionDoc?: QuestionDoc;
+  projectDoc: SFProjectProfileDoc;
   textsByBookId: TextsByBookId;
   projectId: string;
   defaultVerse?: VerseRef;
@@ -117,6 +119,10 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
 
   get isTextRightToLeft(): boolean {
     return this.data.isRightToLeft == null ? false : this.data.isRightToLeft;
+  }
+
+  get projectDoc(): SFProjectProfileDoc {
+    return this.data.projectDoc;
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -167,6 +167,7 @@ class TestEnvironment {
   readonly service: QuestionDialogService;
   readonly mockedDialogRef = mock<MatDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>>(MatDialogRef);
   textsByBookId: TextsByBookId;
+  projectDoc: SFProjectDoc;
   matthewText: TextInfo = {
     bookNum: 40,
     hasSource: false,
@@ -198,6 +199,7 @@ class TestEnvironment {
       id: this.PROJECT01,
       data: this.testProject
     });
+    this.projectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, this.PROJECT01);
 
     when(mockedDialogService.openMatDialog(anything(), anything())).thenReturn(instance(this.mockedDialogRef));
     when(mockedUserService.currentUserId).thenReturn(this.adminUser.id);
@@ -231,7 +233,7 @@ class TestEnvironment {
   }
 
   getQuestionDialogData(questionDoc?: QuestionDoc): QuestionDialogData {
-    return { questionDoc, textsByBookId: this.textsByBookId, projectId: this.PROJECT01 };
+    return { questionDoc, projectDoc: this.projectDoc, textsByBookId: this.textsByBookId, projectId: this.PROJECT01 };
   }
 
   updateUserRole(role: string): void {


### PR DESCRIPTION
This is a followup to the recently-merged font support: https://github.com/sillsdev/web-xforge/pull/2346

The main part of this change is just passing around the project doc to components that are going to render a chapter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2398)
<!-- Reviewable:end -->
