### PR TITLE
Add warning for admins on live site

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -5,6 +5,8 @@
     [class.mat-progress-bar--closed]="isAppLoading !== true"
   ></mat-progress-bar>
   <header [class.overlay-drawer]="!isDrawerPermanent" [dir]="i18n.direction">
+    <!-- site admin notice is deliberately only shown on live site, as a warning that actions impact live projects -->
+    <span class="site-admin" *ngIf="isLive && isSystemAdmin">site admin</span>
     <mat-toolbar color="primary">
       <mat-toolbar-row>
         <button mat-icon-button *ngIf="!isDrawerPermanent && isProjectSelected" (click)="toggleDrawer()">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -235,3 +235,17 @@ header {
   flex-direction: column;
   width: 255px;
 }
+
+.site-admin {
+  position: absolute;
+  background: red;
+  color: white;
+  font-family: monospace;
+  padding: 0.3em;
+  margin: auto;
+  left: 0;
+  right: 0;
+  width: 100px;
+  text-align: center;
+  z-index: 10;
+}


### PR DESCRIPTION
It's easy to forget when you are logged into the live site as an admin, since we often have SF opened in development mode, and it looks identical. This change adds a warning in the banner that is only shown to admins on the live site.

I considered having it be shown on QA as well, and weighed these factors:
- The purpose of QA is to be a simulation of what live does.
- The purpose of this features is to warn admins that they are on the live site, so actions taken have real-world implications.

I believe the second factor weighs a lot more heavily, and therefore only enabled this for live.

Here's what it looks like:

![](https://github.com/sillsdev/web-xforge/assets/6140710/8854ceda-afac-48d9-b7d1-109b5912952d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2419)
<!-- Reviewable:end -->
