### PR TITLE
Fix transloco test errors in EditorDraftComponent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { cloneDeep } from 'lodash-es';
+import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Delta } from 'rich-text';
@@ -40,7 +41,8 @@ describe('EditorDraftComponent', () => {
       SharedModule,
       TestOnlineStatusModule.forRoot(),
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
-      TestTranslocoModule
+      TestTranslocoModule,
+      TranslocoMarkupModule
     ],
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },


### PR DESCRIPTION
This PR fixes the following errors displayed in the console while running tests:

```
ERROR: 'NG0304: 'transloco' is not a known element (used in the 'EditorDraftComponent' component template):
1. If 'transloco' is an Angular component, then verify that it is a part of an @NgModule where this component is declared.
2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.', [[[...]]]
```

```
ERROR: 'NG0303: Can't bind to 'params' since it isn't a known property of 'transloco' (used in the 'EditorDraftComponent' component template).                                                                           
1. If 'transloco' is an Angular component and it has the 'params' input, then verify that it is a part of an @NgModule where this component is declared.
2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.', [[[...]]]
```

These were introduced by #2364 (sorry for letting these slip through in my PR).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2404)
<!-- Reviewable:end -->
