### PR TITLE
SF-2865 Fix nav to open 'Auto Draft' tab from draft gen

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -53,9 +53,12 @@ describe('DraftPreviewBooks', () => {
     env.getBookButtonAtIndex(0).querySelector('button')!.click();
     tick();
     env.fixture.detectChanges();
-    verify(mockedRouter.navigate(anything())).once();
-    const [url] = capture(mockedRouter.navigate).first();
+    verify(mockedRouter.navigate(anything(), anything())).once();
+    const [url, extras] = capture(mockedRouter.navigate).first();
     expect(url).toEqual(['/projects', 'project01', 'translate', 'GEN', '1']);
+    expect(extras).toEqual({
+      queryParams: { 'draft-active': true }
+    });
   }));
 
   it('does not apply draft if user cancels', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -127,6 +127,8 @@ export class DraftPreviewBooksComponent {
   }
 
   navigate(book: BookWithDraft): void {
-    this.router.navigate(this.linkForBookAndChapter(book.bookNumber, book.chaptersWithDrafts[0]));
+    this.router.navigate(this.linkForBookAndChapter(book.bookNumber, book.chaptersWithDrafts[0]), {
+      queryParams: { 'draft-active': true }
+    });
   }
 }


### PR DESCRIPTION
Added back the 'draft-active' query param that was accidentally removed in SF-2617 (#2571).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2601)
<!-- Reviewable:end -->
