### PR TITLE
SF-2760 Fix Observer permissions opening projects as resources

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -13,7 +13,10 @@ export const SF_PROJECT_PROFILES_COLLECTION = 'sf_projects_profile';
 export const SF_PROJECT_PROFILES_INDEX_PATHS: string[] = [];
 
 export const SF_PROJECTS_COLLECTION = 'sf_projects';
-export const SF_PROJECT_INDEX_PATHS: string[] = [obj<SFProject>().pathStr(q => q.name)];
+export const SF_PROJECT_INDEX_PATHS: string[] = [
+  obj<SFProject>().pathStr(q => q.name),
+  obj<SFProject>().pathStr(q => q.paratextId)
+];
 
 export interface SFProjectProfile extends Project {
   paratextId: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -52,44 +52,12 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
   }
 
   /**
-   * Creates an SF project/resource with the given paratext id.
+   * Creates an SF project/resource with the given paratext id, and adds the user to it.
    * @param paratextId The paratext id of the project or resource.
    * @returns The SF project id.
    */
   async onlineCreateResourceProject(paratextId: string): Promise<string | undefined> {
     return this.onlineInvoke<string>('createResourceProject', { paratextId });
-  }
-
-  async getRealtimeProject(paratextId: string): Promise<SFProjectDoc | undefined> {
-    const query: RealtimeQuery<SFProjectDoc> = await this.realtimeService.onlineQuery<SFProjectDoc>(this.collection, {
-      paratextId
-    });
-    return query.docs[0];
-  }
-
-  /**
-   * Gets the SF project Id for the project/resource with the given paratext id.  Creates the project if needed.
-   * @param paratextId The paratext id of the project or resource.
-   * @returns The SF project id.
-   */
-  async getOrCreateRealtimeProject(paratextId: string, role?: string): Promise<string | undefined> {
-    // First check if project exists
-    const project: SFProjectDoc | undefined = await this.getRealtimeProject(paratextId);
-
-    // If SF project exists, return its id
-    if (project != null) {
-      return Promise.resolve(project.id);
-    }
-
-    // Otherwise, create realtime project
-    const projectId: string | undefined = await this.onlineCreateResourceProject(paratextId);
-
-    // Add current user to project
-    if (projectId != null) {
-      await this.onlineAddCurrentUser(projectId, role);
-    }
-
-    return projectId;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -89,11 +89,11 @@ describe('EditorTabAddResourceDialogComponent', () => {
   });
 
   describe('confirmSelection', () => {
-    it('should call fetchProject when confirmSelection is called', fakeAsync(() => {
+    it('should call get or create the project when confirmSelection is called', fakeAsync(() => {
       const env = new TestEnvironment();
       env.component.confirmSelection();
       tick();
-      verify(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).once();
+      verify(mockSFProjectService.onlineCreateResourceProject(env.paratextId)).once();
     }));
 
     it('should call syncProject and not close dialog if fetched project has no texts when confirmSelection is called', fakeAsync(() => {
@@ -128,10 +128,10 @@ describe('EditorTabAddResourceDialogComponent', () => {
 
     it('should set projectFetchFailed to true when fetchProject returns undefined', fakeAsync(() => {
       const env = new TestEnvironment();
-      when(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).thenReturn(Promise.resolve(undefined));
+      when(mockSFProjectService.onlineCreateResourceProject(env.paratextId)).thenReturn(Promise.resolve(undefined));
       env.component.confirmSelection();
       tick();
-      verify(mockSFProjectService.getOrCreateRealtimeProject(env.paratextId)).once();
+      verify(mockSFProjectService.onlineCreateResourceProject(env.paratextId)).once();
       expect(env.component.projectFetchFailed).toBe(true);
     }));
 
@@ -218,7 +218,7 @@ class TestEnvironment {
 
     when(mockParatextService.getProjects()).thenReturn(Promise.resolve(this.projects));
     when(mockParatextService.getResources()).thenReturn(Promise.resolve(this.resources));
-    when(mockSFProjectService.getOrCreateRealtimeProject(this.paratextId)).thenCall(() =>
+    when(mockSFProjectService.onlineCreateResourceProject(this.paratextId)).thenCall(() =>
       Promise.resolve(this.testProjectDoc.id)
     );
     when(mockSFProjectService.get(this.projectId)).thenCall(() => Promise.resolve(this.testProjectDoc));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -184,6 +184,7 @@ describe('EditorTabAddResourceDialogComponent', () => {
       env.component.confirmSelection();
       tick();
       verify(mockSFProjectService.onlineAddCurrentUser(env.projectId)).never();
+      verify(mockSFProjectService.onlineCreateResourceProject(env.paratextId)).once();
       verify(mockMatDialogRef.close(anything())).once();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -146,6 +146,46 @@ describe('EditorTabAddResourceDialogComponent', () => {
       expect(env.component.syncFailed).toBe(true);
       expect(env.component['cancelSync']).toHaveBeenCalled();
     }));
+
+    it('should call onlineAddCurrentUser if the user is not in the project', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const projects = [
+        env.createTestParatextProject(1, { paratextId: env.paratextId, projectId: env.projectId, isConnected: false })
+      ];
+      env.component.projects = projects;
+      when(mockPermissionsService.canSync(anything())).thenReturn(false);
+      env.setupProject({ texts: [{} as any] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineAddCurrentUser(env.projectId)).once();
+      verify(mockMatDialogRef.close(anything())).once();
+    }));
+
+    it('should not call onlineAddCurrentUser if the user is connected to the project', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const projects = [
+        env.createTestParatextProject(1, { paratextId: env.paratextId, projectId: env.projectId, isConnected: true })
+      ];
+      env.component.projects = projects;
+      when(mockPermissionsService.canSync(anything())).thenReturn(false);
+      env.setupProject({ texts: [{} as any] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineAddCurrentUser(env.projectId)).never();
+      verify(mockMatDialogRef.close(anything())).once();
+    }));
+
+    it('should not call onlineAddCurrentUser if the project has not been connected to by anyone', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const projects = [env.createTestParatextProject(1, { paratextId: env.paratextId, projectId: undefined })];
+      env.component.projects = projects;
+      when(mockPermissionsService.canSync(anything())).thenReturn(false);
+      env.setupProject({ texts: [{} as any] });
+      env.component.confirmSelection();
+      tick();
+      verify(mockSFProjectService.onlineAddCurrentUser(env.projectId)).never();
+      verify(mockMatDialogRef.close(anything())).once();
+    }));
   });
 
   it('should reset errors when onProjectSelected is called', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -70,6 +70,14 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
     try {
       if (paratextId != null) {
         this.isLoading = true;
+
+        // If the Paratext project has a SF project id, add the user to that project if they are not already
+        const project = this.projects?.find(p => p.paratextId === paratextId);
+        if (project?.projectId != null && !project.isConnected) {
+          await this.projectService.onlineAddCurrentUser(project.projectId);
+        }
+
+        // Load the project
         this.selectedProjectDoc = await this.fetchProject(paratextId);
 
         if (this.selectedProjectDoc != null) {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -71,7 +71,7 @@ public class SFProjectsRpcController(
     {
         try
         {
-            string projectId = await projectService.CreateResourceProjectAsync(UserId, paratextId);
+            string projectId = await projectService.CreateResourceProjectAsync(UserId, paratextId, addUser: true);
             return Ok(projectId);
         }
         catch (ForbiddenException)

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -10,7 +10,7 @@ namespace SIL.XForge.Scripture.Services;
 public interface ISFProjectService : IProjectService
 {
     Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings);
-    Task<string> CreateResourceProjectAsync(string curUserId, string paratextId);
+    Task<string> CreateResourceProjectAsync(string curUserId, string paratextId, bool addUser);
     Task DeleteProjectAsync(string curUserId, string projectId);
     Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
     Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -43,7 +43,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
     protected IFileSystemService FileSystemService { get; }
     protected abstract string ProjectAdminRole { get; }
 
-    public async Task AddUserAsync(string curUserId, string projectId, string projectRole)
+    public async Task AddUserAsync(string curUserId, string projectId, string? projectRole)
     {
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
         IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
@@ -57,7 +57,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
                 throw new ForbiddenException();
         }
 
-        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole);
+        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole!);
     }
 
     /// <summary>


### PR DESCRIPTION
This Pull Request allows Observers to connect to Paratext projects that have previously been connected to by the project's Administrators.

I have expanded this PR to fix this error for resources as well as projects. Resources that had previously been connected to were producing the following error: https://app.bugsnag.com/sil-international/scripture-forge-v2-plus/errors/666c5bb3c25a2f0008ccf510

Due to the frequency of these errors, I am pushing this to critical path.

I also took the opportunity to add an index to `paratextId` on the `sf_projects` collection, as it is what is queried, both in the previous verison of this logic and this re-implementation of the logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2541)
<!-- Reviewable:end -->
