### PR TITLE
SF-2362 Upgrade legacy mat-dialog to MDC version

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.storybook/story-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/.storybook/story-utils.ts
@@ -1,9 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, Inject, InjectionToken, OnInit, Provider } from '@angular/core';
-import {
-  MatLegacyDialog as MatDialog,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { StoryFn } from '@storybook/angular';
 import { UICommonModule } from 'xforge-common/ui-common.module';

--- a/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
@@ -1,9 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, Inject, InjectionToken, OnInit, Provider } from '@angular/core';
-import {
-  MatLegacyDialog as MatDialog,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { StoryFn } from '@storybook/angular';
 import { hasProp } from '../../src/type-utils';
 import { UICommonModule } from '../../src/xforge-common/ui-common.module';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.scss
@@ -22,7 +22,7 @@
   }
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   .warning {
     font-size: 21px;
     margin-inline-end: unset;
@@ -78,7 +78,7 @@ mat-select.book-select-menu ::ng-deep {
   }
 }
 
-.mat-dialog-actions {
+.mat-mdc-dialog-actions {
   justify-content: end;
 
   .uploading {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.spec.ts
@@ -2,12 +2,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, NgModule, NgZone } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogModule as MatDialogModule,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Canon } from '@sillsdev/scripture';
 import { ngfModule } from 'angular-file';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -1,8 +1,5 @@
 import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
-import {
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Canon } from '@sillsdev/scripture';
 import { reject } from 'lodash-es';
 import cloneDeep from 'lodash-es/cloneDeep';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { MatDialogConfig } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
 import { SFProjectService } from '../../core/sf-project.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { DebugElement, NgModule, NgZone } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatExpansionPanel } from '@angular/material/expansion';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatDialogModule } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Route, RouterModule } from '@angular/router';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -4,7 +4,7 @@ import { Location } from '@angular/common';
 import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { By } from '@angular/platform-browser';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-question-confirmation-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-question-confirmation-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { I18nService } from 'xforge-common/i18n.service';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.html
@@ -1,8 +1,6 @@
 <ng-container *transloco="let t; read: 'import_questions_confirmation_dialog'">
   <mat-dialog [dir]="i18n.direction">
-    <h2 mat-dialog-title>
-      {{ t("some_questions_edited") }}
-    </h2>
+    <h2 mat-dialog-title>{{ t("some_questions_edited") }}</h2>
     <mat-dialog-content>
       {{ t("edited_questions_explanation") }}
       <div class="table-container">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
@@ -1,10 +1,3 @@
-.mat-mdc-dialog-title {
-  &:before {
-    display: none;
-  }
-  padding-top: 20px;
-}
-
 .mat-mdc-dialog-content {
   max-width: 560px;
   display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
@@ -1,4 +1,4 @@
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   max-width: 560px;
   display: flex;
   gap: 20px;
@@ -13,6 +13,6 @@
   background-color: darken(#fff, 10%);
 }
 
-.mat-dialog-actions {
+.mat-mdc-dialog-actions {
   justify-content: end;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.scss
@@ -1,3 +1,10 @@
+.mat-mdc-dialog-title {
+  &:before {
+    display: none;
+  }
+  padding-top: 20px;
+}
+
 .mat-mdc-dialog-content {
   max-width: 560px;
   display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-confirmation-dialog/import-questions-confirmation-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { firstValueFrom } from 'rxjs';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'import_questions_dialog'">
-  <h2 mat-dialog-title>
+  <h2 mat-dialog-title class="dialog-icon-title">
     {{
       status !== "progress"
         ? t("import_questions")

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -3,14 +3,14 @@
 
 // Section: General dialog styles
 
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   margin-bottom: 0.25em;
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   display: flex;
   flex-direction: column;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { ngfModule } from 'angular-file';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -1,11 +1,7 @@
 import { Component, ElementRef, Inject, NgZone, OnDestroy, ViewChild } from '@angular/core';
 import { AbstractControl, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
-import {
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslocoService } from '@ngneat/transloco';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'question_dialog'">
   <div class="dialog-container">
-    <h1 mat-dialog-title fxLayoutAlign="start center">
+    <h1 mat-dialog-title class="dialog-title dialog-icon-title">
       <mat-icon class="mirror-rtl">live_help</mat-icon> {{ modeLabel }}
     </h1>
     <mat-dialog-content [formGroup]="versesForm" class="content-padding">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -2,8 +2,14 @@
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 @use '../checking/checking-global-vars' as checking-vars;
 
-.mat-dialog-content.content-padding {
+.mat-mdc-dialog-content.content-padding {
   padding-top: 0.5em;
+}
+
+.dialog-title {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5em;
 }
 
 .references {
@@ -21,7 +27,7 @@ mat-form-field {
   }
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   max-height: 70vh;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -3,11 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -1,10 +1,6 @@
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
-import {
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { cloneDeep } from 'lodash-es';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';
 import {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -1,8 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { TranslocoService } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -1,12 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogModule as MatDialogModule,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { I18nService } from 'xforge-common/i18n.service';
 import { TextsByBookId } from '../core/models/texts-by-book-id';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'delete_project_dialog'">
   <mat-dialog [dir]="i18n.direction">
-    <h1 mat-dialog-title id="title">
+    <h1 mat-dialog-title id="title" class="dialog-icon-title">
       <mat-icon>warning</mat-icon>
       <span>{{ t("are_you_sure_you_want_to_delete") }}</span>
     </h1>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.scss
@@ -1,4 +1,4 @@
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   max-width: 560px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.spec.ts
@@ -1,11 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
 import { mock } from 'ts-mockito';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
 
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -2,7 +2,7 @@ import { Location } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Route, RouterModule } from '@angular/router';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -3,7 +3,7 @@
     <span>{{ t("share_project", { project: projectName }) }}</span>
     <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
   </h1>
-  <div class="configurations">
+  <div mat-dialog-content class="configurations">
     <div class="configuration-option configuration-invitation-role">
       <mat-icon>public</mat-icon>
       <div>
@@ -74,7 +74,7 @@
   <div mat-dialog-actions>
     <button
       id="copy-btn"
-      mat-button
+      mat-flat-button
       (click)="copyLink()"
       [disabled]="!isLinkReady"
       color="{{ !supportsShareAPI ? 'primary' : '' }}"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -3,84 +3,78 @@
     <span>{{ t("share_project", { project: projectName }) }}</span>
     <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
   </h1>
-  <mat-dialog-content>
-    <div class="configurations">
-      <div class="configuration-option configuration-invitation-role">
-        <mat-icon>public</mat-icon>
+  <div class="configurations">
+    <div class="configuration-option configuration-invitation-role">
+      <mat-icon>public</mat-icon>
+      <div>
+        {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
+        <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}" *ngIf="canUserChangeRole"
+          >({{ t("change") }})</a
+        >
+      </div>
+      <mat-menu #roleMenu>
+        <mat-selection-list [multiple]="false" class="share-selection-role">
+          <mat-list-option *ngFor="let role of availableRoles" [selected]="role === shareRole" (click)="setRole(role)">
+            <div class="role-name">{{ i18n.localizeRole(role) }}</div>
+            <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
+          </mat-list-option>
+        </mat-selection-list>
+      </mat-menu>
+    </div>
+    <div class="configuration-option">
+      <mat-icon>translate</mat-icon>
+      <div>
+        {{ t("invitation_shared_in_language") }} <b>{{ shareLocaleCode.localName }}</b>
+        <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}">({{ t("change") }})</a>
+      </div>
+      <mat-menu #langMenu>
+        <mat-selection-list [multiple]="false">
+          <mat-list-option
+            *ngFor="let locale of i18n.locales"
+            [selected]="locale === shareLocaleCode"
+            (click)="setLocale(locale)"
+          >
+            {{ locale.localName }}
+          </mat-list-option>
+        </mat-selection-list>
+      </mat-menu>
+    </div>
+    <ng-container *ngIf="canUserChangeLinkUsage">
+      <div class="configuration-option configuration-link-type">
+        <mat-icon>groups</mat-icon>
         <div>
-          {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
-          <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}" *ngIf="canUserChangeRole"
+          {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
+          <a
+            [matMenuTriggerFor]="linkUsageMenu"
+            title="{{ t('invitation_link_type') }}"
+            *ngIf="shareLinkUsageOptions.length > 1"
             >({{ t("change") }})</a
           >
         </div>
-        <mat-menu #roleMenu>
-          <mat-selection-list [multiple]="false" class="share-selection-role">
+        <mat-menu #linkUsageMenu>
+          <mat-selection-list [multiple]="false" *ngIf="shareLinkUsageOptions.length > 1">
             <mat-list-option
-              *ngFor="let role of availableRoles"
-              [selected]="role === shareRole"
-              (click)="setRole(role)"
+              *ngFor="let option of shareLinkUsageOptions"
+              [selected]="option === shareLinkType"
+              (click)="setLinkType(option)"
             >
-              <div class="role-name">{{ i18n.localizeRole(role) }}</div>
-              <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
+              {{ t(option) }}
             </mat-list-option>
           </mat-selection-list>
         </mat-menu>
       </div>
-      <div class="configuration-option">
-        <mat-icon>translate</mat-icon>
-        <div>
-          {{ t("invitation_shared_in_language") }} <b>{{ shareLocaleCode.localName }}</b>
-          <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}">({{ t("change") }})</a>
-        </div>
-        <mat-menu #langMenu>
-          <mat-selection-list [multiple]="false">
-            <mat-list-option
-              *ngFor="let locale of i18n.locales"
-              [selected]="locale === shareLocaleCode"
-              (click)="setLocale(locale)"
-            >
-              {{ locale.localName }}
-            </mat-list-option>
-          </mat-selection-list>
-        </mat-menu>
-      </div>
-      <ng-container *ngIf="canUserChangeLinkUsage">
-        <div class="configuration-option configuration-link-type">
-          <mat-icon>groups</mat-icon>
-          <div>
-            {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
-            <a
-              [matMenuTriggerFor]="linkUsageMenu"
-              title="{{ t('invitation_link_type') }}"
-              *ngIf="shareLinkUsageOptions.length > 1"
-              >({{ t("change") }})</a
-            >
-          </div>
-          <mat-menu #linkUsageMenu>
-            <mat-selection-list [multiple]="false" *ngIf="shareLinkUsageOptions.length > 1">
-              <mat-list-option
-                *ngFor="let option of shareLinkUsageOptions"
-                [selected]="option === shareLinkType"
-                (click)="setLinkType(option)"
-              >
-                {{ t(option) }}
-              </mat-list-option>
-            </mat-selection-list>
-          </mat-menu>
-        </div>
-        <app-notice *ngIf="isRecipientOnlyLink" icon="info">
-          {{ t("recipient_only_notice") }}
-        </app-notice>
-      </ng-container>
-    </div>
+      <app-notice *ngIf="isRecipientOnlyLink" icon="info">
+        {{ t("recipient_only_notice") }}
+      </app-notice>
+    </ng-container>
     <app-notice *ngIf="showLinkSharingUnavailable" type="error" icon="cloud_off">
       {{ t("link_sharing_not_available_offline") }}
     </app-notice>
-  </mat-dialog-content>
+  </div>
   <div mat-dialog-actions>
     <button
       id="copy-btn"
-      mat-flat-button
+      mat-button
       (click)="copyLink()"
       [disabled]="!isLinkReady"
       color="{{ !supportsShareAPI ? 'primary' : '' }}"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -1,77 +1,92 @@
 <ng-container *transloco="let t; read: 'share_dialog'">
-  <h1 mat-dialog-title>
-    <span>{{ t("share_project", { project: projectName }) }}</span
-    ><button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
+  <h1 mat-dialog-title class="dialog-icon-title">
+    <span>{{ t("share_project", { project: projectName }) }}</span>
+    <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
   </h1>
-  <div class="configurations">
-    <div class="configuration-option configuration-invitation-role">
-      <mat-icon>public</mat-icon>
-      <div>
-        {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
-        <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}" *ngIf="canUserChangeRole"
-          >({{ t("change") }})</a
-        >
-      </div>
-      <mat-menu #roleMenu>
-        <mat-selection-list [multiple]="false" class="share-selection-role">
-          <mat-list-option *ngFor="let role of availableRoles" [selected]="role === shareRole" (click)="setRole(role)">
-            <div class="role-name">{{ i18n.localizeRole(role) }}</div>
-            <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
-          </mat-list-option>
-        </mat-selection-list>
-      </mat-menu>
-    </div>
-    <div class="configuration-option">
-      <mat-icon>translate</mat-icon>
-      <div>
-        {{ t("invitation_shared_in_language") }} <b>{{ shareLocaleCode.localName }}</b>
-        <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}">({{ t("change") }})</a>
-      </div>
-      <mat-menu #langMenu>
-        <mat-selection-list [multiple]="false">
-          <mat-list-option
-            *ngFor="let locale of i18n.locales"
-            [selected]="locale === shareLocaleCode"
-            (click)="setLocale(locale)"
-          >
-            {{ locale.localName }}
-          </mat-list-option>
-        </mat-selection-list>
-      </mat-menu>
-    </div>
-    <ng-container *ngIf="canUserChangeLinkUsage">
-      <div class="configuration-option configuration-link-type">
-        <mat-icon>groups</mat-icon>
+  <mat-dialog-content>
+    <div class="configurations">
+      <div class="configuration-option configuration-invitation-role">
+        <mat-icon>public</mat-icon>
         <div>
-          {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
-          <a
-            [matMenuTriggerFor]="linkUsageMenu"
-            title="{{ t('invitation_link_type') }}"
-            *ngIf="shareLinkUsageOptions.length > 1"
+          {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
+          <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}" *ngIf="canUserChangeRole"
             >({{ t("change") }})</a
           >
         </div>
-        <mat-menu #linkUsageMenu>
-          <mat-selection-list [multiple]="false" *ngIf="shareLinkUsageOptions.length > 1">
+        <mat-menu #roleMenu>
+          <mat-selection-list [multiple]="false" class="share-selection-role">
             <mat-list-option
-              *ngFor="let option of shareLinkUsageOptions"
-              [selected]="option === shareLinkType"
-              (click)="setLinkType(option)"
+              *ngFor="let role of availableRoles"
+              [selected]="role === shareRole"
+              (click)="setRole(role)"
             >
-              {{ t(option) }}
+              <div class="role-name">{{ i18n.localizeRole(role) }}</div>
+              <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
             </mat-list-option>
           </mat-selection-list>
         </mat-menu>
       </div>
-      <app-notice *ngIf="isRecipientOnlyLink" icon="info">
-        {{ t("recipient_only_notice") }}
-      </app-notice>
-    </ng-container>
-  </div>
-  <app-notice *ngIf="showLinkSharingUnavailable" type="error" icon="cloud_off">
-    {{ t("link_sharing_not_available_offline") }}
-  </app-notice>
+      <div class="configuration-option">
+        <mat-icon>translate</mat-icon>
+        <div>
+          {{ t("invitation_shared_in_language") }} <b>{{ shareLocaleCode.localName }}</b>
+          <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}">({{ t("change") }})</a>
+        </div>
+        <mat-menu #langMenu>
+          <mat-selection-list [multiple]="false">
+            <mat-list-option
+              *ngFor="let locale of i18n.locales"
+              [selected]="locale === shareLocaleCode"
+              (click)="setLocale(locale)"
+            >
+              {{ locale.localName }}
+            </mat-list-option>
+          </mat-selection-list>
+        </mat-menu>
+      </div>
+      <ng-container *ngIf="canUserChangeLinkUsage">
+        <div class="configuration-option configuration-link-type">
+          <mat-icon>groups</mat-icon>
+          <div>
+            {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
+            <a
+              [matMenuTriggerFor]="linkUsageMenu"
+              title="{{ t('invitation_link_type') }}"
+              *ngIf="shareLinkUsageOptions.length > 1"
+              >({{ t("change") }})</a
+            >
+          </div>
+          <mat-menu #linkUsageMenu>
+            <mat-selection-list [multiple]="false" *ngIf="shareLinkUsageOptions.length > 1">
+              <mat-list-option
+                *ngFor="let option of shareLinkUsageOptions"
+                [selected]="option === shareLinkType"
+                (click)="setLinkType(option)"
+              >
+                {{ t(option) }}
+              </mat-list-option>
+            </mat-selection-list>
+          </mat-menu>
+        </div>
+        <app-notice *ngIf="isRecipientOnlyLink" icon="info">
+          {{ t("recipient_only_notice") }}
+        </app-notice>
+      </ng-container>
+    </div>
+    <app-notice *ngIf="showLinkSharingUnavailable" type="error" icon="cloud_off">
+      {{ t("link_sharing_not_available_offline") }}
+    </app-notice>
+  </mat-dialog-content>
   <div mat-dialog-actions>
+    <button
+      id="copy-btn"
+      mat-flat-button
+      (click)="copyLink()"
+      [disabled]="!isLinkReady"
+      color="{{ !supportsShareAPI ? 'primary' : '' }}"
+    >
+      <mat-icon>content_copy</mat-icon>{{ t("copy_link") }}
+    </button>
     <button
       id="share-btn"
       mat-flat-button
@@ -81,15 +96,6 @@
       [disabled]="!isLinkReady"
     >
       <mat-icon>share</mat-icon>{{ t("share") }}
-    </button>
-    <button
-      id="copy-btn"
-      mat-flat-button
-      (click)="copyLink()"
-      [disabled]="!isLinkReady"
-      color="{{ !supportsShareAPI ? 'primary' : '' }}"
-    >
-      <mat-icon>content_copy</mat-icon>{{ t("copy_link") }}
     </button>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   row-gap: 16px;
-  margin: 16px 0;
+  margin: 16px 24px;
   .configuration-option {
     display: flex;
     column-gap: 10px;
@@ -41,7 +41,6 @@
 div[mat-dialog-actions] {
   display: flex;
   place-content: flex-end;
-  column-gap: 10px;
 
   button {
     mat-icon {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
@@ -11,7 +11,6 @@
   display: flex;
   flex-direction: column;
   row-gap: 16px;
-  margin: 16px 24px;
   .configuration-option {
     display: flex;
     column-gap: 10px;
@@ -28,7 +27,6 @@
     }
     div {
       padding-top: 3px;
-      font-size: 0.9em;
       a {
         color: $purpleLight;
         cursor: pointer;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.scss
@@ -1,6 +1,6 @@
 @import 'src/variables';
 
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   margin-bottom: 0.25em;
   display: flex;
   align-items: center;
@@ -40,8 +40,7 @@
 }
 div[mat-dialog-actions] {
   display: flex;
-  flex-direction: row-reverse; /* This was done so the share button would receive the focus */
-  justify-items: flex-end;
+  place-content: flex-end;
   column-gap: 10px;
 
   button {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -1,11 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>
+<h1 mat-dialog-title class="dialog-icon-title">
   <span>{{ type }}</span>
   <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
 </h1>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.scss
@@ -1,4 +1,4 @@
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   margin-bottom: 0.25em;
   display: flex;
   align-items: center;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslocoService } from '@ngneat/transloco';
 import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.scss
@@ -1,6 +1,6 @@
 @use 'src/variables';
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   display: flex;
   flex-direction: column;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';
 import { CookieService } from 'ngx-cookie-service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -1,9 +1,5 @@
 import { Component, ElementRef, Inject, Optional, ViewChild } from '@angular/core';
-import {
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { VerseRef } from '@sillsdev/scripture';
 import { toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { fromEvent } from 'rxjs';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.scss
@@ -1,7 +1,6 @@
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 
 mat-dialog-actions {
-  display: flex;
   place-content: flex-end;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
@@ -1,10 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';
 import cloneDeep from 'lodash-es/cloneDeep';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
@@ -1,9 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { I18nService } from 'xforge-common/i18n.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
@@ -1,9 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { VerseRef } from '@sillsdev/scripture';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1,8 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MatLegacyDialogState as MatDialogState
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import FileSaver from 'file-saver';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,9 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, ViewChild } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MatLegacyDialogState as MatDialogState
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { translate, TranslocoModule } from '@ngneat/transloco';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'supported_back_translation_languages_dialog'">
-  <h2 mat-dialog-title>
+  <h2 mat-dialog-title class="dialog-icon-title">
     {{ t("supported_back_translation_languages_dialog_header") }}
     <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
   </h2>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.scss
@@ -1,11 +1,11 @@
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 10px;
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   display: grid;
   width: 70vw;
   grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatDialogModule } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NllbLanguage, NllbLanguageDict, NLLB_LANGUAGES } from '../../nllb-languages';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angu
 import { MatChipListboxChange, MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { MatDialogConfig } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.scss
@@ -18,7 +18,7 @@
   }
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   .warning {
     font-size: 21px;
     margin-inline-end: unset;
@@ -69,7 +69,7 @@
   }
 }
 
-.mat-dialog-actions {
+.mat-mdc-dialog-actions {
   justify-content: end;
 
   .uploading {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.spec.ts
@@ -2,11 +2,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgModule, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogModule as MatDialogModule,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ngfModule } from 'angular-file';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
@@ -3,11 +3,7 @@ import { AfterViewInit, Component, ElementRef, Inject, ViewChild } from '@angula
 import { MatCheckbox, MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import {
-  MatLegacyDialogModule as MatDialogModule,
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslocoModule } from '@ngneat/transloco';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3,11 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MediaObserver } from '@angular/flex-layout';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Params, Route, Router, RouterModule } from '@angular/router';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -15,10 +15,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MediaObserver } from '@angular/flex-layout';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
-import {
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -1,79 +1,82 @@
 <ng-container *transloco="let t; read: 'note_dialog'">
-  <h1 mat-dialog-title>
-    <img [src]="flagIcon" class="note-thread-icon" alt="" /> <span class="verse-reference">{{ verseRefDisplay }}</span>
-    <div *ngIf="canViewAssignedUser" id="assignedUser" class="assigned-user">
-      >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
-    </div>
-  </h1>
-  <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
-    <div class="text-row">
-      <div class="text">
-        <div *ngIf="!isNewNote || isBiblicalTermNote" class="note-text" [innerHTML]="getNoteContextText()"></div>
-        <div *ngIf="isNewNote && !isBiblicalTermNote" class="note-text" [innerHTML]="segmentText"></div>
-        <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+  <div class="dialog-container">
+    <h1 mat-dialog-title class="dialog-icon-title">
+      <img [src]="flagIcon" class="note-thread-icon" alt="" />
+      <span class="verse-reference">{{ verseRefDisplay }}</span>
+      <div *ngIf="canViewAssignedUser" id="assignedUser" class="assigned-user">
+        >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
       </div>
-      <button
-        *ngIf="!isNewNote && !isBiblicalTermNote && isSegmentDifferentFromContext"
-        id="text-menu-button"
-        mat-icon-button
-        [matMenuTriggerFor]="menu"
-      >
-        <mat-icon>more_vert</mat-icon>
-      </button>
-      <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="toggleSegmentText()">
-          <mat-icon>compare</mat-icon>
-          <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
+    </h1>
+    <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
+      <div class="text-row">
+        <div class="text">
+          <div *ngIf="!isNewNote || isBiblicalTermNote" class="note-text" [innerHTML]="getNoteContextText()"></div>
+          <div *ngIf="isNewNote && !isBiblicalTermNote" class="note-text" [innerHTML]="segmentText"></div>
+          <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+        </div>
+        <button
+          *ngIf="!isNewNote && !isBiblicalTermNote && isSegmentDifferentFromContext"
+          id="text-menu-button"
+          mat-icon-button
+          [matMenuTriggerFor]="menu"
+        >
+          <mat-icon>more_vert</mat-icon>
         </button>
-      </mat-menu>
-    </div>
-    <div class="notes">
-      <div *ngFor="let noteInfo of notesToDisplay" class="note">
-        <div class="content">
-          <div *ngIf="noteInfo.assignment != null" class="assigned-user">>{{ noteInfo.assignment }}</div>
-          <div *ngIf="noteInfo.reattachedVerse != null" class="verse-reattached">{{ noteInfo.reattachedVerse }}</div>
-          <div *ngIf="noteInfo.reattachedText != null" class="text" [innerHTML]="noteInfo.reattachedText"></div>
-          <div class="note-content-and-actions">
-            <div class="note-content" [innerHTML]="noteInfo.content" [ngStyle]="{ fontSize }"></div>
-            <div *ngIf="noteInfo.editable" class="edit-actions">
-              <button mat-icon-button class="edit-button" (click)="editNote(noteInfo.note)">
-                <mat-icon>edit</mat-icon>
-              </button>
-              <button mat-icon-button class="delete-button" (click)="deleteNote(noteInfo.note)">
-                <mat-icon>delete</mat-icon>
-              </button>
+        <mat-menu #menu="matMenu">
+          <button mat-menu-item (click)="toggleSegmentText()">
+            <mat-icon>compare</mat-icon>
+            <span>{{ showSegmentText ? t("hide_changes") : t("show_changes") }}</span>
+          </button>
+        </mat-menu>
+      </div>
+      <div class="notes">
+        <div *ngFor="let noteInfo of notesToDisplay" class="note">
+          <div class="content">
+            <div *ngIf="noteInfo.assignment != null" class="assigned-user">>{{ noteInfo.assignment }}</div>
+            <div *ngIf="noteInfo.reattachedVerse != null" class="verse-reattached">{{ noteInfo.reattachedVerse }}</div>
+            <div *ngIf="noteInfo.reattachedText != null" class="text" [innerHTML]="noteInfo.reattachedText"></div>
+            <div class="note-content-and-actions">
+              <div class="note-content" [innerHTML]="noteInfo.content" [ngStyle]="{ fontSize }"></div>
+              <div *ngIf="noteInfo.editable" class="edit-actions">
+                <button mat-icon-button class="edit-button" (click)="editNote(noteInfo.note)">
+                  <mat-icon>edit</mat-icon>
+                </button>
+                <button mat-icon-button class="delete-button" (click)="deleteNote(noteInfo.note)">
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-        <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
-        <div class="note-user">
-          <div class="user-name">{{ noteInfo.userName }}</div>
-          <small class="date-created">{{ noteInfo.dateCreated }}</small>
+          <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
+          <div class="note-user">
+            <div class="user-name">{{ noteInfo.userName }}</div>
+            <small class="date-created">{{ noteInfo.dateCreated }}</small>
+          </div>
         </div>
       </div>
-    </div>
-    <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="outline">
-      <mat-label>{{ t("your_comment") }}</mat-label>
-      <textarea matInput [(ngModel)]="currentNoteContent"></textarea>
-    </mat-form-field>
-  </mat-dialog-content>
-  <mat-dialog-actions fxLayoutAlign="end">
-    <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
-    <mat-button-toggle-group *ngIf="canInsertNote">
-      <mat-button-toggle class="save-button save-options" (click)="submit()">{{
-        t(saveOption === "save" ? "save" : "resolve")
-      }}</mat-button-toggle>
-      <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
-        <mat-icon>expand_less</mat-icon>
-      </mat-button-toggle>
-      <mat-menu #saveMenu="matMenu" class="save-options-menu" yPosition="above" xPosition="before">
-        <button *ngIf="saveOption === 'resolve'" mat-menu-item (click)="saveOption = 'save'">
-          <span>{{ t("save") }}</span>
-        </button>
-        <button *ngIf="saveOption === 'save'" mat-menu-item (click)="saveOption = 'resolve'">
-          <span>{{ t("resolve") }}</span>
-        </button>
-      </mat-menu>
-    </mat-button-toggle-group>
-  </mat-dialog-actions>
+      <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="outline">
+        <mat-label>{{ t("your_comment") }}</mat-label>
+        <textarea matInput [(ngModel)]="currentNoteContent"></textarea>
+      </mat-form-field>
+    </mat-dialog-content>
+    <mat-dialog-actions fxLayoutAlign="end">
+      <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
+      <mat-button-toggle-group *ngIf="canInsertNote">
+        <mat-button-toggle class="save-button save-options" (click)="submit()">{{
+          t(saveOption === "save" ? "save" : "resolve")
+        }}</mat-button-toggle>
+        <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
+          <mat-icon>expand_less</mat-icon>
+        </mat-button-toggle>
+        <mat-menu #saveMenu="matMenu" class="save-options-menu" yPosition="above" xPosition="before">
+          <button *ngIf="saveOption === 'resolve'" mat-menu-item (click)="saveOption = 'save'">
+            <span>{{ t("save") }}</span>
+          </button>
+          <button *ngIf="saveOption === 'save'" mat-menu-item (click)="saveOption = 'resolve'">
+            <span>{{ t("resolve") }}</span>
+          </button>
+        </mat-menu>
+      </mat-button-toggle-group>
+    </mat-dialog-actions>
+  </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -1,6 +1,11 @@
 @import 'src/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 
+.dialog-container {
+  display: flex;
+  flex-direction: column;
+}
+
 h1 {
   display: flex;
   align-items: center;
@@ -16,7 +21,7 @@ h1 {
     margin-right: -15px;
   }
 }
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   min-height: 300px;
   @include media-breakpoint-down(sm) {
     min-height: 200px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { translate } from '@ngneat/transloco';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { sortBy } from 'lodash-es';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -1,9 +1,9 @@
 <ng-container *transloco="let t; read: 'suggestions_settings_dialog'">
   <h1 mat-dialog-title>{{ t("translator_settings") }}</h1>
-  <div class="offline-text" *ngIf="!onlineStatusService.isOnline">
-    {{ t("settings_not_available_offline") }}
-  </div>
   <mat-dialog-content>
+    <div class="offline-text" *ngIf="!onlineStatusService.isOnline">
+      {{ t("settings_not_available_offline") }}
+    </div>
     <div class="row">
       <div class="col">
         <mat-slide-toggle

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -9,9 +9,7 @@
 
 .row {
   column-gap: 12px;
-  margin-left: 12px;
-  margin-right: 12px;
-  margin-bottom: 25px;
+  margin: 20px 12px;
   flex-direction: row;
   box-sizing: border-box;
   display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.scss
@@ -56,9 +56,6 @@ span {
 }
 
 mat-dialog-actions {
-  place-content: stretch flex-end;
-  align-items: stretch;
-  flex-direction: row;
+  place-content: flex-end;
   box-sizing: border-box;
-  display: flex;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -1,10 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { MatSelect } from '@angular/material/select';
 import { MatSlider } from '@angular/material/slider';
 import { By } from '@angular/platform-browser';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { BehaviorSubject } from 'rxjs';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'roles'">
-  <div mat-dialog-title>
+  <div mat-dialog-title class="dialog-icon-title">
     <app-avatar [user]="data.userProfile" [size]="64"></app-avatar>
     <div>
       <div class="userName">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.scss
@@ -1,8 +1,7 @@
 @use 'src/variables';
 
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   display: flex;
-  flex-direction: row;
   align-items: center;
   column-gap: 16px;
 }
@@ -32,9 +31,7 @@ span {
   height: 18px;
 }
 
-.mat-dialog-content {
-  margin: unset;
-  padding: unset;
+.mat-mdc-dialog-content {
   max-height: unset;
   overflow: unset;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
@@ -2,10 +2,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { Component, DebugElement, Input, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { BrowserModule, By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { forEach } from 'lodash-es';

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -10,9 +10,12 @@
 //  If you specify typography styles for the components you use elsewhere, you should delete this line.
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
-//    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
+//    `@include mat.legacy-typography-hierarchy(mat.define-typography-config());`
+// Remove all-legacy-component-typographies once all legacy components are migrated
 @include mat.all-legacy-component-typographies();
 @include mat.all-component-typographies();
+@include mat.all-component-typographies();
+// Remove legacy-core once all legacy components are migrated
 @include mat.legacy-core();
 @include mat.core();
 
@@ -121,7 +124,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.card-theme($material-app-theme);
 @include mat.checkbox-theme($material-app-theme);
 @include mat.chips-theme($material-app-theme);
-@include mat.legacy-dialog-theme($material-app-theme);
+@include mat.dialog-theme($material-app-theme);
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);
 @include mat.form-field-theme($material-theme-accent-error);

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -91,13 +91,22 @@ $matGreyPalette: mat.define-palette($mat-sf-grey, 800);
 $matGreenLightPalette: mat.define-palette($mat-sf-green, 500, 200);
 $matErrorPalette: mat.define-palette($mat-sf-error, 500);
 
+$app-typography: mat.define-typography-config(
+  $body-1: mat.define-typography-level(16px, 1.2em)
+);
+
+$dialog-typography: mat.define-typography-config(
+  $body-1: mat.define-typography-level(14px, 1.5em)
+);
+
 $material-app-theme: mat.define-light-theme(
   (
     color: (
       primary: $matGreyPalette,
       accent: $matGreenLightPalette,
       warn: $matErrorPalette
-    )
+    ),
+    typography: $app-typography
   )
 );
 
@@ -124,6 +133,7 @@ $material-theme-accent-error: mat.define-light-theme(
 @include mat.checkbox-theme($material-app-theme);
 @include mat.chips-theme($material-app-theme);
 @include mat.dialog-theme($material-app-theme);
+@include mat.dialog-typography($dialog-typography);
 @include mat.divider-theme($material-app-theme);
 @include mat.expansion-theme($material-app-theme);
 @include mat.form-field-theme($material-theme-accent-error);
@@ -191,6 +201,10 @@ mat-card-title {
 
 .mat-mdc-dialog-actions {
   padding: 16px 24px !important;
+}
+
+.mat-mdc-dialog-container {
+  --mdc-dialog-supporting-text-color: rgba(0, 0, 0, 0.9);
 }
 
 @mixin dense_mat_select() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -14,7 +14,6 @@
 // Remove all-legacy-component-typographies once all legacy components are migrated
 @include mat.all-legacy-component-typographies();
 @include mat.all-component-typographies();
-@include mat.all-component-typographies();
 // Remove legacy-core once all legacy components are migrated
 @include mat.legacy-core();
 @include mat.core();
@@ -188,6 +187,10 @@ button.mat-icon-button {
 
 mat-card-title {
   --mat-card-title-text-size: 24px;
+}
+
+.mat-mdc-dialog-actions {
+  padding: 16px 24px !important;
 }
 
 @mixin dense_mat_select() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -38,7 +38,7 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   max-width: 400px !important;
 }
 
-.cdk-overlay-pane.inviteDialogComponent > .mat-dialog-container {
+.cdk-overlay-pane.inviteDialogComponent > .mat-mdc-dialog-container {
   padding-top: 5px !important;
 }
 
@@ -61,6 +61,14 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
 
 .locale-fonts mat-option {
   font-family: variables.$languageFonts;
+}
+
+// Titles with icons need extra padding above the text
+.mat-mdc-dialog-title.dialog-icon-title {
+  padding-top: 20px;
+  &:before {
+    display: none;
+  }
 }
 
 // Decrease the padding around a checkbox to be 0px as spacing is instead usually applied in other ways e.g. padding on

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -1,10 +1,6 @@
 import { ComponentType } from '@angular/cdk/portal';
 import { Injectable } from '@angular/core';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 import {
   GenericDialogComponent,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.scss
@@ -1,3 +1,3 @@
-.mat-dialog-content .mat-mdc-form-field {
+.mat-mdc-dialog-content .mat-mdc-form-field {
   width: 100%;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { mock } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,9 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.scss
@@ -9,4 +9,9 @@ p:first-child {
 
 mat-dialog-content {
   max-width: 620px;
+
+  pre {
+    text-align: left;
+    overflow-x: auto;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
@@ -2,10 +2,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.stories.ts
@@ -1,9 +1,5 @@
 import { Component, Inject, InjectionToken, OnInit } from '@angular/core';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogConfig } from '@angular/material/dialog';
 
 import { CommonModule } from '@angular/common';
 import { Meta, StoryFn } from '@storybook/angular';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { browserLinks, getLinkHTML, issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { Breadcrumb, NotifiableError } from '@bugsnag/js';
 import { CookieService } from 'ngx-cookie-service';
 import { User } from 'realtime-server/lib/esm/common/models/user';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
@@ -1,9 +1,9 @@
-<h2 mat-dialog-title><mat-icon>science</mat-icon> Developer settings</h2>
-<app-notice type="warning" icon="warning">
-  These settings are for developers and testers of Scripture Forge. Do not use them for real projects. Doing so will
-  cause unexpected problems and errors.
-</app-notice>
+<h2 mat-dialog-title class="dialog-icon-title"><mat-icon>science</mat-icon> Developer settings</h2>
 <mat-dialog-content class="mat-typography">
+  <app-notice type="warning" icon="warning">
+    These settings are for developers and testers of Scripture Forge. Do not use them for real projects. Doing so will
+    cause unexpected problems and errors.
+  </app-notice>
   <mat-checkbox *ngFor="let flag of featureFlags.featureFlags" [(ngModel)]="flag.enabled" [disabled]="flag.readonly">
     {{ flag.description }}
   </mat-checkbox>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
@@ -12,4 +12,5 @@
 
 app-notice {
   max-width: 25em;
+  margin: 1em 0;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
@@ -1,17 +1,15 @@
-.mat-dialog-title {
+.mat-mdc-dialog-title {
   display: flex;
   align-items: center;
   column-gap: 0.5em;
 }
 
-.mat-dialog-content {
+.mat-mdc-dialog-content {
   display: flex;
   flex-direction: column;
   row-gap: 0.5em;
-  padding-bottom: 1em;
 }
 
 app-notice {
   max-width: 25em;
-  margin: 1em 0;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.spec.ts
@@ -5,10 +5,7 @@ import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { mock, when } from 'ts-mockito';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
@@ -1,5 +1,5 @@
-<h2 mat-dialog-title>{{ title | async }}</h2>
-<div mat-dialog-content>{{ message | async }}</div>
+<h2 mat-dialog-title>{{ title$ | async }}</h2>
+<div mat-dialog-content *ngIf="message$ | async as message">{{ message }}</div>
 <div mat-dialog-actions align="end">
   <ng-container *ngFor="let option of options">
     <button *ngIf="option.highlight" mat-flat-button color="primary" [mat-dialog-close]="option.value">

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 
 export interface GenericDialogOptions<T> {
@@ -27,11 +27,11 @@ export interface GenericDialogRef<T> {
 export class GenericDialogComponent<T> {
   constructor(@Inject(MAT_DIALOG_DATA) private readonly data: GenericDialogOptions<T>) {}
 
-  get title(): Observable<string> | undefined {
+  get title$(): Observable<string> | undefined {
     return this.data.title;
   }
 
-  get message(): Observable<string> | undefined {
+  get message$(): Observable<string> | undefined {
     return this.data.message;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.ts
@@ -1,8 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import {
-  MatLegacyDialogRef as MatDialogRef,
-  MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA
-} from '@angular/material/legacy-dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Observable } from 'rxjs';
 
 export interface GenericDialogOptions<T> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { I18nService } from 'xforge-common/i18n.service';
 import { browserLinks, isIosDevice } from 'xforge-common/utils';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.scss
@@ -1,6 +1,5 @@
 mat-dialog-content {
   min-width: 280px;
-  padding-bottom: 10px;
   display: flex;
   align-items: center;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.spec.ts
@@ -1,11 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import {
-  MatLegacyDialog as MatDialog,
-  MatLegacyDialogConfig as MatDialogConfig,
-  MatLegacyDialogRef as MatDialogRef
-} from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-delete-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 
 export interface SaDeleteUserDialogData {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, getDebugNode, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialog as MatDialog, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostBinding, OnInit } from '@angular/core';
-import { MatLegacyDialogConfig as MatDialogConfig } from '@angular/material/legacy-dialog';
+import { MatDialogConfig } from '@angular/material/dialog';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -16,7 +16,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { of } from 'rxjs';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { escapeRegExp } from 'lodash-es';
 import merge from 'lodash-es/merge';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatDialogModule } from '@angular/material/dialog';
 import { RouterModule } from '@angular/router';
 import { TranslocoModule, TRANSLOCO_CONFIG, TRANSLOCO_LOADER } from '@ngneat/transloco';
 import { ngfModule } from 'angular-file';


### PR DESCRIPTION
This PR updates the legacy mat-dialog to the MDC based version. This used `ng generate @angular/material:mdc-migration` as a starting point.
Reviewers should test the components thoroughly. This will require tester to test this as it affects a large number of components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2489)
<!-- Reviewable:end -->
