### PR TITLE
Fix: Sort draft books by their book number

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -5,8 +5,8 @@ import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { map, Observable } from 'rxjs';
-import { ActivatedProjectService } from '../../../../xforge-common/activated-project.service';
-import { I18nService } from '../../../../xforge-common/i18n.service';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { I18nService } from 'xforge-common/i18n.service';
 
 interface BookWithDraft {
   bookNumber: number;
@@ -31,6 +31,7 @@ export class DraftPreviewBooksComponent {
           bookNumber: text.bookNum,
           firstChapterWithDraft: text.chapters.find(chapter => chapter.hasDraft)?.number
         }))
+        .sort((a, b) => a.bookNumber - b.bookNumber)
         .filter(book => book.firstChapterWithDraft != null) as BookWithDraft[];
     })
   );


### PR DESCRIPTION
This PR fixes a minor bug I noticed while writing SF-2616 where draft books for viewing were sorted by their order in the `project.texts[]` array, not their canonical order. This especially occurs if OT books are added to the project after NT books.

**Before**
![image](https://github.com/sillsdev/web-xforge/assets/8665431/98702116-b73d-401f-81c0-a30fb0b0abc5)

**After**
![image](https://github.com/sillsdev/web-xforge/assets/8665431/f22e9ef3-c695-451e-b19f-204d4e9ede9f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2491)
<!-- Reviewable:end -->
