### PR TITLE
Update dotnet dependencies

### DIFF
--- a/src/Help/UpdateHelp/UpdateHelp.csproj
+++ b/src/Help/UpdateHelp/UpdateHelp.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.60" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
   </ItemGroup>
 </Project>

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -26,14 +26,14 @@
     <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="31.0.3" />
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="NPOI" Version="2.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="NPOI" Version="2.7.1" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -8,14 +8,14 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Bugsnag.AspNet.Core" Version="3.1.0" />
     <PackageReference Include="EdjCase.JsonRpc.Router" Version="6.0.0" />
-    <PackageReference Include="Hangfire" Version="1.8.12" />
-    <PackageReference Include="Hangfire.Mongo" Version="1.10.5" />
-    <PackageReference Include="IdentityModel" Version="6.2.0" />
+    <PackageReference Include="Hangfire" Version="1.8.14" />
+    <PackageReference Include="Hangfire.Mongo" Version="1.10.7" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.4" />
-    <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
-    <PackageReference Include="MailKit" Version="4.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.7" />
+    <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+    <PackageReference Include="MailKit" Version="4.7.0" />
     <PackageReference Include="idunno.Authentication.Basic" Version="2.3.1" />
     <PackageReference Include="AbrarJahin.DiffMatchPatch" Version="0.1.0" />
     <PackageReference Include="SIL.Core" Version="13.0.1" />

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
This PR contains the following important updates:

**1. Update C# MongoDB.Driver from 2.24.0 to 2.27.0**
 * Release Notes: https://www.mongodb.com/docs/drivers/csharp/current/whats-new/
 * This adds support for newer Debian/Ubuntu based distros that use `libdl.so.2`.

**2. Update Hangfire from 1.8.12 to 1.8.14**
 * Release Notes: https://github.com/HangfireIO/Hangfire/releases
 * Bug fix release.

**3. Update Hangfire.Mongo 1.10.5 to 1.10.7**
 * Release Notes: https://github.com/gottscj/Hangfire.Mongo/releases
 * Supports the latest MongoDB driver, and the latest Hangfire.

**4. Update .NET 8.0 dependencies from 8.0.4 to 8.0.7**
 * Release Notes: https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.7/8.0.7.md.
 * This is a security fix.

**5. Other minor C# dependency updates**

* **Update IdentityModel from 6.2.0 to 7.0.0** (https://github.com/IdentityModel/IdentityModel/releases)
*This is used for JWT tokens. Improved support for .NET 8.0.*

* **Update CsvHelper from 31.0.3 to 33.0.1** (https://joshclose.github.io/CsvHelper/change-log/)
*This is used by the Serval additional file upload feature. Minor bug fix release.*

* **Update HtmlAgilityPack from 1.11.60 to 1.11.61** (https://github.com/zzzprojects/html-agility-pack/releases)
*This is used by UpdateHelp. Minor bug fix release.*

* **Update MailKit from 4.4.0 to 4.7.0** (https://github.com/jstedfast/MimeKit/blob/master/ReleaseNotes.md)
*This is used email invitation links. Minor bug fix release.*

* **Update Microsoft.FeatureManagement.AspNetCore from 3.2.0 to 3.4.0** (https://github.com/microsoft/FeatureManagement-Dotnet/releases)
*This is used for feature flags. Minor bug fix release.*

* **Update Microsoft.VisualStudio.Azure.Containers.Tools.Targets from 1.20.1 to 1.12.0** (https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets)
*This is used for Docker support. Minor bug fix release.*

* **Update NPOI from 2.7.0 to 2.7.1** (https://github.com/nissl-lab/npoi/releases)
*This is used for Excel import for additional files for Serval. Minor bug fix release.*

* **Update Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0** (https://github.com/microsoft/vstest/releases/tag/v17.10.0)
*This is used for unit tests. Minor bug fix release.*
