### PR TITLE
Link learn more button on home page to help site

### DIFF
--- a/src/SIL.XForge.Scripture/Pages/Index.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Index.cshtml
@@ -126,7 +126,7 @@
                     @Localizer["Statement"]
                 </div>
                 <div class="statement-buttons flex justify-content-center">
-                    <a asp-page="LearnMore"
+                    <a href="https://help.scriptureforge.org"
                         class="mdl-button mdl-button--raised mdl-button--colored button-lg">@SharedLocalizer[SharedResource.Keys.LearnMore]</a>
                     <a class="mdl-button mdl-button--raised mdl-button--accent button-lg"
                         href="/login?sign-up=true">@SharedLocalizer[SharedResource.Keys.SignUp]</a>


### PR DESCRIPTION
Linking to our help site isn't really ideal, but I think it's better than our extremely outdated learn more page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2410)
<!-- Reviewable:end -->
