### PR TITLE
SF-2768 Join component supresses unknown errors

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -330,6 +330,7 @@ describe('ConnectProjectComponent', () => {
     env.clickElement(env.submitButton);
     tick();
     env.fixture.detectChanges();
+    tick();
 
     verify(mockedParatextService.getProjects()).once();
     verify(mockedParatextService.getResources()).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -198,7 +198,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
         }
 
         err.message = this.translocoService.translate('connect_project.problem_already_connected');
-        this.errorHandler.handleError(err);
+        await this.errorHandler.handleError(err);
         this.state = 'input';
         this.populateProjectList();
         return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -96,6 +96,7 @@ describe('JoinComponent', () => {
     new TestEnvironment({ callback, isLoggedIn: true });
 
     verify(mockedDialogService.message(anything())).once();
+    verify(mockedErrorHandler.handleError(anything())).never();
     verify(mockedRouter.navigateByUrl('/projects', anything())).once();
     expect().nothing();
   }));
@@ -171,6 +172,7 @@ describe('JoinComponent', () => {
       new TestEnvironment({ callback });
 
       verify(mockedDialogService.message(anything())).once();
+      verify(mockedErrorHandler.handleError(anything())).never();
       verify(mockedLocationService.go('/')).once();
       expect().nothing();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -115,7 +115,7 @@ export class JoinComponent extends DataLoadingComponent {
         this.name.enable();
       }
     } catch (e) {
-      await this.handleErrorJoining(e);
+      await this.handleJoiningError(e);
       this.locationService.go(this.locationService.origin);
     }
     this.status = 'input';
@@ -137,7 +137,7 @@ export class JoinComponent extends DataLoadingComponent {
       const projectId = await this.projectService.onlineJoinWithShareKey(shareKey);
       this.router.navigateByUrl(`/projects/${projectId}`, { replaceUrl: true });
     } catch (err) {
-      this.handleErrorJoining(err);
+      await this.handleJoiningError(err);
       this.router.navigateByUrl('/projects', { replaceUrl: true });
     }
   }
@@ -153,7 +153,7 @@ export class JoinComponent extends DataLoadingComponent {
     try {
       this.joiningResponse = await this.anonymousService.checkShareKey(shareKey);
     } catch (e) {
-      await this.handleErrorJoining(e);
+      await this.handleJoiningError(e);
       this.locationService.go(this.locationService.origin);
     } finally {
       this.loadingFinished();
@@ -177,7 +177,7 @@ export class JoinComponent extends DataLoadingComponent {
     await this.dialogService.message(`join.${key}`);
   }
 
-  private async handleErrorJoining(error: any): Promise<void> {
+  private async handleJoiningError(error: any): Promise<void> {
     const KNOWN_ERROR_CODES: ObjectPaths<typeof en.join>[] = [
       'error_occurred_login',
       'key_already_used',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -183,7 +183,8 @@ export class JoinComponent extends DataLoadingComponent {
       'key_already_used',
       'key_expired',
       'max_users_reached',
-      'role_not_found'
+      'role_not_found',
+      'project_link_is_invalid'
     ];
 
     const isKnownJoinError = (code: any): code is ObjectPaths<typeof en.join> => KNOWN_ERROR_CODES.includes(code);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, Injector, NgZone } from '@angular/core';
 import Bugsnag, { Breadcrumb, BrowserConfig } from '@bugsnag/js';
 import { translate } from '@ngneat/transloco';
+import { firstValueFrom } from 'rxjs';
 import versionData from '../../../version.json';
 import { MACHINE_API_BASE_URL } from '../app/machine-api/http-client';
 import { environment } from '../environments/environment';
@@ -232,7 +233,7 @@ export class ExceptionHandlingService {
         // Don't show a dialog if this is a silent error that we just want sent to Bugsnag
         if (!silently) {
           const stack = hasStringProp(error, 'stack') ? error.stack : undefined;
-          this.handleAlert(ngZone, dialogService, { message, stack, eventId });
+          await this.handleAlert(ngZone, dialogService, { message, stack, eventId });
         }
       } finally {
         // add the pwa installed status here at the moment of reporting an error since the app can be
@@ -256,26 +257,25 @@ export class ExceptionHandlingService {
     });
   }
 
-  private handleAlert(ngZone: NgZone, dialogService: DialogService, error: ErrorAlertData): void {
+  private async handleAlert(ngZone: NgZone, dialogService: DialogService, error: ErrorAlertData): Promise<void> {
     if (!this.alertQueue.some(alert => alert.message === error.message)) {
       this.alertQueue.unshift(error);
-      this.showAlert(ngZone, dialogService);
+      await this.showAlert(ngZone, dialogService);
     }
   }
 
-  private showAlert(ngZone: NgZone, dialogService: DialogService): void {
+  private async showAlert(ngZone: NgZone, dialogService: DialogService): Promise<void> {
     if (!this.dialogOpen && this.alertQueue.length) {
-      ngZone.run(() => {
+      await ngZone.run(async () => {
         this.dialogOpen = true;
         const dialogRef = dialogService.openMatDialog(ErrorDialogComponent, {
           autoFocus: false,
           data: this.alertQueue[this.alertQueue.length - 1]
         });
-        dialogRef.afterClosed().subscribe(() => {
-          this.alertQueue.pop();
-          this.dialogOpen = false;
-          this.showAlert(ngZone, dialogService);
-        });
+        await firstValueFrom(dialogRef.afterClosed());
+        this.alertQueue.pop();
+        this.dialogOpen = false;
+        await this.showAlert(ngZone, dialogService);
       });
     }
   }


### PR DESCRIPTION
* Make the error handler async
* Remove redundant test
* Update tests to return expected response codes
* Use error handler on unknown join errors

For testing an unknown error you can create a share key, expiry it, and then comment out `key_expired` as a known error code. I'm not sure of an easier way to do this for the test team.

As error dialogs are now async there will need to be a good amount of testing to make sure there aren't any side effects that need to be tidied up for existing errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2572)
<!-- Reviewable:end -->
