### PR TITLE
Hide share expiration radio button

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -76,7 +76,7 @@
           </a>
         </div>
         <mat-menu #expireMenu>
-          <mat-selection-list [multiple]="false" *ngIf="linkExpirationOptions.length > 1">
+          <mat-selection-list [multiple]="false" *ngIf="linkExpirationOptions.length > 1" hideSingleSelectionIndicator>
             <mat-list-option
               *ngFor="let key of linkExpirationOptions"
               [selected]="ShareExpiration[key] === shareExpiration"


### PR DESCRIPTION
At some point this must've gotten overwritten accidentally. The menu should look like:
![image](https://github.com/sillsdev/web-xforge/assets/43733878/dae75697-419f-4dab-a971-b160b247b61a)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2570)
<!-- Reviewable:end -->
