### PR TITLE
Fix webhook signature header name

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
@@ -155,7 +155,7 @@ public class AnonymousController(
     /// <remarks>Serval requires a Success code, even on failure, so we return </remarks>
     [HttpPost("webhook")]
     public async Task<ActionResult<bool>> Webhook(
-        [FromHeader(Name = "HTTP_X_HUB_SIGNATURE_256")] string signature,
+        [FromHeader(Name = "X-Hub-Signature-256")] string signature,
         [BindNever, FromBody] object? _ = null
     )
     {


### PR DESCRIPTION
This PR fixes the HTTP header that the webhook endpoint reads to be the correct value. The previous value was incorrect because it was mangled by the PHP script I used for testing the webhook.

This feature is currently broken on QA, resulting in 400 error codes:
```
162.158.79.96 - - [13/May/2024:02:02:25 +0000] "POST /anonymous/webhook HTTP/1.1" 400 4217 "-" "-"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2454)
<!-- Reviewable:end -->
