### PR TITLE
SF-2851 Update source id when tab groups consolidate

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -89,7 +89,7 @@
                 <div class="text-container">
                   <app-text
                     #source
-                    [id]="sourceProjectId | textDocId : bookNum : chapter"
+                    [id]="visibleSourceProjectId | textDocId : bookNum : chapter"
                     [isReadOnly]="true"
                     [highlightSegment]="targetFocused"
                     (loaded)="onTextLoaded('source')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -542,6 +542,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.projectDoc?.data?.translateConfig.source?.projectRef;
   }
 
+  get visibleSourceProjectId(): string | undefined {
+    return this.hasSource ? this.sourceProjectId : undefined;
+  }
+
   private get userRole(): string | undefined {
     return this.projectDoc?.data?.userRoles[this.userService.currentUserId];
   }
@@ -1175,7 +1179,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
    * Returns an observable that can be piped from projectDoc changes, allowing a single call to `subscribe`,
    * avoiding potential NG0911 error 'View has already been destroyed'.
    */
-  initEditorTabs(projectDoc: SFProjectProfileDoc): Observable<any> {
+  private initEditorTabs(projectDoc: SFProjectProfileDoc): Observable<any> {
     // Set tab state from persisted tabs plus non-persisted tabs
     const storeToState$: Observable<any> = this.editorTabPersistenceService.persistedTabs$.pipe(
       take(1),
@@ -1194,17 +1198,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
 
         if (projectSource != null) {
-          const userOnSourceProject: boolean =
-            this.currentUser?.sites[environment.siteId].projects.includes(projectSource.projectRef) === true;
-          if (userOnSourceProject) {
-            sourceTabGroup.addTab(
-              await this.editorTabFactory.createTab('project-source', {
-                projectId: projectSource.projectRef,
-                headerText: projectSource.shortName,
-                tooltip: projectSource.name
-              })
-            );
-          }
+          sourceTabGroup.addTab(
+            await this.editorTabFactory.createTab('project-source', {
+              projectId: projectSource.projectRef,
+              headerText: projectSource.shortName,
+              tooltip: projectSource.name
+            })
+          );
         }
 
         targetTabGroup.addTab(


### PR DESCRIPTION
After doing a git bisect, I found that the commit that introduced the initial error when Commenters navigated to a project was on SF-2808. The id of the source text container was set in the html, causing the text component to try to access the source project, even when users did not have permission.
The change reverts some of the changes in PR #2586 that failed to fix the issue, and introduces a fix to only set the source id if that user has permission to see the source text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2593)
<!-- Reviewable:end -->
