### PR TITLE
Fix spelling of "temporarily" on translate overview page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -519,7 +519,7 @@
     "suggestion_engine": "Suggestion Engine",
     "trained_segments": "trained segments",
     "training": "Training...",
-    "training_unavailable": "Training is temporary unavailable",
+    "training_unavailable": "Training is temporarily unavailable",
     "translate_overview": "Translate Overview",
     "translated_segments": "{{ translatedSegments }} of {{ total }} segments"
   },


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2463)
<!-- Reviewable:end -->
