### PR TITLE
SF-2750 Do not train on all books when no books are specified

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -743,11 +743,13 @@ public class MachineProjectServiceTests
                 Arg.Is<TranslationBuildConfig>(
                     b =>
                         b.TrainOn.Count == 1
-                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
                         && b.TrainOn.First().CorpusId == Corpus01
+                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
+                        && b.TrainOn.First().TextIds == null
                         && b.Pretranslate.Count == 1
                         && b.Pretranslate.First().CorpusId == Corpus01
                         && b.Pretranslate.First().ScriptureRange == "LEV;NUM"
+                        && b.Pretranslate.First().TextIds == null
                 ),
                 CancellationToken.None
             );
@@ -791,11 +793,13 @@ public class MachineProjectServiceTests
                 Arg.Is<TranslationBuildConfig>(
                     b =>
                         b.TrainOn.Count == 1
-                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
                         && b.TrainOn.First().CorpusId == Corpus02
+                        && b.TrainOn.First().ScriptureRange == "GEN;EXO"
+                        && b.TrainOn.First().TextIds == null
                         && b.Pretranslate.Count == 1
                         && b.Pretranslate.First().CorpusId == Corpus01
                         && b.Pretranslate.First().ScriptureRange == "LEV;NUM"
+                        && b.Pretranslate.First().TextIds == null
                 ),
                 CancellationToken.None
             );
@@ -829,8 +833,10 @@ public class MachineProjectServiceTests
                     b =>
                         b.Pretranslate.Count == 1
                         && b.Pretranslate.First().ScriptureRange == null
+                        && b.Pretranslate.First().TextIds == null
                         && b.TrainOn.Count == 1
                         && b.TrainOn.First().ScriptureRange == null
+                        && b.TrainOn.First().TextIds!.Count == 0
                 ),
                 CancellationToken.None
             );
@@ -876,8 +882,10 @@ public class MachineProjectServiceTests
                     b =>
                         b.Pretranslate.Count == 1
                         && b.Pretranslate.First().ScriptureRange == null
+                        && b.Pretranslate.First().TextIds == null
                         && b.TrainOn.Count == 1
                         && b.TrainOn.First().ScriptureRange == null
+                        && b.TrainOn.First().TextIds!.Count == 0
                 ),
                 CancellationToken.None
             );


### PR DESCRIPTION
Currently, when no books are selected for training, due to the way SF sends null values for both `textIds` and `scriptureRange` for the `trainOn` object, Serval ends up training on all books. This results in only blank verses being translated, instead of all verses.

This PR, based on the change https://github.com/sillsdev/serval/issues/383, specifies an empty array for train `textIds` collection when no books are selected for training. This means that all verses in the target will be translated by Serval, instead of just blank verses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2498)
<!-- Reviewable:end -->
