### PR TITLE
SF-2778 Fix digits in USFM filenames

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -2,7 +2,14 @@ import { VerseRef } from '@sillsdev/scripture';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DeltaOperation } from 'rich-text';
 import { SelectableProject } from '../core/paratext.service';
-import { compareProjectsForSorting, getVerseNumbers, isBadDelta, projectLabel, XmlUtils } from './utils';
+import {
+  compareProjectsForSorting,
+  getBookFileNameDigits,
+  getVerseNumbers,
+  isBadDelta,
+  projectLabel,
+  XmlUtils
+} from './utils';
 
 describe('shared utils', () => {
   describe('projectLabel function', () => {
@@ -153,6 +160,33 @@ describe('shared utils', () => {
     });
     it('gets the verse number from a verse range', () => {
       expect(getVerseNumbers(new VerseRef('GEN', '2', '3,4-6'))).toEqual([3, 4, 6]);
+    });
+  });
+
+  describe('getBookFileNameDigits function', () => {
+    it('pads a number less than 10 with 0', () => {
+      expect(getBookFileNameDigits(1)).toEqual('01');
+      expect(getBookFileNameDigits(9)).toEqual('09');
+    });
+    it('does not pad a number between 10 and 39', () => {
+      expect(getBookFileNameDigits(10)).toEqual('10');
+      expect(getBookFileNameDigits(39)).toEqual('39');
+    });
+    it('returns number plus one for numbers between 40 and 99', () => {
+      expect(getBookFileNameDigits(40)).toEqual('41');
+      expect(getBookFileNameDigits(99)).toEqual('100');
+    });
+    it('returns A and the ones place value for numbers between 100 and 109', () => {
+      expect(getBookFileNameDigits(100)).toEqual('A0');
+      expect(getBookFileNameDigits(109)).toEqual('A9');
+    });
+    it('returns B and the ones place value for numbers between 110 and 119', () => {
+      expect(getBookFileNameDigits(110)).toEqual('B0');
+      expect(getBookFileNameDigits(119)).toEqual('B9');
+    });
+    it('returns C and the ones place value for numbers between 120 and 129', () => {
+      expect(getBookFileNameDigits(120)).toEqual('C0');
+      expect(getBookFileNameDigits(129)).toEqual('C9');
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -1,7 +1,7 @@
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { DeltaOperation } from 'rich-text';
 import { SelectableProject } from '../core/paratext.service';
 
@@ -56,6 +56,26 @@ export function combineVerseRefStrs(startStr?: string, endStr?: string): VerseRe
 export function getBaseVerse(segmentRef: string): string | undefined {
   const matchArray: RegExpExecArray | null = VERSE_FROM_SEGMENT_REF_REGEX.exec(segmentRef);
   return matchArray == null ? undefined : matchArray[0];
+}
+
+/**
+ * Gets the digit code for Paratext filenames, such as 01 for GEN, 39 for MAL, and 41 for MAT.
+ *
+ * These are all 2 digits, except for xxg which is "100":
+ * 01...99, 100, A0...A9, B0...B9, C0...C9
+ *
+ * @param bookNum The book number.
+ * @returns The book number file name digits.
+ *
+ * This is based on ParatextData's ProjectSettings.BookFileNameDigits().
+ */
+export function getBookFileNameDigits(bookNum: number): string {
+  if (bookNum < 10) return '0' + bookNum;
+  if (bookNum < 40) return bookNum.toString();
+  if (bookNum < 100) return (bookNum + 1).toString();
+  if (bookNum < 110) return 'A' + (bookNum - 100);
+  if (bookNum < 120) return 'B' + (bookNum - 110);
+  return 'C' + (bookNum - 120);
 }
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -29,6 +29,7 @@ import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { ServalProjectComponent } from '../../serval-administration/serval-project.component';
 import { SharedModule } from '../../shared/shared.module';
+import { getBookFileNameDigits } from '../../shared/utils';
 import { WorkingAnimatedIndicatorComponent } from '../../shared/working-animated-indicator/working-animated-indicator.component';
 import { NllbLanguageService } from '../nllb-language.service';
 import { activeBuildStates, BuildConfig } from './draft-generation';
@@ -349,7 +350,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
       ).then(usfm => {
         if (usfm != null) {
           const fileName: string =
-            bookNum.toString().padStart(2, '0') + Canon.bookNumberToId(bookNum) + projectShortName + '.sfm';
+            getBookFileNameDigits(bookNum) + Canon.bookNumberToId(bookNum) + projectShortName + '.sfm';
           zip.file(fileName, usfm);
           this.downloadBooksProgress++;
         }


### PR DESCRIPTION
The filename for USFM files is in the format 01GENPROJ.SFM.

However, for New Testament books, the number is off by one. For example, Revelation should be 67REVPROJ.SFM, not 66REVPROJ.SFM (as is currently the generated file name when downloading a draft as a zip file).

This PR corrects the numbers in the download draft zip file names to reflect the same numbering convention as Paratext.