### PR TITLE
Fix margin above divider on connect project component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -69,6 +69,10 @@
         padding-inline: 16px;
       }
 
+      .card-content + mat-divider {
+        margin-top: 16px;
+      }
+
       mat-divider + .card-content {
         padding-top: 16px;
       }


### PR DESCRIPTION
This PR fixes the margin above the divider in the connect project card to restore the padding that was lost in the upgrade.

The left hand side is `master`, the right hand side is `sf-live` (which the fix restores the padding of):
![image](https://github.com/sillsdev/web-xforge/assets/8665431/0bcf4142-982d-4371-b4b9-fc82bda29ff5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2477)
<!-- Reviewable:end -->
