### PR TITLE
hotfix: Always trigger pull of user profile from front end (#2522)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -326,9 +326,7 @@ export class AuthService {
     this.localSettings.set(cacheKey.toKey(), cacheEntry);
     await this.localLogIn(authResponse.access_token, authResponse.id_token, authResponse.expires_in);
     await this.remoteStore.init(() => this.getAccessToken());
-    if (!environment.production) {
-      await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
-    }
+    await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
     this._loggedInState$.next({ loggedIn: true, newlyLoggedIn: true, anonymousUser: true });
     return true;
   }
@@ -511,7 +509,7 @@ export class AuthService {
             this.locationService.reload();
           });
       }
-    } else if (!environment.production) {
+    } else {
       try {
         await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
       } catch (err) {

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -6,7 +6,6 @@ using EdjCase.JsonRpc.Router.Abstractions;
 using idunno.Authentication.Basic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
 using SIL.XForge.Services;
 
 namespace SIL.XForge.Controllers;
@@ -80,9 +79,6 @@ public class UsersRpcController : RpcControllerBase
     /// </summary>
     public async Task<IRpcMethodResult> PullAuthUserProfile()
     {
-        if (!(_hostingEnv.IsDevelopment()))
-            return ForbiddenError();
-
         string userProfile = await _authService.GetUserAsync(AuthId);
         await _userService.UpdateUserFromProfileAsync(UserId, userProfile);
         return Ok();


### PR DESCRIPTION
This is a hotfix, cherry-picking #2522

Previously the front end would only trigger a pull of the user profile on localhost, and on production environments, it would be pushed from Auth0.

(cherry picked from commit d419e50f578c1f1e0a7e3028655a35e14502093f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2523)
<!-- Reviewable:end -->
