### PR TITLE
SF-2687 Remove global styles for checkboxes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -364,7 +364,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   openFeatureFlagDialog(): void {
-    this.dialogService.openMatDialog(FeatureFlagsDialogComponent);
+    this.dialogService.openMatDialog(FeatureFlagsDialogComponent, { autoFocus: false });
   }
 
   private async showProjectDeletedDialog(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -64,14 +64,10 @@
                 <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
                   {{ t("enable_translation_suggestions") }}
                 </mat-checkbox>
-                <div>
-                  <div fxFlex="24px" class="indent"></div>
-                  <mat-hint
-                    fxFlex
-                    class="helper-text"
-                    [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                  ></mat-hint>
-                </div>
+                <p
+                  class="helper-text"
+                  [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
+                ></p>
               </div>
             </div>
           </ng-container>
@@ -83,10 +79,7 @@
               {{ t("enable_community_checking") }}
             </mat-checkbox>
           </div>
-          <div>
-            <div fxFlex="24px" class="indent"></div>
-            <mat-hint fxFlex class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</mat-hint>
-          </div>
+          <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
         </mat-card-content>
       </mat-card>
       <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -14,6 +14,14 @@
   padding-bottom: 16px;
 }
 
+.mat-mdc-checkbox {
+  --mdc-checkbox-state-layer-size: 18px;
+
+  ::ng-deep .mdc-label {
+    padding-inline-start: 6px !important;
+  }
+}
+
 .content {
   max-width: 512px;
   width: 100%;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -14,14 +14,6 @@
   padding-bottom: 16px;
 }
 
-.mat-mdc-checkbox {
-  --mdc-checkbox-state-layer-size: 18px;
-
-  ::ng-deep .mdc-label {
-    padding-inline-start: 6px !important;
-  }
-}
-
 .content {
   max-width: 512px;
   width: 100%;
@@ -93,26 +85,12 @@
       }
     }
 
-    p.helper-select,
-    .indented-field-row {
-      margin-top: 16px;
-    }
-
     .helper-text {
       margin: 0;
+      margin-inline-start: 44px;
       font-size: 14px;
-    }
-
-    .select-helper-text,
-    mat-error {
-      font-size: 14px;
-      margin-top: 10px;
     }
   }
-}
-
-#based-on-field {
-  max-width: calc(100% - 44px);
 }
 
 app-project-select {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -264,11 +264,9 @@
               </div>
               <div class="tool-setting" *ngIf="featureFlags.scriptureAudio.enabled">
                 <div class="tool-setting-field checkbox-field">
-                  <mat-checkbox
-                    formControlName="hideCommunityCheckingText"
-                    id="checkbox-hide-community-checking-text"
-                    >{{ t("hide_community_checking_text") }}</mat-checkbox
-                  >
+                  <mat-checkbox formControlName="hideCommunityCheckingText" id="checkbox-hide-community-checking-text">
+                    {{ t("hide_community_checking_text") }}
+                  </mat-checkbox>
                   <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
                   <app-write-status
                     [state]="getControlState('hideCommunityCheckingText')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -28,7 +28,6 @@
               </div>
               <ng-container *ngIf="mainSettingsLoaded">
                 <p class="helper-text">{{ t("select_project_or_resource") }}</p>
-                <mat-hint>{{ t("translation_suggestions_require_source_text") }}</mat-hint>
                 <div class="tool-setting-field">
                   <app-project-select
                     id="sourceParatextId"
@@ -44,6 +43,7 @@
                     [state]="getControlState('sourceParatextId')"
                     [formGroup]="form"
                     id="based-on-status"
+                    style="margin-block-end: 18px"
                   ></app-write-status>
                 </div>
                 <mat-error *ngIf="projectLoadingFailed && resourceLoadingFailed">
@@ -57,8 +57,8 @@
                 </mat-error>
               </ng-container>
             </div>
-            <div class="tool-setting" *ngIf="isBasedOnProjectSet">
-              <div class="tool-setting-field checkbox-field">
+            <div class="tool-setting">
+              <div *ngIf="isBasedOnProjectSet" class="tool-setting-field checkbox-field">
                 <mat-checkbox formControlName="translationSuggestionsEnabled" id="checkbox-translation-suggestions">
                   {{ t("translation_suggestions") }}
                 </mat-checkbox>
@@ -69,26 +69,20 @@
                   id="translation-suggestions-status"
                 ></app-write-status>
               </div>
-              <mat-hint
-                class="helper-text checkbox-helper-text"
-                [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-              ></mat-hint>
+              <mat-hint *ngIf="!isBasedOnProjectSet">{{ t("translation_suggestions_require_source_text") }}</mat-hint>
             </div>
             <div class="tool-setting">
               <div class="tool-setting-field checkbox-field">
                 <mat-checkbox formControlName="biblicalTermsEnabled" id="checkbox-biblical-terms">
                   {{ t("biblical_terms") }}
                 </mat-checkbox>
+                <app-info [text]="t('biblical_terms_will_be_enabled')"></app-info>
                 <app-write-status
                   [state]="getControlState('biblicalTermsEnabled')"
                   [formGroup]="form"
                   id="biblical-terms-status"
                 ></app-write-status>
               </div>
-              <mat-hint
-                class="helper-text checkbox-helper-text"
-                [innerHTML]="i18n.translateAndInsertTags('settings.biblical_terms_will_be_enabled')"
-              ></mat-hint>
               <mat-error *ngIf="biblicalTermsMessage">
                 <app-info
                   *ngIf="biblicalTermsMessage"
@@ -102,9 +96,8 @@
           </mat-card-content>
           <mat-card-content *ngIf="showPreTranslationSettings">
             <mat-card-title>{{ t("pre_translation_drafting") }}</mat-card-title>
-            <div class="tool-setting">
+            <div>
               <ng-container *ngIf="mainSettingsLoaded">
-                <p class="helper-text">{{ t("pre_translation_drafting_description") }}</p>
                 <div class="tool-setting">
                   <div class="tool-setting-field checkbox-field">
                     <mat-checkbox formControlName="alternateSourceEnabled" id="checkbox-alternate-source-enabled">{{
@@ -269,6 +262,21 @@
                   ></app-write-status>
                 </div>
               </div>
+              <div class="tool-setting" *ngIf="featureFlags.scriptureAudio.enabled">
+                <div class="tool-setting-field checkbox-field">
+                  <mat-checkbox
+                    formControlName="hideCommunityCheckingText"
+                    id="checkbox-hide-community-checking-text"
+                    >{{ t("hide_community_checking_text") }}</mat-checkbox
+                  >
+                  <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
+                  <app-write-status
+                    [state]="getControlState('hideCommunityCheckingText')"
+                    [formGroup]="form"
+                    id="hide-community-checking-text-status"
+                  ></app-write-status>
+                </div>
+              </div>
               <div>
                 <p class="helper-text">{{ t("export_checking_answers") }}</p>
                 <div class="tool-setting">
@@ -296,21 +304,6 @@
                       ></app-write-status>
                     </div>
                   </mat-radio-group>
-                </div>
-              </div>
-              <div class="tool-setting" *ngIf="featureFlags.scriptureAudio.enabled">
-                <div class="tool-setting-field checkbox-field">
-                  <mat-checkbox
-                    formControlName="hideCommunityCheckingText"
-                    id="checkbox-hide-community-checking-text"
-                    >{{ t("hide_community_checking_text") }}</mat-checkbox
-                  >
-                  <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
-                  <app-write-status
-                    [state]="getControlState('hideCommunityCheckingText')"
-                    [formGroup]="form"
-                    id="hide-community-checking-text-status"
-                  ></app-write-status>
                 </div>
               </div>
             </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -8,6 +8,14 @@
   padding-block-end: 10px;
 }
 
+.mat-mdc-checkbox {
+  --mdc-checkbox-state-layer-size: 18px;
+
+  ::ng-deep .mdc-label {
+    padding-left: 10px !important;
+  }
+}
+
 .mat-mdc-card {
   padding: 8px 4px;
 }
@@ -26,9 +34,6 @@
   }
 
   > .tool-setting-field {
-    &:not(:last-child) {
-      padding-bottom: 16px;
-    }
     column-gap: 10px;
 
     > app-write-status {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -12,7 +12,7 @@
   --mdc-checkbox-state-layer-size: 18px;
 
   ::ng-deep .mdc-label {
-    padding-left: 10px !important;
+    padding-inline-start: 10px !important;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -8,16 +8,12 @@
   padding-block-end: 10px;
 }
 
-.mat-mdc-checkbox {
-  --mdc-checkbox-state-layer-size: 18px;
-
-  ::ng-deep .mdc-label {
-    padding-inline-start: 10px !important;
-  }
-}
-
 .mat-mdc-card {
   padding: 8px 4px;
+}
+
+.mat-mdc-card-title {
+  margin-block-end: 16px;
 }
 
 .tool-setting {
@@ -34,9 +30,11 @@
   }
 
   > .tool-setting-field {
+    display: flex;
     column-gap: 10px;
 
     > app-write-status {
+      min-width: 24px;
       @include media-breakpoint-up(sm) {
         margin-inline-start: 22px;
       }
@@ -45,9 +43,6 @@
 
   > .helper-text {
     font-size: 14px;
-    &.checkbox-helper-text {
-      margin: 0 0 0 24px;
-    }
   }
   .mat-mdc-form-field-error {
     margin-top: 10px;
@@ -60,6 +55,11 @@
   }
 }
 
+mat-hint {
+  margin-block-start: 8px;
+  margin-block-end: 16px;
+}
+
 a {
   color: $blueMedium;
 }
@@ -70,7 +70,7 @@ mat-icon {
 }
 
 .indent {
-  margin-block-start: 4px;
+  margin-block-start: 16px;
   margin-inline-start: 16px;
   display: flex;
   column-gap: 8px;
@@ -133,12 +133,10 @@ mat-radio-group.tool-setting {
 .mat-mdc-card-content {
   display: flex;
   flex-direction: column;
-  row-gap: 16px;
-  margin: 0;
-}
 
-.mat-mdc-card-title {
-  margin: 0;
+  .mat-mdc-form-field {
+    width: 100%;
+  }
 }
 
 .mat-mdc-card-content:not(:first-child) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -436,7 +436,6 @@
     "pre_translation_alternate_source_info": "Select a different source for drafting, if your currently selected source is not to be used for pre-translation drafting.",
     "pre_translation_alternate_training_source_info": "Selecting a separate translation for training, such as a back translation, can improve drafting quality.",
     "pre_translation_alternate_training_source_text_placeholder": "Alternate training source text (optional)",
-    "pre_translation_drafting_description": "Configure options for generating translation drafts.",
     "pre_translation_additional_training_source_info": "Select another translation in the source language to combine with your training source",
     "pre_translation_additional_training_source_text_placeholder": "Additional training source text (optional)",
     "pre_translation_send_all_segments": "Pre-translate headings and non-verse material",

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -83,34 +83,9 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   }
 }
 
-// Decrease the padding around a checkbox to be 0px as spacing is instead usually applied in other ways e.g. padding on
-// containing element or table row-gap
-.mat-mdc-checkbox {
-  --mdc-checkbox-state-layer-size: 18px;
-
-  .mat-mdc-checkbox-ripple,
-  .mdc-checkbox__ripple {
-    top: -6px;
-    left: -6px;
-    right: -6px;
-    bottom: -6px;
-  }
-
-  label {
-    padding-left: 6px !important;
-  }
-}
-
 // Make checkbox labels inherit parent element's font-weight e.g. if within a table heading
 .mat-mdc-checkbox .mdc-form-field {
   font-weight: inherit !important;
-}
-
-// Remove the ripple background for checkbox focus state to emulate pre-MDC behavior
-.mat-mdc-checkbox {
-  .mdc-checkbox__native-control:focus ~ .mdc-checkbox__ripple {
-    opacity: 0 !important;
-  }
 }
 
 .mat-progress-bar--closed {

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -83,6 +83,10 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   }
 }
 
+.mat-mdc-checkbox {
+  --mdc-checkbox-unselected-focus-state-layer-opacity: 0.08;
+}
+
 // Make checkbox labels inherit parent element's font-weight e.g. if within a table heading
 .mat-mdc-checkbox .mdc-form-field {
   font-weight: inherit !important;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
@@ -7,18 +7,9 @@
 .mat-mdc-dialog-content {
   display: flex;
   flex-direction: column;
-  row-gap: 0.5em;
 }
 
 app-notice {
   max-width: 25em;
   margin: 1em 0;
-}
-
-.mat-mdc-checkbox {
-  --mdc-checkbox-state-layer-size: 18px;
-
-  ::ng-deep .mdc-label {
-    padding-inline-start: 10px !important;
-  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
@@ -14,3 +14,11 @@ app-notice {
   max-width: 25em;
   margin: 1em 0;
 }
+
+.mat-mdc-checkbox {
+  --mdc-checkbox-state-layer-size: 18px;
+
+  ::ng-deep .mdc-label {
+    padding-inline-start: 10px !important;
+  }
+}


### PR DESCRIPTION
This fixes a click area bug in roles and permissions dialog.

I did need a couple of these rules in the settings page, since the whole page is structured off the assumption that the checkboxes are that height. Using the default sizing really messes with the page layout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2557)
<!-- Reviewable:end -->
