### PR TITLE
Make draft generation time estimates consistent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -141,7 +141,7 @@
     "dialog_confirm_draft_regeneration_title": "Are you done with the current draft?",
     "dialog_confirm_draft_regeneration_yes": "Continue",
     "download_draft": "Download draft",
-    "draft_active_detail": "Generating draft; this can take a few hours.",
+    "draft_active_detail": "Generating draft; this usually takes at least 8 hours.",
     "draft_active_header": "Draft in progress",
     "draft_is_ready": "Your draft is ready",
     "draft_queued_detail_multiple": "The translation draft generation is number {{ count }} in the queue, and will begin once the server is finished with other projects. Please check back later.",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2519)
<!-- Reviewable:end -->
