### PR TITLE
Improve gap between save answer buttons

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -84,7 +84,7 @@
                 </button>
               </div>
             </div>
-            <div class="form-actions" *ngIf="isScreenSmall">
+            <div *ngIf="isScreenSmall">
               <button mat-icon-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
                 <mat-icon class="material-icons-outlined">cancel</mat-icon>
               </button>
@@ -92,7 +92,7 @@
                 <mat-icon>check_circle</mat-icon>
               </button>
             </div>
-            <div class="form-actions" *ngIf="!isScreenSmall">
+            <div *ngIf="!isScreenSmall" class="large-form-action-buttons">
               <button mat-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
                 <mat-icon>close</mat-icon>
                 {{ t("cancel") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -61,7 +61,7 @@
       padding: 6px;
     }
   }
-  .form-actions {
+  .large-form-action-buttons {
     display: flex;
     align-items: center;
     column-gap: 8px;


### PR DESCRIPTION
In general we don't put a gap between Material icons, and it seems to work OK. You can see this in this screenshot where every icon button is hovered.

![](https://github.com/sillsdev/web-xforge/assets/6140710/beb0c8e6-2f97-4da4-bcb6-ab8e899fd3d6)

However, as you can see, there's a gap between the "cancel" and "save" buttons for the answer form. The gap feels excessive to me, and off balance with the rest of them, so I've removed it:

![](https://github.com/sillsdev/web-xforge/assets/6140710/b941d743-9169-4acf-9860-a1e9edd76002)

However, the gap is still present when the buttons are the larger size and need a gap to look good:
![](https://github.com/sillsdev/web-xforge/assets/6140710/c9efc5ef-2b44-43db-b998-124273365076)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2525)
<!-- Reviewable:end -->
