### PR TITLE
SF-2730b Fix trainOn Scripture Range for Alternate Training Source

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1175,6 +1175,12 @@ public class MachineProjectService(
                     trainingCorpusConfig.ScriptureRange = !string.IsNullOrWhiteSpace(buildConfig.TrainingScriptureRange)
                         ? buildConfig.TrainingScriptureRange
                         : string.Join(';', buildConfig.TrainingBooks.Select(Canon.BookNumberToId));
+
+                    // Ensure that the alternate training corpus scripture range is null if it is blank
+                    if (string.IsNullOrWhiteSpace(trainingCorpusConfig.ScriptureRange))
+                    {
+                        trainingCorpusConfig.ScriptureRange = null;
+                    }
                 }
 
                 trainOn.Add(trainingCorpusConfig);

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -836,6 +836,53 @@ public class MachineProjectServiceTests
             );
     }
 
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public async Task BuildProjectAsync_SpecifiesNullScriptureRangeForAlternateTrainingSource(string? scriptureRange)
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions
+            {
+                AlternateTrainingSourceEnabled = true,
+                AlternateTrainingSourceConfigured = true,
+            }
+        );
+        await env.SetDataInSync(
+            Project02,
+            preTranslate: true,
+            uploadParatextZipFile: true,
+            alternateTrainingSource: true
+        );
+
+        // SUT
+        await env.Service.BuildProjectAsync(
+            User01,
+            new BuildConfig
+            {
+                ProjectId = Project02,
+                TrainingScriptureRange = scriptureRange,
+                TranslationScriptureRange = scriptureRange,
+            },
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        await env.TranslationEnginesClient.Received()
+            .StartBuildAsync(
+                TranslationEngine02,
+                Arg.Is<TranslationBuildConfig>(
+                    b =>
+                        b.Pretranslate.Count == 1
+                        && b.Pretranslate.First().ScriptureRange == null
+                        && b.TrainOn.Count == 1
+                        && b.TrainOn.First().ScriptureRange == null
+                ),
+                CancellationToken.None
+            );
+    }
+
     [Test]
     public async Task BuildProjectForBackgroundJobAsync_BuildsPreTranslationProjects()
     {


### PR DESCRIPTION
This PR fixes a 400 error from Serval when specifying an alternate training source and no books to train on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2478)
<!-- Reviewable:end -->
