### PR TITLE
Improve layout of draft card

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -224,36 +224,29 @@
           <ng-container *ngIf="isPreviewSupported">
             <ng-container *ngIf="draftJob != null">
               <section *ngIf="!isDraftInProgress(draftJob)" class="draft-complete">
-                <ng-container *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
-                  <div>
-                    <mat-card class="mat-elevation-z2">
-                      <mat-card-content>
-                        <ng-container *ngIf="isDraftComplete(draftJob)">
-                          <h2>{{ t("draft_is_ready") }}</h2>
-                          <p>{{ t("click_book_to_preview") }}</p>
-                          <app-draft-preview-books></app-draft-preview-books>
-                        </ng-container>
-                        <ng-container *ngIf="!isDraftComplete(draftJob)">
-                          <h3>{{ t("preview_last_draft_header") }}</h3>
-                          <p>{{ t("preview_last_draft_detail") }}</p>
-                          <p>{{ t("click_book_to_preview") }}</p>
-                          <app-draft-preview-books></app-draft-preview-books>
-                        </ng-container>
-                        <div class="other-actions">
-                          <button
-                            *ngIf="isGenerationSupported"
-                            mat-button
-                            type="button"
-                            (click)="generateDraft({ withConfirm: true })"
-                          >
-                            <mat-icon>add</mat-icon>
-                            <span>{{ t("generate_new_draft") }}</span>
-                          </button>
-                        </div>
-                      </mat-card-content>
-                    </mat-card>
-                  </div>
-                </ng-container>
+                <mat-card *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
+                  <mat-card-header>
+                    <mat-card-title>
+                      {{ isDraftComplete(draftJob) ? t("draft_is_ready") : t("preview_last_draft_header") }}
+                    </mat-card-title>
+                  </mat-card-header>
+                  <mat-card-content>
+                    <p *ngIf="!isDraftComplete(draftJob)">{{ t("preview_last_draft_detail") }}</p>
+                    <p>{{ t("click_book_to_preview") }}</p>
+                    <app-draft-preview-books></app-draft-preview-books>
+                  </mat-card-content>
+                  <mat-card-actions>
+                    <button
+                      *ngIf="isGenerationSupported"
+                      mat-button
+                      type="button"
+                      (click)="generateDraft({ withConfirm: true })"
+                    >
+                      <mat-icon>add</mat-icon>
+                      {{ t("generate_new_draft") }}
+                    </button>
+                  </mat-card-actions>
+                </mat-card>
               </section>
 
               <section *ngIf="isDraftQueued(draftJob)">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -124,7 +124,7 @@ section {
   padding: 10px 0;
 }
 
-.other-actions {
+.mat-mdc-card-actions {
   display: flex;
   justify-content: flex-end;
   margin-top: 4px;


### PR DESCRIPTION
Before this change, the Material way of specifying a header wasn't being used, which leads to excessive spacing above the header. And mat-card-actions wasn't being used, which led to insufficient vertical spacing between the books and the buttons below the books. (It's not very obvious in this screenshot because the book is aligned left, and the new draft button is aligned right)

Before | After
-------|------
![draft_card_layout_master](https://github.com/sillsdev/web-xforge/assets/6140710/7e2f3564-90ee-442a-ada0-219fce355546) | ![draft_card_layout_branch](https://github.com/sillsdev/web-xforge/assets/6140710/3bfa8e33-3c8f-4b7a-aef9-1dc0b0bbc0cd)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2485)
<!-- Reviewable:end -->
