### PR TITLE
SF-2868 Fix sidenav incorrect focus on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -161,6 +161,7 @@
       *ngIf="isProjectSelected"
       [opened]="isExpanded || isDrawerPermanent"
       (closed)="drawerCollapsed()"
+      autoFocus="false"
     >
       <app-navigation></app-navigation>
     </mat-drawer>


### PR DESCRIPTION
On mobile, a focus was getting added to the first element in the sidenav, which makes it look active. This is now fixed.

(If you saw an earlier screenshot on this PR that didn't seem to show the problem, it's because the act of taking the screenshot removed the focus, and I didn't notice before uploading)

![](https://github.com/user-attachments/assets/c3bf73de-54c2-4575-a1cd-cf9c444eb0fb)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2608)
<!-- Reviewable:end -->
