### PR TITLE
SF-2741 Delete project on server before deleting serval project

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -251,7 +251,6 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 throw new ForbiddenException();
 
             ptProjectId = projectDoc.Data.ParatextId;
-            // delete the project first, so that users get notified about the deletion
             string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", ptProjectId);
             if (FileSystemService.DirectoryExists(projectDir))
                 FileSystemService.DeleteDirectory(projectDir);

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -86,7 +86,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
 
         string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", settings.ParatextId);
         if (FileSystemService.DirectoryExists(projectDir))
-            throw new ApplicationException("The directory already exists.");
+            throw new InvalidOperationException("A directory for this project already exists.");
 
         IReadOnlyList<ParatextProject> ptProjects = await _paratextService.GetProjectsAsync(userSecret);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2778,14 +2778,14 @@ public class SFProjectServiceTests
         string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
         env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
-        ApplicationException thrown = Assert.ThrowsAsync<ApplicationException>(
+        InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(
             () =>
                 env.Service.CreateProjectAsync(
                     User01,
                     new SFProjectCreateSettings() { ParatextId = existingSfProject.ParatextId }
                 )
         );
-        Assert.That(thrown.Message, Does.Contain("The directory already exists."));
+        Assert.That(thrown.Message, Does.Contain("A directory for this project already exists."));
         Assert.That(
             env.RealtimeService.GetRepository<SFProject>().Query().Count(),
             Is.EqualTo(projectCount),


### PR DESCRIPTION
Relocated code for deleting directories and RealtimeServer data to be deleted before deleting serval data and project secrets on Project Deletion.
Added check for existing directory when Creating SF Project (Connecting) and error if directory exists.
Added Test case for directory check on creating project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2610)
<!-- Reviewable:end -->
