### PR TITLE
SF-2714 Upgrade to Node v18.20.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,8 @@ jobs:
         # move to.
         os: ["ubuntu-20.04"]
         dotnet_version: ["8.0.x"]
-        node_version: ["16.15.0"]
-        npm_version: ["8.10.0"]
+        node_version: ["18.20.2"]
+        npm_version: ["10.5.0"]
       # Continue building in other environments to see which are working.
       fail-fast: false
     runs-on: ${{matrix.os}}
@@ -113,8 +113,8 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         dotnet_version: ["8.0.x"]
-        node_version: ["16.15.0"]
-        npm_version: ["8.10.0"]
+        node_version: ["18.20.2"]
+        npm_version: ["10.5.0"]
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        node_version: ["16.15.0"]
-        npm_version: ["8.10.0"]
+        node_version: ["18.20.2"]
+        npm_version: ["10.5.0"]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
         run: cd src/SIL.XForge.Scripture/ClientApp && npm run build-storybook -- --webpack-stats-json
       - id: publish
         name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v11.3.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: src/SIL.XForge.Scripture/ClientApp

--- a/.github/workflows/ci-lint-prettier.yml
+++ b/.github/workflows/ci-lint-prettier.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        node_version: [16.x]
-        npm_version: ["8.10.0"]
+        node_version: ["18.20.2"]
+        npm_version: ["10.5.0"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-production-build.yml
+++ b/.github/workflows/ci-production-build.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node_version: [16.x]
-        npm_version: ["8.10.0"]
+        node_version: ["18.20.2"]
+        npm_version: ["10.5.0"]
         os: [ubuntu-latest]
 
     steps:

--- a/deploy/dependencies.yml
+++ b/deploy/dependencies.yml
@@ -10,7 +10,7 @@
       - "vars/{{ansible_os_family}}.yml"
       - "vars/os_defaults.yml"
   vars:
-    node_version: 16.15.0
+    node_version: 18.20.2
     mongodb_version: 5.0
     repo_path: "{{playbook_dir}}/.."
   pre_tasks:

--- a/src/SIL.XForge.Scripture/Dockerfile
+++ b/src/SIL.XForge.Scripture/Dockerfile
@@ -15,7 +15,7 @@ RUN sed -i 's#htt[p|ps]://archive.ubuntu.com/ubuntu/#mirror://mirrors.ubuntu.com
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
-    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 # Install Dependencies
 RUN apt-get install -y \
     ffmpeg \
@@ -47,7 +47,7 @@ WORKDIR /src
 RUN sed -i 's#htt[p|ps]://archive.ubuntu.com/ubuntu/#mirror://mirrors.ubuntu.com/mirrors.txt#g' /etc/apt/sources.list
 # Install Node Repository
 RUN update-ca-certificates \
-    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 # Install NPM
 RUN apt-get install -y \
     nodejs \


### PR DESCRIPTION
This PR updates our workflows and Dockerfile to support Node v18.

No other code changes are required for support for Node v18.

A successful PR is determined by all of the CodeQL workflows passing. I have tested the Dockerfile.

Also, the Chromatic action's latest version (11.3.2) is faulty. To resolve this issue, I have fixed chromaui/action to version 11.3.0.

**Upgrading Node**

To upgrade your node version in your developer VM run:
```sh
sudo n 18.20.2

```
Alternatively, if you use nvm on your developer PC, run:
```sh
nvm install 18.20.2
nvm use 18.20.2
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2448)
<!-- Reviewable:end -->
