### PR TITLE
SF-2783 Use a specific error message when PT registry is not responding

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -76,7 +76,7 @@
       }}
     </h2>
     <app-notice id="message-trouble-getting-pt-project-list" icon="error" type="error" *ngIf="problemGettingPTProjects">
-      {{ t("problem_getting_pt_list") }}
+      {{ t(errorMessage) }}
     </app-notice>
 
     <mat-card

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
@@ -228,7 +228,9 @@ describe('MyProjectsComponent', () => {
 
   it('trouble connecting to paratext registry is gracefully handled', fakeAsync(() => {
     const env = new TestEnvironment();
-    when(mockedParatextService.getProjects()).thenReject(new HttpErrorResponse({ status: 504 }));
+    when(mockedParatextService.getProjects()).thenReject(
+      new HttpErrorResponse({ status: HttpStatusCode.ServiceUnavailable })
+    );
     env.waitUntilLoaded();
 
     // Trouble message is shown.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
@@ -217,7 +218,23 @@ describe('MyProjectsComponent', () => {
     env.waitUntilLoaded();
 
     // Trouble message is shown.
-    expect(env.messageTroubleGettingPTProjectList).not.toBeNull();
+    expect(env.messageTroubleGettingPTProjectList.nativeElement.textContent).toContain(
+      'There was a problem getting the list of available Paratext projects'
+    );
+    // Show the header above it as well to make the context clear.
+    expect(env.headerNotConnectedProjects).not.toBeNull();
+    // Not throwing an exception.
+  }));
+
+  it('trouble connecting to paratext registry is gracefully handled', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedParatextService.getProjects()).thenReject(new HttpErrorResponse({ status: 504 }));
+    env.waitUntilLoaded();
+
+    // Trouble message is shown.
+    expect(env.messageTroubleGettingPTProjectList.nativeElement.textContent).toContain(
+      'There was a problem connecting to Paratext'
+    );
     // Show the header above it as well to make the context clear.
     expect(env.headerNotConnectedProjects).not.toBeNull();
     // Not throwing an exception.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { isPTUser } from 'realtime-server/lib/esm/common/models/user';
@@ -98,7 +98,7 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
       }
       this.userUnconnectedParatextProjects = userPTProjects.filter(project => !project.isConnected);
     } catch (err) {
-      if (err instanceof HttpErrorResponse && err.status === 504) {
+      if (err instanceof HttpErrorResponse && err.status === HttpStatusCode.ServiceUnavailable) {
         this.errorMessage = 'failed_to_connect_to_pt_server';
       }
       this.problemGettingPTProjects = true;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -1,14 +1,17 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { isPTUser } from 'realtime-server/lib/esm/common/models/user';
 import { isResource } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { Observable } from 'rxjs';
+import { en } from 'xforge-common/i18n.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { UserService } from 'xforge-common/user.service';
 import { environment } from '../../environments/environment';
+import { ObjectPaths } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { ParatextService } from '../core/paratext.service';
@@ -28,6 +31,7 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
   userUnconnectedParatextProjects: ParatextProject[] = [];
   user?: UserDoc;
   problemGettingPTProjects: boolean = false;
+  errorMessage: ObjectPaths<typeof en.my_projects> = 'problem_getting_pt_list';
   loadingPTProjects: boolean = false;
   initialLoadingSFProjects: boolean = true;
   userIsPTUser: boolean = false;
@@ -93,7 +97,10 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
         return;
       }
       this.userUnconnectedParatextProjects = userPTProjects.filter(project => !project.isConnected);
-    } catch {
+    } catch (err) {
+      if (err instanceof HttpErrorResponse && err.status === 504) {
+        this.errorMessage = 'failed_to_connect_to_pt_server';
+      }
       this.problemGettingPTProjects = true;
     } finally {
       this.loadingPTProjects = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -309,8 +309,8 @@
   },
   "error_messages": {
     "error_occurred_login": "An error occurred during login.",
-    "failed_to_update_avatar": "Your avatar image could not be updated.",
     "failed_to_retrieve_suggestions": "Couldn't get translation suggestions.",
+    "failed_to_update_avatar": "Your avatar image could not be updated.",
     "suggestion_engine_requires_retrain": "Couldn't get translation suggestions. Please retrain the suggestions on the Overview page.",
     "go_to_retrain": "Go to Overview",
     "try_again": "Try Again"
@@ -359,6 +359,7 @@
     "dbl_resource": "Digital Bible Library resource",
     "dbl_resources": "Digital Bible Library resources",
     "drafting": "Drafting",
+    "failed_to_connect_to_pt_server": "There was a problem connecting to Paratext to get your projects. Please try again later. If the problem persists after several hours, please report the issue for help.",
     "join": "Join",
     "loading_more_pt_projects": "Loading additional Paratext projects ...",
     "looking_for_another_project": "Looking for another project?",

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Paratext.Data;
 using SIL.XForge.DataAccess;
@@ -26,6 +27,8 @@ namespace SIL.XForge.Scripture.Controllers;
 [Authorize]
 public class ParatextController : ControllerBase
 {
+    private const string ParatextUnavailable = "Could not connect to Paratext";
+
     private readonly IExceptionHandler _exceptionHandler;
     private readonly IMachineProjectService _machineProjectService;
     private readonly IParatextService _paratextService;
@@ -96,6 +99,7 @@ public class ParatextController : ControllerBase
     /// <response code="200">The projects were successfully retrieved.</response>
     /// <response code="204">The user does not have permission to access Paratext.</response>
     /// <response code="401">The user's Paratext tokens have expired, and the user must log in again.</response>
+    /// <response code="503">The Paratext registry is unavailable.</response>
     [HttpGet("projects")]
     public async Task<ActionResult<IEnumerable<ParatextProject>>> GetAsync()
     {
@@ -117,7 +121,7 @@ public class ParatextController : ControllerBase
         }
         catch (CannotConnectException)
         {
-            return StatusCode(504);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, ParatextUnavailable);
         }
     }
 
@@ -210,6 +214,7 @@ public class ParatextController : ControllerBase
     /// </response>
     /// <response code="204">The user does not have permission to access Paratext.</response>
     /// <response code="401">The user's Paratext tokens have expired, and the user must log in again.</response>
+    /// <response code="503">The Paratext registry is unavailable.</response>
     [HttpGet("resources")]
     public async Task<ActionResult<Dictionary<string, string[]>>> ResourcesAsync()
     {
@@ -232,7 +237,7 @@ public class ParatextController : ControllerBase
         }
         catch (CannotConnectException)
         {
-            return StatusCode(504);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, ParatextUnavailable);
         }
     }
 

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Paratext.Data;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
@@ -101,7 +102,6 @@ public class ParatextController : ControllerBase
         Attempt<UserSecret> attempt = await _userSecrets.TryGetAsync(_userAccessor.UserId);
         if (!attempt.TryResult(out UserSecret userSecret))
             return NoContent();
-
         try
         {
             IReadOnlyList<ParatextProject> projects = await _paratextService.GetProjectsAsync(userSecret);
@@ -114,6 +114,10 @@ public class ParatextController : ControllerBase
         catch (UnauthorizedAccessException)
         {
             return Unauthorized();
+        }
+        catch (CannotConnectException)
+        {
+            return StatusCode(504);
         }
     }
 
@@ -225,6 +229,10 @@ public class ParatextController : ControllerBase
         catch (UnauthorizedAccessException)
         {
             return Unauthorized();
+        }
+        catch (CannotConnectException)
+        {
+            return StatusCode(504);
         }
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
+using Paratext.Data;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
 using SIL.XForge.Realtime;
@@ -145,6 +146,20 @@ public class ParatextControllerTests
         ActionResult<IEnumerable<ParatextProject>> actual = await env.Controller.GetAsync();
 
         Assert.IsInstanceOf<UnauthorizedResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetAsync_CannotConnectException()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.ParatextService.GetProjectsAsync(Arg.Any<UserSecret>()).Throws<CannotConnectException>();
+
+        // SUT
+        ActionResult<IEnumerable<ParatextProject>> actual = await env.Controller.GetAsync();
+
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(504, ((StatusCodeResult)actual.Result).StatusCode);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -158,8 +159,8 @@ public class ParatextControllerTests
         // SUT
         ActionResult<IEnumerable<ParatextProject>> actual = await env.Controller.GetAsync();
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(504, ((StatusCodeResult)actual.Result).StatusCode);
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, ((ObjectResult)actual.Result).StatusCode);
     }
 
     [Test]
@@ -341,6 +342,20 @@ public class ParatextControllerTests
         ActionResult<Dictionary<string, string[]>> actual = await env.Controller.ResourcesAsync();
 
         Assert.IsInstanceOf<NoContentResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task ResourcesAsync_CannotConnectException()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.ParatextService.GetResourcesAsync(User01).Throws<CannotConnectException>();
+
+        // SUT
+        ActionResult<Dictionary<string, string[]>> actual = await env.Controller.ResourcesAsync();
+
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, ((ObjectResult)actual.Result).StatusCode);
     }
 
     [Test]


### PR DESCRIPTION
When a user experiences issues connecting to the PT registry, we want to inform the user that they should try again later. This PR introduces a specific error message in the case where connecting with PT results in a timeout.

A look at bugsnag revealed that the most common errors from calling PT are CannotConnectExceptions. But there are instances of HttpRequestExceptions that throw the code 429: Too many attempts. I only covered the former, but perhaps I should also cover the latter. Let me know your suggestions.

This should be tested by a developer, since it relates to errors which are not possible to reproduce by testers.

![Error when PT server not responding](https://github.com/user-attachments/assets/e58d0548-6aca-40b5-9b09-ade268c7834a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2603)
<!-- Reviewable:end -->
