### PR TITLE
SF-2826 Fix sync error badge in firefox

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
@@ -75,6 +75,7 @@ mat-nav-list .mdc-list-item {
   font-size: 1.4rem;
   inset-inline-end: -7px;
   top: -7px;
+  width: auto; // Fixes broken badge icon in Firefox
 }
 
 .navigation-header {


### PR DESCRIPTION
Added `width: auto` override to the badge.  Not sure why, but this fixes it in Firefox.
![image](https://github.com/sillsdev/web-xforge/assets/133386342/2e76f556-8ca6-4dce-a2ab-da83a89afb00)
