### PR TITLE
Fix warnings in test console

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2869,7 +2869,7 @@ class TestEnvironment {
   simulateAudioRecordingFinishedProcessing(): void {
     this.component.answersPanel!.textAndAudio!.audioComponent!.audio = {
       status: 'processed',
-      url: 'example.com/foo.mp3'
+      url: 'test-audio-short.mp3'
     };
     flush();
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -407,7 +407,7 @@ describe('QuestionDialogComponent', () => {
       isArchived: false,
       dateCreated: '',
       dateModified: '',
-      audioUrl: '/path/to/audio.mp3'
+      audioUrl: 'test-audio-short.mp3'
     });
     flush();
     const textDocId = new TextDocId('project01', 42, 1, 'target');
@@ -653,7 +653,7 @@ class TestEnvironment {
     );
     when(mockedProjectService.getProfile(anything())).thenResolve({} as SFProjectProfileDoc);
     when(mockedFileService.findOrUpdateCache(FileType.Audio, anything(), 'question01', anything())).thenResolve(
-      createStorageFileData(QuestionDoc.COLLECTION, 'question01', '/path/to/audio.mp3', getAudioBlob())
+      createStorageFileData(QuestionDoc.COLLECTION, 'question01', 'test-audio-short.mp3', getAudioBlob())
     );
     when(mockedUserService.getCurrentUser()).thenCall(() =>
       this.realtimeService.subscribe(UserDoc.COLLECTION, 'user01')

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -134,13 +134,13 @@ describe('PermissionsService', () => {
 
     it('uses current user id if userId is not provided', () => {
       const env = new TestEnvironment();
-      env.service.canSync(env.projectDoc);
+      expect(env.service.canSync(env.projectDoc)).toBe(false);
       verify(mockedUserService.currentUserId).once();
     });
 
     it('does not use current user id if userId is provided', () => {
       const env = new TestEnvironment();
-      env.service.canSync(env.projectDoc, SFProjectRole.ParatextAdministrator);
+      expect(env.service.canSync(env.projectDoc, SFProjectRole.ParatextAdministrator)).toBe(true);
       verify(mockedUserService.currentUserId).never();
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -1,6 +1,7 @@
 import { QueryList } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
+import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { TabMenuService } from '../../shared/sf-tab-group';
 import { TabAddRequestService } from './base-services/tab-add-request.service';
 import { TabFactoryService } from './base-services/tab-factory.service';
@@ -16,7 +17,7 @@ describe('TabGroupComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SFTabsModule],
+      imports: [SFTabsModule, TestTranslocoModule],
       declarations: [TabGroupComponent, TabComponent],
       providers: [
         { provide: TabFactoryService, useValue: { createTab: () => {} } },


### PR DESCRIPTION
This PR fixes the following warnings displayed in the console when running the Angular tests:

* `WARN: 'Spec 'PermissionsService canSync does not use current user id if userId is provided' has no expectations.', [[[...]]]`
* `WARN: 'Spec 'PermissionsService canSync uses current user id if userId is not provided' has no expectations.', [[[...]]]`
* `WARN [web-server]: 404: /_karma_webpack_/base/app/checking/checking/test-audio/example.com/foo.mp3`
* `WARN [web-server]: 404: /_karma_webpack_/base/app/checking/checking/test-audio/path/to/audio.mp3`
* `WARN: '%c Missing translation for 'en.tab_group_header.no_tabs_available'', [[[...]]]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2521)
<!-- Reviewable:end -->
