### PR TITLE
SF-2790 Fix successful sync message appearing when starting sync

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -139,15 +139,15 @@ public class SyncService(
                 );
                 try
                 {
-                    await sourceProjectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
-                    WarnIfAnomalousQueuedCount(
-                        sourceProjectDoc.Data.Sync.QueuedCount,
-                        $"For parent SF project id {sourceProjectDoc.Id} after inc."
-                    );
                     await projectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
                     WarnIfAnomalousQueuedCount(
                         projectDoc.Data.Sync.QueuedCount,
                         $"For daughter SF project id {projectDoc.Id} after inc."
+                    );
+                    await sourceProjectDoc.SubmitJson0OpAsync(op => op.Inc(pd => pd.Sync.QueuedCount));
+                    WarnIfAnomalousQueuedCount(
+                        sourceProjectDoc.Data.Sync.QueuedCount,
+                        $"For parent SF project id {sourceProjectDoc.Id} after inc."
                     );
 
                     // Store the source job id, so we can cancel the job later if needed


### PR DESCRIPTION
This PR corrects the updating the of source and target project documents on sync so that the target queued count is updated before the source queued count.

This resolves an issue where the successful sync notification was appear when the sync started, due to the subscription to the source project firing before the subscription to the target document.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2528)
<!-- Reviewable:end -->
