### PR TITLE
SF-2865 Fix autodraft open on nav when mobile view with source

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.spec.ts
@@ -21,9 +21,39 @@ describe('TabGroup', () => {
     expect(tabGroup.tabs).toEqual(['tab1', 'tab2', 'tab3', 'tab4']);
   });
 
-  it('should add a tab', () => {
-    tabGroup.addTab('tab3');
-    expect(tabGroup.tabs).toEqual(['tab1', 'tab2', 'tab3']);
+  describe('addTab', () => {
+    it('should add a tab', () => {
+      tabGroup.addTab('tab3');
+      expect(tabGroup.tabs).toEqual(['tab1', 'tab2', 'tab3']);
+    });
+
+    it('should select the added tab', () => {
+      tabGroup.addTab('tab3');
+      expect(tabGroup.selectedIndex).toEqual(2);
+    });
+
+    it('should not select the added tab', () => {
+      tabGroup.addTab('tab3', false);
+      expect(tabGroup.selectedIndex).toEqual(0);
+    });
+
+    it('should emit the added tab with selection', () => {
+      let addedTabEvent: { tabs: string[]; selectedAddTab?: string } | undefined;
+      tabGroup.tabsAdded$.subscribe(event => {
+        addedTabEvent = event;
+      });
+      tabGroup.addTab('tab3');
+      expect(addedTabEvent).toEqual({ tabs: ['tab3'], selectedAddTab: 'tab3' });
+    });
+
+    it('should not emit the added tab selection if no selection', () => {
+      let addedTabEvent: { tabs: string[]; selectedAddTab?: string } | undefined;
+      tabGroup.tabsAdded$.subscribe(event => {
+        addedTabEvent = event;
+      });
+      tabGroup.addTab('tab3', false);
+      expect(addedTabEvent).toEqual({ tabs: ['tab3'] });
+    });
   });
 
   describe('removeTab', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-group.ts
@@ -3,7 +3,7 @@ import { Subject } from 'rxjs';
 export class TabGroup<TKey, T> {
   selectedIndex: number = 0;
 
-  tabsAdded$ = new Subject<{ tabs: T[] }>();
+  tabsAdded$ = new Subject<{ tabs: T[]; selectedAddTab?: T }>();
   tabRemoved$ = new Subject<{ index: number; tab: T }>();
 
   constructor(
@@ -27,7 +27,8 @@ export class TabGroup<TKey, T> {
       this.selectedIndex = this.tabs.length - 1;
     }
 
-    this.tabsAdded$.next({ tabs: [tab] });
+    // Only emit the selectedAddTab property if it is defined
+    this.tabsAdded$.next({ tabs: [tab], ...(selectTab ? { selectedAddTab: tab } : {}) });
   }
 
   removeTab(index: number): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -288,7 +288,7 @@ describe('TabStateService', () => {
         expect(service['tabsToDeconsolidate']?.get('source')).toEqual(sourceTabs.slice(0, 3));
       });
 
-      it('should add tab to restore list and consolidated group when tabs are added after consolidation and before deconsolidation', () => {
+      it('should add tabs to restore list and consolidated group when tabs are added after consolidation and before deconsolidation', () => {
         const tabsToAdd = [
           { type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true },
           { type: 'type-c', headerText: 'added source Source Header 6', closeable: true, movable: true }
@@ -302,6 +302,17 @@ describe('TabStateService', () => {
         expect(service['groups'].get('source')?.tabs).toEqual([]);
         expect(service['groups'].get('target')?.tabs).toEqual([...sourceTabs, ...tabsToAdd, ...targetTabs]);
         expect(service['groups'].get('target')?.selectedIndex).toEqual(selectedIndex + tabsToAdd.length);
+      });
+
+      it('should select added tab when tab with selection is added after consolidation and before deconsolidation', () => {
+        const tabToAdd = { type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true };
+
+        service.consolidateTabGroups('target');
+        service['groups'].get('source')?.addTab(tabToAdd);
+        const targetGroup = service['groups'].get('target');
+
+        expect(service['tabsToDeconsolidate']?.get('source')).toEqual(sourceTabs.concat(tabToAdd));
+        expect(targetGroup?.selectedIndex).toEqual(targetGroup?.tabs.indexOf(tabToAdd));
       });
 
       it('should deconsolidate tab groups', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -226,7 +226,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
             takeUntil(this.tabsConsolidated$.pipe(filter(consolidated => !consolidated))),
             takeUntilDestroyed(this.destroyRef)
           )
-          .subscribe(({ tabs }) => {
+          .subscribe(({ tabs, selectedAddTab }) => {
             const deconsolidationGroupTabs: readonly T[] = this.tabsToDeconsolidate!.get(group.groupId)!;
             const lastTab: T = deconsolidationGroupTabs[deconsolidationGroupTabs.length - 1];
             const updatedConsolidatedTabs: T[] = [...intoGroup.tabs];
@@ -243,7 +243,9 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
             group.setTabs(group.tabs.filter(t => !tabs.includes(t)));
 
             // Update selected index if necessary
-            if (intoGroup.selectedIndex >= insertAt) {
+            if (selectedAddTab != null) {
+              intoGroup.selectedIndex = updatedConsolidatedTabs.indexOf(selectedAddTab);
+            } else if (intoGroup.selectedIndex >= insertAt) {
               intoGroup.selectedIndex += tabs.length;
             }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -1,5 +1,4 @@
-import { DestroyRef, Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable, OnDestroy } from '@angular/core';
 import { VerseRef } from '@sillsdev/scripture';
 import cloneDeep from 'lodash-es/cloneDeep';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
@@ -122,7 +121,7 @@ class SegmentInfo {
  * See text.component.spec.ts for some unit tests.
  */
 @Injectable()
-export class TextViewModel {
+export class TextViewModel implements OnDestroy {
   editor?: Quill;
 
   private readonly _segments: Map<string, RangeStatic> = new Map<string, RangeStatic>();
@@ -178,6 +177,10 @@ export class TextViewModel {
     return this.embeddedElementPositions(Array.from(this._embeddedElements.values()));
   }
 
+  ngOnDestroy(): void {
+    this.unbind();
+  }
+
   /** Associate the existing editor to a (single) specific textdoc. */
   bind(textDocId: TextDocId, textDoc: TextDoc, subscribeToUpdates: boolean): void {
     const editor = this.checkEditor();
@@ -191,13 +194,16 @@ export class TextViewModel {
     editor.history.clear();
 
     if (subscribeToUpdates) {
-      this.changesSub = this.textDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(ops => {
+      this.changesSub = merge(
+        this.textDocService.getLocalSystemChanges$(textDocId),
+        this.textDoc.remoteChanges$
+      ).subscribe(ops => {
         const deltaWithEmbeds: DeltaStatic = this.addEmbeddedElementsToDelta(ops as DeltaStatic);
         editor.updateContents(deltaWithEmbeds, 'api');
       });
     }
 
-    this.onCreateSub = this.textDoc.create$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.onCreateSub = this.textDoc.create$.subscribe(() => {
       if (textDoc.data != null) {
         editor.setContents(textDoc.data as DeltaStatic);
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { VerseRef } from '@sillsdev/scripture';
 import cloneDeep from 'lodash-es/cloneDeep';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
@@ -135,7 +135,7 @@ export class TextViewModel implements OnDestroy {
    */
   private _embeddedElements: Map<string, EmbedPosition> = new Map<string, EmbedPosition>();
 
-  constructor(private readonly destroyRef: DestroyRef) {}
+  constructor(private readonly textDocService: TextDocService) {}
 
   get segments(): IterableIterator<[string, RangeStatic]> {
     return this._segments.entries();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -135,8 +135,6 @@ export class TextViewModel implements OnDestroy {
    */
   private _embeddedElements: Map<string, EmbedPosition> = new Map<string, EmbedPosition>();
 
-  constructor(private readonly textDocService: TextDocService) {}
-
   get segments(): IterableIterator<[string, RangeStatic]> {
     return this._segments.entries();
   }
@@ -194,10 +192,7 @@ export class TextViewModel implements OnDestroy {
     editor.history.clear();
 
     if (subscribeToUpdates) {
-      this.changesSub = merge(
-        this.textDocService.getLocalSystemChanges$(textDocId),
-        this.textDoc.remoteChanges$
-      ).subscribe(ops => {
+      this.changesSub = this.textDoc.remoteChanges$.subscribe(ops => {
         const deltaWithEmbeds: DeltaStatic = this.addEmbeddedElementsToDelta(ops as DeltaStatic);
         editor.updateContents(deltaWithEmbeds, 'api');
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3813,6 +3813,22 @@ describe('EditorComponent', () => {
         expect(spyConsolidate).not.toHaveBeenCalled();
         flush();
       }));
+
+      it('should not consolidate on second editor load', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          when(mockedBreakpointObserver.observe(anything())).thenReturn(of({ matches: true } as any));
+          Object.defineProperty(env.component, 'showSource', { get: () => true });
+        });
+
+        env.component['tabStateInitialized$'].next(true);
+        env.component['targetEditorLoaded$'].next();
+
+        const spyConsolidate = spyOn(env.component.tabState, 'consolidateTabGroups');
+
+        env.component['targetEditorLoaded$'].next();
+        expect(spyConsolidate).not.toHaveBeenCalled();
+        flush();
+      }));
     });
 
     describe('initEditorTabs', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -779,7 +779,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     combineLatest([
       this.breakpointObserver.observe(this.mediaBreakpointService.width('<', Breakpoint.SM)),
       this.tabStateInitialized$.pipe(filter(initialized => initialized)),
-      this.targetEditorLoaded$
+      this.targetEditorLoaded$.pipe(take(1))
     ])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([breakpointState]) => {


### PR DESCRIPTION
This PR fixes issue where 'Auto Draft' tab was not being selected when navigating from draft generation page in mobile view with a source text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2614)
<!-- Reviewable:end -->
