### PR TITLE
SF-2791 Check Auth0 for updated refresh token on rejection

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -78,6 +78,7 @@ public class ParatextService : DisposableBase, IParatextService
     private readonly IWebHostEnvironment _env;
     private readonly DotNetCoreAlert _alertSystem;
     private readonly IDeltaUsxMapper _deltaUsxMapper;
+    private readonly IAuthService _authService;
 
     public ParatextService(
         IWebHostEnvironment env,
@@ -94,7 +95,8 @@ public class ParatextService : DisposableBase, IParatextService
         IGuidService guidService,
         ISFRestClientFactory restClientFactory,
         IHgWrapper hgWrapper,
-        IDeltaUsxMapper deltaUsxMapper
+        IDeltaUsxMapper deltaUsxMapper,
+        IAuthService authService
     )
     {
         _paratextOptions = paratextOptions;
@@ -113,6 +115,7 @@ public class ParatextService : DisposableBase, IParatextService
         _env = env;
         _alertSystem = new DotNetCoreAlert(_logger);
         _deltaUsxMapper = deltaUsxMapper;
+        _authService = authService;
 
         _httpClientHandler = new HttpClientHandler();
         _registryClient = new HttpClient(_httpClientHandler);
@@ -3309,7 +3312,27 @@ public class ParatextService : DisposableBase, IParatextService
                             + $"from call RefreshAccessTokenAsync(). The current access token has issuedAt time "
                             + $"of {userSecret.ParatextTokens.IssuedAt:o}."
                     );
-                    throw;
+
+                    // Get the tokens from auth0, and make sure they are up-to-date
+                    // If they cannot be refreshed, an exception will throw
+                    Attempt<User> userAttempt = await _realtimeService.TryGetSnapshotAsync<User>(sfUserId);
+                    if (!userAttempt.TryResult(out User user))
+                    {
+                        throw;
+                    }
+
+                    refreshedUserTokens = await _authService.GetParatextTokensAsync(user.AuthId, token);
+                    if (string.IsNullOrWhiteSpace(refreshedUserTokens?.RefreshToken))
+                    {
+                        throw;
+                    }
+
+                    refreshedUserTokens = await _jwtTokenHelper.RefreshAccessTokenAsync(
+                        _paratextOptions.Value,
+                        refreshedUserTokens,
+                        _registryClient,
+                        token
+                    );
                 }
 
                 userSecret = await _userSecretRepository.UpdateAsync(

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Models;
 
@@ -6,6 +7,7 @@ namespace SIL.XForge.Services;
 public interface IAuthService
 {
     bool ValidateWebhookCredentials(string username, string password);
+    Task<Tokens?> GetParatextTokensAsync(string authId, CancellationToken token);
     Task<string> GetUserAsync(string authId);
     Task<string> GenerateAnonymousUser(string name, TransparentAuthenticationCredentials credentials, string language);
     Task LinkAccounts(string primaryAuthId, string secondaryAuthId);

--- a/test/SIL.XForge.Tests/Services/AuthServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/AuthServiceTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+
+namespace SIL.XForge.Services;
+
+[TestFixture]
+public class AuthServiceTests
+{
+    [Test]
+    public async Task GetParatextTokensAsync_NoParatextIdentity()
+    {
+        // Set up a mock Auth0 API
+        string userResponse = $$"""
+            {
+                "identities":[
+                    {
+                       "provider":"google-oauth2",
+                       "access_token":"{{TestEnvironment.GenerateToken()}}",
+                       "user_id":"google-user-01",
+                       "connection":"google-oauth2",
+                       "isSocial":true
+                    }
+                ]
+            }
+            """;
+        Dictionary<string, string> responses = new Dictionary<string, string>
+        {
+            { "oauth/token", $$"""{"access_token": "{{TestEnvironment.GenerateToken()}}"}""" },
+            { "users/auth01", userResponse },
+        };
+        var handler = new MockHttpMessageHandler(responses, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        var env = new TestEnvironment(httpClient);
+
+        // SUT
+        var result = await env.Service.GetParatextTokensAsync("auth01", CancellationToken.None);
+        Assert.IsNull(result);
+        Assert.AreEqual(2, handler.NumberOfCalls);
+        Assert.IsNull(handler.LastInput);
+    }
+
+    [Test]
+    public async Task GetParatextTokensAsync_Success()
+    {
+        // Set up a mock Auth0 API
+        string accessToken = TestEnvironment.GenerateToken();
+        const string refreshToken = "refresh_token_here";
+        string userResponse = $$"""
+            {
+                "identities":[
+                    {
+                       "provider":"google-oauth2",
+                       "access_token":"{{TestEnvironment.GenerateToken()}}",
+                       "user_id":"google-user-01",
+                       "connection":"google-oauth2",
+                       "isSocial":true
+                    },
+                    {
+                       "provider":"oauth2",
+                       "access_token":"{{accessToken}}",
+                       "refresh_token":"{{refreshToken}}",
+                       "user_id":"paratext-user-01",
+                       "connection":"paratext",
+                       "isSocial":true
+                    },
+                ]
+            }
+            """;
+        Dictionary<string, string> responses = new Dictionary<string, string>
+        {
+            { "oauth/token", $$"""{"access_token": "{{TestEnvironment.GenerateToken()}}"}""" },
+            { "users/auth01", userResponse },
+        };
+        var handler = new MockHttpMessageHandler(responses, HttpStatusCode.OK);
+        var httpClient = TestEnvironment.CreateHttpClient(handler);
+
+        var env = new TestEnvironment(httpClient);
+
+        // SUT
+        var result = await env.Service.GetParatextTokensAsync("auth01", CancellationToken.None);
+        Assert.AreEqual(accessToken, result?.AccessToken);
+        Assert.AreEqual(refreshToken, result?.RefreshToken);
+        Assert.AreEqual(2, handler.NumberOfCalls);
+        Assert.IsNull(handler.LastInput);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment(HttpClient? httpClient = default)
+        {
+            var authOptions = Substitute.For<IOptions<AuthOptions>>();
+            authOptions.Value.Returns(new AuthOptions { Domain = "localhost", BackendClientSecret = "secret" });
+            var exceptionHandler = Substitute.For<IExceptionHandler>();
+            var httpClientFactory = Substitute.For<IHttpClientFactory>();
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+            Service = new AuthService(authOptions, exceptionHandler, httpClientFactory);
+        }
+
+        public AuthService Service { get; }
+
+        public static HttpClient CreateHttpClient(HttpMessageHandler handler) =>
+            new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+        public static string GenerateToken()
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            SecurityToken token = tokenHandler.CreateToken(
+                new SecurityTokenDescriptor { Expires = DateTime.UtcNow.AddDays(1) }
+            );
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/test/SIL.XForge.Tests/Services/MockHttpMessageHandler.cs
+++ b/test/SIL.XForge.Tests/Services/MockHttpMessageHandler.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SIL.XForge.Services;
+
+public class MockHttpMessageHandler(Dictionary<string, string> responses, HttpStatusCode statusCode)
+    : HttpMessageHandler
+{
+    public string? LastInput { get; private set; }
+    public int NumberOfCalls { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        NumberOfCalls++;
+        LastInput = request.Content is not null ? await request.Content.ReadAsStringAsync(cancellationToken) : null;
+
+        foreach (
+            KeyValuePair<string, string> response in responses.Where(response =>
+                request.RequestUri!.PathAndQuery.Contains(response.Key)
+            )
+        )
+        {
+            return new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(response.Value),
+                RequestMessage = request,
+            };
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(request));
+    }
+}


### PR DESCRIPTION
This PR updates the auth service to allow querying of Auth0 for the last known `access_token` and `refresh_token`.

If the token has not been refreshed since the last login, the `refresh_token` value will be up-to-date, and cause a successful token refresh. If it is not up-to-date, the error will bubble to the frontend, and be handled by the logout prompt added in SF-2762/#2506.

As the testing is technical, this PR should be tested by a developer.

I also took the opportunity to add some testing infrastructure to `AuthService`, and updated some out-of-date code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2533)
<!-- Reviewable:end -->
