### PR TITLE
Update build-and-test to prevent merging fdescribe and fit

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,6 +81,10 @@ jobs:
       - name: "Build: Frontend"
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run build
 
+      - name: "Test: Ensure tests not focused on a subset"
+        # grep returns code 123 when no matches are found. The operator ! negates the exit code.
+        run: |
+          ! git ls-files | grep "\\.spec\\.ts" | xargs grep -P "^\s*(fdescribe|fit)\("
       - name: "Test: RealtimeServer"
         run: cd src/RealtimeServer && npm run test:ci
       - name: "Test: Backend"


### PR DESCRIPTION
It's very easy to accidentally include `fdescribe` and `fit` when opening a PR. This has happened multiple times, most recently in #2373 (which actually has an approved review, and I was about to merge).

This PR updates the build workflow to grep for `fdescribe(` and `fit(` across all `.spec.ts` files, and fails the build if they are present.

It's also possible to accidentally include `xdescribe` and `xit`, but sometimes those will be intentional, and generally it's only a few tests that would be skipped over.

This PR changes a `describe` to `fdescribe` to demonstrate that the change works. Therefore, it deliberately fails the build. After being reviewed, I will revert that one change so it can be merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2416)
<!-- Reviewable:end -->
