### PR TITLE
SF-961 Fix link from settings to sync when offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -8,6 +8,7 @@ import { CheckingAnswerExport } from 'realtime-server/lib/esm/scriptureforge/mod
 import { ProjectType, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { combineLatest, firstValueFrom } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -99,7 +100,8 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly onlineStatusService: OnlineStatusService,
     readonly i18n: I18nService,
     readonly authService: AuthService,
-    readonly featureFlags: FeatureFlagService
+    readonly featureFlags: FeatureFlagService,
+    private readonly activatedProjectService: ActivatedProjectService
   ) {
     super(noticeService);
     this.loading = true;
@@ -153,7 +155,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   }
 
   get projectId(): string {
-    return this.projectDoc?.id || '';
+    return this.activatedProjectService.projectId ?? '';
   }
 
   get projectParatextId(): string | undefined {


### PR DESCRIPTION
This is a trivial issue found several years ago, that the link from the settings page to the sync page was broken when the user was offline, because the project doc isn't loaded. At the time there wasn't a trivial fix, but the ActivatedProjectService makes it easy to just get the project ID from the URL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2553)
<!-- Reviewable:end -->
