### PR TITLE
SF-2771 Inform user when link has been used already

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -157,8 +157,8 @@ export class JoinComponent extends DataLoadingComponent {
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     try {
       this.joiningResponse = await this.anonymousService.checkShareKey(shareKey);
-    } catch {
-      await this.informInvalidShareLinkAndRedirect();
+    } catch (error) {
+      await this.informInvalidShareLinkAndRedirect(error instanceof HttpErrorResponse ? error.error : undefined);
     } finally {
       this.loadingFinished();
     }

--- a/src/SIL.XForge.Scripture/Services/AnonymousService.cs
+++ b/src/SIL.XForge.Scripture/Services/AnonymousService.cs
@@ -29,7 +29,7 @@ public class AnonymousService : IAnonymousService
         // Ensure the key hasn't been used by another recipient
         if (validShareKey.ShareKey.RecipientUserId != null)
         {
-            throw new ForbiddenException();
+            throw new DataNotFoundException("key_already_used");
         }
 
         return new AnonymousShareKeyResponse

--- a/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
@@ -40,7 +40,7 @@ public class AnonymousServiceTests
             );
 
         // SUT
-        Assert.ThrowsAsync<ForbiddenException>(() => env.Service.CheckShareKey(shareKey));
+        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.CheckShareKey(shareKey));
     }
 
     [Test]


### PR DESCRIPTION
This is _kind of_ dependent on #2513, in the sense that the dialog won't properly show without that change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2514)
<!-- Reviewable:end -->
