### PR TITLE
Disable Chromatic snapshot of ButtonWithIcon story

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.stories.ts
@@ -40,7 +40,13 @@ const Template: Story = {
   }
 };
 
-export const ButtonWithIcon: Story = { ...Template };
+export const ButtonWithIcon: Story = {
+  ...Template,
+  parameters: {
+    // Disabled because the tooltip keeps causing the snapshot to be different by a few pixels
+    chromatic: { disableSnapshot: true }
+  }
+};
 
 export const ButtonWithText: Story = {
   ...Template,


### PR DESCRIPTION
This story keeps creating changes in the Chromatic diff

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2431)
<!-- Reviewable:end -->
