### PR TITLE
SF-2847 Do not show source tab group if user does not have source access

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3816,9 +3816,11 @@ describe('EditorComponent', () => {
       }));
 
       it('should not add source tab group when user has no source permissions', fakeAsync(() => {
+        // setup the project so that users only have access to project01
         const env = new TestEnvironment(env => {
           env.setupUsers(['project01']);
-          env.setupProject({ userRoles: { user05: SFProjectRole.None } });
+          env.setupProject({ userRoles: { user05: SFProjectRole.None } }, 'project02');
+          env.setCurrentUser('user05');
         });
         const spyCreateTab = spyOn(env.tabFactory, 'createTab').and.callThrough();
         env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -662,16 +662,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             this.userService.currentUserId
           );
 
-          if (this.sourceProjectId != null) {
-            const userOnProject: boolean = !!this.currentUser?.sites[environment.siteId].projects.includes(
-              this.sourceProjectId
-            );
-            // Only get the project doc if the user is on the project to avoid an error.
-            this.sourceProjectDoc = userOnProject
-              ? await this.projectService.getProfile(this.sourceProjectId)
-              : undefined;
-          }
-
+          this.sourceProjectDoc = await this.getSourceProjectDoc();
           if (this.projectUserConfigChangesSub != null) {
             this.projectUserConfigChangesSub.unsubscribe();
           }
@@ -1203,7 +1194,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         const targetTabGroup = new TabGroup<EditorTabGroupType, EditorTabInfo>('target');
         const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
 
-        if (projectSource != null) {
+        const userOnProject: boolean =
+          this.currentUser?.sites[environment.siteId].projects.includes(this.sourceProjectId!) === true;
+        if (projectSource != null && userOnProject) {
           sourceTabGroup.addTab(
             await this.editorTabFactory.createTab('project-source', {
               projectId: projectSource.projectRef,
@@ -1831,6 +1824,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         })
       );
     }
+  }
+
+  private async getSourceProjectDoc(): Promise<SFProjectProfileDoc | undefined> {
+    // Only get the project doc if the user is on the project to avoid an error.
+    if (this.sourceProjectId == null) return;
+    return await this.projectService.getProfile(this.sourceProjectId);
   }
 
   private async loadNoteThreadDocs(sfProjectId: string, bookNum: number, chapterNum: number): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1829,6 +1829,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private async getSourceProjectDoc(): Promise<SFProjectProfileDoc | undefined> {
     // Only get the project doc if the user is on the project to avoid an error.
     if (this.sourceProjectId == null) return;
+    if (this.currentUser?.sites[environment.siteId].projects.includes(this.sourceProjectId) !== true) return;
     return await this.projectService.getProfile(this.sourceProjectId);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1194,16 +1194,18 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         const targetTabGroup = new TabGroup<EditorTabGroupType, EditorTabInfo>('target');
         const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
 
-        const userOnProject: boolean =
-          this.currentUser?.sites[environment.siteId].projects.includes(this.sourceProjectId!) === true;
-        if (projectSource != null && userOnProject) {
-          sourceTabGroup.addTab(
-            await this.editorTabFactory.createTab('project-source', {
-              projectId: projectSource.projectRef,
-              headerText: projectSource.shortName,
-              tooltip: projectSource.name
-            })
-          );
+        if (projectSource != null) {
+          const userOnSourceProject: boolean =
+            this.currentUser?.sites[environment.siteId].projects.includes(projectSource.projectRef) === true;
+          if (userOnSourceProject) {
+            sourceTabGroup.addTab(
+              await this.editorTabFactory.createTab('project-source', {
+                projectId: projectSource.projectRef,
+                headerText: projectSource.shortName,
+                tooltip: projectSource.name
+              })
+            );
+          }
         }
 
         targetTabGroup.addTab(


### PR DESCRIPTION
Commenters and viewer users will not generally have access to view the source project. An error would be thrown at the moment when the source tab group is being instantiated because the user does not have permission to read the project data of the source. This PR adds a check if the user has source project access before trying to initialize the source tab group.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2586)
<!-- Reviewable:end -->
