### PR TITLE
SF-2780 Correctly parse pre-translation references with slashes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -73,7 +73,7 @@ public class PreTranslationService(
         {
             // A reference will be in one of the formats:
             // FileFormat.Text: "40_1:verse_001_002"
-            // FileFormat.Paratext: "MAT 1:2"
+            // FileFormat.Paratext: "MAT 1:2" or "MAT 1:2/1:p"
             string reference = preTranslation.Refs.FirstOrDefault();
             if (string.IsNullOrWhiteSpace(reference))
             {
@@ -84,6 +84,12 @@ public class PreTranslationService(
             if (useParatextVerseRef)
             {
                 // The file format is FileFormat.Paratext
+
+                // If there is a forward slash, in the reference, the first half is the verse reference
+                if (reference.Contains('/', StringComparison.OrdinalIgnoreCase))
+                {
+                    reference = reference.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                }
 
                 // Ensure we have a valid verse reference and it is for this chapter
                 if (!VerseRef.TryParse(reference, out VerseRef verseRef) || verseRef.ChapterNum != chapterNum)
@@ -290,8 +296,14 @@ public class PreTranslationService(
             {
                 // The file format is FileFormat.Paratext
                 // We need to get the chapter number from the reference, as the textId is the book code
-                // A reference will be in the format: MAT 1:2
-                string reference = preTranslation.Refs.FirstOrDefault();
+                // A reference will be in the format: MAT 1:2 or MAT 1:2/1:p
+                string reference = preTranslation.Refs.FirstOrDefault() ?? string.Empty;
+
+                // If there is a forward slash, in the reference, the first half is the verse reference
+                if (reference.Contains('/', StringComparison.OrdinalIgnoreCase))
+                {
+                    reference = reference.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                }
 
                 // Ensure we have a valid verse reference and it is for this chapter
                 if (string.IsNullOrWhiteSpace(reference) || !VerseRef.TryParse(reference, out VerseRef verseRef))

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -196,9 +196,20 @@ public class PreTranslationServiceTests
                         new Pretranslation
                         {
                             TextId = "MAT",
-                            Refs = { "MAT 1:2" },
-                            Translation =
-                                "Abraham was the father of Isaac , Isaac was the father of James , and James was the father of Jude and his brethren .",
+                            Refs = { "MAT 1:2/0:q1" },
+                            Translation = "Abraham was the father of Isaac ,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "MAT 1:2/1:q2" },
+                            Translation = "Isaac was the father of James ,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "MAT",
+                            Refs = { "MAT 1:2/2:q3" },
+                            Translation = "and James was the father of Jude and his brethren .",
                         },
                         new Pretranslation
                         {
@@ -479,7 +490,7 @@ public class PreTranslationServiceTests
                         new Pretranslation { TextId = "MAT", Refs = ["MAT 1:1"] },
                         new Pretranslation { TextId = "MRK", Refs = ["MRK 1:1"] },
                         new Pretranslation { TextId = "MRK", Refs = ["MRK 1:2"] },
-                        new Pretranslation { TextId = "MRK", Refs = ["MRK 2:1"] },
+                        new Pretranslation { TextId = "MRK", Refs = ["MRK 2:1/3:h"] },
                     }
                 )
             );


### PR DESCRIPTION
Serval includes forward slashes in references to represent segments within verses. This can cause issues for the webhook when a target text's verses contain lots of different USFM tags (i.e. references and footnotes), instead of simple blank verses.

This PR resolves this by stripping off the section after the forward slash, as we only need the verse reference in the webhook.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2520)
<!-- Reviewable:end -->
