### PR TITLE
Add support for Paratext Zip files to the Serval Downloader tool

### DIFF
--- a/tools/ServalDownloader/Program.cs
+++ b/tools/ServalDownloader/Program.cs
@@ -39,11 +39,15 @@ foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorpor
         string sourcePath = Path.Combine(corpusPath, "source");
         Directory.CreateDirectory(sourcePath);
 
+        // Get the file extension
+        DataFile dataFile = await dataFilesClient.GetAsync(sourceFile.File.Id);
+        string extension = dataFile.Format == FileFormat.Paratext ? ".zip" : ".txt";
+
         // Download the file
-        var file = await dataFilesClient.DownloadAsync(sourceFile.File.Id);
+        FileResponse file = await dataFilesClient.DownloadAsync(sourceFile.File.Id);
 
         // Write the file
-        string path = Path.Combine(sourcePath, (sourceFile.TextId ?? sourceFile.File.Id) + ".txt");
+        string path = Path.Combine(sourcePath, (sourceFile.TextId ?? sourceFile.File.Id) + extension);
         Console.WriteLine($"Writing {path}...");
         await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
         file.Stream.CopyTo(fileStream);
@@ -54,11 +58,15 @@ foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorpor
         string targetPath = Path.Combine(corpusPath, "target");
         Directory.CreateDirectory(targetPath);
 
+        // Get the file extension
+        DataFile dataFile = await dataFilesClient.GetAsync(targetFile.File.Id);
+        string extension = dataFile.Format == FileFormat.Paratext ? ".zip" : ".txt";
+
         // Download the file
         FileResponse file = await dataFilesClient.DownloadAsync(targetFile.File.Id);
 
         // Write the file
-        string path = Path.Combine(targetPath, (targetFile.TextId ?? targetFile.File.Id) + ".txt");
+        string path = Path.Combine(targetPath, (targetFile.TextId ?? targetFile.File.Id) + extension);
         Console.WriteLine($"Writing {path}...");
         await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
         file.Stream.CopyTo(fileStream);

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Serval.Client" Version="1.2.0.1" />
+    <PackageReference Include="Serval.Client" Version="1.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds support for properly downloading Paratext zip files from Serval to the Serval Downloader tool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2402)
<!-- Reviewable:end -->
