### PR TITLE
SF-2444 Add editor resource tabs

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/editor-tab.ts
+++ b/src/RealtimeServer/scriptureforge/models/editor-tab.ts
@@ -1,3 +1,4 @@
-export const editorTabTypes = ['history', 'draft', 'project-source', 'project'] as const;
-export type EditorTabType = typeof editorTabTypes[number];
+export const editorTabTypes = ['history', 'draft', 'project-source', 'project-target', 'project-resource'] as const;
+type EditorTabTypes = typeof editorTabTypes;
+export type EditorTabType = EditorTabTypes[number];
 export type EditorTabGroupType = 'source' | 'target';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -29,7 +29,6 @@ import { CoreModule } from './core/core.module';
 import { JoinComponent } from './join/join.component';
 import { NavigationProjectSelectorComponent } from './navigation-project-selector/navigation-project-selector.component';
 import { NavigationComponent } from './navigation/navigation.component';
-import { ProjectSelectComponent } from './project-select/project-select.component';
 import { ProjectComponent } from './project/project.component';
 import { ScriptureChooserDialogComponent } from './scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { DeleteProjectDialogComponent } from './settings/delete-project-dialog/delete-project-dialog.component';
@@ -37,7 +36,6 @@ import { SettingsComponent } from './settings/settings.component';
 import { SharedModule } from './shared/shared.module';
 import { TextNoteDialogComponent } from './shared/text/text-note-dialog/text-note-dialog.component';
 import { StartComponent } from './start/start.component';
-import { SyncProgressComponent } from './sync/sync-progress/sync-progress.component';
 import { SyncComponent } from './sync/sync.component';
 import { TranslateModule } from './translate/translate.module';
 import { UsersModule } from './users/users.module';
@@ -57,8 +55,6 @@ import { UsersModule } from './users/users.module';
     ErrorDialogComponent,
     EditNameDialogComponent,
     FeatureFlagsDialogComponent,
-    ProjectSelectComponent,
-    SyncProgressComponent,
     TextNoteDialogComponent,
     JoinComponent
   ],
@@ -90,7 +86,10 @@ import { UsersModule } from './users/users.module';
     defaultTranslocoMarkupTranspilers(),
     { provide: ErrorHandler, useClass: ExceptionHandlingService },
     { provide: OverlayContainer, useClass: InAppRootOverlayContainer },
-    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { appearance: 'outline' }
+    }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -56,7 +56,7 @@
             placeholder="{{ t('source_text_placeholder') }}"
             [projects]="projects"
             [resources]="resources"
-            [hideProjectId]="paratextIdControl.value"
+            [hiddenParatextIds]="[paratextIdControl.value]"
           ></app-project-select>
           <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
           <ng-container *ngIf="isBasedOnProjectSet">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { mock } from 'ts-mockito';
+import { AuthService } from 'xforge-common/auth.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { ParatextService } from './paratext.service';
+
+describe('ParatextService', () => {
+  let service: ParatextService;
+  const mockHttpClient = mock(HttpClient);
+  const mockAuthService = mock(AuthService);
+
+  configureTestingModule(() => ({
+    providers: [
+      { provide: HttpClient, useMock: mockHttpClient },
+      { provide: AuthService, useMock: mockAuthService }
+    ]
+  }));
+
+  beforeEach(() => {
+    service = TestBed.inject(ParatextService);
+  });
+
+  describe('isResource', () => {
+    it('should return true for a resource id', () => {
+      const id = '1234567890abcdef';
+      expect(service.isResource(id)).toBe(true);
+    });
+
+    it('should return false for a project id', () => {
+      const id = '123456781234567890abcdef1234567890abcdef1234567890abcdef';
+      expect(service.isResource(id)).toBe(false);
+    });
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -8,6 +8,9 @@ import { Snapshot } from 'xforge-common/models/snapshot';
 import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
 import { ParatextProject } from './models/paratext-project';
 
+/** Length of paratext ids for DBL resources. */
+export const RESOURCE_IDENTIFIER_LENGTH = 16;
+
 /**
  * A point-in-time revision of a document.
  */
@@ -95,5 +98,14 @@ export class ParatextService {
       Accept: 'application/json',
       'Content-Type': 'application/json'
     });
+  }
+
+  /**
+   * Determines if a Paratext id refers to a resource.
+   * @param paratextId The Paratext identifier.
+   * @returns True if the Paratext identifier is a resource identifier.
+   */
+  isResource(paratextId: string): boolean {
+    return paratextId.length === RESOURCE_IDENTIFIER_LENGTH;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -11,7 +11,6 @@ import { getSFProjectUserConfigDocId } from 'realtime-server/lib/esm/scripturefo
 import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
 import { Subject } from 'rxjs';
 import { CommandService } from 'xforge-common/command.service';
-import { FileService } from 'xforge-common/file.service';
 import { LocationService } from 'xforge-common/location.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { ProjectService } from 'xforge-common/project.service';
@@ -42,7 +41,6 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   constructor(
     realtimeService: RealtimeService,
     commandService: CommandService,
-    private readonly fileService: FileService,
     private readonly locationService: LocationService,
     protected readonly retryingRequestService: RetryingRequestService
   ) {
@@ -51,6 +49,47 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
 
   async onlineCreate(settings: SFProjectCreateSettings): Promise<string> {
     return (await this.onlineInvoke<string>('create', { settings }))!;
+  }
+
+  /**
+   * Creates an SF project/resource with the given paratext id.
+   * @param paratextId The paratext id of the project or resource.
+   * @returns The SF project id.
+   */
+  async onlineCreateResourceProject(paratextId: string): Promise<string | undefined> {
+    return this.onlineInvoke<string>('createResourceProject', { paratextId });
+  }
+
+  async getRealtimeProject(paratextId: string): Promise<SFProjectDoc | undefined> {
+    const query: RealtimeQuery<SFProjectDoc> = await this.realtimeService.onlineQuery<SFProjectDoc>(this.collection, {
+      paratextId
+    });
+    return query.docs[0];
+  }
+
+  /**
+   * Gets the SF project Id for the project/resource with the given paratext id.  Creates the project if needed.
+   * @param paratextId The paratext id of the project or resource.
+   * @returns The SF project id.
+   */
+  async getOrCreateRealtimeProject(paratextId: string, role?: string): Promise<string | undefined> {
+    // First check if project exists
+    const project: SFProjectDoc | undefined = await this.getRealtimeProject(paratextId);
+
+    // If SF project exists, return its id
+    if (project != null) {
+      return Promise.resolve(project.id);
+    }
+
+    // Otherwise, create realtime project
+    const projectId: string | undefined = await this.onlineCreateResourceProject(paratextId);
+
+    // Add current user to project
+    if (projectId != null) {
+      await this.onlineAddCurrentUser(projectId, role);
+    }
+
+    return projectId;
   }
 
   /**
@@ -159,7 +198,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   onlineSetPreTranslate(projectId: string, preTranslate: boolean): Promise<void> {
-    return this.onlineInvoke<void>('setPreTranslate', { projectId, preTranslate });
+    return this.onlineInvoke<void>('setPreTranslate', {
+      projectId,
+      preTranslate
+    });
   }
 
   onlineUpdateSettings(id: string, settings: SFProjectSettings): Promise<void> {
@@ -167,13 +209,18 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   async onlineIsAlreadyInvited(id: string, email: string): Promise<boolean> {
-    return (await this.onlineInvoke<boolean>('isAlreadyInvited', { projectId: id, email }))!;
+    return (await this.onlineInvoke<boolean>('isAlreadyInvited', {
+      projectId: id,
+      email
+    }))!;
   }
 
   /** Get list of email addresses that have outstanding invitations on project.
    * Caller must be an admin on the project. */
   async onlineInvitedUsers(projectId: string): Promise<InviteeStatus[]> {
-    return (await this.onlineInvoke<InviteeStatus[]>('invitedUsers', { projectId }))!;
+    return (await this.onlineInvoke<InviteeStatus[]>('invitedUsers', {
+      projectId
+    }))!;
   }
 
   /** Get added into project with specified shareKey code. */
@@ -186,11 +233,16 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   async onlineUninviteUser(projectId: string, emailToUninvite: string): Promise<string> {
-    return (await this.onlineInvoke<string>('uninviteUser', { projectId, emailToUninvite }))!;
+    return (await this.onlineInvoke<string>('uninviteUser', {
+      projectId,
+      emailToUninvite
+    }))!;
   }
 
   async onlineIsSourceProject(projectId: string): Promise<boolean> {
-    return (await this.onlineInvoke<boolean>('isSourceProject', { projectId }))!;
+    return (await this.onlineInvoke<boolean>('isSourceProject', {
+      projectId
+    }))!;
   }
 
   async onlineGetLinkSharingKey(projectId: string, role: SFProjectRole, shareLinkType: ShareLinkType): Promise<string> {
@@ -212,7 +264,11 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   async onlineSetUserProjectPermissions(projectId: string, userId: string, permissions: string[]): Promise<void> {
-    return (await this.onlineInvoke<void>('setUserProjectPermissions', { projectId, userId, permissions }))!;
+    return (await this.onlineInvoke<void>('setUserProjectPermissions', {
+      projectId,
+      userId,
+      permissions
+    }))!;
   }
 
   async onlineCreateAudioTimingData(
@@ -222,14 +278,27 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     timingData: AudioTiming[],
     audioUrl: string
   ): Promise<void> {
-    return await this.onlineInvoke('createAudioTimingData', { projectId, book, chapter, timingData, audioUrl });
+    return await this.onlineInvoke('createAudioTimingData', {
+      projectId,
+      book,
+      chapter,
+      timingData,
+      audioUrl
+    });
   }
 
   async onlineDeleteAudioTimingData(projectId: string, book: number, chapter: number): Promise<void> {
-    return await this.onlineInvoke('deleteAudioTimingData', { projectId, book, chapter });
+    return await this.onlineInvoke('deleteAudioTimingData', {
+      projectId,
+      book,
+      chapter
+    });
   }
 
   async onlineSetServalConfig(projectId: string, servalConfig: string | null | undefined): Promise<void> {
-    return await this.onlineInvoke<void>('setServalConfig', { projectId, servalConfig });
+    return await this.onlineInvoke<void>('setServalConfig', {
+      projectId,
+      servalConfig
+    });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
@@ -22,6 +22,7 @@ import { UserService } from 'xforge-common/user.service';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
+import { PermissionsService } from '../core/permissions.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { NmtDraftAuthGuard, SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from '../shared/project-router.guard';
 import { NavigationComponent } from './navigation.component';
@@ -34,6 +35,7 @@ const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedRouter = mock(Router);
 const mockedResumeCheckingService = mock(ResumeCheckingService);
+const mockedPermissionsService = mock(PermissionsService);
 let testActivatedProjectService: ActivatedProjectService;
 
 function setUpMocks(args: StoryState): void {
@@ -64,7 +66,10 @@ function setUpMocks(args: StoryState): void {
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     imports: [I18nStoryModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)],
-    providers: [{ provide: UserService, useValue: instance(mockedUserService) }]
+    providers: [
+      { provide: UserService, useValue: instance(mockedUserService) },
+      { provide: PermissionsService, useValue: instance(mockedPermissionsService) }
+    ]
   });
 
   const realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.spec.ts
@@ -11,7 +11,7 @@ import { ProjectSelectComponent } from './project-select.component';
 
 describe('ProjectSelectComponent', () => {
   it('should list projects and resources', fakeAsync(() => {
-    const env = new TestEnvironment('p02');
+    const env = new TestEnvironment(['p02']);
     env.clickInput();
     // Expect two projects and two resources (one of the projects should be hidden)
     expect(env.groupLabels.length).toBe(2);
@@ -71,13 +71,20 @@ describe('ProjectSelectComponent', () => {
     expect(env.component.sourceParatextId.value).toBe('r02');
   }));
 
+  it("doesn't list multiple hidden projects", fakeAsync(() => {
+    const env = new TestEnvironment(['p01', 'p03', 'r02']);
+    env.clickInput();
+    expect(env.optionsText(0)).toEqual(['P2 - Project 2']);
+    expect(env.optionsText(1)).toEqual(['R1 - Resource 1']);
+  }));
+
   it('adds list items as the user scrolls the list', fakeAsync(() => {
     const resources = [...Array(100).keys()].map(key => ({
       paratextId: 'r' + key,
       name: 'Resource ' + (key + 1),
       shortName: 'R' + key
     }));
-    const env = new TestEnvironment('p03', undefined, resources);
+    const env = new TestEnvironment(['p03'], undefined, resources);
     env.clickInput();
     expect(env.optGroups.length).toBe(2);
     expect(env.optionsText(0)).toEqual(['P1 - Project 1', 'P2 - Project 2']);
@@ -117,7 +124,7 @@ describe('ProjectSelectComponent', () => {
       placeholder="Based on"
       [projects]="projects"
       [resources]="resources"
-      [hideProjectId]="hideProjectId"
+      [hiddenParatextIds]="hiddenParatextIds"
       [nonSelectableProjects]="nonSelectableProjects"
       [isDisabled]="isDisabled"
     ></app-project-select>
@@ -140,7 +147,7 @@ class HostComponent {
     { name: 'Resource 2', paratextId: 'r02', shortName: 'R2' }
   ];
   nonSelectableProjects: SelectableProject[] = [{ name: 'Project 1', paratextId: 'p01', shortName: 'P1' }];
-  hideProjectId: string = '';
+  hiddenParatextIds: string[] = [];
 }
 
 class TestEnvironment {
@@ -148,7 +155,7 @@ class TestEnvironment {
   component: HostComponent;
 
   constructor(
-    hideProjectId?: string,
+    hiddenParatextIds?: string[],
     projects?: SelectableProject[],
     resources?: SelectableProject[],
     nonSelectableProjects?: SelectableProject[]
@@ -164,7 +171,7 @@ class TestEnvironment {
     this.component.projects = projects || this.component.projects;
     this.component.resources = resources || this.component.resources;
     this.component.nonSelectableProjects = nonSelectableProjects || this.component.nonSelectableProjects;
-    this.component.hideProjectId = hideProjectId || this.component.hideProjectId;
+    this.component.hiddenParatextIds = hiddenParatextIds || this.component.hiddenParatextIds;
 
     this.fixture.detectChanges();
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.spec.ts
@@ -22,20 +22,6 @@ describe('ServalAdministrationService', () => {
     ]
   }));
 
-  describe('isResource', () => {
-    it('should return true for a resource id', () => {
-      const env = new TestEnvironment();
-      const id = '1234567890abcdef';
-      expect(env.service.isResource(id)).toBe(true);
-    });
-
-    it('should return false for a project id', () => {
-      const env = new TestEnvironment();
-      const id = '123456781234567890abcdef1234567890abcdef1234567890abcdef';
-      expect(env.service.isResource(id)).toBe(false);
-    });
-  });
-
   describe('downloadProject', () => {
     it('should return a blob', () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.service.ts
@@ -37,15 +37,6 @@ export class ServalAdministrationService extends ProjectService<SFProjectProfile
   }
 
   /**
-   * Determines if a Paratext id refers to a resource.
-   * @param paratextId The Paratext identifier.
-   * @returns True if the Paratext identifier is a resource identifier.
-   */
-  isResource(paratextId?: string): boolean {
-    return (paratextId?.length ?? 0) === 16;
-  }
-
-  /**
    * Starts a job to retrieve the pre-translation status for a project.
    * This is the equivalent of running the webhook.
    * @param projectId The Scripture Forge project identifier.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -8,6 +8,7 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { AuthService } from 'xforge-common/auth.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
@@ -25,6 +26,7 @@ const mockActivatedRoute = mock(ActivatedRoute);
 const mockNoticeService = mock(NoticeService);
 const mockSFProjectService = mock(SFProjectService);
 const mockServalAdministrationService = mock(ServalAdministrationService);
+const mockAuthService = mock(AuthService);
 
 describe('ServalProjectComponent', () => {
   configureTestingModule(() => ({
@@ -41,7 +43,8 @@ describe('ServalProjectComponent', () => {
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: ServalAdministrationService, useMock: mockServalAdministrationService },
-      { provide: SFProjectService, useMock: mockSFProjectService }
+      { provide: SFProjectService, useMock: mockSFProjectService },
+      { provide: AuthService, useMock: mockAuthService }
     ]
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -9,6 +9,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { NoticeComponent } from '../shared/notice/notice.component';
 import { SharedModule } from '../shared/shared.module';
@@ -41,6 +42,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
     noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
+    private readonly paratextService: ParatextService,
     private readonly servalAdministrationService: ServalAdministrationService
   ) {
     super(noticeService);
@@ -74,7 +76,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the source
           if (
             project.translateConfig.source != null &&
-            !this.servalAdministrationService.isResource(project.translateConfig.source.paratextId)
+            !this.paratextService.isResource(project.translateConfig.source.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.source.projectRef,
@@ -87,7 +89,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the alternate source
           if (
             project.translateConfig.draftConfig.alternateSource != null &&
-            !this.servalAdministrationService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
+            !this.paratextService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateSource.projectRef,
@@ -103,9 +105,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the alternate training source
           if (
             project.translateConfig.draftConfig.alternateTrainingSource != null &&
-            !this.servalAdministrationService.isResource(
-              project.translateConfig.draftConfig.alternateTrainingSource.paratextId
-            )
+            !this.paratextService.isResource(project.translateConfig.draftConfig.alternateTrainingSource.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateTrainingSource.projectRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
@@ -12,6 +12,7 @@ import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models
 import { combineLatest, from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { anything, mock, when } from 'ts-mockito';
+import { AuthService } from 'xforge-common/auth.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { ProjectDoc } from 'xforge-common/models/project-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -22,12 +23,15 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { TypeRegistry } from 'xforge-common/type-registry';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { ParatextService } from '../core/paratext.service';
 import { ServalAdministrationService } from './serval-administration.service';
 import { ServalProjectsComponent } from './serval-projects.component';
 
 const mockedNoticeService = mock(NoticeService);
 const mockedServalAdministrationService = mock(ServalAdministrationService);
 const mockedUserService = mock(UserService);
+const mockedParatextService = mock(ParatextService);
+const mockAuthService = mock(AuthService);
 
 describe('ServalProjectsComponent', () => {
   configureTestingModule(() => ({
@@ -43,7 +47,9 @@ describe('ServalProjectsComponent', () => {
     providers: [
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: ServalAdministrationService, useMock: mockedServalAdministrationService },
-      { provide: UserService, useMock: mockedUserService }
+      { provide: UserService, useMock: mockedUserService },
+      { provide: AuthService, useMock: mockAuthService },
+      { provide: ParatextService, useMock: mockedParatextService }
     ]
   }));
 
@@ -145,7 +151,7 @@ class TestEnvironment {
           })
         )
     );
-    when(mockedServalAdministrationService.isResource(anything())).thenCall((paratextId: string) => {
+    when(mockedParatextService.isResource(anything())).thenCall((paratextId: string) => {
       return paratextId?.startsWith('ptresource') ?? false;
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -10,13 +10,11 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { ParatextService } from '../core/paratext.service';
 import { ServalAdministrationService } from './serval-administration.service';
 
 class Row {
-  constructor(
-    public readonly projectDoc: SFProjectProfileDoc,
-    private readonly servalAdministrationService: ServalAdministrationService
-  ) {}
+  constructor(public readonly projectDoc: SFProjectProfileDoc, private readonly paratextService: ParatextService) {}
 
   get alternateSource(): string {
     return this.projectDoc.data?.translateConfig.draftConfig.alternateSource == null
@@ -27,11 +25,10 @@ class Row {
   }
 
   get alternateSourceId(): string | undefined {
-    if (
-      !this.servalAdministrationService.isResource(
-        this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId
-      )
-    ) {
+    const paratextId: string | undefined =
+      this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId;
+
+    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.projectRef;
     } else {
       return undefined;
@@ -47,11 +44,10 @@ class Row {
   }
 
   get alternateTrainingSourceId(): string | undefined {
-    if (
-      !this.servalAdministrationService.isResource(
-        this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId
-      )
-    ) {
+    const paratextId: string | undefined =
+      this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId;
+
+    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.projectRef;
     } else {
       return undefined;
@@ -79,7 +75,9 @@ class Row {
   }
 
   get sourceId(): string | undefined {
-    if (!this.servalAdministrationService.isResource(this.projectDoc.data?.translateConfig.source?.paratextId)) {
+    const paratextId: string | undefined = this.projectDoc.data?.translateConfig.source?.paratextId;
+
+    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.source?.projectRef;
     } else {
       return undefined;
@@ -110,7 +108,8 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
   constructor(
     noticeService: NoticeService,
     readonly i18n: I18nService,
-    private readonly servalAdministrationService: ServalAdministrationService
+    private readonly servalAdministrationService: ServalAdministrationService,
+    private readonly paratextService: ParatextService
   ) {
     super(noticeService);
     this.searchTerm$ = new BehaviorSubject<string>('');
@@ -157,7 +156,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
 
     const rows: Row[] = [];
     for (const projectDoc of this.projectDocs) {
-      rows.push(new Row(projectDoc, this.servalAdministrationService));
+      rows.push(new Row(projectDoc, this.paratextService));
     }
     this.rows = rows;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -36,7 +36,7 @@
                     [projects]="projects"
                     [resources]="resources"
                     [nonSelectableProjects]="nonSelectableProjects"
-                    [hideProjectId]="projectParatextId"
+                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
                     [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
                   ></app-project-select>
                   <app-write-status
@@ -125,7 +125,7 @@
                     [projects]="projects"
                     [resources]="resources"
                     [nonSelectableProjects]="nonSelectableProjects"
-                    [hideProjectId]="projectParatextId"
+                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
                     [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
                   ></app-project-select>
                   <app-write-status
@@ -159,7 +159,7 @@
                     [projects]="projects"
                     [resources]="resources"
                     [nonSelectableProjects]="nonSelectableProjects"
-                    [hideProjectId]="projectParatextId"
+                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
                     [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
                   ></app-project-select>
                   <app-write-status

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-add-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-add-request.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+@Injectable()
+export abstract class TabAddRequestService<TType, T> {
+  /**
+   * Handles a request to add a new tab, including any user prompts for additional info needed to create the tab.
+   * @param tabType The type of the new tab.
+   * @returns An observable that emits any extra tab info needed to create the tab that will be passed as options
+   * to the tab factory. If the observable completes without emitting a value, the tab will not be created.
+   */
+  abstract handleTabAddRequest(tabType: TType): Observable<Partial<T> | never>;
+}
+
+@Injectable()
+export class NoopTabAddRequestService<TType, T> extends TabAddRequestService<TType, T> {
+  handleTabAddRequest(_: TType): Observable<Partial<T>> {
+    return of({});
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-factory.service.ts
@@ -1,3 +1,3 @@
 export abstract class TabFactoryService<TType, T> {
-  abstract createTab(tabType: TType, tabOptions?: Partial<T>): T;
+  abstract createTab(tabType: TType, tabOptions?: Partial<T>): Promise<T>;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatTabsModule } from '@angular/material/tabs';
 import { TranslocoModule } from '@ngneat/transloco';
+import { NoopTabAddRequestService, TabAddRequestService } from './base-services/tab-add-request.service';
 import { TabGroupHeaderComponent } from './tab-group-header/tab-group-header.component';
 import { TabScrollButtonComponent } from './tab-group-header/tab-scroll-button/tab-scroll-button.component';
 import { TabGroupComponent } from './tab-group.component';
@@ -33,6 +34,7 @@ import { TabComponent } from './tab/tab.component';
     DragDropModule,
     TranslocoModule
   ],
-  exports: [TabGroupComponent, TabComponent, TabHeaderDirective]
+  exports: [TabGroupComponent, TabComponent, TabHeaderDirective],
+  providers: [{ provide: TabAddRequestService, useClass: NoopTabAddRequestService }]
 })
 export class SFTabsModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
@@ -7,7 +7,7 @@
   (tabPress)="onTabHeaderPress($event)"
   (tabClick)="onTabHeaderClick($event)"
   (closeClick)="removeTab($event)"
-  (tabAddRequest)="addTab($event)"
+  (tabAddRequest)="onTabAddRequest($event)"
   (tabMove)="moveTab($event)"
 ></app-tab-group-header>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -83,7 +83,7 @@ export default {
         {
           provide: TabFactoryService,
           useValue: {
-            createTab(tabType: string): TabInfo<string> {
+            createTab(tabType: string): Promise<TabInfo<string>> {
               let tab: TabInfo<string>;
 
               switch (tabType) {
@@ -114,7 +114,7 @@ export default {
                   break;
               }
 
-              return tab;
+              return Promise.resolve(tab);
             }
           }
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab-body/tab-body.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab-body/tab-body.component.html
@@ -1,3 +1,1 @@
-<ng-container *ngIf="active">
-  <ng-content></ng-content>
-</ng-container>
+<ng-content></ng-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/shared.module.ts
@@ -11,6 +11,7 @@ import { NoticeComponent } from './notice/notice.component';
 import { ShareButtonComponent } from './share/share-button.component';
 import { ShareControlComponent } from './share/share-control.component';
 import { ShareDialogComponent } from './share/share-dialog.component';
+import { TextDocIdPipe } from './text/text-doc-id.pipe';
 import { TextComponent } from './text/text.component';
 
 const componentExports = [
@@ -21,7 +22,8 @@ const componentExports = [
   ShareDialogComponent,
   TextComponent,
   CheckingQuestionComponent,
-  SingleButtonAudioPlayerComponent
+  SingleButtonAudioPlayerComponent,
+  TextDocIdPipe
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-doc-id.pipe.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-doc-id.pipe.spec.ts
@@ -1,0 +1,24 @@
+import { TextDocId } from '../../core/models/text-doc';
+import { TextDocIdPipe } from './text-doc-id.pipe';
+
+describe('TextDocIdPipe', () => {
+  let pipe: TextDocIdPipe;
+
+  beforeEach(() => {
+    pipe = new TextDocIdPipe();
+  });
+
+  it('should return undefined when any parameter is undefined', () => {
+    expect(pipe.transform(undefined, 1, 1)).toBeUndefined();
+    expect(pipe.transform('projectId', undefined, 1)).toBeUndefined();
+    expect(pipe.transform('projectId', 1, undefined)).toBeUndefined();
+  });
+
+  it('should return a new TextDocId instance when all parameters are defined', () => {
+    const projectId = 'projectId';
+    const bookNum = 1;
+    const chapter = 1;
+    const result = pipe.transform(projectId, bookNum, chapter);
+    expect(result).toEqual(new TextDocId(projectId, bookNum, chapter));
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-doc-id.pipe.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-doc-id.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
+import { TextDocId } from '../../core/models/text-doc';
+
+@Pipe({
+  name: 'textDocId'
+})
+export class TextDocIdPipe implements PipeTransform {
+  transform(
+    projectId: string | undefined,
+    bookNum: number | undefined,
+    chapter: number | undefined,
+    textType: TextType = 'target'
+  ): TextDocId | undefined {
+    return projectId == null || bookNum == null || chapter == null
+      ? undefined
+      : new TextDocId(projectId, bookNum, chapter, textType);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
@@ -1,7 +1,7 @@
 <mat-progress-bar
   class="progress-bar"
-  [mode]="mode"
-  [value]="syncProgressPercent"
+  [mode]="(syncProgressMode$ | async) ?? 'indeterminate'"
+  [value]="syncProgressPercent$ | async"
   [bufferValue]="1"
   color="accent"
 ></mat-progress-bar>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
@@ -1,0 +1,9 @@
+<app-text
+  *ngIf="projectId"
+  [id]="projectId | textDocId : bookNum : chapter"
+  [isReadOnly]="true"
+  [subscribeToUpdates]="false"
+  [isRightToLeft]="isRightToLeft"
+  [fontSize]="fontSize"
+  [style.--project-font]="font"
+></app-text>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
@@ -3,6 +3,8 @@
   [id]="projectId | textDocId : bookNum : chapter"
   [isReadOnly]="true"
   [subscribeToUpdates]="false"
+  [highlightSegment]="highlightSegment ?? false"
+  [segmentRef]="segmentRef ?? ''"
   [isRightToLeft]="isRightToLeft"
   [fontSize]="fontSize"
   [style.--project-font]="font"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { Subject } from 'rxjs';
+import { anything, mock, verify, when } from 'ts-mockito';
+import { FontService } from 'xforge-common/font.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { EditorResourceComponent } from './editor-resource.component';
+
+describe('EditorResourceComponent', () => {
+  let component: EditorResourceComponent;
+  let fixture: ComponentFixture<EditorResourceComponent>;
+  const mockSFProjectService = mock(SFProjectService);
+  const mockFontService = mock(FontService);
+  const projectDoc = {
+    id: 'projectId',
+    data: createTestProject()
+  } as SFProjectDoc;
+
+  configureTestingModule(() => ({
+    providers: [
+      { provide: SFProjectService, useMock: mockSFProjectService },
+      { provide: FontService, useMock: mockFontService }
+    ]
+  }));
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(EditorResourceComponent);
+    component = fixture.componentInstance;
+    component.resourceText = { editorCreated: new Subject<void>() } as any;
+  });
+
+  afterEach(() => {
+    expect(true).toBe(true); // Suppress 'no expectations' warning
+  });
+
+  it('should not init when projectId, bookNum, or chapter is undefined', () => {
+    component.projectId = undefined;
+    component.bookNum = 1;
+    component.chapter = 1;
+    component['initProjectDetails']();
+
+    component.resourceText.editorCreated.next();
+    verify(mockSFProjectService.getProfile(anything())).never();
+
+    component.projectId = 'test';
+    component.bookNum = undefined;
+    component.inputChanged$.next();
+    verify(mockSFProjectService.getProfile(anything())).never();
+
+    component.bookNum = 1;
+    component.chapter = undefined;
+    component.inputChanged$.next();
+    verify(mockSFProjectService.getProfile(anything())).never();
+  });
+
+  it('should init when projectId, bookNum, and chapter are defined', fakeAsync(() => {
+    const projectId = projectDoc.id;
+    component.projectId = projectId;
+    component.bookNum = 1;
+    component.chapter = 1;
+    when(mockSFProjectService.getProfile(projectId)).thenReturn(Promise.resolve(projectDoc));
+    component['initProjectDetails']();
+    component.resourceText.editorCreated.next();
+    tick();
+    verify(mockSFProjectService.getProfile(projectId)).once();
+    verify(mockFontService.getFontFamilyFromProject(projectDoc)).once();
+  }));
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -1,0 +1,59 @@
+import { AfterViewInit, Component, DestroyRef, Input, OnChanges, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest, EMPTY, startWith, Subject, switchMap } from 'rxjs';
+import { FontService } from 'xforge-common/font.service';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TextComponent } from '../../../shared/text/text.component';
+import { formatFontSizeToRems } from '../../../shared/utils';
+
+@Component({
+  selector: 'app-editor-resource',
+  templateUrl: './editor-resource.component.html'
+})
+export class EditorResourceComponent implements AfterViewInit, OnChanges {
+  @Input() projectId?: string;
+  @Input() bookNum?: number;
+  @Input() chapter?: number;
+
+  @ViewChild(TextComponent) resourceText!: TextComponent;
+
+  isRightToLeft = false;
+  fontSize?: string;
+  font?: string;
+
+  inputChanged$ = new Subject<void>();
+
+  constructor(
+    private readonly destroyRef: DestroyRef,
+    private readonly projectService: SFProjectService,
+    private readonly fontService: FontService
+  ) {}
+
+  ngOnChanges(): void {
+    this.inputChanged$.next();
+  }
+
+  ngAfterViewInit(): void {
+    this.initProjectDetails();
+  }
+
+  private initProjectDetails(): void {
+    combineLatest([this.resourceText.editorCreated, this.inputChanged$.pipe(startWith(undefined))])
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        switchMap(() => {
+          if (this.projectId == null || this.bookNum == null || this.chapter == null) {
+            return EMPTY;
+          }
+
+          return this.projectService.getProfile(this.projectId);
+        })
+      )
+      .subscribe((projectDoc: SFProjectProfileDoc) => {
+        this.isRightToLeft = projectDoc.data?.translateConfig?.source?.isRightToLeft ?? false;
+        this.fontSize = formatFontSizeToRems(projectDoc.data?.defaultFontSize);
+        this.font = this.fontService.getFontFamilyFromProject(projectDoc);
+      });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -15,6 +15,8 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
   @Input() projectId?: string;
   @Input() bookNum?: number;
   @Input() chapter?: number;
+  @Input() segmentRef?: string;
+  @Input() highlightSegment?: boolean;
 
   @ViewChild(TextComponent) resourceText!: TextComponent;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -66,6 +66,8 @@
           [projectId]="tab.projectId"
           [bookNum]="bookNum"
           [chapter]="chapter"
+          [segmentRef]="target?.segmentRef"
+          [highlightSegment]="targetFocused"
         ></app-editor-resource>
 
         <div *ngIf="tab.type === 'project-source'" class="project-tab-container">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -61,6 +61,13 @@
           {{ tab.headerText }}
         </ng-template>
 
+        <app-editor-resource
+          *ngIf="tab.type === 'project-resource'"
+          [projectId]="tab.projectId"
+          [bookNum]="bookNum"
+          [chapter]="chapter"
+        ></app-editor-resource>
+
         <div *ngIf="tab.type === 'project-source'" class="project-tab-container">
           <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
             <div>
@@ -104,7 +111,7 @@
           </div>
         </div>
 
-        <div *ngIf="tab.type === 'project'" class="project-tab-container">
+        <div *ngIf="tab.type === 'project-target'" class="project-tab-container">
           <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
             <div>
               {{ targetCopyrightBanner }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -236,8 +236,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -944,8 +944,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('verse_1_1');
       const selection = env.targetEditor.getSelection();
       expect(selection!.index).toBe(50);
@@ -987,8 +987,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       let selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -999,8 +999,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Acts');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1017,8 +1017,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Matthew');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1035,8 +1035,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(2);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1069,8 +1069,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1174,8 +1174,8 @@ describe('EditorComponent', () => {
       verify(mockedSFProjectService.get('resource01')).never();
       expect(env.bookName).toEqual('Acts');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1191,8 +1191,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('John');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
       expect(env.isSourceAreaHidden).toBe(true);
@@ -1207,8 +1207,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Mark');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -1226,8 +1226,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Romans');
       expect(env.component.chapter).toBe(2);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3363,8 +3363,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3400,8 +3400,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3419,8 +3419,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(2);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3438,8 +3438,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Luke');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3475,8 +3475,8 @@ describe('EditorComponent', () => {
       verify(mockedSFProjectService.get('resource01')).never();
       expect(env.bookName).toEqual('Acts');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3493,8 +3493,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Mark');
       expect(env.component.chapter).toBe(1);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3511,8 +3511,8 @@ describe('EditorComponent', () => {
       env.wait();
       expect(env.bookName).toEqual('Romans');
       expect(env.component.chapter).toBe(2);
-      expect(env.component['sourceLabel']).toEqual('SRC');
-      expect(env.component['targetLabel']).toEqual('TRG');
+      expect(env.component.sourceLabel).toEqual('SRC');
+      expect(env.component.targetLabel).toEqual('TRG');
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
@@ -3735,8 +3735,8 @@ describe('EditorComponent', () => {
       const projectDoc = env.getProjectDoc('project01');
       const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
       env.wait();
-
       expect(spyCreateTab).toHaveBeenCalledWith('project-source', {
+        projectId: projectDoc.data?.translateConfig.source?.projectRef,
         headerText: projectDoc.data?.translateConfig.source?.shortName
       });
       discardPeriodicTasks();
@@ -3757,7 +3757,8 @@ describe('EditorComponent', () => {
       const projectDoc = env.getProjectDoc('project01');
       const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
       env.wait();
-      expect(spyCreateTab).toHaveBeenCalledWith('project', {
+      expect(spyCreateTab).toHaveBeenCalledWith('project-target', {
+        projectId: projectDoc.id,
         headerText: projectDoc.data?.shortName
       });
       discardPeriodicTasks();
@@ -3796,11 +3797,11 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('should not add draft tab if draft exists and draft tab is already present', fakeAsync(() => {
+    it('should not add draft tab if draft exists and draft tab is already present', fakeAsync(async () => {
       const env = new TestEnvironment();
       env.wait();
 
-      env.component.tabState.addTab('target', env.tabFactory.createTab('draft'));
+      env.component.tabState.addTab('target', await env.tabFactory.createTab('draft'));
       const addTab = spyOn(env.component.tabState, 'addTab');
 
       env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
@@ -4628,7 +4629,7 @@ class TestEnvironment {
 
   dispose(): void {
     this.wait();
-    this.component.metricsSession!.dispose();
+    this.component.metricsSession?.dispose();
     this.waitForPresenceTimer();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.spec.ts
@@ -1,0 +1,72 @@
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
+import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TabStateService } from '../../../shared/sf-tab-group';
+import { EditorTabAddRequestService } from './editor-tab-add-request.service';
+
+describe('EditorTabAddRequestService', () => {
+  let service: EditorTabAddRequestService;
+  let dialogService: DialogService;
+  let projectService: SFProjectService;
+  let tabStateService: TabStateService<any, any>;
+
+  beforeEach(() => {
+    dialogService = mock(DialogService);
+    projectService = mock(SFProjectService);
+    tabStateService = mock(TabStateService);
+
+    service = new EditorTabAddRequestService(
+      instance(dialogService),
+      instance(projectService),
+      instance(tabStateService)
+    );
+  });
+
+  function createTestProjectDoc(index: number): SFProjectDoc {
+    return {
+      id: `testId${index}`,
+      data: createTestProject({
+        paratextId: `testParatextId${index}`,
+        shortName: `testName${index}`
+      })
+    } as SFProjectDoc;
+  }
+
+  it('should handle tab add request for tab type "project-resource"', done => {
+    const projectDoc = createTestProjectDoc(1);
+
+    when(dialogService.openMatDialog(anything(), anything())).thenReturn({
+      afterClosed: () => of(projectDoc)
+    } as any);
+    when(tabStateService.tabs$).thenReturn(of([]));
+
+    service.handleTabAddRequest('project-resource').subscribe(result => {
+      expect(result).toEqual({ projectId: 'testId1', headerText: 'testName1' });
+      done();
+    });
+  });
+
+  it('should handle tab add request for tab type not "project-resource"', done => {
+    service.handleTabAddRequest('history').subscribe(result => {
+      expect(result).toEqual({});
+      done();
+    });
+  });
+
+  it('should get paratext ids for open tabs', done => {
+    const projectDoc1 = createTestProjectDoc(1);
+    const projectDoc2 = createTestProjectDoc(2);
+
+    when(tabStateService.tabs$).thenReturn(of([{ projectId: projectDoc1.id }, {}, { projectId: projectDoc2.id }]));
+    when(projectService.get(projectDoc1.id)).thenResolve(projectDoc1);
+    when(projectService.get(projectDoc2.id)).thenResolve(projectDoc2);
+
+    service['getParatextIdsForOpenTabs']().subscribe(result => {
+      expect(result).toEqual([projectDoc1.data!.paratextId, projectDoc2.data!.paratextId]);
+      done();
+    });
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
@@ -63,6 +63,7 @@ export class EditorTabAddRequestService implements TabAddRequestService<EditorTa
         {
           panelClass: 'editor-tab-add-resource-dialog',
           disableClose: true, // Ensure explicit cancellation by user
+          autoFocus: false, // Prevent dialog from focusing the select box when user clicks outside the dialog
           width: '700px',
           data: {
             // Don't show projects/resources that are already open in a tab

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@angular/core';
+import { EditorTabGroupType, EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
+import { map, Observable, of, switchMap, take } from 'rxjs';
+import { DialogService } from 'xforge-common/dialog.service';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TabStateService } from '../../../shared/sf-tab-group';
+import { TabAddRequestService } from '../../../shared/sf-tab-group/base-services/tab-add-request.service';
+import {
+  EditorTabAddResourceDialogComponent,
+  EditorTabAddResourceDialogData
+} from './editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component';
+import { EditorTabInfo } from './editor-tabs.types';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EditorTabAddRequestService implements TabAddRequestService<EditorTabType, EditorTabInfo> {
+  constructor(
+    private readonly dialogService: DialogService,
+    private readonly projectService: SFProjectService,
+    private readonly tabState: TabStateService<EditorTabGroupType, EditorTabInfo>
+  ) {}
+
+  handleTabAddRequest(tabType: EditorTabType): Observable<Partial<EditorTabInfo> | never> {
+    switch (tabType) {
+      case 'project-resource':
+        // Exclude any resources that are already open in a tab
+        return this.getParatextIdsForOpenTabs().pipe(
+          switchMap(paratextIds => this.promptUserResourceSelection(paratextIds))
+        );
+      default:
+        // No extra tab info
+        return of({});
+    }
+  }
+
+  /**
+   * Gets the paratext id for each open project tab with a projectId.
+   */
+  private getParatextIdsForOpenTabs(): Observable<string[]> {
+    return this.tabState.tabs$.pipe(
+      take(1),
+      switchMap(tabs =>
+        Promise.all(tabs.map(tab => (tab.projectId != null ? this.projectService.get(tab.projectId) : undefined)))
+      ),
+      map(projectDocs => projectDocs.map(doc => doc?.data?.paratextId).filter(id => id) as string[])
+    );
+  }
+
+  /**
+   * Opens a dialog that prompts the user to select a paratext project or DBL resource, excluding any
+   * resources that are already open in a tab.
+   * @param excludedParatextIds List of paratext ids for resources that should not be listed as options for selection.
+   * @returns An observable containing data for the selected resource.
+   * The returned observable will not emit if no resource was selected.
+   */
+  private promptUserResourceSelection(excludedParatextIds: string[]): Observable<Partial<EditorTabInfo> | never> {
+    return this.dialogService
+      .openMatDialog<EditorTabAddResourceDialogComponent, EditorTabAddResourceDialogData>(
+        EditorTabAddResourceDialogComponent,
+        {
+          panelClass: 'editor-tab-add-resource-dialog',
+          disableClose: true, // Ensure explicit cancellation by user
+          width: '700px',
+          data: {
+            // Don't show projects/resources that are already open in a tab
+            excludedParatextIds
+          }
+        }
+      )
+      .afterClosed()
+      .pipe(
+        filterNullish(),
+        map((projectDoc: SFProjectDoc) => {
+          return {
+            projectId: projectDoc.id,
+            headerText: projectDoc.data?.shortName
+          };
+        })
+      );
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
@@ -1,0 +1,57 @@
+<mat-progress-bar *ngIf="isLoading && !isSyncActive" mode="indeterminate" color="accent"></mat-progress-bar>
+<app-sync-progress
+  *ngIf="isSyncActive"
+  [projectDoc]="selectedProjectDoc"
+  (inProgress)="onSyncProgress($event)"
+></app-sync-progress>
+
+<ng-container *transloco="let t; read: 'editor_add_tab_resource_dialog'">
+  <h1 mat-dialog-title>{{ t("dialog_title") }}</h1>
+  <mat-dialog-content>
+    <div [formGroup]="form">
+      <app-project-select
+        formControlName="sourceParatextId"
+        [placeholder]="isLoading ? t('placeholder_loading') : t('placeholder_ready')"
+        [projects]="projects"
+        [resources]="resources"
+        [hiddenParatextIds]="dialogData.excludedParatextIds"
+        [isDisabled]="
+          (onlineStatus.onlineStatus$ | async) === false ||
+          isLoading ||
+          isSyncActive ||
+          (projectLoadingFailed && resourceLoadingFailed)
+        "
+        (projectSelect)="onProjectSelected($event)"
+      ></app-project-select>
+    </div>
+
+    <div *ngIf="isSyncActive" class="loading-message">
+      {{ t("loading") }} {{ selectedProjectDoc?.data?.shortName }}{{ animatedEllipsis$ | async }}
+    </div>
+
+    <mat-error *ngIf="projectLoadingFailed && resourceLoadingFailed">
+      {{ t("error_fetching_projects_resources") }}
+    </mat-error>
+    <mat-error *ngIf="projectLoadingFailed && !resourceLoadingFailed">
+      {{ t("error_fetching_projects") }}
+    </mat-error>
+    <mat-error *ngIf="resourceLoadingFailed && !projectLoadingFailed">
+      {{ t("error_fetching_resources") }}
+    </mat-error>
+    <mat-error *ngIf="projectFetchFailed || syncFailed">
+      {{ t("error_loading_resource") }}
+    </mat-error>
+  </mat-dialog-content>
+
+  <mat-dialog-actions>
+    <button mat-button (click)="onCancel()">{{ t("cancel") }}</button>
+    <button
+      mat-flat-button
+      color="primary"
+      [disabled]="!form.valid || isLoading || isSyncActive || projectFetchFailed || syncFailed"
+      (click)="confirmSelection()"
+    >
+      {{ t("select") }}
+    </button>
+  </mat-dialog-actions>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.scss
@@ -1,0 +1,23 @@
+mat-progress-bar,
+app-sync-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  border-radius: 4px 4px 0 0;
+}
+
+mat-dialog-actions {
+  display: flex;
+  place-content: flex-end;
+}
+
+::ng-deep .editor-tab-add-resource-dialog {
+  // For positioning the progress bar within the dialog
+  position: relative !important;
+}
+
+.loading-message {
+  font-style: italic;
+  color: #777;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -1,8 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import {
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { anything, mock, verify, when } from 'ts-mockito';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -1,0 +1,215 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+  MatLegacyDialogRef as MatDialogRef
+} from '@angular/material/legacy-dialog';
+import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { anything, mock, verify, when } from 'ts-mockito';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { ParatextProject } from '../../../../core/models/paratext-project';
+import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
+import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
+import { PermissionsService } from '../../../../core/permissions.service';
+import { SFProjectService } from '../../../../core/sf-project.service';
+import { EditorTabAddResourceDialogComponent } from './editor-tab-add-resource-dialog.component';
+
+const mockSFProjectService = mock(SFProjectService);
+const mockParatextService = mock(ParatextService);
+const mockMatDialogRef = mock(MatDialogRef);
+const mockPermissionsService = mock(PermissionsService);
+
+describe('EditorTabAddResourceDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [TestOnlineStatusModule.forRoot(), TestTranslocoModule],
+    providers: [
+      { provide: SFProjectService, useMock: mockSFProjectService },
+      { provide: ParatextService, useMock: mockParatextService },
+      { provide: PermissionsService, useMock: mockPermissionsService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+      { provide: MatDialogRef, useMock: mockMatDialogRef },
+      { provide: MAT_DIALOG_DATA, useValue: {} }
+    ]
+  }));
+
+  afterEach(() => {
+    expect(true).toBe(true); // Suppress 'no expectations' warning
+  });
+
+  it('should call getProjectsAndResources when ngOnInit is called', fakeAsync(() => {
+    const env = new TestEnvironment();
+    spyOn<any>(env.component, 'getProjectsAndResources');
+    env.component.ngOnInit();
+    tick();
+    expect(env.component['getProjectsAndResources']).toHaveBeenCalled();
+  }));
+
+  describe('getProjectsAndResources', () => {
+    it('should set projects and resources and clear error flags', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.component['getProjectsAndResources']();
+      env.component.projectLoadingFailed = true;
+      env.component.resourceLoadingFailed = true;
+      tick();
+      verify(mockParatextService.getProjects()).once();
+      verify(mockParatextService.getResources()).once();
+      expect(env.component.projects).toEqual(env.projects);
+      expect(env.component.resources).toEqual(env.resources);
+      expect(env.component.projectLoadingFailed).toBe(false);
+      expect(env.component.resourceLoadingFailed).toBe(false);
+    }));
+
+    it('should filter projects that already have a corresponding SF project OR are connectable', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const expectedResult = [
+        env.createTestParatextProject(1, { projectId: 'p1', isConnectable: true }),
+        env.createTestParatextProject(2, { projectId: 'p2', isConnectable: false }),
+        env.createTestParatextProject(3, { projectId: undefined, isConnectable: true })
+      ];
+      const projects = [
+        ...expectedResult,
+        env.createTestParatextProject(4, { projectId: undefined, isConnectable: false }),
+        env.createTestParatextProject(5, { projectId: undefined, isConnectable: false })
+      ];
+      when(mockParatextService.getProjects()).thenReturn(Promise.resolve(projects));
+      env.component['getProjectsAndResources']();
+      tick();
+      expect(env.component.projects).toEqual(expectedResult);
+    }));
+
+    it('should set error flags when getProjects or getResources throw an error', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockParatextService.getProjects()).thenReject(new Error());
+      when(mockParatextService.getResources()).thenReject(new Error());
+      env.component['getProjectsAndResources']();
+      tick();
+      expect(env.component.projectLoadingFailed).toBe(true);
+      expect(env.component.resourceLoadingFailed).toBe(true);
+    }));
+  });
+
+  describe('confirmSelection', () => {
+    it('should call fetchProject when confirmSelection is called', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).once();
+    }));
+
+    it('should call syncProject and not close dialog if fetched project has no texts when confirmSelection is called', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockPermissionsService.canSync(anything())).thenReturn(true);
+      env.setupProject({ texts: [] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineSync(env.projectId)).once();
+      verify(mockMatDialogRef.close(anything())).never();
+    }));
+
+    it('should call syncProject and close dialog if fetched project has texts when confirmSelection is called', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockPermissionsService.canSync(anything())).thenReturn(true);
+      env.setupProject({ texts: [{} as any] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineSync(env.projectId)).once();
+      verify(mockMatDialogRef.close(anything())).once();
+    }));
+
+    it('should not call syncProject and close dialog if user does not have sync permission', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockPermissionsService.canSync(anything())).thenReturn(false);
+      env.setupProject({ texts: [{} as any] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineSync(env.projectId)).never();
+      verify(mockMatDialogRef.close(anything())).once();
+    }));
+
+    it('should set projectFetchFailed to true when fetchProject returns undefined', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).thenReturn(Promise.resolve(undefined));
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).once();
+      expect(env.component.projectFetchFailed).toBe(true);
+    }));
+
+    it('should set syncFailed to true and call cancelSync when syncProject throws an error', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockPermissionsService.canSync(anything())).thenReturn(true);
+      env.setupProject({ texts: [] });
+      when(mockSFProjectService.onlineSync(anything())).thenReject(new Error());
+      spyOn<any>(env.component, 'cancelSync');
+      env.component.confirmSelection();
+      tick();
+      expect(env.component.syncFailed).toBe(true);
+      expect(env.component['cancelSync']).toHaveBeenCalled();
+    }));
+  });
+
+  it('should reset errors when onProjectSelected is called', () => {
+    const env = new TestEnvironment();
+    env.component.projectLoadingFailed = true;
+    env.component.resourceLoadingFailed = true;
+    env.component.projectFetchFailed = true;
+    env.component.syncFailed = true;
+    env.component.onProjectSelected({} as SelectableProject);
+    expect(env.component.projectLoadingFailed).toBe(false);
+    expect(env.component.resourceLoadingFailed).toBe(false);
+    expect(env.component.projectFetchFailed).toBe(false);
+    expect(env.component.syncFailed).toBe(false);
+  });
+});
+
+class TestEnvironment {
+  component: EditorTabAddResourceDialogComponent;
+  fixture: ComponentFixture<EditorTabAddResourceDialogComponent>;
+
+  projects: ParatextProject[] = [this.createTestParatextProject(1), this.createTestParatextProject(2)];
+  resources: ParatextProject[] = [this.createTestParatextProject(3), this.createTestParatextProject(4)];
+  testProjectDoc!: SFProjectDoc;
+
+  projectId = 'projectId';
+  paratextId = 'testParatextId';
+
+  constructor() {
+    this.setupProject();
+
+    when(mockParatextService.getProjects()).thenReturn(Promise.resolve(this.projects));
+    when(mockParatextService.getResources()).thenReturn(Promise.resolve(this.resources));
+    when(mockSFProjectService.getOrCreateRealtimeProject(this.paratextId)).thenCall(() =>
+      Promise.resolve(this.testProjectDoc.id)
+    );
+    when(mockSFProjectService.get(this.projectId)).thenCall(() => Promise.resolve(this.testProjectDoc));
+    when(mockSFProjectService.onlineSync(this.projectId)).thenReturn(Promise.resolve());
+
+    this.fixture = TestBed.createComponent(EditorTabAddResourceDialogComponent);
+    this.component = this.fixture.componentInstance;
+
+    this.component.form.setValue({ sourceParatextId: this.paratextId });
+  }
+
+  setupProject(overrides?: Partial<SFProject>): void {
+    this.testProjectDoc = {
+      id: this.projectId,
+      data: createTestProject(overrides)
+    } as SFProjectDoc;
+  }
+
+  createTestParatextProject(index: number, overrides?: Partial<ParatextProject>): ParatextProject {
+    return {
+      paratextId: `ptId${index}`,
+      name: `Paratext Project ${index}`,
+      shortName: `PTProject${index}`,
+      languageTag: 'en',
+      projectId: `projectId${index}`,
+      isConnectable: true,
+      isConnected: false,
+      ...overrides
+    };
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -6,9 +6,10 @@ import { map, repeat, take, timer } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
-import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
+import { SelectableProject } from '../../../../core/paratext.service';
 import { PermissionsService } from '../../../../core/permissions.service';
 import { SFProjectService } from '../../../../core/sf-project.service';
+import { EditorTabAddResourceDialogService } from './editor-tab-add-resource-dialog.service';
 
 export interface EditorTabAddResourceDialogData {
   excludedParatextIds: string[];
@@ -48,7 +49,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
   constructor(
     private readonly destroyRef: DestroyRef,
     readonly onlineStatus: OnlineStatusService,
-    private readonly paratextService: ParatextService,
+    private readonly editorTabAddResourceDialogService: EditorTabAddResourceDialogService,
     private readonly projectService: SFProjectService,
     private readonly permissionsService: PermissionsService,
     private readonly dialogRef: MatDialogRef<EditorTabAddResourceDialogComponent, SFProjectDoc>,
@@ -119,14 +120,14 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
     this.isLoading = true;
 
     await Promise.all([
-      this.paratextService
+      this.editorTabAddResourceDialogService
         .getProjects()
         .then(projects => {
           this.projectLoadingFailed = false;
           this.projects = this.filterConnectable(projects);
         })
         .catch(() => (this.projectLoadingFailed = true)),
-      this.paratextService
+      this.editorTabAddResourceDialogService
         .getResources()
         .then(resources => {
           this.resourceLoadingFailed = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -1,10 +1,7 @@
 import { Component, DestroyRef, Inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import {
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { map, repeat, take, timer } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -1,0 +1,179 @@
+import { Component, DestroyRef, Inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
+  MatLegacyDialogRef as MatDialogRef
+} from '@angular/material/legacy-dialog';
+import { map, repeat, take, timer } from 'rxjs';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { ParatextProject } from '../../../../core/models/paratext-project';
+import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
+import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
+import { PermissionsService } from '../../../../core/permissions.service';
+import { SFProjectService } from '../../../../core/sf-project.service';
+
+export interface EditorTabAddResourceDialogData {
+  excludedParatextIds: string[];
+}
+
+@Component({
+  selector: 'app-editor-tab-add-resource-dialog',
+  templateUrl: './editor-tab-add-resource-dialog.component.html',
+  styleUrls: ['./editor-tab-add-resource-dialog.component.scss']
+})
+export class EditorTabAddResourceDialogComponent implements OnInit {
+  projects?: ParatextProject[];
+  resources?: SelectableProject[];
+
+  selectedProjectDoc?: SFProjectDoc;
+
+  projectLoadingFailed = false;
+  resourceLoadingFailed = false;
+
+  isLoading = false;
+  isSyncActive = false;
+  projectFetchFailed = false;
+  syncFailed = false;
+
+  // Placed after 'Loading' when syncing
+  animatedEllipsis$ = timer(500, 300).pipe(
+    takeUntilDestroyed(this.destroyRef),
+    map(i => '.'.repeat(i % 4)),
+    take(4),
+    repeat()
+  );
+
+  form = new FormGroup({
+    sourceParatextId: new FormControl<string | undefined>(undefined, Validators.required)
+  });
+
+  constructor(
+    private readonly destroyRef: DestroyRef,
+    readonly onlineStatus: OnlineStatusService,
+    private readonly paratextService: ParatextService,
+    private readonly projectService: SFProjectService,
+    private readonly permissionsService: PermissionsService,
+    private readonly dialogRef: MatDialogRef<EditorTabAddResourceDialogComponent, SFProjectDoc>,
+    @Inject(MAT_DIALOG_DATA) readonly dialogData: EditorTabAddResourceDialogData
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    await this.getProjectsAndResources();
+  }
+
+  onProjectSelected(_selectableProject: SelectableProject): void {
+    this.resetErrors();
+  }
+
+  async confirmSelection(): Promise<void> {
+    const paratextId: string | null | undefined = this.form.value.sourceParatextId;
+
+    try {
+      if (paratextId != null) {
+        this.isLoading = true;
+        this.selectedProjectDoc = await this.fetchProject(paratextId);
+
+        if (this.selectedProjectDoc != null) {
+          if (this.permissionsService.canSync(this.selectedProjectDoc)) {
+            // Wait for sync if no texts
+            if (!this.selectedProjectDoc.data?.texts.length) {
+              this.isSyncActive = true;
+              await this.syncProject(this.selectedProjectDoc.id);
+            } else {
+              // Otherwise, start a sync in the background and close dialog
+              this.syncProject(this.selectedProjectDoc.id);
+              this.dialogRef.close(this.selectedProjectDoc);
+            }
+          } else {
+            this.dialogRef.close(this.selectedProjectDoc);
+          }
+        } else {
+          this.projectFetchFailed = true;
+        }
+      }
+    } catch (e) {
+      this.syncFailed = true;
+      try {
+        this.cancelSync();
+      } catch {}
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  onCancel(): void {
+    this.cancelSync();
+
+    // Return undefined to cancel tab creation
+    this.dialogRef.close(undefined);
+  }
+
+  onSyncProgress(isActive: boolean): void {
+    this.isSyncActive = isActive;
+
+    // Wait for sync to complete before closing dialog
+    if (!isActive) {
+      this.dialogRef.close(this.selectedProjectDoc);
+    }
+  }
+
+  private async getProjectsAndResources(): Promise<void> {
+    this.isLoading = true;
+
+    await Promise.all([
+      this.paratextService
+        .getProjects()
+        .then(projects => {
+          this.projectLoadingFailed = false;
+          this.projects = this.filterConnectable(projects);
+        })
+        .catch(() => (this.projectLoadingFailed = true)),
+      this.paratextService
+        .getResources()
+        .then(resources => {
+          this.resourceLoadingFailed = false;
+          this.resources = resources;
+        })
+        .catch(() => (this.resourceLoadingFailed = true))
+    ]).then(() => {
+      this.isLoading = false;
+    });
+  }
+
+  private cancelSync(): void {
+    if (this.selectedProjectDoc?.id != null && this.isSyncActive) {
+      this.projectService.onlineCancelSync(this.selectedProjectDoc.id);
+    }
+
+    this.isSyncActive = false;
+  }
+
+  private resetErrors(): void {
+    this.projectLoadingFailed = false;
+    this.resourceLoadingFailed = false;
+    this.projectFetchFailed = false;
+    this.syncFailed = false;
+  }
+
+  /**
+   * Gets the project/resource with the selected paratext id, creating an SF project for it if needed.
+   */
+  private async fetchProject(paratextId: string): Promise<SFProjectDoc | undefined> {
+    const selectedProjectId: string | undefined = await this.projectService.getOrCreateRealtimeProject(paratextId);
+    return selectedProjectId != null ? this.projectService.get(selectedProjectId) : undefined;
+  }
+
+  private async syncProject(projectId: string): Promise<void> {
+    await this.projectService.onlineSync(projectId);
+  }
+
+  /**
+   * From the given paratext projects, returns those that either:
+   * - already have a corresponding SF project
+   * - or have current user as admin on the PT project
+   */
+  private filterConnectable(projects: ParatextProject[] | undefined): ParatextProject[] | undefined {
+    return projects?.filter(project => project.projectId != null || project.isConnectable);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { mock, verify, when } from 'ts-mockito';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { ParatextProject } from '../../../../core/models/paratext-project';
+import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
+import { EditorTabAddResourceDialogService } from './editor-tab-add-resource-dialog.service';
+
+describe('EditorTabAddResourceDialogService', () => {
+  let service: EditorTabAddResourceDialogService;
+  const mockParatextService = mock(ParatextService);
+  const mockProjects: ParatextProject[] = [
+    { id: '1', name: 'Project 1' },
+    { id: '2', name: 'Project 2' }
+  ] as any;
+  const mockResources: SelectableProject[] = [
+    { id: '1', name: 'Resource 1' },
+    { id: '2', name: 'Resource 2' }
+  ] as any;
+
+  configureTestingModule(() => ({
+    providers: [{ provide: ParatextService, useMock: mockParatextService }]
+  }));
+
+  beforeEach(() => {
+    service = TestBed.inject(EditorTabAddResourceDialogService);
+  });
+
+  it('should return cached projects if available', async () => {
+    service.projects = mockProjects;
+    expect(await service.getProjects()).toEqual(mockProjects);
+  });
+
+  it('should call getProjects if projects are not cached', async () => {
+    when(mockParatextService.getProjects()).thenResolve(mockProjects);
+    expect(await service.getProjects()).toEqual(mockProjects);
+    expect(service.projects).toEqual(mockProjects);
+    verify(mockParatextService.getProjects()).once();
+  });
+
+  it('should return cached resources if available', async () => {
+    service.resources = mockResources;
+    expect(await service.getResources()).toEqual(mockResources);
+  });
+
+  it('should call getResources if resources are not cached', async () => {
+    when(mockParatextService.getResources()).thenResolve(mockResources);
+    expect(await service.getResources()).toEqual(mockResources);
+    expect(service.resources).toEqual(mockResources);
+    verify(mockParatextService.getResources()).once();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ParatextProject } from '../../../../core/models/paratext-project';
+import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EditorTabAddResourceDialogService {
+  // Cache values until page refresh
+  projects?: ParatextProject[];
+  resources?: SelectableProject[];
+
+  constructor(private readonly paratextService: ParatextService) {}
+
+  getProjects(): Promise<ParatextProject[] | undefined> {
+    return this.projects != null
+      ? Promise.resolve(this.projects)
+      : this.paratextService.getProjects().then(projects => (this.projects = projects));
+  }
+
+  getResources(): Promise<SelectableProject[] | undefined> {
+    return this.resources != null
+      ? Promise.resolve(this.resources)
+      : this.paratextService.getResources().then(resources => (this.resources = resources));
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -1,37 +1,49 @@
 import { TestBed } from '@angular/core/testing';
 import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
+import { of } from 'rxjs';
+import { anything, mock, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { EditorTabFactoryService } from './editor-tab-factory.service';
 
 describe('EditorTabFactoryService', () => {
   let service: EditorTabFactoryService;
+  const mockI18nService = mock(I18nService);
+
+  configureTestingModule(() => ({
+    imports: [TestTranslocoModule],
+    providers: [{ provide: I18nService, useMock: mockI18nService }]
+  }));
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(EditorTabFactoryService);
+    when(mockI18nService.translate(anything())).thenReturn(of('Test Header Text'));
   });
 
-  it('should create a "history" tab', () => {
-    const tab = service.createTab('history');
+  it('should create a "history" tab', async () => {
+    const tab = await service.createTab('history');
     expect(tab.type).toEqual('history');
     expect(tab.icon).toEqual('history');
-    expect(tab.headerText).toEqual('History');
+    expect(tab.headerText).toEqual('Test Header Text');
     expect(tab.closeable).toEqual(true);
     expect(tab.movable).toEqual(true);
+    expect(tab.unique).toBeFalsy();
   });
 
-  it('should create a "draft" tab', () => {
-    const tab = service.createTab('draft');
+  it('should create a "draft" tab', async () => {
+    const tab = await service.createTab('draft');
     expect(tab.type).toEqual('draft');
     expect(tab.icon).toEqual('auto_awesome');
-    expect(tab.headerText).toEqual('Auto Draft');
+    expect(tab.headerText).toEqual('Test Header Text');
     expect(tab.closeable).toEqual(false);
     expect(tab.movable).toEqual(true);
     expect(tab.unique).toEqual(true);
   });
 
-  it('should create a "project" tab', () => {
-    const tab = service.createTab('project', { headerText: 'Project 1' });
-    expect(tab.type).toEqual('project');
+  it('should create a "project-target" tab', async () => {
+    const tab = await service.createTab('project-target', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.projectId).toEqual('project1');
+    expect(tab.type).toEqual('project-target');
     expect(tab.icon).toEqual('book');
     expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(false);
@@ -39,8 +51,9 @@ describe('EditorTabFactoryService', () => {
     expect(tab.unique).toEqual(true);
   });
 
-  it('should create a "project-source" tab', () => {
-    const tab = service.createTab('project-source', { headerText: 'Project 1' });
+  it('should create a "project-source" tab', async () => {
+    const tab = await service.createTab('project-source', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-source');
     expect(tab.icon).toEqual('book');
     expect(tab.headerText).toEqual('Project 1');
@@ -49,15 +62,36 @@ describe('EditorTabFactoryService', () => {
     expect(tab.unique).toEqual(true);
   });
 
-  it('should throw error for unknown tab type', () => {
-    expect(() => service.createTab('unknown' as EditorTabType)).toThrowError('Unknown TabType: unknown');
+  it('should create a "project-resource" tab', async () => {
+    const tab = await service.createTab('project-resource', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.projectId).toEqual('project1');
+    expect(tab.type).toEqual('project-resource');
+    expect(tab.icon).toEqual('library_books');
+    expect(tab.headerText).toEqual('Project 1');
+    expect(tab.closeable).toEqual(true);
+    expect(tab.movable).toEqual(true);
+    expect(tab.unique).toBeFalsy();
   });
 
-  it('should throw error for "project" tab without headerText', () => {
-    expect(() => service.createTab('project')).toThrowError("'tabOptions' must include 'headerText'");
+  it('should throw error for unknown tab type', async () => {
+    await expectAsync(service.createTab('unknown' as EditorTabType)).toBeRejectedWithError('Unknown TabType: unknown');
   });
 
-  it('should throw error for "project-source" tab without headerText', () => {
-    expect(() => service.createTab('project-source')).toThrowError("'tabOptions' must include 'headerText'");
+  it('should throw error for "project-target" tab without projectId', async () => {
+    await expectAsync(service.createTab('project-target')).toBeRejectedWithError(
+      "'tabOptions' must include 'projectId'"
+    );
+  });
+
+  it('should throw error for "project-source" tab without projectId', async () => {
+    await expectAsync(service.createTab('project-source')).toBeRejectedWithError(
+      "'tabOptions' must include 'projectId'"
+    );
+  });
+
+  it('should throw error for "project-resource" tab without projectId', async () => {
+    await expectAsync(service.createTab('project-resource')).toBeRejectedWithError(
+      "'tabOptions' must include 'projectId'"
+    );
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
@@ -32,6 +32,20 @@ describe('EditorTabPersistenceService', () => {
     tick();
     expect(env.pucDoc.updateEditorOpenTabs).not.toHaveBeenCalled();
   }));
+
+  it('should ignore undefined properties', fakeAsync(() => {
+    const tabs = [
+      { a: 1, b: 2 },
+      { a: 3, b: 4, c: undefined }
+    ] as unknown as EditorTabPersistData[];
+    const env = new TestEnvironment([]);
+    env.service.persistTabsOpen(tabs);
+    tick();
+    expect(env.pucDoc.updateEditorOpenTabs).toHaveBeenCalledWith([
+      { a: 1, b: 2 },
+      { a: 3, b: 4 }
+    ] as any);
+  }));
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { isEqual } from 'lodash-es';
+import { isEqual, isUndefined, omitBy } from 'lodash-es';
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import { combineLatest, firstValueFrom, Observable, of, startWith, Subject, Subscription, switchMap, tap } from 'rxjs';
 import { distinctUntilChanged, finalize, shareReplay } from 'rxjs/operators';
@@ -35,6 +35,9 @@ export class EditorTabPersistenceService {
   async persistTabsOpen(tabs: EditorTabPersistData[]): Promise<void> {
     const pucDoc = await firstValueFrom(this.projectUserConfigDoc$);
     const existingTabs = pucDoc.data?.editorTabsOpen;
+
+    // Undefined properties are not persisted and should be ignored in the comparison
+    tabs = tabs.map(tab => omitBy(tab, isUndefined) as EditorTabPersistData);
 
     if (existingTabs != null && !isEqual(existingTabs, tabs)) {
       await pucDoc.updateEditorOpenTabs(tabs);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -15,11 +15,13 @@ import { EditorDraftComponent } from './editor/editor-draft/editor-draft.compone
 import { EditorHistoryComponent } from './editor/editor-history/editor-history.component';
 import { HistoryChooserComponent } from './editor/editor-history/history-chooser/history-chooser.component';
 import { HistoryRevisionFormatPipe } from './editor/editor-history/history-chooser/history-revision-format.pipe';
+import { EditorResourceComponent } from './editor/editor-resource/editor-resource.component';
 import { EditorComponent } from './editor/editor.component';
 import { MultiViewerComponent } from './editor/multi-viewer/multi-viewer.component';
 import { NoteDialogComponent } from './editor/note-dialog/note-dialog.component';
 import { SuggestionsSettingsDialogComponent } from './editor/suggestions-settings-dialog.component';
 import { SuggestionsComponent } from './editor/suggestions.component';
+import { EditorTabAddResourceDialogComponent } from './editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component';
 import { TrainingProgressComponent } from './training-progress/training-progress.component';
 import { TranslateOverviewComponent } from './translate-overview/translate-overview.component';
 import { TranslateRoutingModule } from './translate-routing.module';
@@ -38,7 +40,9 @@ import { TranslateRoutingModule } from './translate-routing.module';
     HistoryChooserComponent,
     EditorHistoryComponent,
     EditorDraftComponent,
-    HistoryRevisionFormatPipe
+    HistoryRevisionFormatPipe,
+    EditorTabAddResourceDialogComponent,
+    EditorResourceComponent
   ],
   imports: [
     AngularSplitModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -238,7 +238,14 @@
     "offline_notice": "Editor history is not available offline."
   },
   "editor_tabs_menu": {
-    "history_tab_header": "History",
+    "history_menu_item": "History",
+    "draft_menu_item": "Auto Draft",
+    "project_resource_menu_item": "Resource..."
+  },
+  "editor_tab_factory": {
+    "default_history_tab_header": "History",
+    "default_project_tab_header": "Project",
+    "default_resource_tab_header": "Resource",
     "draft_tab_header": "Auto Draft"
   },
   "history_chooser": {
@@ -436,6 +443,18 @@
     "hide_community_checking_text": "Hide Scripture text",
     "checkers_listen_to_scripture_audio": "Checkers will need to listen to Scripture audio.",
     "will_not_delete_paratext_project": "This will {{ boldStart }}not{{ boldEnd }} delete your Paratext project, but it will delete any unsynchronized data stored in Scripture Forge. It is recommended to {{ templateTagBoundary }}Synchronize{{ templateTagBoundary }} first before deleting."
+  },
+  "editor_add_tab_resource_dialog": {
+    "dialog_title": "Open Resource Tab",
+    "error_fetching_projects_resources": "There was an error fetching projects and resources.",
+    "error_fetching_projects": "There was an error fetching projects. You will only be able to select resources from Digital Bible Library.",
+    "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
+    "error_loading_resource": "There was an error loading the selected resource.",
+    "loading": "Loading",
+    "placeholder_loading": "{{ editor_add_tab_resource_dialog.loading }}...",
+    "placeholder_ready": "Select paratext project or DBL resource",
+    "cancel": "Cancel",
+    "select": "Select"
   },
   "suggestions_settings_dialog": {
     "better": "Better",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -6,7 +6,9 @@ import { RouterModule } from '@angular/router';
 import { TranslocoModule, TRANSLOCO_CONFIG, TRANSLOCO_LOADER } from '@ngneat/transloco';
 import { ngfModule } from 'angular-file';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
+import { ProjectSelectComponent } from '../app/project-select/project-select.component';
 import { PageNotFoundComponent } from '../app/shared/page-not-found/page-not-found.component';
+import { SyncProgressComponent } from '../app/sync/sync-progress/sync-progress.component';
 import { AuthHttpInterceptor } from './auth-http-interceptor';
 import { AvatarComponent } from './avatar/avatar.component';
 import { GenericDialogComponent } from './generic-dialog/generic-dialog.component';
@@ -30,7 +32,9 @@ const componentExports = [
   SystemAdministrationComponent,
   PageNotFoundComponent,
   WriteStatusComponent,
-  OwnerComponent
+  OwnerComponent,
+  ProjectSelectComponent,
+  SyncProgressComponent
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -67,6 +67,34 @@ public class SFProjectsRpcController(
         }
     }
 
+    public async Task<IRpcMethodResult> CreateResourceProject(string paratextId)
+    {
+        try
+        {
+            string projectId = await projectService.CreateResourceProjectAsync(UserId, paratextId);
+            return Ok(projectId);
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (InvalidOperationException e)
+        {
+            return InvalidParamsError(e.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "CreateResourceProject" }, { "ParatextId", paratextId }, }
+            );
+            throw;
+        }
+    }
+
     public async Task<IRpcMethodResult> Delete(string projectId)
     {
         try

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -498,8 +498,15 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     public async Task CancelSyncAsync(string curUserId, string projectId)
     {
         SFProject project = await GetProjectAsync(projectId);
-        if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
+        if (!HasParatextRole(project, curUserId))
             throw new ForbiddenException();
+
+        // Project syncs require admin or translator role.  Resources can sync with any paratext role.
+        if (!_paratextService.IsResource(project.ParatextId))
+        {
+            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
+                throw new ForbiddenException();
+        }
 
         await _syncService.CancelSyncAsync(curUserId, projectId);
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2787,7 +2787,7 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void SyncAsync_AdministratorsCanSync()
+    public void SyncAsync_AdministratorsCanSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
@@ -2797,7 +2797,7 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void SyncAsync_TranslatorsCanSync()
+    public void SyncAsync_TranslatorsCanSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
@@ -2807,7 +2807,37 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void SyncAsync_ObserversCannotSync()
+    public void SyncAsync_AdministratorsCanSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Resource01));
+    }
+
+    [Test]
+    public void SyncAsync_TranslatorsCanSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Resource01));
+    }
+
+    [Test]
+    public void SyncAsync_ObserversCanSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User02, Resource01));
+    }
+
+    [Test]
+    public void SyncAsync_ObserversCannotSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
@@ -3577,6 +3607,12 @@ public class SFProjectServiceTests
                                         }
                                     }
                                 }
+                            },
+                            UserRoles =
+                            {
+                                { User01, SFProjectRole.Administrator },
+                                { User05, SFProjectRole.Translator },
+                                { User02, SFProjectRole.PTObserver },
                             }
                         },
                         new SFProject

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2747,7 +2747,7 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void CancelSyncAsync_AdministratorsCanCancelSync()
+    public void CancelSyncAsync_AdministratorsCanCancelSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
@@ -2757,7 +2757,7 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void CancelSyncAsync_TranslatorsCanCancelSync()
+    public void CancelSyncAsync_TranslatorsCancelCanSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
@@ -2767,7 +2767,37 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void CancelSyncAsync_ObserversCannotCancelSync()
+    public void CancelSyncAsync_AdministratorsCanCancelSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User01, Resource01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_TranslatorsCancelCanSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User05, Resource01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_ObserversCanCancelSyncResource()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrowAsync(() => env.Service.CancelSyncAsync(User02, Resource01));
+    }
+
+    [Test]
+    public void CancelSyncAsync_ObserversCannotCancelSyncProject()
     {
         // Setup
         var env = new TestEnvironment();


### PR DESCRIPTION
This PR adds the ability for the user to create "resource" tabs of other projects or DBL resources.

- Adds 'Resource' tab menu option when online.
- Clicking 'Resource...' in 'add tab' menu brings up dialog to select a project or resource to add.
- Selecting the project or resource will create an SF project, add the user to it, and display a tab.
  - If SF project already exists, and project has texts, a sync is started in the background and the dialog is closed immediately.
  - Otherwise, the dialog waits for the sync to complete before closing and creating the tab.
- Resource tabs should persist.

**Questions to be resolved:**
  - What user role should be used when adding user to SF project?
  - What icon should be used for the tab, and should the icon be different for projects vs DBL resources?
  - How/when should resources be synced?

### Menu
![image](https://github.com/sillsdev/web-xforge/assets/133386342/cc25529f-10dd-41f7-9333-e2b2f84f142c)

### Dialog
![image](https://github.com/sillsdev/web-xforge/assets/133386342/bcdd806b-346c-4a18-8b03-bcf52db7b598)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2457)
<!-- Reviewable:end -->
