### PR TITLE
Allow generic dialog to have message with no title

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>{{ title$ | async }}</h2>
+<h2 mat-dialog-title *ngIf="title$ | async as title">{{ title }}</h2>
 <div mat-dialog-content *ngIf="message$ | async as message">{{ message }}</div>
 <div mat-dialog-actions align="end">
   <ng-container *ngFor="let option of options">


### PR DESCRIPTION
This improves the appearance of the copyright notice dialog (excessive space at the top is now gone).

### Before

![](https://github.com/user-attachments/assets/3b3cdcfb-26bf-4d4b-86a0-d42913f6b924)

### After

![](https://github.com/user-attachments/assets/e0d5e624-d608-4b9a-be35-2b35821d6a22)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2606)
<!-- Reviewable:end -->
