### PR TITLE
Fix legacy draft warning localization unavailable

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -9,7 +9,7 @@
 
   <app-notice *ngIf="draftCheckState === 'draft-legacy'" type="warning" icon="warning">
     <transloco
-      key="draft_viewer.draft_legacy_warning"
+      key="editor_draft_tab.draft_legacy_warning"
       [params]="{ generateDraftUrl: { route: generateDraftUrl } }"
     ></transloco>
   </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -228,6 +228,7 @@
     "apply_to_project": "Add to project",
     "click_book_to_preview": "Click a book below to preview the draft and add it to your project.",
     "draft_indicator_applied": "Added",
+    "draft_legacy_warning": "We have updated our drafting functionality. You can take advantage of this by [link:generateDraftUrl]generating a new draft[/link].",
     "no_draft_notice": "{{ bookChapterName }} has no draft.",
     "offline_notice": "Auto draft is not available offline.",
     "overwrite": "Adding the draft will overwrite the current chapter. Are you sure you want to continue?",


### PR DESCRIPTION
When the old draft preview component was removed, one of the localization strings was accidentally dropped. This adds the string back in the `editor_draft_tab` area.

Before
![image](https://github.com/sillsdev/web-xforge/assets/17931130/4d0d4be1-6fee-4e29-ad2f-eeb20ae6dcf9)


After
![image](https://github.com/sillsdev/web-xforge/assets/17931130/1b03b0ed-408f-451a-b567-bdea998b073b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2500)
<!-- Reviewable:end -->
