### PR TITLE
Fix Angular test failures when display scaling is enabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3240,7 +3240,7 @@ describe('EditorComponent', () => {
 
       const segmentElRect = env.getSegmentElement(segmentRef)!.getBoundingClientRect();
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(fabRect.top).toEqual(segmentElRect.top);
+      expect(Math.ceil(fabRect.top)).toEqual(Math.ceil(segmentElRect.top));
 
       env.dispose();
     }));
@@ -3269,7 +3269,7 @@ describe('EditorComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
 
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(fabRect.top).toEqual(scrollContainerRect.top + env.component.fabVerticalCushion);
+      expect(Math.ceil(fabRect.top)).toEqual(Math.ceil(scrollContainerRect.top + env.component.fabVerticalCushion));
 
       env.dispose();
     }));
@@ -3298,7 +3298,9 @@ describe('EditorComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
 
       const fabRect = env.insertNoteFab.nativeElement.getBoundingClientRect();
-      expect(fabRect.bottom).toEqual(scrollContainerRect.bottom - env.component.fabVerticalCushion);
+      expect(Math.ceil(fabRect.bottom)).toEqual(
+        Math.ceil(scrollContainerRect.bottom - env.component.fabVerticalCushion)
+      );
 
       env.dispose();
     }));


### PR DESCRIPTION
My primary display has display scaling turned on to 125% (I am running Windows 11). Because of this, some unit tests that are measuring pixel calculations with fail often (but not consistently) with errors like:
```
Error: Expected 262.45001220703125 to equal 262.4624938964844.
```
and:
```
Error: Expected 373.8000183105469 to equal 373.8000030517578.
```
To resolve this, this PR updates position checks to round up to same whole number, as within one pixel should be sufficient accuracy for positioning elements.

Note: These tests did not fail on my laptop's external display, which does not have display scaling enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2403)
<!-- Reviewable:end -->
