### PR TITLE
SF-2369 Update Material Progress Spinner

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
@@ -8,7 +8,7 @@
   *transloco="let t; read: 'checking_audio_player'"
 >
   <ng-content *ngIf="isAudioAvailable$ | async"></ng-content>
-  <mat-spinner *ngIf="audioStatus === AudioStatus.Initializing" [diameter]="20" color="primary"></mat-spinner>
+  <mat-spinner *ngIf="audioStatus === AudioStatus.Initializing" diameter="20" color="primary"></mat-spinner>
   <mat-icon *ngIf="!isAudioAvailable$.value && audioStatus !== AudioStatus.Initializing" [matTooltip]="t(audioStatus)">
     play_disabled
   </mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -13,6 +13,6 @@
       </button>
     </form>
     <a (click)="logIn()" [innerHtml]="i18nService.translateAndInsertTags('join.login_existing_account')"></a>
-    <mat-spinner [diameter]="50" color="#fff" [fxHide]="!isJoining"></mat-spinner>
+    <mat-spinner diameter="50" color="#fff" [fxHide]="!isJoining"></mat-spinner>
   </ng-container>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -139,7 +139,7 @@
 
   <ng-container *ngIf="availableTranslateBooks == null">
     <div class="loading">
-      <mat-spinner [diameter]="20" color="primary"></mat-spinner>
+      <mat-spinner diameter="20" color="primary"></mat-spinner>
       <div>{{ t("loading") }}</div>
     </div>
   </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -131,7 +131,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.legacy-menu-theme($material-app-theme);
 @include mat.paginator-theme($material-app-theme);
 @include mat.progress-bar-theme($material-app-theme);
-@include mat.legacy-progress-spinner-theme($material-app-theme);
+@include mat.progress-spinner-theme($material-app-theme);
 @include mat.radio-theme($material-app-theme);
 @include mat.select-theme($material-app-theme);
 @include mat.sidenav-theme($material-app-theme);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -19,9 +19,9 @@ import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-c
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
-import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
 import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
@@ -1,6 +1,6 @@
 <mat-spinner
   *ngIf="state === ElementState.Submitting && !formGroup?.errors"
-  [diameter]="15"
+  diameter="15"
   class="update-button-spinner"
   aria-label="Update in progress"
 ></mat-spinner>


### PR DESCRIPTION
Updates the Material Progress Spinner to use the new component instead of the legacy component.

There are no real changes, and it functions exactly the same. For this reason, it does not require formal testing.

To view the spinner in action, click the Generate draft button, and witness it briefly appear as the list of books is loaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2460)
<!-- Reviewable:end -->
