### PR TITLE
SF-2830 Optimise the syncing of notes to Paratext

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -53,7 +53,6 @@ public interface IParatextService
     Task<SyncMetricInfo> UpdateParatextCommentsAsync(
         UserSecret userSecret,
         string paratextId,
-        int? bookNum,
         IEnumerable<IDocument<NoteThread>> noteThreadDocs,
         IReadOnlyDictionary<string, string> userIdsToUsernames,
         Dictionary<string, ParatextUserProfile> ptProjectUsers,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1315,7 +1315,6 @@ public class ParatextService : DisposableBase, IParatextService
     public async Task<SyncMetricInfo> UpdateParatextCommentsAsync(
         UserSecret userSecret,
         string paratextId,
-        int? bookNum,
         IEnumerable<IDocument<NoteThread>> noteThreadDocs,
         IReadOnlyDictionary<string, string> displayNames,
         Dictionary<string, ParatextUserProfile> ptProjectUsers,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2638,7 +2638,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             ptProjectId,
-            40,
             noteThreadDocs,
             env.usernames,
             ptProjectUsers,
@@ -2717,7 +2716,6 @@ public class ParatextServiceTests
         var syncMetricsInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             paratextUsers,
@@ -2790,7 +2788,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             ptProjectId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -2888,7 +2885,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             ptProjectId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -2990,7 +2986,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             ptProjectId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3062,7 +3057,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3167,7 +3161,6 @@ public class ParatextServiceTests
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3263,7 +3256,6 @@ public class ParatextServiceTests
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3322,7 +3314,6 @@ public class ParatextServiceTests
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             ptProjectId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3395,7 +3386,6 @@ public class ParatextServiceTests
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             new[] { noteThreadDoc },
             env.usernames,
             ptProjectUsers,
@@ -3441,7 +3431,6 @@ public class ParatextServiceTests
         await env.Service.UpdateParatextCommentsAsync(
             userSecret,
             paratextId,
-            40,
             emptyDocs,
             env.usernames,
             ptProjectUsers,
@@ -3487,7 +3476,6 @@ public class ParatextServiceTests
                 env.Service.UpdateParatextCommentsAsync(
                     userSecret,
                     paratextId,
-                    40,
                     new[] { noteThreadDoc },
                     env.usernames,
                     ptProjectUsers,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1720,7 +1720,6 @@ public class ParatextSyncRunnerTests
         env.ParatextService.UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                40,
                 Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),
@@ -1734,7 +1733,6 @@ public class ParatextSyncRunnerTests
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                40,
                 Arg.Is<IEnumerable<IDocument<NoteThread>>>(t => t.Count() == 1 && t.First().Id == "project01:dataId01"),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),
@@ -1760,7 +1758,6 @@ public class ParatextSyncRunnerTests
         env.ParatextService.UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                40,
                 Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),
@@ -1774,7 +1771,6 @@ public class ParatextSyncRunnerTests
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                40,
                 Arg.Is<IEnumerable<IDocument<NoteThread>>>(t => t.Single().Id == "project01:dataId01"),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),
@@ -2654,7 +2650,6 @@ public class ParatextSyncRunnerTests
         env.ParatextService.UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                null,
                 Arg.Any<IEnumerable<IDocument<NoteThread>>>(),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),
@@ -2668,7 +2663,6 @@ public class ParatextSyncRunnerTests
             .UpdateParatextCommentsAsync(
                 Arg.Any<UserSecret>(),
                 "target",
-                null,
                 Arg.Is<IEnumerable<IDocument<NoteThread>>>(t => t.Single().Id == "project01:dataId01"),
                 Arg.Any<Dictionary<string, string>>(),
                 Arg.Any<Dictionary<string, ParatextUserProfile>>(),


### PR DESCRIPTION
This PR optimizes the syncing of notes to Paratext by optimizing the code that writes each book's notes to Paratext to only run once per project (well twice if you include the writing of biblical terms notes).

This is possible because previous work done to SF made the use of the book number sent to `ParatextService.UpdateParatextCommentsAsync()` to be redundant.

This change results in a speed increase when syncing projects with a many books and many notes, especially if few notes are created or edited in Scripture Forge. In my test project that has a full canon and note for every verse, a 2.5 minute sync was reduced to 2 minutes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2569)
<!-- Reviewable:end -->
