### PR TITLE
SF-2734 Change Serval Configuration permissions to Serval Administrators

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -280,7 +280,7 @@ describe('SettingsComponent', () => {
         expect(env.alternateSourceSelectProjectsResources[2].name).toBe('Sob Jonah and Luke');
       }));
 
-      it('should display for back translations for system administrators', fakeAsync(() => {
+      it('should display for back translations for serval administrators', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({
           preTranslate: false,
@@ -294,7 +294,7 @@ describe('SettingsComponent', () => {
           },
           projectType: ProjectType.BackTranslation
         });
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.alternateSourceSelect).not.toBeNull();
@@ -551,7 +551,7 @@ describe('SettingsComponent', () => {
     });
 
     describe('Serval Config TextArea', () => {
-      it('should not display for non-system administrators', fakeAsync(() => {
+      it('should not display for non-serval administrators', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
         env.wait();
@@ -559,7 +559,7 @@ describe('SettingsComponent', () => {
         expect(env.servalConfigTextArea).toBeNull();
       }));
 
-      it('should display for system administrators on back translations', fakeAsync(() => {
+      it('should display for serval administrators on back translations', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({
           preTranslate: false,
@@ -573,32 +573,32 @@ describe('SettingsComponent', () => {
           },
           projectType: ProjectType.BackTranslation
         });
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
       }));
 
-      it('should display for system administrators on forward translations', fakeAsync(() => {
+      it('should display for serval administrators on forward translations', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
       }));
 
-      it('should not display for system administrators when the feature flag is disabled', fakeAsync(() => {
+      it('should not display for serval administrators when the feature flag is disabled', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
         when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).toBeNull();
       }));
 
-      it('should display for system administrators on forward translations when not approved', fakeAsync(() => {
+      it('should display for serval administrators on forward translations when not approved', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({
           preTranslate: false,
@@ -611,7 +611,7 @@ describe('SettingsComponent', () => {
             additionalTrainingData: false
           }
         });
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -620,7 +620,7 @@ describe('SettingsComponent', () => {
       it('should change serval config value', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -653,7 +653,7 @@ describe('SettingsComponent', () => {
           },
           preTranslate: true
         });
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
@@ -675,7 +675,7 @@ describe('SettingsComponent', () => {
       it('should not update an unchanged serval config value', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -135,7 +135,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     const translateConfig = this.projectDoc?.data?.translateConfig;
     if (translateConfig == null || !this.featureFlags.showNmtDrafting.enabled) {
       return false;
-    } else if (this.authService.currentUserRoles.includes(SystemRole.SystemAdmin)) {
+    } else if (this.authService.currentUserRoles.includes(SystemRole.ServalAdmin)) {
       return true;
     } else {
       return translateConfig.preTranslate === true && translateConfig.projectType !== ProjectType.BackTranslation;
@@ -168,7 +168,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   get canUpdateServalConfig(): boolean {
-    return this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
+    return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1418,16 +1418,16 @@ describe('DraftGenerationComponent', () => {
   });
 
   describe('canShowAdditionalInfo', () => {
-    it('should return true if the user is system admin, and build has additional info', () => {
+    it('should return true if the user is serval admin, and build has additional info', () => {
       let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.SystemAdmin] });
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.ServalAdmin] });
       });
       expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(true);
     });
 
     it('should return false if the draft build has no additional info', () => {
       let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.SystemAdmin] });
+        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.ServalAdmin] });
       });
       expect(env.component.canShowAdditionalInfo({} as BuildDto)).toBe(false);
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -385,7 +385,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   }
 
   canShowAdditionalInfo(job?: BuildDto): boolean {
-    return job?.additionalInfo != null && this.authService.currentUserRoles.includes(SystemRole.SystemAdmin);
+    return job?.additionalInfo != null && this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
   }
 
   canCancel(job?: BuildDto): boolean {


### PR DESCRIPTION
This PR changes Serval configuration and diagnostic functions to require the Serval Administrator role instead o the the System Administrator role.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2459)
<!-- Reviewable:end -->
