### PR TITLE
SF-2828 Remove the delete user button on self on system admin page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -35,9 +35,11 @@
       </ng-container>
       <ng-container matColumnDef="remove">
         <td mat-cell *matCellDef="let userRow" class="remove-cell">
+          @if(currentUserId != userRow.id) {
           <button mat-icon-button class="remove-user" (click)="removeUser(userRow.id, userRow.user)">
             <mat-icon>close</mat-icon>
           </button>
+          }
         </td>
       </ng-container>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -35,7 +35,7 @@
       </ng-container>
       <ng-container matColumnDef="remove">
         <td mat-cell *matCellDef="let userRow" class="remove-cell">
-          @if(currentUserId != userRow.id) {
+          @if(currentUserId !== userRow.id) {
           <button mat-icon-button class="remove-user" (click)="removeUser(userRow.id, userRow.user)">
             <mat-icon>close</mat-icon>
           </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.scss
@@ -15,7 +15,6 @@ table {
 
 .mat-column-name {
   padding-right: 0.5em;
-  word-break: break-word;
 }
 
 .mat-column-projects {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.spec.ts
@@ -90,7 +90,7 @@ describe('SaUsersComponent', () => {
     expect(env.cellDisplayName(0, 1).innerText).toEqual('Test user 1');
     expect(env.cellName(0, 1).innerText).toEqual('Name of test user 1');
     expect(env.cellProjectLink(0, 2).text).toEqual('Project 01');
-    expect(env.removeUserButtonOnRow(0)).not.toBeNull();
+    expect(env.removeUserButtonOnRow(0)).toBeNull();
 
     expect(env.cellDisplayName(1, 1).innerText).toEqual('Test user 2');
     expect(env.cellName(1, 1).innerText).toEqual('Name of test user 2');
@@ -191,7 +191,7 @@ class TestEnvironment {
       const query = await this.realtimeService.onlineQuery<TestProjectDoc>(TestProjectDoc.COLLECTION, {});
       return query.docs;
     });
-
+    when(mockedUserService.currentUserId).thenReturn('user01');
     this.fixture = TestBed.createComponent(SaUsersComponent);
     this.component = this.fixture.componentInstance;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -54,6 +54,10 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
     super(noticeService);
   }
 
+  get currentUserId(): string {
+    return this.userService.currentUserId;
+  }
+
   ngOnInit(): void {
     this.loadingStarted();
     this.subscribe(


### PR DESCRIPTION
Prevent logged in admin user from deleting their user in the System Administration page.
Removed word-break css so username displays nicely

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2573)
<!-- Reviewable:end -->
