### PR TITLE
SF-2873 Show "Draft in progress" above "Preview last draft"

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -5,7 +5,10 @@
   </h1>
 
   <section>
-    <div *ngIf="isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild">
+    <div
+      *ngIf="isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild"
+      class="drafting-instructions"
+    >
       <div *ngIf="isBackTranslationMode">
         <p>
           <b>{{ t("instructions_scripture_forge_assist_back_translation") }}</b>
@@ -306,6 +309,39 @@
 
           <ng-container *ngIf="isPreviewSupported">
             <ng-container *ngIf="draftJob != null">
+              <section *ngIf="isDraftQueued(draftJob)">
+                <h3>{{ t("draft_queued_header") }}</h3>
+
+                <p *ngIf="!hasDraftQueueDepth(draftJob)">{{ t("draft_queued_detail") }}</p>
+                <p *ngIf="hasDraftQueueDepth(draftJob)">
+                  {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
+                </p>
+                <app-working-animated-indicator></app-working-animated-indicator>
+
+                <div class="button-strip">
+                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+                    <mat-icon>highlight_off</mat-icon>
+                    {{ t("cancel_generation_button") }}
+                  </button>
+                </div>
+              </section>
+
+              <section *ngIf="isDraftActive(draftJob)" class="progress-active">
+                <h3>{{ t("draft_active_header") }}</h3>
+
+                <div class="progress-text">
+                  <p>{{ t("draft_active_detail", { count: 8 }) }}</p>
+                </div>
+                <circle-progress [percent]="draftJob.percentCompleted * 100"></circle-progress>
+
+                <div class="button-strip">
+                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
+                    <mat-icon>highlight_off</mat-icon>
+                    {{ t("cancel_generation_button") }}
+                  </button>
+                </div>
+              </section>
+
               <section *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild" class="draft-complete">
                 <mat-card>
                   <mat-card-header>
@@ -350,39 +386,6 @@
                     </button>
                   </mat-card-actions>
                 </mat-card>
-              </section>
-
-              <section *ngIf="isDraftQueued(draftJob)">
-                <h3>{{ t("draft_queued_header") }}</h3>
-
-                <p *ngIf="!hasDraftQueueDepth(draftJob)">{{ t("draft_queued_detail") }}</p>
-                <p *ngIf="hasDraftQueueDepth(draftJob)">
-                  {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
-                </p>
-                <app-working-animated-indicator></app-working-animated-indicator>
-
-                <div class="button-strip">
-                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-                    <mat-icon>highlight_off</mat-icon>
-                    {{ t("cancel_generation_button") }}
-                  </button>
-                </div>
-              </section>
-
-              <section *ngIf="isDraftActive(draftJob)" class="progress-active">
-                <h3>{{ t("draft_active_header") }}</h3>
-
-                <div class="progress-text">
-                  <p>{{ t("draft_active_detail", { count: 8 }) }}</p>
-                </div>
-                <circle-progress [percent]="draftJob.percentCompleted * 100"></circle-progress>
-
-                <div class="button-strip">
-                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-                    <mat-icon>highlight_off</mat-icon>
-                    {{ t("cancel_generation_button") }}
-                  </button>
-                </div>
               </section>
             </ng-container>
           </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -164,3 +164,7 @@ section {
     transform: scale(1.03);
   }
 }
+
+.drafting-instructions b {
+  font-weight: 500;
+}


### PR DESCRIPTION
The primary thing on the page is now first. Personally I think the "Draft in progress" section should be in a card too (or we should find something better than a card), but I'm trying to keep this change simple.

Before | After
-------|------
![](https://github.com/user-attachments/assets/3ec63eca-438a-481e-b739-3fb0e5672ae3) | ![](https://github.com/user-attachments/assets/8250a45e-b077-4f36-aa26-c701e706a6ca)

I felt the bold here was excessive and made it more subtle:

Before | After
-------|-------
![](https://github.com/user-attachments/assets/a45c696e-38b1-4418-9345-59a8a4f84c11) | ![](https://github.com/user-attachments/assets/95586aac-630a-4bab-92e8-bfc1da2bef76)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2612)
<!-- Reviewable:end -->
