### PR TITLE
Add Mongo query for errors that caused projects to fail last sync

### DIFF
--- a/mongodb/SyncMetrics/FindCurrentSyncErrors.mongodb
+++ b/mongodb/SyncMetrics/FindCurrentSyncErrors.mongodb
@@ -1,0 +1,66 @@
+use("xforge");
+
+// Find errors that have caused projects to fail their most recent sync
+
+db.sf_projects.aggregate([
+  {
+    $match: {
+      "sync.lastSyncSuccessful": false
+    }
+  },
+  {
+    $project: {
+      _id: 1,
+      name: 1,
+      shortName: 1
+    }
+  },
+  {
+    $lookup: {
+      from: "sync_metrics",
+      as: "syncMetrics",
+      let: {
+        projectRef: "$_id"
+      },
+      pipeline: [
+        {
+          $match: {
+            $expr: {
+              $eq: ["$projectRef", "$$projectRef"]
+            }
+          }
+        },
+        {
+          $sort: {
+            dateQueued: -1
+          }
+        },
+        { $limit: 1 },
+        {
+          $project: {
+            dateStarted: 1,
+            status: 1,
+            errorDetails: 1
+          }
+        }
+      ]
+    }
+  },
+  {
+    $unwind: {
+      path: "$syncMetrics",
+      preserveNullAndEmptyArrays: false
+    }
+  },
+  {
+    $group: {
+      _id: "$syncMetrics.errorDetails",
+      count: { $sum: 1 }
+    }
+  },
+  {
+    $sort: {
+      count: -1
+    }
+  }
+]);


### PR DESCRIPTION
This query is an attempt to answer the question "What errors have caused the most projects to fail their most recent sync?" It does this by looking up the most recent sync failure for each project that has failed its last sync, then finding the most recent sync metrics for that project. Then it groups by error message, which somewhat works to find common errors, though sometimes the same error shows up with a different stack trace and doesn't get grouped properly. This is considered acceptable because we're just looking for most common errors.

This query is inefficient and slow to run.

The current top result, with a count of 17, is this:
```
System.Net.Http.HttpRequestException: HTTP Request error:
    POST https://registry.paratext.org/api8/token
    Response:
    StatusCode: 429, ReasonPhrase: 'Too Many Requests',
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2405)
<!-- Reviewable:end -->
