### PR TITLE
Fix realtime server origin on QA

### DIFF
--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -34,7 +34,7 @@ cat <<EOF > "$BUILD_OUTPUT/app/secrets.json"
     "WebhookPassword": "${AUTH_WEBHOOK_PASSWORD}"
   },
   "Site": {
-    "Origin": "https://scriptureforge.org;${ALTERNATE_DOMAIN}",
+    "Origin": "https://${HOSTNAME};${ALTERNATE_DOMAIN}",
   }
 }
 EOF


### PR DESCRIPTION
This PR fixes an issue on QA, where the realtime server is blocking all requests because it expects them from scriptureforge.org, not qa.scriptureforge.org.

A new QA deployment should be made after this PR is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2565)
<!-- Reviewable:end -->
