### PR TITLE
SF-2776 Cannot download a previously generated draft when generating a new draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -275,15 +275,15 @@
 
           <ng-container *ngIf="isPreviewSupported">
             <ng-container *ngIf="draftJob != null">
-              <section *ngIf="!isDraftInProgress(draftJob)" class="draft-complete">
-                <mat-card *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild">
+              <section *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild" class="draft-complete">
+                <mat-card>
                   <mat-card-header>
                     <mat-card-title>
                       {{ isDraftComplete(draftJob) ? t("draft_is_ready") : t("preview_last_draft_header") }}
                     </mat-card-title>
                   </mat-card-header>
                   <mat-card-content>
-                    <p *ngIf="!isDraftComplete(draftJob)">{{ t("preview_last_draft_detail") }}</p>
+                    <p *ngIf="isDraftFaulted(draftJob)">{{ t("preview_last_draft_detail") }}</p>
                     <p>{{ t("click_book_to_preview") }}</p>
                     <app-draft-preview-books></app-draft-preview-books>
                   </mat-card-content>
@@ -308,7 +308,7 @@
                       <span>{{ t("download_draft") }}</span>
                     </button>
                     <button
-                      *ngIf="isGenerationSupported"
+                      *ngIf="isGenerationSupported && !isDraftInProgress(draftJob)"
                       mat-button
                       type="button"
                       (click)="generateDraft({ withConfirm: true })"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1994,6 +1994,36 @@ describe('DraftGenerationComponent', () => {
       expect(env.downloadButton).not.toBe(null);
     });
 
+    it('button should display if there is a completed build while a build is faulted', () => {
+      const env = new TestEnvironment();
+      env.component.draftJob = { ...buildDto, state: BuildStates.Faulted };
+      env.component.lastCompletedBuild = { ...buildDto, state: BuildStates.Completed };
+      env.component.hasDraftBooksAvailable = true;
+      env.fixture.detectChanges();
+
+      expect(env.downloadButton).not.toBe(null);
+    });
+
+    it('button should display if there is a completed build while a build is queued', () => {
+      const env = new TestEnvironment();
+      env.component.draftJob = { ...buildDto, state: BuildStates.Queued };
+      env.component.lastCompletedBuild = { ...buildDto, state: BuildStates.Completed };
+      env.component.hasDraftBooksAvailable = true;
+      env.fixture.detectChanges();
+
+      expect(env.downloadButton).not.toBe(null);
+    });
+
+    it('button should not display if there is no completed build while a build is faulter', () => {
+      const env = new TestEnvironment();
+      env.component.draftJob = { ...buildDto, state: BuildStates.Faulted };
+      env.component.lastCompletedBuild = undefined;
+      env.component.hasDraftBooksAvailable = true;
+      env.fixture.detectChanges();
+
+      expect(env.downloadButton).toBe(null);
+    });
+
     it('button should display if the project updates the hasDraft field', () => {
       // Setup the project and subject
       const projectDoc: SFProjectProfileDoc = {


### PR DESCRIPTION
This PR fixes a bug that causes the download/view draft functionality to disappear when you generate a new draft, and you already have a previous completed draft.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2516)
<!-- Reviewable:end -->
