### PR TITLE
Add Serval admin component to draft page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -324,3 +324,12 @@
     </ng-template>
   </mat-expansion-panel>
 </section>
+
+<section *ngIf="this.isServalAdmin()">
+  <mat-expansion-panel class="serval-administration">
+    <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
+    <ng-template matExpansionPanelContent>
+      <app-serval-project></app-serval-project>
+    </ng-template>
+  </mat-expansion-panel>
+</section>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -28,6 +28,7 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { issuesEmailTemplate } from 'xforge-common/utils';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
+import { ServalProjectComponent } from '../../serval-administration/serval-project.component';
 import { SharedModule } from '../../shared/shared.module';
 import { WorkingAnimatedIndicatorComponent } from '../../shared/working-animated-indicator/working-animated-indicator.component';
 import { NllbLanguageService } from '../nllb-language.service';
@@ -57,6 +58,7 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
     WorkingAnimatedIndicatorComponent,
     DraftGenerationStepsComponent,
     SupportedBackTranslationLanguagesDialogComponent,
+    ServalProjectComponent,
     DraftPreviewBooksComponent
   ]
 })
@@ -384,8 +386,12 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return (job?.state as BuildStates) === BuildStates.Faulted;
   }
 
+  isServalAdmin(): boolean {
+    return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+  }
+
   canShowAdditionalInfo(job?: BuildDto): boolean {
-    return job?.additionalInfo != null && this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+    return job?.additionalInfo != null && this.isServalAdmin();
   }
 
   canCancel(job?: BuildDto): boolean {


### PR DESCRIPTION
Discussed with Peter. This should make it easier to trigger the webhook, rather than having to go to a separate page, search for a project, click the link, click the webhook button, and go back to the draft page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2481)
<!-- Reviewable:end -->
