### PR TITLE
Fix crash when paging in Serval Administration area

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -1,5 +1,6 @@
 import { Project } from '../../common/models/project';
 import { WritingSystem } from '../../common/models/writing-system';
+import { obj } from '../../common/utils/obj-path';
 import { BiblicalTermsConfig } from './biblical-terms-config';
 import { CheckingConfig } from './checking-config';
 import { NoteTag } from './note-tag';
@@ -12,7 +13,7 @@ export const SF_PROJECT_PROFILES_COLLECTION = 'sf_projects_profile';
 export const SF_PROJECT_PROFILES_INDEX_PATHS: string[] = [];
 
 export const SF_PROJECTS_COLLECTION = 'sf_projects';
-export const SF_PROJECT_INDEX_PATHS: string[] = [];
+export const SF_PROJECT_INDEX_PATHS: string[] = [obj<SFProject>().pathStr(q => q.name)];
 
 export interface SFProjectProfile extends Project {
   paratextId: string;


### PR DESCRIPTION
On production, due to the very large number of projects, paging to projects > 300 in the Serval Administration area or System Administration projects tab can result in the following crash:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/b5111663-1250-40d3-b03b-08d86b8bdc7f)

The query parameters that cause this query to crash are in `ServalProjectsComponent.getQueryParameters()`.

To resolve this, an index is added to the sf_projects name field to enable to the sort operation in the query used in these Administration areas to use an index. See https://www.mongodb.com/docs/manual/tutorial/sort-results-with-indexes/

Because this only occurs on production, it is not testably locally or on QA, although my local tests confirmed that the index is used when paging through projects in the Serval Administration area.

This error is reproducible in MongoDB compass, so is not caused by a restriction of the Realtime Server or MongoDB Node driver:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/b35445a8-5aee-4155-981f-42f16a12f403)

When the backend is run, the following index is created in `sf_projects`:

![image](https://github.com/sillsdev/web-xforge/assets/8665431/4d3c3c78-9f8d-4de5-9fbc-eb541d594a6b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2470)
<!-- Reviewable:end -->
