### PR TITLE
SF-2751 Fix NG0911 error

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3734,38 +3734,37 @@ describe('EditorComponent', () => {
   }));
 
   describe('initEditorTabs', () => {
-    it('should add source tab group when sourceLabel is defined', fakeAsync(() => {
+    it('should add source tab group when source is defined', fakeAsync(() => {
       const env = new TestEnvironment();
-      flush();
+      const projectDoc = env.getProjectDoc('project01');
       const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
-      const sourceLabel = 'source label';
-      env.component['sourceLabel'] = sourceLabel;
-      env.component['targetLabel'] = 'target label';
-      env.component.initEditorTabs();
-      tick(100);
-      expect(spyCreateTab).toHaveBeenCalledWith('project-source', { headerText: sourceLabel });
+      env.wait();
+
+      expect(spyCreateTab).toHaveBeenCalledWith('project-source', {
+        headerText: projectDoc.data?.translateConfig.source?.shortName
+      });
+      discardPeriodicTasks();
     }));
 
-    it('should not add source tab group when sourceLabel is undefined', fakeAsync(() => {
+    it('should not add source tab group when source is undefined', fakeAsync(() => {
       const env = new TestEnvironment();
-      flush();
       const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
-      env.component['sourceLabel'] = undefined;
-      env.component['targetLabel'] = 'target label';
-      env.component.initEditorTabs();
-      tick(100);
+      delete env.testProjectProfile.translateConfig.source;
+      env.setupProject();
+      env.wait();
       expect(spyCreateTab).not.toHaveBeenCalledWith('project-source', jasmine.any(Object));
+      discardPeriodicTasks();
     }));
 
     it('should add target tab group', fakeAsync(() => {
       const env = new TestEnvironment();
-      flush();
+      const projectDoc = env.getProjectDoc('project01');
       const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
-      const targetLabel = 'target label';
-      env.component['targetLabel'] = targetLabel;
-      env.component.initEditorTabs();
-      tick(100);
-      expect(spyCreateTab).toHaveBeenCalledWith('project', { headerText: targetLabel });
+      env.wait();
+      expect(spyCreateTab).toHaveBeenCalledWith('project', {
+        headerText: projectDoc.data?.shortName
+      });
+      discardPeriodicTasks();
     }));
   });
 
@@ -3898,7 +3897,7 @@ class TestEnvironment {
     { tagId: 3, name: 'SF Note Tag', icon: SF_TAG_ICON, creatorResolve: false }
   ];
 
-  private testProjectProfile: SFProjectProfile = createTestProjectProfile({
+  testProjectProfile: SFProjectProfile = createTestProjectProfile({
     shortName: 'TRG',
     isRightToLeft: false,
     userRoles: this.userRolesOnProject,


### PR DESCRIPTION
This PR attempts to fix NG0911 errors that were occasionally being thrown when navigating away from the editor component.

A recent discussion in an open angular issue (https://github.com/angular/angular/issues/54527) suggests that NG0911 is happening when `takeUntilDestroyed` is used with a `DestroyRef` after component has been destroyed, such as when:
 - subscription happens after awaiting an earlier promise,
 - then navigation destroys component,
 - then promise resolves and code flow subscribes with `takeUntilDestroyed`

I suspect that the observables subscribed in `initEditorTabs()` are the offenders.  The solution in this PR is to combine those observables and return them from `initEditorTabs()` so that they can be piped from projectDoc changes, allowing a single call to `subscribe` before any awaited promises.

Note: Some comments in the above angular issue included suggestions to the angular team to change the behavior of `takeUntilDestroyed` to just terminate the subscription rather than throw an error.  This is worth keeping an eye on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2502)
<!-- Reviewable:end -->
