### PR TITLE
Refactor LocaleDirection type

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
@@ -24,12 +24,11 @@ import {
   Observable,
   Subscription
 } from 'rxjs';
+import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 import { TabMenuItem, TabMenuService } from '../../sf-tab-group';
 import { TabHeaderPointerEvent, TabLocation, TabMoveEvent } from '../sf-tabs.types';
 import { TabHeaderComponent } from '../tab-header/tab-header.component';
 import { TabComponent } from '../tab/tab.component';
-
-type LocaleDirection = 'ltr' | 'rtl';
 
 @Component({
   selector: 'app-tab-group-header',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/legacy-dialog';
 import { TranslocoService } from '@ngneat/transloco';
+import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 
 export enum TextNoteType {
   Footnote = 'f',
@@ -24,7 +25,7 @@ export class TextNoteDialogComponent {
     private readonly translocoService: TranslocoService
   ) {}
 
-  get direction(): 'ltr' | 'rtl' {
+  get direction(): LocaleDirection {
     return this.data.isRightToLeft ? 'rtl' : 'ltr';
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -23,6 +23,7 @@ import { takeUntil } from 'rxjs/operators';
 import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import tinyColor from 'tinycolor2';
 import { DialogService } from 'xforge-common/dialog.service';
+import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
@@ -404,7 +405,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     return this._isReadOnly || this.viewModel.isEmpty;
   }
 
-  get textDirection(): 'ltr' | 'rtl' | 'auto' {
+  get textDirection(): LocaleDirection | 'auto' {
     if (this.contentShowing) {
       return this.isRtl ? 'rtl' : 'ltr';
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -85,6 +85,7 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -480,7 +481,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.i18n.localizeReference(verseRef);
   }
 
-  get direction(): 'ltr' | 'rtl' {
+  get direction(): LocaleDirection {
     return this.i18n.direction;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -15,9 +15,9 @@ import { DOCUMENT } from './browser-globals';
 import { BugsnagService } from './bugsnag.service';
 import { FeatureFlagService } from './feature-flags/feature-flag.service';
 import { LocationService } from './location.service';
-import { Locale } from './models/i18n-locale';
+import { Locale, LocaleDirection } from './models/i18n-locale';
 import { PseudoLocalization } from './pseudo-localization';
-import { aspCultureCookieValue, ASP_CULTURE_COOKIE_NAME, getAspCultureCookieLanguage, getI18nLocales } from './utils';
+import { ASP_CULTURE_COOKIE_NAME, aspCultureCookieValue, getAspCultureCookieLanguage, getI18nLocales } from './utils';
 
 export type DateFormat = Intl.DateTimeFormatOptions | ((date: Date) => string);
 
@@ -135,7 +135,7 @@ export class I18nService {
     return this.currentLocale$.value.canonicalTag;
   }
 
-  get direction(): 'ltr' | 'rtl' {
+  get direction(): LocaleDirection {
     return this.currentLocale$.value.direction;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/i18n-locale.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/i18n-locale.ts
@@ -1,8 +1,10 @@
+export type LocaleDirection = 'ltr' | 'rtl';
+
 export interface Locale {
   localName: string;
   englishName: string;
   canonicalTag: string;
-  direction: 'ltr' | 'rtl';
+  direction: LocaleDirection;
   tags: string[];
   production: boolean;
   helps?: string;


### PR DESCRIPTION
This PR moves the `LocaleDirection` type out of `TabGroupHeaderComponent` to `i18n-locale.ts` and replaces usages of `'ltr' | 'rtl'` type with `LocaleDirection`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2495)
<!-- Reviewable:end -->
