### PR TITLE
SF-2743 Explicitly add user id for bug reporting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -13,7 +13,7 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { anything, mock, verify, when } from 'ts-mockito';
+import { anything, capture, mock, verify, when } from 'ts-mockito';
 import { AuthService, LoginResult } from 'xforge-common/auth.service';
 import { AvatarComponent } from 'xforge-common/avatar/avatar.component';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
@@ -287,7 +287,9 @@ describe('AppComponent', () => {
     env.init();
 
     verify(mockedErrorReportingService.addMeta(anything(), 'user')).once();
-    expect().nothing();
+    // The first call sets the locale, the second sets the user
+    const [metadata] = capture(mockedErrorReportingService.addMeta).second();
+    expect(metadata['id']).toEqual('user01');
   }));
 
   it('checks online auth status when browser comes online but app is not fully online', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -19,12 +19,11 @@ import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.ser
 import { FeatureFlagsDialogComponent } from 'xforge-common/feature-flags/feature-flags-dialog.component';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { LocalSettingsService } from 'xforge-common/local-settings.service';
 import { LocationService } from 'xforge-common/location.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { PwaService, PWA_BEFORE_PROMPT_CAN_BE_SHOWN_AGAIN } from 'xforge-common/pwa.service';
+import { PWA_BEFORE_PROMPT_CAN_BE_SHOWN_AGAIN, PwaService } from 'xforge-common/pwa.service';
 import {
   BrowserIssue,
   SupportedBrowsersDialogComponent
@@ -75,7 +74,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly reportingService: ErrorReportingService,
     private readonly userProjectsService: SFUserProjectsService,
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly localSettings: LocalSettingsService,
     readonly noticeService: NoticeService,
     readonly i18n: I18nService,
     readonly media: MediaObserver,
@@ -224,9 +222,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     await this.authService.loggedIn;
     this.loadingStarted();
     this.currentUserDoc = await this.userService.getCurrentUser();
-    const userData = cloneDeep(this.currentUserDoc.data);
+    const userData: User | undefined = cloneDeep(this.currentUserDoc.data);
     if (userData != null) {
-      this.reportingService.addMeta(userData, 'user');
+      const userDataWithId = { ...userData, id: this.currentUserDoc.id };
+      this.reportingService.addMeta(userDataWithId, 'user');
     }
 
     const languageTag = this.currentUserDoc.data!.interfaceLanguage;


### PR DESCRIPTION
In some cases the id of the user in events recorded in bugsnag is set to the user's IP address. It is unclear how that happens, but I suspect that if we provide an explicit id for the user, then the IP address will not be used.

Testing is not required. This PR should be verified by the reviewer. If you want to test this functionally, you can add a line to the error-reporting-service.ts to the notify method and verify the log output contains the user id property.

```
  notify(error: NotifiableError, callback?: (err: any, report: any) => void): void {
    console.log(this.metadata)
    if (Bugsnag.isStarted())
      Bugsnag.notify(error, event => ErrorReportingService.beforeSend(this.metadata, event), callback);
  }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2488)
<!-- Reviewable:end -->
