### PR TITLE
SF-2762 Prompt user to log in again when refresh token is rejected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -5,7 +5,6 @@ import { Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
-import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -55,7 +54,6 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
 
   constructor(
     private readonly authService: AuthService,
-    private readonly dialogService: DialogService,
     private readonly paratextService: ParatextService,
     private readonly projectService: SFProjectService,
     private readonly router: Router,
@@ -239,15 +237,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       }
     } catch (error: any) {
       if (error instanceof HttpErrorResponse && error.status === 401) {
-        this.dialogService
-          .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
-          .then((logOut: boolean) => {
-            if (logOut) {
-              this.authService.logOut();
-            } else {
-              this.router.navigate(['/projects']);
-            }
-          });
+        this.authService.requestParatextCredentialUpdate(() => this.router.navigate(['/projects']));
       } else {
         throw error;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -17,7 +17,7 @@ import { TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-au
 import { createTestTextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio-test-data';
 import { ProjectType, TranslateConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { of } from 'rxjs';
-import { anything, capture, deepEqual, instance, mock, spy, verify, when } from 'ts-mockito';
+import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
@@ -707,35 +707,16 @@ describe('SettingsComponent', () => {
         expect(env.basedOnSelect).not.toBeNull();
       }));
 
-      it('should log the user out if they click the log out button when get projects and resources throws a forbidden error', fakeAsync(() => {
+      it('should display the Paratext credentials update prompt when get projects and resources throws a forbidden error', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
         when(mockedParatextService.getProjects()).thenReject(new HttpErrorResponse({ status: 401 }));
         when(mockedParatextService.getResources()).thenReject(new HttpErrorResponse({ status: 401 }));
-        const dialogSpy = spy(env.component.dialogService);
-        when(dialogSpy.confirm(anything(), anything())).thenResolve(true);
         env.wait();
 
         verify(mockedParatextService.getProjects()).once();
         verify(mockedParatextService.getResources()).once();
-        verify(dialogSpy.confirm(anything(), anything())).once();
-        verify(mockedAuthService.logOut()).once();
-        expect(env.inputElement(env.basedOnSelect).disabled).toBe(true);
-      }));
-
-      it('should not log the user out if they click cancel when get projects throws a forbidden error', fakeAsync(() => {
-        const env = new TestEnvironment();
-        env.setupProject();
-        when(mockedParatextService.getProjects()).thenReject(new HttpErrorResponse({ status: 401 }));
-        when(mockedParatextService.getResources()).thenReject(new HttpErrorResponse({ status: 401 }));
-        const dialogSpy = spy(env.component.dialogService);
-        when(dialogSpy.confirm(anything(), anything())).thenResolve(false);
-        env.wait();
-
-        verify(mockedParatextService.getProjects()).once();
-        verify(mockedParatextService.getResources()).once();
-        verify(dialogSpy.confirm(anything(), anything())).once();
-        verify(mockedAuthService.logOut()).never();
+        verify(mockedAuthService.requestParatextCredentialUpdate()).once();
         expect(env.inputElement(env.basedOnSelect).disabled).toBe(true);
       }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -90,7 +90,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly paratextService: ParatextService,
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
-    readonly dialogService: DialogService,
+    private readonly dialogService: DialogService,
     private readonly router: Router,
     private readonly onlineStatusService: OnlineStatusService,
     readonly i18n: I18nService,
@@ -243,13 +243,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
           await Promise.all([mainSettingsPromise, projectsAndResourcesPromise]);
           this.loading = false;
 
-          if (paratextTokensExpired) {
-            this.dialogService
-              .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
-              .then((logOut: boolean) => {
-                if (logOut) this.authService.logOut();
-              });
-          }
+          if (paratextTokensExpired) this.authService.requestParatextCredentialUpdate();
 
           this.updateFormEnabled();
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatDialogConfig } from '@angular/material/dialog';
@@ -5,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/models/checking-config';
 import { ProjectType, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { combineLatest } from 'rxjs';
+import { combineLatest, firstValueFrom } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -76,6 +77,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   mainSettingsLoaded = false;
 
   private static readonly projectSettingValueUnset = 'unset';
+  private paratextUsername: string | undefined;
   private projectDoc?: SFProjectDoc;
   /** Elements in this component and their states. */
   private controlStates = new Map<keyof SFProjectSettings, ElementState>();
@@ -88,7 +90,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly paratextService: ParatextService,
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
-    private readonly dialogService: DialogService,
+    readonly dialogService: DialogService,
     private readonly router: Router,
     private readonly onlineStatusService: OnlineStatusService,
     readonly i18n: I18nService,
@@ -112,7 +114,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   get isLoggedInToParatext(): boolean {
-    return this.projects != null;
+    return this.paratextUsername != null;
   }
 
   get isTranslationSuggestionsEnabled(): boolean {
@@ -191,6 +193,9 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
             this.projectService
               .onlineIsSourceProject(projectId)
               .then(isActiveSourceProject => (this.isActiveSourceProject = isActiveSourceProject)),
+            firstValueFrom(this.paratextService.getParatextUsername()).then((username: string | undefined) => {
+              if (username != null) this.paratextUsername = username;
+            }),
             this.projectService.get(projectId).then(projectDoc => (this.projectDoc = projectDoc))
           ]).then(() => {
             if (this.projectDoc != null) {
@@ -205,6 +210,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
             }
           });
 
+          let paratextTokensExpired = false;
           const projectsAndResourcesPromise = Promise.all([
             this.paratextService
               .getProjects()
@@ -213,7 +219,12 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
                 this.projects = projects;
                 this.updateNonSelectableProjects();
               })
-              .catch(() => (this.projectLoadingFailed = true)),
+              .catch((error: any) => {
+                this.projectLoadingFailed = true;
+                if (error instanceof HttpErrorResponse && error.status === 401) {
+                  paratextTokensExpired = true;
+                }
+              }),
             this.paratextService
               .getResources()
               .then(resources => {
@@ -221,11 +232,24 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
                 this.resources = resources;
                 this.updateNonSelectableProjects();
               })
-              .catch(() => (this.resourceLoadingFailed = true))
+              .catch((error: any) => {
+                this.resourceLoadingFailed = true;
+                if (error instanceof HttpErrorResponse && error.status === 401) {
+                  paratextTokensExpired = true;
+                }
+              })
           ]);
 
           await Promise.all([mainSettingsPromise, projectsAndResourcesPromise]);
           this.loading = false;
+
+          if (paratextTokensExpired) {
+            this.dialogService
+              .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
+              .then((logOut: boolean) => {
+                if (logOut) this.authService.logOut();
+              });
+          }
 
           this.updateFormEnabled();
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { DebugElement } from '@angular/core';
+import { DebugElement, ErrorHandler } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -30,6 +30,7 @@ import { SyncComponent } from './sync.component';
 
 const mockedAuthService = mock(AuthService);
 const mockedActivatedRoute = mock(ActivatedRoute);
+const mockedErrorHandler = mock(ErrorHandler);
 const mockedNoticeService = mock(NoticeService);
 const mockedDialogService = mock(DialogService);
 const mockedParatextService = mock(ParatextService);
@@ -51,6 +52,7 @@ describe('SyncComponent', () => {
     providers: [
       { provide: AuthService, useMock: mockedAuthService },
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },
+      { provide: ErrorHandler, useMock: mockedErrorHandler },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: DialogService, useMock: mockedDialogService },
       { provide: ParatextService, useMock: mockedParatextService },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -121,33 +121,16 @@ describe('SyncComponent', () => {
     verify(mockedNoticeService.show('Successfully synchronized Sync Test Project with Paratext.')).once();
   }));
 
-  it('should log the user out if they click the log out button when sync throws a forbidden error', fakeAsync(() => {
+  it('should display the Paratext credentials update prompt when sync throws a forbidden error', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineSync(env.projectId)).thenReject(
       new CommandError(CommandErrorCode.Forbidden, 'Forbidden')
     );
-    when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
 
     env.clickElement(env.syncButton);
 
     verify(mockedProjectService.onlineSync(env.projectId)).once();
-    verify(mockedDialogService.confirm(anything(), anything())).once();
-    verify(mockedAuthService.logOut()).once();
-    expect(env.component.syncActive).toBe(false);
-  }));
-
-  it('should not log the user out if they click cancel when a sync throws a forbidden error', fakeAsync(() => {
-    const env = new TestEnvironment();
-    when(mockedProjectService.onlineSync(env.projectId)).thenReject(
-      new CommandError(CommandErrorCode.Forbidden, 'Forbidden')
-    );
-    when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
-
-    env.clickElement(env.syncButton);
-
-    verify(mockedProjectService.onlineSync(env.projectId)).once();
-    verify(mockedDialogService.confirm(anything(), anything())).once();
-    verify(mockedAuthService.logOut()).never();
+    verify(mockedAuthService.requestParatextCredentialUpdate()).once();
     expect(env.component.syncActive).toBe(false);
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -172,11 +172,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     this.projectService.onlineSync(this.projectDoc.id).catch((error: any) => {
       this.checkSyncStatus();
       if ('code' in error && error.code === CommandErrorCode.Forbidden) {
-        this.dialogService
-          .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
-          .then((logOut: boolean) => {
-            if (logOut) this.authService.logOut();
-          });
+        this.authService.requestParatextCredentialUpdate();
       } else {
         throw error;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -123,13 +123,15 @@ describe('DraftGenerationComponent', () => {
 
     // Default setup
     setup(): void {
-      mockAuthService = jasmine.createSpyObj<AuthService>(['logOut'], { currentUserRoles: [SystemRole.User] });
+      mockAuthService = jasmine.createSpyObj<AuthService>(['requestParatextCredentialUpdate'], {
+        currentUserRoles: [SystemRole.User]
+      });
       mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
         'FeatureFlagService',
         {},
         { allowForwardTranslationNmtDrafting: createTestFeatureFlag(false) }
       );
-      mockDialogService = jasmine.createSpyObj<DialogService>(['confirm', 'openGenericDialog']);
+      mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog']);
       mockI18nService = jasmine.createSpyObj<I18nService>(
         ['getLanguageDisplayName', 'translate', 'interpolate', 'localizeBook'],
         {
@@ -1303,12 +1305,11 @@ describe('DraftGenerationComponent', () => {
       verify(mockDialogRef.close()).once();
     });
 
-    it('should log the user out if they click the log out button when startBuild throws a forbidden error', fakeAsync(() => {
+    it('should display the Paratext credentials update prompt when startBuild throws a forbidden error', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
           throwError(() => new HttpErrorResponse({ status: 401 }))
         );
-        mockDialogService.confirm.and.returnValue(Promise.resolve(true));
       });
 
       env.component.startBuild({
@@ -1327,36 +1328,7 @@ describe('DraftGenerationComponent', () => {
         translationBooks: [],
         fastTraining: false
       });
-      expect(mockDialogService.confirm).toHaveBeenCalled();
-      expect(mockAuthService.logOut).toHaveBeenCalled();
-    }));
-
-    it('should not log the user out if they click cancel when startBuild throws a forbidden error', fakeAsync(() => {
-      let env = new TestEnvironment(() => {
-        mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(
-          throwError(() => new HttpErrorResponse({ status: 401 }))
-        );
-        mockDialogService.confirm.and.returnValue(Promise.resolve(false));
-      });
-
-      env.component.startBuild({
-        trainingBooks: [],
-        trainingDataFiles: [],
-        translationBooks: [],
-        fastTraining: false,
-        projectId: projectId
-      });
-      tick();
-
-      expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
-        projectId: projectId,
-        trainingBooks: [],
-        trainingDataFiles: [],
-        translationBooks: [],
-        fastTraining: false
-      });
-      expect(mockDialogService.confirm).toHaveBeenCalled();
-      expect(mockAuthService.logOut).not.toHaveBeenCalled();
+      expect(mockAuthService.requestParatextCredentialUpdate).toHaveBeenCalled();
     }));
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -505,11 +505,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         }),
         catchError(error => {
           if (error instanceof HttpErrorResponse && error.status === 401) {
-            this.dialogService
-              .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
-              .then((logOut: boolean) => {
-                if (logOut) this.authService.logOut();
-              });
+            this.authService.requestParatextCredentialUpdate();
           }
 
           return of(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { MatTabGroup } from '@angular/material/tabs';
@@ -12,7 +13,7 @@ import { RouterLink } from 'ngx-transloco-markup-router-link';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { combineLatest, firstValueFrom, of, Subscription } from 'rxjs';
-import { filter, switchMap, tap } from 'rxjs/operators';
+import { catchError, filter, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -501,6 +502,17 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
           if (this.isDraftComplete(job)) {
             this.lastCompletedBuild = job;
           }
+        }),
+        catchError(error => {
+          if (error instanceof HttpErrorResponse && error.status === 401) {
+            this.dialogService
+              .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
+              .then((logOut: boolean) => {
+                if (logOut) this.authService.logOut();
+              });
+          }
+
+          return of(undefined);
         })
       ),
       (job?: BuildDto) => (this.draftJob = job)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -19,7 +19,6 @@ import { defer, of, Subject } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
-import { DialogService } from 'xforge-common/dialog.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -42,7 +41,6 @@ import { TranslateOverviewComponent } from './translate-overview.component';
 
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedAuthService = mock(AuthService);
-const mockedDialogService = mock(DialogService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedTranslationEngineService = mock(TranslationEngineService);
 const mockedNoticeService = mock(NoticeService);
@@ -64,7 +62,6 @@ describe('TranslateOverviewComponent', () => {
     providers: [
       { provide: AuthService, useMock: mockedAuthService },
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },
-      { provide: DialogService, useMock: mockedDialogService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: TranslationEngineService, useMock: mockedTranslationEngineService },
       { provide: NoticeService, useMock: mockedNoticeService },
@@ -193,34 +190,16 @@ describe('TranslateOverviewComponent', () => {
       expect(env.trainingProgress.mode).toBe('determinate');
     }));
 
-    it('should log the user out if they click the log out button when retrain throws a forbidden error', fakeAsync(() => {
+    it('should display the Paratext credentials update prompt when get projects throws a forbidden error', fakeAsync(() => {
       const env = new TestEnvironment();
       when(env.mockedRemoteTranslationEngine.startTraining()).thenReject(new HttpErrorResponse({ status: 401 }));
-      when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
       env.wait();
 
       env.clickRetrainButton();
       env.wait();
 
       verify(env.mockedRemoteTranslationEngine.startTraining()).once();
-      verify(mockedDialogService.confirm(anything(), anything())).once();
-      verify(mockedAuthService.logOut()).once();
-      expect(env.trainingProgressShown).toBe(false);
-      expect(env.component.isTraining).toBe(false);
-    }));
-
-    it('should not log the user out if they click cancel when retrain throws a forbidden error', fakeAsync(() => {
-      const env = new TestEnvironment();
-      when(env.mockedRemoteTranslationEngine.startTraining()).thenReject(new HttpErrorResponse({ status: 401 }));
-      when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
-      env.wait();
-
-      env.clickRetrainButton();
-      env.wait();
-
-      verify(env.mockedRemoteTranslationEngine.startTraining()).once();
-      verify(mockedDialogService.confirm(anything(), anything())).once();
-      verify(mockedAuthService.logOut()).never();
+      verify(mockedAuthService.requestParatextCredentialUpdate()).once();
       expect(env.trainingProgressShown).toBe(false);
       expect(env.component.isTraining).toBe(false);
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -12,7 +12,6 @@ import { asyncScheduler, Subscription, timer } from 'rxjs';
 import { delayWhen, filter, map, repeat, retryWhen, tap, throttleTime } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
-import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -71,7 +70,6 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
     private readonly authService: AuthService,
-    private readonly dialogService: DialogService,
     private readonly onlineStatusService: OnlineStatusService,
     readonly noticeService: NoticeService,
     private readonly projectService: SFProjectService,
@@ -198,11 +196,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
       .catch((error: any) => {
         this.isTraining = false;
         if (error instanceof HttpErrorResponse && error.status === 401) {
-          this.dialogService
-            .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
-            .then((logOut: boolean) => {
-              if (logOut) this.authService.logOut();
-            });
+          this.authService.requestParatextCredentialUpdate();
         } else {
           this.noticeService.showError(translate('translate_overview.training_unavailable'));
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ar.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ar.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "إلغاء",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_az.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_az.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "Ləğv etmək",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -537,7 +537,7 @@
   },
   "warnings": {
     "cancel": "Cancel",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -538,6 +538,7 @@
   "warnings": {
     "cancel": "Cancel",
     "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
-    "logout": "Yes, log out"
+    "logout": "Yes, log out",
+    "paratext_credentials_expired": "Your Paratext User Credentials have expired. Please log out and log back in again, then synchronize your project."
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_kyu.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "ꤗꤟꤢꤩ꤬ꤕꤜꤤ꤭ꤊꤛꤢ꤭",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_lo.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "ຍົກເລີກ",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_npi.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_npi.json
@@ -351,7 +351,7 @@
   },
   "warnings": {
     "cancel": "Cancel",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_pt_BR.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "Cancelar",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ro.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "Renunță",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_ru.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "Отменить",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_zh_CN.json
@@ -513,7 +513,7 @@
   },
   "warnings": {
     "cancel": "取消",
-    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to logout?",
-    "logout": "Yes, logout"
+    "login_cookie_deletion": "Logging out will remove your ability to log back into this account. Are you sure you want to log out?",
+    "logout": "Yes, log out"
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -693,6 +693,52 @@ describe('AuthService', () => {
     expect(env.isAuthenticated).toBeTrue();
     env.discardTokenExpiryTimer();
   }));
+
+  it('should log the user out if they click the log out button when requesting Paratext credential update', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
+    env.service.requestParatextCredentialUpdate();
+    tick();
+
+    verify(mockedDialogService.confirm(anything(), anything())).once();
+    verify(mockedWebAuth.logout(anything())).once();
+    expect(capture(mockedWebAuth.logout).last()).toBeDefined();
+  }));
+
+  it('should not log the user out if they click cancel when requesting Paratext credential update', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
+    env.service.requestParatextCredentialUpdate();
+    tick();
+
+    verify(mockedDialogService.confirm(anything(), anything())).once();
+    verify(mockedWebAuth.logout(anything())).never();
+    expect().nothing();
+  }));
+
+  it('should execute the callback if the user clicks cancel when requesting Paratext credential update', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedDialogService.confirm(anything(), anything())).thenResolve(false);
+    let callbackExecuted = false;
+    env.service.requestParatextCredentialUpdate(() => (callbackExecuted = true));
+    tick();
+
+    verify(mockedDialogService.confirm(anything(), anything())).once();
+    verify(mockedWebAuth.logout(anything())).never();
+    expect(callbackExecuted).toBe(true);
+  }));
+
+  it('should not execute the callback if the user clicks log out when requesting Paratext credential update', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedDialogService.confirm(anything(), anything())).thenResolve(true);
+    let callbackExecuted = false;
+    env.service.requestParatextCredentialUpdate(() => (callbackExecuted = true));
+    tick();
+
+    verify(mockedDialogService.confirm(anything(), anything())).once();
+    verify(mockedWebAuth.logout(anything())).once();
+    expect(callbackExecuted).toBe(false);
+  }));
 });
 
 interface TestEnvironmentConstructorArgs {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -298,6 +298,16 @@ export class AuthService {
     }
   }
 
+  requestParatextCredentialUpdate(cancelCallback?: () => void): void {
+    this.dialogService.confirm('warnings.paratext_credentials_expired', 'warnings.logout').then((logOut: boolean) => {
+      if (logOut) {
+        this.logOut();
+      } else if (cancelCallback != null) {
+        cancelCallback();
+      }
+    });
+  }
+
   /**
    * Only used when joining with a share key
    */

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -496,6 +496,7 @@ public class MachineApiController : ControllerBase
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The build was successfully started.</response>
+    /// <response code="401">Your Paratext tokens have expired, and you must log in again.</response>
     /// <response code="403">You do not have permission to build this project.</response>
     /// <response code="404">The project does not exist or is not configured on the ML server.</response>
     /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
@@ -527,6 +528,10 @@ public class MachineApiController : ControllerBase
             // Returning Forbid() results in a 400 error when executed in a POST action
             return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized();
+        }
     }
 
     /// <summary>
@@ -535,6 +540,7 @@ public class MachineApiController : ControllerBase
     /// <param name="buildConfig">The build configuration.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The pre-translation build was successfully started.</response>
+    /// <response code="401">Your Paratext tokens have expired, and you must log in again.</response>
     /// <response code="403">You do not have permission to build this project.</response>
     /// <response code="404">The project does not exist or is not configured on the ML server.</response>
     /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
@@ -570,6 +576,10 @@ public class MachineApiController : ControllerBase
         {
             // Returning Forbid() results in a 400 error when executed in a POST action
             return new StatusCodeResult(StatusCodes.Status403Forbidden);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized();
         }
     }
 

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -110,6 +110,10 @@ public class ParatextController : ControllerBase
         {
             return NoContent();
         }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized();
+        }
     }
 
     /// <summary>
@@ -215,6 +219,10 @@ public class ParatextController : ControllerBase
         catch (SecurityException)
         {
             return NoContent();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized();
         }
     }
 

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -94,6 +94,7 @@ public class ParatextController : ControllerBase
     /// </summary>
     /// <response code="200">The projects were successfully retrieved.</response>
     /// <response code="204">The user does not have permission to access Paratext.</response>
+    /// <response code="401">The user's Paratext tokens have expired, and the user must log in again.</response>
     [HttpGet("projects")]
     public async Task<ActionResult<IEnumerable<ParatextProject>>> GetAsync()
     {
@@ -204,6 +205,7 @@ public class ParatextController : ControllerBase
     /// values are an array with the short name followed by the name.
     /// </response>
     /// <response code="204">The user does not have permission to access Paratext.</response>
+    /// <response code="401">The user's Paratext tokens have expired, and the user must log in again.</response>
     [HttpGet("resources")]
     public async Task<ActionResult<Dictionary<string, string[]>>> ResourcesAsync()
     {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -491,7 +491,7 @@ public class SFProjectsRpcController(
             await projectService.SyncAsync(UserId, projectId);
             return Ok();
         }
-        catch (ForbiddenException)
+        catch (Exception ex) when (ex is ForbiddenException or UnauthorizedAccessException)
         {
             return ForbiddenError();
         }

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -14,7 +14,7 @@ public interface ISFProjectService : IProjectService
     Task DeleteProjectAsync(string curUserId, string projectId);
     Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
     Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
-    Task SyncAsync(string curUserId, string projectId);
+    Task<string> SyncAsync(string curUserId, string projectId);
     Task CancelSyncAsync(string curUserId, string projectId);
     Task<bool> InviteAsync(string curUserId, string projectId, string email, string locale, string role);
     Task<string> GetLinkSharingKeyAsync(string curUserId, string projectId, string role, string shareLinkType);

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
@@ -60,6 +61,13 @@ public class JwtTokenHelper : IJwtTokenHelper
         );
         request.Content = new StringContent(requestObj.ToString(), Encoding.Default, "application/json");
         HttpResponseMessage response = await client.SendAsync(request, token);
+
+        // Rethrow 400 errors as unauthorized, as these are related to invalid or expired tokens
+        if (response.StatusCode == HttpStatusCode.BadRequest)
+        {
+            throw new UnauthorizedAccessException();
+        }
+
         await _exceptionHandler.EnsureSuccessStatusCode(response);
 
         string responseJson = await response.Content.ReadAsStringAsync(token);

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -33,6 +33,7 @@ public class MachineApiService(
     IParatextService paratextService,
     IPreTranslationService preTranslationService,
     IRepository<SFProjectSecret> projectSecrets,
+    ISFProjectService projectService,
     IRealtimeService realtimeService,
     IOptions<ServalOptions> servalOptions,
     ISyncService syncService,
@@ -643,7 +644,8 @@ public class MachineApiService(
         MachineApi.EnsureProjectPermission(curUserId, projectDoc.Data);
 
         // Sync the source and target before running the build
-        string syncJobId = await syncService.SyncAsync(new SyncConfig { ProjectId = sfProjectId, UserId = curUserId });
+        // We use project service, as it provides permission and token checks
+        string syncJobId = await projectService.SyncAsync(curUserId, sfProjectId);
 
         // Run the training after the sync has completed
         string buildJobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
@@ -732,9 +734,8 @@ public class MachineApiService(
         });
 
         // Sync the source and target before running the build
-        string jobId = await syncService.SyncAsync(
-            new SyncConfig { ProjectId = buildConfig.ProjectId, UserId = curUserId }
-        );
+        // We use project service, as it provides permission and token checks
+        string jobId = await projectService.SyncAsync(curUserId, buildConfig.ProjectId);
 
         // If we have an alternate source, sync that first
         string alternateSourceProjectId = projectDoc.Data.TranslateConfig.DraftConfig.AlternateSource?.ProjectRef;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -553,9 +553,9 @@ public class ParatextService : DisposableBase, IParatextService
                 _dblServerUri
             );
         }
-        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.BadRequest)
+        catch (UnauthorizedAccessException)
         {
-            // We only trap 400 bad requests, as other exceptions will be connection related
+            // This will usually be caused by refresh token expiration
             canRead = false;
         }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1667,7 +1667,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
             catch (Exception ex)
             {
-                if (ex is HttpRequestException || ex is OperationCanceledException)
+                if (ex is HttpRequestException or OperationCanceledException or UnauthorizedAccessException)
                 {
                     Log(
                         $"CompleteSync: Problem fetching project roles. Maybe the user does not have access to the project or cancelled the sync. ({ex})"

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -481,11 +481,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
     /// <param name="projectId">The paratext project identifier.</param>
-    /// <returns>An asynchronous task.</returns>
+    /// <returns>The job identifier.</returns>
     /// <exception cref="DataNotFoundException">The project or user does not exist.</exception>
     /// <exception cref="ForbiddenException">The user is not an administrator or translator.</exception>
     /// <exception cref="UnauthorizedAccessException">The user cannot access the Paratext Registry or Archives.</exception>
-    public async Task SyncAsync(string curUserId, string projectId)
+    public async Task<string> SyncAsync(string curUserId, string projectId)
     {
         // Ensure the project exists
         Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
@@ -520,7 +520,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             throw new UnauthorizedAccessException();
 
         // Queue the sync
-        await _syncService.SyncAsync(new SyncConfig { ProjectId = projectId, UserId = curUserId });
+        return await _syncService.SyncAsync(new SyncConfig { ProjectId = projectId, UserId = curUserId });
     }
 
     public async Task CancelSyncAsync(string curUserId, string projectId)

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -476,22 +476,50 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         await _translateMetrics.ReplaceAsync(metrics, true);
     }
 
+    /// <summary>
+    /// Starts the sync for the specified project.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="projectId">The paratext project identifier.</param>
+    /// <returns>An asynchronous task.</returns>
+    /// <exception cref="DataNotFoundException">The project or user does not exist.</exception>
+    /// <exception cref="ForbiddenException">The user is not an administrator or translator.</exception>
+    /// <exception cref="UnauthorizedAccessException">The user cannot access the Paratext Registry or Archives.</exception>
     public async Task SyncAsync(string curUserId, string projectId)
     {
+        // Ensure the project exists
         Attempt<SFProject> attempt = await RealtimeService.TryGetSnapshotAsync<SFProject>(projectId);
         if (!attempt.TryResult(out SFProject project))
             throw new DataNotFoundException("The project does not exist.");
 
+        // Ensure that the user has a Paratext role
         if (!HasParatextRole(project, curUserId))
             throw new ForbiddenException();
 
-        // Project syncs require admin or translator role.  Resources can sync with any paratext role.
-        if (!_paratextService.IsResource(project.ParatextId))
+        // Project syncs require admin or translator role. Resources can sync with any Paratext role.
+        if (
+            !_paratextService.IsResource(project.ParatextId)
+            && !(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId))
+        )
         {
-            if (!(IsProjectAdmin(project, curUserId) || IsProjectTranslator(project, curUserId)))
-                throw new ForbiddenException();
+            throw new ForbiddenException();
         }
 
+        // Retrieve the user's secrets
+        Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
+        if (!userSecretAttempt.TryResult(out UserSecret userSecret))
+            throw new DataNotFoundException("The user does not exist.");
+
+        // Ensure that the user can access the Paratext registry
+        // NOTE: These next two methods will throw UnauthorizedAccessException on failure to refresh the token
+        if (!await _paratextService.CanUserAuthenticateToPTRegistryAsync(userSecret))
+            throw new UnauthorizedAccessException();
+
+        // Ensure that the user can access the Paratext archives
+        if (!await _paratextService.CanUserAuthenticateToPTArchivesAsync(curUserId))
+            throw new UnauthorizedAccessException();
+
+        // Queue the sync
         await _syncService.SyncAsync(new SyncConfig { ProjectId = projectId, UserId = curUserId });
     }
 

--- a/src/SIL.XForge/Controllers/RpcControllerBase.cs
+++ b/src/SIL.XForge/Controllers/RpcControllerBase.cs
@@ -12,6 +12,9 @@ namespace SIL.XForge.Controllers;
 [Authorize]
 public abstract class RpcControllerBase : RpcController
 {
+    public const int ForbiddenErrorCode = -32000;
+    public const int NotFoundErrorCode = -32001;
+
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IUserAccessor _userAccessor;
 
@@ -29,7 +32,7 @@ public abstract class RpcControllerBase : RpcController
     protected IRpcMethodResult InvalidParamsError(string message) => Error((int)RpcErrorCode.InvalidParams, message);
 
     protected IRpcMethodResult ForbiddenError() =>
-        Error(-32000, "The user does not have permission to perform this operation.");
+        Error(ForbiddenErrorCode, "The user does not have permission to perform this operation.");
 
-    protected IRpcMethodResult NotFoundError(string message) => Error(-32001, message);
+    protected IRpcMethodResult NotFoundError(string message) => Error(NotFoundErrorCode, message);
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1127,6 +1127,20 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task StartBuildAsync_Unauthorized()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.StartBuildAsync(User01, Project01, CancellationToken.None)
+            .Throws(new UnauthorizedAccessException());
+
+        // SUT
+        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+
+        Assert.IsInstanceOf<UnauthorizedResult>(actual.Result);
+    }
+
+    [Test]
     public async Task StartPreTranslationBuildAsync_MachineApiDown()
     {
         // Set up test environment
@@ -1211,6 +1225,27 @@ public class MachineApiControllerTests
         );
 
         Assert.IsInstanceOf<OkResult>(actual);
+    }
+
+    [Test]
+    public async Task StartPreTranslationBuildAsync_Unauthorized()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.StartPreTranslationBuildAsync(
+            User01,
+            Arg.Is<BuildConfig>(p => p.ProjectId == Project01),
+            CancellationToken.None
+        )
+            .Throws(new UnauthorizedAccessException());
+
+        // SUT
+        ActionResult<ServalBuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+            new BuildConfig { ProjectId = Project01 },
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<UnauthorizedResult>(actual.Result);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1462,8 +1462,7 @@ public class MachineApiServiceTests
         // SUT
         await env.Service.StartBuildAsync(User01, Project01, CancellationToken.None);
 
-        await env.SyncService.Received(1)
-            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.UserId == User01));
+        await env.ProjectService.Received(1).SyncAsync(User01, Project01);
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project01).ServalData!.TranslationJobId);
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.TranslationQueuedAt);
@@ -1619,8 +1618,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService.Received(1)
-            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.UserId == User01));
+        await env.ProjectService.Received(1).SyncAsync(User01, Project01);
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationJobId);
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationQueuedAt);
@@ -1643,8 +1641,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService.Received(1)
-            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.UserId == User01));
+        await env.ProjectService.Received(1).SyncAsync(User01, Project01);
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationJobId);
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationQueuedAt);
@@ -1677,8 +1674,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        await env.SyncService.Received(1)
-            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == Project01 && s.UserId == User01));
+        await env.ProjectService.Received(1).SyncAsync(User01, Project01);
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationJobId);
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationQueuedAt);
@@ -2052,6 +2048,8 @@ public class MachineApiServiceTests
                     },
                 }
             );
+            ProjectService = Substitute.For<ISFProjectService>();
+            ProjectService.SyncAsync(User01, Arg.Any<string>()).Returns(Task.FromResult(JobId));
             var realtimeService = new SFMemoryRealtimeService();
             realtimeService.AddRepository("sf_projects", OTType.Json0, Projects);
 
@@ -2072,6 +2070,7 @@ public class MachineApiServiceTests
                 ParatextService,
                 PreTranslationService,
                 ProjectSecrets,
+                ProjectService,
                 realtimeService,
                 servalOptions,
                 SyncService,
@@ -2088,6 +2087,7 @@ public class MachineApiServiceTests
         public IPreTranslationService PreTranslationService { get; }
         public MemoryRepository<SFProject> Projects { get; }
         public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
+        public ISFProjectService ProjectService { get; }
         public MachineApiService Service { get; }
         public ISyncService SyncService { get; }
         public ITranslationEnginesClient TranslationEnginesClient { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -382,7 +382,7 @@ public class ParatextServiceTests
     }
 
     [Test]
-    public async Task GetResourcePermissionAsync_UserNoResourcePermissionOn400BadRequest()
+    public async Task GetResourcePermissionAsync_UserNoResourcePermissionWhenUnauthorized()
     {
         // Set up environment
         var env = new TestEnvironment();
@@ -392,7 +392,7 @@ public class ParatextServiceTests
             Arg.Any<HttpClient>(),
             CancellationToken.None
         )
-            .Throws(new HttpRequestException("Bad Request", null, HttpStatusCode.BadRequest));
+            .Throws(new UnauthorizedAccessException());
 
         // SUT
         var paratextId = env.Resource2Id;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2817,53 +2817,58 @@ public class SFProjectServiceTests
     }
 
     [Test]
-    public void SyncAsync_AdministratorsCanSyncProject()
+    public async Task SyncAsync_AdministratorsCanSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
 
         // SUT
-        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Project01));
+        await env.Service.SyncAsync(User01, Project01);
+        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
     }
 
     [Test]
-    public void SyncAsync_TranslatorsCanSyncProject()
+    public async Task SyncAsync_TranslatorsCanSyncProject()
     {
         // Setup
         var env = new TestEnvironment();
 
         // SUT
-        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Project01));
+        await env.Service.SyncAsync(User05, Project01);
+        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
     }
 
     [Test]
-    public void SyncAsync_AdministratorsCanSyncResource()
+    public async Task SyncAsync_AdministratorsCanSyncResource()
     {
         // Setup
         var env = new TestEnvironment();
 
         // SUT
-        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User01, Resource01));
+        await env.Service.SyncAsync(User01, Resource01);
+        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
     }
 
     [Test]
-    public void SyncAsync_TranslatorsCanSyncResource()
+    public async Task SyncAsync_TranslatorsCanSyncResource()
     {
         // Setup
         var env = new TestEnvironment();
 
         // SUT
-        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User05, Resource01));
+        await env.Service.SyncAsync(User05, Resource01);
+        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
     }
 
     [Test]
-    public void SyncAsync_ObserversCanSyncResource()
+    public async Task SyncAsync_ObserversCanSyncResource()
     {
         // Setup
         var env = new TestEnvironment();
 
         // SUT
-        Assert.DoesNotThrowAsync(() => env.Service.SyncAsync(User02, Resource01));
+        await env.Service.SyncAsync(User02, Resource01);
+        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
     }
 
     [Test]
@@ -2874,6 +2879,49 @@ public class SFProjectServiceTests
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(() => env.Service.SyncAsync(User02, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_NoArchivesAccess()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        env.ParatextService.CanUserAuthenticateToPTArchivesAsync(User01).Returns(false);
+
+        // SUT
+        Assert.ThrowsAsync<UnauthorizedAccessException>(() => env.Service.SyncAsync(User01, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_NoRegistryAccess()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        env.ParatextService.CanUserAuthenticateToPTRegistryAsync(Arg.Any<UserSecret>()).Returns(false);
+
+        // SUT
+        Assert.ThrowsAsync<UnauthorizedAccessException>(() => env.Service.SyncAsync(User01, Project01));
+    }
+
+    [Test]
+    public void SyncAsync_ProjectDoesNotExist()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.SyncAsync(User01, "invalid_project"));
+    }
+
+    [Test]
+    public async Task SyncAsync_UserDoesNotExist()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        await env.UserSecrets.DeleteAsync(User01);
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.SyncAsync(User01, Project01));
     }
 
     [Test]
@@ -3296,7 +3344,7 @@ public class SFProjectServiceTests
                             Id = User01,
                             Email = "user01@example.com",
                             ParatextId = "pt-user01",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site>
                             {
                                 {
@@ -3310,7 +3358,7 @@ public class SFProjectServiceTests
                             Id = User02,
                             Email = "user02@example.com",
                             ParatextId = "pt-user02",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site>
                             {
                                 {
@@ -3324,21 +3372,21 @@ public class SFProjectServiceTests
                             Id = User03,
                             Email = "user03@example.com",
                             ParatextId = "pt-user03",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
                         },
                         new User
                         {
                             Id = User04,
                             Email = "user04@example.com",
-                            Roles = new List<string> { SystemRole.SystemAdmin },
+                            Roles = [SystemRole.SystemAdmin],
                             Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
                         },
                         new User
                         {
                             Id = LinkExpiredUser,
                             Email = "expired@example.com",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site> { { SiteId, new Site() } },
                         },
                         new User
@@ -3346,7 +3394,7 @@ public class SFProjectServiceTests
                             Id = User05,
                             Email = "user05@example.com",
                             ParatextId = "pt-user05",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site>
                             {
                                 {
@@ -3359,7 +3407,7 @@ public class SFProjectServiceTests
                         {
                             Id = User06,
                             Email = "user06@example.com",
-                            Roles = new List<string> { SystemRole.User },
+                            Roles = [SystemRole.User],
                             Sites = new Dictionary<string, Site>
                             {
                                 {
@@ -3372,7 +3420,7 @@ public class SFProjectServiceTests
                         {
                             Id = User07,
                             Email = "user07@example.com",
-                            Roles = new List<string> { SystemRole.SystemAdmin },
+                            Roles = [SystemRole.SystemAdmin],
                             Sites = new Dictionary<string, Site>
                             {
                                 {
@@ -3407,9 +3455,9 @@ public class SFProjectServiceTests
                                     ParatextId = Resource01PTId,
                                     Name = "resource project",
                                     ShortName = "RES",
-                                    WritingSystem = new WritingSystem { Tag = "qaa" }
+                                    WritingSystem = new WritingSystem { Tag = "qaa" },
                                 },
-                                DraftConfig = new DraftConfig { ServalConfig = "{ existingConfig: true }", },
+                                DraftConfig = new DraftConfig { ServalConfig = "{ existingConfig: true }" },
                             },
                             CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
                             UserRoles = new Dictionary<string, string>
@@ -3417,12 +3465,12 @@ public class SFProjectServiceTests
                                 { User01, SFProjectRole.Administrator },
                                 { User02, SFProjectRole.CommunityChecker },
                                 { User05, SFProjectRole.Translator },
-                                { User06, SFProjectRole.Viewer }
+                                { User06, SFProjectRole.Viewer },
                             },
                             UserPermissions = new Dictionary<string, string[]>
                             {
-                                { User03, new[] { "text_audio.create", "text_audio.delete" } },
-                                { User05, Array.Empty<string>() }
+                                { User03, ["text_audio.create", "text_audio.delete"] },
+                                { User05, [] },
                             },
                             Texts =
                             {
@@ -3436,9 +3484,9 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
+                                            Permissions = [],
+                                        },
+                                    },
                                 },
                                 new TextInfo
                                 {
@@ -3450,7 +3498,7 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { },
+                                            Permissions = [],
                                             HasAudio = true,
                                         },
                                         new Chapter
@@ -3458,10 +3506,10 @@ public class SFProjectServiceTests
                                             Number = 2,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
-                                }
+                                            Permissions = [],
+                                        },
+                                    },
+                                },
                             },
                             WritingSystem = new WritingSystem { Tag = "qaa" },
                         },
@@ -3471,11 +3519,11 @@ public class SFProjectServiceTests
                             Name = "project02",
                             ShortName = "P02",
                             ParatextId = "paratext_" + Project02,
-                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = true, },
+                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = true },
                             UserRoles =
                             {
                                 { User02, SFProjectRole.Administrator },
-                                { User04, SFProjectRole.CommunityChecker }
+                                { User04, SFProjectRole.CommunityChecker },
                             },
                         },
                         new SFProject
@@ -3484,7 +3532,7 @@ public class SFProjectServiceTests
                             Name = "project03",
                             ShortName = "P03",
                             ParatextId = "paratext_" + Project03,
-                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = true, },
+                            CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = true },
                             TranslateConfig =
                             {
                                 TranslationSuggestionsEnabled = false,
@@ -3492,14 +3540,14 @@ public class SFProjectServiceTests
                                 {
                                     ProjectRef = SourceOnly,
                                     ParatextId = "pt_source_no_suggestions",
-                                    Name = "Source Only Project"
-                                }
+                                    Name = "Source Only Project",
+                                },
                             },
                             UserRoles =
                             {
                                 { User01, SFProjectRole.Administrator },
-                                { User02, SFProjectRole.CommunityChecker }
-                            }
+                                { User02, SFProjectRole.CommunityChecker },
+                            },
                         },
                         new SFProject
                         {
@@ -3515,8 +3563,8 @@ public class SFProjectServiceTests
                             UserRoles =
                             {
                                 { User01, SFProjectRole.CommunityChecker },
-                                { User02, SFProjectRole.Administrator }
-                            }
+                                { User02, SFProjectRole.Administrator },
+                            },
                         },
                         new SFProject
                         {
@@ -3533,14 +3581,14 @@ public class SFProjectServiceTests
                                     ParatextId = Resource01PTId,
                                     Name = "resource project",
                                     ShortName = "RES",
-                                    WritingSystem = new WritingSystem { Tag = "qaa" }
-                                }
+                                    WritingSystem = new WritingSystem { Tag = "qaa" },
+                                },
                             },
                             CheckingConfig = new CheckingConfig { CheckingEnabled = true, ShareEnabled = false },
                             UserRoles = new Dictionary<string, string>
                             {
                                 { User01, SFProjectRole.Administrator },
-                                { User02, SFProjectRole.CommunityChecker }
+                                { User02, SFProjectRole.CommunityChecker },
                             },
                             Texts =
                             {
@@ -3554,9 +3602,9 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
+                                            Permissions = [],
+                                        },
+                                    },
                                 },
                                 new TextInfo
                                 {
@@ -3568,31 +3616,31 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
+                                            Permissions = [],
                                         },
                                         new Chapter
                                         {
                                             Number = 2,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
-                                }
-                            }
+                                            Permissions = [],
+                                        },
+                                    },
+                                },
+                            },
                         },
                         new SFProject
                         {
                             Id = Project06,
                             Name = "project06",
                             ParatextId = "paratext_" + Project06,
-                            CheckingConfig = new CheckingConfig { CheckingEnabled = false, ShareEnabled = true, },
+                            CheckingConfig = new CheckingConfig { CheckingEnabled = false, ShareEnabled = true },
                             UserRoles =
                             {
                                 { User01, SFProjectRole.CommunityChecker },
                                 { User02, SFProjectRole.CommunityChecker },
-                                { User07, SFProjectRole.Administrator }
-                            }
+                                { User07, SFProjectRole.Administrator },
+                            },
                         },
                         new SFProject
                         {
@@ -3612,9 +3660,9 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
+                                            Permissions = [],
+                                        },
+                                    },
                                 },
                                 new TextInfo
                                 {
@@ -3626,24 +3674,24 @@ public class SFProjectServiceTests
                                             Number = 1,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
+                                            Permissions = [],
                                         },
                                         new Chapter
                                         {
                                             Number = 2,
                                             LastVerse = 3,
                                             IsValid = true,
-                                            Permissions = { }
-                                        }
-                                    }
-                                }
+                                            Permissions = [],
+                                        },
+                                    },
+                                },
                             },
                             UserRoles =
                             {
                                 { User01, SFProjectRole.Administrator },
                                 { User05, SFProjectRole.Translator },
                                 { User02, SFProjectRole.PTObserver },
-                            }
+                            },
                         },
                         new SFProject
                         {
@@ -3651,8 +3699,8 @@ public class SFProjectServiceTests
                             ParatextId = "pt_source_no_suggestions",
                             Name = "Source Only Project",
                             ShortName = "DSP",
-                            UserRoles = { { User01, SFProjectRole.Administrator } }
-                        }
+                            UserRoles = { { User01, SFProjectRole.Administrator } },
+                        },
                     }
                 )
             );
@@ -3675,7 +3723,7 @@ public class SFProjectServiceTests
                         new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project05, User02) },
                         new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project06, User01) },
                         new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(Project06, User02) },
-                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(SourceOnly, User01) }
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId(SourceOnly, User01) },
                     }
                 )
             );
@@ -3693,21 +3741,21 @@ public class SFProjectServiceTests
                             DataId = TextAudio.GetDocId(Project01, 41, 1),
                             AudioUrl = "http://example.com/41_1.mp3",
                             MimeType = "audio/mp3",
-                            Timings = new List<AudioTiming>
-                            {
+                            Timings =
+                            [
                                 new AudioTiming
                                 {
                                     From = 0.0,
                                     TextRef = "MARK 1:1",
                                     To = 1.1,
                                 },
-                            },
+                            ],
                         },
                     }
                 )
             );
             RealtimeService.AddRepository(
-                "paratext_note_threads",
+                "note_threads",
                 OTType.Json0,
                 new MemoryRepository<NoteThread>(
                     new[]
@@ -3717,22 +3765,22 @@ public class SFProjectServiceTests
                             Id = "project01:dataId01",
                             DataId = "dataId01",
                             ThreadId = "thread01",
-                            Notes = new List<Note>()
-                            {
+                            Notes =
+                            [
                                 new Note { DataId = "thread01:PT01", SyncUserRef = "PT01" },
-                                new Note { DataId = "thread01:PT01", SyncUserRef = "PT02" }
-                            }
+                                new Note { DataId = "thread01:PT01", SyncUserRef = "PT02" },
+                            ],
                         },
                         new NoteThread
                         {
                             Id = "project01:dataId02",
                             DataId = "dataId02",
                             ThreadId = "thread02",
-                            Notes = new List<Note>()
-                            {
+                            Notes =
+                            [
                                 new Note { DataId = "thread02:PT01", SyncUserRef = "PT01" },
-                                new Note { DataId = "thread02:PT02", SyncUserRef = "PT02" }
-                            }
+                                new Note { DataId = "thread02:PT02", SyncUserRef = "PT02" },
+                            ],
                         },
                     }
                 )
@@ -3756,26 +3804,26 @@ public class SFProjectServiceTests
                     new SFProjectSecret
                     {
                         Id = Project01,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Key = "abcd",
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
-                            }
-                        }
+                                ShareLinkType = ShareLinkType.Recipient,
+                            },
+                        ],
                     },
                     new SFProjectSecret
                     {
                         Id = Project02,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Key = "linksharing02",
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Anyone
+                                ShareLinkType = ShareLinkType.Anyone,
                             },
                             new ShareKey
                             {
@@ -3783,22 +3831,22 @@ public class SFProjectServiceTests
                                 Key = "existingkeyuser03",
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
-                            }
-                        }
+                                ShareLinkType = ShareLinkType.Recipient,
+                            },
+                        ],
                     },
                     new SFProjectSecret
                     {
                         Id = Project03,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Email = "bob@example.com",
                                 Key = "key1111",
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
@@ -3806,7 +3854,7 @@ public class SFProjectServiceTests
                                 Key = "keyexp",
                                 ExpirationTime = currentTime.AddDays(-1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
@@ -3814,7 +3862,7 @@ public class SFProjectServiceTests
                                 Key = "key1234",
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
@@ -3822,56 +3870,56 @@ public class SFProjectServiceTests
                                 Key = "key2222",
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
-                            }
-                        }
+                                ShareLinkType = ShareLinkType.Recipient,
+                            },
+                        ],
                     },
                     new SFProjectSecret
                     {
                         Id = Project04,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Key = "linksharing04",
                                 ProjectRole = SFProjectRole.Viewer,
-                                ShareLinkType = ShareLinkType.Anyone
+                                ShareLinkType = ShareLinkType.Anyone,
                             },
-                        }
+                        ],
                     },
                     new SFProjectSecret
                     {
                         Id = Project05,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Email = "user03@example.com",
                                 Key = "key12345",
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
-                            }
-                        }
+                                ShareLinkType = ShareLinkType.Recipient,
+                            },
+                        ],
                     },
                     new SFProjectSecret
                     {
                         Id = Project06,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Key = "expiredKey",
                                 ExpirationTime = currentTime.AddDays(-1),
                                 ProjectRole = SFProjectRole.Viewer,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
                                 Key = "usedKey",
                                 ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient,
-                                RecipientUserId = User02
+                                RecipientUserId = User02,
                             },
                             new ShareKey
                             {
@@ -3879,7 +3927,7 @@ public class SFProjectServiceTests
                                 ExpirationTime = currentTime.AddDays(1),
                                 ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient,
-                                Reserved = true
+                                Reserved = true,
                             },
                             new ShareKey
                             {
@@ -3892,9 +3940,9 @@ public class SFProjectServiceTests
                                 Key = "maxUsersReached",
                                 ProjectRole = SFProjectRole.Viewer,
                                 ShareLinkType = ShareLinkType.Recipient,
-                                UsersGenerated = 250
+                                UsersGenerated = 250,
                             },
-                        }
+                        ]
                     },
                 }
             );
@@ -3908,11 +3956,11 @@ public class SFProjectServiceTests
                 {
                     ParatextId = "changedId",
                     Name = "NewSource",
-                    LanguageTag = "qaa"
+                    LanguageTag = "qaa",
                 },
                 new ParatextProject { ParatextId = GetProject(Project01).ParatextId },
                 new ParatextProject { ParatextId = PTProjectIdNotYetInSF },
-                new ParatextProject { ParatextId = "ptProject123" }
+                new ParatextProject { ParatextId = "ptProject123" },
             };
             ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(ptProjects));
             IReadOnlyList<ParatextResource> ptResources = new[]
@@ -3921,17 +3969,20 @@ public class SFProjectServiceTests
                 {
                     ParatextId = "resource_project",
                     Name = "ResourceProject",
-                    LanguageTag = "qaa"
+                    LanguageTag = "qaa",
                 },
-                new ParatextResource { ParatextId = GetProject(Resource01).ParatextId }
+                new ParatextResource { ParatextId = GetProject(Resource01).ParatextId },
             };
             ParatextService.GetResourcesAsync(Arg.Any<string>()).Returns(ptResources);
+            ParatextService.CanUserAuthenticateToPTRegistryAsync(Arg.Any<UserSecret>()).Returns(Task.FromResult(true));
+            ParatextService.CanUserAuthenticateToPTArchivesAsync(Arg.Any<string>()).Returns(Task.FromResult(true));
             UserSecrets = new MemoryRepository<UserSecret>(
                 new[]
                 {
                     new UserSecret { Id = User01 },
                     new UserSecret { Id = User02 },
-                    new UserSecret { Id = User03 }
+                    new UserSecret { Id = User03 },
+                    new UserSecret { Id = User05 },
                 }
             );
             var translateMetrics = new MemoryRepository<TranslateMetrics>();

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2823,8 +2823,8 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SyncAsync(User01, Project01);
-        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
+        string actual = await env.Service.SyncAsync(User01, Project01);
+        Assert.AreEqual("jobId", actual);
     }
 
     [Test]
@@ -2834,8 +2834,8 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SyncAsync(User05, Project01);
-        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
+        string actual = await env.Service.SyncAsync(User05, Project01);
+        Assert.AreEqual("jobId", actual);
     }
 
     [Test]
@@ -2845,8 +2845,8 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SyncAsync(User01, Resource01);
-        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
+        string actual = await env.Service.SyncAsync(User01, Resource01);
+        Assert.AreEqual("jobId", actual);
     }
 
     [Test]
@@ -2856,8 +2856,8 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SyncAsync(User05, Resource01);
-        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
+        string actual = await env.Service.SyncAsync(User05, Resource01);
+        Assert.AreEqual("jobId", actual);
     }
 
     [Test]
@@ -2867,8 +2867,8 @@ public class SFProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        await env.Service.SyncAsync(User02, Resource01);
-        await env.SyncService.Received(1).SyncAsync(Arg.Any<SyncConfig>());
+        string actual = await env.Service.SyncAsync(User02, Resource01);
+        Assert.AreEqual("jobId", actual);
     }
 
     [Test]
@@ -3942,7 +3942,7 @@ public class SFProjectServiceTests
                                 ShareLinkType = ShareLinkType.Recipient,
                                 UsersGenerated = 250,
                             },
-                        ]
+                        ],
                     },
                 }
             );

--- a/test/SIL.XForge.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Tests/Services/MockLogger.cs
@@ -11,19 +11,20 @@ namespace SIL.XForge.Services;
 /// </summary>
 public class LogEvent
 {
-    public LogLevel LogLevel { get; set; }
-    public EventId EventId { get; set; }
-    public object State { get; set; }
-    public Exception Exception { get; set; }
-    public string Message => State.ToString();
+    public LogLevel LogLevel { get; init; }
+    public EventId EventId { get; init; }
+    public object? State { get; init; }
+    public Exception? Exception { get; init; }
+    public string? Message => State?.ToString();
 
     public override string ToString()
     {
         string summary = $"LogEvent {EventId} {LogLevel}: {Message}";
-        if (Exception != null)
+        if (Exception is not null)
         {
             summary += $" ({Exception})";
         }
+
         return summary;
     }
 }


### PR DESCRIPTION
This PR will prompt the user to log out, then log back in again if their Paratext Refresh Token is invalid.

Due to the need to modify the database to recreate the error state that this PR resolves, testing should be performed by a developer.

**Changes in PR**

 * C# Backend: Check for for PT Archives/Registry access before starting sync.
 * C# Backend: Return Unauthorized errors for Token refresh errors.
 * Angular Frontend: Display prompt to log out on Sync screen.
 * Angular Frontend: Display prompt to log out on Connect Project screen.
 * Angular Frontend: Display prompt to logout/login on Settings screen.
 * Angular Frontend: Display prompt to log out when retraining on Translate Overview screen.
 * Angular Frontend: Correct verb use of the word logout to log out.
 * Angular Frontend: Display prompt to log out on Draft Generation screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2506)
<!-- Reviewable:end -->
