### PR TITLE
Add index to sf_project_secrets.shareKeys.key

### DIFF
--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using MongoDB.Driver;
 using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -20,10 +21,19 @@ public static class SFDataAccessServiceCollectionExtensions
             "sf_project_secrets",
             null,
             idx =>
-                idx.CreateOne(
-                    new CreateIndexModel<SFProjectSecret>(
-                        Builders<SFProjectSecret>.IndexKeys.Ascending(ps => ps.ServalData.PreTranslationEngineId)
-                    )
+                idx.CreateMany(
+                    [
+                        new CreateIndexModel<SFProjectSecret>(
+                            Builders<SFProjectSecret>.IndexKeys.Ascending(ps => ps.ServalData.PreTranslationEngineId)
+                        ),
+                        // The C# Driver still does not support fluent syntax for multi-key indexes.
+                        // See https://jira.mongodb.org/browse/CSHARP-1309
+                        new CreateIndexModel<SFProjectSecret>(
+                            Builders<SFProjectSecret>.IndexKeys.Ascending(
+                                $"{nameof(SFProjectSecret.ShareKeys)}.{nameof(ShareKey.Key)}"
+                            )
+                        ),
+                    ]
                 )
         );
         services.AddMongoRepository<SyncMetrics>("sync_metrics", cm => cm.MapIdProperty(sm => sm.Id));


### PR DESCRIPTION
This PR adds an index to the `shareKeys.key` field of `sf_project_secrets`.

This index will speed up checking for share keys when users attempt to log in via a share key.

When running this PR, you will see a new index appear in the `sf_project_secrets` collection:
![image](https://github.com/sillsdev/web-xforge/assets/8665431/c7b76207-c82c-42df-a708-41ddd2698c78)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2531)
<!-- Reviewable:end -->
