### PR TITLE
SF-2763 Fix history header on small screen widths

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.scss
@@ -13,8 +13,6 @@
     --sf-tab-header-inactive-button-hover-background-color: #c0c0c0;
     --sf-tab-header-button-hover-background-color: #e0e0e0;
     --sf-tab-header-group-scroll-button-background-color: #f7f7f7;
-
-    --sf-tab-toolbar-height: 57px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
@@ -28,7 +28,6 @@ app-notice {
   justify-content: flex-end;
   padding: 0.5em;
   border-bottom: 1px solid var(--sf-tab-group-border-color);
-  height: var(--sf-tab-toolbar-height);
 }
 
 .draft-indicator {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
@@ -17,7 +17,6 @@ app-history-chooser {
   top: 0;
   background: #fff;
   z-index: 1;
-  height: var(--sf-tab-toolbar-height);
 }
 
 app-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
@@ -7,6 +7,7 @@
 .toolbar {
   display: flex;
   overflow: hidden;
+  flex-wrap: wrap;
 
   .history-select {
     @include material-styles.dense_mat_select();


### PR DESCRIPTION
This involved removing the hardcoded toolbar height. This code didn't appear to be actually changing anything, as removing the setting had no effect (other than allowing the toolbar to grow when wrapping).