### PR TITLE
Change the history restore icon to "undo"

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
@@ -31,7 +31,7 @@
       (click)="revertToSnapshot()"
       matTooltip="{{ t('revert_details') }}"
     >
-      <mat-icon class="material-icons-outlined">restore_page</mat-icon>
+      <mat-icon class="material-icons-outlined">undo</mat-icon>
       {{ t("revert") }}
     </button>
   </div>


### PR DESCRIPTION
Previously
![image](https://github.com/sillsdev/web-xforge/assets/17464863/d9fafaee-c771-41ed-9d2c-96c0a0738e56)

Now
![image](https://github.com/sillsdev/web-xforge/assets/17464863/ad7bcc4a-0cd9-4ea7-8491-e318f19ecf87)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2574)
<!-- Reviewable:end -->
