### PR TITLE
SF-2862 Get source project language from the active source for serval

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1099,9 +1099,13 @@ public class MachineProjectService(
                 ?? throw new ArgumentNullException(nameof(project));
         }
 
-        return project.TranslateConfig.DraftConfig.AlternateSource?.WritingSystem.Tag
-            ?? project.TranslateConfig.Source?.WritingSystem.Tag
-            ?? throw new ArgumentNullException(nameof(project));
+        string alternateSourceLanguage = project.TranslateConfig.DraftConfig.AlternateSource?.WritingSystem.Tag;
+        bool useAlternateSourceLanguage =
+            project.TranslateConfig.DraftConfig.AlternateSourceEnabled
+            && !string.IsNullOrWhiteSpace(alternateSourceLanguage);
+        return useAlternateSourceLanguage
+            ? alternateSourceLanguage
+            : project.TranslateConfig.Source?.WritingSystem.Tag ?? throw new ArgumentNullException(nameof(project));
     }
 
     /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -645,7 +645,7 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment(
             new TestEnvironmentOptions { AlternateSourceEnabled = true, AlternateSourceConfigured = true }
         );
-        env.SetDataInSync(Project02, preTranslate: true);
+        await env.SetDataInSync(Project02, preTranslate: true);
         // SUT
         await env.Service.BuildProjectAsync(
             User01,
@@ -672,7 +672,7 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment(
             new TestEnvironmentOptions { AlternateSourceEnabled = false, AlternateSourceConfigured = true }
         );
-        env.SetDataInSync(Project02, preTranslate: true);
+        await env.SetDataInSync(Project02, preTranslate: true);
         // SUT
         await env.Service.BuildProjectAsync(
             User01,
@@ -928,7 +928,6 @@ public class MachineProjectServiceTests
     [TestCase(" ")]
     public async Task BuildProjectAsync_SpecifiesNullScriptureRangeForAlternateTrainingSource(string? scriptureRange)
     {
-        // This looks at something
         // Set up test environment
         var env = new TestEnvironment(
             new TestEnvironmentOptions
@@ -2317,7 +2316,6 @@ public class MachineProjectServiceTests
                                     new ServalCorpus
                                     {
                                         PreTranslate = false,
-                                        // Why is alternate training source true?
                                         AlternateTrainingSource = false,
                                         SourceFiles =
                                         [


### PR DESCRIPTION
When an alternate source project is selected, even if it is disabled, the logic uses the alternate source project language as the language for the serval translation engine build. This resulted in poor quality drafts because the source language of the project sent to serval was incorrect.
This PR updates the logic to retrieve the source language of the project based on the active source language that serval should be using to train on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2600)
<!-- Reviewable:end -->
