### PR TITLE
Update Codecov GHA to use token

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,9 @@ jobs:
             -targetdir:coverage \
             "-reporttypes:HTML;TeamCitySummary"
       - name: "Coverage: Publish to Codecov"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build-production:
     name: "Production build and test"


### PR DESCRIPTION
This PR updates the Codecov GHA to use the token which is configured in GitHub Settings.

The success of this PR is determined by the presence of the comment by Codecov below.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2436)
<!-- Reviewable:end -->
