### PR TITLE
SF-2849 Skip getting draft build when project is a resource

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -3,7 +3,7 @@ import { invert } from 'lodash-es';
 import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { of, take } from 'rxjs';
-import { mock, when } from 'ts-mockito';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -24,7 +24,7 @@ let service: EditorTabMenuService;
 const userServiceMock = mock(UserService);
 const activatedProjectMock = mock(ActivatedProjectService);
 const draftGenerationServiceMock = mock(DraftGenerationService);
-const tabStateMock = mock(TabStateService);
+const tabStateMock: TabStateService<any, any> = mock(TabStateService);
 const mockUserService = mock(UserService);
 const mockAuthService = mock(AuthService);
 
@@ -108,6 +108,27 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('draft');
+      expect(items[0].disabled).toBeFalsy();
+      expect(items[1].type).toBe('project-resource');
+      expect(items[1].disabled).toBeFalsy();
+      done();
+    });
+  });
+
+  it('should get "project-resources" and "history", and not "draft" on resource projects', done => {
+    const projectDoc = {
+      id: 'resource01',
+      data: createTestProjectProfile({ paratextId: 'resource16char01', userRoles: TestEnvironment.rolesByUser })
+    } as SFProjectProfileDoc;
+    const env = new TestEnvironment(projectDoc);
+    env.setExistingTabs([]);
+    service['canShowHistory'] = () => true;
+    service['canShowResource'] = () => true;
+
+    verify(draftGenerationServiceMock.getLastCompletedBuild(anything())).never();
+    service.getMenuItems().subscribe(items => {
+      expect(items.length).toBe(2);
+      expect(items[0].type).toBe('history');
       expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('project-resource');
       expect(items[1].disabled).toBeFalsy();
@@ -202,9 +223,7 @@ describe('EditorTabMenuService', () => {
 });
 
 class TestEnvironment {
-  readonly onlineStatus: TestOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
-
-  readonly rolesByUser = {
+  static readonly rolesByUser = {
     user01: SFProjectRole.ParatextConsultant,
     user02: SFProjectRole.ParatextTranslator,
     user03: SFProjectRole.ParatextAdministrator,
@@ -213,7 +232,8 @@ class TestEnvironment {
     user06: SFProjectRole.Viewer
   };
 
-  readonly usersByRole = invert(this.rolesByUser);
+  readonly onlineStatus: TestOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
+  readonly usersByRole = invert(TestEnvironment.rolesByUser);
 
   readonly projectDoc = {
     id: 'project1',
@@ -221,12 +241,13 @@ class TestEnvironment {
       translateConfig: {
         preTranslate: true
       },
-      userRoles: this.rolesByUser
+      userRoles: TestEnvironment.rolesByUser
     })
   } as SFProjectProfileDoc;
 
-  constructor() {
-    when(activatedProjectMock.projectDoc$).thenReturn(of(this.projectDoc));
+  constructor(explicitProjectDoc?: SFProjectProfileDoc) {
+    const projectDoc: SFProjectProfileDoc = explicitProjectDoc ?? this.projectDoc;
+    when(activatedProjectMock.projectDoc$).thenReturn(of(projectDoc));
     when(mockUserService.currentUserId).thenReturn('user01');
     service = TestBed.inject(EditorTabMenuService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -50,7 +50,9 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
         return combineLatest([
           of(projectDoc),
           of(isOnline),
-          isOnline ? this.draftGenerationService.getLastCompletedBuild(projectDoc.id) : of(undefined),
+          !isOnline || projectDoc.data == null || ParatextService.isResource(projectDoc.data.paratextId)
+            ? of(undefined)
+            : this.draftGenerationService.getLastCompletedBuild(projectDoc.id),
           this.tabState.tabs$
         ]);
       }),


### PR DESCRIPTION
Projects that are DBL resources will never have a draft build. This was causing a console error which would not be visible to users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2592)
<!-- Reviewable:end -->
