### PR TITLE
SF-2366 mat-menu legacy upgrade

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -43,8 +43,8 @@
           <a mat-menu-item target="_blank" [href]="urls.communityAnnouncementPage">{{ t("announcements") }}</a>
           <a mat-menu-item target="_blank" [href]="urls.communitySupport">{{ t("community_support") }}</a>
           <a mat-menu-item target="_blank" [href]="issueMailTo" class="report-issue">
-            {{ t("report_issue") }}
-            <span class="mat-hint">{{ t("report_issue_email", { email: issueEmail }) }}</span>
+            <div>{{ t("report_issue") }}</div>
+            <div class="mat-hint">{{ t("report_issue_email", { email: issueEmail }) }}</div>
           </a>
           <a mat-menu-item target="_blank" href="/3rdpartylicenses.txt">{{ t("open_source_licenses") }}</a>
           <button
@@ -109,9 +109,11 @@
           <button mat-menu-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">
             {{ t("change_password") }}
           </button>
-          <button *ngIf="canInstallOnDevice$ | async" mat-menu-item (click)="installOnDevice()" class="install-button">
-            {{ t("install_on_device") }}
-            <mat-icon>install_mobile</mat-icon>
+          <button *ngIf="canInstallOnDevice$ | async" mat-menu-item (click)="installOnDevice()">
+            <div class="install-button">
+              {{ t("install_on_device") }}
+              <mat-icon>install_mobile</mat-icon>
+            </div>
           </button>
           <button mat-menu-item (click)="logOut()" id="log-out-link">{{ t("log_out") }}</button>
           <mat-divider></mat-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -94,16 +94,12 @@ header {
   }
 }
 
-::ng-deep .mat-menu-panel {
+::ng-deep .mat-mdc-menu-panel {
   // For menu items that should be mostly styled like the others, but cannot be clicked
   .pseudo-menu-item {
     padding: 0 16px;
     line-height: 36px;
-    font-size: 14px;
     color: rgba(0, 0, 0, 0.87);
-    mat-icon {
-      margin: initial;
-    }
   }
 
   &.help-menu {
@@ -144,14 +140,14 @@ header {
     }
 
     .active-locale {
-      font-weight: bold;
+      --mat-menu-item-label-text-weight: 700;
     }
 
-    .mat-menu-item:not(.active-locale) mat-icon {
+    .mat-mdc-menu-item:not(.active-locale) mat-icon {
       visibility: hidden;
     }
 
-    .mat-menu-item {
+    .mat-mdc-menu-item {
       font-family: variables.$languageFonts;
     }
   }
@@ -202,12 +198,6 @@ header {
   direction: inherit; // needed to override direction: rtl from .material-icons
   font-size: 12px;
   color: white;
-}
-
-::ng-deep .mat-menu-item.report-issue {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.6;
 }
 
 .online-status {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -106,7 +106,7 @@
                       >
                         <mat-icon>more_vert</mat-icon>
                       </button>
-                      <mat-menu #menu="matMenu">
+                      <mat-menu #menu="matMenu" class="checking-overview-chapter-menu">
                         <button
                           *ngIf="questionCount(text.bookNum, chapter.number) > 0"
                           mat-menu-item

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -130,3 +130,9 @@ app-donut-chart {
 #warning-some-actions-unavailable-offline {
   margin-top: 16px;
 }
+
+::ng-deep {
+  .checking-overview-chapter-menu {
+    max-width: none;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -5,7 +5,7 @@ import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
 import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
-import { MatLegacyMenuHarness as MatMenuHarness } from '@angular/material/legacy-menu/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -2446,13 +2446,13 @@ class TestEnvironment {
   async getDecreaseFontSizeButton(): Promise<MatButtonHarness> {
     const menu = await this.getFontSizeMenu();
     await menu.open();
-    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group > button:nth-of-type(1)' }));
+    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group button:nth-of-type(1)' }));
   }
 
   async getIncreaseFontSizeButton(): Promise<MatButtonHarness> {
     const menu = await this.getFontSizeMenu();
     await menu.open();
-    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group > button:nth-of-type(2)' }));
+    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group button:nth-of-type(2)' }));
   }
 
   get editQuestionButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.scss
@@ -12,7 +12,7 @@
 
 // Menu exists in overlay, so ::ng-deep cannot be nested under :host
 ::ng-deep {
-  .mat-menu-panel.font-size-menu {
+  .mat-mdc-menu-panel.font-size-menu {
     min-height: 0;
     min-width: 0;
 
@@ -29,8 +29,12 @@
     }
 
     // Trims the top and bottom off the default mat menu
-    > .mat-menu-content {
+    > .mat-mdc-menu-content {
       padding: 0;
+    }
+
+    .mat-mdc-menu-item {
+      min-height: auto;
     }
 
     // Make ripple more visible (otherwise it uses the light green from button hover text color)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/font-size/font-size.component.spec.ts
@@ -2,10 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
-import {
-  MatLegacyMenuHarness as MatMenuHarness,
-  MatLegacyMenuItemHarness as MatMenuItemHarness
-} from '@angular/material/legacy-menu/testing';
+import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
@@ -25,11 +22,11 @@ describe('FontSizeComponent', () => {
   };
 
   const getDecreaseButton = function (menu: MatMenuHarness): Promise<MatButtonHarness> {
-    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group > button:nth-of-type(1)' }));
+    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group button:nth-of-type(1)' }));
   };
 
   const getIncreaseButton = function (menu: MatMenuHarness): Promise<MatButtonHarness> {
-    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group > button:nth-of-type(2)' }));
+    return menu.getHarness(MatButtonHarness.with({ selector: '.button-group button:nth-of-type(2)' }));
   };
 
   beforeEach(waitForAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/sf-tabs.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatTabsModule } from '@angular/material/tabs';
 import { TranslocoModule } from '@ngneat/transloco';
 import { TabGroupHeaderComponent } from './tab-group-header/tab-group-header.component';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -20,13 +20,6 @@
   padding: 0;
 }
 
-.mat-menu-item app-avatar {
-  margin: auto;
-}
-
-.mat-menu-item span {
-  margin: auto 10px;
-}
 app-avatar {
   cursor: pointer;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -111,6 +111,7 @@
                   mat-menu-item
                   (click)="openRolesDialog(userRow)"
                   [disabled]="isAdmin(userRow.role) || userRow.inviteeStatus"
+                  data-test-id="edit-roles-and-permissions"
                 >
                   {{ t("edit_roles_and_permissions") }}
                 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, getDebugNode } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyMenuHarness as MatMenuHarness } from '@angular/material/legacy-menu/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
@@ -515,6 +515,10 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
+  getElementByTestId(testId: string): DebugElement {
+    return this.fixture.debugElement.query(By.css(`[data-test-id="${testId}"]`));
+  }
+
   cell(row: number, column: number): DebugElement {
     return this.userRows[row].children[column];
   }
@@ -536,8 +540,7 @@ class TestEnvironment {
   }
 
   rolesAndPermissionsItem(): DebugElement {
-    const buttons = this.fixture.debugElement.queryAll(By.css('button.mat-menu-item'));
-    return buttons.find(b => b.nativeElement.textContent.includes('roles and permissions'))!;
+    return this.getElementByTestId('edit-roles-and-permissions');
   }
 
   userPermissionIcon(row: number): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -128,7 +128,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.icon-theme($material-app-theme);
 @include mat.input-theme($material-app-theme);
 @include mat.legacy-list-theme($material-app-theme);
-@include mat.legacy-menu-theme($material-app-theme);
+@include mat.menu-theme($material-app-theme);
 @include mat.paginator-theme($material-app-theme);
 @include mat.progress-bar-theme($material-app-theme);
 @include mat.progress-spinner-theme($material-app-theme);
@@ -157,9 +157,12 @@ $material-theme-accent-error: mat.define-light-theme(
 
 // Remove letter spacing (added by Material v15+) that may not work with some language scripts (e.g. Arabic).
 // TODO: Add to this list as needed as we migrate to Material v15+
+html,
 .mdc-tab,
-.mdc-button {
+.mdc-button,
+.mat-mdc-menu-item-text {
   letter-spacing: initial;
+  --mat-menu-item-label-text-tracking: initial;
 }
 
 .card-outline {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -18,7 +18,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
-import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';


### PR DESCRIPTION
This PR upgrades mat-menu from legacy to the Angular Material mdc version. Used `ng generate @angular/material:mdc-migration` as a starting point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2466)
<!-- Reviewable:end -->
