### PR TITLE
Add breakpoint classes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -13,8 +13,8 @@
           <mat-icon>menu</mat-icon>
         </button>
         <span (click)="goHome()" class="title">
-          <img src="/assets/images/sf_logo_with_name.svg" height="40" fxHide.xs />
-          <button mat-icon-button fxHide.gt-xs>
+          <img src="/assets/images/sf_logo_with_name.svg" height="40" class="hide-lt-sm" />
+          <button mat-icon-button class="hide-gt-sm">
             <img src="/assets/images/sf.svg" height="38" />
           </button>
         </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -86,11 +86,11 @@
                   type="button"
                   [matTooltip]="t('add_question')"
                   (click)="questionDialog()"
-                  class="add-question-button"
+                  class="add-question-button hide-gt-xl"
                 >
                   <mat-icon class="mirror-rtl">post_add</mat-icon>
                 </button>
-                <button mat-button type="button" (click)="questionDialog()" class="add-question-button">
+                <button mat-button type="button" (click)="questionDialog()" class="add-question-button hide-lt-xl">
                   <mat-icon class="mirror-rtl">post_add</mat-icon>
                   <span>{{ t("add_question") }}</span>
                 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -197,20 +197,6 @@ header {
 
         &.action-icons {
           justify-content: flex-end;
-
-          .add-question-button.mat-mdc-icon-button {
-            display: none;
-          }
-
-          @include media-breakpoint('<', xl) {
-            .add-question-button.mat-mdc-button {
-              display: none;
-            }
-
-            .add-question-button.mat-mdc-icon-button {
-              display: block;
-            }
-          }
         }
       }
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
@@ -28,7 +28,7 @@
       (click)="prevChapter()"
       [disabled]="isPrevChapterDisabled()"
       title="{{ t('previous_chapter') }}"
-      fxHide.xs
+      class="hide-lt-sm"
     >
       <mat-icon>keyboard_arrow_{{ i18n.backwardDirectionWord }}</mat-icon>
     </button>
@@ -37,7 +37,7 @@
       (click)="nextChapter()"
       [disabled]="isNextChapterDisabled()"
       title="{{ t('next_chapter') }}"
-      fxHide.xs
+      class="hide-lt-sm"
     >
       <mat-icon>keyboard_arrow_{{ i18n.forwardDirectionWord }}</mat-icon>
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use 'variables';
 
 // This creates css variables for common breakpoints (needed when using MediaBreakpointService with BreakpointObserver)
@@ -121,5 +122,60 @@ body[dir='rtl'] .mirror-rtl {
   transform: scaleX(-1);
   .mat-badge-content {
     transform: scaleX(-1);
+  }
+}
+
+// These breakpoints can be somewhat confusing, because a breakpoint can be thought of as a range, or as a specific
+// width. If they're fixed numbers, hide-lt-md and hide-gt-md would be mutually exclusive, but if you think of them as
+// ranges, you would need to use hide-lt-md and hide-gt-sm to make two elements mutually exclusive. For the purposes of
+// these classes, all breakpoints are fixed points, not a range of widths.
+// One of the consequences of this is that there is no such thing as gt-xs, since extra small is defined as anything
+// less than small. The same is not true of xl; xl has an actual value, and a screen can be larger than xl.
+
+.hide-lt-sm {
+  @media (width < map.get(variables.$grid-breakpoints, 'sm')) {
+    display: none !important;
+  }
+}
+
+.hide-lt-md {
+  @media (width < map.get(variables.$grid-breakpoints, 'md')) {
+    display: none !important;
+  }
+}
+
+.hide-lt-lg {
+  @media (width < map.get(variables.$grid-breakpoints, 'lg')) {
+    display: none !important;
+  }
+}
+
+.hide-lt-xl {
+  @media (width < map.get(variables.$grid-breakpoints, 'xl')) {
+    display: none !important;
+  }
+}
+
+.hide-gt-sm {
+  @media (width >= map.get(variables.$grid-breakpoints, 'sm')) {
+    display: none !important;
+  }
+}
+
+.hide-gt-md {
+  @media (width >= map.get(variables.$grid-breakpoints, 'md')) {
+    display: none !important;
+  }
+}
+
+.hide-gt-lg {
+  @media (width >= map.get(variables.$grid-breakpoints, 'lg')) {
+    display: none !important;
+  }
+}
+
+.hide-gt-xl {
+  @media (width >= map.get(variables.$grid-breakpoints, 'xl')) {
+    display: none !important;
   }
 }


### PR DESCRIPTION
The `@angular/flex-layout` package is deprecated. One of the things we use it for the most is hiding elements on certain viewport sizes.

Throughout the repo we have 10 instances of `fxShow` and 22 instances of `fxHide`.

This PR adds a couple helper classes, and replaces a few instances with the use of these classes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2538)
<!-- Reviewable:end -->
