### PR TITLE
SF-2752 Stop reporting errors as 500 OK

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -227,7 +227,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     if (userData != null) {
       const userDataWithId = { ...userData, id: this.currentUserDoc.id };
       this.reportingService.addMeta(userDataWithId, 'user');
-      Bugsnag.setUser(this.currentUserDoc.id);
+      if (Bugsnag.isStarted()) Bugsnag.setUser(this.currentUserDoc.id);
     }
 
     const languageTag = this.currentUserDoc.data!.interfaceLanguage;


### PR DESCRIPTION
Our production and QA web server hosts content in HTTP/1.1, while Cloudflare hosts content using HTTP/2 for clients that support it. HTTP/2 does not carry the status text from an HTTP/1.1 request. As such, when Angular encounters HTTP error status codes over HTTP/2, it substitutes "OK" for the status text.

This PR utilizes the Auth HTTP interceptor to intercept these errors, and correct the status text by looking up the status code in Angular's HttpStatusCode enum, and take that status codes' enum key, separate it by spaces and update the status text and message to have the corresponding text.

This PR cannot be tested on localhost, as Cloudflare is performing the HTTP/1.1 to HTTP/2 conversion, so should be merged into master, then tested on QA.

I have also included a fix for a bug in unit tests I noticed during development, where "Bugsnag.setUser() was called before Bugsnag.start()" was appearing multiple times in the console output.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2503)
<!-- Reviewable:end -->
