### PR TITLE
SF-2711 Do not display sync complete before ops are written to Mongo

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1572,7 +1572,13 @@ public class ParatextSyncRunnerTests
                     string.Join('.', new ObjectPath(ex).Items) == "Sync.DataInSync"
                 )
             );
-        env.Connection.Received(2).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
+        env.Connection.Received(1)
+            .ExcludePropertyFromTransaction(
+                Arg.Is<Expression<Func<SFProject, object>>>(ex =>
+                    string.Join('.', new ObjectPath(ex).Items) == "Sync.LastSyncSuccessful"
+                )
+            );
+        env.Connection.Received(3).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
     }
 
     [Test]


### PR DESCRIPTION
This PR executes the ops that run outside of the transaction to run after the translation is committed or rolled back.

This ensures that the sync is displayed as complete only when it is complete. It also means that actions that modify the project data are not committed outside of the transaction.

As a part of this change, the backup of the Paratext repository now takes place before the transaction is committed. This is because the contents of the repo have been already synced to the Paratext Send/Receive server. If a failure (hypothetically) occurs during the `CommitTransactionAsync()`, then the next sync will just wind the repo back to the appropriate Mercurial commit id when the backup is restored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2575)
<!-- Reviewable:end -->
