### PR TITLE
SF-2859 Inform user when the share link problem is known

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -193,7 +193,7 @@ export class JoinComponent extends DataLoadingComponent {
     } else if (error instanceof CommandError) {
       knownErrorCode = this.getKnownErrorCode(error.message);
     }
-    knownErrorCode == null ? this.errorHandler.handleError(error) : this.showJoinError(knownErrorCode);
+    knownErrorCode == null ? this.errorHandler.handleError(error) : await this.showJoinError(knownErrorCode);
   }
 
   private getKnownErrorCode(code: any): ObjectPaths<typeof en.join> | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -200,7 +200,7 @@ export class JoinComponent extends DataLoadingComponent {
     if (KNOWN_ERROR_CODES.includes(code)) return code;
     if (typeof code === 'string') {
       for (const knownCode of KNOWN_ERROR_CODES) {
-        if (code.match(knownCode)) return knownCode;
+        if (code.includes(knownCode)) return knownCode;
       }
     }
     return undefined;


### PR DESCRIPTION
Error messages that are returned from the server are typically CommandErrors that have a message in the form "Error invoking ... project_link_invalid". We can use the error message to determine if a known error code is included in the message, and then show a message to the user to inform them of the known issue.
This was not previously working because we were assuming the message was in the format that was just the error code, but in reality we should have been checking whether the error code was contained in the error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2613)
<!-- Reviewable:end -->
