### PR TITLE
SF-2445 Confirm before overwriting a chapter when adding draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.component.spec.ts
@@ -26,6 +26,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, MockTranslocoDirective, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { DialogService } from '../../../../xforge-common/dialog.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { EDITOR_READY_TIMEOUT } from '../../../shared/text/text.component';
 import { isBadDelta } from '../../../shared/utils';
@@ -42,6 +43,7 @@ describe('DraftViewerComponent', () => {
   const mockUserService = mock(UserService);
   const mockActivatedProjectService = mock(ActivatedProjectService);
   const mockActivatedRoute = mock(ActivatedRoute);
+  const mockDialogService = mock(DialogService);
   const mockRouter = mock(Router);
 
   class TestEnvironment {
@@ -104,6 +106,7 @@ describe('DraftViewerComponent', () => {
           }
         } as ParamMap)
       );
+      when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
     }
 
     init(): void {
@@ -140,7 +143,8 @@ describe('DraftViewerComponent', () => {
       { provide: ActivatedRoute, useMock: mockActivatedRoute },
       { provide: UserService, useMock: mockUserService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: Router, useMock: mockRouter }
+      { provide: Router, useMock: mockRouter },
+      { provide: DialogService, useMock: mockDialogService }
     ]
   }));
 
@@ -191,6 +195,7 @@ describe('DraftViewerComponent', () => {
     const draftDiff = delta_no_verse_2.diff(new Delta(cleanedOps));
 
     env.component.applyDraft();
+    tick();
     expect(spyEditorSetContents).toHaveBeenCalledWith(delta_no_verse_2, 'silent');
     expect(spyEditorEnable).toHaveBeenCalledWith(true);
     expect(spyEditorUpdateContents).toHaveBeenCalledWith(draftDiff, 'user');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.spec.ts
@@ -155,4 +155,24 @@ describe('DraftViewerService', () => {
       expect(service.toDraftOps(draft, targetOps)).toEqual(expectedResult);
     });
   });
+
+  describe('opsHaveContent', () => {
+    it('should return false if all ops are blank', () => {
+      const ops: DeltaOperation[] = [{ insert: {} }, { insert: {} }];
+      expect(service.opsHaveContent(ops)).toBeFalse();
+    });
+
+    it('should return true if any op has content', () => {
+      const ops: DeltaOperation[] = [{ insert: 'content' }];
+      expect(service.opsHaveContent(ops)).toBeTrue();
+    });
+
+    it('should return false if the only op with content is a trailing newline', () => {
+      const newLineNotFinalOp: DeltaOperation[] = [{ insert: '\n' }, { insert: {} }];
+      expect(service.opsHaveContent(newLineNotFinalOp)).toBeTrue();
+
+      const newLineFinalOp: DeltaOperation[] = [{ insert: {} }, { insert: '\n' }];
+      expect(service.opsHaveContent(newLineFinalOp)).toBeFalse();
+    });
+  });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-viewer/draft-viewer.service.ts
@@ -118,4 +118,18 @@ export class DraftViewerService {
       };
     });
   }
+
+  /**
+   * Checks whether the ops have any content (text) in them. This is defined as any op having text content (verse
+   * numbers and other format markers do not count as "content"). If the final op is a newline, it is not counted as
+   * content since it appears most or all documents have a trailing newline at the end.
+   * @param ops The list of delta operations to check for content.
+   * @returns Whether any of the ops contains text content.
+   */
+  opsHaveContent(ops: DeltaOperation[]): boolean {
+    const indexOfFirstText = ops.findIndex(op => typeof op.insert === 'string');
+    const onlyTextOpIsTrailingNewline = indexOfFirstText === ops.length - 1 && ops[indexOfFirstText].insert === '\n';
+    const hasNoExistingText = indexOfFirstText === -1 || onlyTextOpIsTrailingNewline;
+    return !hasNoExistingText;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -216,7 +216,9 @@
     "select_apply_to_project": "Select [em]\"{{ draft_viewer.apply_to_project }}\"[/em] for each chapter that you want to overwrite with the draft text.",
     "select_edit": "Select [em]\"{{ draft_viewer.edit }}\"[/em] to go to the editor page for this chapter.",
     "select_source_text": "A source text has not been selected for this project. You can select a source text in [link:projectSettingsUrl]project settings[/link].",
-    "source_not_set": "Source not set"
+    "source_not_set": "Source not set",
+    "overwrite_warning": "Adding the draft will overwrite all text in {{ chapter }}. Are you sure you want to continue?",
+    "confirm_overwrite": "Overwrite chapter"
   },
   "editor": {
     "add_comment": "Add Comment",


### PR DESCRIPTION
This change is in conjunction with #2442, which will fetch only the generated draft from Serval and therefore overwrite any content already in the chapter.

![](https://github.com/sillsdev/web-xforge/assets/6140710/5821db24-84f0-4cb8-9ee6-2c38d7903c77)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2444)
<!-- Reviewable:end -->
