### PR TITLE
Add webhook secret to build script

### DIFF
--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -25,7 +25,8 @@ cat <<EOF > "$BUILD_OUTPUT/app/secrets.json"
   },
   "Serval": {
     "ClientId": "${SERVAL_CLIENT_ID}",
-    "ClientSecret": "${SERVAL_CLIENT_SECRET}"
+    "ClientSecret": "${SERVAL_CLIENT_SECRET}",
+    "WebhookSecret": "${SERVAL_WEBHOOK_SECRET}"
   },
   "Auth": {
     "BackendClientSecret": "${AUTH_BACKEND_SECRET}",


### PR DESCRIPTION
This PR adds support for the webhook secret to the build script.

Before this script is merged, `SERVAL_WEBHOOK_SECRET` will need to be set up in TeamCity (I can supply the QA and Prod secrets via PM when this needs to be done).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2420)
<!-- Reviewable:end -->
