### PR TITLE
SF-2721 Get only pre-translated text from Serval

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -37,7 +37,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />
-    <PackageReference Include="Serval.Client" Version="1.3.1" />
+    <PackageReference Include="Serval.Client" Version="1.4.1" />
     <PackageReference Include="SIL.Machine" Version="3.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -235,6 +235,7 @@ public class PreTranslationService(
             translationEngineId,
             corpusId,
             GetTextId(bookNum),
+            PretranslationUsfmTextOrigin.OnlyPretranslated,
             cancellationToken
         );
 

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -708,7 +708,13 @@ public class PreTranslationServiceTests
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
             TranslationEnginesClient
-                .GetPretranslatedUsfmAsync(Arg.Any<string>(), Arg.Any<string>(), "MAT", CancellationToken.None)
+                .GetPretranslatedUsfmAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    "MAT",
+                    PretranslationUsfmTextOrigin.OnlyPretranslated,
+                    CancellationToken.None
+                )
                 .Returns(MatthewBookUsfm);
             Service = new PreTranslationService(projectSecrets, RealtimeService, TranslationEnginesClient);
         }


### PR DESCRIPTION
This PR adjusts the pre-translations we retrieve from Serval to only include pre-translated text, not any of the existing scripture text sent to Serval.

It should not be merged into master before SF-2442 and SF-2443 are merged into master. These are required dependencies for this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2442)
<!-- Reviewable:end -->
