### PR TITLE
SF-2592 Persist editor tabs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "openid",
     "paginator",
     "paratext",
+    "persistable",
     "prefill",
     "punct",
     "realtime",

--- a/src/RealtimeServer/scriptureforge/models/editor-tab-persist-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/editor-tab-persist-data.ts
@@ -1,0 +1,15 @@
+import { EditorTabGroupType, EditorTabType } from './editor-tab';
+
+/**
+ * Minimal data to persist and reconstruct an editor tab.
+ */
+export interface EditorTabPersistData {
+  tabType: EditorTabType;
+  groupId: EditorTabGroupType;
+  isSelected?: boolean;
+
+  /**
+   * The SF project id if tab is a project/resource tab.
+   */
+  projectId?: string;
+}

--- a/src/RealtimeServer/scriptureforge/models/editor-tab.ts
+++ b/src/RealtimeServer/scriptureforge/models/editor-tab.ts
@@ -1,0 +1,3 @@
+export const editorTabTypes = ['history', 'draft', 'project-source', 'project'] as const;
+export type EditorTabType = typeof editorTabTypes[number];
+export type EditorTabGroupType = 'source' | 'target';

--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config-test-data.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config-test-data.ts
@@ -17,7 +17,8 @@ export function createTestProjectUserConfig(overrides?: RecursivePartial<SFProje
     questionRefsRead: [],
     answerRefsRead: [],
     commentRefsRead: [],
-    noteRefsRead: []
+    noteRefsRead: [],
+    editorTabsOpen: []
   };
 
   return merge(defaultSFProjectUserConfig, overrides);

--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
@@ -1,4 +1,5 @@
 import { ProjectData, PROJECT_DATA_INDEX_PATHS } from '../../common/models/project-data';
+import { EditorTabPersistData } from './editor-tab-persist-data';
 
 export const SF_PROJECT_USER_CONFIGS_COLLECTION = 'sf_project_user_configs';
 export const SF_PROJECT_USER_CONFIG_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
@@ -24,4 +25,5 @@ export interface SFProjectUserConfig extends ProjectData {
   questionRefsRead: string[];
   answerRefsRead: string[];
   commentRefsRead: string[];
+  editorTabsOpen: EditorTabPersistData[];
 }

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
@@ -86,6 +86,21 @@ describe('SFProjectUserConfigMigrations', () => {
       expect(userConfigDoc.data.audioRefsPlayed).not.toBeDefined();
     });
   });
+
+  describe('version 6', () => {
+    it('adds editorTabsOpen property', async () => {
+      const env = new TestEnvironment(5);
+      const conn = env.server.connect();
+      await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {});
+      let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
+      expect(userConfigDoc.data.editorTabsOpen).not.toBeDefined();
+
+      await env.server.migrateIfNecessary();
+
+      userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
+      expect(userConfigDoc.data.editorTabsOpen).toEqual([]);
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
@@ -64,10 +64,22 @@ class SFProjectUserConfigMigration5 extends DocMigration {
   }
 }
 
+class SFProjectUserConfigMigration6 extends DocMigration {
+  static readonly VERSION = 6;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    if (doc.data.editorTabsOpen === undefined) {
+      const op: ObjectInsertOp = { p: ['editorTabsOpen'], oi: [] };
+      await submitMigrationOp(SFProjectUserConfigMigration6.VERSION, doc, [op]);
+    }
+  }
+}
+
 export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = [
   SFProjectUserConfigMigration1,
   SFProjectUserConfigMigration2,
   SFProjectUserConfigMigration3,
   SFProjectUserConfigMigration4,
-  SFProjectUserConfigMigration5
+  SFProjectUserConfigMigration5,
+  SFProjectUserConfigMigration6
 ];

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
@@ -84,6 +84,28 @@ export class SFProjectUserConfigService extends SFProjectDataService<SFProjectUs
         items: {
           bsonType: 'string'
         }
+      },
+      editorTabsOpen: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'object',
+          required: ['tabType', 'groupId'],
+          properties: {
+            tabType: {
+              bsonType: 'string'
+            },
+            groupId: {
+              bsonType: 'string'
+            },
+            isSelected: {
+              bsonType: 'bool'
+            },
+            projectId: {
+              bsonType: 'string'
+            }
+          },
+          additionalProperties: false
+        }
       }
     },
     additionalProperties: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-user-config-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-user-config-doc.ts
@@ -1,3 +1,4 @@
+import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import {
   SFProjectUserConfig,
   SF_PROJECT_USER_CONFIGS_COLLECTION,
@@ -8,4 +9,14 @@ import { ProjectDataDoc } from 'xforge-common/models/project-data-doc';
 export class SFProjectUserConfigDoc extends ProjectDataDoc<SFProjectUserConfig> {
   static readonly COLLECTION = SF_PROJECT_USER_CONFIGS_COLLECTION;
   static readonly INDEX_PATHS = SF_PROJECT_USER_CONFIG_INDEX_PATHS;
+
+  async updateEditorOpenTabs(tabs: EditorTabPersistData[]): Promise<void> {
+    if (this.data == null) {
+      return;
+    }
+
+    await this.submitJson0Op(op => {
+      op.set(puc => puc.editorTabsOpen, tabs);
+    });
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -19,7 +19,8 @@ describe('TabGroupComponent', () => {
       declarations: [TabGroupComponent, TabComponent],
       providers: [
         { provide: TabFactoryService, useValue: { createTab: () => {} } },
-        { provide: TabMenuService, useValue: { getMenuItems: () => of([]) } }
+        { provide: TabMenuService, useValue: { getMenuItems: () => of([]) } },
+        TabStateService
       ]
     }).compileComponents();
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.ts
@@ -1,21 +1,18 @@
 export class TabGroup<TKey, T> {
   selectedIndex: number = 0;
 
-  constructor(readonly groupId: TKey, readonly tabs: T[] = []) {}
+  constructor(readonly groupId: TKey, public tabs: ReadonlyArray<T> = []) {}
 
   setTabs(tabs: Iterable<T>): void {
-    this.tabs.splice(0, this.tabs.length); // Clear tabs for group
-    this.addTabs(tabs);
+    this.tabs = [...tabs];
   }
 
   addTabs(tabs: Iterable<T>): void {
-    for (const tab of tabs) {
-      this.addTab(tab, false);
-    }
+    this.tabs = [...this.tabs, ...tabs];
   }
 
   addTab(tab: T, selectTab: boolean = true): void {
-    this.tabs.push(tab);
+    this.tabs = [...this.tabs, tab];
 
     if (selectTab) {
       this.selectedIndex = this.tabs.length - 1;
@@ -23,7 +20,7 @@ export class TabGroup<TKey, T> {
   }
 
   removeTab(index: number): void {
-    this.tabs.splice(index, 1);
+    this.tabs = this.tabs.filter((_, i) => i !== index);
 
     // Select preceding tab if removed tab is or is before before the currently selected tab
     if (index <= this.selectedIndex) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -12,7 +12,9 @@ describe('TabStateService', () => {
   ];
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [TabStateService]
+    });
     service = TestBed.inject(TabStateService);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -116,11 +116,11 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
     }
 
     // Set the revision
-    this.selectedRevision = revision as Revision;
+    this.selectedRevision = revision;
 
     // Get the snapshot from the paratext service
     await this.paratextService.getSnapshot(this.projectId, this.bookId, this.chapter, revision.key).then(snapshot => {
-      this.revisionSelect.emit({ revision: revision, snapshot: snapshot });
+      this.revisionSelect.emit({ revision, snapshot });
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
@@ -8,7 +8,8 @@ import { I18nService } from 'xforge-common/i18n.service';
 export class HistoryRevisionFormatPipe implements PipeTransform {
   constructor(private readonly i18n: I18nService) {}
 
-  transform(revision: Revision): string {
-    return this.i18n.formatDate(new Date(revision.key));
+  transform(revision: Revision | string): string {
+    const revisionKey = typeof revision === 'string' ? revision : revision.key;
+    return this.i18n.formatDate(new Date(revisionKey));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { EditorTabFactoryService } from './editor-tab-factory.service';
-import { EditorTabType } from './editor-tabs.types';
 
 describe('EditorTabFactoryService', () => {
   let service: EditorTabFactoryService;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
+import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { TabFactoryService } from 'src/app/shared/sf-tab-group';
-import { EditorTabInfo, EditorTabType } from './editor-tabs.types';
+import { EditorTabInfo } from './editor-tabs.types';
 
 @Injectable({
   providedIn: 'root'
@@ -9,36 +10,46 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
   createTab(tabType: EditorTabType, tabOptions?: Partial<EditorTabInfo>): EditorTabInfo {
     switch (tabType) {
       case 'history':
-        return {
-          type: 'history',
-          icon: 'history',
-          headerText: 'History',
-          closeable: true,
-          movable: true
-        };
+        return Object.assign(
+          {
+            type: 'history',
+            icon: 'history',
+            headerText: 'History',
+            closeable: true,
+            movable: true,
+            persist: true
+          },
+          tabOptions
+        );
       case 'draft':
-        return {
-          type: 'draft',
-          icon: 'model_training',
-          headerText: 'Auto Draft',
-          closeable: true,
-          movable: true,
-          unique: true
-        };
+        return Object.assign(
+          {
+            type: 'draft',
+            icon: 'model_training',
+            headerText: 'Auto Draft',
+            closeable: true,
+            movable: true,
+            unique: true
+          },
+          tabOptions
+        );
       case 'project-source':
       case 'project':
         if (!tabOptions?.headerText) {
           throw new Error(`'tabOptions' must include 'headerText'`);
         }
 
-        return {
-          type: tabType,
-          icon: 'book',
-          headerText: tabOptions.headerText,
-          closeable: false,
-          movable: false,
-          unique: true
-        };
+        return Object.assign(
+          {
+            type: tabType,
+            icon: 'book',
+            headerText: tabOptions.headerText,
+            closeable: false,
+            movable: false,
+            unique: true
+          },
+          tabOptions
+        );
       default:
         throw new Error(`Unknown TabType: ${tabType}`);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -206,7 +206,7 @@ class TestEnvironment {
   }
 
   setExistingTabs(tabs: EditorTabInfo[]): void {
-    when(tabStateMock.tabs$).thenReturn(of(tabs));
+    when(tabStateMock.tabs$).thenReturn(of(tabs as any));
   }
 
   setLastCompletedBuildExists(exists: boolean): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -1,5 +1,10 @@
 import { DestroyRef, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  EditorTabGroupType,
+  EditorTabType,
+  editorTabTypes
+} from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { combineLatest, forkJoin, map, Observable, of } from 'rxjs';
 import { shareReplay, switchMap, take } from 'rxjs/operators';
@@ -11,7 +16,7 @@ import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
-import { EditorTabGroupType, EditorTabInfo, EditorTabType, editorTabTypes } from './editor-tabs.types';
+import { EditorTabInfo } from './editor-tabs.types';
 
 @Injectable()
 export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
@@ -1,0 +1,67 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { cloneDeep } from 'lodash-es';
+import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
+import { of, Subject } from 'rxjs';
+import { instance, mock, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { UserService } from 'xforge-common/user.service';
+import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { EditorTabPersistenceService } from './editor-tab-persistence.service';
+
+describe('EditorTabPersistenceService', () => {
+  it('should persist tabs if they are not equal', fakeAsync(() => {
+    const tabs = [
+      { a: 1, b: 2 },
+      { a: 3, b: 4 }
+    ] as unknown as EditorTabPersistData[];
+    const env = new TestEnvironment([]);
+    env.service.persistTabsOpen(tabs);
+    tick();
+    expect(env.pucDoc.updateEditorOpenTabs).toHaveBeenCalledWith(tabs);
+  }));
+
+  it('should not persist tabs if they are equal', fakeAsync(() => {
+    const tabs = [
+      { a: 1, b: 2 },
+      { a: 3, b: 4 }
+    ] as unknown as EditorTabPersistData[];
+    const env = new TestEnvironment(tabs);
+    env.service.persistTabsOpen(tabs);
+    tick();
+    expect(env.pucDoc.updateEditorOpenTabs).not.toHaveBeenCalled();
+  }));
+});
+
+class TestEnvironment {
+  service: EditorTabPersistenceService;
+  pucDoc: SFProjectUserConfigDoc;
+  mockActivatedProjectService: ActivatedProjectService;
+  mockUserService: UserService;
+  mockProjectService: SFProjectService;
+
+  constructor(tabs: EditorTabPersistData[]) {
+    this.pucDoc = {
+      data: createTestProjectUserConfig({
+        editorTabsOpen: cloneDeep(tabs)
+      }),
+      updateEditorOpenTabs: jasmine.createSpy('updateEditorOpenTabs'),
+      changes$: new Subject()
+    } as unknown as SFProjectUserConfigDoc;
+
+    this.mockActivatedProjectService = mock(ActivatedProjectService);
+    this.mockUserService = mock(UserService);
+    this.mockProjectService = mock(SFProjectService);
+
+    when(this.mockActivatedProjectService.projectId$).thenReturn(of('project01'));
+    when(this.mockUserService.currentUserId).thenReturn('user01');
+    when(this.mockProjectService.getUserConfig('project01', 'user01')).thenReturn(Promise.resolve(this.pucDoc));
+
+    this.service = new EditorTabPersistenceService(
+      instance(this.mockActivatedProjectService),
+      instance(this.mockUserService),
+      instance(this.mockProjectService)
+    );
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { isEqual } from 'lodash-es';
+import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
+import { combineLatest, firstValueFrom, Observable, of, startWith, Subject, Subscription, switchMap, tap } from 'rxjs';
+import { distinctUntilChanged, finalize, shareReplay } from 'rxjs/operators';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { UserService } from 'xforge-common/user.service';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EditorTabPersistenceService {
+  private readonly projectUserConfigDoc$: Observable<SFProjectUserConfigDoc> = this.getProjectUserConfigDoc();
+
+  /**
+   * Observable list of open editor tabs.
+   */
+  readonly persistedTabs$: Observable<EditorTabPersistData[]> = this.projectUserConfigDoc$.pipe(
+    switchMap(configDoc => of(configDoc.data?.editorTabsOpen ?? [])),
+    distinctUntilChanged(isEqual)
+  );
+
+  constructor(
+    private readonly activatedProject: ActivatedProjectService,
+    private readonly userService: UserService,
+    private readonly projectService: SFProjectService
+  ) {}
+
+  /**
+   * Persist the specified list of open editor tabs to SFProjectUserConfigDoc.
+   */
+  async persistTabsOpen(tabs: EditorTabPersistData[]): Promise<void> {
+    const pucDoc = await firstValueFrom(this.projectUserConfigDoc$);
+    const existingTabs = pucDoc.data?.editorTabsOpen;
+
+    if (existingTabs != null && !isEqual(existingTabs, tabs)) {
+      await pucDoc.updateEditorOpenTabs(tabs);
+    }
+  }
+
+  /**
+   * Get latest project user config (refetch when project id changes or when project user config changes).
+   */
+  private getProjectUserConfigDoc(): Observable<SFProjectUserConfigDoc> {
+    const pucChanged$ = new Subject<void>();
+    let pucChangesSub: Subscription | undefined;
+
+    return combineLatest([
+      this.activatedProject.projectId$.pipe(filterNullish()),
+      pucChanged$.pipe(startWith(undefined))
+    ]).pipe(
+      switchMap(([projectId]) => this.projectService.getUserConfig(projectId, this.userService.currentUserId)),
+      tap(pucDoc => {
+        pucChangesSub?.unsubscribe();
+        pucChangesSub = pucDoc.changes$.subscribe(() => {
+          pucChanged$.next();
+        });
+      }),
+      finalize(() => pucChangesSub?.unsubscribe()),
+      shareReplay(1) // Replay last value
+    );
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tabs.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tabs.types.ts
@@ -1,13 +1,19 @@
+import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { TabInfo } from 'src/app/shared/sf-tab-group';
-
-export type EditorTabGroupType = 'source' | 'target';
-
-export const editorTabTypes = ['history', 'draft', 'project-source', 'project'] as const;
-export type EditorTabType = (typeof editorTabTypes)[number];
 
 export interface EditorTabInfo extends TabInfo<EditorTabType> {
   /**
    * If set, only a single instance of this tab is allowed with uniqueness determined by tab type and projectId.
    */
   unique?: boolean;
+
+  /**
+   * Whether to persist tab.
+   */
+  persist?: boolean;
+
+  /**
+   * The SF project id if tab is a project/resource tab.
+   */
+  projectId?: string;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/array-util.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/array-util.spec.ts
@@ -1,0 +1,69 @@
+import { moveItemInReadonlyArray, transferItemAcrossReadonlyArrays } from './array-util';
+
+describe('array-util', () => {
+  describe('moveItemInReadonlyArray', () => {
+    it('should move an item from one index to another', () => {
+      const arr: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      expect(moveItemInReadonlyArray(arr, 1, 3)).toEqual([1, 3, 4, 2, 5]);
+      expect(moveItemInReadonlyArray(arr, 3, 1)).toEqual([1, 4, 2, 3, 5]);
+    });
+
+    it('should throw an error if fromIndex is out of bounds', () => {
+      const arr: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      expect(() => moveItemInReadonlyArray(arr, -1, 3)).toThrowError('Invalid index');
+      expect(() => moveItemInReadonlyArray(arr, 5, 3)).toThrowError('Invalid index');
+    });
+
+    it('should throw an error if toIndex is out of bounds', () => {
+      const arr: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      expect(() => moveItemInReadonlyArray(arr, 1, -1)).toThrowError('Invalid index');
+      expect(() => moveItemInReadonlyArray(arr, 1, 5)).toThrowError('Invalid index');
+    });
+
+    it('should return a new array and not mutate the original', () => {
+      const arr: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      const result = moveItemInReadonlyArray(arr, 1, 3);
+      expect(result).not.toBe(arr);
+      expect(arr).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe('transferItemAcrossReadonlyArrays', () => {
+    it('should transfer an item from one array to another', () => {
+      const fromArray: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      const toArray: ReadonlyArray<number> = [6, 7, 8, 9, 10];
+
+      const [newFromArray1, newToArray1] = transferItemAcrossReadonlyArrays(fromArray, toArray, 1, 3);
+      expect(newFromArray1).toEqual([1, 3, 4, 5]);
+      expect(newToArray1).toEqual([6, 7, 8, 2, 9, 10]);
+
+      const [newFromArray2, newToArray2] = transferItemAcrossReadonlyArrays(fromArray, toArray, 0, 5);
+      expect(newFromArray2).toEqual([2, 3, 4, 5]);
+      expect(newToArray2).toEqual([6, 7, 8, 9, 10, 1]);
+    });
+
+    it('should throw an error if fromIndex is out of bounds', () => {
+      const fromArray: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      const toArray: ReadonlyArray<number> = [6, 7, 8, 9, 10];
+      expect(() => transferItemAcrossReadonlyArrays(fromArray, toArray, -1, 3)).toThrowError('Invalid index');
+      expect(() => transferItemAcrossReadonlyArrays(fromArray, toArray, 5, 3)).toThrowError('Invalid index');
+    });
+
+    it('should throw an error if toIndex is out of bounds', () => {
+      const fromArray: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      const toArray: ReadonlyArray<number> = [6, 7, 8, 9, 10];
+      expect(() => transferItemAcrossReadonlyArrays(fromArray, toArray, 1, -1)).toThrowError('Invalid index');
+      expect(() => transferItemAcrossReadonlyArrays(fromArray, toArray, 1, 6)).toThrowError('Invalid index');
+    });
+
+    it('should return new arrays and not mutate the original arrays', () => {
+      const fromArray: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+      const toArray: ReadonlyArray<number> = [6, 7, 8, 9, 10];
+      const [newFromArray, newToArray] = transferItemAcrossReadonlyArrays(fromArray, toArray, 1, 3);
+      expect(newFromArray).not.toBe(fromArray);
+      expect(newToArray).not.toBe(toArray);
+      expect(fromArray).toEqual([1, 2, 3, 4, 5]);
+      expect(toArray).toEqual([6, 7, 8, 9, 10]);
+    });
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/array-util.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/array-util.ts
@@ -1,0 +1,50 @@
+/**
+ * Moves an item at one index in a ReadonlyArray to another and returns the new array.
+ * @param arr The ReadonlyArray to move the item within
+ * @param fromIndex The index of the item to move
+ * @param toIndex The index to move the item to
+ * @throws {Error} If fromIndex or toIndex are out of bounds
+ * @returns A new array with the item moved
+ */
+export function moveItemInReadonlyArray<T>(
+  arr: ReadonlyArray<T>,
+  fromIndex: number,
+  toIndex: number
+): ReadonlyArray<T> {
+  if (fromIndex < 0 || fromIndex >= arr.length || toIndex < 0 || toIndex >= arr.length) {
+    throw new Error('Invalid index');
+  }
+
+  const result = [...arr];
+  const [removed] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, removed);
+
+  return result;
+}
+
+/**
+ * Moves an item from one ReadonlyArray to another and returns two new arrays.
+ * @param fromArray The ReadonlyArray to move the item from
+ * @param toArray The ReadonlyArray to move the item to
+ * @param fromIndex The index of the item to move
+ * @param toIndex The index to move the item to
+ * @throws {Error} If fromIndex or toIndex are out of bounds
+ * @returns A tuple with two new arrays, the first with the item removed and the second with the item added
+ */
+export function transferItemAcrossReadonlyArrays<T>(
+  fromArray: ReadonlyArray<T>,
+  toArray: ReadonlyArray<T>,
+  fromIndex: number,
+  toIndex: number
+): [T[], T[]] {
+  if (fromIndex < 0 || fromIndex >= fromArray.length || toIndex < 0 || toIndex > toArray.length) {
+    throw new Error('Invalid index');
+  }
+
+  const newFromArray = [...fromArray];
+  const newToArray = [...toArray];
+  const [removed] = newFromArray.splice(fromIndex, 1);
+  newToArray.splice(toIndex, 0, removed);
+
+  return [newFromArray, newToArray];
+}

--- a/src/SIL.XForge.Scripture/Models/EditorTabPersistData.cs
+++ b/src/SIL.XForge.Scripture/Models/EditorTabPersistData.cs
@@ -1,0 +1,27 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Minimal data to persist and reconstruct an editor tab.
+/// </summary>
+public class EditorTabPersistData
+{
+    /// <summary>
+    /// Corresponds to EditorTabType.
+    /// </summary>
+    public string TabType { get; set; }
+
+    /// <summary>
+    /// Which tab group this tab belongs to.
+    /// </summary>
+    public string GroupId { get; set; }
+
+    /// <summary>
+    /// Whether the tab is selected within its group.
+    /// </summary>
+    public bool? IsSelected { get; set; }
+
+    /// <summary>
+    /// The SF project id if tab is a project/resource tab.
+    /// </summary>
+    public string? ProjectId { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -20,12 +20,13 @@ public class SFProjectUserConfig : ProjectData
     public int? SelectedSegmentChecksum { get; set; }
 
     /// <summary>Ids of notes (not threads) which the user has read.</summary>
-    public List<string> NoteRefsRead { get; set; } = new List<string>();
+    public List<string> NoteRefsRead { get; set; } = [];
 
     // checking
-    public List<string> QuestionRefsRead { get; set; } = new List<string>();
-    public List<string> AnswerRefsRead { get; set; } = new List<string>();
-    public List<string> CommentRefsRead { get; set; } = new List<string>();
+    public List<string> QuestionRefsRead { get; set; } = [];
+    public List<string> AnswerRefsRead { get; set; } = [];
+    public List<string> CommentRefsRead { get; set; } = [];
+    public List<EditorTabPersistData> EditorTabsOpen { get; set; } = [];
     public string? SelectedQuestionRef { get; set; }
     public bool BiblicalTermsEnabled { get; set; }
 }


### PR DESCRIPTION
This PR adds persistence to the editor tabs.  Tab state is stored in `SFProjectUserConfig`.  Page reloads and route changes should maintain the tab state with the caveat that history does not currently maintain the last selected revision (it resets to the first revision in the list).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2413)
<!-- Reviewable:end -->
