### PR TITLE
Replace ID with class in history component to eliminate collisions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'history_chooser'">
-  <div id="toolbar" *ngIf="historyRevisions.length > 0">
-    <mat-form-field id="history-select" appearance="outline">
+  <div class="toolbar" *ngIf="historyRevisions.length > 0">
+    <mat-form-field class="history-select" appearance="outline">
       <mat-select
         [value]="selectedRevision"
         (selectionChange)="onSelectionChanged($event)"
@@ -12,7 +12,7 @@
     </mat-form-field>
 
     <button
-      id="show-diff"
+      class="show-diff"
       mat-button
       appBlurOnClick
       type="button"
@@ -25,7 +25,7 @@
 
     <button
       *ngIf="canRestoreSnapshot"
-      id="revert-history"
+      class="revert-history"
       mat-button
       type="button"
       (click)="revertToSnapshot()"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
@@ -4,11 +4,11 @@
   display: block;
 }
 
-#toolbar {
+.toolbar {
   display: flex;
   overflow: hidden;
 
-  #history-select {
+  .history-select {
     @include material-styles.dense_mat_select();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
@@ -204,15 +204,15 @@ describe('HistoryChooserComponent', () => {
     }
 
     get historySelect(): HTMLElement {
-      return this.fixture.nativeElement.querySelector('#history-select') as HTMLElement;
+      return this.fixture.nativeElement.querySelector('.history-select') as HTMLElement;
     }
 
     get revertHistoryButton(): HTMLElement {
-      return this.fixture.nativeElement.querySelector('#revert-history') as HTMLElement;
+      return this.fixture.nativeElement.querySelector('.revert-history') as HTMLElement;
     }
 
     get showDiffButton(): HTMLElement {
-      return this.fixture.nativeElement.querySelector('#show-diff') as HTMLElement;
+      return this.fixture.nativeElement.querySelector('.show-diff') as HTMLElement;
     }
 
     clickRevertHistoryButton(): void {


### PR DESCRIPTION
IDs [are supposed to be unique within a page:](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)
> The id [global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) defines an identifier (ID) which must be unique in the whole document. Its purpose is to identify the element when linking (using a [fragment identifier](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#fragment)), scripting, or styling (with [CSS](https://developer.mozilla.org/en-US/docs/Glossary/CSS)).


Consequently, components that may appear multiple times on the same page ought not to use IDs. 

In practice, this is an extremely minor concern, and I'm not aware of anything that breaks due to duplicating IDs.

I found the duplicate IDs by running this code (and these were the only duplicates I was able to find):

``` ts
setInterval(() => checkForDuplicateIds(), 500);

function checkForDuplicateIds(): void {
  const ids = Array.from(document.querySelectorAll('[id]')).map(e => e.id);

  const repeats = ids.filter((id, index) => ids.indexOf(id) !== index);

  console.log(repeats);
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2551)
<!-- Reviewable:end -->
