### PR TITLE
SF-2770 Fix message dialog resolving before user closes dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -60,10 +60,10 @@ export class DialogService {
    * provided the button will use a default label for the close button.
    */
   async message(message: I18nKey | Observable<string>, close?: I18nKey | Observable<string>): Promise<void> {
-    await this.openGenericDialog({
+    return await this.openGenericDialog({
       title: this.ensureLocalized(message),
       options: [{ value: undefined, label: this.ensureLocalized(close ?? 'dialog.close'), highlight: true }]
-    });
+    }).result;
   }
 
   get openDialogCount(): number {


### PR DESCRIPTION
Some places we show the message dialog and don't need to wait for the user to close it, but in some places we take an action after the user closes it, for example, when a share key is invalid.

To test this, on master, in a browser where you are not logged in, open this bad share link: http://localhost:5000/join/1234567890
A message dialog will briefly open, but before you can read it you will be redirected to the home page. Then test again on this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2513)
<!-- Reviewable:end -->
