### PR TITLE
SF-2732 Hide history tab option when viewing a resource project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
@@ -24,12 +24,12 @@ describe('ParatextService', () => {
   describe('isResource', () => {
     it('should return true for a resource id', () => {
       const id = '1234567890abcdef';
-      expect(service.isResource(id)).toBe(true);
+      expect(ParatextService.isResource(id)).toBe(true);
     });
 
     it('should return false for a project id', () => {
       const id = '123456781234567890abcdef1234567890abcdef1234567890abcdef';
-      expect(service.isResource(id)).toBe(false);
+      expect(ParatextService.isResource(id)).toBe(false);
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.spec.ts
@@ -1,12 +1,10 @@
 import { HttpClient } from '@angular/common/http';
-import { TestBed } from '@angular/core/testing';
 import { mock } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { ParatextService } from './paratext.service';
 
 describe('ParatextService', () => {
-  let service: ParatextService;
   const mockHttpClient = mock(HttpClient);
   const mockAuthService = mock(AuthService);
 
@@ -16,10 +14,6 @@ describe('ParatextService', () => {
       { provide: AuthService, useMock: mockAuthService }
     ]
   }));
-
-  beforeEach(() => {
-    service = TestBed.inject(ParatextService);
-  });
 
   describe('isResource', () => {
     it('should return true for a resource id', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -27,6 +27,11 @@ const mockedUserService = mock(UserService);
 const mockedProjectService = mock(SFProjectService);
 const mockedProjectDoc = mock(SFProjectProfileDoc);
 describe('PermissionsService', () => {
+  afterEach(() => {
+    // suppress no expectations warning
+    expect(true).toBe(true);
+  });
+
   configureTestingModule(() => ({
     imports: [
       RouterModule.forRoot([]),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -27,11 +27,6 @@ const mockedUserService = mock(UserService);
 const mockedProjectService = mock(SFProjectService);
 const mockedProjectDoc = mock(SFProjectProfileDoc);
 describe('PermissionsService', () => {
-  afterEach(() => {
-    // suppress no expectations warning
-    expect(true).toBe(true);
-  });
-
   configureTestingModule(() => ({
     imports: [
       RouterModule.forRoot([]),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -14,11 +14,7 @@ import { SFProjectService } from './sf-project.service';
 
 @Injectable({ providedIn: 'root' })
 export class PermissionsService {
-  constructor(
-    private readonly userService: UserService,
-    private readonly projectService: SFProjectService,
-    private readonly paratextService: ParatextService
-  ) {}
+  constructor(private readonly userService: UserService, private readonly projectService: SFProjectService) {}
 
   canAccessCommunityChecking(project: SFProjectProfileDoc, userId?: string): boolean {
     if (project.data == null) return false;
@@ -73,7 +69,7 @@ export class PermissionsService {
     const role: string = projectDoc.data.userRoles[userId ?? this.userService.currentUserId];
 
     // Any paratext user role can sync DBL resources
-    if (this.paratextService.isResource(projectDoc.data.paratextId)) {
+    if (ParatextService.isResource(projectDoc.data.paratextId)) {
       return isParatextRole(role);
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -42,7 +42,6 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
     noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    private readonly paratextService: ParatextService,
     private readonly servalAdministrationService: ServalAdministrationService
   ) {
     super(noticeService);
@@ -76,7 +75,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the source
           if (
             project.translateConfig.source != null &&
-            !this.paratextService.isResource(project.translateConfig.source.paratextId)
+            !ParatextService.isResource(project.translateConfig.source.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.source.projectRef,
@@ -89,7 +88,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the alternate source
           if (
             project.translateConfig.draftConfig.alternateSource != null &&
-            !this.paratextService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
+            !ParatextService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateSource.projectRef,
@@ -105,7 +104,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           // Add the alternate training source
           if (
             project.translateConfig.draftConfig.alternateTrainingSource != null &&
-            !this.paratextService.isResource(project.translateConfig.draftConfig.alternateTrainingSource.paratextId)
+            !ParatextService.isResource(project.translateConfig.draftConfig.alternateTrainingSource.paratextId)
           ) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateTrainingSource.projectRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
@@ -23,14 +23,12 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { TypeRegistry } from 'xforge-common/type-registry';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { ParatextService } from '../core/paratext.service';
 import { ServalAdministrationService } from './serval-administration.service';
 import { ServalProjectsComponent } from './serval-projects.component';
 
 const mockedNoticeService = mock(NoticeService);
 const mockedServalAdministrationService = mock(ServalAdministrationService);
 const mockedUserService = mock(UserService);
-const mockedParatextService = mock(ParatextService);
 const mockAuthService = mock(AuthService);
 
 describe('ServalProjectsComponent', () => {
@@ -48,8 +46,7 @@ describe('ServalProjectsComponent', () => {
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: ServalAdministrationService, useMock: mockedServalAdministrationService },
       { provide: UserService, useMock: mockedUserService },
-      { provide: AuthService, useMock: mockAuthService },
-      { provide: ParatextService, useMock: mockedParatextService }
+      { provide: AuthService, useMock: mockAuthService }
     ]
   }));
 
@@ -151,9 +148,6 @@ class TestEnvironment {
           })
         )
     );
-    when(mockedParatextService.isResource(anything())).thenCall((paratextId: string) => {
-      return paratextId?.startsWith('ptresource') ?? false;
-    });
 
     this.fixture = TestBed.createComponent(ServalProjectsComponent);
     this.component = this.fixture.componentInstance;
@@ -250,13 +244,13 @@ class TestEnvironment {
           translateConfig: {
             draftConfig: {
               alternateSource: {
-                paratextId: 'ptresource02',
+                paratextId: 'resource16char02',
                 projectRef: 'resource02',
                 name: 'Resource 02',
                 shortName: 'R2'
               },
               alternateTrainingSource: {
-                paratextId: 'ptresource03',
+                paratextId: 'resource16char03',
                 projectRef: 'resource03',
                 name: 'Resource 03',
                 shortName: 'R3'
@@ -264,7 +258,7 @@ class TestEnvironment {
             },
             preTranslate: false,
             source: {
-              paratextId: 'ptresource01',
+              paratextId: 'resource16char01',
               projectRef: 'resource01',
               name: 'Resource 01',
               shortName: 'R1'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -14,7 +14,7 @@ import { ParatextService } from '../core/paratext.service';
 import { ServalAdministrationService } from './serval-administration.service';
 
 class Row {
-  constructor(public readonly projectDoc: SFProjectProfileDoc, private readonly paratextService: ParatextService) {}
+  constructor(public readonly projectDoc: SFProjectProfileDoc) {}
 
   get alternateSource(): string {
     return this.projectDoc.data?.translateConfig.draftConfig.alternateSource == null
@@ -28,7 +28,7 @@ class Row {
     const paratextId: string | undefined =
       this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.paratextId;
 
-    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
+    if (paratextId != null && !ParatextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.projectRef;
     } else {
       return undefined;
@@ -47,7 +47,7 @@ class Row {
     const paratextId: string | undefined =
       this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.paratextId;
 
-    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
+    if (paratextId != null && !ParatextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.projectRef;
     } else {
       return undefined;
@@ -77,7 +77,7 @@ class Row {
   get sourceId(): string | undefined {
     const paratextId: string | undefined = this.projectDoc.data?.translateConfig.source?.paratextId;
 
-    if (paratextId != null && !this.paratextService.isResource(paratextId)) {
+    if (paratextId != null && !ParatextService.isResource(paratextId)) {
       return this.projectDoc.data?.translateConfig.source?.projectRef;
     } else {
       return undefined;
@@ -156,7 +156,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
 
     const rows: Row[] = [];
     for (const projectDoc of this.projectDocs) {
-      rows.push(new Row(projectDoc, this.paratextService));
+      rows.push(new Row(projectDoc));
     }
     this.rows = rows;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -176,6 +176,19 @@ describe('EditorTabMenuService', () => {
         expect(service['canShowHistory'](env.projectDoc)).toBe(isParatextRole(role));
       });
     });
+
+    it('should return false if project is resource', () => {
+      const env = new TestEnvironment();
+      expect(service['canShowHistory'](env.projectDoc)).toBe(true);
+      const resourceProjectDoc = {
+        id: 'resource01',
+        data: createTestProjectProfile({
+          paratextId: 'resourceid16char',
+          userRoles: { user01: SFProjectRole.ParatextObserver }
+        })
+      } as SFProjectProfileDoc;
+      expect(service['canShowHistory'](resourceProjectDoc)).toBe(false);
+    });
   });
 
   describe('canShowResource', () => {
@@ -214,6 +227,7 @@ class TestEnvironment {
 
   constructor() {
     when(activatedProjectMock.projectDoc$).thenReturn(of(this.projectDoc));
+    when(mockUserService.currentUserId).thenReturn('user01');
     service = TestBed.inject(EditorTabMenuService);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -14,6 +14,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { ParatextService } from '../../../core/paratext.service';
 import { PermissionsService } from '../../../core/permissions.service';
 import { TabMenuItem, TabMenuService, TabStateService } from '../../../shared/sf-tab-group';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
@@ -130,8 +131,10 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
   }
 
   private canShowHistory(projectDoc: SFProjectProfileDoc): boolean {
+    if (projectDoc.data == null) return false;
+    if (ParatextService.isResource(projectDoc.data.paratextId)) return false;
     // The user must be a Paratext user. No specific edit permission for the chapter is required.
-    return isParatextRole(projectDoc.data?.userRoles[this.userService.currentUserId]);
+    return isParatextRole(projectDoc.data.userRoles[this.userService.currentUserId]);
   }
 
   private canShowResource(projectDoc: SFProjectProfileDoc): boolean {


### PR DESCRIPTION
Resource projects have a 16 character paratextId. This PR determines if the active project is a resource and will hide the option to show the project history in a tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2510)
<!-- Reviewable:end -->
