### PR TITLE
SF-2656 Fix Audio Highlight Bug

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-test.utils.ts
@@ -5,7 +5,7 @@ import { AudioPlayer } from '../shared/audio/audio-player';
 
 export function getAudioTimings(): AudioTiming[] {
   return [
-    { textRef: '1', from: 0.0, to: 1.0 },
+    { textRef: '1', from: 0.7, to: 1.0 },
     { textRef: '2', from: 1.0, to: 2.0 },
     { textRef: '3-4', from: 2.0, to: 3.0 }
   ];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.spec.ts
@@ -16,6 +16,7 @@ describe('CheckingUtils', () => {
   });
 
   it('can parse audio text ref', () => {
+    expect(CheckingUtils.parseAudioRefByTime(env.audioTimingBasic, 0)).toEqual(undefined);
     expect(CheckingUtils.parseAudioRefByTime(env.audioTimingBasic, 0.9)).toEqual({ verseStr: '1' });
     expect(CheckingUtils.parseAudioRefByTime(env.audioTimingBasic, 1.9)).toEqual({ verseStr: '2' });
     expect(CheckingUtils.parseAudioRefByTime(env.audioTimingBasic, 2.9)).toEqual({ verseStr: '3-4' });
@@ -57,10 +58,7 @@ describe('CheckingUtils', () => {
 
   it('can parse audio heading ref', () => {
     // audio timing files should only ever have 1 chapter
-    expect(CheckingUtils.parseAudioHeadingRefByTime(env.audioTimingHearThis, 0.0)).toEqual({
-      label: 'c',
-      iteration: 1
-    });
+    expect(CheckingUtils.parseAudioHeadingRefByTime(env.audioTimingHearThis, 0.0)).toEqual(undefined);
     expect(CheckingUtils.parseAudioHeadingRefByTime(env.audioTimingHearThis, 0.1)).toEqual({
       label: 'c',
       iteration: 1

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.utils.ts
@@ -104,10 +104,10 @@ export class CheckingUtils {
   /**
    * Finds the current audio text reference based on the current time.
    * @returns The audio text reference with the verse string, phrase, and word if available.
-   * Undefined if the current text reference is for a heading.
+   * Undefined if the current text reference is for a heading or if there is no match for the given time.
    */
   static parseAudioRefByTime(timingData: AudioTiming[], currentTime: number): AudioTextRef | undefined {
-    let indexInTimings: number = timingData.findIndex(t => t.to > currentTime);
+    let indexInTimings: number = timingData.findIndex(t => t.to > currentTime && t.from <= currentTime);
     for (indexInTimings; indexInTimings >= 0; indexInTimings--) {
       // find the first non-empty textRef because phrase level timings can have entries with empty textRefs
       if (timingData[indexInTimings].textRef !== '') {
@@ -127,10 +127,10 @@ export class CheckingUtils {
   /**
    * Finds the current audio heading reference based on the current time.
    * @returns The audio heading reference with the label and iteration if available.
-   * Undefined if the current audio timing entry is not a heading.
+   * Undefined if the current audio timing entry is not a heading or if there is no match for the given time.
    */
   static parseAudioHeadingRefByTime(timingData: AudioTiming[], currentTime: number): AudioHeadingRef | undefined {
-    const indexInTimings: number = timingData.findIndex(t => t.to > currentTime);
+    const indexInTimings: number = timingData.findIndex(t => t.to > currentTime && t.from <= currentTime);
     if (indexInTimings < 0) return;
     const currentAudioTiming: AudioTiming | undefined = timingData[indexInTimings];
     const match: RegExpExecArray | null = AUDIO_HEADING_REF_REGEX.exec(currentAudioTiming.textRef);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -77,11 +77,12 @@ describe('ScriptureAudioComponent', () => {
   it('emits verse changed event', fakeAsync(() => {
     const env = new TestEnvironment();
 
-    expect(env.verseChangedSpy).withContext('it already announced where we started').toHaveBeenCalledTimes(1);
+    expect(env.component.audioPlayer.isAudioAvailable).toBe(true);
+    expect(env.verseChangedSpy).withContext('it should not be called on init').toHaveBeenCalledTimes(0);
 
     env.audioPlayer.audio.currentTime = 1.5;
     env.audioPlayer.audio.timeUpdated$.next();
-    expect(env.verseChangedSpy).toHaveBeenCalledTimes(2);
+    expect(env.verseChangedSpy).toHaveBeenCalledTimes(1);
     expect(env.verseChangedSpy).toHaveBeenCalledWith('verse_1_2');
   }));
 
@@ -111,6 +112,8 @@ describe('ScriptureAudioComponent', () => {
         { textRef: '1', from: 2.0, to: 3.0 }
       ]
     });
+
+    env.audioPlayer.audio.timeUpdated$.next();
     expect(env.verseChangedSpy).toHaveBeenCalledWith('s_1');
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, DebugElement, Input, NgZone, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { BehaviorSubject } from 'rxjs';
@@ -10,7 +10,7 @@ import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { TextDocId } from '../../../core/models/text-doc';
 import { AudioTimePipe } from '../../../shared/audio/audio-time-pipe';
-import { AudioPlayerStub, getAudioTimings, getAudioTimingWithHeadings } from '../../checking-test.utils';
+import { AudioPlayerStub, getAudioTimingWithHeadings, getAudioTimings } from '../../checking-test.utils';
 import { CheckingScriptureAudioPlayerComponent } from './checking-scripture-audio-player.component';
 
 const audioFile = 'test-audio-player.webm';
@@ -36,16 +36,21 @@ describe('ScriptureAudioComponent', () => {
 
   it('can skip to next and previous verse', fakeAsync(() => {
     const env = new TestEnvironment();
+    const timings = getAudioTimings();
 
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
 
     env.clickNextRef();
     env.wait();
-    expect(env.audioPlayer.audio.currentTime).toBe(1);
+    expect(env.audioPlayer.audio.currentTime).toBe(timings[0].from);
+    expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
+    env.clickNextRef();
+    env.wait();
+    expect(env.audioPlayer.audio.currentTime).toBe(timings[1].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:2');
     env.clickPreviousRef();
     env.wait();
-    expect(env.audioPlayer.audio.currentTime).toBe(0);
+    expect(env.audioPlayer.audio.currentTime).toBe(timings[0].from);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
     env.clickPreviousRef();
     env.wait();
@@ -114,7 +119,7 @@ describe('ScriptureAudioComponent', () => {
     });
 
     env.audioPlayer.audio.timeUpdated$.next();
-    expect(env.verseChangedSpy).toHaveBeenCalledWith('s_1');
+    expect(env.verseChangedSpy).toHaveBeenCalledWith(undefined);
     expect(env.verseLabel.nativeElement.textContent).toEqual('Genesis 1:1');
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -220,7 +220,10 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
             this._timing,
             audio.currentTime
           );
-          if (audioHeadingRef == null) return;
+          if (audioHeadingRef == null) {
+            this.currentVerseChanged.emit(undefined);
+            return;
+          }
           const segmentRef: string = `${audioHeadingRef.label}_${audioHeadingRef.iteration}`;
           this.currentVerseChanged.emit(segmentRef);
           return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, first, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, first, map, skip } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { TextDocId } from '../../../core/models/text-doc';
@@ -204,6 +204,7 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
     this.verseChangeSubscription?.unsubscribe();
     this.verseChangeSubscription = this.subscribe(
       audio.timeUpdated$.pipe(
+        skip(1), //suppress on subscribe, as isPlaying == false
         map(() => this.getCurrentIndexInTimings(audio.currentTime)),
         distinctUntilChanged()
       ),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, first, map, skip } from 'rxjs/operators';
+import { distinctUntilChanged, filter, first, map } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { TextDocId } from '../../../core/models/text-doc';
@@ -204,7 +204,6 @@ export class CheckingScriptureAudioPlayerComponent extends SubscriptionDisposabl
     this.verseChangeSubscription?.unsubscribe();
     this.verseChangeSubscription = this.subscribe(
       audio.timeUpdated$.pipe(
-        skip(1), //suppress on subscribe, as isPlaying == false
         map(() => this.getCurrentIndexInTimings(audio.currentTime)),
         distinctUntilChanged()
       ),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { formatFileSource, isLocalBlobUrl } from 'xforge-common/file.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -23,7 +23,7 @@ export class AudioPlayer extends SubscriptionDisposable {
 
   readonly status$: BehaviorSubject<AudioStatus> = new BehaviorSubject<AudioStatus>(AudioStatus.Initializing);
   readonly finishedPlaying$: EventEmitter<void> = new EventEmitter<void>();
-  readonly timeUpdated$: BehaviorSubject<void> = new BehaviorSubject<void>(undefined);
+  readonly timeUpdated$: Subject<void> = new Subject<void>();
 
   constructor(source: string, private readonly onlineStatusService: OnlineStatusService) {
     super();


### PR DESCRIPTION
Since rxjs calls its event handlers immediately after subscribing to them, the verse change subscription value gets initially set to -1, given the currentTime will be 0 and not resolve to any segment in the timing data. And since we're using distinctUntilChanged(), the handler isn't called again until we reach a found index, e.g. the chapter header/title.

This was causing the software to keep the previous highlight when playing chapter audio until the first timing index was reached. This was confusing for users.

My change ignores the handle called on subscribe, when the time was 0 and the audio hasn't fully loaded yet. Now, the first time the event is handled, the audio will be playing, and thus the checking component will update/clear the highlight correctly.

---

The above comment was made in reference to the scripture audio player. The event handler is called on subscribe, on creation, just after the play button has been pushed, but just before the audio has loaded. Simultaneously, the distinctUntilChanged() call means that it won't be called again until the value changes. Simultaneously to this, the checking component ignores its processing (i.e. the highlight) if the audio isn't playing. So we skip the first event, knowing that the audio isn't loaded yet, which allows the initial "distinct-ified" value to be processed after the audio has loaded.

---

Note that the software before and after this change does not update the highlight while audio is paused. I thought this was weird, but probably intended. Just be aware in testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2447)
<!-- Reviewable:end -->
