### PR TITLE
Simplify history chooser styles

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
@@ -1,26 +1,11 @@
 @use 'src/material-styles';
 
-:host {
-  display: block;
-}
-
 .toolbar {
   display: flex;
-  overflow: hidden;
   flex-wrap: wrap;
+  gap: 4px;
+}
 
-  .history-select {
-    @include material-styles.dense_mat_select();
-  }
-
-  mat-form-field {
-    height: auto;
-  }
-
-  button {
-    margin-left: 5px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+.history-select {
+  @include material-styles.dense_mat_select();
 }


### PR DESCRIPTION
### Before, LTR
- No vertical spacing
- Button on second line not left-aligned
![](https://github.com/sillsdev/web-xforge/assets/6140710/b2272d3f-80a1-4f70-b2ac-f9a6cb582497)

### Before, RTL
- No spacing between anything
![](https://github.com/sillsdev/web-xforge/assets/6140710/07240dcd-ae94-489b-9896-2924a248fa66)

### After
![](https://github.com/sillsdev/web-xforge/assets/6140710/d6806c9f-77fe-4d4c-b798-e6db9c99f966)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2566)
<!-- Reviewable:end -->
