### PR TITLE
SF-2842 Improve font unsupported notice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.html
@@ -1,0 +1,23 @@
+<ng-container *transloco="let t; read: 'font_unsupported_message'">
+  @if (showUnsupportedFontWarning || showGraphiteWarning) {
+    <app-notice type="warning" mode="fill-dark" class="font-warning">
+      @for (portion of i18n.interpolateVariables(warningI18nKey, { selectedFont, fallbackFont }); track portion.text) {
+        @if (portion.id === "selectedFont" || portion.id === "fallbackFont") {
+          <strong>{{ portion.text }}</strong>
+        } @else if (portion.id === "graphite") {
+          <a [href]="externalUrlService.graphite" target="_blank" rel="noreferrer">Graphite</a>
+        }
+        <!-- prettier-ignore -->
+        @if (portion.id == null) {{{ portion.text }}}
+      }
+
+      @for (portion of i18n.interpolate(suggestedRemedyI18nKey); track portion.text) {
+        @if (portion.id === 1) {
+          <a [href]="issueMailTo" target="_blank" rel="noreferrer">{{ portion.text }}</a>
+        } @else if (portion.id == null) {
+          {{ portion.text }}
+        }
+      }
+    </app-notice>
+  }
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.scss
@@ -1,0 +1,7 @@
+app-notice {
+  margin-bottom: 1em;
+}
+
+strong {
+  font-weight: 500;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
@@ -1,0 +1,67 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { TranslocoModule } from '@ngneat/transloco';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { ExternalUrlService } from 'xforge-common/external-url.service';
+import { FontService } from 'xforge-common/font.service';
+import { I18nKey, I18nService } from 'xforge-common/i18n.service';
+import { issuesEmailTemplate } from 'xforge-common/utils';
+import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
+import { ParatextService } from '../../core/paratext.service';
+import { NoticeComponent } from '../../shared/notice/notice.component';
+
+@Component({
+  selector: 'app-font-unsupported-message',
+  standalone: true,
+  imports: [CommonModule, NoticeComponent, TranslocoModule],
+  templateUrl: './font-unsupported-message.component.html',
+  styleUrl: './font-unsupported-message.component.scss'
+})
+export class FontUnsupportedMessageComponent {
+  constructor(
+    private readonly fontService: FontService,
+    private readonly activatedProjectService: ActivatedProjectService,
+    readonly i18n: I18nService,
+    readonly externalUrlService: ExternalUrlService
+  ) {}
+
+  get showUnsupportedFontWarning(): boolean {
+    return !this.fontService.isFontFullySupported(this.selectedFont ?? '');
+  }
+
+  get showGraphiteWarning(): boolean {
+    return this.fontService.isGraphiteFont(this.selectedFont ?? '');
+  }
+
+  get projectDoc(): SFProjectProfileDoc | undefined {
+    return this.activatedProjectService.projectDoc;
+  }
+
+  get issueMailTo(): string {
+    return issuesEmailTemplate();
+  }
+
+  get selectedFont(): string | undefined {
+    return this.projectDoc?.data?.defaultFont;
+  }
+
+  get fallbackFont(): string {
+    return this.fontService.isGraphiteFont(this.selectedFont ?? '')
+      ? this.fontService.nonGraphiteFallback(this.selectedFont ?? '')
+      : this.fontService.fontFallback(this.selectedFont ?? '');
+  }
+
+  get warningI18nKey(): I18nKey {
+    return this.showGraphiteWarning
+      ? 'font_unsupported_message.warn_font_requires_graphite'
+      : 'font_unsupported_message.warn_font_unsupported';
+  }
+
+  get suggestedRemedyI18nKey(): I18nKey {
+    if (this.projectDoc?.data != null && ParatextService.isResource(this.projectDoc.data.paratextId)) {
+      return 'font_unsupported_message.contact_for_help';
+    } else {
+      return 'font_unsupported_message.change_font_or_contact_for_help';
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.stories.ts
@@ -1,0 +1,99 @@
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { expect } from '@storybook/jest';
+import { within } from '@storybook/testing-library';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { instance, mock, when } from 'ts-mockito';
+import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
+import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
+import { RESOURCE_IDENTIFIER_LENGTH } from '../../core/paratext.service';
+import { FontUnsupportedMessageComponent } from './font-unsupported-message.component';
+
+const mockedActivatedProjectService = mock(ActivatedProjectService);
+
+interface FontUnsupportedMessageStoryState {
+  fontName: string;
+  isResource: boolean;
+}
+
+const defaultArgs: FontUnsupportedMessageStoryState = {
+  fontName: 'Arial',
+  isResource: false
+};
+
+export default {
+  title: 'Translate/Font Unsupported Message',
+  component: FontUnsupportedMessageComponent,
+  decorators: [
+    (story, context) => {
+      when(mockedActivatedProjectService.projectDoc).thenReturn({
+        data: createTestProjectProfile({
+          defaultFont: context.args['fontName'],
+          paratextId: new Array(context.args['isResource'] ? RESOURCE_IDENTIFIER_LENGTH : 40).fill('a').join('')
+        })
+      } as SFProjectProfileDoc);
+
+      return story;
+    },
+    moduleMetadata({
+      imports: [],
+      providers: [{ provide: ActivatedProjectService, useValue: instance(mockedActivatedProjectService) }]
+    })
+  ],
+  args: defaultArgs
+} as Meta<FontUnsupportedMessageStoryState>;
+
+type Story = StoryObj<FontUnsupportedMessageStoryState>;
+
+export const ProjectWithUnsupportedFont: Story = {
+  args: {
+    fontName: 'Arial',
+    isResource: false
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/select a different font/i)).toBeInTheDocument();
+    expect(canvas.queryByText(/will only work in Firefox/i)).toBeNull();
+    expect((canvas.getByRole('link', { name: /contact us/i }) as HTMLAnchorElement).href).toMatch(/mailto:help@/);
+  }
+};
+
+export const ProjectWithGraphiteFont: Story = {
+  args: {
+    fontName: 'Awami Nastaliq',
+    isResource: false
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/select a different font/i)).toBeInTheDocument();
+    expect(canvas.getByText(/will only work in Firefox/i)).toBeInTheDocument();
+    expect((canvas.getByRole('link', { name: /contact us/i }) as HTMLAnchorElement).href).toMatch(/mailto:help@/);
+    expect(canvas.getByRole('link', { name: /Graphite/i })).toHaveAttribute('href', 'https://graphite.sil.org/');
+  }
+};
+
+export const ResourceWithUnsupportedFont: Story = {
+  args: {
+    fontName: 'Times New Roman',
+    isResource: true
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByText(/select a different font/i)).toBeNull();
+    expect(canvas.queryByText(/will only work in Firefox/i)).toBeNull();
+    expect((canvas.getByRole('link', { name: /contact us/i }) as HTMLAnchorElement).href).toMatch(/mailto:help@/);
+  }
+};
+
+export const ResourceWithGraphiteFont: Story = {
+  args: {
+    fontName: 'Awami Nastaliq',
+    isResource: true
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByText(/select a different font/i)).toBeNull();
+    expect(canvas.getByText(/will only work in Firefox/i)).toBeInTheDocument();
+    expect((canvas.getByRole('link', { name: /contact us/i }) as HTMLAnchorElement).href).toMatch(/mailto:help@/);
+    expect(canvas.getByRole('link', { name: /Graphite/i })).toHaveAttribute('href', 'https://graphite.sil.org/');
+  }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,30 +1,7 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-headline-4">{{ t("translate_overview") }}</div>
 
-  <app-notice
-    *ngIf="isPTUser && !fontService.isFontFullySupported(selectedFont ?? '')"
-    type="warning"
-    mode="fill-dark"
-    class="font-warning"
-  >
-    {{ t("warn_font_unsupported", { selectedFont, fallbackFont: fontService.fontFallback(selectedFont ?? "") }) }}
-    {{ t(isPtProject ? "change_font_or_contact_for_help" : "contact_for_help") }}
-  </app-notice>
-
-  <app-notice
-    *ngIf="isPTUser && fontService.isGraphiteFont(selectedFont ?? '')"
-    type="warning"
-    mode="fill-dark"
-    class="font-warning"
-  >
-    {{
-      t("warn_font_requires_graphite", {
-        selectedFont,
-        fallbackFont: fontService.nonGraphiteFallback(selectedFont ?? "")
-      })
-    }}
-    {{ t(isPtProject ? "change_font_or_contact_for_help" : "contact_for_help") }}
-  </app-notice>
+  <app-font-unsupported-message *ngIf="isPTUser"></app-font-unsupported-message>
 
   <div class="card-wrapper">
     <mat-card class="books-card">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -122,7 +122,3 @@ mat-card {
     padding: 8px;
   }
 }
-
-.font-warning {
-  margin-bottom: 1em;
-}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -36,7 +36,7 @@ import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
-import { NoticeComponent } from '../../shared/notice/notice.component';
+import { FontUnsupportedMessageComponent } from '../font-unsupported-message/font-unsupported-message.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 import { TranslateOverviewComponent } from './translate-overview.component';
 
@@ -59,7 +59,7 @@ describe('TranslateOverviewComponent', () => {
       HttpClientTestingModule,
       TestOnlineStatusModule.forRoot(),
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
-      NoticeComponent
+      FontUnsupportedMessageComponent
     ],
     providers: [
       { provide: AuthService, useMock: mockedAuthService },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -18,11 +18,8 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
-import { FontService } from '../../../xforge-common/font.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
-import { ParatextService } from '../../core/paratext.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
@@ -76,8 +73,6 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     private readonly authService: AuthService,
     private readonly onlineStatusService: OnlineStatusService,
     noticeService: NoticeService,
-    readonly activatedProjectService: ActivatedProjectService,
-    readonly fontService: FontService,
     private readonly projectService: SFProjectService,
     private readonly translationEngineService: TranslationEngineService,
     private readonly userService: UserService,
@@ -127,14 +122,6 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
 
   get projectId(): string | undefined {
     return this.projectDoc?.id;
-  }
-
-  get selectedFont(): string | undefined {
-    return this.activatedProjectService.projectDoc?.data?.defaultFont;
-  }
-
-  get isPtProject(): boolean {
-    return this.projectDoc?.data != null && !ParatextService.isResource(this.projectDoc?.data?.paratextId);
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -22,6 +22,7 @@ import { NoteDialogComponent } from './editor/note-dialog/note-dialog.component'
 import { SuggestionsSettingsDialogComponent } from './editor/suggestions-settings-dialog.component';
 import { SuggestionsComponent } from './editor/suggestions.component';
 import { EditorTabAddResourceDialogComponent } from './editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component';
+import { FontUnsupportedMessageComponent } from './font-unsupported-message/font-unsupported-message.component';
 import { TrainingProgressComponent } from './training-progress/training-progress.component';
 import { TranslateOverviewComponent } from './translate-overview/translate-overview.component';
 import { TranslateRoutingModule } from './translate-routing.module';
@@ -55,7 +56,8 @@ import { TranslateRoutingModule } from './translate-routing.module';
     TranslocoMarkupModule,
     AvatarComponent,
     SFTabsModule,
-    DraftPreviewBooksComponent
+    DraftPreviewBooksComponent,
+    FontUnsupportedMessageComponent
   ]
 })
 export class TranslateModule {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -264,6 +264,12 @@
     "default_resource_tab_header": "Resource",
     "draft_tab_header": "Auto Draft"
   },
+  "font_unsupported_message": {
+    "change_font_or_contact_for_help": "If this does not meet the needs of this project, please select a different font in the Paratext project settings, or { 1 }contact us for help.{ 2 }",
+    "contact_for_help": "If this does not meet the needs of this project, please { 1 }contact us for help.{ 2 }",
+    "warn_font_requires_graphite": "The font selected for this project, {{ selectedFont }}, can only be rendered by web browsers that support {{ graphite }}. This means it will only work in Firefox, except on iOS devices, where it will not work even in Firefox. In browsers that do not support Graphite, {{ fallbackFont }} is used instead.",
+    "warn_font_unsupported": "The font selected for this project, {{ selectedFont }}, is not supported. {{ fallbackFont }} is used instead."
+  },
   "history_chooser": {
     "confirm_revert": "Are you sure you want to restore this chapter to the selected revision?",
     "confirm_yes": "Restore",
@@ -549,11 +555,7 @@
     "training": "Training...",
     "training_unavailable": "Training is temporarily unavailable",
     "translate_overview": "Translate Overview",
-    "translated_segments": "{{ translatedSegments }} of {{ total }} segments",
-    "warn_font_unsupported": "The font selected for this project, {{ selectedFont }}, is not supported. {{ fallbackFont }} is used instead.",
-    "warn_font_requires_graphite": "The font selected for this project, {{ selectedFont }}, can only be rendered by web browsers that support Graphite. This means it will only work in Firefox, except on iOS devices, where it will not work even in Firefox. In browsers that do not support Graphite, {{ fallbackFont }} is used instead.",
-    "contact_for_help": "If this does not meet the needs of this project, please contact us for help.",
-    "change_font_or_contact_for_help": "If this does not meet the needs of this project, please select a different font in the Paratext project settings, or contact us for help."
+    "translated_segments": "{{ translatedSegments }} of {{ total }} segments"
   },
   "users": {
     "collaborators": "Collaborators",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.ts
@@ -41,4 +41,8 @@ export class ExternalUrlService {
   get chapterAudioHelpPage(): string {
     return this.helps + '/community-checking#fd31ef9b6d74417099996e7dadb5068e';
   }
+
+  get graphite(): string {
+    return 'https://graphite.sil.org/';
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -293,7 +293,7 @@ export class I18nService {
    * view, or a link for the email address.
    */
   interpolateVariables(key: I18nKey, params: object = {}): { text: string; id?: string }[] {
-    const translation: string = this.transloco.getTranslation(this.transloco.getActiveLang())[key];
+    const translation = this.getTranslation(key);
 
     // find instances of "Some {{ variable }} text"
     const regex = /\{\{\s*(\w+)\s*\}\}/g;
@@ -368,5 +368,12 @@ export class I18nService {
       // Some language codes are unsupported in some browsers. For example, Firefox 122 errors on nsk-Cans-CA-x-nasksyl
       return languageCode;
     }
+  }
+
+  private getTranslation(key: I18nKey): string {
+    return (
+      this.transloco.getTranslation(this.transloco.getActiveLang())[key] ??
+      this.transloco.getTranslation(I18nService.defaultLocale.canonicalTag)[key]
+    );
   }
 }


### PR DESCRIPTION
Here's how it looks now (in one of it's four possible states):

![](https://github.com/user-attachments/assets/84b1cd40-5bdf-495c-83e6-c05c1bb78902)

You can review all the states at https://644bffe327c540a62f0fd260-gmceedwsox.chromatic.com/?path=/story/translate-font-unsupported-message--project-with-unsupported-font

I also moved it to its own component so we can put it wherever we want, rather than tied to the translate overview.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2611)
<!-- Reviewable:end -->
