### PR TITLE
SF-2580 Add API backend for chapter selection UI

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -34,7 +34,9 @@ export interface DraftConfig {
   alternateTrainingSource?: TranslateSource;
   lastSelectedTrainingBooks: number[];
   lastSelectedTrainingDataFiles: string[];
+  lastSelectedTrainingScriptureRange?: string;
   lastSelectedTranslationBooks: number[];
+  lastSelectedTranslationScriptureRange?: string;
   sendAllSegments: boolean;
   servalConfig?: string;
 }

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -201,11 +201,17 @@ export class SFProjectService extends ProjectService<SFProject> {
                   bsonType: 'string'
                 }
               },
+              lastSelectedTrainingScriptureRange: {
+                bsonType: 'string'
+              },
               lastSelectedTranslationBooks: {
                 bsonType: 'array',
                 items: {
                   bsonType: 'int'
                 }
+              },
+              lastSelectedTranslationScriptureRange: {
+                bsonType: 'string'
               },
               sendAllSegments: {
                 bsonType: 'bool'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -25,7 +25,9 @@ import { TrainingDataService } from '../training-data/training-data.service';
 export interface DraftGenerationStepsResult {
   trainingBooks: number[];
   trainingDataFiles: string[];
+  trainingScriptureRange?: string;
   translationBooks: number[];
+  translationScriptureRange?: string;
   fastTraining: boolean;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -338,7 +338,9 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
       projectId: this.activatedProject.projectId!,
       trainingBooks: result.trainingBooks,
       trainingDataFiles: result.trainingDataFiles,
+      trainingScriptureRange: result.trainingScriptureRange,
       translationBooks: result.translationBooks,
+      translationScriptureRange: result.translationScriptureRange,
       fastTraining: result.fastTraining
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -8,7 +8,9 @@ export interface BuildConfig {
   projectId: string;
   trainingBooks: number[];
   trainingDataFiles: string[];
+  trainingScriptureRange?: string;
   translationBooks: number[];
+  translationScriptureRange?: string;
   fastTraining: boolean;
 }
 

--- a/src/SIL.XForge.Scripture/Models/BuildConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/BuildConfig.cs
@@ -18,19 +18,45 @@ public class BuildConfig
     /// Gets or sets the books to use for training the draft.
     /// </summary>
     /// <value>The numbers of the books to use as the source texts for training.</value>
-    public HashSet<int> TrainingBooks { get; set; } = new HashSet<int>();
+    /// <remarks>
+    /// You should not set this property and <see cref="TrainingScriptureRange"/> at the same time.
+    /// </remarks>
+    public HashSet<int> TrainingBooks { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the DataIds of the files to use for training.
     /// </summary>
     /// <value>The DataIds of the files to use as for training.</value>
-    public HashSet<string> TrainingDataFiles { get; set; } = new HashSet<string>();
+    public HashSet<string> TrainingDataFiles { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the books and chapters to use for training.
+    /// </summary>
+    /// <value>The book ids and chapter numbers separated by semicolons.</value>
+    /// <remarks>
+    /// See https://github.com/sillsdev/serval/wiki/Filtering-Paratext-Project-Data-with-a-Scripture-Range for syntax.
+    /// You should not set this property and <see cref="TrainingBooks"/> at the same time.
+    /// </remarks>
+    public string? TrainingScriptureRange { get; set; }
 
     /// <summary>
     /// Gets or sets the books to use for translation.
     /// </summary>
     /// <value>The numbers of the books to use as the source texts for training.</value>
-    public HashSet<int> TranslationBooks { get; set; } = new HashSet<int>();
+    /// <remarks>
+    /// You should not set this property and <see cref="TranslationScriptureRange"/> at the same time.
+    /// </remarks>
+    public HashSet<int> TranslationBooks { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the books and chapters to use for translation.
+    /// </summary>
+    /// <value>The book ids and chapter numbers separated by semicolons.</value>
+    /// <remarks>
+    /// See https://github.com/sillsdev/serval/wiki/Filtering-Paratext-Project-Data-with-a-Scripture-Range for syntax.
+    /// You should not set this property and <see cref="TranslationBooks"/> at the same time.
+    /// </remarks>
+    public string? TranslationScriptureRange { get; set; }
 
     /// <summary>
     /// Gets or sets the project identifier.

--- a/src/SIL.XForge.Scripture/Models/DraftConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftConfig.cs
@@ -10,8 +10,10 @@ public class DraftConfig
     public bool AlternateTrainingSourceEnabled { get; set; }
     public TranslateSource? AlternateTrainingSource { get; set; }
     public IList<int> LastSelectedTrainingBooks { get; set; } = new List<int>();
+    public string? LastSelectedTrainingScriptureRange { get; set; }
     public IList<string> LastSelectedTrainingDataFiles { get; set; } = new List<string>();
     public IList<int> LastSelectedTranslationBooks { get; set; } = new List<int>();
+    public string? LastSelectedTranslationScriptureRange { get; set; }
     public bool SendAllSegments { get; set; }
     public string? ServalConfig { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
+++ b/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
@@ -36,10 +36,22 @@ public class BuildConfigJsonConverter : JsonConverter<BuildConfig>
             serializer.Serialize(writer, value.TrainingDataFiles);
         }
 
+        if (!string.IsNullOrWhiteSpace(value.TrainingScriptureRange))
+        {
+            writer.WritePropertyName(nameof(value.TrainingScriptureRange));
+            serializer.Serialize(writer, value.TrainingScriptureRange);
+        }
+
         if (value.TranslationBooks.Count > 0)
         {
             writer.WritePropertyName(nameof(value.TranslationBooks));
             serializer.Serialize(writer, value.TranslationBooks);
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.TranslationScriptureRange))
+        {
+            writer.WritePropertyName(nameof(value.TranslationScriptureRange));
+            serializer.Serialize(writer, value.TranslationScriptureRange);
         }
 
         if (value.FastTraining)

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -755,6 +755,21 @@ public class MachineApiService(
         // Ensure that the user has permission on the project
         MachineApi.EnsureProjectPermission(curUserId, projectDoc.Data);
 
+        // Do not allow using scripture ranges with send all segments, as we must send a Paratext project
+        if (
+            projectDoc.Data.TranslateConfig.DraftConfig.SendAllSegments
+            && (
+                !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
+                || !string.IsNullOrWhiteSpace(buildConfig.TranslationScriptureRange)
+            )
+        )
+        {
+            throw new DataNotFoundException(
+                $"You may not pre-translate non-Scripture material and specify "
+                    + $"{nameof(buildConfig.TranslationScriptureRange)} or {nameof(buildConfig.TranslationScriptureRange)}"
+            );
+        }
+
         // Save the selected books
         await projectDoc.SubmitJson0OpAsync(op =>
         {
@@ -769,9 +784,17 @@ public class MachineApiService(
                 _listStringComparer
             );
             op.Set(
+                p => p.TranslateConfig.DraftConfig.LastSelectedTrainingScriptureRange,
+                buildConfig.TrainingScriptureRange
+            );
+            op.Set(
                 p => p.TranslateConfig.DraftConfig.LastSelectedTranslationBooks,
                 buildConfig.TranslationBooks.ToList(),
                 _listIntComparer
+            );
+            op.Set(
+                p => p.TranslateConfig.DraftConfig.LastSelectedTranslationScriptureRange,
+                buildConfig.TranslationScriptureRange
             );
         });
 

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -744,6 +744,23 @@ public class MachineApiService(
         CancellationToken cancellationToken
     )
     {
+        // Ensure that there are no errors in the build configuration
+        if (!string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange) && buildConfig.TrainingBooks.Count > 0)
+        {
+            throw new DataNotFoundException(
+                $"You cannot specify both {nameof(buildConfig.TrainingScriptureRange)}"
+                    + $" and {nameof(buildConfig.TrainingBooks)}."
+            );
+        }
+
+        if (!string.IsNullOrWhiteSpace(buildConfig.TranslationScriptureRange) && buildConfig.TranslationBooks.Count > 0)
+        {
+            throw new DataNotFoundException(
+                $"You cannot specify both {nameof(buildConfig.TranslationScriptureRange)}"
+                    + $" and {nameof(buildConfig.TranslationBooks)}."
+            );
+        }
+
         // Load the project from the realtime service
         await using IConnection conn = await realtimeService.ConnectAsync(curUserId);
         IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(buildConfig.ProjectId);

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1218,7 +1218,11 @@ public class MachineProjectService(
             if (corpus.Value.UploadParatextZipFile)
             {
                 // Since all books are uploaded via the zip file, we need to specify the target books to translate
-                preTranslateCorpusConfig.TextIds = buildConfig.TranslationBooks.Select(Canon.BookNumberToId).ToList();
+                preTranslateCorpusConfig.ScriptureRange = !string.IsNullOrWhiteSpace(
+                    buildConfig.TranslationScriptureRange
+                )
+                    ? buildConfig.TranslationScriptureRange
+                    : string.Join(';', buildConfig.TranslationBooks.Select(Canon.BookNumberToId));
 
                 if (!useAlternateTrainingCorpus)
                 {
@@ -1228,7 +1232,9 @@ public class MachineProjectService(
                         new TrainingCorpusConfig
                         {
                             CorpusId = corpus.Key,
-                            TextIds = buildConfig.TrainingBooks.Select(Canon.BookNumberToId).ToList(),
+                            ScriptureRange = !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
+                                ? buildConfig.TrainingScriptureRange
+                                : string.Join(';', buildConfig.TrainingBooks.Select(Canon.BookNumberToId)),
                         }
                     );
                 }
@@ -1252,7 +1258,9 @@ public class MachineProjectService(
                 if (corpus.Value.UploadParatextZipFile)
                 {
                     // As all books are uploaded via the zip file, specify the source books to train on
-                    trainingCorpusConfig.TextIds = buildConfig.TrainingBooks.Select(Canon.BookNumberToId).ToList();
+                    trainingCorpusConfig.ScriptureRange = !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
+                        ? buildConfig.TrainingScriptureRange
+                        : string.Join(';', buildConfig.TrainingBooks.Select(Canon.BookNumberToId));
                 }
 
                 trainOn.Add(trainingCorpusConfig);

--- a/test/SIL.XForge.Scripture.Tests/Services/BuildConfigJsonConverterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/BuildConfigJsonConverterTests.cs
@@ -23,8 +23,8 @@ public class BuildConfigJsonConverterTests
         var buildConfig = new BuildConfig
         {
             FastTraining = true,
-            TrainingBooks = new HashSet<int> { 1, 2, 3 },
-            TranslationBooks = new HashSet<int> { 4, 5, 6 },
+            TrainingBooks = [1, 2, 3],
+            TranslationBooks = [4, 5, 6],
             ProjectId = Project01,
         };
 
@@ -51,8 +51,8 @@ public class BuildConfigJsonConverterTests
         var serializer = Substitute.For<JsonSerializer>();
         var buildConfig = new BuildConfig
         {
-            TrainingBooks = new HashSet<int> { 1, 2, 3 },
-            TranslationBooks = new HashSet<int> { 4, 5, 6 },
+            TrainingBooks = [1, 2, 3],
+            TranslationBooks = [4, 5, 6],
             ProjectId = Project01,
         };
 
@@ -76,7 +76,7 @@ public class BuildConfigJsonConverterTests
         var converter = new BuildConfigJsonConverter();
         var writer = Substitute.For<JsonWriter>();
         var serializer = Substitute.For<JsonSerializer>();
-        var buildConfig = new BuildConfig { ProjectId = Project01, };
+        var buildConfig = new BuildConfig { ProjectId = Project01 };
 
         // SUT
         converter.WriteJson(writer, buildConfig, serializer);
@@ -94,11 +94,7 @@ public class BuildConfigJsonConverterTests
         var converter = new BuildConfigJsonConverter();
         var writer = Substitute.For<JsonWriter>();
         var serializer = Substitute.For<JsonSerializer>();
-        var buildConfig = new BuildConfig
-        {
-            ProjectId = Project01,
-            TranslationBooks = new HashSet<int> { 1, 2, 3 }
-        };
+        var buildConfig = new BuildConfig { ProjectId = Project01, TranslationBooks = [1, 2, 3], };
 
         // SUT
         converter.WriteJson(writer, buildConfig, serializer);
@@ -118,11 +114,7 @@ public class BuildConfigJsonConverterTests
         var converter = new BuildConfigJsonConverter();
         var writer = Substitute.For<JsonWriter>();
         var serializer = Substitute.For<JsonSerializer>();
-        var buildConfig = new BuildConfig
-        {
-            ProjectId = Project01,
-            TrainingBooks = new HashSet<int> { 1, 2, 3 }
-        };
+        var buildConfig = new BuildConfig { ProjectId = Project01, TrainingBooks = [1, 2, 3], };
 
         // SUT
         converter.WriteJson(writer, buildConfig, serializer);
@@ -142,10 +134,7 @@ public class BuildConfigJsonConverterTests
         var converter = new BuildConfigJsonConverter();
         var writer = Substitute.For<JsonWriter>();
         var serializer = Substitute.For<JsonSerializer>();
-        var buildConfig = new BuildConfig
-        {
-            TrainingDataFiles = new HashSet<string> { Data01, Data02 },
-        };
+        var buildConfig = new BuildConfig { TrainingDataFiles = [Data01, Data02], };
 
         // SUT
         converter.WriteJson(writer, buildConfig, serializer);
@@ -153,6 +142,40 @@ public class BuildConfigJsonConverterTests
         writer.Received().WriteStartObject();
         writer.Received().WritePropertyName(nameof(buildConfig.TrainingDataFiles));
         serializer.Received().Serialize(writer, buildConfig.TrainingDataFiles);
+        writer.Received().WriteEndObject();
+    }
+
+    [Test]
+    public void WriteJson_Serializes_BuildConfig_TrainingScriptureRange()
+    {
+        var converter = new BuildConfigJsonConverter();
+        var writer = Substitute.For<JsonWriter>();
+        var serializer = Substitute.For<JsonSerializer>();
+        var buildConfig = new BuildConfig { TrainingScriptureRange = "MAT;MRK1-2,4", };
+
+        // SUT
+        converter.WriteJson(writer, buildConfig, serializer);
+
+        writer.Received().WriteStartObject();
+        writer.Received().WritePropertyName(nameof(buildConfig.TrainingScriptureRange));
+        serializer.Received().Serialize(writer, buildConfig.TrainingScriptureRange);
+        writer.Received().WriteEndObject();
+    }
+
+    [Test]
+    public void WriteJson_Serializes_BuildConfig_TranslationScriptureRange()
+    {
+        var converter = new BuildConfigJsonConverter();
+        var writer = Substitute.For<JsonWriter>();
+        var serializer = Substitute.For<JsonSerializer>();
+        var buildConfig = new BuildConfig { TrainingScriptureRange = "JHN", };
+
+        // SUT
+        converter.WriteJson(writer, buildConfig, serializer);
+
+        writer.Received().WriteStartObject();
+        writer.Received().WritePropertyName(nameof(buildConfig.TrainingScriptureRange));
+        serializer.Received().Serialize(writer, buildConfig.TrainingScriptureRange);
         writer.Received().WriteEndObject();
     }
 
@@ -183,7 +206,7 @@ public class BuildConfigJsonConverterTests
 
         Assert.IsNotNull(result);
         Assert.IsInstanceOf<BuildConfig>(result);
-        Assert.AreEqual(Project01, result.ProjectId);
+        Assert.AreEqual(Project01, result!.ProjectId);
     }
 
     [Test]
@@ -201,7 +224,7 @@ public class BuildConfigJsonConverterTests
 
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
-        Assert.IsTrue(buildConfig.FastTraining);
+        Assert.IsTrue(buildConfig!.FastTraining);
         CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, buildConfig.TrainingBooks);
         CollectionAssert.AreEqual(new List<int> { 4, 5, 6 }, buildConfig.TranslationBooks);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
@@ -222,7 +245,7 @@ public class BuildConfigJsonConverterTests
 
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
-        Assert.IsFalse(buildConfig.FastTraining);
+        Assert.IsFalse(buildConfig!.FastTraining);
         CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, buildConfig.TrainingBooks);
         CollectionAssert.AreEqual(new List<int> { 4, 5, 6 }, buildConfig.TranslationBooks);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
@@ -243,8 +266,50 @@ public class BuildConfigJsonConverterTests
 
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
-        Assert.IsFalse(buildConfig.FastTraining);
+        Assert.IsFalse(buildConfig!.FastTraining);
         CollectionAssert.AreEqual(new List<string> { Data01, Data02 }, buildConfig.TrainingDataFiles);
+        Assert.AreEqual(Project01, buildConfig.ProjectId);
+    }
+
+    [Test]
+    public void ReadJson_Deserializes_JSON_Object_TrainingScriptureRange()
+    {
+        var converter = new BuildConfigJsonConverter();
+        const string scriptureRange = "MAT;MRK1-2,4";
+        const string jsonString =
+            $"{{\"{nameof(BuildConfig.ProjectId)}\":\"{Project01}\",\"{nameof(BuildConfig.TrainingScriptureRange)}\":\"{scriptureRange}\"}}";
+        using var stringReader = new StringReader(jsonString);
+        using var reader = new JsonTextReader(stringReader);
+        var serializer = new JsonSerializer();
+
+        // SUT
+        var buildConfig = converter.ReadJson(reader, typeof(BuildConfig), null, false, serializer);
+
+        Assert.IsNotNull(buildConfig);
+        Assert.IsInstanceOf<BuildConfig>(buildConfig);
+        Assert.IsFalse(buildConfig!.FastTraining);
+        CollectionAssert.AreEqual(scriptureRange, buildConfig.TrainingScriptureRange);
+        Assert.AreEqual(Project01, buildConfig.ProjectId);
+    }
+
+    [Test]
+    public void ReadJson_Deserializes_JSON_Object_TranslationScriptureRange()
+    {
+        var converter = new BuildConfigJsonConverter();
+        const string scriptureRange = "JHN";
+        const string jsonString =
+            $"{{\"{nameof(BuildConfig.ProjectId)}\":\"{Project01}\",\"{nameof(BuildConfig.TranslationScriptureRange)}\":\"{scriptureRange}\"}}";
+        using var stringReader = new StringReader(jsonString);
+        using var reader = new JsonTextReader(stringReader);
+        var serializer = new JsonSerializer();
+
+        // SUT
+        var buildConfig = converter.ReadJson(reader, typeof(BuildConfig), null, false, serializer);
+
+        Assert.IsNotNull(buildConfig);
+        Assert.IsInstanceOf<BuildConfig>(buildConfig);
+        Assert.IsFalse(buildConfig!.FastTraining);
+        CollectionAssert.AreEqual(scriptureRange, buildConfig.TranslationScriptureRange);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1657,6 +1657,32 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public async Task StartPreTranslationBuildAsync_DoNotAllowScriptureRangesWithSendAllSegments()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.Projects.UpdateAsync(
+            p => p.Id == Project01,
+            u => u.Set(s => s.TranslateConfig.DraftConfig, new DraftConfig { SendAllSegments = true })
+        );
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.StartPreTranslationBuildAsync(
+                    User01,
+                    new BuildConfig
+                    {
+                        ProjectId = Project01,
+                        TrainingScriptureRange = "GEN",
+                        TranslationScriptureRange = "GEN",
+                    },
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
     public async Task StartPreTranslationBuildAsync_SuccessNoTrainingOrTranslationBooks()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1683,6 +1683,50 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void StartPreTranslationBuildAsync_DoNotAllowTrainingScriptureRangeWithTrainingBooks()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.StartPreTranslationBuildAsync(
+                    User01,
+                    new BuildConfig
+                    {
+                        ProjectId = Project01,
+                        TrainingScriptureRange = "GEN",
+                        TrainingBooks = [1],
+                    },
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
+    public void StartPreTranslationBuildAsync_DoNotAllowTranslationScriptureRangeWithTranslationBooks()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () =>
+                env.Service.StartPreTranslationBuildAsync(
+                    User01,
+                    new BuildConfig
+                    {
+                        ProjectId = Project01,
+                        TranslationScriptureRange = "GEN",
+                        TranslationBooks = [1],
+                    },
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
     public async Task StartPreTranslationBuildAsync_SuccessNoTrainingOrTranslationBooks()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -889,11 +889,11 @@ public class MachineProjectServiceTests
                 Arg.Is<TranslationBuildConfig>(
                     b =>
                         b.TrainOn.Count == 1
-                        && b.TrainOn.First().TextIds.SequenceEqual(new[] { "GEN", "EXO" })
+                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
                         && b.TrainOn.First().CorpusId == Corpus01
                         && b.Pretranslate.Count == 1
                         && b.Pretranslate.First().CorpusId == Corpus01
-                        && b.Pretranslate.First().TextIds.SequenceEqual(new[] { "LEV", "NUM" })
+                        && b.Pretranslate.First().ScriptureRange == "LEV;NUM"
                 ),
                 CancellationToken.None
             );
@@ -939,11 +939,11 @@ public class MachineProjectServiceTests
                 Arg.Is<TranslationBuildConfig>(
                     b =>
                         b.TrainOn.Count == 1
-                        && b.TrainOn.First().TextIds.SequenceEqual(new[] { "GEN", "EXO" })
+                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
                         && b.TrainOn.First().CorpusId == Corpus02
                         && b.Pretranslate.Count == 1
                         && b.Pretranslate.First().CorpusId == Corpus01
-                        && b.Pretranslate.First().TextIds.SequenceEqual(new[] { "LEV", "NUM" })
+                        && b.Pretranslate.First().ScriptureRange == "LEV;NUM"
                 ),
                 CancellationToken.None
             );


### PR DESCRIPTION
This PR enables support for specifying chapters for drafting or training when generating a draft. This is done in a backwards compatible way with the current "specify book only" method.

See https://github.com/sillsdev/serval/wiki/Filtering-Paratext-Project-Data-with-a-Scripture-Range for the syntax used.

When the frontend implements the corresponding change, it will need to generate the string using that syntax, and feed it through the updated `BuildConfig` object to the backend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2412)
<!-- Reviewable:end -->
