### PR TITLE
Update list of supported SIL fonts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
@@ -68,7 +68,7 @@ export const FONT_FACE_DEFINITIONS: { [key: string]: string } = {
     'https://fonts.languagetechnology.org/fonts/sil/gentiumbookplus/web/GentiumBookPlus-Regular.woff2',
   'Gentium Plus': 'https://fonts.languagetechnology.org/fonts/sil/gentiumplus/web/GentiumPlus-Regular.woff2',
   Harmattan: 'https://fonts.languagetechnology.org/fonts/sil/harmattan/web/Harmattan-Regular.woff2',
-  'Japa Sans Oriya': 'https://fonts.languagetechnology.org/fonts/sil/japasansoriya/woff/JapaSansOriya-Regular.woff2',
+  'Japa Sans Oriya': 'https://fonts.languagetechnology.org/fonts/sil/japasansoriya/web/JapaSansOriya-Regular.woff2',
   Kanchenjunga: 'https://fonts.languagetechnology.org/fonts/sil/kanchenjunga/web/Kanchenjunga-Regular.woff2',
   'Kay Pho Du': 'https://fonts.languagetechnology.org/fonts/sil/kayphodu/web/KayPhoDu-Regular.woff2',
   Lateef: 'https://fonts.languagetechnology.org/fonts/sil/lateef/web/Lateef-Regular.woff2',
@@ -86,6 +86,8 @@ export const FONT_FACE_DEFINITIONS: { [key: string]: string } = {
   'Scheherazade New':
     'https://fonts.languagetechnology.org/fonts/sil/scheherazadenew/web/ScheherazadeNew-Regular.woff2',
   Surma: 'https://fonts.languagetechnology.org/fonts/other/surma/Surma-Regular.woff2',
+  SymChar: 'https://fonts.languagetechnology.org/fonts/sil/symchar/web/SymChar-Regular.woff2',
+  SymCharK: 'https://fonts.languagetechnology.org/fonts/sil/symchark/web/SymCharK-Regular.woff2',
   Tagmukay: 'https://fonts.languagetechnology.org/fonts/sil/tagmukay/web/Tagmukay-Regular.woff',
   'Tai Heritage Pro': 'https://fonts.languagetechnology.org/fonts/sil/taiheritagepro/web/TaiHeritagePro-Regular.woff',
   ThiruValluvar: 'https://fonts.languagetechnology.org/fonts/other/thiruvalluvar/woff/ThiruValluvar-Regular.woff2'


### PR DESCRIPTION
Every PR has had Chromatic showing a change to the fonts, because "Japa Sans Oriya" was no longer loading. It turns out this wasn't a network problem; the font is no longer available at the same URL. Updating this should get rid of the visual diff we're seeing in a number of PRs.

I plan to open a PR to add a script for updating this list; however, the script is more complicated and right now I just want to get this change in.

How to test this:
- Verify old URL for "Japa Sans Oriya" leads to 404
- Verify new URL does not

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2504)
<!-- Reviewable:end -->
