### PR TITLE
SF-2730 Specify null when scripture range is empty for Serval builds

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1130,19 +1130,27 @@ public class MachineProjectService(
                     ? buildConfig.TranslationScriptureRange
                     : string.Join(';', buildConfig.TranslationBooks.Select(Canon.BookNumberToId));
 
+                // Ensure that the pre-translate scripture range is null if it is blank
+                if (string.IsNullOrWhiteSpace(preTranslateCorpusConfig.ScriptureRange))
+                {
+                    preTranslateCorpusConfig.ScriptureRange = null;
+                }
+
                 if (!useAlternateTrainingCorpus)
                 {
+                    string? scriptureRange = !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
+                        ? buildConfig.TrainingScriptureRange
+                        : string.Join(';', buildConfig.TrainingBooks.Select(Canon.BookNumberToId));
+
+                    // Ensure that the trainOn scripture range is null if it is blank
+                    if (string.IsNullOrWhiteSpace(scriptureRange))
+                    {
+                        scriptureRange = null;
+                    }
+
                     // As we do not have an alternate train on source specified, use the source texts to train on
                     trainOn ??= [];
-                    trainOn.Add(
-                        new TrainingCorpusConfig
-                        {
-                            CorpusId = corpus.Key,
-                            ScriptureRange = !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
-                                ? buildConfig.TrainingScriptureRange
-                                : string.Join(';', buildConfig.TrainingBooks.Select(Canon.BookNumberToId)),
-                        }
-                    );
+                    trainOn.Add(new TrainingCorpusConfig { CorpusId = corpus.Key, ScriptureRange = scriptureRange });
                 }
             }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -802,6 +802,72 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    public async Task BuildProjectAsync_SpecifiesNullScriptureRangeIfBlank()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = false });
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig
+            {
+                ProjectId = Project01,
+                TrainingScriptureRange = string.Empty,
+                TranslationScriptureRange = string.Empty
+            },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        await env.TranslationEnginesClient.Received()
+            .StartBuildAsync(
+                TranslationEngine01,
+                Arg.Is<TranslationBuildConfig>(
+                    b =>
+                        b.Pretranslate.Count == 1
+                        && b.Pretranslate.First().ScriptureRange == null
+                        && b.TrainOn.Count == 1
+                        && b.TrainOn.First().ScriptureRange == null
+                ),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
+    public async Task BuildProjectAsync_SpecifiesNullScriptureRangeIfEmpty()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = false });
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig
+            {
+                ProjectId = Project01,
+                TrainingBooks = [],
+                TranslationBooks = []
+            },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        await env.TranslationEnginesClient.Received()
+            .StartBuildAsync(
+                TranslationEngine01,
+                Arg.Is<TranslationBuildConfig>(
+                    b =>
+                        b.Pretranslate.Count == 1
+                        && b.Pretranslate.First().ScriptureRange == null
+                        && b.TrainOn.Count == 1
+                        && b.TrainOn.First().ScriptureRange == null
+                ),
+                CancellationToken.None
+            );
+    }
+
+    [Test]
     public async Task BuildProjectForBackgroundJobAsync_BuildsPreTranslationProjects()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -801,8 +801,10 @@ public class MachineProjectServiceTests
             );
     }
 
-    [Test]
-    public async Task BuildProjectAsync_SpecifiesNullScriptureRangeIfBlank()
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public async Task BuildProjectAsync_SpecifiesNullScriptureRange(string? scriptureRange)
     {
         // Set up test environment
         var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = false });
@@ -813,41 +815,8 @@ public class MachineProjectServiceTests
             new BuildConfig
             {
                 ProjectId = Project01,
-                TrainingScriptureRange = string.Empty,
-                TranslationScriptureRange = string.Empty
-            },
-            preTranslate: true,
-            CancellationToken.None
-        );
-
-        await env.TranslationEnginesClient.Received()
-            .StartBuildAsync(
-                TranslationEngine01,
-                Arg.Is<TranslationBuildConfig>(
-                    b =>
-                        b.Pretranslate.Count == 1
-                        && b.Pretranslate.First().ScriptureRange == null
-                        && b.TrainOn.Count == 1
-                        && b.TrainOn.First().ScriptureRange == null
-                ),
-                CancellationToken.None
-            );
-    }
-
-    [Test]
-    public async Task BuildProjectAsync_SpecifiesNullScriptureRangeIfEmpty()
-    {
-        // Set up test environment
-        var env = new TestEnvironment(new TestEnvironmentOptions { BuildIsPending = false });
-
-        // SUT
-        await env.Service.BuildProjectAsync(
-            User01,
-            new BuildConfig
-            {
-                ProjectId = Project01,
-                TrainingBooks = [],
-                TranslationBooks = []
+                TrainingScriptureRange = scriptureRange,
+                TranslationScriptureRange = scriptureRange,
             },
             preTranslate: true,
             CancellationToken.None


### PR DESCRIPTION
This PR fixes a bug where Serval returns a 400 error when starting a build that has no training books specified.

This bug currently affects QA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2453)
<!-- Reviewable:end -->
