### PR TITLE
SF-2758 Stack import questions dialog buttons on small devices

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.scss
@@ -57,6 +57,11 @@
     margin-block-end: 16px;
   }
 
+  mat-card-actions {
+    flex-wrap: wrap;
+    row-gap: 8px;
+  }
+
   ol {
     padding-left: 1.25em;
   }


### PR DESCRIPTION
Before

![Import questions dialog before](https://github.com/sillsdev/web-xforge/assets/17931130/5117992d-99f2-4c6c-9d60-0d129e1747b4)

After

![Import Questions Dialog After](https://github.com/sillsdev/web-xforge/assets/17931130/c595b603-f56f-4517-95b1-b168d2d7e0ec)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2511)
<!-- Reviewable:end -->
