### PR TITLE
SF-2825 Place Additional Training Source behind a Feature Flag

### DIFF
--- a/scripts/db_tools/parse-version.ts
+++ b/scripts/db_tools/parse-version.ts
@@ -35,7 +35,8 @@ class ParseVersion {
     'Use Serval for Suggestions',
     'Use Echo for Pre-Translation Drafting',
     'Allow Fast Pre-Translation Training',
-    'Upload Paratext Zip Files for Pre-Translation Drafting'
+    'Upload Paratext Zip Files for Pre-Translation Drafting',
+    'Allow mixing in an additional training source'
   ];
 
   constructor() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -167,7 +167,10 @@
                     id="alternate-training-source-status"
                   ></app-write-status>
                 </div>
-                <div class="tool-setting">
+                <div
+                  *ngIf="isAdditionalTrainingSourceEnabled || featureFlags.allowAdditionalTrainingSource.enabled"
+                  class="tool-setting"
+                >
                   <div class="tool-setting-field checkbox-field">
                     <mat-checkbox
                       formControlName="additionalTrainingSourceEnabled"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -683,13 +683,35 @@ describe('SettingsComponent', () => {
         expect(env.additionalTrainingSourceSelect).toBeNull();
       }));
 
-      it('should not display when the feature flag is disabled', fakeAsync(() => {
+      it('should not display when the nmt drafting feature flag is disabled', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject();
         when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
         env.wait();
         env.wait();
         expect(env.additionalTrainingSourceSelect).toBeNull();
+      }));
+
+      it('should not display when the additional training source feature flag is disabled', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject();
+        when(mockedFeatureFlagService.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(false));
+        env.wait();
+        expect(env.additionalTrainingSourceCheckbox).toBeNull();
+      }));
+
+      it('should display when the feature flag is disabled and the additional source is enabled', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          preTranslate: true,
+          draftConfig: {
+            additionalTrainingSourceEnabled: true
+          } as DraftConfig
+        });
+        when(mockedFeatureFlagService.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(false));
+        env.wait();
+        expect(env.additionalTrainingSourceCheckbox).not.toBeNull();
+        expect(env.inputElement(env.additionalTrainingSourceCheckbox).checked).toBe(true);
       }));
 
       it('should not display for forward translations when not approved', fakeAsync(() => {
@@ -1274,6 +1296,7 @@ class TestEnvironment {
     ]);
     when(mockedFeatureFlagService.scriptureAudio).thenReturn(createTestFeatureFlag(true));
     when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(true));
+    when(mockedFeatureFlagService.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(true));
 
     when(mockedSFProjectService.queryAudioText(anything())).thenCall(sfProjectId => {
       const queryParams: QueryParameters = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -297,6 +297,13 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
+  readonly allowAdditionalTrainingSource: FeatureFlag = new FeatureFlagFromStorage(
+    'AllowAdditionalTrainingSource',
+    'Allow mixing in an additional training source',
+    13,
+    this.featureFlagStore
+  );
+
   get featureFlags(): FeatureFlag[] {
     return Object.values(this).filter(value => value instanceof FeatureFlagFromStorage);
   }


### PR DESCRIPTION
This PR hides the Mixed source UI in Settings behind a feature flag.

If the feature is enabled, then the UI will display, if it is disabled then it will only display if the feature flag is enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2568)
<!-- Reviewable:end -->
