### PR TITLE
SF-2719 Fix 403 and 404 errors in the Serval Admin area

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.spec.ts
@@ -36,12 +36,24 @@ describe('cache service', () => {
     ]
   }));
   describe('load all texts', () => {
+    it('does not get texts from project service if no permission', fakeAsync(async () => {
+      const env = new TestEnvironment();
+      when(mockedPermissionService.canAccessText(anything())).thenResolve(false);
+      await env.service.cache(env.projectDoc);
+      env.wait();
+
+      verify(mockedProjectService.getText(anything())).times(0);
+
+      flush();
+      expect(true).toBeTruthy();
+    }));
+
     it('gets all texts from project service', fakeAsync(async () => {
       const env = new TestEnvironment();
       await env.service.cache(env.projectDoc);
       env.wait();
 
-      verify(mockedProjectService.getText(anything())).times(200 * 100);
+      verify(mockedProjectService.getText(anything())).times(200 * 100 * 2);
 
       flush();
       expect(true).toBeTruthy();
@@ -74,7 +86,6 @@ describe('cache service', () => {
 
     it('gets the source texts if they are present and the user can access', fakeAsync(async () => {
       const env = new TestEnvironment();
-      when(mockedPermissionService.canAccessText(anything())).thenResolve(true);
       when(mockedPermissionService.canAccessText(deepEqual(new TextDocId('sourceId', 0, 0, 'target')))).thenResolve(
         false
       ); //remove access for one source doc
@@ -109,6 +120,7 @@ class TestEnvironment {
     });
 
     when(mockedProjectDoc.data).thenReturn(data);
+    when(mockedPermissionService.canAccessText(anything())).thenResolve(true);
   }
 
   createTexts(): TextInfo[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache-service.ts
@@ -34,7 +34,9 @@ export class CacheService {
           }
 
           const textDocId = new TextDocId(project.id, text.bookNum, chapter.number, 'target');
-          await this.projectService.getText(textDocId);
+          if (await this.permissionsService.canAccessText(textDocId)) {
+            await this.projectService.getText(textDocId);
+          }
 
           if (text.hasSource && sourceId != null) {
             const sourceTextDocId = new TextDocId(sourceId, text.bookNum, chapter.number, 'target');


### PR DESCRIPTION
This PR fixes 403 and 404 errors that have occurred in the Serval Administration area on production.

The 404 errors are caused by a project not being on disk, because it was never synced successfully in the first place. When this state occurs, a more informative error is displayed to the Serval Administrator.

The 403 errors are caused the the cache service attempting to background cache texts that the Serval Administrator does not have access to (and does not need access to). To resolve this, a permission check is performed before the cache service attempts to retrieve a text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2437)
<!-- Reviewable:end -->
