### PR TITLE
SF-2538 Update page when user role changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -255,6 +255,19 @@ describe('AppComponent', () => {
     expect(env.location.path()).toEqual('/projects');
   }));
 
+  it('response to project role changed', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.navigate(['/projects', 'project01']);
+    env.init();
+    env.setCurrentUser('user04');
+
+    expect(env.selectedProjectId).toEqual('project01');
+    when(mockedLocationService.pathname).thenReturn('/projects/project01/translate');
+    env.changeUserRole('project01', 'user04', SFProjectRole.CommunityChecker);
+    expect(env.location.path()).toEqual('/projects/project01');
+    env.wait();
+  }));
+
   it('shows banner when update is available', fakeAsync(() => {
     const env = new TestEnvironment();
     env.navigate(['/projects', 'project01']);
@@ -714,6 +727,12 @@ class TestEnvironment {
     const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(op => op.set<string>(p => p.userRoles['user01'], SFProjectRole.CommunityChecker), false);
     this.currentUserDoc.submitJson0Op(op => op.add<string>(u => u.sites['sf'].projects, 'project04'), false);
+    this.wait();
+  }
+
+  changeUserRole(projectId: string, userId: string, role: SFProjectRole): void {
+    const projectDoc = this.realtimeService.get<SFProjectProfileDoc>(SFProjectProfileDoc.COLLECTION, projectId);
+    projectDoc.submitJson0Op(op => op.set<string>(p => p.userRoles[userId], role), false);
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -35,7 +35,7 @@ import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import versionData from '../../../version.json';
 import { environment } from '../environments/environment';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
-import { roleCanAccessTranslate } from './core/models/sf-project-role-info';
+import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from './core/models/sf-project-role-info';
 import { SFProjectService } from './core/sf-project.service';
 
 declare function gtag(...args: any): void;
@@ -61,7 +61,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   private isLoggedInUserAnonymous: boolean = false;
   private _selectedProjectDoc?: SFProjectProfileDoc;
   private selectedProjectDeleteSub?: Subscription;
-  private removedFromProjectSub?: Subscription;
+  private permissionsChangedSub?: Subscription;
   private _isDrawerPermanent: boolean = true;
 
   constructor(
@@ -286,18 +286,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
           }
         });
 
-        if (this.removedFromProjectSub != null) {
-          this.removedFromProjectSub.unsubscribe();
-        }
-        this.removedFromProjectSub = this._selectedProjectDoc.remoteChanges$.subscribe(() => {
-          if (
-            this._selectedProjectDoc?.data != null &&
-            this.currentUserDoc != null &&
-            !(this.currentUserDoc.id in this._selectedProjectDoc.data.userRoles)
-          ) {
-            // The user has been removed from the project
-            this.showProjectDeletedDialog();
-            this.projectService.localDelete(this._selectedProjectDoc.id);
+        this.permissionsChangedSub?.unsubscribe();
+        this.permissionsChangedSub = this._selectedProjectDoc.remoteChanges$.subscribe(() => {
+          if (this._selectedProjectDoc?.data != null) {
+            if (this.currentUserDoc != null && !(this.currentUserDoc.id in this._selectedProjectDoc.data.userRoles)) {
+              // The user has been removed from the project
+              this.showProjectDeletedDialog();
+              this.projectService.localDelete(this._selectedProjectDoc.id);
+            }
+
+            if (this.permissionForPageRevoked()) {
+              this.router.navigate(['/projects', this._selectedProjectDoc.id]);
+            }
           }
         });
 
@@ -310,12 +310,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   ngOnDestroy(): void {
     super.ngOnDestroy();
-    if (this.selectedProjectDeleteSub != null) {
-      this.selectedProjectDeleteSub.unsubscribe();
-    }
-    if (this.removedFromProjectSub != null) {
-      this.removedFromProjectSub.unsubscribe();
-    }
+    this.selectedProjectDeleteSub?.unsubscribe();
+    this.permissionsChangedSub?.unsubscribe();
   }
 
   setLocale(locale: string): void {
@@ -410,6 +406,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   get appName(): string {
     return environment.siteName;
+  }
+
+  private permissionForPageRevoked(): boolean {
+    const route: string = this.locationService.pathname;
+    if (this.selectedProjectRole == null) return false;
+    if (route.includes('translate') && !roleCanAccessTranslate(this.selectedProjectRole)) {
+      return true;
+    }
+    if (route.includes('checking') && !roleCanAccessCommunityChecking(this.selectedProjectRole)) {
+      return true;
+    }
+    return false;
   }
 
   private async showProjectDeletedDialog(): Promise<void> {


### PR DESCRIPTION
When the user's role changes, it is possible that the page they are currently on is no longer accessible to the role that they have been given. If a Commenter's role is updated to Community Checker, they no longer have permission on the edit and review page.

This PR adds a subscription to listen to the project doc and update the current user's page if their role's permission to view a page has been revoked.