### PR TITLE
Log response times from Paratext registry

### DIFF
--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
 using SIL.XForge.Models;
@@ -14,16 +15,19 @@ public class InternetSharedRepositorySourceProvider : IInternetSharedRepositoryS
     private readonly IJwtTokenHelper _jwtTokenHelper;
     private readonly IOptions<SiteOptions> _siteOptions;
     private readonly IHgWrapper _hgWrapper;
+    private readonly ILogger<InternetSharedRepositorySourceProvider> _logger;
 
     public InternetSharedRepositorySourceProvider(
         IJwtTokenHelper jwtTokenHelper,
         IOptions<SiteOptions> siteOptions,
-        IHgWrapper hgWrapper
+        IHgWrapper hgWrapper,
+        ILogger<InternetSharedRepositorySourceProvider> logger
     )
     {
         _jwtTokenHelper = jwtTokenHelper;
         _siteOptions = siteOptions;
         _hgWrapper = hgWrapper;
+        _logger = logger;
     }
 
     public IInternetSharedRepositorySource GetSource(
@@ -49,7 +53,8 @@ public class InternetSharedRepositorySourceProvider : IInternetSharedRepositoryS
             jwtClient,
             _hgWrapper,
             ptUser,
-            sendReceiveServerUri
+            sendReceiveServerUri,
+            _logger
         );
         source.RefreshToken(userSecret.ParatextTokens.AccessToken);
         return source;

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -7,7 +7,8 @@
       "SIL.XForge.Services.EmailService": "Warning",
       "SIL.XForge.Scripture.Services.ParatextService": "Warning",
       "SIL.Machine.WebApi.Services.EngineRuntime": "Information",
-      "SIL.XForge.Scripture.Services.ParatextSyncRunner": "Information"
+      "SIL.XForge.Scripture.Services.ParatextSyncRunner": "Information",
+      "SIL.XForge.Scripture.Services.InternetSharedRepositorySourceProvider": "Information"
     }
   },
   "AllowedHosts": "*",

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -83,7 +83,8 @@ public class InternetSharedRepositorySourceProviderTests
             Provider = new InternetSharedRepositorySourceProvider(
                 MockJwtTokenHelper,
                 siteOptions,
-                Substitute.For<IHgWrapper>()
+                Substitute.For<IHgWrapper>(),
+                new MockLogger<InternetSharedRepositorySourceProvider>()
             );
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Paratext.Data;
 using Paratext.Data.Users;
 using SIL.XForge.Scripture.Models;
+using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -71,7 +72,8 @@ public class JwtInternetSharedRepositorySourceTests
                 mockPTRegistryClient,
                 Substitute.For<IHgWrapper>(),
                 ptUser,
-                "sr-server-uri"
+                "sr-server-uri",
+                new MockLogger<InternetSharedRepositorySourceProvider>()
             );
             MockPTArchivesClient = Substitute.For<RESTClient>("pt-archives-server.example.com", "product-version-123");
             RepoSource.Configure().GetClient().Returns(MockPTArchivesClient);


### PR DESCRIPTION
The registry seems to be slow a lot of the time, but not all of the time. We don't have concrete data. This PR adds logging regarding response times so we can analyze whether this is the cause of our problems, and determine if/when the problem is actually fixed.

This is not an ideal solution, but it's quick.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2423)
<!-- Reviewable:end -->
