### PR TITLE
SF-2729 Fix ShareDB apply ops crash due to array out of order

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -136,7 +136,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         // Otherwise, add to unusable books.
         // Ensure books are displayed in ascending canonical order.
         const targetBooks = new Set<number>();
-        for (const text of target.texts.sort((a, b) => a.bookNum - b.bookNum)) {
+        for (const text of target.texts.slice().sort((a, b) => a.bookNum - b.bookNum)) {
           const bookNum = text.bookNum;
           targetBooks.add(bookNum);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
@@ -132,7 +132,7 @@ export class DraftSourcesService {
         data: {
           name: translateSource.name,
           shortName: translateSource.shortName,
-          texts: texts ?? [],
+          texts: texts?.slice() ?? [],
           writingSystem: translateSource.writingSystem,
           noAccess: true
         }


### PR DESCRIPTION
This PR fixes the "Referenced element not an object (it was undefined)." error that occurs when syncing updates the texts array of the project.

This because occurs because the reference to the `texts` array for an `sf_projects_profile` in IndexedDB is sorted by `bookNum`.

To resolve this, I ensure that the copy of the texts array used for drafting is `slice()`'ed from the `sf_project_profile` object.

I also updated the code that performs the sort on this array to `slice()` from the object it was passed, as we should only `sort()` on a `slice()`'ed copy of an array, not the array the method was passed by reference.

Testing may be done by a developer, but given the change is very small with very low risk, I do not think testing is required. Full testing details are in the JIRA ticket, however, for those interested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2492)
<!-- Reviewable:end -->
