### PR TITLE
SF-2673 Gracefully handle Serval outages in the editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -146,6 +146,7 @@ describe('DraftGenerationComponent', () => {
             draftConfig: {
               alternateTrainingSourceEnabled: false
             },
+            preTranslate: true,
             projectType: ProjectType.BackTranslation,
             source: {
               projectRef: 'testSourceProjectId',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -242,11 +242,15 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     );
 
     this.subscribe(
-      this.activatedProject.projectId$.pipe(
+      this.activatedProject.projectDoc$.pipe(
         filterNullish(),
-        switchMap(projectId =>
-          this.draftGenerationService.getLastCompletedBuild(projectId).pipe(map(build => !isEmpty(build)))
-        )
+        switchMap(projectDoc => {
+          // Pre-translation must be enabled for the project
+          if (!(projectDoc.data?.translateConfig.preTranslate ?? false)) {
+            return of(false);
+          }
+          return this.draftGenerationService.getLastCompletedBuild(projectDoc.id).pipe(map(build => !isEmpty(build)));
+        })
       ),
       (hasAnyCompletedBuild: boolean) => {
         this.hasAnyCompletedBuild = hasAnyCompletedBuild;
@@ -415,17 +419,21 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   private pollBuild(): void {
     this.jobSubscription?.unsubscribe();
     this.jobSubscription = this.subscribe(
-      this.activatedProject.projectId$.pipe(
+      this.activatedProject.projectDoc$.pipe(
         filterNullish(),
-        switchMap(projectId =>
-          this.draftGenerationService
-            .getBuildProgress(projectId)
+        switchMap(projectDoc => {
+          // Pre-translation must be enabled for the project
+          if (!(projectDoc.data?.translateConfig.preTranslate ?? false)) {
+            return of(undefined);
+          }
+          return this.draftGenerationService
+            .getBuildProgress(projectDoc.id)
             .pipe(
               switchMap((job: BuildDto | undefined) =>
-                this.isDraftInProgress(job) ? this.draftGenerationService.pollBuildProgress(projectId) : of(job)
+                this.isDraftInProgress(job) ? this.draftGenerationService.pollBuildProgress(projectDoc.id) : of(job)
               )
-            )
-        )
+            );
+        })
       ),
       (job?: BuildDto) => {
         this.draftJob = job;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -443,35 +443,51 @@ describe('DraftGenerationService', () => {
   });
 
   describe('draftExists', () => {
-    it('should return true if draft exists', done => {
+    it('should return true if draft exists', fakeAsync(() => {
+      const book = 43;
+      const chapter = 3;
       const preTranslationData = {
-        data: {
-          preTranslations: [
-            { reference: 'verse_3_16', translation: 'For God so loved the world' },
-            { reference: 'verse_1_1', translation: 'In the beginning was the Word' }
-          ]
-        }
+        preTranslations: [
+          { reference: 'verse_3_16', translation: 'For God so loved the world' },
+          { reference: 'verse_1_1', translation: 'In the beginning was the Word' }
+        ]
       };
 
-      httpClient.get = jasmine.createSpy().and.returnValue(of(preTranslationData));
-      service.draftExists(projectId, 43, 3).subscribe(result => {
+      // SUT
+      service.draftExists(projectId, book, chapter).subscribe(result => {
         expect(result).toBe(true);
-        done();
       });
-    });
+      tick();
 
-    it('should return false if draft does not exist', done => {
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(preTranslationData);
+      tick();
+    }));
+
+    it('should return false if draft does not exist', fakeAsync(() => {
+      const book = 43;
+      const chapter = 3;
       const preTranslationData = {
-        data: {
-          preTranslations: []
-        }
+        preTranslations: []
       };
 
-      httpClient.get = jasmine.createSpy().and.returnValue(of(preTranslationData));
-      service.draftExists(projectId, 43, 3).subscribe(result => {
+      // SUT
+      service.draftExists(projectId, book, chapter).subscribe(result => {
         expect(result).toBe(false);
-        done();
       });
-    });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(preTranslationData);
+      tick();
+    }));
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -45,7 +45,7 @@ export class DraftGenerationService {
   }
 
   /**
-   * Gets pretranslation build job state for specified project.
+   * Gets pre-translation build job state for specified project.
    * @param projectId The SF project id for the target translation.
    * @returns An observable BuildDto describing the state and progress of the current build job,
    * or the latest build job if no build is currently running, or undefined if no build has ever
@@ -62,7 +62,7 @@ export class DraftGenerationService {
         if (err.status === 403 || err.status === 404) {
           return of(undefined);
         }
-        return throwError(err);
+        return throwError(() => err);
       })
     );
   }
@@ -74,6 +74,9 @@ export class DraftGenerationService {
    * or undefined if no build has ever been completed.
    */
   getLastCompletedBuild(projectId: string): Observable<BuildDto | undefined> {
+    if (!this.onlineStatusService.isOnline) {
+      return of(undefined);
+    }
     return this.httpClient
       .get<BuildDto>(`translation/engines/project:${projectId}/actions/getLastCompletedPreTranslationBuild`)
       .pipe(
@@ -83,13 +86,13 @@ export class DraftGenerationService {
           if (err.status === 403 || err.status === 404) {
             return of(undefined);
           }
-          return throwError(err);
+          return throwError(() => err);
         })
       );
   }
 
   /**
-   * Starts a pretranslation build job if one is not already active.
+   * Starts a pre-translation build job if one is not already active.
    * @param buildConfig The build configuration.
    * @returns An observable BuildDto describing the state and progress of a currently active or newly started build job.
    */
@@ -111,7 +114,7 @@ export class DraftGenerationService {
   }
 
   /**
-   * Cancels any pretranslation builds for the specified project.
+   * Cancels any pre-translation builds for the specified project.
    * @param projectId The SF project id for the target translation.
    */
   cancelBuild(projectId: string): Observable<void> {
@@ -122,30 +125,33 @@ export class DraftGenerationService {
         if (err.status === 404) {
           return EMPTY;
         }
-        return throwError(err);
+        return throwError(() => err);
       })
     );
   }
 
   /**
-   * Gets the pretranslations for the specified book/chapter using the last completed build.
+   * Gets the pre-translations for the specified book/chapter using the last completed build.
    * @param projectId The SF project id for the target translation.
    * @param book The book number.
    * @param chapter The chapter number.
    * @returns An observable dictionary of 'segmentRef -> segment text',
-   * or an empty dictionary if no pretranslations exist.
+   * or an empty dictionary if no pre-translations exist.
    */
   getGeneratedDraft(projectId: string, book: number, chapter: number): Observable<DraftSegmentMap> {
+    if (!this.onlineStatusService.isOnline) {
+      return of({});
+    }
     return this.httpClient
       .get<PreTranslationData>(`translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}`)
       .pipe(
         map(res => (res.data && this.toDraftSegmentMap(res.data.preTranslations)) ?? {}),
         catchError(err => {
-          // If no pretranslations exist, return empty dictionary
+          // If no pre-translations exist, return empty dictionary
           if (err.status === 403 || err.status === 404 || err.status === 409) {
             return of({});
           }
-          return throwError(err);
+          return throwError(() => err);
         })
       );
   }
@@ -159,6 +165,9 @@ export class DraftGenerationService {
    * The 405 error that occurs when there is no USFM support is thrown to the caller.
    */
   getGeneratedDraftDeltaOperations(projectId: string, book: number, chapter: number): Observable<DeltaOperation[]> {
+    if (!this.onlineStatusService.isOnline) {
+      return of([]);
+    }
     return this.httpClient
       .get<Snapshot<TextData> | undefined>(
         `translation/engines/project:${projectId}/actions/pretranslate/${book}_${chapter}/delta`
@@ -187,7 +196,7 @@ export class DraftGenerationService {
   }
 
   /**
-   * Calls the machine api to start a pretranslation build job.
+   * Calls the machine api to start a pre-translation build job.
    * This should only be called if no build is currently active.
    * @param buildConfig The build configuration.
    */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4204,6 +4204,9 @@ class TestEnvironment {
       projectProfileData.translateConfig.translationSuggestionsEnabled =
         data.translateConfig.translationSuggestionsEnabled;
     }
+    if (data.translateConfig?.preTranslate != null) {
+      projectProfileData.translateConfig.preTranslate = data.translateConfig.preTranslate;
+    }
     if (data.translateConfig?.source !== undefined) {
       projectProfileData.translateConfig.source = merge(
         projectProfileData.translateConfig.source,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -279,8 +279,7 @@ class TestEnvironment {
 
   set isOnline(value: boolean) {
     this.testOnlineStatusService.setIsOnline(value);
-    this.fixture.detectChanges();
-    tick();
+    this.wait();
   }
 
   closeDialog(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -195,6 +195,9 @@ class TestEnvironment {
   readonly projectDoc = {
     id: 'project1',
     data: createTestProjectProfile({
+      translateConfig: {
+        preTranslate: true
+      },
       userRoles: this.rolesByUser
     })
   } as SFProjectProfileDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -46,7 +46,9 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
           of(projectDoc),
           this.onlineStatus.onlineStatus$.pipe(
             switchMap(isOnline =>
-              isOnline ? this.draftGenerationService.getLastCompletedBuild(projectDoc.id) : of(undefined)
+              isOnline && (projectDoc.data?.translateConfig.preTranslate ?? false)
+                ? this.draftGenerationService.getLastCompletedBuild(projectDoc.id)
+                : of(undefined)
             )
           ),
           this.tabState.tabs$

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -70,7 +70,13 @@
       </mat-card-content>
       <mat-divider></mat-divider>
       <mat-card-actions>
-        <button id="retrain-button" mat-button [disabled]="isTraining" type="button" (click)="startTraining()">
+        <button
+          id="retrain-button"
+          mat-button
+          [disabled]="isTraining || !isOnline"
+          type="button"
+          (click)="startTraining()"
+        >
           {{ isTraining ? t("training") : t("retrain") }}
         </button>
       </mat-card-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -356,8 +356,7 @@ class TestEnvironment {
 
   set isOnline(value: boolean) {
     this.testOnlineStatusService.setIsOnline(value);
-    this.fixture.detectChanges();
-    tick();
+    this.wait();
   }
 
   setCurrentUser(userId: string = 'user01'): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -182,7 +182,7 @@
     "report_problem": "Report problem",
     "sign_up_for_drafting": "Sign up for drafting",
     "suggested_workflow": "A suggested workflow is to draft and edit one book before generating a draft for the next book.",
-    "temporarily_unavailable": "Drafting is temporarily unavailable",
+    "temporarily_unavailable": "Generating drafts is temporarily unavailable.",
     "warning_generation_faulted": "Last generation attempt failed. Click [em]\"{{ generateButtonText }}\"[/em] below to try again."
   },
   "draft_generation_steps": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -182,6 +182,7 @@
     "report_problem": "Report problem",
     "sign_up_for_drafting": "Sign up for drafting",
     "suggested_workflow": "A suggested workflow is to draft and edit one book before generating a draft for the next book.",
+    "temporarily_unavailable": "Drafting is temporarily unavailable",
     "warning_generation_faulted": "Last generation attempt failed. Click [em]\"{{ generateButtonText }}\"[/em] below to try again."
   },
   "draft_generation_steps": {
@@ -518,6 +519,7 @@
     "suggestion_engine": "Suggestion Engine",
     "trained_segments": "trained segments",
     "training": "Training...",
+    "training_unavailable": "Training is temporary unavailable",
     "translate_overview": "Translate Overview",
     "translated_segments": "{{ translatedSegments }} of {{ total }} segments"
   },


### PR DESCRIPTION
This PR updates our use of Serval to handle more gracefully the following scenarios:

 * Serval being offline (but Scripture Forge online)
 * Scripture Forge being offline
 * The user's connection being offline

This is achieved by limiting querying of the machine-api to projects that have pre-translation drafting enabled, and by handling most errors thrown by the machine-api when communicating with the draft generation service. When an error occurs with machine-api, a small red notice is displayed at the bottom of the screen:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/585d1923-24df-48de-9920-abcc77296e9c)

Also, the draft generate service's tests have been rewritten to mock the HTTP requests correctly, as this was required for the online status service to function correctly in tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2414)
<!-- Reviewable:end -->
