### PR TITLE
Fix test warnings about projectUserConfigDoc not being needed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
@@ -34,7 +34,6 @@ const mockedSFProjectUserConfigDoc = mock(SFProjectUserConfigDoc);
   template: `<app-checking-question
     #question
     [questionDoc]="questionDoc"
-    [projectUserConfigDoc]="projectUserConfigDoc"
     (audioPlayed)="played = true"
   ></app-checking-question>`
 })


### PR DESCRIPTION
This property was removed from `checking-question.component.ts` in #2374

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2418)
<!-- Reviewable:end -->
