### PR TITLE
SF-2636b Fallback from Awami to Scheherazade when Graphite unsupported

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
@@ -1,10 +1,13 @@
 import { Inject, Injectable } from '@angular/core';
 import { SFProjectProfileDoc } from 'src/app/core/models/sf-project-profile-doc';
 import { DOCUMENT } from './browser-globals';
+import { isGecko } from './utils';
 
 const DEFAULT_SERIF_FONT_FAMILY = 'Charis SIL';
 const DEFAULT_SANS_SERIF_FONT_FAMILY = 'Andika';
 const DEFAULT_FONT_FAMILY = DEFAULT_SERIF_FONT_FAMILY;
+
+const GRAPHITE_SUPPORTED = isGecko();
 
 export const FONT_FACE_FALLBACKS: { [key: string]: string } = {
   // Proprietary fonts typically used for English (where we suspect the specified font isn't that critical)
@@ -37,6 +40,12 @@ export const FONT_FACE_FALLBACKS: { [key: string]: string } = {
   'Karenni Unicode': 'Kay Pho Du',
   'Adobe Arabic': 'Scheherazade New',
   'Simplified Arabic': 'Scheherazade New'
+};
+
+// Only Gecko supports Graphite. When Graphite is not supported, sometimes a non-ideal font is better than trying to
+// use the Graphite font.
+export const NON_GRAPHITE_FALLBACKS: { [key: string]: string } = {
+  'Awami Nastaliq': 'Scheherazade New'
 };
 
 export const FONT_FACE_DEFINITIONS: { [key: string]: string } = {
@@ -106,6 +115,8 @@ export class FontService {
       projectFont = DEFAULT_FONT_FAMILY;
     } else if (FONT_FACE_DEFINITIONS[projectFont] == null && FONT_FACE_FALLBACKS[projectFont] != null) {
       projectFont = FONT_FACE_FALLBACKS[projectFont];
+    } else if (!GRAPHITE_SUPPORTED && NON_GRAPHITE_FALLBACKS[projectFont] != null) {
+      projectFont = NON_GRAPHITE_FALLBACKS[projectFont];
     } else if (FONT_FACE_DEFINITIONS[projectFont] == null) {
       this.warnUnsupportedFont(projectFont);
       projectFont = DEFAULT_FONT_FAMILY;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { FONT_FACE_DEFINITIONS, FontService } from './font.service';
+
+// Example text, only included for frequently used non-Latin fonts
+const EXAMPLE_TEXT = {
+  'Awami Nastaliq':
+    'اقوام متحدہ نے ہر کہیں دے حقوق دی حفاظت تے ودھارے دا جھنڈا اچار کھڻ دا ارادہ کیتا ہوے۔ ایہو ڄئے و حشیانہ کماں دی صورت وچ ظاہر تھئی ہے  ',
+  'Annapurna SIL':
+    '१० दिसम्बर १९४८ को यूनाइटेड नेशन्स की जनरल असेम्बली ने मानव अधिकारों की सार्वभौम घोषणा को स्वीकृत और घोषित किया । इसका पूर्ण पाठ आगे के पृष्ठों में दिया गया है । इस ऐतिहासिक कार्य के बाद ही असेम्बली ने सभी सदस्य देशों से अपील की कि वे इस घोषणा का प्रचार करें और देशों अथवा प्रदेशों की राजनैतिक स्थिति पर आधारित भेदभाव का विचार किए बिना, विशेषतः स्कूलों और अन्य शिक्षा संस्थाओं में इसके प्रचार, प्रदर्शन, पठन और व्याख्या का प्रबन्ध करें ।',
+  Lateef:
+    'شِیلِلیکده، ابراهیمدان داوودا چِنلی بوُلان نِسیلِّر جِمی اوُن دؤرت آرقادئر. داووددان بابئل سوٚرگوٚنینه چِنلی هِم اوُن دؤرت، بابئل سوٚرگوٚنیندِن مِسیحه چِنلی هِم اوُن دؤرت آرقادئر. ۝٢٣ رامادان بیر سِس اِشیدیلدی،  '
+};
+
+// This set of stories is no testing a component, but is intended to show what fonts are available, demonstrate that
+// they all are able to load, demonstrate differences between browsers, and differences between fonts (e.g. line height)
+const meta: Meta = {
+  title: 'Fonts',
+  render: ({ text }) => {
+    const fontService = new FontService(document);
+    const elements = Object.keys(FONT_FACE_DEFINITIONS).map(
+      font =>
+        `<span>${font}</span><span style="font-family: '${fontService.getCSSFontName(font)}'">${
+          EXAMPLE_TEXT[font] ?? text
+        }</span>`
+    );
+    return {
+      template: `<div style="display: grid; grid-template-columns: auto 1fr; gap: 4px;">${elements.join('\n')}</div>`
+    };
+  }
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const AllFonts: Story = {
+  args: { text: 'This is example text.' }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -55,6 +55,10 @@ export function getBrowserEngine(): string {
   return engine == null ? '' : engine.toLowerCase();
 }
 
+export function isGecko(): boolean {
+  return getBrowserEngine() === 'gecko';
+}
+
 export function issuesEmailTemplate(errorId?: string): string {
   const bowser = Bowser.getParser(window.navigator.userAgent);
   const subject: string = translate('issue_email.subject', { siteName: environment.siteName });


### PR DESCRIPTION
A Graphite font, when used in a browser engine that doesn't support it, renders completely wrong. It turns out that for Urdu, using the Arabic script is significantly better, even though it's less readable than the Awami Nastaliq font. I've added it as a fallback in browsers that don't support Graphite.

I've added a story that shows all the fonts we support. This change can be tested by opening the story in both Chrome and Firefox, and using the dev tools to check that the proper font was used in each browser.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2406)
<!-- Reviewable:end -->
