### PR TITLE
SF-2753 Shorten email template

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -326,10 +326,9 @@
     "text_size": "Text size"
   },
   "issue_email": {
-    "body": "Thanks for reporting the issue!\nIt would help us if you fill out some of the information below, but please submit even if you can't fill out much.\nIf you are requesting a feature many of the fields may not be applicable.\n\nBug report\nA clear and concise description of what the bug is.\n\nSteps to reproduce\nFor example:\n1. Go to ...\n2. Click on ...\n3. Scroll down to ...\n4. See error\n\nActual behavior\nPlease describe actual behavior of the issue you are observing.\n\nExpected behavior\nA clear and concise description of what you expected to happen.\n\nScreenshots\nIf applicable, add screenshots to help explain your issue.\n\nAdditional context\nAdd any other context about the problem here.\n\nPossible solution\nAdd any possible solutions to the problem here.\n\nYour environment:\nSoftware                 Version\n-----------------------------------------\n{{ siteName }} - {{ siteVersion }}\n{{ browserName }} - {{ browserVersion }}\n{{ operatingSystem }} - {{ operatingSystemVersion }}\n\nURL: {{ url }}\nError id: {{ errorId }}",
-    "not_applicable": "not applicable",
-    "subject": "{{ siteName }} issue",
-    "unknown": "unknown"
+    "heading": "Please explain the problem.",
+    "technical_details": "Technical details",
+    "unknown": "Unknown"
   },
   "join": {
     "error_occurred_login": "An error occurred trying to join the project",


### PR DESCRIPTION
Here's how the email template now looks on my local dev machine:
```
Please explain the problem.




--- Technical details ---
Scripture Forge: 9.9.9
Chrome: 125.0.0.0
Brave: Yes
Linux: Unknown
URL: http://localhost:5000/projects/65eb63b90a55c8594e4e9f17/translate/GEN/1
```

### Changes
1. The request to explain the problem is the only thing at the beginning of the email so it's harder to miss. New lines separate it from the technical details.
2. A default subject is no longer provided
   a. This prevents all our support requests from having the same "Scripture Forge issue" subject
   b. Most mail clients ask a user if they're sure they want to send an email with no subject, so the user will at least have to write *something* about what the problem is
3. The old email template dictated what technical details should be provided. This means we couldn't change the technical details without updating a localization string. The technical details can now be updated with no localization impact.
4. We now indicate whether the user is using Brave or not. Some of our users are more security conscious, and therefore it's likely an outsized number of users using Brave, and it might be the reason why some error IDs we get through email don't have matches in Bugsnag. This will help us understand whether this is the case or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2499)
<!-- Reviewable:end -->
