### PR TITLE
Add draft preview section to draft generation page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-user-config-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-user-config-doc.ts
@@ -1,8 +1,8 @@
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import {
-  SFProjectUserConfig,
+  SF_PROJECT_USER_CONFIG_INDEX_PATHS,
   SF_PROJECT_USER_CONFIGS_COLLECTION,
-  SF_PROJECT_USER_CONFIG_INDEX_PATHS
+  SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { ProjectDataDoc } from 'xforge-common/models/project-data-doc';
 
@@ -17,6 +17,21 @@ export class SFProjectUserConfigDoc extends ProjectDataDoc<SFProjectUserConfig> 
 
     await this.submitJson0Op(op => {
       op.set(puc => puc.editorTabsOpen, tabs);
+    });
+  }
+
+  /** Add a tab to the list of persisted tabs if it does not already exist. */
+  async addTab(tab: EditorTabPersistData): Promise<void> {
+    if (this.data == null) {
+      return;
+    }
+
+    if (this.data.editorTabsOpen.some(t => t.groupId === tab.groupId && t.tabType === tab.tabType)) {
+      return;
+    }
+
+    await this.submitJson0Op(op => {
+      op.add(puc => puc.editorTabsOpen, tab);
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -233,16 +233,7 @@
                     <div>
                       <ng-container *ngIf="isDraftComplete(draftJob)">
                         <h3>{{ t("draft_generation_complete") }}</h3>
-                        <p>
-                          <transloco
-                            key="draft_generation.go_to_draft_viewer"
-                            [params]="{ draftViewerUrl: { route: draftViewerUrl } }"
-                          ></transloco>
-                        </p>
-                        <a mat-flat-button color="primary" [routerLink]="draftViewerUrl">
-                          <mat-icon>edit_note</mat-icon>
-                          {{ t("preview_draft_button") }}
-                        </a>
+                        <app-draft-preview></app-draft-preview>
                       </ng-container>
 
                       <ng-container *ngIf="!isDraftComplete(draftJob)">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -7,6 +7,7 @@ import {
 import { MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
+import { Canon } from '@sillsdev/scripture';
 import { isEmpty } from 'lodash-es';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { RouterLink } from 'ngx-transloco-markup-router-link';
@@ -61,6 +62,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
   draftJob?: BuildDto;
 
   draftViewerUrl?: string;
+  previewDraftUrl?: string;
   projectSettingsUrl?: string;
   // This component url, but with a hash for opening a dialog
   supportedLanguagesUrl: RouterLink = { route: [], fragment: 'supported-languages' };
@@ -94,6 +96,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
    * from that build can still be retrieved.
    */
   hasAnyCompletedBuild = false;
+  completedDraftBooks: number[] = [];
 
   isPreTranslationApproved = false;
   signupFormUrl?: string;
@@ -110,7 +113,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
     private readonly draftSourcesService: DraftSourcesService,
     private readonly featureFlags: FeatureFlagService,
     private readonly nllbService: NllbLanguageService,
-    private readonly i18n: I18nService,
+    readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly preTranslationSignupUrlService: PreTranslationSignupUrlService
   ) {
@@ -191,6 +194,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
             this.isSourceProjectSet = translateConfig?.source?.projectRef !== undefined;
             this.targetLanguage = projectDoc.data?.writingSystem.tag;
             this.isSourceAndTargetDifferent = translateConfig?.source?.writingSystem.tag !== this.targetLanguage;
+            this.completedDraftBooks = translateConfig?.draftConfig.lastSelectedTranslationBooks ?? [];
 
             // The alternate training source and source languages must match
             if (
@@ -219,6 +223,7 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
             this.isPreTranslationApproved = translateConfig?.preTranslate ?? false;
 
             this.draftViewerUrl = `/projects/${projectDoc.id}/draft-preview`;
+            this.previewDraftUrl = `/projects/${projectDoc.id}/translate/`;
             this.projectSettingsUrl = `/projects/${projectDoc.id}/settings`;
           })
         ),
@@ -410,6 +415,10 @@ export class DraftGenerationComponent extends SubscriptionDisposable implements 
       ),
       (job?: BuildDto) => (this.draftJob = job)
     );
+  }
+
+  getDraftPreviewUrl(bookNumber: number): string {
+    return `${this.previewDraftUrl}/${Canon.bookNumberToId(bookNumber)}`;
   }
 
   private getTargetLanguageDisplayName(): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview/draft-preview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview/draft-preview.component.html
@@ -1,0 +1,5 @@
+<ng-container>
+  <a mat-raised-button *ngFor="let i of booksWithDrafts$ | async" (click)="navigateToDraftPreview(i)">
+    {{ i18n.localizeBook(i) }}
+  </a>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview/draft-preview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview/draft-preview.component.ts
@@ -1,0 +1,87 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Canon } from '@sillsdev/scripture';
+import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
+import { TextInfo } from 'realtime-server/scriptureforge/models/text-info';
+import { Subject } from 'rxjs';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { UserService } from 'xforge-common/user.service';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
+import { SFProjectService } from '../../../core/sf-project.service';
+
+@Component({
+  selector: 'app-draft-preview',
+  standalone: true,
+  templateUrl: './draft-preview.component.html',
+  styleUrls: ['./draft-preview.component.scss'],
+  imports: [CommonModule, UICommonModule]
+})
+export class DraftPreviewComponent extends SubscriptionDisposable implements OnInit {
+  booksWithDrafts$ = new Subject<number[]>();
+
+  private projectUserConfigDoc: SFProjectUserConfigDoc | undefined;
+  private textsWithDrafts: Map<number, number[]> = new Map<number, number[]>();
+
+  constructor(
+    private readonly router: Router,
+    private readonly userService: UserService,
+    private readonly projectService: SFProjectService,
+    private readonly activatedProject: ActivatedProjectService,
+    readonly i18n: I18nService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.subscribe(this.activatedProject.changes$.pipe(filterNullish()), async projectDoc => {
+      this.projectUserConfigDoc = await this.projectService.getUserConfig(
+        projectDoc.id,
+        this.userService.currentUserId
+      );
+      const texts: TextInfo[] = projectDoc.data?.texts ?? [];
+
+      // Find all chapters of every book that has a draft
+      texts.forEach(text => {
+        const bookNum: number = text.bookNum;
+        const chaptersWithDrafts: number[] = text.chapters
+          .filter(chapter => chapter.hasDraft)
+          .map(chapter => chapter.number);
+        if (chaptersWithDrafts.length > 0) {
+          this.textsWithDrafts.set(bookNum, chaptersWithDrafts);
+        }
+      });
+      this.booksWithDrafts$.next(Array.from(this.textsWithDrafts.keys()));
+    });
+  }
+
+  /** Navigate to the draft preview for the given book number. */
+  async navigateToDraftPreview(bookNumber: number): Promise<void> {
+    await this.persistEditorDraftTab();
+    const textChaptersWithDrafts: number[] | undefined = this.textsWithDrafts.get(bookNumber);
+    const chapterNum: number = textChaptersWithDrafts == null ? 1 : textChaptersWithDrafts[0];
+    this.router.navigate([
+      'projects',
+      this.activatedProject.projectId!,
+      'translate',
+      Canon.bookNumberToId(bookNumber),
+      chapterNum
+    ]);
+  }
+
+  private async persistEditorDraftTab(): Promise<void> {
+    if (this.projectUserConfigDoc == null) return;
+
+    const tab: EditorTabPersistData = {
+      groupId: 'target',
+      tabType: 'draft',
+      isSelected: true
+    };
+
+    await this.projectUserConfigDoc.addTab(tab);
+  }
+}


### PR DESCRIPTION
This PR adds the draft preview section to allow users to select the book they want to navigate to when a draft preview is available. From the draft generation page, the user will be redirected to the edit and review page with the editor draft panel opened to the book that the user selected from the generate draft page.