### PR TITLE
Fix no font definition warning in test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.spec.ts
@@ -1,4 +1,5 @@
 import { FontService, FONT_FACE_DEFINITIONS, FONT_FACE_FALLBACKS } from './font.service';
+import { MockConsole } from './mock-console';
 
 // Mocking the document with ts-mockito does not work because the type definitions for document.fonts does not include
 // the add method
@@ -10,6 +11,8 @@ class FakeDocument {
     }
   };
 }
+
+const mockedConsole: MockConsole = MockConsole.install();
 
 describe('FontService', () => {
   let fontService: FontService;
@@ -24,7 +27,10 @@ describe('FontService', () => {
   });
 
   it('should default to Charis SIL when font is not recognized', () => {
+    mockedConsole.expectAndHide(/No font definition/);
     expect(fontService.getCSSFontName('zyz123')).toEqual('Charis SIL');
+    mockedConsole.verify();
+    mockedConsole.reset();
   });
 
   it('should default to Charis SIL for proprietary serif fonts', () => {


### PR DESCRIPTION
This  PR fixes a recently introduced warning that appears when running the Angular unit tests:
```
WARN: 'No font definition for zyz123', [[[]]]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2400)
<!-- Reviewable:end -->
