### PR TITLE
Change "user edit counts" report to group data by year, then month, then user, then chapter

### DIFF
--- a/scripts/db_tools/report-user-edits.ts
+++ b/scripts/db_tools/report-user-edits.ts
@@ -327,14 +327,14 @@ class UserEditReport {
         description: 'Whether to log the word diff between snapshots'
       })
       .check(argv => {
-        const dateFormatRegex = /^\d{4}-\d{1,2}-\d{1,2}$/;
+        const dateFormatRegex = /^\d{4}-\d{1,2}-\d{1,2}(T\d{2}:\d{2}(:\d{2})?)?$/;
 
         if (argv.from && !dateFormatRegex.test(argv.from)) {
-          throw new Error("The 'from' date must be in the format YYYY-M-D");
+          throw new Error("The 'from' date must be in the format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS");
         }
 
         if (argv.to && !dateFormatRegex.test(argv.to)) {
-          throw new Error("The 'to' date must be in the format YYYY-M-D");
+          throw new Error("The 'to' date must be in the format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS");
         }
 
         if (argv.from && argv.to && new Date(argv.from) > new Date(argv.to)) {

--- a/scripts/db_tools/report-user-edits.ts
+++ b/scripts/db_tools/report-user-edits.ts
@@ -191,7 +191,7 @@ class UserEditReport {
                       } as UserEditReportUserData;
                     })
                   )
-                } as UserEditReportMonthData)
+                }) as UserEditReportMonthData
             )
           )
         } as UserEditReportYearData);
@@ -360,7 +360,7 @@ class UserEditReport {
           throw new Error("The 'to' date must be in the format YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS");
         }
 
-        if (argv.from && argv.to && new Date(argv.from) > new Date(argv.to)) {
+        if (argv.from && argv.to && new Date(argv.from) >= new Date(argv.to)) {
           throw new Error('Start date must be before end date');
         }
 

--- a/scripts/db_tools/report-user-edits.ts
+++ b/scripts/db_tools/report-user-edits.ts
@@ -9,6 +9,7 @@
  *        --from [YYYY-MM-DD] (optional)
  *        --to [YYYY-MM-DD] (optional)
  *        --outfile [filename] (default: [project]_[report]_([dateFrom]_to_[dateTo]).tsv)
+ *        --log-diff [true|false] (default: false)
  */
 
 import diff from 'fast-diff';
@@ -20,22 +21,55 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { colored, colors, ConnectionSettings, createWS, databaseConfigs, fetchSnapshotByVersion } from './utils';
 
+function getColorFunc(color: number) {
+  return colored.bind(null, color);
+}
+
+const yellow = getColorFunc(colors.yellow);
+const blue = getColorFunc(colors.lightBlue);
+const green = getColorFunc(colors.lightGreen);
+const red = getColorFunc(colors.orange);
+
 interface ScriptArgs {
-  env?: string;
+  env: string;
   project: string;
   from?: string;
   to?: string;
-  outfile?: string;
+  outfile: string;
+  logDiff: boolean;
 }
 
-interface UserEditData {
+interface UserEditReportData {
+  years: UserEditReportYearData[];
+}
+
+interface UserEditReportYearData {
+  year: number;
+  months: UserEditReportMonthData[];
+}
+
+interface UserEditReportMonthData {
+  month: number;
+  users: UserEditReportUserData[];
+}
+
+interface UserEditReportUserData {
   userId: string;
-  userDisplayName: string;
+  userName: string;
+  bookChapters: UserEditReportBookChapterData[];
+}
+
+interface UserEditReportBookChapterData {
   bookChapter: string;
   inserts: number;
   deletes: number;
   wordAdds: number;
   wordDeletes: number;
+}
+
+interface VersionOp {
+  v: number;
+  op: { ops: DeltaOperation[] };
 }
 
 class UserEditReport {
@@ -46,22 +80,22 @@ class UserEditReport {
   from?: Date;
   to?: Date;
   outfile: string;
+  logDiff: boolean;
 
   fromPretty: string;
   toPretty: string;
-
-  summary?: Map<string, UserEditData>;
 
   readonly reportName = 'user-edit-counts';
 
   constructor() {
     const args: ScriptArgs = this.processArgs();
-    this.env = args.env!;
+    this.env = args.env;
     this.connectionConfig = databaseConfigs.get(this.env)!;
     this.projectShortName = args.project;
-    this.from = args.from ? new Date(`${this.normalizeDateString(args.from)}T00:00`) : undefined; // Start of day
-    this.to = args.to ? new Date(`${this.normalizeDateString(args.to)}T23:59:59`) : undefined; // End of day
-    this.outfile = args.outfile!;
+    this.from = this.toDate(args.from, 'start-of-day'); // Use start of day for 'from' date if time not specified
+    this.to = this.toDate(args.to, 'end-of-day'); // Use end of day for 'to' date if time not specified
+    this.outfile = args.outfile;
+    this.logDiff = args.logDiff;
 
     this.fromPretty = this.formatDate(this.from) ?? 'beginning';
     this.toPretty = this.formatDate(this.to ?? new Date())!;
@@ -70,7 +104,7 @@ class UserEditReport {
   async run() {
     console.log(`Connecting to ${this.env} at ${this.connectionConfig.dbLocation}`);
 
-    this.summary = new Map<string, UserEditData>();
+    const summary: UserEditReportData = { years: [] };
     const client = new MongoClient(this.connectionConfig.dbLocation);
     const ws = createWS(this.connectionConfig);
 
@@ -78,42 +112,69 @@ class UserEditReport {
       await client.connect();
       const conn = new Connection(ws);
       const cursor = await this.queryDB(client.db());
-      let baselineSnapshotVersion = 0;
-      let prevKey: string | null = null;
-      let prevDoc: any = null;
 
       for await (const doc of cursor) {
-        const isLastDoc = !(await cursor.hasNext());
-        const key = this.initSummaryKey(doc);
+        summary.years.push({
+          year: doc._id,
+          months: await Promise.all(
+            (doc.months as []).map(
+              async (monthData: any) =>
+                ({
+                  month: monthData.month,
+                  users: await Promise.all(
+                    (monthData.users as []).map(async (user: any) => {
+                      return {
+                        userId: user.userId,
+                        userName: user.userName,
+                        bookChapters: await Promise.all(
+                          (user.bookChapters as []).map(async (bookChapterData: any) => {
+                            const result: UserEditReportBookChapterData = {
+                              bookChapter: bookChapterData.bookChapter,
+                              inserts: 0,
+                              deletes: 0,
+                              wordAdds: 0,
+                              wordDeletes: 0
+                            };
 
-        // Get initial key for comparison and get baseline from the version previous to the first queried doc
-        if (prevKey == null) {
-          baselineSnapshotVersion = doc.v;
-          prevKey = key;
-        }
+                            const userBookChapterLastVersion =
+                              bookChapterData.versionOps[bookChapterData.versionOps.length - 1].v;
 
-        // Calc word count edits when the user or book/chapter changes
-        if (key !== prevKey) {
-          // Snapshot version is one more than op doc version
-          await this.parseNetWordEdits(conn, prevDoc.d, baselineSnapshotVersion, prevDoc.v + 1, prevKey);
+                            // Baseline is the first version for the user-book-chapter grouping
+                            const baselineVersion = bookChapterData.versionOps[0].v;
 
-          // Update baseline for comparison to next user changes
-          baselineSnapshotVersion = doc.v;
-          prevKey = key;
-        }
+                            const netWordEdits = await this.parseNetWordEdits(
+                              conn,
+                              bookChapterData.snapshotId,
+                              baselineVersion,
+                              userBookChapterLastVersion + 1, // Snapshot version is one more than op doc version
+                              user.userName,
+                              doc._id,
+                              monthData.month
+                            );
 
-        if (isLastDoc) {
-          // Calculate last doc word count edits
-          await this.parseNetWordEdits(conn, doc.d, baselineSnapshotVersion, doc.v + 1, key);
-        }
+                            result.wordAdds = netWordEdits.inserts;
+                            result.wordDeletes = netWordEdits.deletes;
 
-        // Add the raw edit counts to the summary
-        this.parseRawEdits(doc, key);
+                            // Sum the raw edit counts
+                            for (const versionOp of bookChapterData.versionOps) {
+                              const { inserts, deletes } = this.parseRawEdits(versionOp);
+                              result.inserts += inserts;
+                              result.deletes += deletes;
+                            }
 
-        prevDoc = doc;
+                            return result;
+                          })
+                        )
+                      } as UserEditReportUserData;
+                    })
+                  )
+                } as UserEditReportMonthData)
+            )
+          )
+        } as UserEditReportYearData);
       }
 
-      this.writeFile();
+      this.writeFile(summary);
     } finally {
       ws.close();
       await client.close();
@@ -127,8 +188,13 @@ class UserEditReport {
     return date?.toLocaleDateString('en-CA', { year: 'numeric', month: 'numeric', day: 'numeric' });
   }
 
-  private getColorFunc(color: number) {
-    return colored.bind(null, color);
+  /**
+   * Returns the name of the month given its number (1-12).
+   */
+  getMonthName(month: number): string {
+    const date = new Date();
+    date.setMonth(month - 1); // Months are 0-indexed
+    return date.toLocaleString('default', { month: 'long' });
   }
 
   private getOutfileName(): string {
@@ -140,40 +206,35 @@ class UserEditReport {
   }
 
   /**
-   * Get or create a key that represents the user and book/chapter.
+   * Converts a date string from 'YYYY-M-D' to 'YYYY-MM-DD'.  Time is preserved if present.
    */
-  private initSummaryKey(doc: any): string {
-    if (this.summary == null) {
-      throw new Error('Summary not initialized.');
-    }
+  private normalizeDateString(date: string): string {
+    const [dateToken, timeToken] = date.split('T');
+    const [year, month, day] = dateToken.split('-').map(Number);
 
-    const userId = doc.userId;
-    const userDisplayName = doc.userDisplayName;
+    let normalizedDate = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+    const timeSuffix = timeToken ? `T${timeToken}` : '';
 
-    const [_, book, chapter] = doc.d.split(':');
-    const key = `${userId}|${book}|${chapter}`;
-
-    if (!this.summary[key]) {
-      this.summary[key] = {
-        userId,
-        userDisplayName,
-        bookChapter: `${book}:${chapter}`,
-        inserts: 0,
-        deletes: 0,
-        wordAdds: 0,
-        wordDeletes: 0
-      };
-    }
-
-    return key;
+    return normalizedDate + timeSuffix;
   }
 
   /**
-   * Converts a date string from 'YYYY-M-D' to 'YYYY-MM-DD'.
+   * Converts the date string to a Date object. 'time' specifies the time to use if time not present in the date string.
    */
-  private normalizeDateString(date: string): string {
-    const [year, month, day] = date.split('-').map(Number);
-    return `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+  private toDate(dateString: string | undefined, time: 'start-of-day' | 'end-of-day'): Date | undefined {
+    if (dateString == null) {
+      return undefined;
+    }
+
+    const normalizedDateString: string = this.normalizeDateString(dateString);
+    let timeString: string = '';
+
+    // Add time if not already present in date string
+    if (!normalizedDateString.includes('T')) {
+      timeString = `T${time === 'start-of-day' ? '00:00' : '23:59:59'}`;
+    }
+
+    return new Date(this.normalizeDateString(normalizedDateString) + timeString);
   }
 
   /**
@@ -184,44 +245,48 @@ class UserEditReport {
     docId: any,
     versionA: number,
     versionB: number,
-    key: string
-  ): Promise<void> {
-    if (this.summary == null) {
-      throw new Error('Summary not initialized.');
-    }
-
+    userName: string,
+    year: number,
+    month: number
+  ): Promise<{ inserts: number; deletes: number }> {
     if (versionA === versionB) {
       throw new Error('Versions must be different.');
     }
-
-    const user = this.summary[key].userDisplayName;
-    const bookChapter = this.summary[key].bookChapter;
-    const yellow = this.getColorFunc(colors.yellow);
-    console.log(`\n${yellow(user)} - Net word edits for ${yellow(bookChapter)} v${versionA} -> v${versionB}`);
-
     const snapshotA = await fetchSnapshotByVersion(conn, 'texts', docId, versionA);
     const snapshotB = await fetchSnapshotByVersion(conn, 'texts', docId, versionB);
-    const { inserts, deletes } = SnapshotDiffer.diffDocs(snapshotA.data.ops, snapshotB.data.ops);
 
-    this.summary[key].wordAdds += inserts;
-    this.summary[key].wordDeletes += deletes;
+    console.log(`\n${yellow(`${this.getMonthName(month)} ${year}`)}`);
+    console.log(`${yellow(userName)} - Net word edits for ${yellow(docId)} v${versionA} -> v${versionB}`);
+
+    const results = SnapshotDiffer.diffDocs(snapshotA.data.ops, snapshotB.data.ops, this.logDiff);
+
+    console.log(
+      `${yellow('===')}  ${green(results.inserts.toString())} words added, ${red(
+        results.deletes.toString()
+      )} words deleted.\n`
+    );
+
+    return results;
   }
 
   /**
-   * Parses the user raw insert/delete counts in a projection from an o_text doc and adds it to the summary map.
+   * Parses the user raw insert/delete counts.
    */
-  private parseRawEdits(doc: any, key: string): void {
-    if (this.summary == null) {
-      throw new Error('Summary not initialized.');
-    }
+  private parseRawEdits(versionOp: VersionOp): { inserts: number; deletes: number } {
+    const result = {
+      inserts: 0,
+      deletes: 0
+    };
 
-    for (const op of doc.op.ops) {
+    for (const op of versionOp.op.ops) {
       if (typeof op.insert === 'string') {
-        this.summary[key].inserts += op.insert.length;
+        result.inserts += op.insert.length;
       } else if (op.delete) {
-        this.summary[key].deletes += op.delete;
+        result.deletes += op.delete;
       }
     }
+
+    return result;
   }
 
   private processArgs(): ScriptArgs {
@@ -255,6 +320,12 @@ class UserEditReport {
         requiresArg: true,
         description: 'File path to write report to'
       })
+      .option('log-diff', {
+        type: 'boolean',
+        default: false,
+        requiresArg: false,
+        description: 'Whether to log the word diff between snapshots'
+      })
       .check(argv => {
         const dateFormatRegex = /^\d{4}-\d{1,2}-\d{1,2}$/;
 
@@ -277,8 +348,6 @@ class UserEditReport {
   }
 
   private async queryDB(db: Db): Promise<AbstractCursor> {
-    const blue = this.getColorFunc(colors.lightBlue);
-
     console.log(
       `Querying edits for project "${blue(this.projectShortName)}" from ${blue(this.fromPretty)} to ${blue(
         this.toPretty
@@ -323,6 +392,19 @@ class UserEditReport {
       {
         $match: query
       },
+      {
+        // Convert the dateModified field from ms to date object for each text op
+        $addFields: {
+          timestampDate: { $toDate: '$m.ts' },
+          bookChapter: {
+            $concat: [
+              { $arrayElemAt: [{ $split: ['$d', ':'] }, 1] }, // Gets the 'book' part
+              ':',
+              { $arrayElemAt: [{ $split: ['$d', ':'] }, 2] } // Gets the 'chapter' part
+            ]
+          }
+        }
+      },
       // Join users collection to get user display name
       {
         $lookup: {
@@ -337,7 +419,7 @@ class UserEditReport {
       },
       {
         $addFields: {
-          userDisplayName: '$user.name',
+          userName: '$user.name',
           userId: '$m.uId'
         }
       },
@@ -347,7 +429,104 @@ class UserEditReport {
           v: 1,
           op: 1,
           userId: 1,
-          userDisplayName: 1
+          userName: 1,
+          year: { $year: '$timestampDate' },
+          month: { $month: '$timestampDate' },
+          bookChapter: 1
+        }
+      },
+      {
+        // Group by year, month, user, and book chapter to collect version ops
+        $group: {
+          _id: {
+            year: '$year',
+            month: '$month',
+            userId: '$userId',
+            userName: '$userName',
+            bookChapter: '$bookChapter',
+            snapshotId: '$d'
+          },
+          versionOps: {
+            $push: {
+              v: '$v',
+              op: '$op'
+            }
+          }
+        }
+      },
+      {
+        $sort: {
+          '_id.year': 1,
+          '_id.month': 1,
+          '_id.userName': 1,
+          '_id.bookChapter': 1
+        }
+      },
+      {
+        // Regroup the documents by year, month, and user name to collect book chapters and their version ops
+        $group: {
+          _id: {
+            year: '$_id.year',
+            month: '$_id.month',
+            userId: '$_id.userId',
+            userName: '$_id.userName'
+          },
+          bookChapters: {
+            $push: {
+              bookChapter: '$_id.bookChapter',
+              snapshotId: '$_id.snapshotId',
+              versionOps: '$versionOps'
+            }
+          }
+        }
+      },
+      {
+        // Sort the regrouped results by year, month, and user name
+        $sort: {
+          '_id.year': 1,
+          '_id.month': 1,
+          '_id.userName': 1
+        }
+      },
+      {
+        // Group by year and month, pushing user details and their book chapters into an array
+        $group: {
+          _id: {
+            year: '$_id.year',
+            month: '$_id.month'
+          },
+          users: {
+            $push: {
+              userId: '$_id.userId',
+              userName: '$_id.userName',
+              bookChapters: '$bookChapters'
+            }
+          }
+        }
+      },
+      {
+        // Sort the regrouped results by year and month
+        $sort: {
+          '_id.year': 1,
+          '_id.month': 1
+        }
+      },
+      {
+        // Group by year to collect all months, including the users and their book chapters for each month
+        $group: {
+          _id: '$_id.year',
+          months: {
+            $push: {
+              month: '$_id.month',
+              users: '$users'
+            }
+          }
+        }
+      },
+      {
+        // Sort the final output by year
+        $sort: {
+          _id: 1
         }
       }
     ];
@@ -356,20 +535,12 @@ class UserEditReport {
   }
 
   /**
-   * Stringifies a UserEditData object to a TSV row.
+   * Converts UserEditReportData object to a TSV string.
    */
-  private toDataRow(data: UserEditData): string {
-    return [data.userDisplayName, data.bookChapter, data.inserts, data.deletes, data.wordAdds, data.wordDeletes].join(
-      '\t'
-    );
-  }
-
-  /**
-   * Converts a map of UserEditData objects to a TSV string.
-   */
-  private toTsv(summary: Map<string, UserEditData>): string {
-    const title = `User edits on ${this.env} for project "${this.projectShortName} (${this.projectId})" from ${this.fromPretty} to ${this.toPretty}`;
+  private toTsv(summary: UserEditReportData): string {
     const header: string[] = [
+      'Year',
+      'Month',
       'User Name',
       'Book:Chapter',
       'Raw Insertions',
@@ -377,21 +548,38 @@ class UserEditReport {
       'Net Word Insertions',
       'Net Word Deletions'
     ];
-    const dataRows: string[] = Object.values(summary).map(this.toDataRow);
 
-    return [title + '\n', header.join('\t'), ...dataRows].join('\n');
-  }
+    const dataRows = [];
 
-  private writeFile() {
-    if (this.summary == null) {
-      throw new Error('Summary not initialized.');
+    for (const yearData of summary.years) {
+      dataRows.push(yearData.year);
+
+      for (const monthData of yearData.months) {
+        dataRows.push(`\t${this.getMonthName(monthData.month)}`);
+
+        for (const userData of monthData.users) {
+          dataRows.push(`\t\t${userData.userName}`);
+
+          for (const bookChapterData of userData.bookChapters) {
+            const countsColumns = `${bookChapterData.inserts}\t${bookChapterData.deletes}\t${bookChapterData.wordAdds}\t${bookChapterData.wordDeletes}`;
+            dataRows.push(`\t\t\t${bookChapterData.bookChapter}\t${countsColumns}`);
+            console.log(
+              `${yearData.year}/${monthData.month} - ${userData.userName} - ${bookChapterData.bookChapter} - ${countsColumns}`
+            );
+          }
+        }
+      }
     }
 
+    return [header.join('\t'), ...dataRows].join('\n');
+  }
+
+  private writeFile(summary: UserEditReportData) {
     const outfile = this.getOutfileName();
 
     console.log(`\nWriting summary to "${outfile}"`);
     const encoder = new TextEncoder();
-    fs.writeFileSync(outfile, encoder.encode(this.toTsv(this.summary)));
+    fs.writeFileSync(outfile, encoder.encode(this.toTsv(summary)));
   }
 }
 
@@ -399,9 +587,9 @@ class SnapshotDiffer {
   /**
    * Gets the word count number of inserts and deletes between two snapshots.
    */
-  static diffDocs(opsA: DeltaOperation[], opsB: DeltaOperation[]): { inserts: number; deletes: number } {
+  static diffDocs(opsA: DeltaOperation[], opsB: DeltaOperation[], log: boolean): { inserts: number; deletes: number } {
     const rawDiff = this.createRawDiff(opsA, opsB);
-    return this.processRawDiff(rawDiff);
+    return this.processRawDiff(rawDiff, log);
   }
 
   private static countWords(text: string) {
@@ -416,7 +604,7 @@ class SnapshotDiffer {
     return diff(aStr, bStr, undefined, true);
   }
 
-  private static processRawDiff(diffArr: [number, string][]): { inserts: number; deletes: number } {
+  private static processRawDiff(diffArr: [number, string][], log: boolean): { inserts: number; deletes: number } {
     const result = {
       inserts: 0,
       deletes: 0
@@ -426,10 +614,16 @@ class SnapshotDiffer {
       const wordsChanged = this.countWords(text);
 
       if (i === 1) {
-        console.log(`+${wordsChanged}`, colored(colors.lightGreen, text));
+        if (log) {
+          console.log(`+${wordsChanged}`, green(text));
+        }
+
         result.inserts += wordsChanged;
       } else if (i === -1) {
-        console.log(`-${wordsChanged}`, colored(colors.orange, text));
+        if (log) {
+          console.log(`-${wordsChanged}`, red(text));
+        }
+
         result.deletes += wordsChanged;
       }
     }


### PR DESCRIPTION
This grouping will make it easier for Biblica to see month-by-month updates.  The net word edits counts may be different from the old script due to the new grouping of version ops.

To view the net word diffs in the console, add `--log-diff` flag when executing script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2585)
<!-- Reviewable:end -->
