### PR TITLE
SF-2717 Update zone.js to 0.14.5

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -58,7 +58,7 @@
         "tinycolor2": "^1.4.2",
         "tslib": "^2.4.0",
         "uuid": "^8.3.2",
-        "zone.js": "^0.13.3"
+        "zone.js": "^0.14.5"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^16.2.11",
@@ -34698,9 +34698,9 @@
       "dev": true
     },
     "node_modules/zone.js": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.3.tgz",
-      "integrity": "sha512-MKPbmZie6fASC/ps4dkmIhaT5eonHkEt6eAy80K42tAm0G2W+AahLJjbfi6X9NPdciOE9GRFTTM8u2IiF6O3ww==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.5.tgz",
+      "integrity": "sha512-9XYWZzY6PhHOSdkYryNcMm7L8EK7a4q+GbTvxbIA2a9lMdRUpGuyaYvLDcg8D6bdn+JomSsbPcilVKg6SmUx6w==",
       "dependencies": {
         "tslib": "^2.3.0"
       }

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -79,7 +79,7 @@
     "tinycolor2": "^1.4.2",
     "tslib": "^2.4.0",
     "uuid": "^8.3.2",
-    "zone.js": "^0.13.3"
+    "zone.js": "^0.14.5"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^16.2.11",


### PR DESCRIPTION
This PR updates zone.js from 0.13.3 to 0.14.5, a pre-requisite for Angular 17 and 18.

I have tested this update locally, and it performs satisfactorily.

No other changes are required for this update, as we were already correctly importing `zone.js` and `zone.js/testing`, as per the breaking change in 0.14.0.

Changelog: https://github.com/angular/angular/blob/main/packages/zone.js/CHANGELOG.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2446)
<!-- Reviewable:end -->
