### PR TITLE
SF-2789 Fix paratext login button content misaligned

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -5,9 +5,8 @@
     <div *ngSwitchCase="'login'" class="paratext-login-container">
       <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
       <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
-        <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />{{
-          t("log_in_with_paratext")
-        }}
+        <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+        {{ t("log_in_with_paratext") }}
       </button>
     </div>
     <mat-card *ngSwitchCase="'connecting'" class="progress-container card-outline">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -30,9 +30,7 @@
       height: 40px;
 
       .paratext-logo {
-        width: 24px;
-        height: 24px;
-        margin-right: 8px;
+        width: 100%;
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -16,9 +16,10 @@
                   (click)="logInWithParatext()"
                   id="btn-log-in-settings"
                 >
-                  <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />{{
-                    t("log_in_with_paratext")
-                  }}
+                  <mat-icon>
+                    <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+                  </mat-icon>
+                  {{ t("log_in_with_paratext") }}
                 </button>
                 <span
                   class="more-options"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -87,9 +87,7 @@ mat-icon {
   margin-left: 24px;
 
   .paratext-logo {
-    width: 24px;
-    height: 24px;
-    margin-right: 8px;
+    width: 100%;
   }
 
   > .more-options {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -17,9 +17,8 @@
           (click)="logInWithParatext()"
           id="btn-log-in"
         >
-          <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />{{
-            t("log_in_to_paratext")
-          }}
+          <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+          {{ t("log_in_to_paratext") }}
         </button>
         <ng-container *ngIf="isLoggedIntoParatext || isLoading || !isAppOnline">
           <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -29,9 +29,7 @@ app-sync-progress {
 }
 
 .paratext-logo {
-  width: 2rem;
-  height: 2rem;
-  margin-right: 0.5rem;
+  width: 100%;
 }
 
 #sync-disabled-message,


### PR DESCRIPTION
Paratext login button was misaligned due to the mat-button mdc upgrade
Before
![Paratext logo button before](https://github.com/sillsdev/web-xforge/assets/17931130/3dbeb568-47c4-4072-875a-4f2b2ccdb075)


After
![Paratext logo button](https://github.com/sillsdev/web-xforge/assets/17931130/e13814ab-dff2-4165-b772-74eecfa980fb)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2524)
<!-- Reviewable:end -->
