### PR TITLE
Make error ID in error dialog monospace

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
@@ -4,7 +4,12 @@
     <p>{{ data.message }}</p>
     <p [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></p>
     <p *ngIf="browserUnsupported" class="unsupported-browser" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
-    <p class="error-id">{{ t("error_id", { errorId: data.eventId }) }}</p>
+    <p>
+      <ng-container *ngFor="let portion of i18n.interpolateVariables('error.error_id', { errorId: data.eventId })">
+        <ng-container *ngIf="portion.id == null">{{ portion.text }}</ng-container>
+        <span *ngIf="portion.id === 'errorId'" class="error-id">{{ portion.text }}</span>
+      </ng-container>
+    </p>
 
     <ng-container *ngIf="data.stack">
       <a (click)="this.showDetails = !this.showDetails">{{ showDetails ? t("hide_details") : t("show_details") }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.scss
@@ -15,3 +15,7 @@ mat-dialog-content {
     overflow-x: auto;
   }
 }
+
+.error-id {
+  font-family: monospace;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
@@ -4,13 +4,18 @@ import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { mock } from 'ts-mockito';
+import { FeatureFlagService } from '../feature-flags/feature-flag.service';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { ErrorAlertData, ErrorDialogComponent } from './error-dialog.component';
 
+const mockedFeatureFlagService = mock(FeatureFlagService);
+
 describe('ErrorDialogComponent', () => {
   configureTestingModule(() => ({
-    imports: [DialogTestModule]
+    imports: [DialogTestModule],
+    providers: [{ provide: FeatureFlagService, useMock: mockedFeatureFlagService }]
   }));
 
   let overlayContainer: OverlayContainer;
@@ -35,7 +40,7 @@ describe('ErrorDialogComponent', () => {
 
     expect(env.errorMessage.textContent).toBe(dialogData.message);
     expect(env.showDetails?.textContent).toBe('Show details');
-    expect(env.errorId.textContent).toBe(`Error ID: ${dialogData.eventId}`);
+    expect(env.errorId.textContent).toBe(dialogData.eventId);
     expect(env.stackTrace).toBeNull();
 
     env.showDetails?.click();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.stories.ts
@@ -49,7 +49,7 @@ const defaultArgs = {
   dialogData: {
     message: 'The error message',
     stack: 'Error Stack line 1\nError Stack line 2\nError Stack line 3',
-    eventId: '12345'
+    eventId: '667adf9d90c462f4d7f3f6b8'
   }
 };
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
@@ -1,7 +1,8 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { browserLinks, getLinkHTML, issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
+import { I18nService } from '../i18n.service';
 
 export interface ErrorAlertData {
   message: string;
@@ -21,7 +22,8 @@ export class ErrorDialogComponent {
 
   constructor(
     public dialogRef: MatDialogRef<ErrorDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: ErrorAlertData
+    @Inject(MAT_DIALOG_DATA) public data: ErrorAlertData,
+    readonly i18n: I18nService
   ) {}
 
   get browserLinks(): { chromeLink: string; firefoxLink: string; safariLink: string } {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -111,7 +111,7 @@ describe('I18nService', () => {
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });
 
-  it('should interpolate translations', () => {
+  it('should interpolate translations around and within numbered template tags', () => {
     when(mockedTranslocoService.translate<string>('app.settings', anything())).thenReturn(
       'A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.'
     );
@@ -122,6 +122,19 @@ describe('I18nService', () => {
       { text: ' jumps over the lazy ' },
       { text: 'dog', id: 3 },
       { text: '.' }
+    ]);
+  });
+
+  it('should interpolate translations around template variables', () => {
+    when(mockedTranslocoService.getActiveLang()).thenReturn('en');
+    when(mockedTranslocoService.getTranslation('en')).thenReturn({
+      'error.to_report_issue_email': 'Please email {{ email }} for help.'
+    });
+    const service = getI18nService();
+    expect(service.interpolateVariables('error.to_report_issue_email', { email: 'email@example.com' })).toEqual([
+      { text: 'Please email ' },
+      { text: 'email@example.com', id: 'email' },
+      { text: ' for help.' }
     ]);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -98,8 +98,6 @@ export class I18nService {
 
   private currentLocale$ = new BehaviorSubject<Locale>(defaultLocale);
 
-  private interpolationCache: { [key: string]: { text: string; id?: number }[] } = {};
-
   constructor(
     locationService: LocationService,
     private readonly bugsnagService: BugsnagService,
@@ -284,6 +282,40 @@ export class I18nService {
   }
 
   /**
+   * Given a translation string like `Please email {{ email }} for help.` and a params object like
+   * `{ email: 'help@example.com' }`, this function will return an array of objects like:
+   * `[
+   *  { text: 'Please email ' },
+   *  { text: 'help@example.com', id: 'email' },
+   *  { text: ' for help.' }
+   * ]`
+   * This array can then be iterated in the view and based on the value of the id, either a plain string added to the
+   * view, or a link for the email address.
+   */
+  interpolateVariables(key: I18nKey, params: object = {}): { text: string; id?: string }[] {
+    const translation: string = this.transloco.getTranslation(this.transloco.getActiveLang())[key];
+
+    // find instances of "Some {{ variable }} text"
+    const regex = /\{\{\s*(\w+)\s*\}\}/g;
+
+    const sections: { text: string; id?: string }[] = [];
+    let i = 0;
+    for (const match of translation.matchAll(regex)) {
+      const variableWithBraces = match[0];
+      const variable = match[1];
+      // Add the text before the variable
+      sections.push({ text: translation.substring(i, match.index) });
+      // Add the variable itself
+      sections.push({ text: params[variable], id: variable });
+      // The index on a match can only be undefined when calling String.prototype.match with a non-global regex
+      i = match.index! + variableWithBraces.length;
+    }
+    sections.push({ text: translation.substring(i) });
+
+    return sections;
+  }
+
+  /**
    * Looks up a given translation and then breaks it up into chunks according it its numbered tags. For example, a
    * translation of 'A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.'
    * would result in an array of items as shown below:
@@ -299,36 +331,24 @@ export class I18nService {
    * that reorder "fox" and "dog".
    */
   interpolate(key: I18nKey, params?: HashMap): { text: string; id?: number }[] {
-    const hashKey = this.localeCode + ' ' + key;
-    if (this.interpolationCache[hashKey] != null) {
-      return this.interpolationCache[hashKey];
-    }
-
     const translation: string = this.transloco.translate(key, params);
     // find instances of "{ 1 } text { 2 }"
     const regex = /\{\s*\d+\s*\}(.*?)\{\s*\d+\s*\}/g;
-    const matches: RegExpExecArray[] = [];
-
-    // ES2020 introduces string.matchAll(regex), but as of the time of writing SF is using ES2018
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(translation)) !== null) {
-      matches.push(match);
-    }
 
     const sections: { text: string; id?: number }[] = [];
     let i = 0;
-    for (const match of matches) {
+    for (const match of translation.matchAll(regex)) {
       const fullMatchText = match[0];
       const matchInnerText = match[1];
       sections.push({ text: translation.substring(i, match.index) });
       const id = Number.parseInt(fullMatchText.match(/\d+/)![0], 10);
       sections.push({ text: matchInnerText, id });
-      i = match.index + fullMatchText.length;
+      // The index on a match can only be undefined when calling String.prototype.match with a non-global regex
+      i = match.index! + fullMatchText.length;
     }
     sections.push({ text: translation.substring(i) });
 
-    this.interpolationCache[hashKey] = sections.filter(section => !(section.text === '' && section.id == null));
-    return this.interpolationCache[hashKey];
+    return sections;
   }
 
   /**


### PR DESCRIPTION
This PR could also be title *Add new i18n interpolation function*, as that's what most of the change ended up being.

---

Users often send us screenshots of the error dialog, requiring me to use an OCR to extract the error ID from the error dialog. The OCR often makes mistakes, and I think making the error ID monospaced may help with that.

Trying to add that sent me down a rabbit hole to add better support for mixing localized strings with HTML elements.

`I18nService` has `translateTextAroundTemplateTags` which works with strings like this:
``` js
"Administrators can always invite people from the {{ templateTagBoundary }}Users{{ templateTagBoundary }} page."
```
The drawbacks are:
1. Requires planning ahead of time to use `templateTagBoundary` prior to translators translating the string.
2. Only works for a single item in the string (it returns an object of the type `{ before: string; templateTagText: string; after: string; }`)

`I18nService` also has `interpolate`, which can work with strings of the form:
``` js
"For more information, { 1 } see the help site{ 2 }.",
```
This is great for when the text you want to format also needs to be translated. However, we don't have a good way (before this PR) to handle this very common type of string:
``` js
"Email {{ email }} for help."
```

A future improvement may be to combine `I18nService.interpolate` with the new `I18nService.interpolateVariables`, so this format of string will be supported:
``` js
"Write to {{ email }} if you need help { 1 }connecting a project.{ 2 }"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2545)
<!-- Reviewable:end -->
