### PR TITLE
SF-2788 Reduce calls to the Paratext Registry

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextProjectUser.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProjectUser.cs
@@ -1,0 +1,27 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A user for a project from the Paratext Registry.
+/// </summary>
+public record ParatextProjectUser
+{
+    /// <summary>
+    /// The Scripture Forge User Identifier.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Paratext User Identifier.
+    /// </summary>
+    public string ParatextId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The user's role in the project.
+    /// </summary>
+    public string Role { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The users' Paratext username.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+}

--- a/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/IInternetSharedRepositorySource.cs
@@ -1,13 +1,17 @@
 using System.Collections.Generic;
 using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
+using Paratext.Data.Users;
 
 namespace SIL.XForge.Scripture.Services;
 
 public interface IInternetSharedRepositorySource
 {
     IEnumerable<SharedRepository> GetRepositories();
+    IEnumerable<SharedRepository> GetRepositories(List<ProjectLicense> licenses);
+    ProjectLicense? GetLicenseForUserProject(string paratextId);
     IEnumerable<ProjectMetadata> GetProjectsMetaData();
+    ProjectMetadata? GetProjectMetadata(string paratextId);
     string[] Pull(string repository, SharedRepository pullRepo);
     void RefreshToken(string jwtToken);
     void UnlockRemoteRepository(SharedRepository sharedRepo);

--- a/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextNotesMapper.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using SIL.XForge.Models;
@@ -10,7 +9,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IParatextNotesMapper
 {
-    Task InitAsync(UserSecret currentUserSecret, List<User> ptUsers, SFProject project, CancellationToken token);
+    void Init(UserSecret currentUserSecret, IReadOnlyList<ParatextProjectUser> users);
     Task<XElement> GetNotesChangelistAsync(
         XElement oldNotesElem,
         IEnumerable<IDocument<Question>> questionsDocs,

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -19,17 +19,12 @@ public interface IParatextService
     Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
     string? GetParatextUsername(UserSecret userSecret);
     Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
-    Task<IReadOnlyDictionary<string, string>> GetProjectRolesAsync(
-        UserSecret userSecret,
-        SFProject project,
-        CancellationToken token
-    );
     ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
 
     Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
     bool IsResource(string paratextId);
     Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
-    Task<IReadOnlyDictionary<string, string>> GetParatextUsernameMappingAsync(
+    Task<IReadOnlyList<ParatextProjectUser>> GetParatextUsersAsync(
         UserSecret userSecret,
         SFProject project,
         CancellationToken token

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -43,7 +43,12 @@ public interface ISFProjectService : IProjectService
     Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
     bool IsSourceProject(string projectId);
     Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestions(string curUserId, string projectId);
-    Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token);
+    Task UpdatePermissionsAsync(
+        string curUserId,
+        IDocument<SFProject> projectDoc,
+        IReadOnlyList<ParatextProjectUser>? users = null,
+        CancellationToken token = default
+    );
     Task EnsureWritingSystemTagIsSetAsync(string curUserId, string projectId);
     Task CreateAudioTimingData(
         string userId,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -626,6 +626,7 @@ public class ParatextService : DisposableBase, IParatextService
         if (IsResource(project.ParatextId))
         {
             // Resources don't have project members or roles
+            return users;
         }
         else if (await IsRegisteredAsync(userSecret, project.ParatextId, token))
         {
@@ -666,6 +667,8 @@ public class ParatextService : DisposableBase, IParatextService
                     user.Id = id;
                 }
             }
+
+            return users;
         }
         else
         {
@@ -751,9 +754,9 @@ public class ParatextService : DisposableBase, IParatextService
                     users.Add(user);
                 }
             }
-        }
 
-        return users;
+            return users;
+        }
     }
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -219,13 +219,40 @@ public class ParatextService : DisposableBase, IParatextService
             _alertSystem.AddListener(alertListener);
 
             IInternetSharedRepositorySource source = await GetInternetSharedRepositorySource(userSecret.Id, token);
-            IEnumerable<SharedRepository> repositories = GetRepositories(
-                source,
-                $"For SF user id {userSecret.Id}, while attempting to sync PT project id {paratextId}."
-            );
-            IEnumerable<ProjectMetadata> projectsMetadata = source.GetProjectsMetaData();
-            IEnumerable<string> projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
-            SharedRepository sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
+
+            // See if we can retrieve the project metadata and repository directly via the Paratext id
+            ProjectMetadata? projectMetadata = source.GetProjectMetadata(paratextId);
+            SharedRepository? sendReceiveRepository = null;
+            IEnumerable<ProjectMetadata> projectsMetadata = [];
+            IEnumerable<string> projectGuids = [];
+            if (projectMetadata is not null)
+            {
+                // Get the project license, so we can get the repositories for it
+                ProjectLicense? projectLicense = source.GetLicenseForUserProject(paratextId);
+                if (projectLicense is not null)
+                {
+                    // Get the repository for the project
+                    IEnumerable<SharedRepository> repositories = source.GetRepositories([projectLicense]);
+                    sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
+
+                    // Set up the projects metadata
+                    projectsMetadata = [projectMetadata];
+                    projectGuids = [projectMetadata.ProjectGuid.Id];
+                }
+            }
+
+            // If we could not get the send/receive repository, this project shares a registration with another project
+            if (sendReceiveRepository is null)
+            {
+                IEnumerable<SharedRepository> repositories = GetRepositories(
+                    source,
+                    $"For SF user id {userSecret.Id}, while attempting to sync PT project id {paratextId}."
+                );
+                projectsMetadata = source.GetProjectsMetaData();
+                projectGuids = projectsMetadata.Select(pmd => pmd.ProjectGuid.Id);
+                sendReceiveRepository = repositories.FirstOrDefault(r => r.SendReceiveId.Id == paratextId);
+            }
+
             if (TryGetProject(userSecret, sendReceiveRepository, projectsMetadata, out ParatextProject ptProject))
             {
                 if (!projectGuids.Contains(paratextId))

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -640,21 +640,17 @@ public class ParatextService : DisposableBase, IParatextService
 
             users = JArray
                 .Parse(response)
-                .Where(
-                    m =>
-                        !string.IsNullOrEmpty((string?)m["userId"])
-                        && !string.IsNullOrEmpty((string)m["username"])
-                        && !string.IsNullOrEmpty((string?)m["role"])
+                .Where(m =>
+                    !string.IsNullOrEmpty((string?)m["userId"])
+                    && !string.IsNullOrEmpty((string)m["username"])
+                    && !string.IsNullOrEmpty((string?)m["role"])
                 )
-                .Select(
-                    m =>
-                        new ParatextProjectUser
-                        {
-                            ParatextId = (string)m["userId"] ?? string.Empty,
-                            Role = (string)m["role"] ?? string.Empty,
-                            Username = (string)m["username"] ?? string.Empty,
-                        }
-                )
+                .Select(m => new ParatextProjectUser
+                {
+                    ParatextId = (string)m["userId"] ?? string.Empty,
+                    Role = (string)m["role"] ?? string.Empty,
+                    Username = (string)m["username"] ?? string.Empty,
+                })
                 .ToList();
 
             // Get the mapping of Scripture Forge user IDs to Paratext usernames
@@ -691,9 +687,10 @@ public class ParatextService : DisposableBase, IParatextService
 
             // Build a dictionary of user IDs mapped to usernames using the user secrets
             foreach (
-                ParatextProjectUser user in project.UserRoles.Keys.Select(
-                    userId => new ParatextProjectUser { Id = userId }
-                )
+                ParatextProjectUser user in project.UserRoles.Keys.Select(userId => new ParatextProjectUser
+                {
+                    Id = userId
+                })
             )
             {
                 UserSecret projectUserSecret;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1974,8 +1974,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
     private Dictionary<string, ParatextUserProfile> GetCurrentProjectPtUsers()
     {
-        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(
-            p => p.Username
+        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(p =>
+            p.Username
         );
         foreach (ParatextProjectUser paratextUser in _paratextUsers)
         {

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -97,6 +96,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     internal SyncMetrics _syncMetrics;
     private Dictionary<string, ParatextUserProfile> _currentPtSyncUsers;
     private Dictionary<string, string> _userIdsToDisplayNames;
+    private IReadOnlyList<ParatextProjectUser> _paratextUsers = [];
 
     public ParatextSyncRunner(
         IRepository<UserSecret> userSecrets,
@@ -442,7 +442,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
             // We will always update permissions, even if this is a resource project
             LogMetric("Updating permissions");
-            await _projectService.UpdatePermissionsAsync(userId, _projectDoc, token);
+            await _projectService.UpdatePermissionsAsync(userId, _projectDoc, _paratextUsers, token);
 
             await NotifySyncProgress(SyncPhase.Phase9, 40.0);
 
@@ -1028,16 +1028,13 @@ public class ParatextSyncRunner : IParatextSyncRunner
             return false;
         }
 
-        _currentPtSyncUsers = await GetCurrentProjectPTUsers(token);
-        List<User> paratextUsers = await _realtimeService
-            .QuerySnapshots<User>()
-            .Where(u => _projectDoc.Data.UserRoles.Keys.Contains(u.Id) && u.ParatextId != null)
-            .ToListAsync();
-
         // Report on authentication success before other attempts.
         await PreflightAuthenticationReportAsync();
 
-        await _notesMapper.InitAsync(_userSecret, paratextUsers, _projectDoc.Data, token);
+        _paratextUsers = await _paratextService.GetParatextUsersAsync(_userSecret, _projectDoc.Data, token);
+        _currentPtSyncUsers = GetCurrentProjectPtUsers();
+
+        _notesMapper.Init(_userSecret, _paratextUsers);
 
         await NotifySyncProgress(SyncPhase.Phase1, 20.0);
         return true;
@@ -1650,7 +1647,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         LogMetric("Completing sync");
         bool updateRoles = true;
         IReadOnlyDictionary<string, string> ptUserRoles;
-        if (_paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
+        if (!successful || _paratextService.IsResource(_projectDoc.Data.ParatextId) || token.IsCancellationRequested)
         {
             // Do not update permissions on sync, if this is a resource project, as then,
             // permission updates will be performed when a target project is synchronized.
@@ -1660,29 +1657,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         }
         else
         {
-            try
-            {
-                ptUserRoles = await _paratextService.GetProjectRolesAsync(_userSecret, _projectDoc.Data, token);
-            }
-            catch (Exception ex)
-            {
-                if (ex is HttpRequestException or OperationCanceledException or UnauthorizedAccessException)
-                {
-                    Log(
-                        $"CompleteSync: Problem fetching project roles. Maybe the user does not have access to the project or cancelled the sync. ({ex})"
-                    );
-                    // This throws a 404 if the user does not have access to the project
-                    // A task cancelled exception will be thrown if the user cancels the task
-                    // Note: OperationCanceledException includes TaskCanceledException
-                    ptUserRoles = new Dictionary<string, string>();
-                    updateRoles = false;
-                }
-                else
-                {
-                    Log($"CompleteSync: Problem fetching project roles. Rethrowing: ({ex})");
-                    throw;
-                }
-            }
+            ptUserRoles = _paratextUsers.ToDictionary(u => u.ParatextId, u => u.Role);
         }
 
         var userIdsToRemove = new List<string>();
@@ -1997,24 +1972,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
         }
     }
 
-    private async Task<Dictionary<string, ParatextUserProfile>> GetCurrentProjectPTUsers(CancellationToken token)
+    private Dictionary<string, ParatextUserProfile> GetCurrentProjectPtUsers()
     {
-        IReadOnlyDictionary<string, string> sfUserIdsToUsernames =
-            await _paratextService.GetParatextUsernameMappingAsync(_userSecret, _projectDoc.Data, token);
-        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(p =>
-            p.Username
+        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(
+            p => p.Username
         );
-        foreach (var (sfUserId, username) in sfUserIdsToUsernames)
+        foreach (ParatextProjectUser paratextUser in _paratextUsers)
         {
-            if (!paratextUsers.TryGetValue(username, out ParatextUserProfile profile))
+            if (!paratextUsers.TryGetValue(paratextUser.Username, out ParatextUserProfile profile))
             {
                 ParatextUserProfile userProfile = new ParatextUserProfile
                 {
-                    Username = username,
-                    SFUserId = sfUserId,
-                    OpaqueUserId = _guidService.NewObjectId()
+                    Username = paratextUser.Username,
+                    SFUserId = paratextUser.Id,
+                    OpaqueUserId = _guidService.NewObjectId(),
                 };
-                paratextUsers.TryAdd(username, userProfile);
+                paratextUsers.TryAdd(paratextUser.Username, userProfile);
             }
             else
             {
@@ -2022,10 +1995,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 // We create a new object to so that the logic in projectDoc.SubmitJson0OpAsync() will see the change.
                 if (profile.SFUserId is null)
                 {
-                    paratextUsers[username] = new ParatextUserProfile
+                    paratextUsers[paratextUser.Username] = new ParatextUserProfile
                     {
                         Username = profile.Username,
-                        SFUserId = sfUserId,
+                        SFUserId = paratextUser.Id,
                         OpaqueUserId = profile.OpaqueUserId,
                     };
                 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1238,9 +1238,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         }
 
         string paratextId = projectDoc.Data.ParatextId;
-        HashSet<int> booksInProject = [.._paratextService.GetBookList(userSecret, paratextId)];
+        HashSet<int> booksInProject = [.. _paratextService.GetBookList(userSecret, paratextId)];
         users ??= await _paratextService.GetParatextUsersAsync(userSecret, projectDoc.Data, token);
-        IReadOnlyDictionary<string, string> ptUsernameMapping = users.ToDictionary(u => u.Id, u => u.Username);
+        IReadOnlyDictionary<string, string> ptUsernameMapping = users
+            .Where(u => !string.IsNullOrWhiteSpace(u.Id) && !string.IsNullOrWhiteSpace(u.Username))
+            .ToDictionary(u => u.Id, u => u.Username);
         bool isResource = _paratextService.IsResource(paratextId);
         // Place to collect all chapter permissions to record in the project.
         var projectChapterPermissions =

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1191,7 +1191,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         // in order to query the PT roles and DBL permissions of other SF project/resource users.
         if ((await TryGetProjectRoleAsync(projectDoc.Data, userDoc.Id)).Success)
         {
-            await UpdatePermissionsAsync(userDoc.Id, projectDoc, CancellationToken.None);
+            await UpdatePermissionsAsync(userDoc.Id, projectDoc);
         }
 
         // Add to the source project, if required
@@ -1224,7 +1224,12 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// Note that this method is not necessarily applying permissions for user `curUserId`, but rather using that
     /// user to perform PT queries and set values in the SF DB.
     /// </summary>
-    public async Task UpdatePermissionsAsync(string curUserId, IDocument<SFProject> projectDoc, CancellationToken token)
+    public async Task UpdatePermissionsAsync(
+        string curUserId,
+        IDocument<SFProject> projectDoc,
+        IReadOnlyList<ParatextProjectUser>? users = null,
+        CancellationToken token = default
+    )
     {
         Attempt<UserSecret> userSecretAttempt = await _userSecrets.TryGetAsync(curUserId);
         if (!userSecretAttempt.TryResult(out UserSecret userSecret))
@@ -1233,12 +1238,9 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         }
 
         string paratextId = projectDoc.Data.ParatextId;
-        HashSet<int> booksInProject = new HashSet<int>(_paratextService.GetBookList(userSecret, paratextId));
-        IReadOnlyDictionary<string, string> ptUsernameMapping = await _paratextService.GetParatextUsernameMappingAsync(
-            userSecret,
-            projectDoc.Data,
-            token
-        );
+        HashSet<int> booksInProject = [.._paratextService.GetBookList(userSecret, paratextId)];
+        users ??= await _paratextService.GetParatextUsersAsync(userSecret, projectDoc.Data, token);
+        IReadOnlyDictionary<string, string> ptUsernameMapping = users.ToDictionary(u => u.Id, u => u.Username);
         bool isResource = _paratextService.IsResource(paratextId);
         // Place to collect all chapter permissions to record in the project.
         var projectChapterPermissions =

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4013,7 +4013,7 @@ public class ParatextServiceTests
     }
 
     [Test]
-    public async Task GetProjectRolesAsync_UsesTheRepositoryForUnregisteredProjects()
+    public async Task GetParatextUsersAsync_UsesTheRepositoryForUnregisteredProjects()
     {
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -4024,16 +4024,67 @@ public class ParatextServiceTests
         Assert.That(project.UserRoles.Count, Is.EqualTo(3), "setup");
         env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
         // SUT
-        var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
-        Assert.That(roles.Count, Is.EqualTo(2));
-        var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
-        Assert.That(roles.First(), Is.EqualTo(firstRole));
-        var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
-        Assert.That(roles.Last(), Is.EqualTo(secondRole));
+        IReadOnlyList<ParatextProjectUser> users = await env.Service.GetParatextUsersAsync(
+            userSecret,
+            project,
+            CancellationToken.None
+        );
+        Assert.That(users.Count, Is.EqualTo(2));
+        Assert.That(users.First(), Is.EqualTo(env.ParatextProjectUser01));
+        Assert.That(users.Last(), Is.EqualTo(env.ParatextProjectUser02));
     }
 
     [Test]
-    public async Task GetProjectRolesAsync_UnregisteredProject_SkipsNonPTUsers()
+    public async Task GetParatextUsersAsync_UsesTheRegistryForRegisteredProjects()
+    {
+        var env = new TestEnvironment();
+        env.AddUserRepository();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+        Assert.That(project.UserRoles.Count, Is.EqualTo(3), "setup");
+
+        // Set up the OK request for IsRegisteredAsync()
+        using HttpResponseMessage okResponse = TestEnvironment.MakeOkHttpResponseMessage($"\"{project.ParatextId}\"");
+        env.MakeRegistryClientReturn(okResponse);
+
+        // Set up the call of the list of users in the project
+        using HttpResponseMessage usersResponse = TestEnvironment.MakeOkHttpResponseMessage(
+            $$"""
+              [
+                {
+                  "role": "{{SFProjectRole.Administrator}}",
+                  "userId": "{{env.ParatextUserId01}}",
+                  "username": "{{env.Username01}}"
+                },
+                {
+                  "role": "{{SFProjectRole.Administrator}}",
+                  "userId": "{{env.ParatextUserId02}}",
+                  "username": "{{env.Username02}}"
+                }
+              ]
+              """
+        );
+        env.MockRegistryHttpClient.SendAsync(
+            Arg.Is<HttpRequestMessage>(r => r.RequestUri.ToString().Contains("/members")),
+            CancellationToken.None
+        )
+            .Returns(usersResponse);
+
+        // SUT
+        IReadOnlyList<ParatextProjectUser> users = await env.Service.GetParatextUsersAsync(
+            userSecret,
+            project,
+            CancellationToken.None
+        );
+        Assert.That(users.Count, Is.EqualTo(2));
+        Assert.That(users.First(), Is.EqualTo(env.ParatextProjectUser01));
+        Assert.That(users.Last(), Is.EqualTo(env.ParatextProjectUser02));
+    }
+
+    [Test]
+    public async Task GetParatextUsersAsync_UnregisteredProject_SkipsNonPTUsers()
     {
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -4047,16 +4098,18 @@ public class ParatextServiceTests
         Assert.That(project.UserRoles.Count, Is.EqualTo(4), "setup");
         env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
         // SUT
-        var roles = await env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None);
-        Assert.That(roles.Count, Is.EqualTo(2), "map of PT roles should only include PT users");
-        var firstRole = new KeyValuePair<string, string>(env.ParatextUserId01, SFProjectRole.Administrator);
-        Assert.That(roles.First(), Is.EqualTo(firstRole));
-        var secondRole = new KeyValuePair<string, string>(env.ParatextUserId02, SFProjectRole.Administrator);
-        Assert.That(roles.Last(), Is.EqualTo(secondRole));
+        IReadOnlyList<ParatextProjectUser> users = await env.Service.GetParatextUsersAsync(
+            userSecret,
+            project,
+            CancellationToken.None
+        );
+        Assert.That(users.Count, Is.EqualTo(2), "map of PT roles should only include PT users");
+        Assert.That(users.First(), Is.EqualTo(env.ParatextProjectUser01));
+        Assert.That(users.Last(), Is.EqualTo(env.ParatextProjectUser02));
     }
 
     [Test]
-    public async Task GetProjectRolesAsync_UnregisteredProject_MoreInfoWhenHttpException()
+    public async Task GetParatextUsersAsync_UnregisteredProject_MoreInfoWhenHttpException()
     {
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
@@ -4074,11 +4127,11 @@ public class ParatextServiceTests
 
         // SUT
         Assert.ThrowsAsync<HttpException>(
-            () => env.Service.GetProjectRolesAsync(userSecret, project, CancellationToken.None)
+            () => env.Service.GetParatextUsersAsync(userSecret, project, CancellationToken.None)
         );
 
         // Various pieces of significant data are reported when a 401 Unauthorized goes thru.
-        string[] notes = { "unregistered", project.ParatextId, project.Id, userSecret.Id, "role" };
+        string[] notes = ["unregistered", project.ParatextId, project.Id, userSecret.Id, "role"];
         env.MockLogger.AssertHasEvent(
             (LogEvent logEvent) => notes.All((string note) => logEvent.Message.Contains(note))
         );
@@ -4114,33 +4167,13 @@ public class ParatextServiceTests
     }
 
     [Test]
-    public async Task GetParatextUsernameMappingAsync_UsesTheRepositoryForUnregisteredProjects()
-    {
-        var env = new TestEnvironment();
-        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-        TestEnvironment.MakeUserSecret(env.User02, env.Username02, env.ParatextUserId02);
-        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-        var project = projects.First();
-        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-        // SUT
-        var mapping = await env.Service.GetParatextUsernameMappingAsync(userSecret, project, CancellationToken.None);
-        KeyValuePair<string, string>[] expected = new[]
-        {
-            new KeyValuePair<string, string>(env.User01, env.Username01),
-            new KeyValuePair<string, string>(env.User02, env.Username02)
-        };
-        Assert.That(mapping, Is.EquivalentTo(expected));
-    }
-
-    [Test]
-    public async Task GetParatextUsernameMappingAsync_ReturnsEmptyMappingForResourceProject()
+    public async Task GetParatextUsersAsync_ReturnsEmptyMappingForResourceProject()
     {
         var env = new TestEnvironment();
         const string resourceId = "1234567890abcdef";
         Assert.That(resourceId.Length, Is.EqualTo(SFInstallableDblResource.ResourceIdentifierLength));
         var userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-        var mapping = await env.Service.GetParatextUsernameMappingAsync(
+        var mapping = await env.Service.GetParatextUsersAsync(
             userSecret,
             new SFProject { ParatextId = resourceId },
             CancellationToken.None
@@ -4148,37 +4181,12 @@ public class ParatextServiceTests
         Assert.That(mapping.Count, Is.EqualTo(0));
     }
 
-    [Test]
-    public async Task GetParatextUsernameMappingAsync_WarnsWhenDuplicatePTUsernamesInUnregisteredProject()
-    {
-        var env = new TestEnvironment();
-        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-        // Note that the following user secret has same PT username and id as the other user. This presumably
-        // represents a bad DB state.
-        TestEnvironment.MakeUserSecret(env.User02, env.Username01, env.ParatextUserId01);
-        env.MockJwtTokenHelper.GetParatextUsername(Arg.Is<UserSecret>(u => u.Id == env.User02)).Returns(env.Username01);
-
-        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
-        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-        var project = projects.First();
-        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
-        // SUT
-        var mapping = await env.Service.GetParatextUsernameMappingAsync(userSecret, project, CancellationToken.None);
-        string[] requiredLogWords = { "unregistered", env.Username01, "duplicate" };
-        // Warn about the situation.
-        env.MockLogger.AssertHasEvent(
-            (LogEvent ev) => requiredLogWords.All((string requiredWord) => ev.Message.Contains(requiredWord))
-        );
-        // And still return the data.
-        Assert.That(mapping.Count, Is.EqualTo(2));
-    }
-
     enum SelectionType
     {
         Standard,
         RelatedVerse,
         Section,
-        SectionEnd
+        SectionEnd,
     }
 
     struct ThreadComponents
@@ -5044,19 +5052,21 @@ public class ParatextServiceTests
         public readonly string RuthBookUsfm =
             "\\id RUT - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
 
-        public readonly HttpResponseMessage UnauthorizedHttpResponseMessage =
-            new(HttpStatusCode.Unauthorized)
-            {
-                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("big problem"))
-            };
+        public readonly HttpResponseMessage UnauthorizedHttpResponseMessage = new HttpResponseMessage(
+            HttpStatusCode.Unauthorized
+        )
+        {
+            RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("big problem")),
+        };
 
-        public readonly HttpResponseMessage NotFoundHttpResponseMessage =
-            new(HttpStatusCode.NotFound)
-            {
-                RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("we looked everywhere"))
-            };
+        public readonly HttpResponseMessage NotFoundHttpResponseMessage = new HttpResponseMessage(
+            HttpStatusCode.NotFound
+        )
+        {
+            RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("we looked everywhere")),
+        };
 
         public readonly IWebHostEnvironment MockWebHostEnvironment;
         public readonly IOptions<ParatextOptions> MockParatextOptions;
@@ -5219,14 +5229,30 @@ public class ParatextServiceTests
         public CommentManager ProjectCommentManager { get; set; }
         public ProjectFileManager ProjectFileManager { get; set; }
 
-        public static HttpResponseMessage MakeOkHttpResponseMessage(string content)
-        {
-            return new HttpResponseMessage(HttpStatusCode.OK)
+        public ParatextProjectUser ParatextProjectUser01 =>
+            new ParatextProjectUser
+            {
+                Id = User01,
+                ParatextId = ParatextUserId01,
+                Role = SFProjectRole.Administrator,
+                Username = Username01,
+            };
+
+        public ParatextProjectUser ParatextProjectUser02 =>
+            new ParatextProjectUser
+            {
+                Id = User02,
+                ParatextId = ParatextUserId02,
+                Role = SFProjectRole.Administrator,
+                Username = Username02,
+            };
+
+        public static HttpResponseMessage MakeOkHttpResponseMessage(string content) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
             {
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, "some-request-uri"),
-                Content = new ByteArrayContent(Encoding.UTF8.GetBytes(content))
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes(content)),
             };
-        }
 
         public static UserSecret MakeUserSecret(string userSecretId, string username, string paratextUserId)
         {
@@ -5404,9 +5430,8 @@ public class ParatextServiceTests
             return mockSource;
         }
 
-        public SFProject NewSFProject()
-        {
-            return new SFProject
+        public SFProject NewSFProject() =>
+            new SFProject
             {
                 Id = "sf_id_" + Project01,
                 ParatextId = PTProjectIds[Project01].Id,
@@ -5421,7 +5446,7 @@ public class ParatextServiceTests
                         ParatextId = "paratextId",
                         Name = "Source",
                         ShortName = "SRC",
-                        WritingSystem = new WritingSystem { Tag = "qaa" }
+                        WritingSystem = new WritingSystem { Tag = "qaa" },
                     }
                 },
                 CheckingConfig = new CheckingConfig { ShareEnabled = false },
@@ -5429,7 +5454,7 @@ public class ParatextServiceTests
                 {
                     { User01, SFProjectRole.Administrator },
                     { User02, SFProjectRole.CommunityChecker },
-                    { User05, SFProjectRole.Commenter }
+                    { User05, SFProjectRole.Commenter },
                 },
                 Texts =
                 {
@@ -5443,9 +5468,9 @@ public class ParatextServiceTests
                                 Number = 1,
                                 LastVerse = 6,
                                 IsValid = true,
-                                Permissions = { }
-                            }
-                        }
+                                Permissions = [],
+                            },
+                        },
                     },
                     new TextInfo
                     {
@@ -5457,25 +5482,24 @@ public class ParatextServiceTests
                                 Number = 1,
                                 LastVerse = 3,
                                 IsValid = true,
-                                Permissions = { }
+                                Permissions = [],
                             },
                             new Chapter
                             {
                                 Number = 2,
                                 LastVerse = 3,
                                 IsValid = true,
-                                Permissions = { }
-                            }
-                        }
-                    }
-                }
+                                Permissions = [],
+                            },
+                        },
+                    },
+                },
             };
-        }
 
         public void AddProjectRepository(SFProject proj = null)
         {
             proj ??= NewSFProject();
-            RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(new[] { proj }));
+            RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>([proj]));
             MockFileSystemService
                 .DirectoryExists(
                     Arg.Is<string>((string path) => path.EndsWith(Path.Combine(PTProjectIds[Project01].Id, "target")))
@@ -5483,8 +5507,20 @@ public class ParatextServiceTests
                 .Returns(true);
         }
 
-        public void AddUserRepository(User[]? users = null) =>
-            RealtimeService.AddRepository("users", OTType.Json0, new MemoryRepository<User>(users ?? []));
+        public void AddUserRepository() =>
+            RealtimeService.AddRepository(
+                "users",
+                OTType.Json0,
+                new MemoryRepository<User>(
+                    [
+                        new User { Id = User01, ParatextId = ParatextUserId01 },
+                        new User { Id = User02, ParatextId = ParatextUserId02 },
+                        new User { Id = User03, ParatextId = ParatextUserId03 },
+                        new User { Id = User04 },
+                        new User { Id = User05 },
+                    ]
+                )
+            );
 
         public void AddTextDocs(
             int bookNum,
@@ -6041,12 +6077,10 @@ public class ParatextServiceTests
             return changes;
         }
 
-        public void MakeRegistryClientReturn(HttpResponseMessage responseMessage)
-        {
+        public void MakeRegistryClientReturn(HttpResponseMessage responseMessage) =>
             MockRegistryHttpClient
                 .SendAsync(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
                 .Returns(responseMessage);
-        }
 
         public void Dispose()
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4096,24 +4096,24 @@ public class ParatextServiceTests
         // Set up the call of the list of users in the project
         using HttpResponseMessage usersResponse = TestEnvironment.MakeOkHttpResponseMessage(
             $$"""
-              [
-                {
-                  "role": "{{SFProjectRole.Administrator}}",
-                  "userId": "{{env.ParatextUserId01}}",
-                  "username": "{{env.Username01}}"
-                },
-                {
-                  "role": "{{SFProjectRole.Administrator}}",
-                  "userId": "{{env.ParatextUserId02}}",
-                  "username": "{{env.Username02}}"
-                }
-              ]
-              """
+            [
+              {
+                "role": "{{SFProjectRole.Administrator}}",
+                "userId": "{{env.ParatextUserId01}}",
+                "username": "{{env.Username01}}"
+              },
+              {
+                "role": "{{SFProjectRole.Administrator}}",
+                "userId": "{{env.ParatextUserId02}}",
+                "username": "{{env.Username02}}"
+              }
+            ]
+            """
         );
         env.MockRegistryHttpClient.SendAsync(
-            Arg.Is<HttpRequestMessage>(r => r.RequestUri.ToString().Contains("/members")),
-            CancellationToken.None
-        )
+                Arg.Is<HttpRequestMessage>(r => r.RequestUri.ToString().Contains("/members")),
+                CancellationToken.None
+            )
             .Returns(usersResponse);
 
         // SUT
@@ -5463,17 +5463,17 @@ public class ParatextServiceTests
             {
                 JObject projectLicense = JObject.Parse(
                     $$"""
-                                       {
-                                         "type": "translator",
-                                         "licensedToParatextId": "{{paratextId}}",
-                                         "licensedToOrgs": [
-                                           "5494956f5117ad586f2e2f40"
-                                         ],
-                                         "issuedAt": "2024-06-18T22:26:28.854Z",
-                                         "expiresAt": "2024-06-18T22:26:28.854Z",
-                                         "revoked": true
-                                       }
-                                       """
+                    {
+                      "type": "translator",
+                      "licensedToParatextId": "{{paratextId}}",
+                      "licensedToOrgs": [
+                        "5494956f5117ad586f2e2f40"
+                      ],
+                      "issuedAt": "2024-06-18T22:26:28.854Z",
+                      "expiresAt": "2024-06-18T22:26:28.854Z",
+                      "revoked": true
+                    }
+                    """
                 );
                 mockSource.GetLicenseForUserProject(paratextId).Returns(new ProjectLicense(projectLicense));
                 if (paratextId == PTProjectIds[Project01].Id)
@@ -5584,18 +5584,20 @@ public class ParatextServiceTests
                 .Returns(true);
         }
 
-        public void AddUserRepository() =>
+        public void AddUserRepository(User[]? users = null) =>
             RealtimeService.AddRepository(
                 "users",
                 OTType.Json0,
                 new MemoryRepository<User>(
-                    [
-                        new User { Id = User01, ParatextId = ParatextUserId01 },
-                        new User { Id = User02, ParatextId = ParatextUserId02 },
-                        new User { Id = User03, ParatextId = ParatextUserId03 },
-                        new User { Id = User04 },
-                        new User { Id = User05 },
-                    ]
+                    users
+                        ??
+                        [
+                            new User { Id = User01, ParatextId = ParatextUserId01 },
+                            new User { Id = User02, ParatextId = ParatextUserId02 },
+                            new User { Id = User03, ParatextId = ParatextUserId03 },
+                            new User { Id = User04 },
+                            new User { Id = User05 },
+                        ]
                 )
             );
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -575,10 +575,10 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is((SFProject project) => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01 with { Role = SFProjectRole.Translator }]);
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -600,10 +600,10 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is((SFProject project) => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01 with { Role = SFProjectRole.Translator }]);
 
         // SUT
@@ -654,10 +654,10 @@ public class ParatextSyncRunnerTests
         SFProject project = env.GetProject("project01");
         Assert.That(project.Editable, Is.True, "setup");
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is((SFProject project) => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01]);
 
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
@@ -808,10 +808,10 @@ public class ParatextSyncRunnerTests
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is<SFProject>(project => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is<SFProject>(project => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01]);
         int fontSize = 10;
         string font = ProjectSettings.defaultFontName;
@@ -923,10 +923,10 @@ public class ParatextSyncRunnerTests
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is((SFProject project) => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01]);
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
 
@@ -947,10 +947,10 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Any<UserSecret>(),
-            Arg.Is((SFProject project) => project.ParatextId == "target"),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Any<UserSecret>(),
+                Arg.Is((SFProject project) => project.ParatextId == "target"),
+                Arg.Any<CancellationToken>()
+            )
             .Returns([TestEnvironment.ParatextProjectUser01]);
 
         await env.SetUserRole("user02", SFProjectRole.CommunityChecker);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -571,16 +571,15 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_UserRoleChangedAndUserRemoved()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
-        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01 with { Role = SFProjectRole.Translator }]);
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
@@ -597,16 +596,15 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_SetsUserPermissions()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
-        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Translator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01 with { Role = SFProjectRole.Translator }]);
 
         // SUT
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -619,6 +617,7 @@ public class ParatextSyncRunnerTests
                     (IDocument<SFProject> sfProjDoc) =>
                         sfProjDoc.Data.Id == "project01" && sfProjDoc.Data.ParatextId == "target"
                 ),
+                Arg.Any<IReadOnlyList<ParatextProjectUser>>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -630,13 +629,7 @@ public class ParatextSyncRunnerTests
         Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
-        env.ParatextService.GetParatextUsernameMappingAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Any<SFProject>(),
-                CancellationToken.None
-            )
-            .Throws<UnauthorizedAccessException>();
-        env.ParatextService.GetProjectRolesAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), CancellationToken.None)
+        env.ParatextService.GetParatextUsersAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), CancellationToken.None)
             .Throws<UnauthorizedAccessException>();
 
         // SUT
@@ -655,18 +648,17 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_ProjectTextSetToNotEditable()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
         SFProject project = env.GetProject("project01");
         Assert.That(project.Editable, Is.True, "setup");
-        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01]);
 
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(new ParatextSettings { Editable = false });
@@ -810,17 +802,17 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_SetsProjectSettings()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is<SFProject>(project => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is<SFProject>(project => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01]);
         int fontSize = 10;
         string font = ProjectSettings.defaultFontName;
         string sourceWritingSystemTag = "en";
@@ -925,17 +917,17 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_ProjectSettingsIsNull_SyncFailsAndTextNotUpdated()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
 
         var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01]);
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>()).Returns(x => null);
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
@@ -951,16 +943,15 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_CheckerWithPTAccountNotRemoved()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
-        var ptUserRoles = new Dictionary<string, string> { { "pt01", SFProjectRole.Administrator } };
-        env.ParatextService.GetProjectRolesAsync(
-                Arg.Any<UserSecret>(),
-                Arg.Is((SFProject project) => project.ParatextId == "target"),
-                Arg.Any<CancellationToken>()
-            )
-            .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+        env.ParatextService.GetParatextUsersAsync(
+            Arg.Any<UserSecret>(),
+            Arg.Is((SFProject project) => project.ParatextId == "target"),
+            Arg.Any<CancellationToken>()
+        )
+            .Returns([TestEnvironment.ParatextProjectUser01]);
 
         await env.SetUserRole("user02", SFProjectRole.CommunityChecker);
         SFProject project = env.GetProject();
@@ -1335,14 +1326,7 @@ public class ParatextSyncRunnerTests
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Setup a trap to crash the task
-        env.NotesMapper.When(x =>
-                x.InitAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<List<User>>(),
-                    Arg.Any<SFProject>(),
-                    Arg.Any<CancellationToken>()
-                )
-            )
+        env.NotesMapper.When(x => x.Init(Arg.Any<UserSecret>(), Arg.Any<IReadOnlyList<ParatextProjectUser>>()))
             .Do(_ => throw new ArgumentException());
 
         // Run the task
@@ -1403,14 +1387,7 @@ public class ParatextSyncRunnerTests
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Setup a trap to cancel the task
-        env.NotesMapper.When(x =>
-                x.InitAsync(
-                    Arg.Any<UserSecret>(),
-                    Arg.Any<List<User>>(),
-                    Arg.Any<SFProject>(),
-                    Arg.Any<CancellationToken>()
-                )
-            )
+        env.NotesMapper.When(x => x.Init(Arg.Any<UserSecret>(), Arg.Any<IReadOnlyList<ParatextProjectUser>>()))
             .Do(_ =>
             {
                 cancellationTokenSource.Cancel();
@@ -3276,6 +3253,30 @@ public class ParatextSyncRunnerTests
         private bool _sendReceivedCalled = false;
         private readonly int _guidStartNum = 3;
 
+        public static readonly ParatextProjectUser ParatextProjectUser01 = new ParatextProjectUser
+        {
+            Id = "user01",
+            ParatextId = "pt01",
+            Role = SFProjectRole.Administrator,
+            Username = "User 1",
+        };
+
+        public static readonly ParatextProjectUser ParatextProjectUser02 = new ParatextProjectUser
+        {
+            Id = "user02",
+            ParatextId = "pt02",
+            Role = SFProjectRole.Translator,
+            Username = "User 2",
+        };
+
+        public static readonly ParatextProjectUser ParatextProjectUser03 = new ParatextProjectUser
+        {
+            Id = "user03",
+            ParatextId = "pt03",
+            Role = SFProjectRole.PTObserver,
+            Username = "User 3",
+        };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestEnvironment" /> class.
         /// </summary>
@@ -3293,11 +3294,7 @@ public class ParatextSyncRunnerTests
             _projectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]
                 {
-                    new SFProjectSecret
-                    {
-                        Id = "project01",
-                        JobIds = new List<string> { "test_jobid" },
-                    },
+                    new SFProjectSecret { Id = "project01", JobIds = ["test_jobid"], },
                     new SFProjectSecret { Id = "project02" },
                     new SFProjectSecret { Id = "project03" },
                     new SFProjectSecret { Id = "project04" },
@@ -3320,21 +3317,16 @@ public class ParatextSyncRunnerTests
             SFProjectService = Substitute.For<ISFProjectService>();
             ParatextService = Substitute.For<IParatextService>();
 
-            var ptUserRoles = new Dictionary<string, string>
-            {
-                { "pt01", SFProjectRole.Administrator },
-                { "pt02", SFProjectRole.Translator }
-            };
             ParatextService
                 .GetBiblicalTermsAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), Arg.Any<IEnumerable<int>>())
                 .Returns(Task.FromResult(new BiblicalTermsChanges()));
             ParatextService
-                .GetProjectRolesAsync(
+                .GetParatextUsersAsync(
                     Arg.Any<UserSecret>(),
                     Arg.Is((SFProject project) => project.ParatextId == "target"),
                     Arg.Any<CancellationToken>()
                 )
-                .Returns(Task.FromResult<IReadOnlyDictionary<string, string>>(ptUserRoles));
+                .Returns([ParatextProjectUser01, ParatextProjectUser02]);
             ParatextService
                 .When(x =>
                     x.SendReceiveAsync(
@@ -3411,19 +3403,10 @@ public class ParatextSyncRunnerTests
 
         public SFProjectSecret GetProjectSecret(string projectId = "project01") => _projectSecrets.Get(projectId);
 
-        public SFProjectUserConfig GetProjectUserConfig(string projectId, string userId)
-        {
-            return RealtimeService
-                .GetRepository<SFProjectUserConfig>()
-                .Get(SFProjectUserConfig.GetDocId(projectId, userId));
-        }
-
-        public bool ContainsText(string projectId, string bookId, int chapter)
-        {
-            return RealtimeService
+        public bool ContainsText(string projectId, string bookId, int chapter) =>
+            RealtimeService
                 .GetRepository<TextData>()
                 .Contains(TextData.GetTextDocId(projectId, Canon.BookIdToNumber(bookId), chapter));
-        }
 
         /// <summary>
         /// Fetches the text docs for a book.
@@ -3948,19 +3931,9 @@ public class ParatextSyncRunnerTests
                         Arg.Any<Dictionary<string, ParatextUserProfile>>()
                     )
                     .Returns(new[] { noteThreadChange });
-                Dictionary<string, string> userIdsToUsernames = new Dictionary<string, string>
-                {
-                    { "user01", "User 1" },
-                    { "user02", "User 2" },
-                    { "user03", "User 3" },
-                };
                 ParatextService
-                    .GetParatextUsernameMappingAsync(
-                        Arg.Any<UserSecret>(),
-                        Arg.Any<SFProject>(),
-                        CancellationToken.None
-                    )
-                    .Returns(userIdsToUsernames);
+                    .GetParatextUsersAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), CancellationToken.None)
+                    .Returns([ParatextProjectUser01, ParatextProjectUser02, ParatextProjectUser03]);
             }
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1054,10 +1054,10 @@ public class SFProjectServiceTests
         // EdjCase.JsonRpc.Common.RpcException. Our test should not end up doing down a path that causes this
         // exception.
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-            Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<CancellationToken>()
+            )
             .Returns(Task.FromException<IReadOnlyList<ParatextProjectUser>>(new HttpRequestException()));
 
         string userRoleOnPTProject = null;
@@ -1234,10 +1234,10 @@ public class SFProjectServiceTests
         Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False, "setup");
 
         env.ParatextService.GetParatextUsersAsync(
-            Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
-            Arg.Is((SFProject project) => project.ParatextId == project05PTId),
-            Arg.Any<CancellationToken>()
-        )
+                Arg.Is<UserSecret>((UserSecret userSecret) => userSecret.Id == User03),
+                Arg.Is((SFProject project) => project.ParatextId == project05PTId),
+                Arg.Any<CancellationToken>()
+            )
             .Returns(Task.FromException<IReadOnlyList<ParatextProjectUser>>(new HttpRequestException()));
 
         string userRoleOnPTProject = null;


### PR DESCRIPTION
This PR reduces calls to the Paratext Registry by combining:

 * `ParatextService.GetProjectRolesAsync()`
 * `ParatextService.GetParatextUsernameMappingAsync()`

Into `ParatextService.GetUsersAsync()`, and by passings the list of users from the Registry to `ParatextNotesMapper`, rather than having `ParatextNotesMapper` request the list of users from the Registry again.

I have also added a second commit that checks whether a project is registered, and if so, uses just that project's meta data and license to retrieve the repositories from the PT archives server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2529)
<!-- Reviewable:end -->
