### PR TITLE
SF-2769 Mark the Scripture Reference box as touched on dialog close

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -289,6 +289,22 @@ describe('QuestionDialogComponent', () => {
     expect(env.component.scriptureEnd.dirty).toBe(true);
   }));
 
+  it('control marked as touched after reference chooser closed', fakeAsync(() => {
+    env = new TestEnvironment();
+    when(env.mockedScriptureChooserMatDialogRef.afterOpened()).thenReturn(of());
+    when(env.mockedScriptureChooserMatDialogRef.afterClosed()).thenReturn(of('close'));
+    flush();
+
+    env.clickElement(env.scriptureStartInputIcon);
+    flush();
+
+    verify(env.dialogServiceSpy.openMatDialog(anything(), anything())).once();
+    flush();
+
+    expect(env.component.scriptureStart.touched).toBe(true);
+    expect(env.component.scriptureStart.dirty).toBe(false);
+  }));
+
   it('passes start reference to end-reference chooser', fakeAsync(() => {
     env = new TestEnvironment();
     flush();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
-import { MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { cloneDeep } from 'lodash-es';
@@ -241,8 +241,8 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
       });
     }
     dialogRef.afterClosed().subscribe(result => {
+      control.markAsTouched();
       if (result != null && result !== 'close') {
-        control.markAsTouched();
         control.markAsDirty();
         control.setValue(result.toString());
       }


### PR DESCRIPTION
This PR updates the Scripture Reference box in the Add Question dialog to be marked as touched when the Scripture picker dialog is closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2542)
<!-- Reviewable:end -->
