### PR TITLE
Hide avatar menu until logged in

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -66,6 +66,7 @@
         </mat-menu>
 
         <button
+          *ngIf="currentUser"
           mat-icon-button
           title="{{ currentUser?.displayName }}"
           [matMenuTriggerFor]="userMenu"


### PR DESCRIPTION
This is a simple change to hide the avatar menu until a user is logged in.

Currently a user can interact with any of the available options in the menu which don't make any sense yet i.e. edit name, my logout, etc.

**Before**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/b6fd2b28-e60f-4c4c-ac63-11a413438fb8)

**After**
![image](https://github.com/sillsdev/web-xforge/assets/17464863/c8314d4d-8d81-4360-b304-18dda8728584)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2494)
<!-- Reviewable:end -->
