### PR TITLE
Improve layout of suggestion engine card

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -73,7 +73,8 @@ mat-card {
   .engine-card-content {
     display: flex;
     flex-direction: column;
-    margin-bottom: 0;
+    padding: 0;
+    font-size: 14px;
 
     .engine-card-quality {
       display: flex;


### PR DESCRIPTION
The recent upgrade from the legacy MatCard introduced some changes that I think make the suggestion engine card layout worse.

Here's the timeline:

Before MatCard update | Current master | This branch
----------------------|----------------|------------
![suggestion_card_before_mat_update](https://github.com/sillsdev/web-xforge/assets/6140710/5d5be68e-6e68-4f81-9083-49be6d41e2ec) | ![suggestion_card_master](https://github.com/sillsdev/web-xforge/assets/6140710/ffe51893-67fd-49f4-9b1f-ce0b9f473366) | ![suggestion_card_branch](https://github.com/sillsdev/web-xforge/assets/6140710/d498d7b5-4f79-462d-ad08-54554ce27131)

This branch does not cause a pixel-perfect match with the original, but that wasn't a goal. Instead, it fixes two problems:
- "Trained segments" always wraps, which looks bad
- The background for the stars didn't span the whole width, which makes it look odd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2476)
<!-- Reviewable:end -->
