### PR TITLE
SF-2764 Add pwa installed flag on bugsnag errors

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.spec.ts
@@ -7,7 +7,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { Observable } from 'rxjs';
-import { anything, mock, verify, when } from 'ts-mockito';
+import { anything, capture, mock, verify, when } from 'ts-mockito';
 import { AuthService } from './auth.service';
 import { CONSOLE } from './browser-globals';
 import { DialogService } from './dialog.service';
@@ -16,6 +16,7 @@ import { ErrorReportingService } from './error-reporting.service';
 import { ExceptionHandlingService } from './exception-handling-service';
 import { UserDoc } from './models/user-doc';
 import { NoticeService } from './notice.service';
+import { PwaService } from './pwa.service';
 import { configureTestingModule, TestTranslocoModule } from './test-utils';
 import { UserService } from './user.service';
 
@@ -24,6 +25,7 @@ const mockedDialogService = mock(DialogService);
 const mockedUserService = mock(UserService);
 const mockedErrorReportingService = mock(ErrorReportingService);
 const mockedNoticeService = mock(NoticeService);
+const mockedPwaService = mock(PwaService);
 const mockedCookieService = mock(CookieService);
 
 // suppress any expected logging so it won't be shown in the test results
@@ -49,7 +51,6 @@ class MockConsole {
     }
   }
 }
-
 describe('ExceptionHandlingService', () => {
   configureTestingModule(() => ({
     declarations: [HostComponent],
@@ -60,6 +61,7 @@ describe('ExceptionHandlingService', () => {
       { provide: UserService, useMock: mockedUserService },
       { provide: ErrorReportingService, useMock: mockedErrorReportingService },
       { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: PwaService, useMock: mockedPwaService },
       { provide: CONSOLE, useValue: new MockConsole() },
       { provide: CookieService, useMock: mockedCookieService }
     ],
@@ -194,6 +196,14 @@ describe('ExceptionHandlingService', () => {
         expect(breadcrumb.metadata.targetSelector).toBe(test.expectedSelector);
       }
     }));
+
+    it('should report if pwa is installed', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.handleError({ message: 'Should report pwa installed' });
+      verify(mockedErrorReportingService.addMeta(anything())).once();
+      const [meta] = capture(mockedErrorReportingService.addMeta).first();
+      expect(meta['isPwaInstalled']).toBeDefined();
+    }));
   });
 });
 
@@ -249,6 +259,8 @@ class TestEnvironment {
           }
         } as Observable<{}>)
     } as MatDialogRef<ErrorDialogComponent, {}>);
+
+    when(mockedPwaService.isRunningInstalledApp).thenReturn(false);
 
     when(mockedErrorReportingService.notify(anything(), anything())).thenCall((error: NotifiableError) =>
       this.errorReports.push({ error })

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -11,6 +11,7 @@ import { DialogService } from './dialog.service';
 import { ErrorAlertData, ErrorDialogComponent } from './error-dialog/error-dialog.component';
 import { ErrorReportingService } from './error-reporting.service';
 import { NoticeService } from './notice.service';
+import { PwaService } from './pwa.service';
 import { COMMAND_API_NAMESPACE } from './url-constants';
 import { objectId } from './utils';
 
@@ -144,11 +145,13 @@ export class ExceptionHandlingService {
     let noticeService: NoticeService;
     let dialogService: DialogService;
     let errorReportingService: ErrorReportingService;
+    let pwaService: PwaService;
     try {
       ngZone = this.injector.get(NgZone);
       noticeService = this.injector.get(NoticeService);
       dialogService = this.injector.get(DialogService);
       errorReportingService = this.injector.get(ErrorReportingService);
+      pwaService = this.injector.get(PwaService);
       this.console = this.injector.get(CONSOLE);
     } catch {
       this.console.log(`Error occurred. Unable to report to Bugsnag, because dependency injection failed.`);
@@ -232,7 +235,9 @@ export class ExceptionHandlingService {
           this.handleAlert(ngZone, dialogService, { message, stack, eventId });
         }
       } finally {
-        errorReportingService.addMeta({ eventId });
+        // add the pwa installed status here at the moment of reporting an error since the app can be
+        // installed or uninstalled at any time
+        errorReportingService.addMeta({ eventId, isPwaInstalled: pwaService.isRunningInstalledApp });
         this.sendReport(errorReportingService, error);
       }
     } finally {


### PR DESCRIPTION
This change will require a developer to test the changes and confirm that it is working as expected.
From Nathaniel
>Pro tip: If you edit enabledReleaseStages in exception-reporter.ts to include "dev", you can actually get Bugsnag to show errors that happen locally. This is useful for testing changes like this.

**Acceptance tests:**
1. Update the code to allow the `exception-reporter.ts` to report errors for dev environments.
2. Add a line to the code to throw an error (e.g. on the sync page when sync is clicked)
3. Build the app for PWA testing and open the app without installing the PWA
4. Cause the error to occur.
5. Install the PWA app
6. Cause the error to occur.
Expected: In bugsnag, there should be 2 different errors reported, one with the `isPwaInstalled` set to `true`, and one set to `false`

![Report PWA installed](https://github.com/sillsdev/web-xforge/assets/17931130/e0e9375f-a0d5-47f3-949d-8b4398d73df9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2515)
<!-- Reviewable:end -->
