### PR TITLE
Using default port when starting angular in dev env

### DIFF
--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -279,16 +279,17 @@ public class Startup
                     // see https://go.microsoft.com/fwlink/?linkid=864501
                     spa.Options.SourcePath = "ClientApp";
 
+                    int port = 4200;
                     switch (SpaDevServerStartup)
                     {
                         case SpaDevServerStartup.Start:
+                            spa.Options.DevServerPort = port;
                             string npmScript = "start";
                             Console.WriteLine($"Info: SF is serving angular using script {npmScript}.");
                             spa.UseAngularCliServer(npmScript);
                             break;
 
                         case SpaDevServerStartup.Listen:
-                            int port = 4200;
                             string ngServeUri = $"http://localhost:{port}";
                             Console.WriteLine($"Info: SF will use an existing angular server at {ngServeUri}.");
                             spa.UseProxyToSpaDevelopmentServer(ngServeUri);


### PR DESCRIPTION
This fixes the numerous browser console errors when using "npm start" or "dotnet run" in developer environments. We're configured, in angular.json, to look for the host at 4200 for all dev config's, but the host would only start at that port when starting "ng serve" manually. Now, neither "start server" nor "listen" modes throw browser errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2597)
<!-- Reviewable:end -->
