### PR TITLE
SF-2319a Remove asterisk from required form fields

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { DatePipe } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { ErrorHandler, NgModule } from '@angular/core';
-import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
@@ -85,11 +84,7 @@ import { UsersModule } from './users/users.module';
     translocoMarkupRouterLinkRenderer(),
     defaultTranslocoMarkupTranspilers(),
     { provide: ErrorHandler, useClass: ExceptionHandlingService },
-    { provide: OverlayContainer, useClass: InAppRootOverlayContainer },
-    {
-      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
-      useValue: { appearance: 'outline' }
-    }
+    { provide: OverlayContainer, useClass: InAppRootOverlayContainer }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.spec.ts
@@ -470,5 +470,6 @@ class TestEnvironment {
   wait(): void {
     flush();
     this.fixture.detectChanges();
+    flush();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -14,7 +14,7 @@ import { MatOptionModule } from '@angular/material/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { MatFormFieldModule } from '@angular/material/form-field';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
@@ -149,6 +149,10 @@ const appFlexLayoutBreakPoints = [
       provide: MatPaginatorIntl,
       useClass: Paginator,
       deps: [TranslocoService]
+    },
+    {
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { appearance: 'outline', hideRequiredMarker: true }
     }
   ]
 })


### PR DESCRIPTION
James Post pointed out that having an asterisk here is not particularly helpful and doesn't have a corresponding asterisk:

![](https://github.com/sillsdev/web-xforge/assets/6140710/fcb1bfa9-3213-48a6-a2b7-723a5d8ea8ad)

I understand the usefulness of denoting required form fields in a long form, but I don't think it's needed in the context of a one-field form, as it should be pretty obvious to the user that the field is required.

The longest form I could find is this:

![](https://github.com/sillsdev/web-xforge/assets/6140710/129477b6-8229-4782-a258-cee69cb0e692)

And I don't think the asterisks are particularly meaningful here either. And if a user is at all confused and tries to continue, it's made explicit that these fields are required.

I think a proper use of asterisks to denote required form fields is in a long(ish) form where it is stated at the beginning that the asterisks denote required fields.

In addition to reviewing code changes, please make sure to review visual changes in Chromatic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2540)
<!-- Reviewable:end -->
