### PR TITLE
SF-2831 Null check for remote changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3956,6 +3956,18 @@ describe('EditorComponent', () => {
           env.dispose();
         });
       }));
+
+      it('should not throw exception on remote change when source is undefined', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setProjectUserConfig();
+        env.wait();
+
+        env.component.source = undefined;
+
+        expect(() => env.updateFontSize('project01', 24)).not.toThrow();
+
+        env.dispose();
+      }));
     });
 
     describe('tab header tooltips', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -716,7 +716,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
                 this.text.bookNum,
                 this._chapter
               );
-              if (!isEqual(this.source!.id, sourceId)) {
+              if (this.source != null && !isEqual(this.source.id, sourceId)) {
                 this.sourceLoaded = false;
                 this.loadingStarted();
               }


### PR DESCRIPTION
The problem here was that the source GUI property hasn't been updated when the remote change arrives. So the hasSource check is true when the source is undefined. The block that was failing accounts for when the source changes from one source to another, but not for when the source doesn't exist. Ideally, we would have the source tab open after the source is set, which would prevent this, but I'm sure there's a reason we haven't done this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2584)
<!-- Reviewable:end -->
