### PR TITLE
SF-2718 Add button to run webhook manually

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -561,6 +561,7 @@ describe('ChapterAudioDialogComponent', () => {
     expect(env.wrapperAudio.classList.contains('valid')).toBe(true);
     expect(env.wrapperTiming.classList.contains('valid')).toBe(true);
 
+    await env.component.audioUpdate(env.audioFile);
     await env.component.prepareTimingFileUpload(anything());
     await env.component.save();
     await env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
-import { mock } from 'ts-mockito';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { anything, mock, verify } from 'ts-mockito';
 import { CommandService } from 'xforge-common/command.service';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RetryingRequestService } from 'xforge-common/retrying-request.service';
@@ -50,6 +50,16 @@ describe('ServalAdministrationService', () => {
       request.flush(mockBlob);
       env.httpTestingController.verify();
     });
+  });
+
+  describe('onlineRetrievePreTranslationStatus', () => {
+    it('should invoke the command service', fakeAsync(async () => {
+      const env = new TestEnvironment();
+      const id = '1234567890abcdef';
+      await env.service.onlineRetrievePreTranslationStatus(id);
+      verify(mockedCommandService.onlineInvoke(anything(), 'retrievePreTranslationStatus', anything())).once();
+      expect().nothing();
+    }));
   });
 
   class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
@@ -44,4 +44,14 @@ export class ServalAdministrationService extends ProjectService<SFProjectProfile
   isResource(paratextId?: string): boolean {
     return (paratextId?.length ?? 0) === 16;
   }
+
+  /**
+   * Starts a job to retrieve the pre-translation status for a project.
+   * This is the equivalent of running the webhook.
+   * @param projectId The Scripture Forge project identifier.
+   * @returns An promise.
+   */
+  onlineRetrievePreTranslationStatus(projectId: string): Promise<void> {
+    return this.onlineInvoke<void>('retrievePreTranslationStatus', { projectId });
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -2,9 +2,27 @@
 <a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
 
 <h2>Pre-Translation Configuration</h2>
-<mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)" [disabled]="!isOnline">
-  Pre-Translation Drafting Enabled
-</mat-checkbox>
+<div class="admin-tool">
+  <div class="admin-tool-control">
+    <mat-checkbox [checked]="preTranslate" (change)="onUpdatePreTranslate($event.checked)" [disabled]="!isOnline">
+      Pre-Translation Drafting Enabled
+    </mat-checkbox>
+  </div>
+  <div class="admin-tool-control">
+    <button
+      id="run-webhook"
+      mat-raised-button
+      color="primary"
+      (click)="retrievePreTranslationStatus()"
+      [disabled]="!isOnline"
+    >
+      Run webhook to update draft status
+    </button>
+    <app-info
+      text="This will check Serval for any draft pre-translations for this project and update the project's chapters."
+    ></app-info>
+  </div>
+</div>
 
 <h2>Downloads</h2>
 <app-notice icon="info">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
@@ -1,0 +1,11 @@
+.admin-tool {
+  display: flex;
+  flex-direction: column;
+  row-gap: 32px;
+
+  > .admin-tool-control {
+    display: flex;
+    flex-direction: row;
+    column-gap: 10px;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -10,6 +10,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectService } from '../core/sf-project.service';
 import { NoticeComponent } from '../shared/notice/notice.component';
+import { SharedModule } from '../shared/shared.module';
 import { ServalAdministrationService } from './serval-administration.service';
 
 interface Row {
@@ -23,7 +24,7 @@ interface Row {
   selector: 'app-serval-project',
   templateUrl: './serval-project.component.html',
   styleUrls: ['./serval-project.component.scss'],
-  imports: [CommonModule, NoticeComponent, UICommonModule],
+  imports: [CommonModule, NoticeComponent, SharedModule, UICommonModule],
   standalone: true
 })
 export class ServalProjectComponent extends DataLoadingComponent implements OnInit {
@@ -163,5 +164,10 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
   onUpdatePreTranslate(newValue: boolean): Promise<void> {
     return this.projectService.onlineSetPreTranslate(this.activatedProjectService.projectId!, newValue);
+  }
+
+  async retrievePreTranslationStatus(): Promise<void> {
+    await this.servalAdministrationService.onlineRetrievePreTranslationStatus(this.activatedProjectService.projectId!);
+    await this.noticeService.show('Webhook job started.');
   }
 }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Router.Abstractions;
+using Hangfire;
 using SIL.XForge.Controllers;
 using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
@@ -17,32 +19,24 @@ namespace SIL.XForge.Scripture.Controllers;
 /// assembly. Unfortunately, the <see cref="EdjCase.JsonRpc.Router"/> library does not support methods defined in
 /// base classes.
 /// </summary>
-public class SFProjectsRpcController : RpcControllerBase
+public class SFProjectsRpcController(
+    IBackgroundJobClient backgroundJobClient,
+    IExceptionHandler exceptionHandler,
+    ISFProjectService projectService,
+    ITrainingDataService trainingDataService,
+    IUserAccessor userAccessor
+) : RpcControllerBase(userAccessor, exceptionHandler)
 {
-    internal const string AlreadyProjectMemberResponse = "alreadyProjectMember";
+    private const string AlreadyProjectMemberResponse = "alreadyProjectMember";
 
-    private readonly IExceptionHandler _exceptionHandler;
-    private readonly ISFProjectService _projectService;
-    private readonly ITrainingDataService _trainingDataService;
-
-    public SFProjectsRpcController(
-        IUserAccessor userAccessor,
-        ISFProjectService projectService,
-        ITrainingDataService trainingDataService,
-        IExceptionHandler exceptionHandler
-    )
-        : base(userAccessor, exceptionHandler)
-    {
-        _exceptionHandler = exceptionHandler;
-        _projectService = projectService;
-        _trainingDataService = trainingDataService;
-    }
+    // Keep a reference in this class to prevent duplicate allocation (Warning CS9107)
+    private readonly IExceptionHandler _exceptionHandler = exceptionHandler;
 
     public async Task<IRpcMethodResult> Create(SFProjectCreateSettings settings)
     {
         try
         {
-            string projectId = await _projectService.CreateProjectAsync(UserId, settings);
+            string projectId = await projectService.CreateProjectAsync(UserId, settings);
             return Ok(projectId);
         }
         catch (ForbiddenException)
@@ -77,7 +71,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.DeleteProjectAsync(UserId, projectId);
+            await projectService.DeleteProjectAsync(UserId, projectId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -101,7 +95,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.UpdateSettingsAsync(UserId, projectId, settings);
+            await projectService.UpdateSettingsAsync(UserId, projectId, settings);
             return Ok();
         }
         catch (ForbiddenException)
@@ -142,7 +136,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.AddUserAsync(UserId, projectId, projectRole);
+            await projectService.AddUserAsync(UserId, projectId, projectRole);
             return Ok();
         }
         catch (ForbiddenException)
@@ -173,7 +167,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.RemoveUserAsync(UserId, projectId, projectUserId);
+            await projectService.RemoveUserAsync(UserId, projectId, projectUserId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -202,7 +196,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            string role = await _projectService.GetProjectRoleAsync(UserId, projectId);
+            string role = await projectService.GetProjectRoleAsync(UserId, projectId);
             return Ok(role);
         }
         catch (DataNotFoundException dnfe)
@@ -222,7 +216,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.UpdateRoleAsync(UserId, SystemRoles, projectId, userId, projectRole);
+            await projectService.UpdateRoleAsync(UserId, SystemRoles, projectId, userId, projectRole);
             return Ok();
         }
         catch (ForbiddenException)
@@ -252,7 +246,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            if (await _projectService.InviteAsync(UserId, projectId, email, locale, role))
+            if (await projectService.InviteAsync(UserId, projectId, email, locale, role))
                 return Ok();
             return Ok(AlreadyProjectMemberResponse);
         }
@@ -284,7 +278,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.UninviteUserAsync(UserId, projectId, emailToUninvite);
+            await projectService.UninviteUserAsync(UserId, projectId, emailToUninvite);
             return Ok();
         }
         catch (ForbiddenException)
@@ -308,7 +302,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            return Ok(await _projectService.IsAlreadyInvitedAsync(UserId, projectId, email));
+            return Ok(await projectService.IsAlreadyInvitedAsync(UserId, projectId, email));
         }
         catch (ForbiddenException)
         {
@@ -331,7 +325,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            return Ok(await _projectService.InvitedUsersAsync(UserId, projectId));
+            return Ok(await projectService.InvitedUsersAsync(UserId, projectId));
         }
         catch (ForbiddenException)
         {
@@ -357,7 +351,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            return Ok(await _projectService.JoinWithShareKeyAsync(UserId, shareKey));
+            return Ok(await projectService.JoinWithShareKeyAsync(UserId, shareKey));
         }
         catch (ForbiddenException)
         {
@@ -380,13 +374,13 @@ public class SFProjectsRpcController : RpcControllerBase
     public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey) =>
         await CheckLinkSharing(shareKey);
 
-    public IRpcMethodResult IsSourceProject(string projectId) => Ok(_projectService.IsSourceProject(projectId));
+    public IRpcMethodResult IsSourceProject(string projectId) => Ok(projectService.IsSourceProject(projectId));
 
     public async Task<IRpcMethodResult> LinkSharingKey(string projectId, string role, string shareLinkType)
     {
         try
         {
-            return Ok(await _projectService.GetLinkSharingKeyAsync(UserId, projectId, role, shareLinkType));
+            return Ok(await projectService.GetLinkSharingKeyAsync(UserId, projectId, role, shareLinkType));
         }
         catch (DataNotFoundException dnfe)
         {
@@ -417,7 +411,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.ReserveLinkSharingKeyAsync(UserId, shareKey);
+            await projectService.ReserveLinkSharingKeyAsync(UserId, shareKey);
             return Ok();
         }
         catch (DataNotFoundException dnfe)
@@ -437,7 +431,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.AddTranslateMetricsAsync(UserId, projectId, metrics);
+            await projectService.AddTranslateMetricsAsync(UserId, projectId, metrics);
             return Ok();
         }
         catch (ForbiddenException)
@@ -466,7 +460,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SyncAsync(UserId, projectId);
+            await projectService.SyncAsync(UserId, projectId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -490,7 +484,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.CancelSyncAsync(UserId, projectId);
+            await projectService.CancelSyncAsync(UserId, projectId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -514,7 +508,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.DeleteAudioAsync(UserId, projectId, ownerId, dataId);
+            await projectService.DeleteAudioAsync(UserId, projectId, ownerId, dataId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -548,7 +542,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _trainingDataService.DeleteTrainingDataAsync(UserId, projectId, ownerId, dataId);
+            await trainingDataService.DeleteTrainingDataAsync(UserId, projectId, ownerId, dataId);
             return Ok();
         }
         catch (ForbiddenException)
@@ -578,11 +572,34 @@ public class SFProjectsRpcController : RpcControllerBase
         }
     }
 
+    public IRpcMethodResult RetrievePreTranslationStatus(string projectId)
+    {
+        try
+        {
+            // Run the background job
+            backgroundJobClient.Enqueue<MachineApiService>(
+                r => r.RetrievePreTranslationStatusAsync(projectId, CancellationToken.None)
+            );
+            return Ok();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string>
+                {
+                    { "method", "RetrievePreTranslationStatus" },
+                    { "projectId", projectId },
+                }
+            );
+            throw;
+        }
+    }
+
     public async Task<IRpcMethodResult> SetPreTranslate(string projectId, bool preTranslate)
     {
         try
         {
-            await _projectService.SetPreTranslateAsync(UserId, SystemRoles, projectId, preTranslate);
+            await projectService.SetPreTranslateAsync(UserId, SystemRoles, projectId, preTranslate);
             return Ok();
         }
         catch (ForbiddenException)
@@ -611,7 +628,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetSyncDisabledAsync(UserId, SystemRoles, projectId, isDisabled);
+            await projectService.SetSyncDisabledAsync(UserId, SystemRoles, projectId, isDisabled);
             return Ok();
         }
         catch (ForbiddenException)
@@ -640,7 +657,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetServalConfigAsync(UserId, SystemRoles, projectId, servalConfig);
+            await projectService.SetServalConfigAsync(UserId, SystemRoles, projectId, servalConfig);
             return Ok();
         }
         catch (ForbiddenException)
@@ -669,7 +686,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            return Ok(await _projectService.TransceleratorQuestions(UserId, projectId));
+            return Ok(await projectService.TransceleratorQuestions(UserId, projectId));
         }
         catch (ForbiddenException)
         {
@@ -692,7 +709,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.SetUserProjectPermissions(UserId, projectId, userId, permissions);
+            await projectService.SetUserProjectPermissions(UserId, projectId, userId, permissions);
             return Ok();
         }
         catch (ForbiddenException)
@@ -729,7 +746,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.CreateAudioTimingData(UserId, projectId, book, chapter, timingData, audioUrl);
+            await projectService.CreateAudioTimingData(UserId, projectId, book, chapter, timingData, audioUrl);
             return Ok();
         }
         catch (ForbiddenException)
@@ -761,7 +778,7 @@ public class SFProjectsRpcController : RpcControllerBase
     {
         try
         {
-            await _projectService.DeleteAudioTimingData(UserId, projectId, book, chapter);
+            await projectService.DeleteAudioTimingData(UserId, projectId, book, chapter);
             return Ok();
         }
         catch (ForbiddenException)


### PR DESCRIPTION
This PR adds a button to the Serval Administration area to run the webhook which updates the `hasDraft` property of the project's chapters.

This enables either re-running of the webhook on Production/QA, or executing the webhook for Developer machines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2438)
<!-- Reviewable:end -->
