### PR TITLE
Remove extraneous $ from C# interpolated strings

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -570,7 +570,7 @@ public class MachineApiService(
         {
             // Log the error and report to bugsnag
             string message =
-                $"Retrieve pre-translation status exception occurred for project ${sfProjectId} running in background job.";
+                $"Retrieve pre-translation status exception occurred for project {sfProjectId} running in background job.";
             logger.LogError(e, message);
             exceptionHandler.ReportException(e);
 

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -385,14 +385,13 @@ public class MachineProjectService(
         {
             // This will occur if the project is deleted while the job is running
             string message =
-                $"Build DataNotFoundException occurred for project ${buildConfig.ProjectId} running in background job.";
+                $"Build DataNotFoundException occurred for project {buildConfig.ProjectId} running in background job.";
             logger.LogWarning(e, message);
         }
         catch (Exception e)
         {
             // Log the error and report to bugsnag
-            string message =
-                $"Build exception occurred for project ${buildConfig.ProjectId} running in background job.";
+            string message = $"Build exception occurred for project {buildConfig.ProjectId} running in background job.";
             logger.LogError(e, message);
             exceptionHandler.ReportException(e);
 


### PR DESCRIPTION
I saw a weird error message while testing #2438 locally, and realized some extra `$` characters are included a few places.

(The error was supposed to happen; nothing was misbehaving)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2440)
<!-- Reviewable:end -->
