### PR TITLE
SF-2833 Use Source USFM for pre-translation drafts

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -37,7 +37,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />
-    <PackageReference Include="Serval.Client" Version="1.4.1" />
+    <PackageReference Include="Serval.Client" Version="1.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -12,7 +12,6 @@ using SIL.XForge.Realtime;
 using SIL.XForge.Realtime.Json0;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
-using SIL.XForge.Utils;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -40,13 +39,6 @@ public class PreTranslationService(
         if (!(await projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
         {
             throw new DataNotFoundException("The project secret cannot be found.");
-        }
-
-        // Load the project from the realtime service
-        Attempt<SFProject> attempt = await realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
-        if (!attempt.TryResult(out SFProject project))
-        {
-            throw new DataNotFoundException("The project does not exist.");
         }
 
         // Ensure we have the parameters to retrieve the pre-translation
@@ -228,6 +220,7 @@ public class PreTranslationService(
             corpusId,
             GetTextId(bookNum),
             PretranslationUsfmTextOrigin.OnlyPretranslated,
+            PretranslationUsfmTemplate.Source,
             cancellationToken
         );
 

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -650,6 +650,7 @@ public class PreTranslationServiceTests
                     Arg.Any<string>(),
                     "MAT",
                     PretranslationUsfmTextOrigin.OnlyPretranslated,
+                    PretranslationUsfmTemplate.Source,
                     CancellationToken.None
                 )
                 .Returns(MatthewBookUsfm);


### PR DESCRIPTION
This PR adds support for using the source chapter's USFM structure, a feature currently on Serval QA.

While testing this feature, I noticed that documents were visually corrupted when applying drafts, particularly if the draft had different segments to the target, something that will be much more common when using the source USFM. I have resolved that issue by rather than updating the editor (which resulted in segments getting mashed), I rebind the editor when resotirng from history or applying a draft.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2579)
<!-- Reviewable:end -->
