### PR TITLE
SF-2878 Migrate component templates to new control flow syntax

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -6,17 +6,16 @@
   ></mat-progress-bar>
   <header [class.overlay-drawer]="!isDrawerPermanent" [dir]="i18n.direction">
     <!-- site admin notice is deliberately only shown on live site, as a warning that actions impact live projects -->
-    <span class="site-admin" *ngIf="isLive && isSystemAdmin">site admin</span>
+    @if (isLive && isSystemAdmin) {
+      <span class="site-admin">site admin</span>
+    }
     <mat-toolbar color="primary">
       <mat-toolbar-row>
-        <button
-          id="hamburger-menu-button"
-          mat-icon-button
-          *ngIf="!isDrawerPermanent && isProjectSelected"
-          (click)="toggleDrawer()"
-        >
-          <mat-icon>menu</mat-icon>
-        </button>
+        @if (!isDrawerPermanent && isProjectSelected) {
+          <button id="hamburger-menu-button" mat-icon-button (click)="toggleDrawer()">
+            <mat-icon>menu</mat-icon>
+          </button>
+        }
         @if (isLoggedIn | async) {
           <a id="sf-logo-button" mat-icon-button class="hide-lt-sm" [routerLink]="appIconLink">
             <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
@@ -26,24 +25,29 @@
             <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
           </a>
         }
-        <span class="project-name-wrapper hide-lt-sm" *ngIf="isProjectSelected">
-          <span class="project-name">{{ selectedProjectDoc?.data?.name }}</span>
-          <span class="project-short-name">{{ selectedProjectDoc?.data?.shortName }}</span>
-        </span>
+        @if (isProjectSelected) {
+          <span class="project-name-wrapper hide-lt-sm">
+            <span class="project-name">{{ selectedProjectDoc?.data?.name }}</span>
+            <span class="project-short-name">{{ selectedProjectDoc?.data?.shortName }}</span>
+          </span>
+        }
         <span class="toolbar-spacer"></span>
-        <button mat-icon-button title="{{ t('language') }}" [matMenuTriggerFor]="localeMenu" *ngIf="isAppOnline">
-          <mat-icon>translate</mat-icon>
-        </button>
-        <mat-menu #localeMenu="matMenu" class="locale-menu">
-          <button
-            mat-menu-item
-            *ngFor="let locale of i18n.locales"
-            [class.active-locale]="locale.canonicalTag === i18n.localeCode"
-            (click)="setLocale(locale.canonicalTag)"
-          >
-            <mat-icon>check</mat-icon>
-            <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
+        @if (isAppOnline) {
+          <button mat-icon-button title="{{ t('language') }}" [matMenuTriggerFor]="localeMenu">
+            <mat-icon>translate</mat-icon>
           </button>
+        }
+        <mat-menu #localeMenu="matMenu" class="locale-menu">
+          @for (locale of i18n.locales; track locale) {
+            <button
+              mat-menu-item
+              [class.active-locale]="locale.canonicalTag === i18n.localeCode"
+              (click)="setLocale(locale.canonicalTag)"
+            >
+              <mat-icon>check</mat-icon>
+              <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
+            </button>
+          }
         </mat-menu>
 
         <button mat-icon-button title="{{ t('help') }}" [matMenuTriggerFor]="helpMenu">
@@ -66,14 +70,12 @@
           <a mat-menu-item target="_blank" href="/3rdpartylicenses.txt">
             <mat-icon>copyright</mat-icon> {{ t("open_source_licenses") }}
           </a>
-          <button
-            *ngIf="versionNumberClickCount >= 7 || featureFlags.showFeatureFlags.enabled"
-            mat-menu-item
-            (click)="openFeatureFlagDialog()"
-          >
-            <mat-icon>science</mat-icon>
-            Developer settings
-          </button>
+          @if (versionNumberClickCount >= 7 || featureFlags.showFeatureFlags.enabled) {
+            <button mat-menu-item (click)="openFeatureFlagDialog()">
+              <mat-icon>science</mat-icon>
+              Developer settings
+            </button>
+          }
           <mat-divider></mat-divider>
           <div
             mat-menu-item
@@ -85,18 +87,23 @@
           </div>
         </mat-menu>
 
-        <button
-          *ngIf="currentUser"
-          mat-icon-button
-          title="{{ currentUser.displayName }}"
-          [matMenuTriggerFor]="userMenu"
-          (click)="dismissInstallIcon()"
-          class="user-menu-btn"
-        >
-          <mat-icon *ngIf="showInstallIconOnAvatar$ | async" class="install-badge">install_mobile</mat-icon>
-          <app-avatar id="avatarId" [user]="currentUser"></app-avatar>
-          <mat-icon class="offline-indicator" *ngIf="!isAppOnline"> cloud_off</mat-icon>
-        </button>
+        @if (currentUser) {
+          <button
+            mat-icon-button
+            title="{{ currentUser.displayName }}"
+            [matMenuTriggerFor]="userMenu"
+            (click)="dismissInstallIcon()"
+            class="user-menu-btn"
+          >
+            @if (showInstallIconOnAvatar$ | async) {
+              <mat-icon class="install-badge">install_mobile</mat-icon>
+            }
+            <app-avatar id="avatarId" [user]="currentUser"></app-avatar>
+            @if (!isAppOnline) {
+              <mat-icon class="offline-indicator"> cloud_off</mat-icon>
+            }
+          </button>
+        }
         <mat-menu #userMenu="matMenu" class="user-menu">
           <div class="pseudo-menu-item user-info">
             <div>{{ t("logged_in_as") }}</div>
@@ -108,76 +115,87 @@
             </div>
           </div>
           <mat-divider></mat-divider>
-          <button
-            mat-menu-item
-            *ngIf="isSystemAdmin"
-            id="system-admin-btn"
-            [disabled]="!isAppOnline"
-            appRouterLink="/system-administration"
-          >
-            <mat-icon>admin_panel_settings</mat-icon>
-            {{ t("system_administration") }}
-          </button>
-          <button
-            mat-menu-item
-            *ngIf="isServalAdmin"
-            id="serval-admin-btn"
-            [disabled]="!isAppOnline"
-            appRouterLink="/serval-administration"
-          >
-            <mat-icon>tune</mat-icon>
-            {{ t("serval_administration") }}
-          </button>
+          @if (isSystemAdmin) {
+            <button
+              mat-menu-item
+              id="system-admin-btn"
+              [disabled]="!isAppOnline"
+              appRouterLink="/system-administration"
+            >
+              <mat-icon>admin_panel_settings</mat-icon>
+              {{ t("system_administration") }}
+            </button>
+          }
+          @if (isServalAdmin) {
+            <button
+              mat-menu-item
+              id="serval-admin-btn"
+              [disabled]="!isAppOnline"
+              appRouterLink="/serval-administration"
+            >
+              <mat-icon>tune</mat-icon>
+              {{ t("serval_administration") }}
+            </button>
+          }
           <button mat-menu-item appRouterLink="/projects" id="project-home-link">
             <mat-icon>home</mat-icon> {{ "my_projects.my_projects" | transloco }}
           </button>
-          <button mat-menu-item *ngIf="canChangePassword" (click)="changePassword()" [disabled]="!isAppOnline">
-            <mat-icon>vpn_key</mat-icon>
-            {{ t("change_password") }}
-          </button>
-          <button *ngIf="canInstallOnDevice$ | async" mat-menu-item (click)="installOnDevice()">
-            <div class="install-button"><mat-icon>install_mobile</mat-icon> {{ t("install_on_device") }}</div>
-          </button>
+          @if (canChangePassword) {
+            <button mat-menu-item (click)="changePassword()" [disabled]="!isAppOnline">
+              <mat-icon>vpn_key</mat-icon>
+              {{ t("change_password") }}
+            </button>
+          }
+          @if (canInstallOnDevice$ | async) {
+            <button mat-menu-item (click)="installOnDevice()">
+              <div class="install-button"><mat-icon>install_mobile</mat-icon> {{ t("install_on_device") }}</div>
+            </button>
+          }
           <button mat-menu-item (click)="logOut()" id="log-out-link">
             <mat-icon>logout</mat-icon> {{ t("log_out") }}
           </button>
           <mat-divider></mat-divider>
           <div class="pseudo-menu-item online-status">
-            <ng-container *ngIf="isAppOnline">
+            @if (isAppOnline) {
               <mat-icon>cloud</mat-icon>
               {{ t("online") }}
-            </ng-container>
-            <ng-container *ngIf="!isAppOnline">
+            }
+            @if (!isAppOnline) {
               <mat-icon>cloud_off</mat-icon>
               {{ t("offline") }}
-            </ng-container>
+            }
           </div>
         </mat-menu>
       </mat-toolbar-row>
-      <mat-toolbar-row *ngIf="hasUpdate" class="update-banner">
-        <span class="refresh-message">{{ t("update_is_available") }}</span>
-        <button mat-raised-button color="accent" (click)="reloadWithUpdates()">{{ t("refresh") }}</button>
-      </mat-toolbar-row>
+      @if (hasUpdate) {
+        <mat-toolbar-row class="update-banner">
+          <span class="refresh-message">{{ t("update_is_available") }}</span>
+          <button mat-raised-button color="accent" (click)="reloadWithUpdates()">{{ t("refresh") }}</button>
+        </mat-toolbar-row>
+      }
     </mat-toolbar>
   </header>
 
   <mat-drawer-container class="top-app-bar-adjust" [class.top-app-bar-adjust-double]="hasUpdate" [dir]="i18n.direction">
-    <mat-drawer
-      #drawer
-      id="menu-drawer"
-      [mode]="isDrawerPermanent ? 'side' : 'over'"
-      *ngIf="isProjectSelected"
-      [opened]="isExpanded || isDrawerPermanent"
-      (closed)="drawerCollapsed()"
-      autoFocus="false"
-    >
-      <app-navigation></app-navigation>
-    </mat-drawer>
+    @if (isProjectSelected) {
+      <mat-drawer
+        #drawer
+        id="menu-drawer"
+        [mode]="isDrawerPermanent ? 'side' : 'over'"
+        [opened]="isExpanded || isDrawerPermanent"
+        (closed)="drawerCollapsed()"
+        autoFocus="false"
+      >
+        <app-navigation></app-navigation>
+      </mat-drawer>
+    }
     <!-- The cdkScrollable attribute is needed so the CDK can listen to scroll events within this container -->
     <div #appContent cdkScrollable class="app-content" [dir]="i18n.direction">
       <div>
         <router-outlet></router-outlet>
-        <p *ngIf="showCheckingDisabled" class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>
+        @if (showCheckingDisabled) {
+          <p class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>
+        }
       </div>
     </div>
   </mat-drawer-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -8,20 +8,21 @@
     </div>
     <div class="data-blocks">
       <div class="wrapper wrapper-book-chapter valid">
-        <mat-icon *ngIf="!selectionHasAudioAlready || inEditState">book</mat-icon>
-        <app-info
-          *ngIf="selectionHasAudioAlready && !inEditState"
-          [text]="t('audio_already_exists')"
-          icon="warning"
-          type="warning"
-        ></app-info>
+        @if (!selectionHasAudioAlready || inEditState) {
+          <mat-icon>book</mat-icon>
+        }
+        @if (selectionHasAudioAlready && !inEditState) {
+          <app-info [text]="t('audio_already_exists')" icon="warning" type="warning"></app-info>
+        }
         <mat-select
           [(value)]="book"
           [disabled]="inEditState"
           class="book-select-menu"
           [hideSingleSelectionIndicator]="true"
         >
-          <mat-option *ngFor="let b of books" [value]="b">{{ bookName(b) }}</mat-option>
+          @for (b of books; track b) {
+            <mat-option [value]="b">{{ bookName(b) }}</mat-option>
+          }
         </mat-select>
         <div class="divider"></div>
         <mat-select
@@ -31,11 +32,13 @@
           [hideSingleSelectionIndicator]="true"
           [panelWidth]="80"
         >
-          <mat-option *ngFor="let c of chapters" [value]="c">{{ c }}</mat-option>
+          @for (c of chapters; track c) {
+            <mat-option [value]="c">{{ c }}</mat-option>
+          }
         </mat-select>
       </div>
       <div class="wrapper wrapper-audio" [ngClass]="{ valid: hasAudioBeenUploaded, invalid: isAudioInvalid }">
-        <ng-container *ngIf="hasAudioBeenUploaded">
+        @if (hasAudioBeenUploaded) {
           <app-single-button-audio-player
             #chapterAudio
             id="chapterAudio"
@@ -44,43 +47,61 @@
           >
             <mat-icon>{{ chapterAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
           </app-single-button-audio-player>
-          <span *ngIf="hasAudioBeenUploaded && !hasAudioDataError">{{ audioFilename }}</span>
-          <mat-icon *ngIf="hasAudioBeenUploaded" (click)="deleteAudioData()" class="delete">delete</mat-icon>
-        </ng-container>
-        <ng-container *ngIf="!hasAudioBeenUploaded">
+          @if (hasAudioBeenUploaded && !hasAudioDataError) {
+            <span>{{ audioFilename }}</span>
+          }
+          @if (hasAudioBeenUploaded) {
+            <mat-icon (click)="deleteAudioData()" class="delete">delete</mat-icon>
+          }
+        }
+        @if (!hasAudioBeenUploaded) {
           <mat-icon>play_disabled</mat-icon>
-          <span *ngIf="!hasAudioDataError">{{ t("no_audio_file_uploaded") }}</span>
-          <span *ngIf="hasAudioDataError">{{ t(audioErrorMessageKey) }}</span>
-        </ng-container>
+          @if (!hasAudioDataError) {
+            <span>{{ t("no_audio_file_uploaded") }}</span>
+          }
+          @if (hasAudioDataError) {
+            <span>{{ t(audioErrorMessageKey) }}</span>
+          }
+        }
       </div>
       <div
         class="wrapper wrapper-timing"
         [ngClass]="{ valid: hasTimingBeenUploaded, invalid: timingErrorMessageKey !== '' }"
       >
         <mat-icon class="material-icons-outlined">timer</mat-icon>
-        <span *ngIf="hasTimingBeenUploaded && !hasTimingDataError">
-          {{ t("segments_found", { segments: numberOfTimingSegments }) }}
-        </span>
-        <span *ngIf="!hasTimingBeenUploaded && !hasTimingDataError">{{ t("no_timing_data_uploaded") }}</span>
-        <span *ngIf="hasTimingDataError">{{ t(timingErrorMessageKey) }}</span>
-        <mat-icon *ngIf="hasTimingBeenUploaded && !hasTimingDataError" (click)="deleteTimingData()" class="delete"
-          >delete</mat-icon
-        >
+        @if (hasTimingBeenUploaded && !hasTimingDataError) {
+          <span>
+            {{ t("segments_found", { segments: numberOfTimingSegments }) }}
+          </span>
+        }
+        @if (!hasTimingBeenUploaded && !hasTimingDataError) {
+          <span>{{ t("no_timing_data_uploaded") }}</span>
+        }
+        @if (hasTimingDataError) {
+          <span>{{ t(timingErrorMessageKey) }}</span>
+        }
+        @if (hasTimingBeenUploaded && !hasTimingDataError) {
+          <mat-icon (click)="deleteTimingData()" class="delete">delete</mat-icon>
+        }
       </div>
     </div>
-    <app-notice id="offline-error" *ngIf="!isOnline" type="error" icon="cloud_off">
-      {{ t("not_upload_audio_offline") }}
-    </app-notice>
+    @if (!isOnline) {
+      <app-notice id="offline-error" type="error" icon="cloud_off">
+        {{ t("not_upload_audio_offline") }}
+      </app-notice>
+    }
   </mat-dialog-content>
   <mat-dialog-actions>
     <a mat-button [href]="externalUrlService.chapterAudioHelpPage" target="_blank">
       <mat-icon>help</mat-icon> {{ t("help") }}
     </a>
     <span class="flex-spacer"></span>
-    <div class="uploading" *ngIf="isLoadingAudio">
-      <span>{{ t("uploading") }}</span>
-      <mat-spinner diameter="24"></mat-spinner>
-    </div>
+    @if (isLoadingAudio) {
+      <div class="uploading">
+        <span>{{ t("uploading") }}</span>
+        <mat-spinner diameter="24"></mat-spinner>
+      </div>
+    }
     <button mat-button [mat-dialog-close]="'close'" type="button" id="audio-cancel-btn">
       {{ t("cancel") }}
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -2,249 +2,249 @@
   <div [ngClass]="{ 'reviewer-panels': !canCreateQuestion }" class="header">
     <mat-icon class="mirror-rtl">list</mat-icon>
     <h2>{{ t(canCreateQuestion ? "manage_questions" : "my_progress") }}</h2>
-    <ng-container *ngIf="canCreateQuestion; else overallProgressChart" class="primary-actions">
-      <button mat-button type="button" *ngIf="showImportButton" (click)="importDialog()" id="import-btn">
-        {{ t("import_questions") }}
-      </button>
-      <button
-        *ngIf="!isLoading"
-        class="add-question-button hide-lt-sm"
-        mat-flat-button
-        type="button"
-        color="primary"
-        (click)="questionDialog()"
-      >
-        <mat-icon class="mirror-rtl">post_add</mat-icon> <span>{{ t("add_question") }}</span>
-      </button>
-      <button
-        *ngIf="!isLoading"
-        class="add-question-button hide-gt-sm"
-        mat-mini-fab
-        type="button"
-        color="primary"
-        (click)="questionDialog()"
-      >
-        <mat-icon class="mirror-rtl">post_add</mat-icon>
-      </button>
-    </ng-container>
-    <ng-template #overallProgressChart>
+    @if (canCreateQuestion) {
+      <ng-container class="primary-actions">
+        @if (showImportButton) {
+          <button mat-button type="button" (click)="importDialog()" id="import-btn">
+            {{ t("import_questions") }}
+          </button>
+        }
+        @if (!isLoading) {
+          <button
+            class="add-question-button hide-lt-sm"
+            mat-flat-button
+            type="button"
+            color="primary"
+            (click)="questionDialog()"
+          >
+            <mat-icon class="mirror-rtl">post_add</mat-icon> <span>{{ t("add_question") }}</span>
+          </button>
+        }
+        @if (!isLoading) {
+          <button
+            class="add-question-button hide-gt-sm"
+            mat-mini-fab
+            type="button"
+            color="primary"
+            (click)="questionDialog()"
+          >
+            <mat-icon class="mirror-rtl">post_add</mat-icon>
+          </button>
+        }
+      </ng-container>
+    } @else {
       <div id="overall-progress-chart">
         <app-donut-chart [colors]="['#3a3a3a', '#edecec', '#B8D332']" [data]="overallProgress()"></app-donut-chart>
       </div>
-    </ng-template>
+    }
   </div>
 
-  <div
-    fxLayout="column"
-    fxLayoutAlign="space-around"
-    *ngIf="canEditQuestion; else reviewerQuestionPanel"
-    id="text-with-questions-list"
-  >
-    <app-notice
-      id="warning-some-actions-unavailable-offline"
-      *ngIf="!isOnline && (canCreateScriptureAudio || canDeleteScriptureAudio)"
-      icon="cloud_off"
-      type="warning"
-      >{{ t("some_actions_unavailable_offline") }}</app-notice
-    >
-    <ng-container *ngFor="let text of texts">
-      <mat-expansion-panel
-        *ngIf="bookQuestionCount(text) > 0 || bookHasChapterAudio(text)"
-        [togglePosition]="'before'"
-        class="book-expander mat-elevation-z0"
-      >
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <span fxFlex>{{ getBookName(text) }}</span>
-            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
-              {{ questionCountLabel(bookQuestionCount(text)) }}
-            </span>
-            <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
-              {{ answerCountLabel(bookAnswerCount(text)) }}
-            </span>
-            <span fxFlex="64px" fxLayoutAlign="end center">
-              <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
-              <button
-                *ngIf="bookQuestionCount(text) > 0"
-                mat-icon-button
-                (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, true)"
-                [title]="t('archive_multiple', { location: getBookName(text) })"
-                class="archive-btn"
-              >
-                <mat-icon>archive</mat-icon>
-              </button>
-            </span>
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent>
-          <mat-selection-list>
-            <ng-container *ngFor="let chapter of text.chapters">
-              <mat-expansion-panel
-                [disabled]="!questionCount(text.bookNum, chapter.number)"
-                dense
-                *ngIf="
-                  questionCount(text.bookNum, chapter.number) > 0 ||
-                  (chapter.hasAudio && featureFlagsService.scriptureAudio.enabled)
-                "
-                [togglePosition]="'before'"
-                class="mat-elevation-z0"
-              >
-                <mat-expansion-panel-header>
-                  <mat-panel-title fxLayoutAlign="start center">
-                    <span fxFlex fxLayout class="book-chapter-heading"
-                      >{{ getBookName(text) + " " + chapter?.number }}
-                      <mat-icon
-                        *ngIf="featureFlagsService.scriptureAudio.enabled && chapter.hasAudio"
-                        title="{{ t('chapter_audio_attached') }}"
-                        class="material-icons-outlined"
-                        >audio_file</mat-icon
-                      ></span
+  @if (canEditQuestion) {
+    <div fxLayout="column" fxLayoutAlign="space-around" id="text-with-questions-list">
+      @if (!isOnline && (canCreateScriptureAudio || canDeleteScriptureAudio)) {
+        <app-notice id="warning-some-actions-unavailable-offline" icon="cloud_off" type="warning">{{
+          t("some_actions_unavailable_offline")
+        }}</app-notice>
+      }
+      @for (text of texts; track text) {
+        @if (bookQuestionCount(text) > 0 || bookHasChapterAudio(text)) {
+          <mat-expansion-panel [togglePosition]="'before'" class="book-expander mat-elevation-z0">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <span fxFlex>{{ getBookName(text) }}</span>
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
+                  {{ questionCountLabel(bookQuestionCount(text)) }}
+                </span>
+                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                  {{ answerCountLabel(bookAnswerCount(text)) }}
+                </span>
+                <span fxFlex="64px" fxLayoutAlign="end center">
+                  <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                  @if (bookQuestionCount(text) > 0) {
+                    <button
+                      mat-icon-button
+                      (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, true)"
+                      [title]="t('archive_multiple', { location: getBookName(text) })"
+                      class="archive-btn"
                     >
-                    <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
-                      {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
-                    </span>
-                    <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
-                      {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
-                    </span>
-                    <span fxFlex="64px" fxLayoutAlign="end center">
-                      <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
-                      <button
-                        class="chapter-menu-button"
-                        mat-icon-button
-                        [matMenuTriggerFor]="menu"
-                        (click)="$event.stopPropagation()"
-                      >
-                        <mat-icon>more_vert</mat-icon>
-                      </button>
-                      <mat-menu #menu="matMenu" class="checking-overview-chapter-menu">
-                        <button
-                          *ngIf="questionCount(text.bookNum, chapter.number) > 0"
-                          mat-menu-item
-                          (click)="setArchiveStatusForQuestionsInChapter(text, chapter, true)"
-                          class="archive-btn"
-                        >
-                          <mat-icon>archive</mat-icon>
-                          <span>{{ t("archive_multiple", { location: getBookName(text) }) }}</span>
-                        </button>
-                        <button
-                          *ngIf="!chapter.hasAudio && canCreateScriptureAudio"
-                          mat-menu-item
-                          (click)="chapterAudioDialog(text, chapter)"
-                          class="add-audio-btn"
-                        >
-                          <mat-icon>audio_file</mat-icon>
-                          <span>{{ t("add_chapter_audio") }}</span>
-                        </button>
-                        <ng-container *ngIf="chapter.hasAudio">
-                          <button
-                            *ngIf="canCreateScriptureAudio"
-                            mat-menu-item
-                            (click)="chapterAudioDialog(text, chapter)"
-                            class="edit-audio-btn"
-                          >
-                            <mat-icon>edit</mat-icon>
-                            <span>{{ t("edit_chapter_audio") }}</span>
-                          </button>
-                          <button
-                            *ngIf="canDeleteScriptureAudio"
-                            mat-menu-item
-                            (click)="deleteChapterAudio(text, chapter)"
-                            class="delete-audio-btn"
-                            [disabled]="!isOnline"
-                          >
-                            <mat-icon>delete</mat-icon>
-                            <span>{{ t("delete_chapter_audio") }}</span>
-                          </button>
-                        </ng-container>
-                      </mat-menu>
-                    </span>
-                  </mat-panel-title>
-                </mat-expansion-panel-header>
-                <ng-template matExpansionPanelContent>
-                  <mat-selection-list [multiple]="false">
-                    <mat-list-item
-                      *ngFor="let questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number))"
-                      disableRipple
+                      <mat-icon>archive</mat-icon>
+                    </button>
+                  }
+                </span>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <ng-template matExpansionPanelContent>
+              <mat-selection-list>
+                @for (chapter of text.chapters; track chapter) {
+                  @if (
+                    questionCount(text.bookNum, chapter.number) > 0 ||
+                    (chapter.hasAudio && featureFlagsService.scriptureAudio.enabled)
+                  ) {
+                    <mat-expansion-panel
+                      [disabled]="!questionCount(text.bookNum, chapter.number)"
+                      dense
+                      [togglePosition]="'before'"
+                      class="mat-elevation-z0"
                     >
-                      <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                        <button
-                          mat-icon-button
-                          (click)="questionDialog(questionDoc)"
-                          class="edit-btn"
-                          [matTooltip]="t('tooltip_edit')"
-                          matTooltipPosition="left"
-                        >
-                          <mat-icon>edit</mat-icon>
-                        </button>
-                        v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
-                        <mat-icon class="audio-icon material-icons-outlined" *ngIf="questionDoc.data?.audioUrl">
-                          audio_file
-                        </mat-icon>
-                        <span fxFlex class="no-overflow-ellipsis">
-                          <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
-                        </span>
-                        <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
-                          {{ answerCountLabel(questionDoc.getAnswers().length) }}
-                        </span>
-                        <span fxFlex="64px" fxLayoutAlign="end center">
-                          <button
-                            mat-icon-button
-                            (click)="setQuestionArchiveStatus(questionDoc, true)"
-                            title="{{ t('archive') }}"
-                            class="archive-btn"
-                          >
-                            <mat-icon>archive</mat-icon>
-                          </button>
-                        </span>
-                      </div>
-                    </mat-list-item>
-                  </mat-selection-list>
-                </ng-template>
-              </mat-expansion-panel>
-            </ng-container>
-          </mat-selection-list>
-        </ng-template>
-      </mat-expansion-panel>
-    </ng-container>
-  </div>
-
-  <div
-    fxLayout="row"
-    fxLayoutAlign="space-around"
-    class="reviewer-panels"
-    *ngIf="showNoQuestionsMessage"
-    id="no-questions-label"
-  >
-    <p>
-      {{ t("no_questions") }}
-      <span
-        *ngIf="canCreateQuestion"
-        [innerHtml]="i18n.translateAndInsertTags('checking_overview.click_add_question')"
-      ></span>
-    </p>
-  </div>
-
-  <p id="loading-questions-message" *ngIf="showQuestionsLoadingMessage">{{ t("loading_questions") }}</p>
-
-  <ng-template #reviewerQuestionPanel>
+                      <mat-expansion-panel-header>
+                        <mat-panel-title fxLayoutAlign="start center">
+                          <span fxFlex fxLayout class="book-chapter-heading"
+                            >{{ getBookName(text) + " " + chapter?.number }}
+                            @if (featureFlagsService.scriptureAudio.enabled && chapter.hasAudio) {
+                              <mat-icon title="{{ t('chapter_audio_attached') }}" class="material-icons-outlined"
+                                >audio_file</mat-icon
+                              >
+                            }
+                          </span>
+                          <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
+                            {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
+                          </span>
+                          <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                            {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
+                          </span>
+                          <span fxFlex="64px" fxLayoutAlign="end center">
+                            <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                            <button
+                              class="chapter-menu-button"
+                              mat-icon-button
+                              [matMenuTriggerFor]="menu"
+                              (click)="$event.stopPropagation()"
+                            >
+                              <mat-icon>more_vert</mat-icon>
+                            </button>
+                            <mat-menu #menu="matMenu" class="checking-overview-chapter-menu">
+                              @if (questionCount(text.bookNum, chapter.number) > 0) {
+                                <button
+                                  mat-menu-item
+                                  (click)="setArchiveStatusForQuestionsInChapter(text, chapter, true)"
+                                  class="archive-btn"
+                                >
+                                  <mat-icon>archive</mat-icon>
+                                  <span>{{ t("archive_multiple", { location: getBookName(text) }) }}</span>
+                                </button>
+                              }
+                              @if (!chapter.hasAudio && canCreateScriptureAudio) {
+                                <button mat-menu-item (click)="chapterAudioDialog(text, chapter)" class="add-audio-btn">
+                                  <mat-icon>audio_file</mat-icon>
+                                  <span>{{ t("add_chapter_audio") }}</span>
+                                </button>
+                              }
+                              @if (chapter.hasAudio) {
+                                @if (canCreateScriptureAudio) {
+                                  <button
+                                    mat-menu-item
+                                    (click)="chapterAudioDialog(text, chapter)"
+                                    class="edit-audio-btn"
+                                  >
+                                    <mat-icon>edit</mat-icon>
+                                    <span>{{ t("edit_chapter_audio") }}</span>
+                                  </button>
+                                }
+                                @if (canDeleteScriptureAudio) {
+                                  <button
+                                    mat-menu-item
+                                    (click)="deleteChapterAudio(text, chapter)"
+                                    class="delete-audio-btn"
+                                    [disabled]="!isOnline"
+                                  >
+                                    <mat-icon>delete</mat-icon>
+                                    <span>{{ t("delete_chapter_audio") }}</span>
+                                  </button>
+                                }
+                              }
+                            </mat-menu>
+                          </span>
+                        </mat-panel-title>
+                      </mat-expansion-panel-header>
+                      <ng-template matExpansionPanelContent>
+                        <mat-selection-list [multiple]="false">
+                          @for (
+                            questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number));
+                            track questionDoc
+                          ) {
+                            <mat-list-item disableRipple>
+                              <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                                <button
+                                  mat-icon-button
+                                  (click)="questionDialog(questionDoc)"
+                                  class="edit-btn"
+                                  [matTooltip]="t('tooltip_edit')"
+                                  matTooltipPosition="left"
+                                >
+                                  <mat-icon>edit</mat-icon>
+                                </button>
+                                v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
+                                @if (questionDoc.data?.audioUrl) {
+                                  <mat-icon class="audio-icon material-icons-outlined"> audio_file </mat-icon>
+                                }
+                                <span fxFlex class="no-overflow-ellipsis">
+                                  @if (questionDoc.data?.text) {
+                                    <span>{{ questionDoc.data?.text }}</span>
+                                  }
+                                </span>
+                                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                                  {{ answerCountLabel(questionDoc.getAnswers().length) }}
+                                </span>
+                                <span fxFlex="64px" fxLayoutAlign="end center">
+                                  <button
+                                    mat-icon-button
+                                    (click)="setQuestionArchiveStatus(questionDoc, true)"
+                                    title="{{ t('archive') }}"
+                                    class="archive-btn"
+                                  >
+                                    <mat-icon>archive</mat-icon>
+                                  </button>
+                                </span>
+                              </div>
+                            </mat-list-item>
+                          }
+                        </mat-selection-list>
+                      </ng-template>
+                    </mat-expansion-panel>
+                  }
+                }
+              </mat-selection-list>
+            </ng-template>
+          </mat-expansion-panel>
+        }
+      }
+    </div>
+  } @else {
     <div fxLayout="column" fxLayoutAlign="space-around" class="reviewer-panels" id="reviewer-question-panel">
       <mat-list dense id="reviewer-questions-list">
-        <ng-container *ngFor="let text of texts">
-          <mat-list-item *ngIf="bookQuestionCount(text) > 0" [appRouterLink]="getRouterLink(getBookId(text))">
-            <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-              <span fxFlex>{{ getBookName(text) }}</span>
-              <span>
-                <app-donut-chart
-                  [colors]="['#3a3a3a', '#edecec', '#B8D332']"
-                  [data]="bookProgress(text)"
-                ></app-donut-chart>
-              </span>
-            </div>
-          </mat-list-item>
-        </ng-container>
+        @for (text of texts; track text) {
+          @if (bookQuestionCount(text) > 0) {
+            <mat-list-item [appRouterLink]="getRouterLink(getBookId(text))">
+              <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                <span fxFlex>{{ getBookName(text) }}</span>
+                <span>
+                  <app-donut-chart
+                    [colors]="['#3a3a3a', '#edecec', '#B8D332']"
+                    [data]="bookProgress(text)"
+                  ></app-donut-chart>
+                </span>
+              </div>
+            </mat-list-item>
+          }
+        }
       </mat-list>
     </div>
-  </ng-template>
+  }
+
+  @if (showNoQuestionsMessage) {
+    <div fxLayout="row" fxLayoutAlign="space-around" class="reviewer-panels" id="no-questions-label">
+      <p>
+        {{ t("no_questions") }}
+        @if (canCreateQuestion) {
+          <span [innerHtml]="i18n.translateAndInsertTags('checking_overview.click_add_question')"></span>
+        }
+      </p>
+    </div>
+  }
+
+  @if (showQuestionsLoadingMessage) {
+    <p id="loading-questions-message">{{ t("loading_questions") }}</p>
+  }
 
   <div class="header">
     <mat-icon class="mirror-rtl">bar_chart</mat-icon>
@@ -252,15 +252,17 @@
   </div>
 
   <div fxLayout="row wrap" fxLayoutAlign="space-between" class="reviewer-panels stat-panels">
-    <mat-card class="card card-content-question mat-elevation-z2" *ngIf="canCreateQuestion">
-      <mat-card-content>
-        <span fxFlex>
-          <div class="stat-total">{{ allQuestionsCount }}</div>
-          <div class="stat-label">{{ t("questions") }}</div>
-        </span>
-        <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">help</mat-icon> </span>
-      </mat-card-content>
-    </mat-card>
+    @if (canCreateQuestion) {
+      <mat-card class="card card-content-question mat-elevation-z2">
+        <mat-card-content>
+          <span fxFlex>
+            <div class="stat-total">{{ allQuestionsCount }}</div>
+            <div class="stat-label">{{ t("questions") }}</div>
+          </span>
+          <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">help</mat-icon> </span>
+        </mat-card-content>
+      </mat-card>
+    }
     <mat-card class="card card-content-answer">
       <mat-card-content>
         <span fxFlex>
@@ -279,125 +281,137 @@
         <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">comment</mat-icon> </span>
       </mat-card-content>
     </mat-card>
-    <mat-card *ngIf="canSeeOtherUserResponses" class="card card-content-like">
-      <mat-card-content>
-        <span fxFlex>
-          <div class="stat-total">{{ myLikeCount }}</div>
-          <div class="stat-label">{{ t("likes") }}</div>
-        </span>
-        <span fxLayoutAlign="start center"> <mat-icon>thumb_up</mat-icon> </span>
-      </mat-card-content>
-    </mat-card>
+    @if (canSeeOtherUserResponses) {
+      <mat-card class="card card-content-like">
+        <mat-card-content>
+          <span fxFlex>
+            <div class="stat-total">{{ myLikeCount }}</div>
+            <div class="stat-label">{{ t("likes") }}</div>
+          </span>
+          <span fxLayoutAlign="start center"> <mat-icon>thumb_up</mat-icon> </span>
+        </mat-card-content>
+      </mat-card>
+    }
   </div>
 
-  <div *ngIf="canEditQuestion" class="header">
-    <mat-icon>archive</mat-icon>
-    <h2>{{ t("archived_questions") }}</h2>
-  </div>
-
-  <div fxLayout="column" *ngIf="canEditQuestion" id="text-with-archived-questions">
-    <ng-container *ngFor="let text of texts">
-      <mat-expansion-panel
-        *ngIf="bookQuestionCount(text, true) > 0"
-        [togglePosition]="'before'"
-        class="book-expander mat-elevation-z0"
-      >
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-              <span fxFlex>{{ getBookName(text) }}</span>
-              <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
-                {{ questionCountLabel(bookQuestionCount(text, true)) }}
-              </span>
-              <span fxFlex="64px" fxLayoutAlign="end center">
-                <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
-                <button
-                  mat-icon-button
-                  (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, false)"
-                  [title]="t('republish_multiple', { location: getBookName(text) })"
-                  class="publish-btn"
-                >
-                  <mat-icon>public</mat-icon>
-                </button>
-              </span>
-            </div>
-          </mat-panel-title>
-        </mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent>
-          <ng-container *ngFor="let chapter of text.chapters">
-            <mat-expansion-panel
-              [togglePosition]="'before'"
-              class="mat-elevation-z0"
-              *ngIf="questionCount(text.bookNum, chapter.number, true) > 0"
-            >
-              <mat-expansion-panel-header>
-                <mat-panel-title>
-                  <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                    <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
-                    <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
-                      {{ questionCountLabel(questionCount(text.bookNum, chapter.number, true)) }}
-                    </span>
-                    <span fxFlex="64px" fxLayoutAlign="end center">
-                      <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
-                      <button
-                        mat-icon-button
-                        (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInChapter(text, chapter, false)"
-                        [title]="t('republish_multiple', { location: getBookName(text) + ' ' + chapter.number })"
-                        class="publish-btn"
-                      >
-                        <mat-icon>public</mat-icon>
-                      </button>
-                    </span>
-                  </div>
-                </mat-panel-title>
-              </mat-expansion-panel-header>
-              <ng-template matExpansionPanelContent>
-                <mat-selection-list [multiple]="false">
-                  <mat-list-item
-                    *ngFor="let questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number), true)"
-                    disableRipple
-                  >
-                    <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                      v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
-                      <mat-icon *ngIf="questionDoc.data?.audioUrl" class="audio-icon material-icons-outlined">
-                        audio_file
-                      </mat-icon>
-                      <span fxFlex class="no-overflow-ellipsis">
-                        <span *ngIf="questionDoc.data?.text">{{ questionDoc.data?.text }}</span>
-                      </span>
-                      <span fxFlex="260px" fxHide.lt-sm fxLayoutAlign="end center" class="date-archived">{{
-                        timeArchivedStamp(questionDoc.data?.dateArchived)
-                      }}</span>
-                      <span fxFlex="64px" fxLayoutAlign="end center">
-                        <button
-                          mat-icon-button
-                          (click)="setQuestionArchiveStatus(questionDoc, false)"
-                          title="{{ t('republish') }}"
-                          class="publish-btn"
-                        >
-                          <mat-icon>public</mat-icon>
-                        </button>
-                      </span>
-                    </div>
-                  </mat-list-item>
-                </mat-selection-list>
-              </ng-template>
-            </mat-expansion-panel>
-          </ng-container>
-        </ng-template>
-      </mat-expansion-panel>
-    </ng-container>
-    <div
-      fxLayout="row"
-      fxLayoutAlign="space-around"
-      class="reviewer-panels"
-      *ngIf="showNoArchivedQuestionsMessage"
-      id="no-archived-questions-label"
-    >
-      <p>{{ t("no_archived_questions") }}</p>
+  @if (canEditQuestion) {
+    <div class="header">
+      <mat-icon>archive</mat-icon>
+      <h2>{{ t("archived_questions") }}</h2>
     </div>
-  </div>
-  <p *ngIf="showArchivedQuestionsLoadingMessage" id="loading-archived-questions-message">
-    {{ t("loading_questions") }}
-  </p>
+  }
+
+  @if (canEditQuestion) {
+    <div fxLayout="column" id="text-with-archived-questions">
+      @for (text of texts; track text) {
+        @if (bookQuestionCount(text, true) > 0) {
+          <mat-expansion-panel [togglePosition]="'before'" class="book-expander mat-elevation-z0">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                  <span fxFlex>{{ getBookName(text) }}</span>
+                  <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
+                    {{ questionCountLabel(bookQuestionCount(text, true)) }}
+                  </span>
+                  <span fxFlex="64px" fxLayoutAlign="end center">
+                    <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                    <button
+                      mat-icon-button
+                      (click)="$event.stopPropagation(); setArchiveStatusForQuestionsInBook(text, false)"
+                      [title]="t('republish_multiple', { location: getBookName(text) })"
+                      class="publish-btn"
+                    >
+                      <mat-icon>public</mat-icon>
+                    </button>
+                  </span>
+                </div>
+              </mat-panel-title>
+            </mat-expansion-panel-header>
+            <ng-template matExpansionPanelContent>
+              @for (chapter of text.chapters; track chapter) {
+                @if (questionCount(text.bookNum, chapter.number, true) > 0) {
+                  <mat-expansion-panel [togglePosition]="'before'" class="mat-elevation-z0">
+                    <mat-expansion-panel-header>
+                      <mat-panel-title>
+                        <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                          <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
+                          <span
+                            fxFlex="110px"
+                            fxShow
+                            fxHide.xs
+                            fxLayoutAlign="end center"
+                            class="archived-questions-count"
+                          >
+                            {{ questionCountLabel(questionCount(text.bookNum, chapter.number, true)) }}
+                          </span>
+                          <span fxFlex="64px" fxLayoutAlign="end center">
+                            <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
+                            <button
+                              mat-icon-button
+                              (click)="
+                                $event.stopPropagation(); setArchiveStatusForQuestionsInChapter(text, chapter, false)
+                              "
+                              [title]="t('republish_multiple', { location: getBookName(text) + ' ' + chapter.number })"
+                              class="publish-btn"
+                            >
+                              <mat-icon>public</mat-icon>
+                            </button>
+                          </span>
+                        </div>
+                      </mat-panel-title>
+                    </mat-expansion-panel-header>
+                    <ng-template matExpansionPanelContent>
+                      <mat-selection-list [multiple]="false">
+                        @for (
+                          questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number), true);
+                          track questionDoc
+                        ) {
+                          <mat-list-item disableRipple>
+                            <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                              v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
+                              @if (questionDoc.data?.audioUrl) {
+                                <mat-icon class="audio-icon material-icons-outlined"> audio_file </mat-icon>
+                              }
+                              <span fxFlex class="no-overflow-ellipsis">
+                                @if (questionDoc.data?.text) {
+                                  <span>{{ questionDoc.data?.text }}</span>
+                                }
+                              </span>
+                              <span fxFlex="260px" fxHide.lt-sm fxLayoutAlign="end center" class="date-archived">{{
+                                timeArchivedStamp(questionDoc.data?.dateArchived)
+                              }}</span>
+                              <span fxFlex="64px" fxLayoutAlign="end center">
+                                <button
+                                  mat-icon-button
+                                  (click)="setQuestionArchiveStatus(questionDoc, false)"
+                                  title="{{ t('republish') }}"
+                                  class="publish-btn"
+                                >
+                                  <mat-icon>public</mat-icon>
+                                </button>
+                              </span>
+                            </div>
+                          </mat-list-item>
+                        }
+                      </mat-selection-list>
+                    </ng-template>
+                  </mat-expansion-panel>
+                }
+              }
+            </ng-template>
+          </mat-expansion-panel>
+        }
+      }
+      @if (showNoArchivedQuestionsMessage) {
+        <div fxLayout="row" fxLayoutAlign="space-around" class="reviewer-panels" id="no-archived-questions-label">
+          <p>{{ t("no_archived_questions") }}</p>
+        </div>
+      }
+    </div>
+  }
+  @if (showArchivedQuestionsLoadingMessage) {
+    <p id="loading-archived-questions-message">
+      {{ t("loading_questions") }}
+    </p>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -1,228 +1,259 @@
 <ng-container *transloco="let t; read: 'checking_answers'">
   <div class="answers-component">
     <div class="answers-component-scrollable-content">
-      <app-checking-question
-        *ngIf="featureFlags.scriptureAudio.enabled"
-        [questionDoc]="questionDoc"
-        (audioPlayed)="playAudio()"
-      >
-      </app-checking-question>
+      @if (featureFlags.scriptureAudio.enabled) {
+        <app-checking-question [questionDoc]="questionDoc" (audioPlayed)="playAudio()"> </app-checking-question>
+      }
       <div class="answer-question">
         <div class="question">
-          <ng-container *ngIf="!featureFlags.scriptureAudio.enabled">
+          @if (!featureFlags.scriptureAudio.enabled) {
             <div class="question-text">{{ questionDoc?.data?.text }}</div>
-            <div *ngIf="questionDoc?.data?.audioUrl" class="question-audio">
-              <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
-              </app-checking-audio-player>
-            </div>
-          </ng-container>
-          <div class="question-footer" *ngIf="canEditQuestion">
-            <div class="actions">
-              <button mat-button type="button" (click)="questionDialog()" class="edit-question-button short-button">
-                {{ t("edit") }}
-              </button>
-              <button mat-button type="button" (click)="archiveQuestion()" class="archive-question-button short-button">
-                {{ t("archive") }}
-              </button>
-            </div>
-          </div>
-        </div>
-        <div *ngIf="!answerFormVisible" class="actions">
-          <button
-            *ngIf="currentUserTotalAnswers === 0 && canAddAnswer"
-            mat-flat-button
-            color="primary"
-            (click)="showAnswerForm()"
-            id="add-answer"
-          >
-            {{ t("add_answer") }}
-          </button>
-        </div>
-      </div>
-      <div *ngIf="answerFormVisible">
-        <form autocomplete="off" id="answer-form" appScrollIntoView>
-          <app-text-and-audio
-            #answer
-            appAutofocus
-            [input]="activeAnswer"
-            [textLabel]="t('your_answer')"
-          ></app-text-and-audio>
-          <div class="bottom-row">
-            <div class="attachments">
-              <div class="add-audio">
-                <button
-                  mat-icon-button
-                  *ngIf="!answer.input?.audioUrl && answer.audioAttachment.status !== 'recording'"
-                  (click)="startRecording()"
-                  [matTooltip]="t('tooltip_record')"
-                >
-                  <mat-icon>mic</mat-icon>
-                </button>
-                <button
-                  mat-icon-button
-                  *ngIf="answer.audioAttachment.status === 'recording'"
-                  (click)="stopRecording()"
-                  [matTooltip]="t('tooltip_stop')"
-                >
-                  <mat-icon class="stop-recording">stop</mat-icon>
-                </button>
+            @if (questionDoc?.data?.audioUrl) {
+              <div class="question-audio">
+                <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
+                </app-checking-audio-player>
               </div>
-              <div class="audio-added" *ngIf="answer.input?.audioUrl">
-                <app-single-button-audio-player
-                  #audio
-                  [source]="answer.input?.audioUrl"
-                  (click)="toggleAudio()"
-                  theme="secondary"
-                >
-                  <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
-                </app-single-button-audio-player>
-                <button mat-icon-button (click)="deleteAudio()" class="clear">
-                  <mat-icon>clear</mat-icon>
-                </button>
-              </div>
-              <button
-                mat-icon-button
-                *ngIf="!selectedText"
-                id="select-scripture"
-                (click)="selectScripture()"
-                [matTooltip]="t('tooltip_attach')"
-              >
-                <mat-icon class="attach-icon">attach_file</mat-icon>
-              </button>
-              <div *ngIf="selectedText" class="answer-scripture">
-                <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
-                <button mat-icon-button (click)="clearSelection()" class="answer-scripture-clear">
-                  <mat-icon>clear</mat-icon>
-                </button>
-              </div>
-            </div>
-            <div *ngIf="isScreenSmall">
-              <button mat-icon-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
-                <mat-icon class="material-icons-outlined">cancel</mat-icon>
-              </button>
-              <button mat-icon-button color="primary" id="save-answer" (click)="submit()" [disabled]="submittingAnswer">
-                <mat-icon>check_circle</mat-icon>
-              </button>
-            </div>
-            <div *ngIf="!isScreenSmall" class="large-form-action-buttons">
-              <button mat-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
-                <mat-icon>close</mat-icon>
-                {{ t("cancel") }}
-              </button>
-              <button mat-flat-button color="primary" id="save-answer" (click)="submit()" [disabled]="submittingAnswer">
-                <mat-icon>check</mat-icon>
-                {{ t("save_answer") }}
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-      <div class="answers-container" *ngIf="shouldShowAnswers">
-        <h3 id="totalAnswersMessage">
-          <div *ngIf="shouldSeeAnswersList; else noAnswerCountReport">
-            {{ t("answers", { count: totalAnswers }) }}
-          </div>
-          <ng-template #noAnswerCountReport
-            ><div>{{ t("your_answer") }}</div></ng-template
-          >
-        </h3>
-        <div
-          class="answer"
-          *ngFor="let answer of answers"
-          [ngClass]="{ attention: answersHighlightStatus.get(answer.dataId) }"
-        >
-          <div *ngIf="canSeeOtherUserResponses" class="like">
-            <button
-              mat-icon-button
-              class="like-answer"
-              (click)="likeAnswer(answer)"
-              [ngClass]="{ liked: hasUserLikedAnswer(answer) }"
-            >
-              <mat-icon>thumb_up</mat-icon>
-            </button>
-            <span class="like-count">{{ answer.likes.length }}</span>
-          </div>
-          <div class="answer-detail">
-            <div *ngIf="answer.text" class="answer-text">{{ answer.text }}</div>
-            <div *ngIf="answer.scriptureText" class="answer-scripture" dir="auto">
-              <span class="answer-scripture-text">{{
-                (answer.selectionStartClipped ? "…" : "") +
-                  (answer.scriptureText || "") +
-                  (answer.selectionEndClipped ? "…" : "")
-              }}</span>
-              <span class="answer-scripture-verse">{{ "(" + scriptureTextVerseRef(answer.verseRef) + ")" }}</span>
-            </div>
-            <app-checking-audio-player *ngIf="answer.audioUrl" [source]="getFileSource(answer.audioUrl)">
-            </app-checking-audio-player>
-            <div class="answer-footer">
-              <app-owner
-                [ownerRef]="answer.ownerRef"
-                [includeAvatar]="true"
-                [layoutStacked]="true"
-                [dateTime]="answer.dateCreated"
-              ></app-owner>
+            }
+          }
+          @if (canEditQuestion) {
+            <div class="question-footer">
               <div class="actions">
-                <button
-                  *ngIf="canChangeAnswerStatus(answer)"
-                  mat-button
-                  type="button"
-                  (click)="markAnswerForExport(answer)"
-                  class="answer-status answer-export short-button"
-                  [class.status-exportable]="isMarkedForExport(answer)"
-                  [matTooltip]="t('tooltip_status_export')"
-                  matTooltipPosition="above"
-                >
-                  {{ t(isMarkedForExport(answer) ? "marked_for_export" : "mark_for_export") }}
-                </button>
-                <button
-                  *ngIf="canChangeAnswerStatus(answer)"
-                  mat-button
-                  type="button"
-                  (click)="markAnswerAsResolved(answer)"
-                  class="answer-status answer-resolve short-button"
-                  [class.status-resolved]="isAnswerResolved(answer)"
-                  [matTooltip]="t('tooltip_status_resolve')"
-                  matTooltipPosition="above"
-                >
-                  {{ t(isAnswerResolved(answer) ? "resolved" : "resolve") }}
-                </button>
-
-                <button
-                  *ngIf="canEditAnswer(answer)"
-                  mat-button
-                  type="button"
-                  (click)="editAnswer(answer)"
-                  class="answer-edit short-button"
-                >
+                <button mat-button type="button" (click)="questionDialog()" class="edit-question-button short-button">
                   {{ t("edit") }}
                 </button>
-                <div *ngIf="canDeleteAnswer(answer)" class="delete-divider">|</div>
                 <button
-                  *ngIf="canDeleteAnswer(answer)"
                   mat-button
                   type="button"
-                  (click)="deleteAnswerClicked(answer)"
-                  class="answer-delete short-button"
+                  (click)="archiveQuestion()"
+                  class="archive-question-button short-button"
                 >
-                  {{ t("delete") }}
+                  {{ t("archive") }}
                 </button>
               </div>
             </div>
-            <app-checking-comments
-              [project]="project"
-              [projectUserConfigDoc]="projectUserConfigDoc"
-              [questionDoc]="questionDoc"
-              (action)="submitCommentAction($event)"
-              [answer]="answer"
-            ></app-checking-comments>
-          </div>
+          }
         </div>
+        @if (!answerFormVisible) {
+          <div class="actions">
+            @if (currentUserTotalAnswers === 0 && canAddAnswer) {
+              <button mat-flat-button color="primary" (click)="showAnswerForm()" id="add-answer">
+                {{ t("add_answer") }}
+              </button>
+            }
+          </div>
+        }
       </div>
+      @if (answerFormVisible) {
+        <div>
+          <form autocomplete="off" id="answer-form" appScrollIntoView>
+            <app-text-and-audio
+              #answer
+              appAutofocus
+              [input]="activeAnswer"
+              [textLabel]="t('your_answer')"
+            ></app-text-and-audio>
+            <div class="bottom-row">
+              <div class="attachments">
+                <div class="add-audio">
+                  @if (!answer.input?.audioUrl && answer.audioAttachment.status !== "recording") {
+                    <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
+                      <mat-icon>mic</mat-icon>
+                    </button>
+                  }
+                  @if (answer.audioAttachment.status === "recording") {
+                    <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
+                      <mat-icon class="stop-recording">stop</mat-icon>
+                    </button>
+                  }
+                </div>
+                @if (answer.input?.audioUrl) {
+                  <div class="audio-added">
+                    <app-single-button-audio-player
+                      #audio
+                      [source]="answer.input?.audioUrl"
+                      (click)="toggleAudio()"
+                      theme="secondary"
+                    >
+                      <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
+                    </app-single-button-audio-player>
+                    <button mat-icon-button (click)="deleteAudio()" class="clear">
+                      <mat-icon>clear</mat-icon>
+                    </button>
+                  </div>
+                }
+                @if (!selectedText) {
+                  <button
+                    mat-icon-button
+                    id="select-scripture"
+                    (click)="selectScripture()"
+                    [matTooltip]="t('tooltip_attach')"
+                  >
+                    <mat-icon class="attach-icon">attach_file</mat-icon>
+                  </button>
+                }
+                @if (selectedText) {
+                  <div class="answer-scripture">
+                    <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
+                    <button mat-icon-button (click)="clearSelection()" class="answer-scripture-clear">
+                      <mat-icon>clear</mat-icon>
+                    </button>
+                  </div>
+                }
+              </div>
+              @if (isScreenSmall) {
+                <div>
+                  <button mat-icon-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
+                    <mat-icon class="material-icons-outlined">cancel</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    id="save-answer"
+                    (click)="submit()"
+                    [disabled]="submittingAnswer"
+                  >
+                    <mat-icon>check_circle</mat-icon>
+                  </button>
+                </div>
+              }
+              @if (!isScreenSmall) {
+                <div class="large-form-action-buttons">
+                  <button mat-button type="button" (click)="hideAnswerForm()" id="cancel-answer">
+                    <mat-icon>close</mat-icon>
+                    {{ t("cancel") }}
+                  </button>
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    id="save-answer"
+                    (click)="submit()"
+                    [disabled]="submittingAnswer"
+                  >
+                    <mat-icon>check</mat-icon>
+                    {{ t("save_answer") }}
+                  </button>
+                </div>
+              }
+            </div>
+          </form>
+        </div>
+      }
+      @if (shouldShowAnswers) {
+        <div class="answers-container">
+          <h3 id="totalAnswersMessage">
+            @if (shouldSeeAnswersList) {
+              <div>
+                {{ t("answers", { count: totalAnswers }) }}
+              </div>
+            } @else {
+              <div>{{ t("your_answer") }}</div>
+            }
+          </h3>
+          @for (answer of answers; track answer) {
+            <div class="answer" [ngClass]="{ attention: answersHighlightStatus.get(answer.dataId) }">
+              @if (canSeeOtherUserResponses) {
+                <div class="like">
+                  <button
+                    mat-icon-button
+                    class="like-answer"
+                    (click)="likeAnswer(answer)"
+                    [ngClass]="{ liked: hasUserLikedAnswer(answer) }"
+                  >
+                    <mat-icon>thumb_up</mat-icon>
+                  </button>
+                  <span class="like-count">{{ answer.likes.length }}</span>
+                </div>
+              }
+              <div class="answer-detail">
+                @if (answer.text) {
+                  <div class="answer-text">{{ answer.text }}</div>
+                }
+                @if (answer.scriptureText) {
+                  <div class="answer-scripture" dir="auto">
+                    <span class="answer-scripture-text">{{
+                      (answer.selectionStartClipped ? "…" : "") +
+                        (answer.scriptureText || "") +
+                        (answer.selectionEndClipped ? "…" : "")
+                    }}</span>
+                    <span class="answer-scripture-verse">{{ "(" + scriptureTextVerseRef(answer.verseRef) + ")" }}</span>
+                  </div>
+                }
+                @if (answer.audioUrl) {
+                  <app-checking-audio-player [source]="getFileSource(answer.audioUrl)"> </app-checking-audio-player>
+                }
+                <div class="answer-footer">
+                  <app-owner
+                    [ownerRef]="answer.ownerRef"
+                    [includeAvatar]="true"
+                    [layoutStacked]="true"
+                    [dateTime]="answer.dateCreated"
+                  ></app-owner>
+                  <div class="actions">
+                    @if (canChangeAnswerStatus(answer)) {
+                      <button
+                        mat-button
+                        type="button"
+                        (click)="markAnswerForExport(answer)"
+                        class="answer-status answer-export short-button"
+                        [class.status-exportable]="isMarkedForExport(answer)"
+                        [matTooltip]="t('tooltip_status_export')"
+                        matTooltipPosition="above"
+                      >
+                        {{ t(isMarkedForExport(answer) ? "marked_for_export" : "mark_for_export") }}
+                      </button>
+                    }
+                    @if (canChangeAnswerStatus(answer)) {
+                      <button
+                        mat-button
+                        type="button"
+                        (click)="markAnswerAsResolved(answer)"
+                        class="answer-status answer-resolve short-button"
+                        [class.status-resolved]="isAnswerResolved(answer)"
+                        [matTooltip]="t('tooltip_status_resolve')"
+                        matTooltipPosition="above"
+                      >
+                        {{ t(isAnswerResolved(answer) ? "resolved" : "resolve") }}
+                      </button>
+                    }
+                    @if (canEditAnswer(answer)) {
+                      <button mat-button type="button" (click)="editAnswer(answer)" class="answer-edit short-button">
+                        {{ t("edit") }}
+                      </button>
+                    }
+                    @if (canDeleteAnswer(answer)) {
+                      <div class="delete-divider">|</div>
+                    }
+                    @if (canDeleteAnswer(answer)) {
+                      <button
+                        mat-button
+                        type="button"
+                        (click)="deleteAnswerClicked(answer)"
+                        class="answer-delete short-button"
+                      >
+                        {{ t("delete") }}
+                      </button>
+                    }
+                  </div>
+                </div>
+                <app-checking-comments
+                  [project]="project"
+                  [projectUserConfigDoc]="projectUserConfigDoc"
+                  [questionDoc]="questionDoc"
+                  (action)="submitCommentAction($event)"
+                  [answer]="answer"
+                ></app-checking-comments>
+              </div>
+            </div>
+          }
+        </div>
+      }
     </div>
-    <div class="answers-component-footer" *ngIf="remoteAnswersCount > 0 && !answerFormVisible && shouldSeeAnswersList">
-      <button mat-button id="show-unread-answers-button" (click)="showRemoteAnswers(true)">
-        {{ t("show_more_unread", { count: remoteAnswersCount }) }}
-      </button>
-    </div>
+    @if (remoteAnswersCount > 0 && !answerFormVisible && shouldSeeAnswersList) {
+      <div class="answers-component-footer">
+        <button mat-button id="show-unread-answers-button" (click)="showRemoteAnswers(true)">
+          {{ t("show_more_unread", { count: remoteAnswersCount }) }}
+        </button>
+      </div>
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comment-form/checking-comment-form.component.html
@@ -3,7 +3,9 @@
     <mat-form-field appearance="outline">
       <mat-label>{{ t("your_comment") }}</mat-label>
       <input matInput type="text" appAutofocus formControlName="commentText" />
-      <mat-error *ngIf="showValidationError">{{ t("comment_cannot_be_blank") }}</mat-error>
+      @if (showValidationError) {
+        <mat-error>{{ t("comment_cannot_be_blank") }}</mat-error>
+      }
     </mat-form-field>
     <div class="form-actions">
       <button mat-button type="button" (click)="submitCancel()" class="cancel-comment">{{ t("cancel") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
@@ -1,64 +1,47 @@
 <ng-container *transloco="let t; read: 'checking_comments'">
-  <div *ngFor="let comment of getSortedComments(); index as i">
-    <div
-      class="comment"
-      [ngClass]="{ 'comment-unread': !hasUserReadComment(comment) }"
-      *ngIf="
+  @for (comment of getSortedComments(); track comment; let i = $index) {
+    <div>
+      @if (
         (activeComment == null || (commentFormVisible && activeComment?.dataId !== comment.dataId)) &&
         (i + 1 < maxCommentsToShow || commentCount === maxCommentsToShow || showAllComments)
-      "
-    >
-      <span class="comment-text">{{ comment.text }}</span> <span class="divider">-</span>
-      <app-owner [ownerRef]="comment.ownerRef" [dateTime]="comment.dateCreated"></app-owner>
-      <div class="actions">
-        <button
-          *ngIf="canEditComment(comment)"
-          mat-button
-          type="button"
-          (click)="editComment(comment)"
-          class="comment-edit"
-        >
-          {{ t("edit") }}
-        </button>
-        <button
-          *ngIf="canDeleteComment(comment)"
-          mat-button
-          type="button"
-          (click)="deleteCommentClicked(comment)"
-          class="comment-delete"
-        >
-          {{ t("delete") }}
-        </button>
-      </div>
+      ) {
+        <div class="comment" [ngClass]="{ 'comment-unread': !hasUserReadComment(comment) }">
+          <span class="comment-text">{{ comment.text }}</span> <span class="divider">-</span>
+          <app-owner [ownerRef]="comment.ownerRef" [dateTime]="comment.dateCreated"></app-owner>
+          <div class="actions">
+            @if (canEditComment(comment)) {
+              <button mat-button type="button" (click)="editComment(comment)" class="comment-edit">
+                {{ t("edit") }}
+              </button>
+            }
+            @if (canDeleteComment(comment)) {
+              <button mat-button type="button" (click)="deleteCommentClicked(comment)" class="comment-delete">
+                {{ t("delete") }}
+              </button>
+            }
+          </div>
+        </div>
+      }
+      @if (commentFormVisible && activeComment?.dataId === comment.dataId) {
+        <app-checking-comment-form
+          (save)="submit($event)"
+          (cancel)="hideCommentForm()"
+          [text]="comment.text"
+        ></app-checking-comment-form>
+      }
     </div>
-    <app-checking-comment-form
-      *ngIf="commentFormVisible && activeComment?.dataId === comment.dataId"
-      (save)="submit($event)"
-      (cancel)="hideCommentForm()"
-      [text]="comment.text"
-    ></app-checking-comment-form>
-  </div>
-  <app-checking-comment-form
-    *ngIf="commentFormVisible && activeComment == null"
-    (save)="submit($event)"
-    (cancel)="hideCommentForm()"
-  ></app-checking-comment-form>
-  <button
-    *ngIf="!commentFormVisible && commentCount > maxCommentsToShow && !showAllComments"
-    mat-button
-    type="button"
-    (click)="showComments()"
-    class="show-all-comments"
-  >
-    {{ showMoreCommentsLabel }}
-  </button>
-  <button
-    *ngIf="!commentFormVisible && (commentCount <= maxCommentsToShow || showAllComments) && canAddComment"
-    mat-button
-    type="button"
-    (click)="showCommentForm()"
-    class="add-comment"
-  >
-    {{ t("add_a_comment") }}
-  </button>
+  }
+  @if (commentFormVisible && activeComment == null) {
+    <app-checking-comment-form (save)="submit($event)" (cancel)="hideCommentForm()"></app-checking-comment-form>
+  }
+  @if (!commentFormVisible && commentCount > maxCommentsToShow && !showAllComments) {
+    <button mat-button type="button" (click)="showComments()" class="show-all-comments">
+      {{ showMoreCommentsLabel }}
+    </button>
+  }
+  @if (!commentFormVisible && (commentCount <= maxCommentsToShow || showAllComments) && canAddComment) {
+    <button mat-button type="button" (click)="showCommentForm()" class="add-comment">
+      {{ t("add_a_comment") }}
+    </button>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
@@ -1,38 +1,43 @@
 <ng-container *transloco="let t; read: 'checking_questions'">
   <div>
-    <div class="scripture-audio" [class]="focusedText" *ngIf="scriptureAudioUrl != null">
-      <span class="spacer"></span>
-      <app-single-button-audio-player
-        #scriptureAudio
-        id="scriptureAudio"
-        [class]="focusedText"
-        [source]="scriptureAudioUrl"
-        [start]="scriptureAudioStart"
-        [end]="scriptureAudioEnd"
-        (click)="playScripture()"
-      >
-        <mat-icon>{{ scriptureAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
-      </app-single-button-audio-player>
-      <p (click)="selectScripture()">
-        {{ t("scripture_audio_label", { referenceForDisplay: referenceForDisplay }) }}
-      </p>
-    </div>
+    @if (scriptureAudioUrl != null) {
+      <div class="scripture-audio" [class]="focusedText">
+        <span class="spacer"></span>
+        <app-single-button-audio-player
+          #scriptureAudio
+          id="scriptureAudio"
+          [class]="focusedText"
+          [source]="scriptureAudioUrl"
+          [start]="scriptureAudioStart"
+          [end]="scriptureAudioEnd"
+          (click)="playScripture()"
+        >
+          <mat-icon>{{ scriptureAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
+        </app-single-button-audio-player>
+        <p (click)="selectScripture()">
+          {{ t("scripture_audio_label", { referenceForDisplay: referenceForDisplay }) }}
+        </p>
+      </div>
+    }
 
     <div class="question-text" [class]="focusedText">
       <span class="spacer"></span>
-      <div *ngIf="!questionAudioUrl" id="noQuestionAudio" [class]="focusedText">
-        <mat-icon class="mirror-rtl">question_answer</mat-icon>
-      </div>
-      <app-single-button-audio-player
-        #questionAudio
-        *ngIf="questionAudioUrl"
-        id="questionAudio"
-        [class]="focusedText"
-        [source]="questionAudioUrl"
-        (click)="playQuestion()"
-      >
-        <mat-icon>{{ questionAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
-      </app-single-button-audio-player>
+      @if (!questionAudioUrl) {
+        <div id="noQuestionAudio" [class]="focusedText">
+          <mat-icon class="mirror-rtl">question_answer</mat-icon>
+        </div>
+      }
+      @if (questionAudioUrl) {
+        <app-single-button-audio-player
+          #questionAudio
+          id="questionAudio"
+          [class]="focusedText"
+          [source]="questionAudioUrl"
+          (click)="playQuestion()"
+        >
+          <mat-icon>{{ questionAudio.playing ? "stop" : "play_arrow" }}</mat-icon>
+        </app-single-button-audio-player>
+      }
       <p (click)="selectQuestion()">
         {{ questionText }}
       </p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -1,14 +1,20 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
   <div class="audio-area">
     <div class="player" dir="ltr">
-      <div *ngIf="isAudioAvailable">
-        <button *ngIf="!isPlaying()" mat-icon-button type="button" (click)="play()" class="play">
-          <mat-icon>play_arrow</mat-icon>
-        </button>
-        <button *ngIf="isPlaying()" mat-icon-button type="button" (click)="pause()" class="pause">
-          <mat-icon>pause</mat-icon>
-        </button>
-      </div>
+      @if (isAudioAvailable) {
+        <div>
+          @if (!isPlaying()) {
+            <button mat-icon-button type="button" (click)="play()" class="play">
+              <mat-icon>play_arrow</mat-icon>
+            </button>
+          }
+          @if (isPlaying()) {
+            <button mat-icon-button type="button" (click)="pause()" class="pause">
+              <mat-icon>pause</mat-icon>
+            </button>
+          }
+        </div>
+      }
       <app-audio-player #audioPlayer [source]="source"></app-audio-player>
     </div>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
@@ -1,38 +1,46 @@
 <ng-container *transloco="let t; read: 'checking_audio_recorder'">
-  <div *ngIf="!hasAudioAttachment" class="no-attachment">
-    <button
-      *ngIf="!isRecording"
-      mat-button
-      (click)="startRecording()"
-      class="record"
-      [matTooltip]="t('record_audio')"
-      matTooltipPosition="before"
-    >
-      <mat-icon>mic</mat-icon>
-    </button>
-    <button
-      *ngIf="isRecording"
-      mat-button
-      (click)="stopRecording()"
-      class="stop"
-      [matTooltip]="t('stop_recording')"
-      matTooltipPosition="before"
-    >
-      <mat-icon>stop</mat-icon>
-    </button>
-  </div>
-  <div *ngIf="hasAudioAttachment" class="has-attachment">
-    <app-single-button-audio-player *ngIf="!!audio.url" [source]="audio.url" (click)="toggleAudio()">
-      <mat-icon>{{ audioPlayer?.playing ? "stop" : "play_arrow" }}</mat-icon>
-    </app-single-button-audio-player>
-    <button
-      mat-button
-      (click)="resetRecording()"
-      [matTooltip]="t('delete')"
-      class="remove-audio-file"
-      matTooltipPosition="before"
-    >
-      <mat-icon>close</mat-icon>
-    </button>
-  </div>
+  @if (!hasAudioAttachment) {
+    <div class="no-attachment">
+      @if (!isRecording) {
+        <button
+          mat-button
+          (click)="startRecording()"
+          class="record"
+          [matTooltip]="t('record_audio')"
+          matTooltipPosition="before"
+        >
+          <mat-icon>mic</mat-icon>
+        </button>
+      }
+      @if (isRecording) {
+        <button
+          mat-button
+          (click)="stopRecording()"
+          class="stop"
+          [matTooltip]="t('stop_recording')"
+          matTooltipPosition="before"
+        >
+          <mat-icon>stop</mat-icon>
+        </button>
+      }
+    </div>
+  }
+  @if (hasAudioAttachment) {
+    <div class="has-attachment">
+      @if (!!audio.url) {
+        <app-single-button-audio-player [source]="audio.url" (click)="toggleAudio()">
+          <mat-icon>{{ audioPlayer?.playing ? "stop" : "play_arrow" }}</mat-icon>
+        </app-single-button-audio-player>
+      }
+      <button
+        mat-button
+        (click)="resetRecording()"
+        [matTooltip]="t('delete')"
+        class="remove-audio-file"
+        matTooltipPosition="before"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -1,34 +1,47 @@
 <ng-container *transloco="let t; read: 'checking_questions'">
-  <mat-list *ngIf="hasQuestions">
-    <mat-list-item
-      *ngFor="let questionDoc of questionDocs"
-      (click)="activateQuestion(questionDoc)"
-      [ngClass]="{
-        'question-read': hasUserReadQuestion(questionDoc),
-        'question-unread': !hasUserReadQuestion(questionDoc),
-        'question-answered': hasUserAnswered(questionDoc),
-        'question-has-answers': getUnreadAnswers(questionDoc),
-        selected: activeQuestionDoc?.id === questionDoc.id
-      }"
-    >
-      <div class="question-item">
-        <div class="question-text">{{ questionText(questionDoc) }}</div>
-        <div class="question-meta">
-          <span class="question-verse">{{ questionVerseRef(questionDoc) }}</span>
-          <a *ngIf="getUnreadAnswers(questionDoc) > 0" class="view-answers" title="{{ t('view_answers') }}">
-            <div [matBadge]="getUnreadAnswers(questionDoc)" matBadgePosition="before" matBadgeSize="small">
-              <mat-icon aria-hidden="false" class="mirror-rtl">forum</mat-icon>
+  @if (hasQuestions) {
+    <mat-list>
+      @for (questionDoc of questionDocs; track questionDoc) {
+        <mat-list-item
+          (click)="activateQuestion(questionDoc)"
+          [ngClass]="{
+            'question-read': hasUserReadQuestion(questionDoc),
+            'question-unread': !hasUserReadQuestion(questionDoc),
+            'question-answered': hasUserAnswered(questionDoc),
+            'question-has-answers': getUnreadAnswers(questionDoc),
+            selected: activeQuestionDoc?.id === questionDoc.id
+          }"
+        >
+          <div class="question-item">
+            <div class="question-text">{{ questionText(questionDoc) }}</div>
+            <div class="question-meta">
+              <span class="question-verse">{{ questionVerseRef(questionDoc) }}</span>
+              @if (getUnreadAnswers(questionDoc) > 0) {
+                <a class="view-answers" title="{{ t('view_answers') }}">
+                  <div [matBadge]="getUnreadAnswers(questionDoc)" matBadgePosition="before" matBadgeSize="small">
+                    <mat-icon aria-hidden="false" class="mirror-rtl">forum</mat-icon>
+                  </div>
+                </a>
+              }
             </div>
-          </a>
-        </div>
-      </div>
-    </mat-list-item>
-  </mat-list>
-  <div *ngIf="!hasQuestions && haveQuestionsLoaded" class="no-questions-found">
-    <ng-container *ngIf="isFiltered">{{ t("no_questions_found_filtered") }}</ng-container>
-    <ng-container *ngIf="!isFiltered">{{ t("no_questions_found_unfiltered") }}</ng-container>
-  </div>
-  <div *ngIf="!haveQuestionsLoaded" class="loading-text">
-    {{ t("loading") }}
-  </div>
+          </div>
+        </mat-list-item>
+      }
+    </mat-list>
+  }
+  @if (!hasQuestions && haveQuestionsLoaded) {
+    <div class="no-questions-found">
+      @if (isFiltered) {
+        {{ t("no_questions_found_filtered") }}
+      }
+      @if (!isFiltered) {
+        {{ t("no_questions_found_unfiltered") }}
+      }
+    </div>
+  }
+  @if (!haveQuestionsLoaded) {
+    <div class="loading-text">
+      {{ t("loading") }}
+    </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.html
@@ -16,9 +16,11 @@
         <mat-icon>skip_next</mat-icon>
       </button>
     </div>
-    <button *ngIf="canClose" mat-icon-button class="close-button" (click)="close()">
-      <mat-icon>close</mat-icon>
-    </button>
+    @if (canClose) {
+      <button mat-icon-button class="close-button" (click)="close()">
+        <mat-icon>close</mat-icon>
+      </button>
+    }
   </div>
   <app-audio-player #audioPlayer [source]="audioSource"></app-audio-player>
   <span class="verse-label">{{ verseLabel }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -1,13 +1,11 @@
 <ng-container *transloco="let t; read: 'checking'">
   <div id="checking-app-container">
     <div id="questions-panel" #questionsPanel [ngClass]="{ 'overlay-visible': isQuestionsOverlayVisible }">
-      <span
-        *ngIf="
-          hideChapterText && hasQuestionWithoutAudio && featureFlags.scriptureAudio.enabled && canCreateScriptureAudio
-        "
-        class="audio-checking-warning"
-        >{{ t("questions_on_chapters_no_audio") }}</span
-      >
+      @if (
+        hideChapterText && hasQuestionWithoutAudio && featureFlags.scriptureAudio.enabled && canCreateScriptureAudio
+      ) {
+        <span class="audio-checking-warning">{{ t("questions_on_chapters_no_audio") }}</span>
+      }
       <header [ngClass]="{ 'filter-applied': isQuestionFilterApplied }">
         <div class="header-main">
           <h2>
@@ -16,25 +14,27 @@
           <mat-menu #questionFilterMenu>
             <mat-selection-list [multiple]="true" class="menu-list">
               <h2 matSubheader>{{ t("questions_range") }}</h2>
-              <button
-                *ngFor="let scope of questionScopes | keyvalue"
-                mat-menu-item
-                [class.selected]="scope.key === activeQuestionScope"
-                (click)="setQuestionScope(scope.key)"
-              >
-                <mat-icon>check</mat-icon>
-                {{ t(scope.value) }}
-              </button>
+              @for (scope of questionScopes | keyvalue; track scope) {
+                <button
+                  mat-menu-item
+                  [class.selected]="scope.key === activeQuestionScope"
+                  (click)="setQuestionScope(scope.key)"
+                >
+                  <mat-icon>check</mat-icon>
+                  {{ t(scope.value) }}
+                </button>
+              }
               <h2 matSubheader>{{ t("filter_questions") }}</h2>
-              <button
-                mat-menu-item
-                *ngFor="let filter of questionFilters | keyvalue"
-                [class.selected]="filter.key === activeQuestionFilter"
-                (click)="setQuestionFilter(filter.key)"
-              >
-                <mat-icon>check</mat-icon>
-                {{ t(filter.value) }}
-              </button>
+              @for (filter of questionFilters | keyvalue; track filter) {
+                <button
+                  mat-menu-item
+                  [class.selected]="filter.key === activeQuestionFilter"
+                  (click)="setQuestionFilter(filter.key)"
+                >
+                  <mat-icon>check</mat-icon>
+                  {{ t(filter.value) }}
+                </button>
+              }
             </mat-selection-list>
           </mat-menu>
           <button mat-icon-button class="questions-overlay-close" (click)="setQuestionsOverlayVisibility(false)">
@@ -80,7 +80,7 @@
             </app-book-chapter-chooser>
 
             <div class="action-icons">
-              <ng-container *ngIf="canCreateQuestions">
+              @if (canCreateQuestions) {
                 <button
                   mat-icon-button
                   type="button"
@@ -94,37 +94,39 @@
                   <mat-icon class="mirror-rtl">post_add</mat-icon>
                   <span>{{ t("add_question") }}</span>
                 </button>
-              </ng-container>
-              <button
-                *ngIf="canCreateScriptureAudio"
-                type="button"
-                mat-icon-button
-                [matTooltip]="t('manage_audio')"
-                (click)="addAudioTimingData()"
-                class="add-audio-button"
-              >
-                <mat-icon class="material-icons-outlined">audio_file</mat-icon>
-              </button>
-              <button
-                *ngIf="featureFlags.scriptureAudio.enabled && chapterHasAudio"
-                type="button"
-                mat-icon-button
-                [matTooltip]="t('play_chapter')"
-                [matTooltipDisabled]="isAudioPlaying()"
-                (click)="toggleAudio()"
-              >
-                <mat-icon>{{ isAudioPlaying() ? "stop" : "play_circle_outline" }}</mat-icon>
-              </button>
+              }
+              @if (canCreateScriptureAudio) {
+                <button
+                  type="button"
+                  mat-icon-button
+                  [matTooltip]="t('manage_audio')"
+                  (click)="addAudioTimingData()"
+                  class="add-audio-button"
+                >
+                  <mat-icon class="material-icons-outlined">audio_file</mat-icon>
+                </button>
+              }
+              @if (featureFlags.scriptureAudio.enabled && chapterHasAudio) {
+                <button
+                  type="button"
+                  mat-icon-button
+                  [matTooltip]="t('play_chapter')"
+                  [matTooltipDisabled]="isAudioPlaying()"
+                  (click)="toggleAudio()"
+                >
+                  <mat-icon>{{ isAudioPlaying() ? "stop" : "play_circle_outline" }}</mat-icon>
+                </button>
+              }
               <app-font-size [class.hidden]="hideChapterText" (apply)="applyFontChange($event)"></app-font-size>
-              <app-share-button *ngIf="canShare" [defaultRole]="defaultShareRole"></app-share-button>
+              @if (canShare) {
+                <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
+              }
             </div>
           </div>
         </header>
-        <span
-          class="no-audio-message"
-          *ngIf="!chapterHasAudio && hideChapterText && featureFlags.scriptureAudio.enabled"
-          >{{ t("question_does_not_have_audio") }}</span
-        >
+        @if (!chapterHasAudio && hideChapterText && featureFlags.scriptureAudio.enabled) {
+          <span class="no-audio-message">{{ t("question_does_not_have_audio") }}</span>
+        }
         <div id="split-container" #splitContainer>
           <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
           <as-split
@@ -161,18 +163,20 @@
               [size]="hideChapterText ? '*' : 0"
               [visible]="!showScriptureAudioPlayer || hideChapterText"
             >
-              <div *ngIf="questionsList.activeQuestionDoc" id="answer-panel" #answerPanelContainer>
-                <app-checking-answers
-                  #answersPanel
-                  [checkingTextComponent]="textPanel"
-                  [projectProfileDoc]="projectDoc"
-                  [textsByBookId]="textsByBookId"
-                  [questionDoc]="questionsList.activeQuestionDoc"
-                  [projectUserConfigDoc]="projectUserConfigDoc"
-                  (action)="answerAction($event)"
-                  (commentAction)="commentAction($event)"
-                ></app-checking-answers>
-              </div>
+              @if (questionsList.activeQuestionDoc) {
+                <div id="answer-panel" #answerPanelContainer>
+                  <app-checking-answers
+                    #answersPanel
+                    [checkingTextComponent]="textPanel"
+                    [projectProfileDoc]="projectDoc"
+                    [textsByBookId]="textsByBookId"
+                    [questionDoc]="questionsList.activeQuestionDoc"
+                    [projectUserConfigDoc]="projectUserConfigDoc"
+                    (action)="answerAction($event)"
+                    (commentAction)="commentAction($event)"
+                  ></app-checking-answers>
+                </div>
+              }
             </as-split-area>
             <as-split-area
               lockSize="true"
@@ -181,75 +185,75 @@
               [visible]="showScriptureAudioPlayer"
             >
               <div class="scripture-audio-player-wrapper">
-                <app-checking-scripture-audio-player
-                  *ngIf="showScriptureAudioPlayer"
-                  [source]="chapterAudioSource"
-                  [timing]="chapterTextAudioTiming"
-                  [textDocId]="textDocId"
-                  [canClose]="!hideChapterText"
-                  (currentVerseChanged)="highlightSegments($event)"
-                  (closed)="hideChapterAudio()"
-                ></app-checking-scripture-audio-player>
+                @if (showScriptureAudioPlayer) {
+                  <app-checking-scripture-audio-player
+                    [source]="chapterAudioSource"
+                    [timing]="chapterTextAudioTiming"
+                    [textDocId]="textDocId"
+                    [canClose]="!hideChapterText"
+                    (currentVerseChanged)="highlightSegments($event)"
+                    (closed)="hideChapterAudio()"
+                  ></app-checking-scripture-audio-player>
+                }
               </div>
             </as-split-area>
           </as-split>
         </div>
       </div>
-      <div *ngIf="projectDoc" id="question-nav">
-        <button
-          mat-button
-          *ngIf="!this.isQuestionListPermanent"
-          type="button"
-          (click)="setQuestionsOverlayVisibility(true)"
-        >
-          {{ t("view_questions") }}
-        </button>
-        <div class="question-nav-wrapper">
-          <button
-            mat-button
-            type="button"
-            (click)="activateQuestion(prevQuestion!)"
-            [disabled]="prevQuestion == null"
-            class="prev-question"
-          >
-            <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon
-            >{{ t("previous") }}
-          </button>
-          <button
-            mat-button
-            type="button"
-            (click)="activateQuestion(nextQuestion!)"
-            [disabled]="nextQuestion == null"
-            class="next-question"
-          >
-            {{ t("next") }}<mat-icon iconPositionEnd>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
-          </button>
-          <button
-            mat-icon-button
-            type="button"
-            (click)="activateQuestion(prevQuestion!)"
-            [disabled]="prevQuestion == null"
-            class="prev-question"
-          >
-            <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon>
-          </button>
-          <button
-            mat-icon-button
-            type="button"
-            (click)="activateQuestion(nextQuestion!)"
-            [disabled]="nextQuestion == null"
-            class="next-question"
-          >
-            <mat-icon>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
-          </button>
-          <a [appRouterLink]="routerLink" id="project-summary">
-            <app-donut-chart
-              [colors]="['#3a3a3a', '#fff', '#B8D332']"
-              [data]="[summary.unread, summary.read, summary.answered]"
-            ></app-donut-chart>
-          </a>
+      @if (projectDoc) {
+        <div id="question-nav">
+          @if (!this.isQuestionListPermanent) {
+            <button mat-button type="button" (click)="setQuestionsOverlayVisibility(true)">
+              {{ t("view_questions") }}
+            </button>
+          }
+          <div class="question-nav-wrapper">
+            <button
+              mat-button
+              type="button"
+              (click)="activateQuestion(prevQuestion!)"
+              [disabled]="prevQuestion == null"
+              class="prev-question"
+            >
+              <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon
+              >{{ t("previous") }}
+            </button>
+            <button
+              mat-button
+              type="button"
+              (click)="activateQuestion(nextQuestion!)"
+              [disabled]="nextQuestion == null"
+              class="next-question"
+            >
+              {{ t("next") }}<mat-icon iconPositionEnd>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
+            </button>
+            <button
+              mat-icon-button
+              type="button"
+              (click)="activateQuestion(prevQuestion!)"
+              [disabled]="prevQuestion == null"
+              class="prev-question"
+            >
+              <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon>
+            </button>
+            <button
+              mat-icon-button
+              type="button"
+              (click)="activateQuestion(nextQuestion!)"
+              [disabled]="nextQuestion == null"
+              class="next-question"
+            >
+              <mat-icon>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
+            </button>
+            <a [appRouterLink]="routerLink" id="project-summary">
+              <app-donut-chart
+                [colors]="['#3a3a3a', '#fff', '#B8D332']"
+                [data]="[summary.unread, summary.read, summary.answered]"
+              ></app-donut-chart>
+            </a>
+          </div>
         </div>
-      </div>
+      }
     </div>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/single-button-audio-player/single-button-audio-player.component.html
@@ -7,9 +7,13 @@
   }"
   *transloco="let t; read: 'checking_audio_player'"
 >
-  <ng-content *ngIf="isAudioAvailable$ | async"></ng-content>
-  <mat-spinner *ngIf="audioStatus === AudioStatus.Initializing" diameter="20" color="primary"></mat-spinner>
-  <mat-icon *ngIf="!isAudioAvailable$.value && audioStatus !== AudioStatus.Initializing" [matTooltip]="t(audioStatus)">
-    play_disabled
-  </mat-icon>
+  @if (isAudioAvailable$ | async) {
+    <ng-content></ng-content>
+  }
+  @if (audioStatus === AudioStatus.Initializing) {
+    <mat-spinner diameter="20" color="primary"></mat-spinner>
+  }
+  @if (!isAudioAvailable$.value && audioStatus !== AudioStatus.Initializing) {
+    <mat-icon [matTooltip]="t(audioStatus)"> play_disabled </mat-icon>
+  }
 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -5,211 +5,273 @@
         ? t("import_questions")
         : t("import_progress", { completed: importedCount, total: toImportCount })
     }}
-    <button *ngIf="showCloseIcon" mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
+    @if (showCloseIcon) {
+      <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
+    }
   </h2>
   <mat-dialog-content class="mat-typography">
-    <div *ngIf="status === 'file_import_errors'" class="dialog-content-header">
-      {{ t("invalid_csv_rows_will_be_skipped") }}
-    </div>
+    @if (status === "file_import_errors") {
+      <div class="dialog-content-header">
+        {{ t("invalid_csv_rows_will_be_skipped") }}
+      </div>
+    }
 
     <div class="dialog-content-body" (scroll)="dialogScroll()" #dialogContentBody>
-      <div *ngIf="status === 'initial'" class="initial-import-screen">
-        <div class="card-wrapper">
-          <mat-card>
-            <mat-card-title>{{ t("import_from_transcelerator") }}</mat-card-title>
-            <mat-card-content>
-              <ng-container *ngFor="let i of i18n.interpolate('import_questions_dialog.transcelerator_paratext')">
-                {{ i.id == null ? i.text : "" }}
-                <a *ngIf="i.id === 1" [href]="urls.transcelerator" target="_blank">{{ i.text }}</a>
-                <a *ngIf="i.id === 3" [href]="urls.paratext" target="_blank">{{ i.text }}</a>
-              </ng-container>
-
-              <ol>
-                <li *ngFor="let line of transceleratorInstructions" [innerHTML]="line"></li>
-              </ol>
-            </mat-card-content>
-            <mat-card-actions>
-              <button
-                mat-flat-button
-                color="primary"
-                (click)="importFromTranscelerator()"
-                [disabled]="transceleratorRequest.status !== 'complete'"
-              >
-                {{ t("import_from_transcelerator") }}
-              </button>
-              <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
-              <mat-error *ngIf="transceleratorRequest.status === 'offline'">
-                {{ t("no_transcelerator_offline") }}
-              </mat-error>
-              <mat-error *ngIf="transceleratorRequest.status === 'trying' && transceleratorRequest.failedAttempts > 0">
-                {{ t("network_error_transcelerator", { count: transceleratorRequest.failedAttempts }) }}
-              </mat-error>
-            </mat-card-actions>
-          </mat-card>
-          <mat-card>
-            <mat-card-title>{{ t("import_from_spreadsheet") }}</mat-card-title>
-            <mat-card-content>
-              <ol>
-                <li>
-                  {{ csvInstructions[0] }}
-                  <table>
-                    <!-- TODO internationalize the references and headings, but only once we accept localized inputs -->
-                    <tr>
-                      <th>Reference</th>
-                      <th>Question</th>
-                    </tr>
-                    <tr *ngFor="let verseNumber of [1, 2]">
-                      <td>1JN 1:{{ verseNumber }}</td>
-                      <td>{{ t("question_for_verse", { number: verseNumber }) }}</td>
-                    </tr>
-                  </table>
-                </li>
-                <li *ngFor="let line of csvInstructions.slice(1)" [innerHTML]="line"></li>
-              </ol>
-            </mat-card-content>
-
-            <mat-card-actions>
-              <button mat-flat-button color="primary" ngfSelect accept=".csv,.tsv" (fileChange)="fileSelected($event)">
-                {{ t("import_from_csv_file") }}
-              </button>
-              <a mat-button [href]="urls.csvImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
-            </mat-card-actions>
-          </mat-card>
-        </div>
-        <div class="support-message">
-          <ng-container *ngFor="let i of i18n.interpolate('import_questions_dialog.help_options')">
-            <ng-container *ngIf="i.id == null">{{ i.text }}</ng-container>
-            <a *ngIf="i.id === 1" [href]="urls.communitySupport" target="_blank">{{ i.text }}</a>
-            <a *ngIf="i.id === 3" href="mailto:{{ issueEmail }}" target="_blank">{{ issueEmail }}</a>
-          </ng-container>
-        </div>
-      </div>
-
-      <div *ngIf="status === 'loading'" class="loading"><mat-spinner></mat-spinner></div>
-
-      <div *ngIf="status === 'file_import_errors'">
-        <table mat-table [dataSource]="invalidRowsForDisplay">
-          <ng-container matColumnDef="rowNumber">
-            <th mat-header-cell *matHeaderCellDef>{{ t("row") }}</th>
-            <td mat-cell *matCellDef="let element">{{ element[0] }}</td>
-          </ng-container>
-          <ng-container matColumnDef="reference">
-            <th mat-header-cell *matHeaderCellDef>{{ t("reference") }}</th>
-            <td mat-cell *matCellDef="let element">{{ element[1] }}</td>
-          </ng-container>
-          <ng-container matColumnDef="question">
-            <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
-            <td mat-cell *matCellDef="let element">{{ element[2] }}</td>
-          </ng-container>
-
-          <tr mat-header-row *matHeaderRowDef="['rowNumber', 'reference', 'question']"></tr>
-          <tr mat-row *matRowDef="let row; columns: ['rowNumber', 'reference', 'question']"></tr>
-        </table>
-      </div>
-
-      <form *ngIf="status === 'filter'" [formGroup]="filterForm" autocomplete="off">
-        <div class="filter-references">
-          <mat-form-field appearance="outline">
-            <mat-label>{{ t("reference_from") }}</mat-label>
-            <input matInput type="text" formControlName="from" />
-            <button mat-icon-button matSuffix #fromRef id="from-btn" (click)="openScriptureChooser(fromControl)">
-              <mat-icon>expand_more</mat-icon>
-            </button>
-            <mat-error *ngIf="fromControl.invalid">{{ t("must_be_valid_reference") }}</mat-error>
-          </mat-form-field>
-          <mat-form-field appearance="outline">
-            <mat-label>{{ t("reference_to") }}</mat-label>
-            <input matInput type="text" formControlName="to" />
-            <button mat-icon-button matSuffix (click)="openScriptureChooser(toControl)">
-              <mat-icon>expand_more</mat-icon>
-            </button>
-            <mat-error *ngIf="toControl.invalid">{{ t("must_be_valid_reference") }}</mat-error>
-          </mat-form-field>
-        </div>
-        <div colspan="2" class="filter-text">
-          <div>
-            <mat-form-field appearance="fill" subscriptSizing="dynamic">
-              <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
-            </mat-form-field>
-            <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
+      @if (status === "initial") {
+        <div class="initial-import-screen">
+          <div class="card-wrapper">
+            <mat-card>
+              <mat-card-title>{{ t("import_from_transcelerator") }}</mat-card-title>
+              <mat-card-content>
+                @for (i of i18n.interpolate("import_questions_dialog.transcelerator_paratext"); track i) {
+                  {{ i.id == null ? i.text : "" }}
+                  @if (i.id === 1) {
+                    <a [href]="urls.transcelerator" target="_blank">{{ i.text }}</a>
+                  }
+                  @if (i.id === 3) {
+                    <a [href]="urls.paratext" target="_blank">{{ i.text }}</a>
+                  }
+                }
+                <ol>
+                  @for (line of transceleratorInstructions; track line) {
+                    <li [innerHTML]="line"></li>
+                  }
+                </ol>
+              </mat-card-content>
+              <mat-card-actions>
+                <button
+                  mat-flat-button
+                  color="primary"
+                  (click)="importFromTranscelerator()"
+                  [disabled]="transceleratorRequest.status !== 'complete'"
+                >
+                  {{ t("import_from_transcelerator") }}
+                </button>
+                <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
+                @if (transceleratorRequest.status === "offline") {
+                  <mat-error>
+                    {{ t("no_transcelerator_offline") }}
+                  </mat-error>
+                }
+                @if (transceleratorRequest.status === "trying" && transceleratorRequest.failedAttempts > 0) {
+                  <mat-error>
+                    {{ t("network_error_transcelerator", { count: transceleratorRequest.failedAttempts }) }}
+                  </mat-error>
+                }
+              </mat-card-actions>
+            </mat-card>
+            <mat-card>
+              <mat-card-title>{{ t("import_from_spreadsheet") }}</mat-card-title>
+              <mat-card-content>
+                <ol>
+                  <li>
+                    {{ csvInstructions[0] }}
+                    <table>
+                      <!-- TODO internationalize the references and headings, but only once we accept localized inputs -->
+                      <tr>
+                        <th>Reference</th>
+                        <th>Question</th>
+                      </tr>
+                      @for (verseNumber of [1, 2]; track verseNumber) {
+                        <tr>
+                          <td>1JN 1:{{ verseNumber }}</td>
+                          <td>{{ t("question_for_verse", { number: verseNumber }) }}</td>
+                        </tr>
+                      }
+                    </table>
+                  </li>
+                  @for (line of csvInstructions.slice(1); track line) {
+                    <li [innerHTML]="line"></li>
+                  }
+                </ol>
+              </mat-card-content>
+              <mat-card-actions>
+                <button
+                  mat-flat-button
+                  color="primary"
+                  ngfSelect
+                  accept=".csv,.tsv"
+                  (fileChange)="fileSelected($event)"
+                >
+                  {{ t("import_from_csv_file") }}
+                </button>
+                <a mat-button [href]="urls.csvImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
+              </mat-card-actions>
+            </mat-card>
+          </div>
+          <div class="support-message">
+            @for (i of i18n.interpolate("import_questions_dialog.help_options"); track i) {
+              @if (i.id == null) {
+                {{ i.text }}
+              }
+              @if (i.id === 1) {
+                <a [href]="urls.communitySupport" target="_blank">{{ i.text }}</a>
+              }
+              @if (i.id === 3) {
+                <a href="mailto:{{ issueEmail }}" target="_blank">{{ issueEmail }}</a>
+              }
+            }
           </div>
         </div>
-        <table mat-table [dataSource]="questionsForDisplay" class="question-list">
-          <ng-container matColumnDef="verse">
-            <th mat-header-cell *matHeaderCellDef>
-              <mat-checkbox #selectAllCheckbox (change)="selectAllChanged($event.checked)">{{
-                t("select_all")
-              }}</mat-checkbox>
-            </th>
-            <td mat-cell *matCellDef="let element">
-              <mat-checkbox
-                [(ngModel)]="element.checked"
-                (ngModelChange)="checkboxChanged(element)"
-                [ngModelOptions]="{ standalone: true }"
-                >{{ referenceForDisplay(element.question) }}</mat-checkbox
-              >
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="question">
-            <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.question.text }}</td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="['verse', 'question']"></tr>
-          <tr mat-row *matRowDef="let row; columns: ['verse', 'question']"></tr>
-        </table>
-      </form>
+      }
 
-      <div *ngIf="status === 'no_questions'">{{ t("no_questions_available") }}</div>
+      @if (status === "loading") {
+        <div class="loading"><mat-spinner></mat-spinner></div>
+      }
 
-      <div *ngIf="status === 'update_transcelerator'">{{ t("update_transcelerator") }}</div>
+      @if (status === "file_import_errors") {
+        <div>
+          <table mat-table [dataSource]="invalidRowsForDisplay">
+            <ng-container matColumnDef="rowNumber">
+              <th mat-header-cell *matHeaderCellDef>{{ t("row") }}</th>
+              <td mat-cell *matCellDef="let element">{{ element[0] }}</td>
+            </ng-container>
+            <ng-container matColumnDef="reference">
+              <th mat-header-cell *matHeaderCellDef>{{ t("reference") }}</th>
+              <td mat-cell *matCellDef="let element">{{ element[1] }}</td>
+            </ng-container>
+            <ng-container matColumnDef="question">
+              <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
+              <td mat-cell *matCellDef="let element">{{ element[2] }}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="['rowNumber', 'reference', 'question']"></tr>
+            <tr mat-row *matRowDef="let row; columns: ['rowNumber', 'reference', 'question']"></tr>
+          </table>
+        </div>
+      }
 
-      <div
-        *ngIf="status === 'missing_header_row'"
-        [innerHTML]="i18n.translateAndInsertTags('import_questions_dialog.missing_header_row')"
-      ></div>
+      @if (status === "filter") {
+        <form [formGroup]="filterForm" autocomplete="off">
+          <div class="filter-references">
+            <mat-form-field appearance="outline">
+              <mat-label>{{ t("reference_from") }}</mat-label>
+              <input matInput type="text" formControlName="from" />
+              <button mat-icon-button matSuffix #fromRef id="from-btn" (click)="openScriptureChooser(fromControl)">
+                <mat-icon>expand_more</mat-icon>
+              </button>
+              @if (fromControl.invalid) {
+                <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>{{ t("reference_to") }}</mat-label>
+              <input matInput type="text" formControlName="to" />
+              <button mat-icon-button matSuffix (click)="openScriptureChooser(toControl)">
+                <mat-icon>expand_more</mat-icon>
+              </button>
+              @if (toControl.invalid) {
+                <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
+              }
+            </mat-form-field>
+          </div>
+          <div colspan="2" class="filter-text">
+            <div>
+              <mat-form-field appearance="fill" subscriptSizing="dynamic">
+                <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
+              </mat-form-field>
+              <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
+            </div>
+          </div>
+          <table mat-table [dataSource]="questionsForDisplay" class="question-list">
+            <ng-container matColumnDef="verse">
+              <th mat-header-cell *matHeaderCellDef>
+                <mat-checkbox #selectAllCheckbox (change)="selectAllChanged($event.checked)">{{
+                  t("select_all")
+                }}</mat-checkbox>
+              </th>
+              <td mat-cell *matCellDef="let element">
+                <mat-checkbox
+                  [(ngModel)]="element.checked"
+                  (ngModelChange)="checkboxChanged(element)"
+                  [ngModelOptions]="{ standalone: true }"
+                  >{{ referenceForDisplay(element.question) }}</mat-checkbox
+                >
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="question">
+              <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.question.text }}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="['verse', 'question']"></tr>
+            <tr mat-row *matRowDef="let row; columns: ['verse', 'question']"></tr>
+          </table>
+        </form>
+      }
 
-      <div *ngIf="status === 'progress'">
-        <mat-progress-bar mode="determinate" [value]="(importedCount / toImportCount) * 100"></mat-progress-bar>
-      </div>
+      @if (status === "no_questions") {
+        <div>{{ t("no_questions_available") }}</div>
+      }
+
+      @if (status === "update_transcelerator") {
+        <div>{{ t("update_transcelerator") }}</div>
+      }
+
+      @if (status === "missing_header_row") {
+        <div [innerHTML]="i18n.translateAndInsertTags('import_questions_dialog.missing_header_row')"></div>
+      }
+
+      @if (status === "progress") {
+        <div>
+          <mat-progress-bar mode="determinate" [value]="(importedCount / toImportCount) * 100"></mat-progress-bar>
+        </div>
+      }
     </div>
 
-    <div *ngIf="status === 'filter'" class="dialog-content-footer">
-      <mat-error *ngIf="importClicked && selectedCount < 1">
-        {{ t("select_questions") }}
-      </mat-error>
-      <div *ngIf="showDuplicateImportNote && questionSource === 'transcelerator'">
-        {{ t("transcelerator_some_questions_already_imported") }}
+    @if (status === "filter") {
+      <div class="dialog-content-footer">
+        @if (importClicked && selectedCount < 1) {
+          <mat-error>
+            {{ t("select_questions") }}
+          </mat-error>
+        }
+        @if (showDuplicateImportNote && questionSource === "transcelerator") {
+          <div>
+            {{ t("transcelerator_some_questions_already_imported") }}
+          </div>
+        }
+        @if (showDuplicateImportNote && questionSource === "csv_file") {
+          <div>
+            {{ t("csv_questions_duplicates") }}
+          </div>
+        }
       </div>
-      <div *ngIf="showDuplicateImportNote && questionSource === 'csv_file'">
-        {{ t("csv_questions_duplicates") }}
-      </div>
-    </div>
+    }
 
-    <div *ngIf="status === 'progress'" class="dialog-content-footer">
-      {{ t("canceling_import_not_remove_questions") }}
-      <div *ngIf="importCanceled" class="canceling-import">{{ t("canceling_import") }}</div>
-    </div>
+    @if (status === "progress") {
+      <div class="dialog-content-footer">
+        {{ t("canceling_import_not_remove_questions") }}
+        @if (importCanceled) {
+          <div class="canceling-import">{{ t("canceling_import") }}</div>
+        }
+      </div>
+    }
   </mat-dialog-content>
-  <mat-dialog-actions *ngIf="questionSource != null && importCanceled === false" align="end">
-    <button *ngIf="status === 'filter' || status === 'file_import_errors'" mat-button mat-dialog-close>
-      {{ t("cancel") }}
-    </button>
-    <button
-      *ngIf="status === 'no_questions' || status === 'update_transcelerator' || status === 'missing_header_row'"
-      mat-flat-button
-      mat-dialog-close
-      color="primary"
-    >
-      {{ t("close") }}
-    </button>
-
-    <button *ngIf="status === 'file_import_errors'" mat-flat-button color="primary" (click)="invalidRows = []">
-      {{ t("continue_import") }}
-    </button>
-    <button id="import-button" *ngIf="status === 'filter'" mat-flat-button color="primary" (click)="importQuestions()">
-      <span fxShow fxHide.xs>{{ t("import_count_questions", { count: selectedCount }) }}</span>
-      <span fxHide fxShow.xs>{{ t("import") }}</span>
-    </button>
-    <button *ngIf="status === 'progress'" mat-button (click)="importCanceled = true">{{ t("cancel") }}</button>
-  </mat-dialog-actions>
+  @if (questionSource != null && importCanceled === false) {
+    <mat-dialog-actions align="end">
+      @if (status === "filter" || status === "file_import_errors") {
+        <button mat-button mat-dialog-close>
+          {{ t("cancel") }}
+        </button>
+      }
+      @if (status === "no_questions" || status === "update_transcelerator" || status === "missing_header_row") {
+        <button mat-flat-button mat-dialog-close color="primary">
+          {{ t("close") }}
+        </button>
+      }
+      @if (status === "file_import_errors") {
+        <button mat-flat-button color="primary" (click)="invalidRows = []">
+          {{ t("continue_import") }}
+        </button>
+      }
+      @if (status === "filter") {
+        <button id="import-button" mat-flat-button color="primary" (click)="importQuestions()">
+          <span fxShow fxHide.xs>{{ t("import_count_questions", { count: selectedCount }) }}</span>
+          <span fxHide fxShow.xs>{{ t("import") }}</span>
+        </button>
+      }
+      @if (status === "progress") {
+        <button mat-button (click)="importCanceled = true">{{ t("cancel") }}</button>
+      }
+    </mat-dialog-actions>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -23,7 +23,7 @@
             <mat-card>
               <mat-card-title>{{ t("import_from_transcelerator") }}</mat-card-title>
               <mat-card-content>
-                @for (i of i18n.interpolate("import_questions_dialog.transcelerator_paratext"); track i) {
+                @for (i of transceleratorInfo | async; track i) {
                   {{ i.id == null ? i.text : "" }}
                   @if (i.id === 1) {
                     <a [href]="urls.transcelerator" target="_blank">{{ i.text }}</a>
@@ -100,10 +100,9 @@
             </mat-card>
           </div>
           <div class="support-message">
-            @for (i of i18n.interpolate("import_questions_dialog.help_options"); track i) {
-              @if (i.id == null) {
-                {{ i.text }}
-              }
+            @for (i of helpInstructions | async; track i) {
+              <!-- prettier-ignore -->
+              @if (i.id == null) {{{ i.text }}}
               @if (i.id === 1) {
                 <a [href]="urls.communitySupport" target="_blank">{{ i.text }}</a>
               }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -99,6 +99,8 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
   transceleratorRequest: RetryingRequest<TransceleratorQuestion[]>;
   promiseForTransceleratorQuestions: Promise<TransceleratorQuestion[] | undefined>;
   promiseForQuestionDocQuery: Promise<RealtimeQuery<QuestionDoc>>;
+  helpInstructions = this.i18n.interpolate('import_questions_dialog.help_options');
+  transceleratorInfo = this.i18n.interpolate('import_questions_dialog.transcelerator_paratext');
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public readonly data: ImportQuestionsDialogData,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -28,10 +28,11 @@
           </button>
           <mat-error id="question-scripture-end-helper-text">
             {{ scriptureInputErrorMessages.endError }}
-            <span
-              *ngIf="versesForm.hasError('verseBeforeStart')"
-              [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
-            ></span>
+            @if (versesForm.hasError("verseBeforeStart")) {
+              <span
+                [innerHTML]="i18n.translateAndInsertTags('question_dialog.must_be_after_scripture_reference')"
+              ></span>
+            }
           </mat-error>
         </mat-form-field>
       </div>
@@ -47,36 +48,32 @@
       <app-text-and-audio #input [input]="question" [textLabel]="t('question')"></app-text-and-audio>
       <div class="attachments">
         <div class="add-audio">
-          <button
-            mat-icon-button
-            *ngIf="!input.input?.audioUrl && input.audioAttachment.status !== 'recording'"
-            (click)="startRecording()"
-            [matTooltip]="t('tooltip_record')"
-          >
-            <mat-icon>mic</mat-icon>
-          </button>
-          <button
-            mat-icon-button
-            *ngIf="input.audioAttachment.status === 'recording'"
-            (click)="stopRecording()"
-            [matTooltip]="t('tooltip_stop')"
-          >
-            <mat-icon class="stop-recording">stop</mat-icon>
-          </button>
+          @if (!input.input?.audioUrl && input.audioAttachment.status !== "recording") {
+            <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
+              <mat-icon>mic</mat-icon>
+            </button>
+          }
+          @if (input.audioAttachment.status === "recording") {
+            <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
+              <mat-icon class="stop-recording">stop</mat-icon>
+            </button>
+          }
         </div>
-        <div class="audio-added" *ngIf="input.input?.audioUrl">
-          <app-single-button-audio-player
-            #audio
-            [source]="input.input?.audioUrl"
-            (click)="toggleAudio()"
-            theme="secondary"
-          >
-            <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
-          </app-single-button-audio-player>
-          <button mat-icon-button (click)="deleteAudio()" class="clear">
-            <mat-icon>clear</mat-icon>
-          </button>
-        </div>
+        @if (input.input?.audioUrl) {
+          <div class="audio-added">
+            <app-single-button-audio-player
+              #audio
+              [source]="input.input?.audioUrl"
+              (click)="toggleAudio()"
+              theme="secondary"
+            >
+              <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
+            </app-single-button-audio-player>
+            <button mat-icon-button (click)="deleteAudio()" class="clear">
+              <mat-icon>clear</mat-icon>
+            </button>
+          </div>
+        }
       </div>
     </mat-dialog-content>
     <mat-dialog-actions [align]="'end'">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -1,90 +1,106 @@
 <ng-container *transloco="let t; read: 'connect_project'">
   <div class="title mat-headline-4">{{ t("connect_paratext_project") }}</div>
-  <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
-  <div class="content" [ngSwitch]="state">
-    <div *ngSwitchCase="'login'" class="paratext-login-container">
-      <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
-      <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
-        <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-        {{ t("log_in_with_paratext") }}
-      </button>
-    </div>
-    <mat-card *ngSwitchCase="'connecting'" class="progress-container card-outline">
-      <mat-card-content>
-        <div class="progress-label">{{ t("connecting_to_project", { projectName: connectProjectName }) }}</div>
-        <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
-      </mat-card-content>
-    </mat-card>
-    <form *ngSwitchDefault [formGroup]="connectProjectForm" (ngSubmit)="submit()">
-      <ng-container *ngIf="projects.length > 0 || state === 'offline'; else noProjectMsg">
-        <p *ngIf="hasNonAdministratorProject && !showSettings && isAppOnline" id="connect-non-admin-msg">
-          {{ t("only_paratext_admins_can_start") }}
-        </p>
-        <mat-form-field appearance="outline">
-          <mat-label>{{ t("paratext_project") }}</mat-label>
-          <mat-select #projectSelect id="project-select" disableOptionCentering formControlName="paratextId">
-            <mat-option
-              *ngFor="let project of projects"
-              [value]="project.paratextId"
-              [disabled]="!project.isConnectable"
-            >
-              {{ projectLabel(project) }}
-              <ng-container *ngIf="!project.isConnectable && project.isConnected">
-                &nbsp;{{ t("already_connected") }}
-              </ng-container>
-              <ng-container *ngIf="!project.isConnectable && !project.isConnected">&nbsp;**</ng-container>
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
-      </ng-container>
-      <ng-template #noProjectMsg>
-        <p
-          *ngIf="state !== 'loading'"
-          id="no-projects-msg"
-          [innerHtml]="i18n.translateAndInsertTags('connect_project.no_connectable_projects')"
-        ></p>
-      </ng-template>
-      <mat-card id="settings-card" *ngIf="showSettings" class="card-outline" formGroupName="settings">
-        <mat-card-title>{{ t("project_settings") }}</mat-card-title>
-        <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
-        <mat-card-content class="card-content">
-          <p>{{ t("select_project_or_resource") }}</p>
-          <p>{{ t("translation_suggestions_require_source_text") }}</p>
-          <app-project-select
-            formControlName="sourceParatextId"
-            placeholder="{{ t('source_text_placeholder') }}"
-            [projects]="projects"
-            [resources]="resources"
-            [hiddenParatextIds]="[paratextIdControl.value]"
-          ></app-project-select>
-          <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
-          <ng-container *ngIf="isBasedOnProjectSet">
-            <div fxLayout="row" fxLayoutAlign="start center">
-              <div fxLayout="column" fxFlex="grow">
-                <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                  {{ t("enable_translation_suggestions") }}
-                </mat-checkbox>
-                <p
-                  class="helper-text"
-                  [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                ></p>
-              </div>
-            </div>
-          </ng-container>
-        </mat-card-content>
-        <mat-divider></mat-divider>
-        <mat-card-content class="card-content">
-          <div>
-            <mat-checkbox formControlName="checking" id="checking-checkbox">
-              {{ t("enable_community_checking") }}
-            </mat-checkbox>
-          </div>
-          <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
-        </mat-card-content>
-      </mat-card>
-      <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
-        {{ t("connect") }}
-      </button>
-    </form>
+  @if (!isAppOnline) {
+    <span class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
+  }
+  <div class="content">
+    @switch (state) {
+      @case ("login") {
+        <div class="paratext-login-container">
+          <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
+          <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
+            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+            {{ t("log_in_with_paratext") }}
+          </button>
+        </div>
+      }
+      @case ("connecting") {
+        <mat-card class="progress-container card-outline">
+          <mat-card-content>
+            <div class="progress-label">{{ t("connecting_to_project", { projectName: connectProjectName }) }}</div>
+            <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
+          </mat-card-content>
+        </mat-card>
+      }
+      @default {
+        <form [formGroup]="connectProjectForm" (ngSubmit)="submit()">
+          @if (projects.length > 0 || state === "offline") {
+            @if (hasNonAdministratorProject && !showSettings && isAppOnline) {
+              <p id="connect-non-admin-msg">
+                {{ t("only_paratext_admins_can_start") }}
+              </p>
+            }
+            <mat-form-field appearance="outline">
+              <mat-label>{{ t("paratext_project") }}</mat-label>
+              <mat-select #projectSelect id="project-select" disableOptionCentering formControlName="paratextId">
+                @for (project of projects; track project) {
+                  <mat-option [value]="project.paratextId" [disabled]="!project.isConnectable">
+                    {{ projectLabel(project) }}
+                    @if (!project.isConnectable && project.isConnected) {
+                      &nbsp;{{ t("already_connected") }}
+                    }
+                    @if (!project.isConnectable && !project.isConnected) {
+                      &nbsp;**
+                    }
+                  </mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          } @else {
+            @if (state !== "loading") {
+              <p
+                id="no-projects-msg"
+                [innerHtml]="i18n.translateAndInsertTags('connect_project.no_connectable_projects')"
+              ></p>
+            }
+          }
+          @if (showSettings) {
+            <mat-card id="settings-card" class="card-outline" formGroupName="settings">
+              <mat-card-title>{{ t("project_settings") }}</mat-card-title>
+              <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
+              <mat-card-content class="card-content">
+                <p>{{ t("select_project_or_resource") }}</p>
+                <p>{{ t("translation_suggestions_require_source_text") }}</p>
+                <app-project-select
+                  formControlName="sourceParatextId"
+                  placeholder="{{ t('source_text_placeholder') }}"
+                  [projects]="projects"
+                  [resources]="resources"
+                  [hiddenParatextIds]="[paratextIdControl.value]"
+                ></app-project-select>
+                @if (showResourcesLoadingFailedMessage) {
+                  <mat-error>{{ t("error_fetching_resources") }}</mat-error>
+                }
+                @if (isBasedOnProjectSet) {
+                  <div fxLayout="row" fxLayoutAlign="start center">
+                    <div fxLayout="column" fxFlex="grow">
+                      <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
+                        {{ t("enable_translation_suggestions") }}
+                      </mat-checkbox>
+                      <p
+                        class="helper-text"
+                        [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
+                      ></p>
+                    </div>
+                  </div>
+                }
+              </mat-card-content>
+              <mat-divider></mat-divider>
+              <mat-card-content class="card-content">
+                <div>
+                  <mat-checkbox formControlName="checking" id="checking-checkbox">
+                    {{ t("enable_community_checking") }}
+                  </mat-checkbox>
+                </div>
+                <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
+              </mat-card-content>
+            </mat-card>
+          }
+          <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
+            {{ t("connect") }}
+          </button>
+        </form>
+      }
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -1,8 +1,10 @@
 <ng-container *transloco="let t; read: 'join'">
-  <ng-container *ngIf="!isLoading">
+  @if (!isLoading) {
     <h1>{{ t("join_a_project") }}</h1>
     <p [innerHTML]="inviteText"></p>
-    <app-notice *ngIf="!isOnline" type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>
+    @if (!isOnline) {
+      <app-notice type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>
+    }
     <form>
       <mat-form-field appearance="fill">
         <mat-label>{{ t("your_name") }}</mat-label>
@@ -14,5 +16,5 @@
     </form>
     <a (click)="logIn()" [innerHtml]="i18nService.translateAndInsertTags('join.login_existing_account')"></a>
     <mat-spinner diameter="50" color="#fff" [fxHide]="!isJoining"></mat-spinner>
-  </ng-container>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -1,123 +1,141 @@
 <ng-container *transloco="let t; read: 'my_projects'">
   <h1>{{ t("my_projects") }}</h1>
-  <app-notice
-    id="message-no-pt-or-sf-projects"
-    icon="warning"
-    type="warning"
-    *ngIf="!userHasProjects && !initialLoadingSFProjects && !loadingPTProjects"
-  >
-    {{ t("no_projects") }} {{ t("access_another_project") }}
-  </app-notice>
-  <h2 id="header-connected-projects" *ngIf="userConnectedProjects.length > 0 || initialLoadingSFProjects">
-    {{ t("connected") }}
-  </h2>
-  <mat-card
-    *ngFor="let projectDoc of userConnectedProjects"
-    [class.active-project]="isLastSelectedProject(projectDoc)"
-    id="user-connected-project-card-{{ projectDoc.data?.paratextId }}"
-    attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
-    data-project-type="user-connected-project"
-  >
-    <span class="project-name">
-      <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
-    </span>
-    <span class="project-description">
-      {{ projectTypeDescription(projectDoc) }}
-    </span>
-    <a appRouterLink="/projects/{{ projectDoc.id }}" mat-flat-button color="primary">{{ t("open") }}</a>
-  </mat-card>
-  <mat-card id="sf-loading-card" *ngIf="initialLoadingSFProjects" class="loading-card">
-    <div class="loading-project-name"></div>
-    <div class="loading-project-description"></div>
-    <div class="loading-action"></div>
-  </mat-card>
-  <mat-card class="loading-card" *ngIf="initialLoadingSFProjects">
-    <div class="loading-project-name"></div>
-    <div class="loading-project-description"></div>
-    <div class="loading-action"></div>
-  </mat-card>
-  <mat-expansion-panel id="message-looking-for-another-project" hideToggle *ngIf="userHasProjects && !userIsPTUser">
-    <mat-expansion-panel-header>{{ t("looking_for_another_project") }}</mat-expansion-panel-header>
-    <p>
-      {{ t("access_another_project") }}
-    </p>
-  </mat-expansion-panel>
+  @if (!userHasProjects && !initialLoadingSFProjects && !loadingPTProjects) {
+    <app-notice id="message-no-pt-or-sf-projects" icon="warning" type="warning">
+      {{ t("no_projects") }} {{ t("access_another_project") }}
+    </app-notice>
+  }
+  @if (userConnectedProjects.length > 0 || initialLoadingSFProjects) {
+    <h2 id="header-connected-projects">
+      {{ t("connected") }}
+    </h2>
+  }
+  @for (projectDoc of userConnectedProjects; track projectDoc) {
+    <mat-card
+      [class.active-project]="isLastSelectedProject(projectDoc)"
+      id="user-connected-project-card-{{ projectDoc.data?.paratextId }}"
+      attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
+      data-project-type="user-connected-project"
+    >
+      <span class="project-name">
+        <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
+      </span>
+      <span class="project-description">
+        {{ projectTypeDescription(projectDoc) }}
+      </span>
+      <a appRouterLink="/projects/{{ projectDoc.id }}" mat-flat-button color="primary">{{ t("open") }}</a>
+    </mat-card>
+  }
+  @if (initialLoadingSFProjects) {
+    <mat-card id="sf-loading-card" class="loading-card">
+      <div class="loading-project-name"></div>
+      <div class="loading-project-description"></div>
+      <div class="loading-action"></div>
+    </mat-card>
+  }
+  @if (initialLoadingSFProjects) {
+    <mat-card class="loading-card">
+      <div class="loading-project-name"></div>
+      <div class="loading-project-description"></div>
+      <div class="loading-action"></div>
+    </mat-card>
+  }
+  @if (userHasProjects && !userIsPTUser) {
+    <mat-expansion-panel id="message-looking-for-another-project" hideToggle>
+      <mat-expansion-panel-header>{{ t("looking_for_another_project") }}</mat-expansion-panel-header>
+      <p>
+        {{ t("access_another_project") }}
+      </p>
+    </mat-expansion-panel>
+  }
 
-  <h2 *ngIf="userConnectedResources.length > 0">{{ t("dbl_resources") }}</h2>
-  <mat-card
-    *ngFor="let projectDoc of userConnectedResources"
-    [class.active-project]="isLastSelectedProject(projectDoc)"
-    attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
-    data-project-type="user-connected-resource"
-  >
-    <span class="project-name">
-      <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
-    </span>
-    <span class="project-description">{{ t("dbl_resource") }}</span>
-    <a appRouterLink="/projects/{{ projectDoc.id }}" mat-flat-button color="primary">{{ t("open") }}</a>
-  </mat-card>
+  @if (userConnectedResources.length > 0) {
+    <h2>{{ t("dbl_resources") }}</h2>
+  }
+  @for (projectDoc of userConnectedResources; track projectDoc) {
+    <mat-card
+      [class.active-project]="isLastSelectedProject(projectDoc)"
+      attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
+      data-project-type="user-connected-resource"
+    >
+      <span class="project-name">
+        <b>{{ projectDoc.data?.shortName }}</b> - {{ projectDoc.data?.name }}
+      </span>
+      <span class="project-description">{{ t("dbl_resource") }}</span>
+      <a appRouterLink="/projects/{{ projectDoc.id }}" mat-flat-button color="primary">{{ t("open") }}</a>
+    </mat-card>
+  }
 
-  <div class="pt-content" *ngIf="userIsPTUser">
-    <h2
-      id="header-not-connected-projects"
-      *ngIf="
+  @if (userIsPTUser) {
+    <div class="pt-content">
+      @if (
         userUnconnectedParatextProjects.length > 0 ||
         loadingPTProjects ||
         problemGettingPTProjects ||
         (isOnline | async) === false
-      "
-    >
-      {{
-        loadingPTProjects
-          ? t("loading_more_pt_projects")
-          : userConnectedProjects.length === 0
-            ? t("connect_a_project_to_get_started")
-            : t("not_connected")
-      }}
-    </h2>
-    <app-notice id="message-trouble-getting-pt-project-list" icon="error" type="error" *ngIf="problemGettingPTProjects">
-      {{ t(errorMessage) }}
-    </app-notice>
-
-    <mat-card
-      *ngFor="let ptProject of userUnconnectedParatextProjects"
-      attr.data-pt-project-id="{{ ptProject.paratextId }}"
-      data-project-type="user-unconnected-project"
-      [class.cannot-connect]="!ptProject.isConnectable"
-    >
-      <span class="project-name">
-        <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
-      </span>
-      <span *ngIf="!ptProject.isConnectable" class="project-description">
-        {{ t("not_admin_cannot_connect_project") }}
-      </span>
-      <a
-        *ngIf="ptProject.isConnectable"
-        appRouterLink="/connect-project"
-        [state]="{ ptProjectId: ptProject.paratextId }"
-        mat-flat-button
-        color="primary"
-      >
-        {{ paratextService.isParatextProjectInSF(ptProject) ? t("join") : ("connect_project.connect" | transloco) }}
-      </a>
-    </mat-card>
-    <mat-card id="pt-loading-card" *ngIf="loadingPTProjects" class="loading-card">
-      <div class="loading-project-name"></div>
-      <div class="loading-project-description"></div>
-      <div class="loading-action"></div>
-    </mat-card>
-    <mat-card class="loading-card" *ngIf="loadingPTProjects">
-      <div class="loading-project-name"></div>
-      <div class="loading-project-description"></div>
-      <div class="loading-action"></div>
-    </mat-card>
-    <app-notice
-      id="message-offline"
-      icon="cloud_off"
-      [type]="userHasProjects ? 'info' : 'error'"
-      *ngIf="(isOnline | async) === false"
-    >
-      {{ t("offline") }}
-    </app-notice>
-  </div>
+      ) {
+        <h2 id="header-not-connected-projects">
+          {{
+            loadingPTProjects
+              ? t("loading_more_pt_projects")
+              : userConnectedProjects.length === 0
+                ? t("connect_a_project_to_get_started")
+                : t("not_connected")
+          }}
+        </h2>
+      }
+      @if (problemGettingPTProjects) {
+        <app-notice id="message-trouble-getting-pt-project-list" icon="error" type="error">
+          {{ t(errorMessage) }}
+        </app-notice>
+      }
+      @for (ptProject of userUnconnectedParatextProjects; track ptProject) {
+        <mat-card
+          attr.data-pt-project-id="{{ ptProject.paratextId }}"
+          data-project-type="user-unconnected-project"
+          [class.cannot-connect]="!ptProject.isConnectable"
+        >
+          <span class="project-name">
+            <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
+          </span>
+          @if (!ptProject.isConnectable) {
+            <span class="project-description">
+              {{ t("not_admin_cannot_connect_project") }}
+            </span>
+          }
+          @if (ptProject.isConnectable) {
+            <a
+              appRouterLink="/connect-project"
+              [state]="{ ptProjectId: ptProject.paratextId }"
+              mat-flat-button
+              color="primary"
+            >
+              {{
+                paratextService.isParatextProjectInSF(ptProject) ? t("join") : ("connect_project.connect" | transloco)
+              }}
+            </a>
+          }
+        </mat-card>
+      }
+      @if (loadingPTProjects) {
+        <mat-card id="pt-loading-card" class="loading-card">
+          <div class="loading-project-name"></div>
+          <div class="loading-project-description"></div>
+          <div class="loading-action"></div>
+        </mat-card>
+      }
+      @if (loadingPTProjects) {
+        <mat-card class="loading-card">
+          <div class="loading-project-name"></div>
+          <div class="loading-project-description"></div>
+          <div class="loading-action"></div>
+        </mat-card>
+      }
+      @if ((isOnline | async) === false) {
+        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
+          {{ t("offline") }}
+        </app-notice>
+      }
+    </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'app'">
   <mat-nav-list id="tools-menu-list" (click)="clickWithinNavList($event)">
-    <ng-container *ngIf="isTranslateEnabled">
+    @if (isTranslateEnabled) {
       <mat-list-item disableRipple class="navigation-header">
         {{ t("translate") }}
       </mat-list-item>
@@ -12,54 +12,67 @@
         <mat-icon>edit_note</mat-icon>
         {{ t("edit_review") }}
       </a>
-      <a *ngIf="canGenerateDraft$ | async" mat-list-item [appRouterLink]="draftGenerationLink">
-        <mat-icon class="mirror-rtl">auto_awesome</mat-icon>
-        {{ t("generate_draft") }} <span class="nav-label">{{ t("beta") }}</span>
-      </a>
-    </ng-container>
-    <ng-container *ngIf="isCheckingEnabled">
+      @if (canGenerateDraft$ | async) {
+        <a mat-list-item [appRouterLink]="draftGenerationLink">
+          <mat-icon class="mirror-rtl">auto_awesome</mat-icon>
+          {{ t("generate_draft") }} <span class="nav-label">{{ t("beta") }}</span>
+        </a>
+      }
+    }
+    @if (isCheckingEnabled) {
       <mat-list-item disableRipple class="navigation-header">
         {{ t("community_checking") }}
       </mat-list-item>
-      <a *ngIf="canManageQuestions" mat-list-item [appRouterLink]="getProjectLink('checking')">
-        <mat-icon class="mirror-rtl">list</mat-icon>
-        {{ t("manage_questions") }}
-      </a>
-      <a *ngIf="!canManageQuestions" mat-list-item [appRouterLink]="getProjectLink('checking')">
-        <mat-icon class="mirror-rtl">bar_chart</mat-icon>
-        {{ t("my_progress") }}
-      </a>
+      @if (canManageQuestions) {
+        <a mat-list-item [appRouterLink]="getProjectLink('checking')">
+          <mat-icon class="mirror-rtl">list</mat-icon>
+          {{ t("manage_questions") }}
+        </a>
+      }
+      @if (!canManageQuestions) {
+        <a mat-list-item [appRouterLink]="getProjectLink('checking')">
+          <mat-icon class="mirror-rtl">bar_chart</mat-icon>
+          {{ t("my_progress") }}
+        </a>
+      }
       <a mat-list-item [appRouterLink]="(answerQuestionsLink$ | async) ?? ['']" [class.active]="answerQuestionsActive">
         <mat-icon class="mirror-rtl">question_answer</mat-icon>
         {{ t("questions_answers") }}
       </a>
-    </ng-container>
+    }
   </mat-nav-list>
-  <mat-nav-list
-    [class.disabled-offline]="!isAppOnline"
-    id="admin-pages-menu-list"
-    *ngIf="canSeeAdminPages$ | async"
-    (click)="clickWithinNavList($event)"
-  >
-    <mat-divider></mat-divider>
-    <a *ngIf="canSync$ | async" mat-list-item [appRouterLink]="getProjectLink('sync')">
-      <mat-icon
-        aria-hidden="false"
-        matBadge="error"
-        [matBadgeHidden]="!lastSyncFailed || syncInProgress"
-        [class.sync-in-progress]="syncInProgress && !featureFlags.stillness.enabled"
-        id="sync-icon"
-        >sync</mat-icon
-      >
-      {{ t("synchronize") }}
-    </a>
-    <a *ngIf="canSeeUsers$ | async" mat-list-item [appRouterLink]="getProjectLink('users')">
-      <mat-icon class="mirror-rtl">people</mat-icon>
-      {{ t("users") }}
-    </a>
-    <a *ngIf="canSeeSettings$ | async" mat-list-item [appRouterLink]="getProjectLink('settings')">
-      <mat-icon>settings</mat-icon>
-      {{ t("settings") }}
-    </a>
-  </mat-nav-list>
+  @if (canSeeAdminPages$ | async) {
+    <mat-nav-list
+      [class.disabled-offline]="!isAppOnline"
+      id="admin-pages-menu-list"
+      (click)="clickWithinNavList($event)"
+    >
+      <mat-divider></mat-divider>
+      @if (canSync$ | async) {
+        <a mat-list-item [appRouterLink]="getProjectLink('sync')">
+          <mat-icon
+            aria-hidden="false"
+            matBadge="error"
+            [matBadgeHidden]="!lastSyncFailed || syncInProgress"
+            [class.sync-in-progress]="syncInProgress && !featureFlags.stillness.enabled"
+            id="sync-icon"
+            >sync</mat-icon
+          >
+          {{ t("synchronize") }}
+        </a>
+      }
+      @if (canSeeUsers$ | async) {
+        <a mat-list-item [appRouterLink]="getProjectLink('users')">
+          <mat-icon class="mirror-rtl">people</mat-icon>
+          {{ t("users") }}
+        </a>
+      }
+      @if (canSeeSettings$ | async) {
+        <a mat-list-item [appRouterLink]="getProjectLink('settings')">
+          <mat-icon>settings</mat-icon>
+          {{ t("settings") }}
+        </a>
+      }
+    </mat-nav-list>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -16,14 +16,20 @@
       (opened)="autocompleteOpened()"
       class="project-select"
     >
-      <mat-optgroup label="{{ t('projects') }}" *ngIf="nullableLength(projects$ | async) > 0">
-        <mat-option *ngFor="let project of projects$ | async" [value]="project">{{ projectLabel(project) }}</mat-option>
-      </mat-optgroup>
-      <mat-optgroup label="{{ t('resources') }}" *ngIf="nullableLength(resources$ | async) > 0">
-        <mat-option *ngFor="let resource of resources$ | async" [value]="resource">{{
-          projectLabel(resource)
-        }}</mat-option>
-      </mat-optgroup>
+      @if (nullableLength(projects$ | async) > 0) {
+        <mat-optgroup label="{{ t('projects') }}">
+          @for (project of projects$ | async; track project) {
+            <mat-option [value]="project">{{ projectLabel(project) }}</mat-option>
+          }
+        </mat-optgroup>
+      }
+      @if (nullableLength(resources$ | async) > 0) {
+        <mat-optgroup label="{{ t('resources') }}">
+          @for (resource of resources$ | async; track resource) {
+            <mat-option [value]="resource">{{ projectLabel(resource) }}</mat-option>
+          }
+        </mat-optgroup>
+      }
     </mat-autocomplete>
   </mat-form-field>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,101 +1,124 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
   <div class="dialog-container">
-    <div id="bookPane" *ngIf="showing === 'books'">
-      <h1 mat-dialog-title>
-        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
-          <mat-icon>close</mat-icon>
-        </button>
-        <span>{{ t("choose_book") }}</span>
-      </h1>
-      <div mat-dialog-content>
-        <div class="upperBookSet">
+    @if (showing === "books") {
+      <div id="bookPane">
+        <h1 mat-dialog-title>
           <button
-            *ngFor="let book of otBooks"
-            mat-button
-            [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
-            (click)="onClickBook(book)"
+            mat-icon-button
+            class="backout-button"
+            (click)="onClickBackoutButton()"
+            (focus)="onCloseFocus($event)"
           >
-            {{ i18n.localizeBook(book) }}
+            <mat-icon>close</mat-icon>
           </button>
+          <span>{{ t("choose_book") }}</span>
+        </h1>
+        <div mat-dialog-content>
+          <div class="upperBookSet">
+            @for (book of otBooks; track book) {
+              <button
+                mat-button
+                [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
+                (click)="onClickBook(book)"
+              >
+                {{ i18n.localizeBook(book) }}
+              </button>
+            }
+          </div>
+          @for (book of ntBooks; track book) {
+            <button mat-button [ngClass]="{ 'mat-flat-button': data.input?.book === book }" (click)="onClickBook(book)">
+              {{ i18n.localizeBook(book) }}
+            </button>
+          }
         </div>
-        <button
-          *ngFor="let book of ntBooks"
-          mat-button
-          [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
-          (click)="onClickBook(book)"
-        >
-          {{ i18n.localizeBook(book) }}
-        </button>
       </div>
-    </div>
-    <div id="chapterPane" *ngIf="showing === 'chapters'">
-      <h1 mat-dialog-title>
-        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
-          <mat-icon>navigate_before</mat-icon>
-        </button>
-        <span>{{ t("choose_chapter") }}</span>
-      </h1>
-      <div mat-dialog-content>
-        <div class="reference">{{ getBookName(selection.book) }}</div>
-        <button
-          *ngFor="let chapter of chaptersOf(selection.book)"
-          mat-button
-          [ngClass]="{
-            'mat-flat-button': data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter
-          }"
-          (click)="onClickChapter(chapter)"
-        >
-          {{ chapter }}
-        </button>
+    }
+    @if (showing === "chapters") {
+      <div id="chapterPane">
+        <h1 mat-dialog-title>
+          <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+            <mat-icon>navigate_before</mat-icon>
+          </button>
+          <span>{{ t("choose_chapter") }}</span>
+        </h1>
+        <div mat-dialog-content>
+          <div class="reference">{{ getBookName(selection.book) }}</div>
+          @for (chapter of chaptersOf(selection.book); track chapter) {
+            <button
+              mat-button
+              [ngClass]="{
+                'mat-flat-button':
+                  data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter
+              }"
+              (click)="onClickChapter(chapter)"
+            >
+              {{ chapter }}
+            </button>
+          }
+        </div>
       </div>
-    </div>
-    <div id="versePane" *ngIf="showing === 'verses'">
-      <h1 mat-dialog-title>
-        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
-          <mat-icon>navigate_before</mat-icon>
-        </button>
-        <span>{{ t("choose_verse") }}</span>
-      </h1>
-      <div mat-dialog-content>
-        <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
-        <button
-          *ngFor="let verse of versesOf(selection?.book, selection?.chapter)"
-          mat-button
-          [ngClass]="{
-            'mat-flat-button':
-              data.input?.book === selection.book &&
-              data.input?.chapter === selection.chapter &&
-              getNumOrNaN(data.input?.verseNum) === +verse
-          }"
-          (click)="onClickVerse(verse)"
-        >
-          {{ verse }}
-        </button>
+    }
+    @if (showing === "verses") {
+      <div id="versePane">
+        <h1 mat-dialog-title>
+          <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+            <mat-icon>navigate_before</mat-icon>
+          </button>
+          <span>{{ t("choose_verse") }}</span>
+        </h1>
+        <div mat-dialog-content>
+          <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
+          @for (verse of versesOf(selection?.book, selection?.chapter); track verse) {
+            <button
+              mat-button
+              [ngClass]="{
+                'mat-flat-button':
+                  data.input?.book === selection.book &&
+                  data.input?.chapter === selection.chapter &&
+                  getNumOrNaN(data.input?.verseNum) === +verse
+              }"
+              (click)="onClickVerse(verse)"
+            >
+              {{ verse }}
+            </button>
+          }
+        </div>
       </div>
-    </div>
-    <div id="rangeEndPane" *ngIf="showing === 'rangeEnd'">
-      <div mat-dialog-title>
-        <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()" (focus)="onCloseFocus($event)">
-          <mat-icon>close</mat-icon>
-        </button>
-        <span>{{ t("choose_end_verse") }}</span>
+    }
+    @if (showing === "rangeEnd") {
+      <div id="rangeEndPane">
+        <div mat-dialog-title>
+          <button
+            mat-icon-button
+            class="backout-button"
+            (click)="onClickBackoutButton()"
+            (focus)="onCloseFocus($event)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+          <span>{{ t("choose_end_verse") }}</span>
+        </div>
+        <div mat-dialog-content>
+          <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
+          @for (
+            verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum);
+            track verse
+          ) {
+            <button
+              mat-button
+              [ngClass]="{
+                'mat-flat-button':
+                  data.input?.book === data.rangeStart?.book &&
+                  data.input?.chapter === data.rangeStart?.chapter &&
+                  getNumOrNaN(data.input?.verseNum) === +verse
+              }"
+              (click)="onClickVerse(verse)"
+            >
+              {{ verse }}
+            </button>
+          }
+        </div>
       </div>
-      <div mat-dialog-content>
-        <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
-        <button
-          *ngFor="let verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum)"
-          mat-button
-          [ngClass]="{
-            'mat-flat-button':
-              data.input?.book === data.rangeStart?.book &&
-              data.input?.chapter === data.rangeStart?.chapter &&
-              getNumOrNaN(data.input?.verseNum) === +verse
-          }"
-          (click)="onClickVerse(verse)"
-        >
-          {{ verse }}
-        </button>
-      </div>
-    </div>
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -30,13 +30,12 @@
 </app-notice>
 <div class="table-container">
   <table mat-table [dataSource]="rows">
-    <ng-container
-      *ngFor="let column of columnsToDisplay | slice: 0 : columnsToDisplay.length - 1"
-      [matColumnDef]="column"
-    >
-      <th mat-header-cell *matHeaderCellDef>{{ headingsToDisplay[column] }}</th>
-      <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
-    </ng-container>
+    @for (column of columnsToDisplay | slice: 0 : columnsToDisplay.length - 1; track column) {
+      <ng-container [matColumnDef]="column">
+        <th mat-header-cell *matHeaderCellDef>{{ headingsToDisplay[column] }}</th>
+        <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
+      </ng-container>
+    }
 
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef></th>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -4,8 +4,8 @@
     <input matInput (keyup)="updateSearchTerm($event.target)" id="project-filter" />
   </mat-form-field>
 </div>
-<ng-container *ngIf="!isLoading">
-  <ng-container *ngIf="length > 0">
+@if (!isLoading) {
+  @if (length > 0) {
     <table mat-table id="projects-table" [dataSource]="rows">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>Name</th>
@@ -16,45 +16,52 @@
       <ng-container matColumnDef="preTranslate">
         <th mat-header-cell *matHeaderCellDef>Pre-Translation</th>
         <td mat-cell *matCellDef="let row">
-          <strong *ngIf="row.preTranslate">Enabled</strong>
-          <span *ngIf="!row.preTranslate">Disabled</span>
+          @if (row.preTranslate) {
+            <strong>Enabled</strong>
+          }
+          @if (!row.preTranslate) {
+            <span>Disabled</span>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="source">
         <th mat-header-cell *matHeaderCellDef>Source</th>
         <td mat-cell *matCellDef="let row">
-          <a *ngIf="row.sourceId != null" [appRouterLink]="['/serval-administration', row.sourceId]">{{
-            row.source
-          }}</a>
-          <span *ngIf="row.sourceId == null">{{ row.source }}</span>
+          @if (row.sourceId != null) {
+            <a [appRouterLink]="['/serval-administration', row.sourceId]">{{ row.source }}</a>
+          }
+          @if (row.sourceId == null) {
+            <span>{{ row.source }}</span>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="alternateSource">
         <th mat-header-cell *matHeaderCellDef>Alternate Source</th>
         <td mat-cell *matCellDef="let row">
-          <a
-            *ngIf="row.alternateSourceId != null"
-            [appRouterLink]="['/serval-administration', row.alternateSourceId]"
-            >{{ row.alternateSource }}</a
-          >
-          <span *ngIf="row.alternateSourceId == null">{{ row.alternateSource }}</span>
+          @if (row.alternateSourceId != null) {
+            <a [appRouterLink]="['/serval-administration', row.alternateSourceId]">{{ row.alternateSource }}</a>
+          }
+          @if (row.alternateSourceId == null) {
+            <span>{{ row.alternateSource }}</span>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="alternateTrainingSource">
         <th mat-header-cell *matHeaderCellDef>Alternate Training Source</th>
         <td mat-cell *matCellDef="let row">
-          <a
-            *ngIf="row.alternateTrainingSourceId != null"
-            [appRouterLink]="['/serval-administration', row.alternateTrainingSourceId]"
-            >{{ row.alternateTrainingSource }}</a
-          >
-          <span *ngIf="row.alternateTrainingSourceId == null">{{ row.alternateTrainingSource }}</span>
+          @if (row.alternateTrainingSourceId != null) {
+            <a [appRouterLink]="['/serval-administration', row.alternateTrainingSourceId]">{{
+              row.alternateTrainingSource
+            }}</a>
+          }
+          @if (row.alternateTrainingSourceId == null) {
+            <span>{{ row.alternateTrainingSource }}</span>
+          }
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
       <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
     </table>
-
     <mat-paginator
       [pageIndex]="pageIndex"
       [length]="length"
@@ -63,6 +70,8 @@
       (page)="updatePage($event.pageIndex, $event.pageSize)"
     >
     </mat-paginator>
-  </ng-container>
-  <div *ngIf="length === 0" class="no-projects-label">No projects found</div>
-</ng-container>
+  }
+  @if (length === 0) {
+    <div class="no-projects-label">No projects found</div>
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
@@ -90,7 +89,7 @@ class Row {
   templateUrl: './serval-projects.component.html',
   styleUrls: ['./serval-projects.component.scss'],
   standalone: true,
-  imports: [CommonModule, UICommonModule]
+  imports: [UICommonModule]
 })
 export class ServalProjectsComponent extends DataLoadingComponent implements OnInit {
   columnsToDisplay: string[] = ['name', 'preTranslate', 'source', 'alternateSource', 'alternateTrainingSource'];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -1,32 +1,36 @@
 <ng-container *transloco="let t; read: 'settings'">
   <div fxLayout="column" fxLayoutGap="2rem" class="container">
     <div class="mat-headline-4">{{ t("settings") }}</div>
-    <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_change_settings") }} </span>
+    @if (!isAppOnline) {
+      <span class="offline-text"> {{ t("connect_network_to_change_settings") }} </span>
+    }
     <div>
       <form [formGroup]="form">
         <mat-card class="card card-outline">
           <mat-card-content>
             <mat-card-title>{{ t("translate") }}</mat-card-title>
             <div class="tool-setting">
-              <div *ngIf="!isLoading && !isLoggedInToParatext && isAppOnline" class="paratext-login-container">
-                <button
-                  class="action-button"
-                  mat-flat-button
-                  type="button"
-                  (click)="logInWithParatext()"
-                  id="btn-log-in-settings"
-                >
-                  <mat-icon>
-                    <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
-                  </mat-icon>
-                  {{ t("log_in_with_paratext") }}
-                </button>
-                <span
-                  class="more-options"
-                  [innerHTML]="i18n.translateAndInsertTags('settings.enable_translation_suggestions')"
-                ></span>
-              </div>
-              <ng-container *ngIf="mainSettingsLoaded">
+              @if (!isLoading && !isLoggedInToParatext && isAppOnline) {
+                <div class="paratext-login-container">
+                  <button
+                    class="action-button"
+                    mat-flat-button
+                    type="button"
+                    (click)="logInWithParatext()"
+                    id="btn-log-in-settings"
+                  >
+                    <mat-icon>
+                      <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+                    </mat-icon>
+                    {{ t("log_in_with_paratext") }}
+                  </button>
+                  <span
+                    class="more-options"
+                    [innerHTML]="i18n.translateAndInsertTags('settings.enable_translation_suggestions')"
+                  ></span>
+                </div>
+              }
+              @if (mainSettingsLoaded) {
                 <p class="helper-text">{{ t("select_project_or_resource") }}</p>
                 <div class="tool-setting-field">
                   <app-project-select
@@ -46,30 +50,40 @@
                     style="margin-block-end: 18px"
                   ></app-write-status>
                 </div>
-                <mat-error *ngIf="projectLoadingFailed && resourceLoadingFailed">
-                  {{ t("error_fetching_projects_resources") }}
-                </mat-error>
-                <mat-error *ngIf="projectLoadingFailed && !resourceLoadingFailed">
-                  {{ t("error_fetching_projects") }}
-                </mat-error>
-                <mat-error *ngIf="resourceLoadingFailed && !projectLoadingFailed">
-                  {{ t("error_fetching_resources") }}
-                </mat-error>
-              </ng-container>
+                @if (projectLoadingFailed && resourceLoadingFailed) {
+                  <mat-error>
+                    {{ t("error_fetching_projects_resources") }}
+                  </mat-error>
+                }
+                @if (projectLoadingFailed && !resourceLoadingFailed) {
+                  <mat-error>
+                    {{ t("error_fetching_projects") }}
+                  </mat-error>
+                }
+                @if (resourceLoadingFailed && !projectLoadingFailed) {
+                  <mat-error>
+                    {{ t("error_fetching_resources") }}
+                  </mat-error>
+                }
+              }
             </div>
             <div class="tool-setting">
-              <div *ngIf="isBasedOnProjectSet" class="tool-setting-field checkbox-field">
-                <mat-checkbox formControlName="translationSuggestionsEnabled" id="checkbox-translation-suggestions">
-                  {{ t("translation_suggestions") }}
-                </mat-checkbox>
-                <app-info [text]="t('translations_will_be_suggested')"></app-info>
-                <app-write-status
-                  [state]="getControlState('translationSuggestionsEnabled')"
-                  [formGroup]="form"
-                  id="translation-suggestions-status"
-                ></app-write-status>
-              </div>
-              <mat-hint *ngIf="!isBasedOnProjectSet">{{ t("translation_suggestions_require_source_text") }}</mat-hint>
+              @if (isBasedOnProjectSet) {
+                <div class="tool-setting-field checkbox-field">
+                  <mat-checkbox formControlName="translationSuggestionsEnabled" id="checkbox-translation-suggestions">
+                    {{ t("translation_suggestions") }}
+                  </mat-checkbox>
+                  <app-info [text]="t('translations_will_be_suggested')"></app-info>
+                  <app-write-status
+                    [state]="getControlState('translationSuggestionsEnabled')"
+                    [formGroup]="form"
+                    id="translation-suggestions-status"
+                  ></app-write-status>
+                </div>
+              }
+              @if (!isBasedOnProjectSet) {
+                <mat-hint>{{ t("translation_suggestions_require_source_text") }}</mat-hint>
+              }
             </div>
             <div class="tool-setting">
               <div class="tool-setting-field checkbox-field">
@@ -83,157 +97,163 @@
                   id="biblical-terms-status"
                 ></app-write-status>
               </div>
-              <mat-error *ngIf="biblicalTermsMessage">
-                <app-info
-                  *ngIf="biblicalTermsMessage"
-                  icon="error"
-                  type="error"
-                  [text]="biblicalTermsMessage"
-                ></app-info>
-                <span>{{ biblicalTermsMessage }}</span>
-              </mat-error>
+              @if (biblicalTermsMessage) {
+                <mat-error>
+                  @if (biblicalTermsMessage) {
+                    <app-info icon="error" type="error" [text]="biblicalTermsMessage"></app-info>
+                  }
+                  <span>{{ biblicalTermsMessage }}</span>
+                </mat-error>
+              }
             </div>
           </mat-card-content>
-          <mat-card-content *ngIf="showPreTranslationSettings">
-            <mat-card-title>{{ t("pre_translation_drafting") }}</mat-card-title>
-            <div>
-              <ng-container *ngIf="mainSettingsLoaded">
-                <div class="tool-setting">
-                  <div class="tool-setting-field checkbox-field">
-                    <mat-checkbox formControlName="alternateSourceEnabled" id="checkbox-alternate-source-enabled">{{
-                      t("enable_alternate_source")
-                    }}</mat-checkbox>
-                    <app-info [text]="t('pre_translation_alternate_source_info')"></app-info>
-                    <app-write-status
-                      [state]="getControlState('alternateSourceEnabled')"
-                      [formGroup]="form"
-                      id="alternate-source-enabled-status"
-                    ></app-write-status>
+          @if (showPreTranslationSettings) {
+            <mat-card-content>
+              <mat-card-title>{{ t("pre_translation_drafting") }}</mat-card-title>
+              <div>
+                @if (mainSettingsLoaded) {
+                  <div class="tool-setting">
+                    <div class="tool-setting-field checkbox-field">
+                      <mat-checkbox formControlName="alternateSourceEnabled" id="checkbox-alternate-source-enabled">{{
+                        t("enable_alternate_source")
+                      }}</mat-checkbox>
+                      <app-info [text]="t('pre_translation_alternate_source_info')"></app-info>
+                      <app-write-status
+                        [state]="getControlState('alternateSourceEnabled')"
+                        [formGroup]="form"
+                        id="alternate-source-enabled-status"
+                      ></app-write-status>
+                    </div>
                   </div>
-                </div>
-                <div *ngIf="isAlternateSourceEnabled" class="tool-setting-field">
-                  <app-project-select
-                    id="alternateSourceParatextId"
-                    formControlName="alternateSourceParatextId"
-                    [placeholder]="t('pre_translation_source_text_placeholder')"
-                    [projects]="projects"
-                    [resources]="resources"
-                    [nonSelectableProjects]="nonSelectableProjects"
-                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                    [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
-                  ></app-project-select>
-                  <app-write-status
-                    [state]="getControlState('alternateSourceParatextId')"
-                    [formGroup]="form"
-                    id="alternate-source-status"
-                  ></app-write-status>
-                </div>
-                <div class="tool-setting">
-                  <div class="tool-setting-field checkbox-field">
-                    <mat-checkbox
-                      formControlName="alternateTrainingSourceEnabled"
-                      id="checkbox-alternate-training-source-enabled"
-                      >{{ t("enable_alternate_training_source") }}</mat-checkbox
-                    >
-                    <app-info [text]="t('pre_translation_alternate_training_source_info')"></app-info>
-                    <app-write-status
-                      [state]="getControlState('alternateTrainingSourceEnabled')"
-                      [formGroup]="form"
-                      id="alternate-training-source-enabled-status"
-                    ></app-write-status>
+                  @if (isAlternateSourceEnabled) {
+                    <div class="tool-setting-field">
+                      <app-project-select
+                        id="alternateSourceParatextId"
+                        formControlName="alternateSourceParatextId"
+                        [placeholder]="t('pre_translation_source_text_placeholder')"
+                        [projects]="projects"
+                        [resources]="resources"
+                        [nonSelectableProjects]="nonSelectableProjects"
+                        [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
+                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                      ></app-project-select>
+                      <app-write-status
+                        [state]="getControlState('alternateSourceParatextId')"
+                        [formGroup]="form"
+                        id="alternate-source-status"
+                      ></app-write-status>
+                    </div>
+                  }
+                  <div class="tool-setting">
+                    <div class="tool-setting-field checkbox-field">
+                      <mat-checkbox
+                        formControlName="alternateTrainingSourceEnabled"
+                        id="checkbox-alternate-training-source-enabled"
+                        >{{ t("enable_alternate_training_source") }}</mat-checkbox
+                      >
+                      <app-info [text]="t('pre_translation_alternate_training_source_info')"></app-info>
+                      <app-write-status
+                        [state]="getControlState('alternateTrainingSourceEnabled')"
+                        [formGroup]="form"
+                        id="alternate-training-source-enabled-status"
+                      ></app-write-status>
+                    </div>
                   </div>
-                </div>
-                <div *ngIf="isAlternateTrainingSourceEnabled" class="tool-setting-field">
-                  <app-project-select
-                    id="alternateTrainingSourceParatextId"
-                    formControlName="alternateTrainingSourceParatextId"
-                    [placeholder]="t('pre_translation_alternate_training_source_text_placeholder')"
-                    [projects]="projects"
-                    [resources]="resources"
-                    [nonSelectableProjects]="nonSelectableProjects"
-                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                    [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
-                  ></app-project-select>
-                  <app-write-status
-                    [state]="getControlState('alternateTrainingSourceParatextId')"
-                    [formGroup]="form"
-                    id="alternate-training-source-status"
-                  ></app-write-status>
-                </div>
-                <div
-                  *ngIf="isAdditionalTrainingSourceEnabled || featureFlags.allowAdditionalTrainingSource.enabled"
-                  class="tool-setting"
-                >
-                  <div class="tool-setting-field checkbox-field">
-                    <mat-checkbox
-                      formControlName="additionalTrainingSourceEnabled"
-                      id="checkbox-additional-training-source-enabled"
-                      >{{ t("enable_additional_training_source") }}</mat-checkbox
-                    >
-                    <app-info [text]="t('pre_translation_additional_training_source_info')"></app-info>
-                    <app-write-status
-                      [state]="getControlState('additionalTrainingSourceEnabled')"
-                      [formGroup]="form"
-                      id="additional-training-source-enabled-status"
-                    ></app-write-status>
+                  @if (isAlternateTrainingSourceEnabled) {
+                    <div class="tool-setting-field">
+                      <app-project-select
+                        id="alternateTrainingSourceParatextId"
+                        formControlName="alternateTrainingSourceParatextId"
+                        [placeholder]="t('pre_translation_alternate_training_source_text_placeholder')"
+                        [projects]="projects"
+                        [resources]="resources"
+                        [nonSelectableProjects]="nonSelectableProjects"
+                        [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
+                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                      ></app-project-select>
+                      <app-write-status
+                        [state]="getControlState('alternateTrainingSourceParatextId')"
+                        [formGroup]="form"
+                        id="alternate-training-source-status"
+                      ></app-write-status>
+                    </div>
+                  }
+                  @if (isAdditionalTrainingSourceEnabled || featureFlags.allowAdditionalTrainingSource.enabled) {
+                    <div class="tool-setting">
+                      <div class="tool-setting-field checkbox-field">
+                        <mat-checkbox
+                          formControlName="additionalTrainingSourceEnabled"
+                          id="checkbox-additional-training-source-enabled"
+                          >{{ t("enable_additional_training_source") }}</mat-checkbox
+                        >
+                        <app-info [text]="t('pre_translation_additional_training_source_info')"></app-info>
+                        <app-write-status
+                          [state]="getControlState('additionalTrainingSourceEnabled')"
+                          [formGroup]="form"
+                          id="additional-training-source-enabled-status"
+                        ></app-write-status>
+                      </div>
+                    </div>
+                  }
+                  @if (isAdditionalTrainingSourceEnabled) {
+                    <div class="tool-setting-field">
+                      <app-project-select
+                        id="additionalTrainingSourceParatextId"
+                        formControlName="additionalTrainingSourceParatextId"
+                        [placeholder]="t('pre_translation_additional_training_source_text_placeholder')"
+                        [projects]="projects"
+                        [resources]="resources"
+                        [nonSelectableProjects]="nonSelectableProjects"
+                        [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
+                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                      ></app-project-select>
+                      <app-write-status
+                        [state]="getControlState('additionalTrainingSourceParatextId')"
+                        [formGroup]="form"
+                        id="additional-training-source-status"
+                      ></app-write-status>
+                    </div>
+                  }
+                  <div class="tool-setting">
+                    <div class="tool-setting-field checkbox-field">
+                      <mat-checkbox
+                        formControlName="additionalTrainingData"
+                        id="checkbox-pre-translation-additional-training-data"
+                        >{{ t("pre_translation_additional_training_data") }}</mat-checkbox
+                      >
+                      <app-info [text]="t('pre_translation_additional_training_data_info')"></app-info>
+                      <app-write-status
+                        [state]="getControlState('additionalTrainingData')"
+                        [formGroup]="form"
+                        id="pre-translation-additional-training-data-status"
+                      ></app-write-status>
+                    </div>
                   </div>
-                </div>
-                <div *ngIf="isAdditionalTrainingSourceEnabled" class="tool-setting-field">
-                  <app-project-select
-                    id="additionalTrainingSourceParatextId"
-                    formControlName="additionalTrainingSourceParatextId"
-                    [placeholder]="t('pre_translation_additional_training_source_text_placeholder')"
-                    [projects]="projects"
-                    [resources]="resources"
-                    [nonSelectableProjects]="nonSelectableProjects"
-                    [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                    [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
-                  ></app-project-select>
-                  <app-write-status
-                    [state]="getControlState('additionalTrainingSourceParatextId')"
-                    [formGroup]="form"
-                    id="additional-training-source-status"
-                  ></app-write-status>
-                </div>
-                <div class="tool-setting">
-                  <div class="tool-setting-field checkbox-field">
-                    <mat-checkbox
-                      formControlName="additionalTrainingData"
-                      id="checkbox-pre-translation-additional-training-data"
-                      >{{ t("pre_translation_additional_training_data") }}</mat-checkbox
-                    >
-                    <app-info [text]="t('pre_translation_additional_training_data_info')"></app-info>
+                }
+                @if (canUpdateServalConfig) {
+                  <p
+                    class="helper-text"
+                    [innerHTML]="i18n.translateAndInsertTags('settings.serval_config_description')"
+                  ></p>
+                  <mat-form-field [formGroup]="form" appearance="outline">
+                    <mat-label>{{ t("serval_config") }}</mat-label>
+                    <textarea
+                      matInput
+                      cdkTextareaAutosize
+                      id="serval-config"
+                      formControlName="servalConfig"
+                      (blur)="updateServalConfig()"
+                    ></textarea>
                     <app-write-status
-                      [state]="getControlState('additionalTrainingData')"
+                      [state]="getControlState('servalConfig')"
                       [formGroup]="form"
-                      id="pre-translation-additional-training-data-status"
+                      id="serval-config-status"
                     ></app-write-status>
-                  </div>
-                </div>
-              </ng-container>
-              <ng-container *ngIf="canUpdateServalConfig">
-                <p
-                  class="helper-text"
-                  [innerHTML]="i18n.translateAndInsertTags('settings.serval_config_description')"
-                ></p>
-                <mat-form-field [formGroup]="form" appearance="outline">
-                  <mat-label>{{ t("serval_config") }}</mat-label>
-                  <textarea
-                    matInput
-                    cdkTextareaAutosize
-                    id="serval-config"
-                    formControlName="servalConfig"
-                    (blur)="updateServalConfig()"
-                  ></textarea>
-                  <app-write-status
-                    [state]="getControlState('servalConfig')"
-                    [formGroup]="form"
-                    id="serval-config-status"
-                  ></app-write-status>
-                </mat-form-field>
-              </ng-container>
-            </div>
-          </mat-card-content>
+                  </mat-form-field>
+                }
+              </div>
+            </mat-card-content>
+          }
           <mat-card-content>
             <mat-card-title>{{ t("community_checking_settings") }}</mat-card-title>
             <div class="tool-setting">
@@ -249,7 +269,7 @@
                 ></app-write-status>
               </div>
             </div>
-            <ng-container *ngIf="isCheckingEnabled">
+            @if (isCheckingEnabled) {
               <div class="tool-setting">
                 <div class="tool-setting-field checkbox-field">
                   <mat-checkbox formControlName="usersSeeEachOthersResponses" id="checkbox-see-others-responses">{{
@@ -262,19 +282,24 @@
                   ></app-write-status>
                 </div>
               </div>
-              <div class="tool-setting" *ngIf="featureFlags.scriptureAudio.enabled">
-                <div class="tool-setting-field checkbox-field">
-                  <mat-checkbox formControlName="hideCommunityCheckingText" id="checkbox-hide-community-checking-text">
-                    {{ t("hide_community_checking_text") }}
-                  </mat-checkbox>
-                  <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
-                  <app-write-status
-                    [state]="getControlState('hideCommunityCheckingText')"
-                    [formGroup]="form"
-                    id="hide-community-checking-text-status"
-                  ></app-write-status>
+              @if (featureFlags.scriptureAudio.enabled) {
+                <div class="tool-setting">
+                  <div class="tool-setting-field checkbox-field">
+                    <mat-checkbox
+                      formControlName="hideCommunityCheckingText"
+                      id="checkbox-hide-community-checking-text"
+                    >
+                      {{ t("hide_community_checking_text") }}
+                    </mat-checkbox>
+                    <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
+                    <app-write-status
+                      [state]="getControlState('hideCommunityCheckingText')"
+                      [formGroup]="form"
+                      id="hide-community-checking-text-status"
+                    ></app-write-status>
+                  </div>
                 </div>
-              </div>
+              }
               <div>
                 <p class="helper-text">{{ t("export_checking_answers") }}</p>
                 <div class="tool-setting">
@@ -304,7 +329,7 @@
                   </mat-radio-group>
                 </div>
               </div>
-            </ng-container>
+            }
           </mat-card-content>
           <mat-card-content>
             <mat-card-title>{{ t("sharing") }}</mat-card-title>
@@ -321,19 +346,21 @@
                 ></app-write-status>
               </div>
             </div>
-            <div class="tool-setting" *ngIf="isCheckingEnabled">
-              <div class="tool-setting-field checkbox-field">
-                <mat-checkbox formControlName="checkingShareEnabled" id="checkbox-checking-share">
-                  {{ t("shareChecking") }}
-                </mat-checkbox>
-                <app-info [text]="t('users_can_share_the_project')"></app-info>
-                <app-write-status
-                  [state]="getControlState('checkingShareEnabled')"
-                  [formGroup]="form"
-                  id="checking-share-status"
-                ></app-write-status>
+            @if (isCheckingEnabled) {
+              <div class="tool-setting">
+                <div class="tool-setting-field checkbox-field">
+                  <mat-checkbox formControlName="checkingShareEnabled" id="checkbox-checking-share">
+                    {{ t("shareChecking") }}
+                  </mat-checkbox>
+                  <app-info [text]="t('users_can_share_the_project')"></app-info>
+                  <app-write-status
+                    [state]="getControlState('checkingShareEnabled')"
+                    [formGroup]="form"
+                    id="checking-share-status"
+                  ></app-write-status>
+                </div>
               </div>
-            </div>
+            }
             <div class="indent">
               <mat-icon class="no-hover">admin_panel_settings</mat-icon>
               <span>
@@ -351,17 +378,18 @@
       <div class="mat-headline-6">{{ t("danger_zone") }}</div>
       <mat-card class="card-content" id="delete-project">
         <h4>{{ t("delete_this_project") }}</h4>
-        <p *ngIf="isActiveSourceProject; else deleteMessage" class="source-project-msg">
-          {{ t("source_projects_cannot_be_deleted") }}
-        </p>
-        <ng-template #deleteMessage>
+        @if (isActiveSourceProject) {
+          <p class="source-project-msg">
+            {{ t("source_projects_cannot_be_deleted") }}
+          </p>
+        } @else {
           <p>{{ t("delete_project_cannot_be_undone") }}</p>
           <p>
             <span [innerHTML]="synchronizeWarning?.before"></span>
             <a [appRouterLink]="['/projects', projectId, 'sync']">{{ synchronizeWarning?.templateTagText }}</a>
             <span>{{ synchronizeWarning?.after }}</span>
           </p>
-        </ng-template>
+        }
         <div fxLayout="row" fxLayoutAlign="end stretch">
           <button
             id="delete-btn"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -1,16 +1,22 @@
 <ng-container *transloco="let t; read: 'checking_audio_player'">
-  <div *ngIf="!hasProblem" class="content" dir="ltr">
-    <div class="current-time">{{ audio?.currentTime ?? 0 | audioTime }}</div>
-    <mat-slider class="slider" [disabled]="!isAudioAvailable" [min]="0" [max]="100">
-      <input matSliderThumb [value]="seek" (dragEnd)="onSeek($event)" />
-    </mat-slider>
-    <div class="duration">{{ duration | audioTime }}</div>
-  </div>
-  <div *ngIf="hasProblem" class="audio-not-available">
-    <mat-icon>volume_off</mat-icon>
-    <span>{{ t("audio_unavailable") }}</span>
-    <div *ngIf="audio?.hasErrorState">
-      <app-info id="error-load" [text]="t(audioStatus)"></app-info>
+  @if (!hasProblem) {
+    <div class="content" dir="ltr">
+      <div class="current-time">{{ audio?.currentTime ?? 0 | audioTime }}</div>
+      <mat-slider class="slider" [disabled]="!isAudioAvailable" [min]="0" [max]="100">
+        <input matSliderThumb [value]="seek" (dragEnd)="onSeek($event)" />
+      </mat-slider>
+      <div class="duration">{{ duration | audioTime }}</div>
     </div>
-  </div>
+  }
+  @if (hasProblem) {
+    <div class="audio-not-available">
+      <mat-icon>volume_off</mat-icon>
+      <span>{{ t("audio_unavailable") }}</span>
+      @if (audio?.hasErrorState) {
+        <div>
+          <app-info id="error-load" [text]="t(audioStatus)"></app-info>
+        </div>
+      }
+    </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
@@ -8,7 +8,9 @@
       panelWidth="200"
       panelClass="book-select-menu"
     >
-      <mat-option *ngFor="let b of books" [value]="b">{{ bookName(b) }}</mat-option>
+      @for (b of books; track b) {
+        <mat-option [value]="b">{{ bookName(b) }}</mat-option>
+      }
     </mat-select>
   </mat-form-field>
   <mat-form-field appearance="outline" id="chapter-select">
@@ -20,10 +22,12 @@
       panelClass="chapter-select-menu"
       [panelWidth]="chapters.length < 100 ? 70 : 80"
     >
-      <mat-option *ngFor="let c of chapters" [value]="c">{{ c }}</mat-option>
+      @for (c of chapters; track c) {
+        <mat-option [value]="c">{{ c }}</mat-option>
+      }
     </mat-select>
   </mat-form-field>
-  <ng-container *ngIf="!prevNextHidden">
+  @if (!prevNextHidden) {
     <button
       mat-icon-button
       (click)="prevChapter()"
@@ -42,5 +46,5 @@
     >
       <mat-icon>keyboard_arrow_{{ i18n.forwardDirectionWord }}</mat-icon>
     </button>
-  </ng-container>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,37 +1,44 @@
 <ng-container *transloco="let t; read: 'book_select'">
-  <div *ngIf="availableBooks.length > 0 && !readonly">
-    <mat-card class="bulk-select">
-      <mat-card-content>
-        <div>
-          <span>{{ t("select") }}:</span>
-          <mat-button-toggle-group (change)="select($event.value)" [(ngModel)]="selection">
-            <mat-button-toggle value="OT" [disabled]="!isOldTestamentAvailable()">
-              {{ t("old_testament") }}
-            </mat-button-toggle>
-            <mat-button-toggle value="NT" [disabled]="!isNewTestamentAvailable()">
-              {{ t("new_testament") }}
-            </mat-button-toggle>
-            <mat-button-toggle value="DC" *ngIf="isDeuterocanonAvailable()">
-              {{ t("deuterocanon") }}
-            </mat-button-toggle>
-          </mat-button-toggle-group>
-          <button mat-button *ngIf="selectedBooks.length > 0" (click)="clear()">{{ t("clear") }}</button>
-        </div>
-      </mat-card-content>
-    </mat-card>
-  </div>
+  @if (availableBooks.length > 0 && !readonly) {
+    <div>
+      <mat-card class="bulk-select">
+        <mat-card-content>
+          <div>
+            <span>{{ t("select") }}:</span>
+            <mat-button-toggle-group (change)="select($event.value)" [(ngModel)]="selection">
+              <mat-button-toggle value="OT" [disabled]="!isOldTestamentAvailable()">
+                {{ t("old_testament") }}
+              </mat-button-toggle>
+              <mat-button-toggle value="NT" [disabled]="!isNewTestamentAvailable()">
+                {{ t("new_testament") }}
+              </mat-button-toggle>
+              @if (isDeuterocanonAvailable()) {
+                <mat-button-toggle value="DC">
+                  {{ t("deuterocanon") }}
+                </mat-button-toggle>
+              }
+            </mat-button-toggle-group>
+            @if (selectedBooks.length > 0) {
+              <button mat-button (click)="clear()">{{ t("clear") }}</button>
+            }
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  }
   <div class="flex-row">
-    <mat-chip-listbox
-      *ngFor="let book of bookOptions"
-      hideSingleSelectionIndicator
-      [selectable]="!readonly"
-      class="book-multi-select"
-      [disabled]="readonly"
-      (change)="onChipListChange(book)"
-    >
-      <mat-chip-option [value]="book" [selected]="book.selected">
-        {{ "canon.book_names." + book.bookId | transloco }}
-      </mat-chip-option>
-    </mat-chip-listbox>
+    @for (book of bookOptions; track book) {
+      <mat-chip-listbox
+        hideSingleSelectionIndicator
+        [selectable]="!readonly"
+        class="book-multi-select"
+        [disabled]="readonly"
+        (change)="onChipListChange(book)"
+      >
+        <mat-chip-option [value]="book" [selected]="book.selected">
+          {{ "canon.book_names." + book.bookId | transloco }}
+        </mat-chip-option>
+      </mat-chip-listbox>
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
 import { TranslocoModule } from '@ngneat/transloco';
@@ -15,7 +14,7 @@ export interface BookOption {
   selector: 'app-book-multi-select',
   templateUrl: './book-multi-select.component.html',
   standalone: true,
-  imports: [CommonModule, UICommonModule, MatChipsModule, TranslocoModule],
+  imports: [UICommonModule, MatChipsModule, TranslocoModule],
   styleUrls: ['./book-multi-select.component.scss']
 })
 export class BookMultiSelectComponent implements OnChanges {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.html
@@ -1,2 +1,4 @@
-<mat-icon *ngIf="icon" [class.mirror-rtl]="mirrorRtl">{{ icon }}</mat-icon>
+@if (icon) {
+  <mat-icon [class.mirror-rtl]="mirrorRtl">{{ icon }}</mat-icon>
+}
 <span class="notice-content"><ng-content></ng-content></span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, HostBinding, Input, OnChanges } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { ICONS_TO_MIRROR_RTL } from '../utils';
@@ -9,7 +8,7 @@ import { NoticeMode, NoticeType } from './notice.types';
   templateUrl: './notice.component.html',
   styleUrls: ['./notice.component.scss'],
   standalone: true,
-  imports: [CommonModule, MatIconModule]
+  imports: [MatIconModule]
 })
 export class NoticeComponent implements OnChanges {
   @Input() type: NoticeType = 'primary';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -16,22 +16,21 @@
   [cdkDropListSortPredicate]="movablePredicate.bind(this)"
   (cdkDropListDropped)="onTabDrop($event)"
 >
-  @for (tab of tabs; track tab; let i = $index) {
-    <app-tab-header
-      [closeable]="tab.closeable"
-      [movable]="tab.movable"
-      [tooltip]="tab.tooltip"
-      [active]="i === selectedIndex"
-      (tabPress)="tabPress.next({ index: i, pointerEvent: $event })"
-      (tabClick)="tabClick.next({ index: i, pointerEvent: $event })"
-      (closeClick)="closeClick.next(i)"
-      cdkDrag
-      [cdkDragDisabled]="!tab.movable"
-      [cdkDragData]="tab"
-    >
-      <ng-container *ngTemplateOutlet="tab.tabHeaderTemplate"></ng-container>
-    </app-tab-header>
-  }
+  <app-tab-header
+    *ngFor="let tab of tabs; let i = index"
+    [closeable]="tab.closeable"
+    [movable]="tab.movable"
+    [tooltip]="tab.tooltip"
+    [active]="i === selectedIndex"
+    (tabPress)="tabPress.next({ index: i, pointerEvent: $event })"
+    (tabClick)="tabClick.next({ index: i, pointerEvent: $event })"
+    (closeClick)="closeClick.next(i)"
+    cdkDrag
+    [cdkDragDisabled]="!tab.movable"
+    [cdkDragData]="tab"
+  >
+    <ng-container *ngTemplateOutlet="tab.tabHeaderTemplate"></ng-container>
+  </app-tab-header>
 
   <app-tab-header
     #menuTrigger="matMenuTrigger"
@@ -47,18 +46,21 @@
   </app-tab-header>
 
   <mat-menu #newTabMenu>
-    @if ((menuItems$ | async)?.length) {
-      @for (item of menuItems$ | async; track item) {
-        <button mat-menu-item [disabled]="item.disabled" (click)="tabAddRequest.next(item.type)">
-          @if (item.icon) {
-            <mat-icon>{{ item.icon }}</mat-icon>
-          }
-          <span>{{ item.text }}</span>
-        </button>
-      }
-    } @else {
+    <!-- Migrating to control flow causes an "Expression changed after check" error when tabs are dragged -->
+    <ng-container *ngIf="(menuItems$ | async)?.length; else emptyMenu">
+      <button
+        *ngFor="let item of menuItems$ | async"
+        mat-menu-item
+        [disabled]="item.disabled"
+        (click)="tabAddRequest.next(item.type)"
+      >
+        <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
+        <span>{{ item.text }}</span>
+      </button>
+    </ng-container>
+    <ng-template #emptyMenu>
       <button mat-menu-item disabled>{{ "tab_group_header.no_tabs_available" | transloco }}</button>
-    }
+    </ng-template>
   </mat-menu>
 </div>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -16,21 +16,22 @@
   [cdkDropListSortPredicate]="movablePredicate.bind(this)"
   (cdkDropListDropped)="onTabDrop($event)"
 >
-  <app-tab-header
-    *ngFor="let tab of tabs; let i = index"
-    [closeable]="tab.closeable"
-    [movable]="tab.movable"
-    [tooltip]="tab.tooltip"
-    [active]="i === selectedIndex"
-    (tabPress)="tabPress.next({ index: i, pointerEvent: $event })"
-    (tabClick)="tabClick.next({ index: i, pointerEvent: $event })"
-    (closeClick)="closeClick.next(i)"
-    cdkDrag
-    [cdkDragDisabled]="!tab.movable"
-    [cdkDragData]="tab"
-  >
-    <ng-container *ngTemplateOutlet="tab.tabHeaderTemplate"></ng-container>
-  </app-tab-header>
+  @for (tab of tabs; track tab; let i = $index) {
+    <app-tab-header
+      [closeable]="tab.closeable"
+      [movable]="tab.movable"
+      [tooltip]="tab.tooltip"
+      [active]="i === selectedIndex"
+      (tabPress)="tabPress.next({ index: i, pointerEvent: $event })"
+      (tabClick)="tabClick.next({ index: i, pointerEvent: $event })"
+      (closeClick)="closeClick.next(i)"
+      cdkDrag
+      [cdkDragDisabled]="!tab.movable"
+      [cdkDragData]="tab"
+    >
+      <ng-container *ngTemplateOutlet="tab.tabHeaderTemplate"></ng-container>
+    </app-tab-header>
+  }
 
   <app-tab-header
     #menuTrigger="matMenuTrigger"
@@ -46,20 +47,18 @@
   </app-tab-header>
 
   <mat-menu #newTabMenu>
-    <ng-container *ngIf="(menuItems$ | async)?.length; else emptyMenu">
-      <button
-        *ngFor="let item of menuItems$ | async"
-        mat-menu-item
-        [disabled]="item.disabled"
-        (click)="tabAddRequest.next(item.type)"
-      >
-        <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
-        <span>{{ item.text }}</span>
-      </button>
-    </ng-container>
-    <ng-template #emptyMenu>
+    @if ((menuItems$ | async)?.length) {
+      @for (item of menuItems$ | async; track item) {
+        <button mat-menu-item [disabled]="item.disabled" (click)="tabAddRequest.next(item.type)">
+          @if (item.icon) {
+            <mat-icon>{{ item.icon }}</mat-icon>
+          }
+          <span>{{ item.text }}</span>
+        </button>
+      }
+    } @else {
       <button mat-menu-item disabled>{{ "tab_group_header.no_tabs_available" | transloco }}</button>
-    </ng-template>
+    }
   </mat-menu>
 </div>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
@@ -11,6 +11,8 @@
   (tabMove)="moveTab($event)"
 ></app-tab-group-header>
 
-<app-tab-body *ngFor="let tab of tabs; let i = index" [active]="selectedIndex === i">
-  <ng-container *ngTemplateOutlet="tab.contentTemplate"></ng-container>
-</app-tab-body>
+@for (tab of tabs; track tab; let i = $index) {
+  <app-tab-body [active]="selectedIndex === i">
+    <ng-container *ngTemplateOutlet="tab.contentTemplate"></ng-container>
+  </app-tab-body>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -27,17 +27,20 @@ import {
     `
   ],
   template: `
-    <app-tab-group
-      *ngFor="let tabGroup of tabState.tabGroups$ | async | keyvalue"
-      [groupId]="tabGroup.key"
-      [selectedIndex]="tabGroup.value.selectedIndex"
-      [connectedTo]="tabState.groupIds$ | async"
-    >
-      <app-tab *ngFor="let tab of tabGroup.value.tabs" [closeable]="tab.closeable" [movable]="tab.movable">
-        <ng-template sf-tab-header><div [innerHTML]="tab.headerText"></div></ng-template>
-        <p><span [innerHTML]="tab.headerText"></span> in {{ tabGroup.key }}</p>
-      </app-tab>
-    </app-tab-group>
+    @for (tabGroup of tabState.tabGroups$ | async | keyvalue; track tabGroup) {
+      <app-tab-group
+        [groupId]="tabGroup.key"
+        [selectedIndex]="tabGroup.value.selectedIndex"
+        [connectedTo]="tabState.groupIds$ | async"
+      >
+        @for (tab of tabGroup.value.tabs; track tab) {
+          <app-tab [closeable]="tab.closeable" [movable]="tab.movable">
+            <ng-template sf-tab-header><div [innerHTML]="tab.headerText"></div></ng-template>
+            <p><span [innerHTML]="tab.headerText"></span> in {{ tabGroup.key }}</p>
+          </app-tab>
+        }
+      </app-tab-group>
+    }
   `
 })
 class SFTabGroupStoriesComponent implements OnChanges {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.html
@@ -2,13 +2,14 @@
   <ng-content></ng-content>
 </div>
 
-<button
-  *ngIf="closeable"
-  mat-icon-button
-  class="close-button"
-  (click)="onCloseClick($event)"
-  (mousedown)="onClosePress($event)"
-  (touchstart)="onClosePress($event)"
->
-  <mat-icon>close</mat-icon>
-</button>
+@if (closeable) {
+  <button
+    mat-icon-button
+    class="close-button"
+    (click)="onCloseClick($event)"
+    (mousedown)="onClosePress($event)"
+    (touchstart)="onClosePress($event)"
+  >
+    <mat-icon>close</mat-icon>
+  </button>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
@@ -1,8 +1,12 @@
 <ng-container *transloco="let t; read: 'share'">
-  <button *ngIf="iconOnlyButton" (click)="openDialog()" mat-icon-button [matTooltip]="t('share')" id="share-btn">
-    <mat-icon class="mirror-rtl">person_add</mat-icon>
-  </button>
-  <button *ngIf="!iconOnlyButton" mat-flat-button (click)="openDialog()" color="primary" class="button-with-text">
-    <mat-icon class="mirror-rtl">person_add</mat-icon> {{ t("share") }}
-  </button>
+  @if (iconOnlyButton) {
+    <button (click)="openDialog()" mat-icon-button [matTooltip]="t('share')" id="share-btn">
+      <mat-icon class="mirror-rtl">person_add</mat-icon>
+    </button>
+  }
+  @if (!iconOnlyButton) {
+    <button mat-flat-button (click)="openDialog()" color="primary" class="button-with-text">
+      <mat-icon class="mirror-rtl">person_add</mat-icon> {{ t("share") }}
+    </button>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -2,7 +2,9 @@
   <h2>{{ t("invite_people") }}</h2>
   <p class="mat-hint">{{ t("invite_people_intro") }}</p>
   <p class="mat-hint">{{ t("email_sharing") }}</p>
-  <div *ngIf="!isAppOnline" class="offline-text">{{ t("share_not_available_offline") }}</div>
+  @if (!isAppOnline) {
+    <div class="offline-text">{{ t("share_not_available_offline") }}</div>
+  }
   <div fxLayout="column" fxLayoutGap="20px">
     <div class="invite-by-email">
       <h3>{{ t("send_a_link") }}</h3>
@@ -11,9 +13,11 @@
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>
             <input matInput type="email" formControlName="email" (input)="onEmailInput()" />
-            <mat-error *ngIf="email.hasError('pattern') || email.hasError('required')">
-              {{ t("email_invalid") }}
-            </mat-error>
+            @if (email.hasError("pattern") || email.hasError("required")) {
+              <mat-error>
+                {{ t("email_invalid") }}
+              </mat-error>
+            }
           </mat-form-field>
           <mat-form-field id="invitation-role">
             <mat-label>{{ t("invitation_role") }}</mat-label>
@@ -21,21 +25,29 @@
               <mat-select-trigger>
                 {{ roleControl.value ? i18n.localizeRole(roleControl.value) : "" }}
               </mat-select-trigger>
-              <mat-option *ngFor="let roleInfo of availableRolesInfo" [value]="roleInfo.role">
-                <div class="role-name">{{ i18n.localizeRole(roleInfo.role) }}</div>
-                <div class="role-description">{{ i18n.localizeRoleDescription(roleInfo.role) }}</div>
-              </mat-option>
+              @for (roleInfo of availableRolesInfo; track roleInfo) {
+                <mat-option [value]="roleInfo.role">
+                  <div class="role-name">{{ i18n.localizeRole(roleInfo.role) }}</div>
+                  <div class="role-description">{{ i18n.localizeRoleDescription(roleInfo.role) }}</div>
+                </mat-option>
+              }
             </mat-select>
-            <mat-error *ngIf="roleControl.hasError('required')">{{ t("select_invitation_role") }}</mat-error>
+            @if (roleControl.hasError("required")) {
+              <mat-error>{{ t("select_invitation_role") }}</mat-error>
+            }
           </mat-form-field>
           <mat-form-field id="invitation-language">
             <mat-label>{{ t("invitation_language") }}</mat-label>
             <mat-select formControlName="locale" panelClass="locale-fonts" [hideSingleSelectionIndicator]="true">
-              <mat-option *ngFor="let locale of i18n.locales" [value]="locale.canonicalTag">
-                {{ locale.localName }}
-              </mat-option>
+              @for (locale of i18n.locales; track locale) {
+                <mat-option [value]="locale.canonicalTag">
+                  {{ locale.localName }}
+                </mat-option>
+              }
             </mat-select>
-            <mat-error *ngIf="localeControl.hasError('required')">{{ t("select_invitation_language") }}</mat-error>
+            @if (localeControl.hasError("required")) {
+              <mat-error>{{ t("select_invitation_language") }}</mat-error>
+            }
           </mat-form-field>
           <button
             id="send-btn"
@@ -51,10 +63,12 @@
         </form>
       </div>
     </div>
-    <div *ngIf="isLinkSharingEnabled" class="invite-by-link">
-      <h3>{{ t("share_a_link") }}</h3>
-      <p class="mat-hint">{{ t("link_sharing") }}</p>
-      <app-share-button [iconOnlyButton]="false"></app-share-button>
-    </div>
+    @if (isLinkSharingEnabled) {
+      <div class="invite-by-link">
+        <h3>{{ t("share_a_link") }}</h3>
+        <p class="mat-hint">{{ t("link_sharing") }}</p>
+        <app-share-button [iconOnlyButton]="false"></app-share-button>
+      </div>
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -8,97 +8,98 @@
       <mat-icon>public</mat-icon>
       <div>
         {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
-        <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}" *ngIf="canUserChangeRole"
-          >({{ t("change") }})</a
-        >
+        @if (canUserChangeRole) {
+          <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}">({{ t("change") }})</a>
+        }
       </div>
       <mat-menu #roleMenu>
         <mat-selection-list [multiple]="false" class="share-selection-role" hideSingleSelectionIndicator>
-          <mat-list-option *ngFor="let role of availableRoles" [selected]="role === shareRole" (click)="setRole(role)">
-            <div class="role-name">{{ i18n.localizeRole(role) }}</div>
-            <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
-          </mat-list-option>
+          @for (role of availableRoles; track role) {
+            <mat-list-option [selected]="role === shareRole" (click)="setRole(role)">
+              <div class="role-name">{{ i18n.localizeRole(role) }}</div>
+              <div class="role-description">{{ i18n.localizeRoleDescription(role) }}</div>
+            </mat-list-option>
+          }
         </mat-selection-list>
       </mat-menu>
     </div>
-    <ng-container *ngIf="canUserChangeLinkUsage">
+    @if (canUserChangeLinkUsage) {
       <div class="configuration-option configuration-link-type">
         <mat-icon>{{ shareLinkType === "anyone" ? "groups" : "person" }}</mat-icon>
         <div>
           {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
-          <a
-            [matMenuTriggerFor]="linkUsageMenu"
-            title="{{ t('invitation_link_type') }}"
-            *ngIf="shareLinkUsageOptions.length > 1"
-            >({{ t("change") }})</a
-          >
+          @if (shareLinkUsageOptions.length > 1) {
+            <a [matMenuTriggerFor]="linkUsageMenu" title="{{ t('invitation_link_type') }}">({{ t("change") }})</a>
+          }
         </div>
         <mat-menu #linkUsageMenu>
-          <mat-selection-list [multiple]="false" *ngIf="shareLinkUsageOptions.length > 1" hideSingleSelectionIndicator>
-            <mat-list-option
-              *ngFor="let option of shareLinkUsageOptions"
-              [selected]="option === shareLinkType"
-              (click)="setLinkType(option)"
-            >
-              {{ t(option) }}
-            </mat-list-option>
-          </mat-selection-list>
+          @if (shareLinkUsageOptions.length > 1) {
+            <mat-selection-list [multiple]="false" hideSingleSelectionIndicator>
+              @for (option of shareLinkUsageOptions; track option) {
+                <mat-list-option [selected]="option === shareLinkType" (click)="setLinkType(option)">
+                  {{ t(option) }}
+                </mat-list-option>
+              }
+            </mat-selection-list>
+          }
         </mat-menu>
       </div>
       <div class="configuration-option">
         <mat-icon>schedule</mat-icon>
         <div>
           <transloco key="share_dialog.will_expire_in" [params]="{ count: shareExpiration }"></transloco>
-          <a
-            [matMenuTriggerFor]="expireMenu"
-            *ngIf="linkExpirationOptions.length > 1"
-            title="{{ t('expiration_description') }}"
-          >
-            ({{ t("change") }})
-          </a>
+          @if (linkExpirationOptions.length > 1) {
+            <a [matMenuTriggerFor]="expireMenu" title="{{ t('expiration_description') }}"> ({{ t("change") }}) </a>
+          }
         </div>
         <mat-menu #expireMenu>
-          <mat-selection-list [multiple]="false" *ngIf="linkExpirationOptions.length > 1" hideSingleSelectionIndicator>
-            <mat-list-option
-              *ngFor="let key of linkExpirationOptions"
-              [selected]="ShareExpiration[key] === shareExpiration"
-              (click)="setLinkExpiration(key)"
-            >
-              {{ t(key) }}
-            </mat-list-option>
-          </mat-selection-list>
+          @if (linkExpirationOptions.length > 1) {
+            <mat-selection-list [multiple]="false" hideSingleSelectionIndicator>
+              @for (key of linkExpirationOptions; track key) {
+                <mat-list-option [selected]="ShareExpiration[key] === shareExpiration" (click)="setLinkExpiration(key)">
+                  {{ t(key) }}
+                </mat-list-option>
+              }
+            </mat-selection-list>
+          }
         </mat-menu>
       </div>
-    </ng-container>
+    }
     <div class="configuration-option">
       <mat-icon>translate</mat-icon>
       <div>
         <div>
           {{ t("invitation_shared_in_language") }}
-          <b *ngIf="shareLocaleCode?.localName">{{ shareLocaleCode?.localName }}</b>
-          <b *ngIf="!shareLocaleCode?.localName" class="empty-field" [ngClass]="{ error: error }"> ________________ </b>
+          @if (shareLocaleCode?.localName) {
+            <b>{{ shareLocaleCode?.localName }}</b>
+          }
+          @if (!shareLocaleCode?.localName) {
+            <b class="empty-field" [ngClass]="{ error: error }"> ________________ </b>
+          }
           <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}"> ({{ t("change") }}) </a>
         </div>
         <span class="error help-text" [ngClass]="{ hidden: !error }">{{ t("error_language") }}</span>
       </div>
       <mat-menu #langMenu>
         <mat-selection-list [multiple]="false" hideSingleSelectionIndicator>
-          <mat-list-option
-            *ngFor="let locale of i18n.locales"
-            [selected]="locale === shareLocaleCode"
-            (click)="setLocale(locale)"
-          >
-            {{ locale.localName }}
-          </mat-list-option>
+          @for (locale of i18n.locales; track locale) {
+            <mat-list-option [selected]="locale === shareLocaleCode" (click)="setLocale(locale)">
+              {{ locale.localName }}
+            </mat-list-option>
+          }
         </mat-selection-list>
       </mat-menu>
     </div>
-    <app-notice *ngIf="isRecipientOnlyLink" icon="info">
-      {{ t("recipient_only_notice", { shareExpiration: shareExpiration }) }}
-    </app-notice>
-    <app-notice *ngIf="showLinkSharingUnavailable" type="error" icon="cloud_off">
-      {{ t("link_sharing_not_available_offline") }}
-    </app-notice>
+    @if (isRecipientOnlyLink) {
+      <app-notice icon="info">
+        {{ t("recipient_only_notice", { shareExpiration: shareExpiration }) }}
+      </app-notice>
+    }
+    @if (showLinkSharingUnavailable) {
+      <app-notice type="error" icon="cloud_off">
+        {{ t("link_sharing_not_available_offline") }}
+      </app-notice>
+    }
   </div>
   <div mat-dialog-actions>
     <button
@@ -110,15 +111,10 @@
     >
       <mat-icon>content_copy</mat-icon>{{ t("copy_link") }}
     </button>
-    <button
-      id="share-btn"
-      mat-flat-button
-      color="primary"
-      *ngIf="supportsShareAPI"
-      (click)="shareLink()"
-      [disabled]="!isLinkReady"
-    >
-      <mat-icon>share</mat-icon>{{ t("share") }}
-    </button>
+    @if (supportsShareAPI) {
+      <button id="share-btn" mat-flat-button color="primary" (click)="shareLink()" [disabled]="!isLinkReady">
+        <mat-icon>share</mat-icon>{{ t("share") }}
+      </button>
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -1,58 +1,60 @@
 <ng-container *transloco="let t; read: 'sync'">
   <div class="base-container">
     <h2 id="title">{{ t("synchronize_project", { projectName: projectName }) }}</h2>
-    <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_synchronize") }} </span>
-    <span *ngIf="syncDisabled" id="sync-disabled-message" [innerHTML]="syncDisabledMessage"> </span>
-    <span
-      *ngIf="showSyncFailureSupportMessage"
-      id="sync-failure-support-message"
-      [innerHTML]="syncFailureSupportMessage"
-    ></span>
+    @if (!isAppOnline) {
+      <span class="offline-text"> {{ t("connect_network_to_synchronize") }} </span>
+    }
+    @if (syncDisabled) {
+      <span id="sync-disabled-message" [innerHTML]="syncDisabledMessage"> </span>
+    }
+    @if (showSyncFailureSupportMessage) {
+      <span id="sync-failure-support-message" [innerHTML]="syncFailureSupportMessage"></span>
+    }
     <mat-card class="sync-card">
       <div class="card-content">
-        <button
-          *ngIf="showParatextLogin && isAppOnline"
-          mat-flat-button
-          type="button"
-          (click)="logInWithParatext()"
-          id="btn-log-in"
-        >
-          <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-          {{ t("log_in_to_paratext") }}
-        </button>
-        <ng-container *ngIf="isLoggedIntoParatext || isLoading || !isAppOnline">
-          <button
-            *ngIf="!syncActive"
-            mat-flat-button
-            color="primary"
-            type="button"
-            (click)="syncProject()"
-            [disabled]="isLoading || !isAppOnline || syncDisabled"
-            id="btn-sync"
-          >
-            <mat-icon>sync</mat-icon>
-            {{ t("synchronize") }}
+        @if (showParatextLogin && isAppOnline) {
+          <button mat-flat-button type="button" (click)="logInWithParatext()" id="btn-log-in">
+            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+            {{ t("log_in_to_paratext") }}
           </button>
-          <mat-hint *ngIf="syncActive" id="sync-message">{{ t("your_project_is_being_synchronized") }}</mat-hint>
-          <app-sync-progress
-            *ngIf="syncActive"
-            [projectDoc]="projectDoc"
-            (inProgress)="syncActive = $event"
-          ></app-sync-progress>
-          <button
-            *ngIf="syncActive"
-            mat-button
-            type="button"
-            (click)="cancelSync()"
-            [disabled]="isLoading || !isAppOnline || syncDisabled"
-            id="btn-cancel-sync"
-          >
-            {{ t("cancel") }}
-          </button>
-          <mat-hint *ngIf="!syncActive" [title]="lastSyncDisplayDate" id="date-last-sync">
-            {{ lastSyncNotice }}
-          </mat-hint>
-        </ng-container>
+        }
+        @if (isLoggedIntoParatext || isLoading || !isAppOnline) {
+          @if (!syncActive) {
+            <button
+              mat-flat-button
+              color="primary"
+              type="button"
+              (click)="syncProject()"
+              [disabled]="isLoading || !isAppOnline || syncDisabled"
+              id="btn-sync"
+            >
+              <mat-icon>sync</mat-icon>
+              {{ t("synchronize") }}
+            </button>
+          }
+          @if (syncActive) {
+            <mat-hint id="sync-message">{{ t("your_project_is_being_synchronized") }}</mat-hint>
+          }
+          @if (syncActive) {
+            <app-sync-progress [projectDoc]="projectDoc" (inProgress)="syncActive = $event"></app-sync-progress>
+          }
+          @if (syncActive) {
+            <button
+              mat-button
+              type="button"
+              (click)="cancelSync()"
+              [disabled]="isLoading || !isAppOnline || syncDisabled"
+              id="btn-cancel-sync"
+            >
+              {{ t("cancel") }}
+            </button>
+          }
+          @if (!syncActive) {
+            <mat-hint [title]="lastSyncDisplayDate" id="date-last-sync">
+              {{ lastSyncNotice }}
+            </mat-hint>
+          }
+        }
       </div>
     </mat-card>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.html
@@ -19,7 +19,9 @@
           <span class="selection-reference">{{ referenceForDisplay }}</span>
         </p>
       </div>
-      <span class="error-message" *ngIf="showError">{{ t("select_text_error_message") }}</span>
+      @if (showError) {
+        <span class="error-message">{{ t("select_text_error_message") }}</span>
+      }
     </mat-dialog-content>
     <mat-dialog-actions align="end">
       <button mat-button type="button" id="cancel-button" [mat-dialog-close]="'close'">{{ t("cancel") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
@@ -28,8 +28,10 @@
   </mat-dialog-content>
   <mat-dialog-actions>
     <button mat-button mat-dialog-close>{{ t(canEdit() ? "cancel" : "close") }}</button>
-    <button *ngIf="canEdit()" mat-flat-button class="save-button" color="primary" (click)="submit()">
-      {{ t("save") }}
-    </button>
+    @if (canEdit()) {
+      <button mat-flat-button class="save-button" color="primary" (click)="submit()">
+        {{ t("save") }}
+      </button>
+    }
   </mat-dialog-actions>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.html
@@ -15,13 +15,12 @@
           t("biblical_terms_renderings") + selectedReferenceForCaption
         }}
       </caption>
-      <ng-container
-        *ngFor="let column of columnsToDisplay | slice: 0 : columnsToDisplay.length - 1"
-        [matColumnDef]="column"
-      >
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ t(column) }}</th>
-        <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
-      </ng-container>
+      @for (column of columnsToDisplay | slice: 0 : columnsToDisplay.length - 1; track column) {
+        <ng-container [matColumnDef]="column">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ t(column) }}</th>
+          <td mat-cell *matCellDef="let row">{{ row[column] }}</td>
+        </ng-container>
+      }
 
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef class="actions">{{ t("actions") }}</th>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,47 +1,50 @@
 <ng-container *transloco="let t; read: 'draft_generation_steps'">
-  <ng-container *ngIf="availableTranslateBooks && availableTranslateBooks.length > 0">
+  @if (availableTranslateBooks && availableTranslateBooks.length > 0) {
     <mat-stepper orientation="vertical" linear (selectionChange)="onStepChange()">
       <mat-step [completed]="userSelectedTranslateBooks.length > 0">
         <ng-template matStepLabel>
           {{ t("choose_books_to_translate") }}
         </ng-template>
-
         <app-book-multi-select
           [availableBooks]="availableTranslateBooks"
           [selectedBooks]="initialSelectedTranslateBooks"
           (bookSelect)="onTranslateBookSelect($event)"
           data-test-id="draft-stepper-translate-books"
         ></app-book-multi-select>
-
-        <app-notice *ngIf="unusableTranslateTargetBooks.length">
-          <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-        </app-notice>
-
-        <app-notice *ngIf="unusableTranslateSourceBooks.length">
-          <h4 *ngIf="unusableTranslateSourceBooks.length">
-            <transloco
-              key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
-              [params]="{ draftingSourceProjectName }"
-            ></transloco>
-          </h4>
-          <app-book-multi-select
-            *ngIf="unusableTranslateSourceBooks.length"
-            [availableBooks]="unusableTranslateSourceBooks"
-            [readonly]="true"
-          ></app-book-multi-select>
-        </app-notice>
-
-        <app-notice *ngIf="showBookSelectionError" type="error">
-          {{ t("choose_books_to_translate_error") }}
-        </app-notice>
-
+        @if (unusableTranslateTargetBooks.length) {
+          <app-notice>
+            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
+          </app-notice>
+        }
+        @if (unusableTranslateSourceBooks.length) {
+          <app-notice>
+            @if (unusableTranslateSourceBooks.length) {
+              <h4>
+                <transloco
+                  key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
+                  [params]="{ draftingSourceProjectName }"
+                ></transloco>
+              </h4>
+            }
+            @if (unusableTranslateSourceBooks.length) {
+              <app-book-multi-select
+                [availableBooks]="unusableTranslateSourceBooks"
+                [readonly]="true"
+              ></app-book-multi-select>
+            }
+          </app-notice>
+        }
+        @if (showBookSelectionError) {
+          <app-notice type="error">
+            {{ t("choose_books_to_translate_error") }}
+          </app-notice>
+        }
         <div class="button-strip">
           <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
             {{ t("next") }}
           </button>
         </div>
       </mat-step>
-
       <mat-step [completed]="isTrainingOptional || userSelectedTrainingBooks.length > 0">
         <ng-template matStepLabel>
           <div class="stepper-multi-header">
@@ -49,37 +52,40 @@
             <h3>{{ t("choose_books_for_training_subheader") }}</h3>
           </div>
         </ng-template>
-
         <app-book-multi-select
           [availableBooks]="availableTrainingBooks"
           [selectedBooks]="initialSelectedTrainingBooks"
           (bookSelect)="onTrainingBookSelect($event)"
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
-
-        <app-notice *ngIf="unusableTranslateTargetBooks.length">
-          <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-        </app-notice>
-
-        <app-notice *ngIf="unusableTrainingSourceBooks.length">
-          <h4>
-            <transloco
-              *ngIf="unusableTrainingSourceBooks.length"
-              key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
-              [params]="{ trainingSourceProjectName }"
-            ></transloco>
-          </h4>
-          <app-book-multi-select
-            *ngIf="unusableTrainingSourceBooks.length"
-            [availableBooks]="unusableTrainingSourceBooks"
-            [readonly]="true"
-          ></app-book-multi-select>
-        </app-notice>
-
-        <app-notice *ngIf="showBookSelectionError" type="error">
-          {{ t("choose_books_for_training_error") }}
-        </app-notice>
-
+        @if (unusableTranslateTargetBooks.length) {
+          <app-notice>
+            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
+          </app-notice>
+        }
+        @if (unusableTrainingSourceBooks.length) {
+          <app-notice>
+            <h4>
+              @if (unusableTrainingSourceBooks.length) {
+                <transloco
+                  key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
+                  [params]="{ trainingSourceProjectName }"
+                ></transloco>
+              }
+            </h4>
+            @if (unusableTrainingSourceBooks.length) {
+              <app-book-multi-select
+                [availableBooks]="unusableTrainingSourceBooks"
+                [readonly]="true"
+              ></app-book-multi-select>
+            }
+          </app-notice>
+        }
+        @if (showBookSelectionError) {
+          <app-notice type="error">
+            {{ t("choose_books_for_training_error") }}
+          </app-notice>
+        }
         <div class="button-strip">
           <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
           <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
@@ -87,60 +93,60 @@
           </button>
         </div>
       </mat-step>
-
-      <mat-step *ngIf="trainingDataFilesAvailable" [completed]="true">
-        <ng-template matStepLabel>
-          <div class="stepper-multi-header">
-            <h2>{{ t("choose_additional_training_data_files") }}</h2>
-            <h3>{{ t("choose_additional_training_data_files_subheader") }}</h3>
+      @if (trainingDataFilesAvailable) {
+        <mat-step [completed]="true">
+          <ng-template matStepLabel>
+            <div class="stepper-multi-header">
+              <h2>{{ t("choose_additional_training_data_files") }}</h2>
+              <h3>{{ t("choose_additional_training_data_files_subheader") }}</h3>
+            </div>
+          </ng-template>
+          <app-training-data-multi-select
+            [availableTrainingData]="availableTrainingData"
+            [selectedTrainingDataIds]="selectedTrainingDataIds"
+            (trainingDataSelect)="onTrainingDataSelect($event)"
+            data-test-id="draft-stepper-training-data-files"
+          ></app-training-data-multi-select>
+          <div class="button-strip">
+            <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
+            <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+              {{ featureFlags.allowFastTraining.enabled ? t("next") : t("generate_draft") }}
+            </button>
           </div>
-        </ng-template>
-
-        <app-training-data-multi-select
-          [availableTrainingData]="availableTrainingData"
-          [selectedTrainingDataIds]="selectedTrainingDataIds"
-          (trainingDataSelect)="onTrainingDataSelect($event)"
-          data-test-id="draft-stepper-training-data-files"
-        ></app-training-data-multi-select>
-
-        <div class="button-strip">
-          <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-          <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
-            {{ featureFlags.allowFastTraining.enabled ? t("next") : t("generate_draft") }}
-          </button>
-        </div>
-      </mat-step>
-
-      <mat-step *ngIf="featureFlags.allowFastTraining.enabled" [completed]="true">
-        <ng-template matStepLabel>
-          <div class="stepper-multi-header">
-            <h2>{{ t("configure_advanced_settings") }}</h2>
+        </mat-step>
+      }
+      @if (featureFlags.allowFastTraining.enabled) {
+        <mat-step [completed]="true">
+          <ng-template matStepLabel>
+            <div class="stepper-multi-header">
+              <h2>{{ t("configure_advanced_settings") }}</h2>
+            </div>
+          </ng-template>
+          <div>
+            <mat-checkbox [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
           </div>
-        </ng-template>
-        <div>
-          <mat-checkbox [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
-        </div>
-        <app-notice *ngIf="fastTraining" icon="warning" type="warning" class="warning">{{
-          t("fast_training_warning")
-        }}</app-notice>
-        <div class="button-strip">
-          <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-          <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
-            {{ t("generate_draft") }}
-          </button>
-        </div>
-      </mat-step>
+          @if (fastTraining) {
+            <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>
+          }
+          <div class="button-strip">
+            <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
+            <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+              {{ t("generate_draft") }}
+            </button>
+          </div>
+        </mat-step>
+      }
     </mat-stepper>
-  </ng-container>
+  }
 
-  <ng-container *ngIf="availableTranslateBooks && availableTranslateBooks.length <= 0">
+  @if (availableTranslateBooks && availableTranslateBooks.length <= 0) {
     <p>{{ t("no_available_books") }}</p>
-  </ng-container>
+  }
 
-  <ng-container *ngIf="availableTranslateBooks == null">
+  @if (availableTranslateBooks == null) {
     <div class="loading">
       <mat-spinner diameter="20" color="primary"></mat-spinner>
       <div>{{ t("loading") }}</div>
     </div>
-  </ng-container>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
 import { TranslocoModule } from '@ngneat/transloco';
@@ -37,7 +36,6 @@ export interface DraftGenerationStepsResult {
   styleUrls: ['./draft-generation-steps.component.scss'],
   standalone: true,
   imports: [
-    CommonModule,
     SharedModule,
     UICommonModule,
     TranslocoModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -40,10 +40,9 @@
           {{ t("instructions_draft_process_subtext") }}
         </p>
         <p>
-          @for (i of i18n.interpolate("draft_generation.instructions_help"); track i) {
-            @if (i.id == null) {
-              {{ i.text }}
-            }
+          @for (i of draftHelp | async; track i) {
+            <!-- prettier-ignore -->
+            @if (i.id == null) {{{ i.text }}}
             @if (i.id === 1) {
               <a [href]="urlService.autoDrafts" target="_blank">{{ i.text }}</a>
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -1,397 +1,402 @@
 <ng-container *transloco="let t; read: 'draft_generation'">
-  <h1 *ngIf="isBackTranslationMode" class="mat-headline-4">{{ t("generate_back_translation_drafts_header") }}</h1>
-  <h1 *ngIf="!isBackTranslationMode" class="mat-headline-4">
-    {{ t("generate_forward_translation_drafts_header") }}
-  </h1>
+  @if (isBackTranslationMode) {
+    <h1 class="mat-headline-4">{{ t("generate_back_translation_drafts_header") }}</h1>
+  }
+  @if (!isBackTranslationMode) {
+    <h1 class="mat-headline-4">
+      {{ t("generate_forward_translation_drafts_header") }}
+    </h1>
+  }
 
   <section>
-    <div
-      *ngIf="isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild"
-      class="drafting-instructions"
-    >
-      <div *ngIf="isBackTranslationMode">
+    @if (isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {
+      <div class="drafting-instructions">
+        @if (isBackTranslationMode) {
+          <div>
+            <p>
+              <b>{{ t("instructions_scripture_forge_assist_back_translation") }}</b>
+              <br />
+              {{ t("instructions_scripture_forge_assist_back_translation_subtext") }}
+            </p>
+          </div>
+        }
+        @if (!isBackTranslationMode) {
+          <div>
+            <p>
+              <b>{{ t("instructions_scripture_forge_assist_forward_translation") }}</b>
+              <br />
+              {{ t("instructions_scripture_forge_assist_forward_translation_subtext") }}
+            </p>
+          </div>
+        }
         <p>
-          <b>{{ t("instructions_scripture_forge_assist_back_translation") }}</b>
+          <b>{{ t("instructions_keep_in_mind") }}</b>
           <br />
-          {{ t("instructions_scripture_forge_assist_back_translation_subtext") }}
+          {{ t("instructions_keep_in_mind_subtext") }}
+        </p>
+        <p>
+          <b>{{ t("instructions_draft_process", { count: 8 }) }}</b>
+          <br />
+          {{ t("instructions_draft_process_subtext") }}
+        </p>
+        <p>
+          @for (i of i18n.interpolate("draft_generation.instructions_help"); track i) {
+            @if (i.id == null) {
+              {{ i.text }}
+            }
+            @if (i.id === 1) {
+              <a [href]="urlService.autoDrafts" target="_blank">{{ i.text }}</a>
+            }
+          }
         </p>
       </div>
-      <div *ngIf="!isBackTranslationMode">
+    }
+
+    @if (isBackTranslationMode && !isTargetLanguageSupported) {
+      <app-notice type="warning" class="requirements">
         <p>
-          <b>{{ t("instructions_scripture_forge_assist_forward_translation") }}</b>
-          <br />
-          {{ t("instructions_scripture_forge_assist_forward_translation_subtext") }}
+          <transloco
+            key="draft_generation.back_translation_requirement"
+            [params]="{ supportedLanguagesUrl }"
+          ></transloco>
         </p>
-      </div>
-
-      <p>
-        <b>{{ t("instructions_keep_in_mind") }}</b>
-        <br />
-        {{ t("instructions_keep_in_mind_subtext") }}
-      </p>
-      <p>
-        <b>{{ t("instructions_draft_process", { count: 8 }) }}</b>
-        <br />
-        {{ t("instructions_draft_process_subtext") }}
-      </p>
-      <p>
-        <ng-container *ngFor="let i of i18n.interpolate('draft_generation.instructions_help')">
-          <ng-container *ngIf="i.id == null">{{ i.text }}</ng-container>
-          <a *ngIf="i.id === 1" [href]="urlService.autoDrafts" target="_blank">{{ i.text }}</a>
-        </ng-container>
-      </p>
-    </div>
-
-    <app-notice *ngIf="isBackTranslationMode && !isTargetLanguageSupported" type="warning" class="requirements">
-      <p>
-        <transloco key="draft_generation.back_translation_requirement" [params]="{ supportedLanguagesUrl }"></transloco>
-      </p>
-      <ul>
-        <li>
-          <mat-icon class="criteria-not-met">clear</mat-icon>
-          <p>
-            <transloco
-              key="draft_generation.criteria_project_language_not_in_nllb_with_language"
-              [params]="{ targetLanguageDisplayName }"
-            ></transloco>
-          </p>
-        </li>
-      </ul>
-    </app-notice>
+        <ul>
+          <li>
+            <mat-icon class="criteria-not-met">clear</mat-icon>
+            <p>
+              <transloco
+                key="draft_generation.criteria_project_language_not_in_nllb_with_language"
+                [params]="{ targetLanguageDisplayName }"
+              ></transloco>
+            </p>
+          </li>
+        </ul>
+      </app-notice>
+    }
 
     <!-- Only show warnings if target language is supported -->
-    <ng-container *ngIf="isTargetLanguageSupported">
-      <app-notice *ngIf="!isSourceProjectSet" type="warning" icon="warning" data-test-id="warning-source-text-missing">
-        @if (isProjectAdmin) {
+    @if (isTargetLanguageSupported) {
+      @if (!isSourceProjectSet) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-source-text-missing">
+          @if (isProjectAdmin) {
+            <transloco
+              key="draft_generation.info_alert_source_text_not_selected"
+              [params]="{ projectSettingsUrl: { route: projectSettingsUrl } }"
+            ></transloco>
+          } @else {
+            <transloco key="draft_generation.non_pa_info_alert_source_text_not_selected"></transloco>
+          }
+        </app-notice>
+      }
+      @if (isSourceProjectSet && !isSourceAndTargetDifferent) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-source-target-same">
+          @if (isProjectAdmin) {
+            <transloco
+              key="draft_generation.info_alert_same_source_and_target_language"
+              [params]="{ targetLanguageDisplayName, projectSettingsUrl: { route: projectSettingsUrl } }"
+            ></transloco>
+          } @else {
+            <transloco
+              key="draft_generation.non_pa_info_alert_same_source_and_target_language"
+              [params]="{ targetLanguageDisplayName }"
+            ></transloco>
+          }
+        </app-notice>
+      }
+      @if (isSourceProjectSet && isSourceAndTargetDifferent && !isSourceAndTrainingSourceLanguageIdentical) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-source-training-different">
+          @if (isProjectAdmin) {
+            <transloco
+              key="draft_generation.info_alert_different_training_and_source_language"
+              [params]="{
+                alternateTrainingSourceLanguageDisplayName,
+                sourceLanguageDisplayName,
+                projectSettingsUrl: { route: projectSettingsUrl }
+              }"
+            ></transloco>
+          } @else {
+            <transloco
+              key="draft_generation.non_pa_info_alert_different_training_and_source_language"
+              [params]="{
+                alternateTrainingSourceLanguageDisplayName,
+                sourceLanguageDisplayName
+              }"
+            ></transloco>
+          }
+        </app-notice>
+      }
+      @if (
+        isSourceProjectSet &&
+        isSourceAndTargetDifferent &&
+        isSourceAndTrainingSourceLanguageIdentical &&
+        !isSourceAndAdditionalTrainingSourceLanguageIdentical
+      ) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-mix-source-different">
+          @if (isProjectAdmin) {
+            <transloco
+              key="draft_generation.info_alert_different_additional_training_and_source_language"
+              [params]="{
+                additionalTrainingSourceLanguageDisplayName,
+                alternateTrainingSourceLanguageDisplayName,
+                projectSettingsUrl: { route: projectSettingsUrl }
+              }"
+            ></transloco>
+          } @else {
+            <transloco
+              key="draft_generation.non_pa_info_alert_different_additional_training_and_source_language"
+              [params]="{
+                additionalTrainingSourceLanguageDisplayName,
+                alternateTrainingSourceLanguageDisplayName
+              }"
+            ></transloco>
+          }
+        </app-notice>
+      }
+      @if (
+        isSourceProjectSet &&
+        isSourceAndTargetDifferent &&
+        isSourceAndTrainingSourceLanguageIdentical &&
+        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
+        !canAccessDraftSourceIfAvailable(source)
+      ) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-source-no-access">
           <transloco
-            key="draft_generation.info_alert_source_text_not_selected"
-            [params]="{ projectSettingsUrl: { route: projectSettingsUrl } }"
-          ></transloco>
-        } @else {
-          <transloco key="draft_generation.non_pa_info_alert_source_text_not_selected"></transloco>
-        }
-      </app-notice>
-
-      <app-notice
-        *ngIf="isSourceProjectSet && !isSourceAndTargetDifferent"
-        type="warning"
-        icon="warning"
-        data-test-id="warning-source-target-same"
-      >
-        @if (isProjectAdmin) {
-          <transloco
-            key="draft_generation.info_alert_same_source_and_target_language"
-            [params]="{ targetLanguageDisplayName, projectSettingsUrl: { route: projectSettingsUrl } }"
-          ></transloco>
-        } @else {
-          <transloco
-            key="draft_generation.non_pa_info_alert_same_source_and_target_language"
-            [params]="{ targetLanguageDisplayName }"
-          ></transloco>
-        }
-      </app-notice>
-
-      <app-notice
-        *ngIf="isSourceProjectSet && isSourceAndTargetDifferent && !isSourceAndTrainingSourceLanguageIdentical"
-        type="warning"
-        icon="warning"
-        data-test-id="warning-source-training-different"
-      >
-        @if (isProjectAdmin) {
-          <transloco
-            key="draft_generation.info_alert_different_training_and_source_language"
+            key="draft_generation.info_alert_no_source_access"
             [params]="{
-              alternateTrainingSourceLanguageDisplayName,
-              sourceLanguageDisplayName,
-              projectSettingsUrl: { route: projectSettingsUrl }
+              connectProjectUrl: { route: '/connect-project' },
+              name: source?.name
             }"
           ></transloco>
-        } @else {
+        </app-notice>
+      }
+      @if (
+        isSourceProjectSet &&
+        isSourceAndTargetDifferent &&
+        isSourceAndTrainingSourceLanguageIdentical &&
+        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
+        canAccessDraftSourceIfAvailable(source) &&
+        !canAccessDraftSourceIfAvailable(alternateSource)
+      ) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-alternate-source-no-access">
           <transloco
-            key="draft_generation.non_pa_info_alert_different_training_and_source_language"
+            key="draft_generation.info_alert_no_alternate_source_access"
             [params]="{
-              alternateTrainingSourceLanguageDisplayName,
-              sourceLanguageDisplayName
+              connectProjectUrl: { route: '/connect-project' },
+              name: alternateSource?.name
             }"
           ></transloco>
-        }
-      </app-notice>
-
-      <app-notice
-        *ngIf="
-          isSourceProjectSet &&
-          isSourceAndTargetDifferent &&
-          isSourceAndTrainingSourceLanguageIdentical &&
-          !isSourceAndAdditionalTrainingSourceLanguageIdentical
-        "
-        type="warning"
-        icon="warning"
-        data-test-id="warning-mix-source-different"
-      >
-        @if (isProjectAdmin) {
+        </app-notice>
+      }
+      @if (
+        isSourceProjectSet &&
+        isSourceAndTargetDifferent &&
+        isSourceAndTrainingSourceLanguageIdentical &&
+        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
+        canAccessDraftSourceIfAvailable(source) &&
+        canAccessDraftSourceIfAvailable(alternateSource) &&
+        !canAccessDraftSourceIfAvailable(alternateTrainingSource)
+      ) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-alternate-training-source-no-access">
           <transloco
-            key="draft_generation.info_alert_different_additional_training_and_source_language"
+            key="draft_generation.info_alert_no_alternate_training_source_access"
             [params]="{
-              additionalTrainingSourceLanguageDisplayName,
-              alternateTrainingSourceLanguageDisplayName,
-              projectSettingsUrl: { route: projectSettingsUrl }
+              connectProjectUrl: { route: '/connect-project' },
+              name: alternateTrainingSource?.name
             }"
           ></transloco>
-        } @else {
+        </app-notice>
+      }
+      @if (
+        isSourceProjectSet &&
+        isSourceAndTargetDifferent &&
+        isSourceAndTrainingSourceLanguageIdentical &&
+        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
+        canAccessDraftSourceIfAvailable(source) &&
+        canAccessDraftSourceIfAvailable(alternateSource) &&
+        canAccessDraftSourceIfAvailable(alternateTrainingSource) &&
+        !canAccessDraftSourceIfAvailable(additionalTrainingSource)
+      ) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-mix-source-no-access">
           <transloco
-            key="draft_generation.non_pa_info_alert_different_additional_training_and_source_language"
+            key="draft_generation.info_alert_no_additional_training_source_access"
             [params]="{
-              additionalTrainingSourceLanguageDisplayName,
-              alternateTrainingSourceLanguageDisplayName
+              connectProjectUrl: { route: '/connect-project' },
+              name: additionalTrainingSource?.name
             }"
           ></transloco>
-        }
-      </app-notice>
-
-      <app-notice
-        *ngIf="
-          isSourceProjectSet &&
-          isSourceAndTargetDifferent &&
-          isSourceAndTrainingSourceLanguageIdentical &&
-          isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-          !canAccessDraftSourceIfAvailable(source)
-        "
-        type="warning"
-        icon="warning"
-        data-test-id="warning-source-no-access"
-      >
-        <transloco
-          key="draft_generation.info_alert_no_source_access"
-          [params]="{
-            connectProjectUrl: { route: '/connect-project' },
-            name: source?.name
-          }"
-        ></transloco>
-      </app-notice>
-
-      <app-notice
-        *ngIf="
-          isSourceProjectSet &&
-          isSourceAndTargetDifferent &&
-          isSourceAndTrainingSourceLanguageIdentical &&
-          isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-          canAccessDraftSourceIfAvailable(source) &&
-          !canAccessDraftSourceIfAvailable(alternateSource)
-        "
-        type="warning"
-        icon="warning"
-        data-test-id="warning-alternate-source-no-access"
-      >
-        <transloco
-          key="draft_generation.info_alert_no_alternate_source_access"
-          [params]="{
-            connectProjectUrl: { route: '/connect-project' },
-            name: alternateSource?.name
-          }"
-        ></transloco>
-      </app-notice>
-
-      <app-notice
-        *ngIf="
-          isSourceProjectSet &&
-          isSourceAndTargetDifferent &&
-          isSourceAndTrainingSourceLanguageIdentical &&
-          isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-          canAccessDraftSourceIfAvailable(source) &&
-          canAccessDraftSourceIfAvailable(alternateSource) &&
-          !canAccessDraftSourceIfAvailable(alternateTrainingSource)
-        "
-        type="warning"
-        icon="warning"
-        data-test-id="warning-alternate-training-source-no-access"
-      >
-        <transloco
-          key="draft_generation.info_alert_no_alternate_training_source_access"
-          [params]="{
-            connectProjectUrl: { route: '/connect-project' },
-            name: alternateTrainingSource?.name
-          }"
-        ></transloco>
-      </app-notice>
-
-      <app-notice
-        *ngIf="
-          isSourceProjectSet &&
-          isSourceAndTargetDifferent &&
-          isSourceAndTrainingSourceLanguageIdentical &&
-          isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-          canAccessDraftSourceIfAvailable(source) &&
-          canAccessDraftSourceIfAvailable(alternateSource) &&
-          canAccessDraftSourceIfAvailable(alternateTrainingSource) &&
-          !canAccessDraftSourceIfAvailable(additionalTrainingSource)
-        "
-        type="warning"
-        icon="warning"
-        data-test-id="warning-mix-source-no-access"
-      >
-        <transloco
-          key="draft_generation.info_alert_no_additional_training_source_access"
-          [params]="{
-            connectProjectUrl: { route: '/connect-project' },
-            name: additionalTrainingSource?.name
-          }"
-        ></transloco>
-      </app-notice>
-    </ng-container>
+        </app-notice>
+      }
+    }
 
     <!-- Only show sync related messages if approved or a back translation and a build is not underway -->
-    <ng-container *ngIf="(this.isBackTranslationMode || this.isPreTranslationApproved) && !isDraftInProgress(draftJob)">
-      <app-notice *ngIf="!lastSyncSuccessful" type="warning" icon="warning" data-test-id="warning-last-sync-failed">
-        <transloco key="draft_generation.info_alert_last_sync_failed"></transloco>
-      </app-notice>
-    </ng-container>
+    @if ((this.isBackTranslationMode || this.isPreTranslationApproved) && !isDraftInProgress(draftJob)) {
+      @if (!lastSyncSuccessful) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-last-sync-failed">
+          <transloco key="draft_generation.info_alert_last_sync_failed"></transloco>
+        </app-notice>
+      }
+    }
   </section>
 
-  <ng-container *ngIf="!isOnline">
+  @if (!isOnline) {
     <section>
       <p class="offline-text">{{ t("offline_message") }}</p>
     </section>
-  </ng-container>
+  }
 
-  <ng-container *ngIf="isOnline">
+  @if (isOnline) {
     <mat-tab-group>
       <mat-tab>
-        <section *ngIf="!this.isBackTranslationMode && !this.isPreTranslationApproved" data-test-id="approval-needed">
-          <a [href]="signupFormUrl" mat-flat-button color="primary" target="_blank" rel="noopener noreferrer">
-            {{ t("sign_up_for_drafting") }}
-          </a>
-        </section>
-
-        <div *ngIf="isDraftJobFetched">
-          <ng-container *ngIf="isGenerationSupported">
-            <ng-container *ngIf="isDraftFaulted(draftJob)">
-              <app-notice type="error" icon="error" data-test-id="warning-generation-failed">
-                <div class="draft-generation-failed-message">
-                  <span
-                    ><transloco
-                      key="draft_generation.warning_generation_faulted"
-                      [params]="{
-                        generateButtonText: t('generate_draft_button')
-                      }"
-                    ></transloco
-                  ></span>
-                  <a mat-button target="_blank" [href]="issueMailTo">
-                    {{ t("report_problem") }}
-                  </a>
-                </div>
-              </app-notice>
-              <section data-test-id="technical-details">
-                <div>
-                  <p class="error-text">Technical details:</p>
+        @if (!this.isBackTranslationMode && !this.isPreTranslationApproved) {
+          <section data-test-id="approval-needed">
+            <a [href]="signupFormUrl" mat-flat-button color="primary" target="_blank" rel="noopener noreferrer">
+              {{ t("sign_up_for_drafting") }}
+            </a>
+          </section>
+        }
+        @if (isDraftJobFetched) {
+          <div>
+            @if (isGenerationSupported) {
+              @if (isDraftFaulted(draftJob)) {
+                <app-notice type="error" icon="error" data-test-id="warning-generation-failed">
+                  <div class="draft-generation-failed-message">
+                    <span
+                      ><transloco
+                        key="draft_generation.warning_generation_faulted"
+                        [params]="{
+                          generateButtonText: t('generate_draft_button')
+                        }"
+                      ></transloco
+                    ></span>
+                    <a mat-button target="_blank" [href]="issueMailTo">
+                      {{ t("report_problem") }}
+                    </a>
+                  </div>
+                </app-notice>
+                <section data-test-id="technical-details">
                   <div>
-                    <div><strong>Message:</strong> {{ draftJob?.message ?? "unknown" }}</div>
+                    <p class="error-text">Technical details:</p>
                     <div>
-                      <strong>Translation Engine Id:</strong>
-                      {{ draftJob?.additionalInfo?.translationEngineId ?? "unknown" }}
-                    </div>
-                    <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId ?? "unknown" }}</div>
-                    <div>
-                      <strong>Corpora Ids:</strong>
-                      {{ draftJob?.additionalInfo?.corporaIds?.join(", ") ?? "unknown" }}
+                      <div><strong>Message:</strong> {{ draftJob?.message ?? "unknown" }}</div>
+                      <div>
+                        <strong>Translation Engine Id:</strong>
+                        {{ draftJob?.additionalInfo?.translationEngineId ?? "unknown" }}
+                      </div>
+                      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId ?? "unknown" }}</div>
+                      <div>
+                        <strong>Corpora Ids:</strong>
+                        {{ draftJob?.additionalInfo?.corporaIds?.join(", ") ?? "unknown" }}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </section>
-            </ng-container>
-
-            <section *ngIf="!isDraftInProgress(draftJob) && !hasAnyCompletedBuild">
-              <button mat-flat-button color="primary" (click)="generateDraft()">
-                <mat-icon>auto_awesome</mat-icon>
-                {{ t("generate_draft_button") }}
-              </button>
-            </section>
-          </ng-container>
-
-          <ng-container *ngIf="isPreviewSupported">
-            <ng-container *ngIf="draftJob != null">
-              <section *ngIf="isDraftQueued(draftJob)">
-                <h3>{{ t("draft_queued_header") }}</h3>
-
-                <p *ngIf="!hasDraftQueueDepth(draftJob)">{{ t("draft_queued_detail") }}</p>
-                <p *ngIf="hasDraftQueueDepth(draftJob)">
-                  {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
-                </p>
-                <app-working-animated-indicator></app-working-animated-indicator>
-
-                <div class="button-strip">
-                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-                    <mat-icon>highlight_off</mat-icon>
-                    {{ t("cancel_generation_button") }}
+                </section>
+              }
+              @if (!isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {
+                <section>
+                  <button mat-flat-button color="primary" (click)="generateDraft()">
+                    <mat-icon>auto_awesome</mat-icon>
+                    {{ t("generate_draft_button") }}
                   </button>
-                </div>
-              </section>
-
-              <section *ngIf="isDraftActive(draftJob)" class="progress-active">
-                <h3>{{ t("draft_active_header") }}</h3>
-
-                <div class="progress-text">
-                  <p>{{ t("draft_active_detail", { count: 8 }) }}</p>
-                </div>
-                <circle-progress [percent]="draftJob.percentCompleted * 100"></circle-progress>
-
-                <div class="button-strip">
-                  <button *ngIf="canCancel(draftJob)" mat-flat-button color="primary" (click)="cancel()">
-                    <mat-icon>highlight_off</mat-icon>
-                    {{ t("cancel_generation_button") }}
-                  </button>
-                </div>
-              </section>
-
-              <section *ngIf="isDraftComplete(draftJob) || hasAnyCompletedBuild" class="draft-complete">
-                <mat-card>
-                  <mat-card-header>
-                    <mat-card-title>
-                      {{ isDraftComplete(draftJob) ? t("draft_is_ready") : t("preview_last_draft_header") }}
-                    </mat-card-title>
-                  </mat-card-header>
-                  <mat-card-content>
-                    <p *ngIf="isDraftFaulted(draftJob)">{{ t("preview_last_draft_detail") }}</p>
-                    <p>{{ t("click_book_to_preview") }}</p>
-                    <app-draft-preview-books></app-draft-preview-books>
-                  </mat-card-content>
-                  <mat-card-actions>
-                    <button
-                      *ngIf="hasDraftBooksAvailable"
-                      mat-button
-                      type="button"
-                      (click)="downloadDraft()"
-                      [disabled]="downloadProgress > 0"
-                      data-test-id="download-button"
-                    >
-                      <mat-icon *ngIf="downloadProgress === 0" class="material-icons-outlined">cloud_download</mat-icon>
-                      <mat-icon *ngIf="downloadProgress > 0">
-                        <mat-spinner
-                          diameter="18"
-                          [value]="downloadProgress"
-                          mode="determinate"
-                          color="accent"
-                          data-test-id="download-spinner"
-                        ></mat-spinner>
-                      </mat-icon>
-                      <span>{{ t("download_draft") }}</span>
-                    </button>
-                    <button
-                      *ngIf="isGenerationSupported && !isDraftInProgress(draftJob)"
-                      mat-button
-                      type="button"
-                      (click)="generateDraft({ withConfirm: true })"
-                    >
-                      <mat-icon>add</mat-icon>
-                      {{ t("generate_new_draft") }}
-                    </button>
-                  </mat-card-actions>
-                </mat-card>
-              </section>
-            </ng-container>
-          </ng-container>
-        </div>
+                </section>
+              }
+            }
+            @if (isPreviewSupported) {
+              @if (draftJob != null) {
+                @if (isDraftQueued(draftJob)) {
+                  <section>
+                    <h3>{{ t("draft_queued_header") }}</h3>
+                    @if (!hasDraftQueueDepth(draftJob)) {
+                      <p>{{ t("draft_queued_detail") }}</p>
+                    }
+                    @if (hasDraftQueueDepth(draftJob)) {
+                      <p>
+                        {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
+                      </p>
+                    }
+                    <app-working-animated-indicator></app-working-animated-indicator>
+                    <div class="button-strip">
+                      @if (canCancel(draftJob)) {
+                        <button mat-flat-button color="primary" (click)="cancel()">
+                          <mat-icon>highlight_off</mat-icon>
+                          {{ t("cancel_generation_button") }}
+                        </button>
+                      }
+                    </div>
+                  </section>
+                }
+                @if (isDraftActive(draftJob)) {
+                  <section class="progress-active">
+                    <h3>{{ t("draft_active_header") }}</h3>
+                    <div class="progress-text">
+                      <p>{{ t("draft_active_detail", { count: 8 }) }}</p>
+                    </div>
+                    <circle-progress [percent]="draftJob.percentCompleted * 100"></circle-progress>
+                    <div class="button-strip">
+                      @if (canCancel(draftJob)) {
+                        <button mat-flat-button color="primary" (click)="cancel()">
+                          <mat-icon>highlight_off</mat-icon>
+                          {{ t("cancel_generation_button") }}
+                        </button>
+                      }
+                    </div>
+                  </section>
+                }
+                @if (isDraftComplete(draftJob) || hasAnyCompletedBuild) {
+                  <section class="draft-complete">
+                    <mat-card>
+                      <mat-card-header>
+                        <mat-card-title>
+                          {{ isDraftComplete(draftJob) ? t("draft_is_ready") : t("preview_last_draft_header") }}
+                        </mat-card-title>
+                      </mat-card-header>
+                      <mat-card-content>
+                        @if (isDraftFaulted(draftJob)) {
+                          <p>{{ t("preview_last_draft_detail") }}</p>
+                        }
+                        <p>{{ t("click_book_to_preview") }}</p>
+                        <app-draft-preview-books></app-draft-preview-books>
+                      </mat-card-content>
+                      <mat-card-actions>
+                        @if (hasDraftBooksAvailable) {
+                          <button
+                            mat-button
+                            type="button"
+                            (click)="downloadDraft()"
+                            [disabled]="downloadProgress > 0"
+                            data-test-id="download-button"
+                          >
+                            @if (downloadProgress === 0) {
+                              <mat-icon class="material-icons-outlined">cloud_download</mat-icon>
+                            }
+                            @if (downloadProgress > 0) {
+                              <mat-icon>
+                                <mat-spinner
+                                  diameter="18"
+                                  [value]="downloadProgress"
+                                  mode="determinate"
+                                  color="accent"
+                                  data-test-id="download-spinner"
+                                ></mat-spinner>
+                              </mat-icon>
+                            }
+                            <span>{{ t("download_draft") }}</span>
+                          </button>
+                        }
+                        @if (isGenerationSupported && !isDraftInProgress(draftJob)) {
+                          <button mat-button type="button" (click)="generateDraft({ withConfirm: true })">
+                            <mat-icon>add</mat-icon>
+                            {{ t("generate_new_draft") }}
+                          </button>
+                        }
+                      </mat-card-actions>
+                    </mat-card>
+                  </section>
+                }
+              }
+            }
+          </div>
+        }
       </mat-tab>
-
       <mat-tab>
         <!-- Lazy load tab content -->
         <ng-template matTabContent>
@@ -403,32 +408,36 @@
         </ng-template>
       </mat-tab>
     </mat-tab-group>
-  </ng-container>
+  }
 </ng-container>
 
-<section *ngIf="this.canShowAdditionalInfo(draftJob)">
-  <mat-expansion-panel class="diagnostic-info">
-    <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
-    <ng-template matExpansionPanelContent>
-      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
-      <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
-      <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
-      <div><strong>Message:</strong> {{ draftJob?.message }}</div>
-      <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
-      <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
-      <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
-      <div><strong>State:</strong> {{ draftJob?.state }}</div>
-      <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
-      <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
-    </ng-template>
-  </mat-expansion-panel>
-</section>
+@if (this.canShowAdditionalInfo(draftJob)) {
+  <section>
+    <mat-expansion-panel class="diagnostic-info">
+      <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
+        <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+        <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
+        <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+        <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
+        <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
+        <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
+        <div><strong>State:</strong> {{ draftJob?.state }}</div>
+        <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
+        <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
+      </ng-template>
+    </mat-expansion-panel>
+  </section>
+}
 
-<section *ngIf="this.isServalAdmin()">
-  <mat-expansion-panel class="serval-administration">
-    <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
-    <ng-template matExpansionPanelContent>
-      <app-serval-project></app-serval-project>
-    </ng-template>
-  </mat-expansion-panel>
-</section>
+@if (this.isServalAdmin()) {
+  <section>
+    <mat-expansion-panel class="serval-administration">
+      <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <app-serval-project></app-serval-project>
+      </ng-template>
+    </mat-expansion-panel>
+  </section>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
@@ -50,6 +51,7 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
   styleUrls: ['./draft-generation.component.scss'],
   standalone: true,
   imports: [
+    CommonModule,
     UICommonModule,
     RouterModule,
     TranslocoModule,
@@ -69,6 +71,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   projectSettingsUrl?: string;
   // This component url, but with a hash for opening a dialog
   supportedLanguagesUrl: RouterLink = { route: [], fragment: 'supported-languages' };
+  draftHelp = this.i18n.interpolate('draft_generation.instructions_help');
 
   additionalTrainingSourceLanguage?: string;
   additionalTrainingSourceLanguageDisplayName?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
@@ -51,7 +50,6 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
   styleUrls: ['./draft-generation.component.scss'],
   standalone: true,
   imports: [
-    CommonModule,
     UICommonModule,
     RouterModule,
     TranslocoModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { translate, TranslocoModule } from '@ngneat/transloco';
@@ -26,7 +27,7 @@ export interface BookWithDraft {
   templateUrl: './draft-preview-books.component.html',
   styleUrls: ['./draft-preview-books.component.scss'],
   standalone: true,
-  imports: [UICommonModule, RouterModule, TranslocoModule]
+  imports: [CommonModule, UICommonModule, RouterModule, TranslocoModule]
 })
 export class DraftPreviewBooksComponent {
   booksWithDrafts$: Observable<BookWithDraft[]> = this.activatedProjectService.changes$.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { translate, TranslocoModule } from '@ngneat/transloco';
@@ -27,7 +26,7 @@ export interface BookWithDraft {
   templateUrl: './draft-preview-books.component.html',
   styleUrls: ['./draft-preview-books.component.scss'],
   standalone: true,
-  imports: [CommonModule, UICommonModule, RouterModule, TranslocoModule]
+  imports: [UICommonModule, RouterModule, TranslocoModule]
 })
 export class DraftPreviewBooksComponent {
   booksWithDrafts$: Observable<BookWithDraft[]> = this.activatedProjectService.changes$.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.html
@@ -5,9 +5,11 @@
   </h2>
 
   <mat-dialog-content>
-    <div *ngFor="let language of supportedLanguages">
-      <span class="code">({{ language.iso639_2t }})</span>
-      <span class="name">{{ getLanguageDisplayName(language) }}</span>
-    </div>
+    @for (language of supportedLanguages; track language) {
+      <div>
+        <span class="code">({{ language.iso639_2t }})</span>
+        <span class="name">{{ getLanguageDisplayName(language) }}</span>
+      </div>
+    }
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -10,7 +9,7 @@ import { NLLB_LANGUAGES, NllbLanguage, NllbLanguageDict } from '../../nllb-langu
 @Component({
   selector: 'app-supported-back-translation-languages-dialog',
   standalone: true,
-  imports: [CommonModule, MatIconModule, MatDialogModule, MatButtonModule, TranslocoModule],
+  imports: [MatIconModule, MatDialogModule, MatButtonModule, TranslocoModule],
   templateUrl: './supported-back-translation-languages-dialog.component.html',
   styleUrls: ['./supported-back-translation-languages-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -1,22 +1,21 @@
 <ng-container *transloco="let t; read: 'training_data_multi_select'">
   <div class="flex-row">
-    <mat-chip-listbox
-      *ngFor="let trainingData of trainingDataOptions"
-      class="training-data-multi-select"
-      hideSingleSelectionIndicator
-      (change)="onChipListChange(trainingData)"
-    >
-      <mat-chip-option [value]="trainingData.value" [selected]="trainingData.selected">
-        {{ trainingData.value.title }}
-        <button
-          *ngIf="canDeleteTrainingData(trainingData.value)"
-          matChipRemove
-          (click)="deleteTrainingData(trainingData.value)"
-        >
-          <mat-icon>cancel</mat-icon>
-        </button>
-      </mat-chip-option>
-    </mat-chip-listbox>
+    @for (trainingData of trainingDataOptions; track trainingData) {
+      <mat-chip-listbox
+        class="training-data-multi-select"
+        hideSingleSelectionIndicator
+        (change)="onChipListChange(trainingData)"
+      >
+        <mat-chip-option [value]="trainingData.value" [selected]="trainingData.selected">
+          {{ trainingData.value.title }}
+          @if (canDeleteTrainingData(trainingData.value)) {
+            <button matChipRemove (click)="deleteTrainingData(trainingData.value)">
+              <mat-icon>cancel</mat-icon>
+            </button>
+          }
+        </mat-chip-option>
+      </mat-chip-listbox>
+    }
     <button mat-flat-button (click)="openUploadDialog()" color="accent">
       <mat-icon matChipAvatar>file_upload</mat-icon>
       {{ t("upload_csv") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -8,7 +8,7 @@
       >
         <mat-chip-option [value]="trainingData.value" [selected]="trainingData.selected">
           {{ trainingData.value.title }}
-          @if (canDeleteTrainingData(trainingData.value)) {
+          @if (canDeleteTrainingData(trainingData.value) | async) {
             <button matChipRemove (click)="deleteTrainingData(trainingData.value)">
               <mat-icon>cancel</mat-icon>
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
@@ -30,7 +29,7 @@ export interface TrainingDataOption {
   selector: 'app-training-data-multi-select',
   templateUrl: './training-data-multi-select.component.html',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatChipsModule, MatIconModule, SharedModule, TranslocoModule],
+  imports: [MatButtonModule, MatChipsModule, MatIconModule, SharedModule, TranslocoModule],
   styleUrls: ['./training-data-multi-select.component.scss']
 })
 export class TrainingDataMultiSelectComponent extends SubscriptionDisposable implements OnChanges, OnInit {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
@@ -29,7 +30,7 @@ export interface TrainingDataOption {
   selector: 'app-training-data-multi-select',
   templateUrl: './training-data-multi-select.component.html',
   standalone: true,
-  imports: [MatButtonModule, MatChipsModule, MatIconModule, SharedModule, TranslocoModule],
+  imports: [CommonModule, MatButtonModule, MatChipsModule, MatIconModule, SharedModule, TranslocoModule],
   styleUrls: ['./training-data-multi-select.component.scss']
 })
 export class TrainingDataMultiSelectComponent extends SubscriptionDisposable implements OnChanges, OnInit {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
@@ -13,28 +13,27 @@
         </ng-container>
       </div>
       <div class="wrapper wrapper-training-data-file" [ngClass]="{ valid: hasBeenUploaded }">
-        <ng-container *ngIf="hasBeenUploaded">
-          <app-info
-            *ngIf="showFilenameExists"
-            [text]="t('filename_already_exists')"
-            icon="warning"
-            type="warning"
-          ></app-info>
+        @if (hasBeenUploaded) {
+          @if (showFilenameExists) {
+            <app-info [text]="t('filename_already_exists')" icon="warning" type="warning"></app-info>
+          }
           <span>{{ trainingDataFilename }}</span>
           <mat-icon (click)="deleteTrainingData()" class="delete">delete</mat-icon>
-        </ng-container>
-        <ng-container *ngIf="!hasBeenUploaded">
+        }
+        @if (!hasBeenUploaded) {
           <mat-icon>file_download_off</mat-icon>
           <span>{{ t("no_training_data_file_uploaded") }}</span>
-        </ng-container>
+        }
       </div>
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>
-    <div class="uploading" *ngIf="isUploading">
-      <span>{{ t("uploading") }}</span>
-      <mat-spinner diameter="24"></mat-spinner>
-    </div>
+    @if (isUploading) {
+      <div class="uploading">
+        <span>{{ t("uploading") }}</span>
+        <mat-spinner diameter="24"></mat-spinner>
+      </div>
+    }
     <button mat-button [mat-dialog-close]="'close'" type="button" id="upload-cancel-btn">
       {{ t("cancel") }}
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -1,37 +1,48 @@
-<ng-container *ngIf="onlineStatusService.onlineStatus$ | async; else offline">
-  <mat-progress-bar *ngIf="draftCheckState === 'draft-unknown'" mode="indeterminate" color="accent"></mat-progress-bar>
+@if (onlineStatusService.onlineStatus$ | async) {
+  @if (draftCheckState === "draft-unknown") {
+    <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
+  }
+  @if (draftCheckState === "draft-empty") {
+    <app-notice icon="info" type="primary" mode="outline">
+      {{ "editor_draft_tab.no_draft_notice" | transloco: { bookChapterName } }}
+      <p>{{ "editor_draft_tab.click_book_to_preview" | transloco }}</p>
+      <app-draft-preview-books></app-draft-preview-books>
+    </app-notice>
+  }
+  @if (draftCheckState === "draft-legacy") {
+    <app-notice type="warning" icon="warning">
+      <transloco
+        key="editor_draft_tab.draft_legacy_warning"
+        [params]="{ generateDraftUrl: { route: generateDraftUrl } }"
+      ></transloco>
+    </app-notice>
+  }
+} @else {
+  @if (draftCheckState !== "draft-present") {
+    <app-notice icon="warning" type="warning">
+      {{ "editor_draft_tab.offline_notice" | transloco }}
+    </app-notice>
+  }
+}
 
-  <app-notice *ngIf="draftCheckState === 'draft-empty'" icon="info" type="primary" mode="outline">
-    {{ "editor_draft_tab.no_draft_notice" | transloco: { bookChapterName } }}
-    <p>{{ "editor_draft_tab.click_book_to_preview" | transloco }}</p>
-    <app-draft-preview-books></app-draft-preview-books>
-  </app-notice>
-
-  <app-notice *ngIf="draftCheckState === 'draft-legacy'" type="warning" icon="warning">
-    <transloco
-      key="editor_draft_tab.draft_legacy_warning"
-      [params]="{ generateDraftUrl: { route: generateDraftUrl } }"
-    ></transloco>
-  </app-notice>
-</ng-container>
-
-<div class="toolbar" *ngIf="isDraftReady">
-  <div class="apply-draft-button-container">
-    <span *ngIf="isDraftApplied && isDraftReady" class="draft-indicator">
-      <mat-icon class="check-icon">check</mat-icon>
-      <transloco key="editor_draft_tab.draft_indicator_applied"></transloco>
-    </span>
-    <button
-      *ngIf="!isDraftApplied && isDraftReady && canApplyDraft"
-      mat-flat-button
-      color="primary"
-      (click)="applyDraft()"
-    >
-      <mat-icon>auto_awesome</mat-icon>
-      <transloco key="editor_draft_tab.apply_to_project"></transloco>
-    </button>
+@if (isDraftReady) {
+  <div class="toolbar">
+    <div class="apply-draft-button-container">
+      @if (isDraftApplied && isDraftReady) {
+        <span class="draft-indicator">
+          <mat-icon class="check-icon">check</mat-icon>
+          <transloco key="editor_draft_tab.draft_indicator_applied"></transloco>
+        </span>
+      }
+      @if (!isDraftApplied && isDraftReady && canApplyDraft) {
+        <button mat-flat-button color="primary" (click)="applyDraft()">
+          <mat-icon>auto_awesome</mat-icon>
+          <transloco key="editor_draft_tab.apply_to_project"></transloco>
+        </button>
+      }
+    </div>
   </div>
-</div>
+}
 
 <app-text
   [isReadOnly]="true"
@@ -41,9 +52,3 @@
   [ngClass]="draftCheckState"
   [style.--project-font]="fontService.getFontFamilyFromProject(targetProject)"
 ></app-text>
-
-<ng-template #offline>
-  <app-notice *ngIf="draftCheckState !== 'draft-present'" icon="warning" type="warning">
-    {{ "editor_draft_tab.offline_notice" | transloco }}
-  </app-notice>
-</ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.html
@@ -1,6 +1,12 @@
-<ng-container *ngIf="onlineStatusService.onlineStatus$ | async; else offline">
-  <mat-progress-bar *ngIf="historyChooser?.isLoading$ | async" mode="indeterminate" color="accent"></mat-progress-bar>
-</ng-container>
+@if (onlineStatusService.onlineStatus$ | async) {
+  @if (historyChooser?.isLoading$ | async) {
+    <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
+  }
+} @else {
+  @if (!loadedRevision) {
+    <app-notice icon="warning" type="warning">{{ "editor_history_tab.offline_notice" | transloco }}</app-notice>
+  }
+}
 
 <app-history-chooser
   [projectId]="projectId"
@@ -18,9 +24,3 @@
   [class.empty]="!loadedRevision"
   [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
 ></app-text>
-
-<ng-template #offline>
-  <app-notice *ngIf="!loadedRevision" icon="warning" type="warning">{{
-    "editor_history_tab.offline_notice" | transloco
-  }}</app-notice>
-</ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
@@ -1,47 +1,52 @@
 <ng-container *transloco="let t; read: 'history_chooser'">
-  <div class="toolbar" *ngIf="historyRevisions.length > 0">
-    <mat-form-field class="history-select" appearance="outline">
-      <mat-select
-        [value]="selectedRevision"
-        (selectionChange)="onSelectionChanged($event)"
-        panelWidth="''"
-        [disabled]="isSelectDisabled$ | async"
-        hideSingleSelectionIndicator
+  @if (historyRevisions.length > 0) {
+    <div class="toolbar">
+      <mat-form-field class="history-select" appearance="outline">
+        <mat-select
+          [value]="selectedRevision"
+          (selectionChange)="onSelectionChanged($event)"
+          panelWidth="''"
+          [disabled]="isSelectDisabled$ | async"
+          hideSingleSelectionIndicator
+        >
+          <mat-select-trigger>
+            {{ selectedRevision ?? "" | revisionFormat }}
+          </mat-select-trigger>
+          @for (r of historyRevisions; track r) {
+            <mat-option [value]="r">
+              <div class="option-content">
+                <span>{{ r | revisionFormat }}</span>
+                <mat-icon>{{
+                  r.source === "Draft" ? "auto_awesome" : r.source === "History" ? "history" : ""
+                }}</mat-icon>
+              </div>
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <button
+        class="show-diff"
+        mat-button
+        appBlurOnClick
+        type="button"
+        (click)="toggleDiff()"
+        matTooltip="{{ !showDiff ? t('show_diff') : t('hide_diff') }}"
       >
-        <mat-select-trigger>
-          {{ selectedRevision ?? "" | revisionFormat }}
-        </mat-select-trigger>
-        <mat-option *ngFor="let r of historyRevisions" [value]="r">
-          <div class="option-content">
-            <span>{{ r | revisionFormat }}</span>
-            <mat-icon>{{ r.source === "Draft" ? "auto_awesome" : r.source === "History" ? "history" : "" }}</mat-icon>
-          </div>
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <button
-      class="show-diff"
-      mat-button
-      appBlurOnClick
-      type="button"
-      (click)="toggleDiff()"
-      matTooltip="{{ !showDiff ? t('show_diff') : t('hide_diff') }}"
-    >
-      <mat-icon [ngClass]="{ 'material-icons-outlined': !showDiff }">difference</mat-icon>
-      {{ showDiff ? t("hide_changes") : t("show_changes") }}
-    </button>
-
-    <button
-      *ngIf="canRestoreSnapshot"
-      class="revert-history"
-      mat-button
-      type="button"
-      (click)="revertToSnapshot()"
-      matTooltip="{{ t('revert_details') }}"
-    >
-      <mat-icon class="material-icons-outlined">undo</mat-icon>
-      {{ t("revert") }}
-    </button>
-  </div>
+        <mat-icon [ngClass]="{ 'material-icons-outlined': !showDiff }">difference</mat-icon>
+        {{ showDiff ? t("hide_changes") : t("show_changes") }}
+      </button>
+      @if (canRestoreSnapshot) {
+        <button
+          class="revert-history"
+          mat-button
+          type="button"
+          (click)="revertToSnapshot()"
+          matTooltip="{{ t('revert_details') }}"
+        >
+          <mat-icon class="material-icons-outlined">undo</mat-icon>
+          {{ t("revert") }}
+        </button>
+      }
+    </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
@@ -1,11 +1,12 @@
-<app-text
-  *ngIf="projectId"
-  [id]="projectId | textDocId: bookNum : chapter"
-  [isReadOnly]="true"
-  [subscribeToUpdates]="false"
-  [highlightSegment]="highlightSegment ?? false"
-  [segmentRef]="segmentRef ?? ''"
-  [isRightToLeft]="isRightToLeft"
-  [fontSize]="fontSize"
-  [style.--project-font]="font"
-></app-text>
+@if (projectId) {
+  <app-text
+    [id]="projectId | textDocId: bookNum : chapter"
+    [isReadOnly]="true"
+    [subscribeToUpdates]="false"
+    [highlightSegment]="highlightSegment ?? false"
+    [segmentRef]="segmentRef ?? ''"
+    [isRightToLeft]="isRightToLeft"
+    [fontSize]="fontSize"
+    [style.--project-font]="font"
+  ></app-text>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -9,275 +9,281 @@
           [(chapter)]="chapter"
           [chapters]="chapters"
         ></app-book-chapter-chooser>
-        <ng-container *ngIf="showSource || suggestionsSettingsEnabled">
+        @if (showSource || suggestionsSettingsEnabled) {
           <div class="toolbar-separator" [fxHide.xs]="!suggestionsSettingsEnabled">&nbsp;</div>
-          <button
-            *ngIf="showSource"
-            mat-icon-button
-            appBlurOnClick
-            type="button"
-            (click)="isTargetTextRight = !isTargetTextRight"
-            title="{{ t('swap_source_and_target') }}"
-            fxHide.xs
-          >
-            <mat-icon>swap_horiz</mat-icon>
-          </button>
-          <button
-            *ngIf="suggestionsSettingsEnabled"
-            mat-icon-button
-            appBlurOnClick
-            type="button"
-            id="settings-btn"
-            (click)="openSuggestionsSettings()"
-            title="{{ t('configure_translation_suggestions') }}"
-          >
-            <mat-icon>settings</mat-icon>
-          </button>
-        </ng-container>
-        <ng-container *ngIf="canShare">
+          @if (showSource) {
+            <button
+              mat-icon-button
+              appBlurOnClick
+              type="button"
+              (click)="isTargetTextRight = !isTargetTextRight"
+              title="{{ t('swap_source_and_target') }}"
+              fxHide.xs
+            >
+              <mat-icon>swap_horiz</mat-icon>
+            </button>
+          }
+          @if (suggestionsSettingsEnabled) {
+            <button
+              mat-icon-button
+              appBlurOnClick
+              type="button"
+              id="settings-btn"
+              (click)="openSuggestionsSettings()"
+              title="{{ t('configure_translation_suggestions') }}"
+            >
+              <mat-icon>settings</mat-icon>
+            </button>
+          }
+        }
+        @if (canShare) {
           <div class="toolbar-separator">&nbsp;</div>
           <app-share-button [defaultRole]="defaultShareRole"></app-share-button>
-        </ng-container>
+        }
       </div>
-      <ng-container *ngIf="showMultiViewers">
+      @if (showMultiViewers) {
         <div fxFlexAlign="end" class="avatar-padding">
           <app-multi-viewer [viewers]="multiCursorViewers" (viewerClick)="onViewerClicked($event)"></app-multi-viewer>
         </div>
-      </ng-container>
+      }
     </div>
 
-    <app-tab-group
-      *ngFor="let tabGroup of tabState.tabGroups$ | async | keyvalue"
-      id="{{ tabGroup.key }}-text-area"
-      class="text-area"
-      [groupId]="tabGroup.key"
-      [selectedIndex]="tabGroup.value.selectedIndex"
-      [connectedTo]="(tabState.groupIds$ | async) ?? []"
-    >
-      <app-tab
-        *ngFor="let tab of tabGroup.value.tabs"
-        [closeable]="tab.closeable"
-        [movable]="tab.movable"
-        [tooltip]="tab.tooltip"
+    @for (tabGroup of tabState.tabGroups$ | async | keyvalue; track tabGroup) {
+      <app-tab-group
+        id="{{ tabGroup.key }}-text-area"
+        class="text-area"
+        [groupId]="tabGroup.key"
+        [selectedIndex]="tabGroup.value.selectedIndex"
+        [connectedTo]="(tabState.groupIds$ | async) ?? []"
       >
-        <!-- TODO: Localize tab header text -->
-        <ng-template sf-tab-header>
-          <mat-icon *ngIf="tab.icon">{{ tab.icon }}</mat-icon>
-          {{ tab.headerText }}
-        </ng-template>
-
-        <app-editor-resource
-          *ngIf="tab.type === 'project-resource'"
-          [projectId]="tab.projectId"
-          [bookNum]="bookNum"
-          [chapter]="chapter"
-          [segmentRef]="target?.segmentRef"
-          [highlightSegment]="targetFocused"
-        ></app-editor-resource>
-
-        <div *ngIf="tab.type === 'project-source'" class="project-tab-container">
-          <app-notice *ngIf="hasSourceCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
-            <div>
-              {{ sourceCopyrightBanner }}
-              <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{ t("more_info") }}</span>
-            </div>
-          </app-notice>
-          <div class="container-for-split">
-            <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-            <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
-              <as-split-area [size]="75" [minSize]="20">
-                <div class="text-container">
-                  <app-text
-                    #source
-                    [id]="visibleSourceProjectId | textDocId: bookNum : chapter"
-                    [isReadOnly]="true"
-                    [highlightSegment]="targetFocused"
-                    (loaded)="onTextLoaded('source')"
-                    (updated)="onSourceUpdated($event.delta != null)"
-                    [isRightToLeft]="isSourceRightToLeft"
-                    [fontSize]="sourceFontSize"
-                    [style.--project-font]="fontService.getFontFamilyFromProject(sourceProjectDoc)"
-                  ></app-text>
-                </div>
-              </as-split-area>
-              <as-split-area
-                [size]="25"
-                *ngIf="biblicalTermsEnabledForSource"
-                [dir]="i18n.direction"
-                class="biblical-terms"
-              >
-                <app-biblical-terms
-                  id="source-biblical-terms"
-                  [bookNum]="bookNum"
-                  [chapter]="chapter"
-                  [verse]="verse"
-                  [configProjectId]="projectId"
-                  [projectId]="sourceProjectId"
-                ></app-biblical-terms>
-              </as-split-area>
-            </as-split>
-          </div>
-        </div>
-
-        <div *ngIf="tab.type === 'project-target'" class="project-tab-container">
-          <app-notice *ngIf="hasTargetCopyrightBanner" icon="copyright" type="warning" class="copyright-banner">
-            <div>
-              {{ targetCopyrightBanner }}
-              <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{ t("more_info") }}</span>
-            </div>
-          </app-notice>
-          <app-notice
-            *ngIf="!isUsfmValid && hasEditRight"
-            type="warning"
-            icon="warning"
-            class="formatting-invalid-warning"
-          >
-            {{ t("cannot_edit_chapter_formatting_invalid") }}
-          </app-notice>
-          <app-notice *ngIf="!dataInSync && hasEditRight" type="warning" icon="warning" class="out-of-sync-warning">
-            {{ t("project_data_out_of_sync") }}
-          </app-notice>
-          <app-notice
-            *ngIf="target.areOpsCorrupted && hasEditRight"
-            type="error"
-            icon="error"
-            class="doc-corrupted-warning"
-          >
-            {{ t("text_doc_corrupted") }}
-            <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
-          </app-notice>
-          <app-notice
-            *ngIf="projectTextNotEditable && hasEditRight"
-            type="info"
-            icon="info"
-            class="project-text-not-editable"
-          >
-            {{ t("project_text_not_editable") }}
-          </app-notice>
-          <app-notice *ngIf="showNoEditPermissionMessage" type="info" icon="info" class="no-edit-permission-message">
-            {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
-          </app-notice>
-          <div class="container-for-split">
-            <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-            <as-split direction="vertical" [style.height]="targetSplitHeight">
-              <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
-                <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
-                  <app-text
-                    #target
-                    [id]="projectId | textDocId: bookNum : chapter"
-                    [isReadOnly]="!canEdit"
-                    (updated)="
-                      onTargetUpdated(
-                        $event.segment,
-                        $event.delta,
-                        $event.prevSegment,
-                        $event.affectedEmbeds,
-                        $event.isLocalUpdate
-                      )
-                    "
-                    (loaded)="onTextLoaded('target')"
-                    (focused)="targetFocused = $event"
-                    (segmentRefChange)="onSegmentRefChange($event)"
-                    (presenceChange)="onPresenceChange($event)"
-                    [highlightSegment]="targetFocused && canEdit"
-                    [enablePresence]="true"
-                    [markInvalid]="true"
-                    [isRightToLeft]="isTargetRightToLeft"
-                    [fontSize]="fontSize"
-                    [selectableVerses]="showAddCommentUI"
-                    [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
-                    [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
-                  ></app-text>
-                  <app-suggestions
-                    class="mat-elevation-z2"
-                    [show]="showSuggestions && translationSuggestionsEnabled"
-                    [suggestions]="suggestions"
-                    [text]="target"
-                    (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
-                    (showChange)="showSuggestions = $event"
-                  ></app-suggestions>
-                  <ng-template #fabBottomSheet>
-                    <div class="fab-bottom-sheet" [dir]="direction">
-                      <b>{{ currentSegmentReference }}</b>
-                      <button
-                        *ngIf="!addingMobileNote && !hasEditRight"
-                        mat-flat-button
-                        (click)="toggleAddingMobileNote()"
-                        color="accent"
-                      >
-                        <mat-icon>add_comment</mat-icon>
-                        {{ t("add_comment") }}
-                      </button>
-                      <form *ngIf="addingMobileNote">
-                        <mat-form-field class="full-width" appearance="outline">
-                          <mat-label>{{ t("your_comment") }}</mat-label>
-                          <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
-                        </mat-form-field>
-                        <div class="fab-action-buttons">
-                          <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
-                            {{ t("cancel") }}
-                          </button>
-                          <button mat-flat-button class="save-button" color="primary" (click)="saveMobileNote()">
-                            {{ t("save") }}
-                          </button>
-                        </div>
-                      </form>
+        @for (tab of tabGroup.value.tabs; track tab) {
+          <app-tab [closeable]="tab.closeable" [movable]="tab.movable" [tooltip]="tab.tooltip">
+            <!-- TODO: Localize tab header text -->
+            <ng-template sf-tab-header>
+              @if (tab.icon) {
+                <mat-icon>{{ tab.icon }}</mat-icon>
+              }
+              {{ tab.headerText }}
+            </ng-template>
+            @if (tab.type === "project-resource") {
+              <app-editor-resource
+                [projectId]="tab.projectId"
+                [bookNum]="bookNum"
+                [chapter]="chapter"
+                [segmentRef]="target?.segmentRef"
+                [highlightSegment]="targetFocused"
+              ></app-editor-resource>
+            }
+            @if (tab.type === "project-source") {
+              <div class="project-tab-container">
+                @if (hasSourceCopyrightBanner) {
+                  <app-notice icon="copyright" type="warning" class="copyright-banner">
+                    <div>
+                      {{ sourceCopyrightBanner }}
+                      <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{
+                        t("more_info")
+                      }}</span>
                     </div>
-                  </ng-template>
-                  <button
-                    *ngIf="canInsertNote"
-                    #fabButton
-                    class="insert-note-fab"
-                    mat-mini-fab
-                    title="{{ t('add_comment') }}"
-                    (click)="insertNote()"
-                  >
-                    <mat-icon>add_comment</mat-icon>
-                  </button>
+                  </app-notice>
+                }
+                <div class="container-for-split">
+                  <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+                  <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
+                    <as-split-area [size]="75" [minSize]="20">
+                      <div class="text-container">
+                        <app-text
+                          #source
+                          [id]="visibleSourceProjectId | textDocId: bookNum : chapter"
+                          [isReadOnly]="true"
+                          [highlightSegment]="targetFocused"
+                          (loaded)="onTextLoaded('source')"
+                          (updated)="onSourceUpdated($event.delta != null)"
+                          [isRightToLeft]="isSourceRightToLeft"
+                          [fontSize]="sourceFontSize"
+                          [style.--project-font]="fontService.getFontFamilyFromProject(sourceProjectDoc)"
+                        ></app-text>
+                      </div>
+                    </as-split-area>
+                    @if (biblicalTermsEnabledForSource) {
+                      <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
+                        <app-biblical-terms
+                          id="source-biblical-terms"
+                          [bookNum]="bookNum"
+                          [chapter]="chapter"
+                          [verse]="verse"
+                          [configProjectId]="projectId"
+                          [projectId]="sourceProjectId"
+                        ></app-biblical-terms>
+                      </as-split-area>
+                    }
+                  </as-split>
                 </div>
-              </as-split-area>
-              <as-split-area
-                [size]="25"
-                *ngIf="biblicalTermsEnabledForTarget"
-                [dir]="i18n.direction"
-                class="biblical-terms"
+              </div>
+            }
+            @if (tab.type === "project-target") {
+              <div class="project-tab-container">
+                @if (hasTargetCopyrightBanner) {
+                  <app-notice icon="copyright" type="warning" class="copyright-banner">
+                    <div>
+                      {{ targetCopyrightBanner }}
+                      <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{
+                        t("more_info")
+                      }}</span>
+                    </div>
+                  </app-notice>
+                }
+                @if (!isUsfmValid && hasEditRight) {
+                  <app-notice type="warning" icon="warning" class="formatting-invalid-warning">
+                    {{ t("cannot_edit_chapter_formatting_invalid") }}
+                  </app-notice>
+                }
+                @if (!dataInSync && hasEditRight) {
+                  <app-notice type="warning" icon="warning" class="out-of-sync-warning">
+                    {{ t("project_data_out_of_sync") }}
+                  </app-notice>
+                }
+                @if (target.areOpsCorrupted && hasEditRight) {
+                  <app-notice type="error" icon="error" class="doc-corrupted-warning">
+                    {{ t("text_doc_corrupted") }}
+                    <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
+                  </app-notice>
+                }
+                @if (projectTextNotEditable && hasEditRight) {
+                  <app-notice type="info" icon="info" class="project-text-not-editable">
+                    {{ t("project_text_not_editable") }}
+                  </app-notice>
+                }
+                @if (showNoEditPermissionMessage) {
+                  <app-notice type="info" icon="info" class="no-edit-permission-message">
+                    {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
+                  </app-notice>
+                }
+                <div class="container-for-split">
+                  <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+                  <as-split direction="vertical" [style.height]="targetSplitHeight">
+                    <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
+                      <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
+                        <app-text
+                          #target
+                          [id]="projectId | textDocId: bookNum : chapter"
+                          [isReadOnly]="!canEdit"
+                          (updated)="
+                            onTargetUpdated(
+                              $event.segment,
+                              $event.delta,
+                              $event.prevSegment,
+                              $event.affectedEmbeds,
+                              $event.isLocalUpdate
+                            )
+                          "
+                          (loaded)="onTextLoaded('target')"
+                          (focused)="targetFocused = $event"
+                          (segmentRefChange)="onSegmentRefChange($event)"
+                          (presenceChange)="onPresenceChange($event)"
+                          [highlightSegment]="targetFocused && canEdit"
+                          [enablePresence]="true"
+                          [markInvalid]="true"
+                          [isRightToLeft]="isTargetRightToLeft"
+                          [fontSize]="fontSize"
+                          [selectableVerses]="showAddCommentUI"
+                          [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
+                          [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
+                        ></app-text>
+                        <app-suggestions
+                          class="mat-elevation-z2"
+                          [show]="showSuggestions && translationSuggestionsEnabled"
+                          [suggestions]="suggestions"
+                          [text]="target"
+                          (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
+                          (showChange)="showSuggestions = $event"
+                        ></app-suggestions>
+                        <ng-template #fabBottomSheet>
+                          <div class="fab-bottom-sheet" [dir]="direction">
+                            <b>{{ currentSegmentReference }}</b>
+                            @if (!addingMobileNote && !hasEditRight) {
+                              <button mat-flat-button (click)="toggleAddingMobileNote()" color="accent">
+                                <mat-icon>add_comment</mat-icon>
+                                {{ t("add_comment") }}
+                              </button>
+                            }
+                            @if (addingMobileNote) {
+                              <form>
+                                <mat-form-field class="full-width" appearance="outline">
+                                  <mat-label>{{ t("your_comment") }}</mat-label>
+                                  <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
+                                </mat-form-field>
+                                <div class="fab-action-buttons">
+                                  <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
+                                    {{ t("cancel") }}
+                                  </button>
+                                  <button
+                                    mat-flat-button
+                                    class="save-button"
+                                    color="primary"
+                                    (click)="saveMobileNote()"
+                                  >
+                                    {{ t("save") }}
+                                  </button>
+                                </div>
+                              </form>
+                            }
+                          </div>
+                        </ng-template>
+                        @if (canInsertNote) {
+                          <button
+                            #fabButton
+                            class="insert-note-fab"
+                            mat-mini-fab
+                            title="{{ t('add_comment') }}"
+                            (click)="insertNote()"
+                          >
+                            <mat-icon>add_comment</mat-icon>
+                          </button>
+                        }
+                      </div>
+                    </as-split-area>
+                    @if (biblicalTermsEnabledForTarget) {
+                      <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
+                        <app-biblical-terms
+                          id="target-biblical-terms"
+                          [bookNum]="bookNum"
+                          [chapter]="chapter"
+                          [verse]="verse"
+                          [configProjectId]="projectId"
+                          [projectId]="projectId"
+                        ></app-biblical-terms>
+                      </as-split-area>
+                    }
+                  </as-split>
+                </div>
+              </div>
+            }
+            @if (tab.type === "history") {
+              <app-editor-history
+                [projectId]="projectId"
+                [bookNum]="bookNum"
+                [chapter]="chapter"
+                [isRightToLeft]="isTargetRightToLeft"
+                [fontSize]="fontSize"
+                [diffText]="target"
+                (revisionSelect)="onHistoryTabRevisionSelect(tab, $event)"
               >
-                <app-biblical-terms
-                  id="target-biblical-terms"
-                  [bookNum]="bookNum"
-                  [chapter]="chapter"
-                  [verse]="verse"
-                  [configProjectId]="projectId"
-                  [projectId]="projectId"
-                ></app-biblical-terms>
-              </as-split-area>
-            </as-split>
-          </div>
-        </div>
-
-        <app-editor-history
-          *ngIf="tab.type === 'history'"
-          [projectId]="projectId"
-          [bookNum]="bookNum"
-          [chapter]="chapter"
-          [isRightToLeft]="isTargetRightToLeft"
-          [fontSize]="fontSize"
-          [diffText]="target"
-          (revisionSelect)="onHistoryTabRevisionSelect(tab, $event)"
-        >
-        </app-editor-history>
-
-        <app-editor-draft
-          *ngIf="tab.type === 'draft'"
-          [projectId]="projectId"
-          [bookNum]="bookNum"
-          [chapter]="chapter"
-          [isRightToLeft]="isTargetRightToLeft"
-          [fontSize]="fontSize"
-        >
-        </app-editor-draft>
-      </app-tab>
-    </app-tab-group>
+              </app-editor-history>
+            }
+            @if (tab.type === "draft") {
+              <app-editor-draft
+                [projectId]="projectId"
+                [bookNum]="bookNum"
+                [chapter]="chapter"
+                [isRightToLeft]="isTargetRightToLeft"
+                [fontSize]="fontSize"
+              >
+              </app-editor-draft>
+            }
+          </app-tab>
+        }
+      </app-tab-group>
+    }
   </div>
   <app-training-progress [projectId]="projectId"></app-training-progress>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -1,5 +1,5 @@
 <div fxLayout="row" fxLayoutAlign="start center">
-  <ng-container *ngFor="let viewer of avatarViewers">
+  @for (viewer of avatarViewers; track viewer) {
     <div class="app-avatar-container" [title]="viewer.displayName">
       <app-avatar
         [user]="viewer"
@@ -8,8 +8,8 @@
         (click)="clickAvatar(viewer)"
       ></app-avatar>
     </div>
-  </ng-container>
-  <ng-container *ngIf="viewers.length > maxAvatars">
+  }
+  @if (viewers.length > maxAvatars) {
     <div class="app-avatar-container">
       <button
         mat-mini-fab
@@ -18,18 +18,27 @@
         [title]="otherViewersLabel"
         (click)="toggleMenu()"
       >
-        <span *ngIf="!isMenuOpen"><span *ngIf="maxAvatars > 1">+</span>{{ viewers.length - maxAvatars + 1 }}</span>
-        <mat-icon *ngIf="isMenuOpen">arrow_drop_up</mat-icon>
+        @if (!isMenuOpen) {
+          <span>
+            @if (maxAvatars > 1) {
+              <span>+</span>
+            }
+            {{ viewers.length - maxAvatars + 1 }}</span
+          >
+        }
+        @if (isMenuOpen) {
+          <mat-icon>arrow_drop_up</mat-icon>
+        }
       </button>
       <mat-menu #menu="matMenu" (closed)="closeMenu()">
         <button mat-menu-item disabled>{{ otherViewersLabel }}</button>
-        <ng-container *ngFor="let viewer of viewers">
+        @for (viewer of viewers; track viewer) {
           <button mat-menu-item (click)="closeMenu(); clickAvatar(viewer)">
             <app-avatar [user]="viewer" [size]="32" [borderColor]="viewer.cursorColor"></app-avatar>
             <span fxFlex>{{ viewer.displayName }}</span>
           </button>
-        </ng-container>
+        }
       </mat-menu>
     </div>
-  </ng-container>
+  }
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -3,25 +3,28 @@
     <h1 mat-dialog-title class="dialog-icon-title">
       <img [src]="flagIcon" class="note-thread-icon" alt="" />
       <span class="verse-reference">{{ verseRefDisplay }}</span>
-      <div *ngIf="canViewAssignedUser" id="assignedUser" class="assigned-user">
-        >{{ getAssignedUserString(noteThreadAssignedUserRef) }}
-      </div>
+      @if (canViewAssignedUser) {
+        <div id="assignedUser" class="assigned-user">>{{ getAssignedUserString(noteThreadAssignedUserRef) }}</div>
+      }
     </h1>
     <mat-dialog-content class="content-padding" [ngClass]="{ rtl: isRtl, ltr: !isRtl }">
       <div class="text-row">
         <div class="text">
-          <div *ngIf="!isNewNote || isBiblicalTermNote" class="note-text" [innerHTML]="getNoteContextText()"></div>
-          <div *ngIf="isNewNote && !isBiblicalTermNote" class="note-text" [innerHTML]="segmentText"></div>
-          <div *ngIf="showSegmentText" class="segment-text" [innerHTML]="segmentText"></div>
+          @if (!isNewNote || isBiblicalTermNote) {
+            <div class="note-text" [innerHTML]="getNoteContextText()"></div>
+          }
+          @if (isNewNote && !isBiblicalTermNote) {
+            <div class="note-text" [innerHTML]="segmentText"></div>
+          }
+          @if (showSegmentText) {
+            <div class="segment-text" [innerHTML]="segmentText"></div>
+          }
         </div>
-        <button
-          *ngIf="!isNewNote && !isBiblicalTermNote && isSegmentDifferentFromContext"
-          id="text-menu-button"
-          mat-icon-button
-          [matMenuTriggerFor]="menu"
-        >
-          <mat-icon>more_vert</mat-icon>
-        </button>
+        @if (!isNewNote && !isBiblicalTermNote && isSegmentDifferentFromContext) {
+          <button id="text-menu-button" mat-icon-button [matMenuTriggerFor]="menu">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+        }
         <mat-menu #menu="matMenu">
           <button mat-menu-item (click)="toggleSegmentText()">
             <mat-icon>compare</mat-icon>
@@ -30,53 +33,73 @@
         </mat-menu>
       </div>
       <div class="notes">
-        <div *ngFor="let noteInfo of notesToDisplay" class="note">
-          <div class="content">
-            <div *ngIf="noteInfo.assignment != null" class="assigned-user">>{{ noteInfo.assignment }}</div>
-            <div *ngIf="noteInfo.reattachedVerse != null" class="verse-reattached">{{ noteInfo.reattachedVerse }}</div>
-            <div *ngIf="noteInfo.reattachedText != null" class="text" [innerHTML]="noteInfo.reattachedText"></div>
-            <div class="note-content-and-actions">
-              <div class="note-content" [innerHTML]="noteInfo.content" [ngStyle]="{ fontSize }"></div>
-              <div *ngIf="noteInfo.editable" class="edit-actions">
-                <button mat-icon-button class="edit-button" (click)="editNote(noteInfo.note)">
-                  <mat-icon>edit</mat-icon>
-                </button>
-                <button mat-icon-button class="delete-button" (click)="deleteNote(noteInfo.note)">
-                  <mat-icon>delete</mat-icon>
-                </button>
+        @for (noteInfo of notesToDisplay; track noteInfo) {
+          <div class="note">
+            <div class="content">
+              @if (noteInfo.assignment != null) {
+                <div class="assigned-user">>{{ noteInfo.assignment }}</div>
+              }
+              @if (noteInfo.reattachedVerse != null) {
+                <div class="verse-reattached">{{ noteInfo.reattachedVerse }}</div>
+              }
+              @if (noteInfo.reattachedText != null) {
+                <div class="text" [innerHTML]="noteInfo.reattachedText"></div>
+              }
+              <div class="note-content-and-actions">
+                <div class="note-content" [innerHTML]="noteInfo.content" [ngStyle]="{ fontSize }"></div>
+                @if (noteInfo.editable) {
+                  <div class="edit-actions">
+                    <button mat-icon-button class="edit-button" (click)="editNote(noteInfo.note)">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                    <button mat-icon-button class="delete-button" (click)="deleteNote(noteInfo.note)">
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  </div>
+                }
               </div>
             </div>
+            <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
+            <div class="note-user">
+              <div class="user-name">{{ noteInfo.userName }}</div>
+              <small class="date-created">{{ noteInfo.dateCreated }}</small>
+            </div>
           </div>
-          <img [src]="noteInfo.icon" alt="" [title]="noteInfo.title" />
-          <div class="note-user">
-            <div class="user-name">{{ noteInfo.userName }}</div>
-            <small class="date-created">{{ noteInfo.dateCreated }}</small>
-          </div>
-        </div>
+        }
       </div>
-      <mat-form-field *ngIf="canInsertNote" class="full-width" appearance="outline">
-        <mat-label>{{ t("your_comment") }}</mat-label>
-        <textarea matInput [(ngModel)]="currentNoteContent"></textarea>
-      </mat-form-field>
+      @if (canInsertNote) {
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>{{ t("your_comment") }}</mat-label>
+          <textarea matInput [(ngModel)]="currentNoteContent"></textarea>
+        </mat-form-field>
+      }
     </mat-dialog-content>
     <mat-dialog-actions fxLayoutAlign="end">
       <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
-      <mat-button-toggle-group *ngIf="canInsertNote">
-        <mat-button-toggle class="save-button save-options" (click)="submit()">{{
-          t(saveOption === "save" ? "save" : "resolve")
-        }}</mat-button-toggle>
-        <mat-button-toggle *ngIf="canResolve" class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
-          <mat-icon>expand_less</mat-icon>
-        </mat-button-toggle>
-        <mat-menu #saveMenu="matMenu" class="save-options-menu" yPosition="above" xPosition="before">
-          <button *ngIf="saveOption === 'resolve'" mat-menu-item (click)="saveOption = 'save'">
-            <span>{{ t("save") }}</span>
-          </button>
-          <button *ngIf="saveOption === 'save'" mat-menu-item (click)="saveOption = 'resolve'">
-            <span>{{ t("resolve") }}</span>
-          </button>
-        </mat-menu>
-      </mat-button-toggle-group>
+      @if (canInsertNote) {
+        <mat-button-toggle-group>
+          <mat-button-toggle class="save-button save-options" (click)="submit()">{{
+            t(saveOption === "save" ? "save" : "resolve")
+          }}</mat-button-toggle>
+          @if (canResolve) {
+            <mat-button-toggle class="save-options-trigger save-options" [matMenuTriggerFor]="saveMenu">
+              <mat-icon>expand_less</mat-icon>
+            </mat-button-toggle>
+          }
+          <mat-menu #saveMenu="matMenu" class="save-options-menu" yPosition="above" xPosition="before">
+            @if (saveOption === "resolve") {
+              <button mat-menu-item (click)="saveOption = 'save'">
+                <span>{{ t("save") }}</span>
+              </button>
+            }
+            @if (saveOption === "save") {
+              <button mat-menu-item (click)="saveOption = 'resolve'">
+                <span>{{ t("resolve") }}</span>
+              </button>
+            }
+          </mat-menu>
+        </mat-button-toggle-group>
+      }
     </mat-dialog-actions>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.html
@@ -1,9 +1,11 @@
 <ng-container *transloco="let t; read: 'suggestions_settings_dialog'">
   <h1 mat-dialog-title>{{ t("translator_settings") }}</h1>
   <mat-dialog-content>
-    <div class="offline-text" *ngIf="!onlineStatusService.isOnline">
-      {{ t("settings_not_available_offline") }}
-    </div>
+    @if (!onlineStatusService.isOnline) {
+      <div class="offline-text">
+        {{ t("settings_not_available_offline") }}
+      </div>
+    }
     <div class="row">
       <div class="col">
         <mat-slide-toggle
@@ -20,9 +22,11 @@
             [disabled]="translationSuggestionsDisabled"
             [(ngModel)]="numSuggestions"
           >
-            <mat-option *ngFor="let value of ['1', '2', '3', '4', '5']" [value]="value">
-              {{ value }}
-            </mat-option>
+            @for (value of ["1", "2", "3", "4", "5"]; track value) {
+              <mat-option [value]="value">
+                {{ value }}
+              </mat-option>
+            }
           </mat-select>
         </mat-form-field>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.html
@@ -1,18 +1,15 @@
-<div class="loading-indicator" *ngIf="isLoading"><span></span> <span></span> <span></span></div>
-<mat-selection-list
-  *ngIf="!isLoading"
-  #list
-  dense
-  [multiple]="false"
-  (click)="selectAll($event)"
-  hideSingleSelectionIndicator
->
-  <ng-container *ngFor="let suggestion of suggestions; let i = index">
-    <mat-list-option [selected]="suggestion && i === 0">
-      <div class="suggestion">
-        {{ suggestion.words.join(" ") }}
-        <span class="suggestion-confidence">{{ getPercentage(suggestion.confidence) }}%</span>
-      </div>
-    </mat-list-option>
-  </ng-container>
-</mat-selection-list>
+@if (isLoading) {
+  <div class="loading-indicator"><span></span> <span></span> <span></span></div>
+}
+@if (!isLoading) {
+  <mat-selection-list #list dense [multiple]="false" (click)="selectAll($event)" hideSingleSelectionIndicator>
+    @for (suggestion of suggestions; track suggestion; let i = $index) {
+      <mat-list-option [selected]="suggestion && i === 0">
+        <div class="suggestion">
+          {{ suggestion.words.join(" ") }}
+          <span class="suggestion-confidence">{{ getPercentage(suggestion.confidence) }}%</span>
+        </div>
+      </mat-list-option>
+    }
+  </mat-selection-list>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
@@ -1,9 +1,9 @@
-<mat-progress-bar *ngIf="isLoading && !isSyncActive" mode="indeterminate" color="accent"></mat-progress-bar>
-<app-sync-progress
-  *ngIf="isSyncActive"
-  [projectDoc]="selectedProjectDoc"
-  (inProgress)="onSyncProgress($event)"
-></app-sync-progress>
+@if (isLoading && !isSyncActive) {
+  <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
+}
+@if (isSyncActive) {
+  <app-sync-progress [projectDoc]="selectedProjectDoc" (inProgress)="onSyncProgress($event)"></app-sync-progress>
+}
 
 <ng-container *transloco="let t; read: 'editor_add_tab_resource_dialog'">
   <h1 mat-dialog-title>{{ t("dialog_title") }}</h1>
@@ -25,22 +25,32 @@
       ></app-project-select>
     </div>
 
-    <div *ngIf="isSyncActive" class="loading-message">
-      {{ t("loading") }} {{ selectedProjectDoc?.data?.shortName }}{{ animatedEllipsis$ | async }}
-    </div>
+    @if (isSyncActive) {
+      <div class="loading-message">
+        {{ t("loading") }} {{ selectedProjectDoc?.data?.shortName }}{{ animatedEllipsis$ | async }}
+      </div>
+    }
 
-    <mat-error *ngIf="projectLoadingFailed && resourceLoadingFailed">
-      {{ t("error_fetching_projects_resources") }}
-    </mat-error>
-    <mat-error *ngIf="projectLoadingFailed && !resourceLoadingFailed">
-      {{ t("error_fetching_projects") }}
-    </mat-error>
-    <mat-error *ngIf="resourceLoadingFailed && !projectLoadingFailed">
-      {{ t("error_fetching_resources") }}
-    </mat-error>
-    <mat-error *ngIf="projectFetchFailed || syncFailed">
-      {{ t("error_loading_resource") }}
-    </mat-error>
+    @if (projectLoadingFailed && resourceLoadingFailed) {
+      <mat-error>
+        {{ t("error_fetching_projects_resources") }}
+      </mat-error>
+    }
+    @if (projectLoadingFailed && !resourceLoadingFailed) {
+      <mat-error>
+        {{ t("error_fetching_projects") }}
+      </mat-error>
+    }
+    @if (resourceLoadingFailed && !projectLoadingFailed) {
+      <mat-error>
+        {{ t("error_fetching_resources") }}
+      </mat-error>
+    }
+    @if (projectFetchFailed || syncFailed) {
+      <mat-error>
+        {{ t("error_loading_resource") }}
+      </mat-error>
+    }
   </mat-dialog-content>
 
   <mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.html
@@ -11,7 +11,7 @@
         @if (portion.id == null) {{{ portion.text }}}
       }
 
-      @for (portion of i18n.interpolate(suggestedRemedyI18nKey); track portion.text) {
+      @for (portion of suggestedRemedy | async; track portion.text) {
         @if (portion.id === 1) {
           <a [href]="issueMailTo" target="_blank" rel="noreferrer">{{ portion.text }}</a>
         } @else if (portion.id == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
@@ -13,7 +12,7 @@ import { NoticeComponent } from '../../shared/notice/notice.component';
 @Component({
   selector: 'app-font-unsupported-message',
   standalone: true,
-  imports: [CommonModule, NoticeComponent, TranslocoModule],
+  imports: [NoticeComponent, TranslocoModule],
   templateUrl: './font-unsupported-message.component.html',
   styleUrl: './font-unsupported-message.component.scss'
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/font-unsupported-message/font-unsupported-message.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
@@ -12,7 +13,7 @@ import { NoticeComponent } from '../../shared/notice/notice.component';
 @Component({
   selector: 'app-font-unsupported-message',
   standalone: true,
-  imports: [NoticeComponent, TranslocoModule],
+  imports: [CommonModule, NoticeComponent, TranslocoModule],
   templateUrl: './font-unsupported-message.component.html',
   styleUrl: './font-unsupported-message.component.scss'
 })
@@ -23,6 +24,8 @@ export class FontUnsupportedMessageComponent {
     readonly i18n: I18nService,
     readonly externalUrlService: ExternalUrlService
   ) {}
+
+  suggestedRemedy = this.i18n.interpolate(this.suggestedRemedyI18nKey);
 
   get showUnsupportedFontWarning(): boolean {
     return !this.fontService.isFontFullySupported(this.selectedFont ?? '');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
@@ -1,26 +1,31 @@
 <ng-container *transloco="let t; read: 'training_progress'">
-  <div *ngIf="showTrainingProgress" class="training-progress mat-card">
-    <div class="training-title" fxLayout="row" fxLayoutAlign="space-between center">
-      <div>{{ t("training") }}</div>
-      <button id="training-close-button" mat-icon-button type="button" (click)="closeTrainingProgress()">
-        <mat-icon>close</mat-icon>
-      </button>
-    </div>
-    <div class="training-content" fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="5px">
-      <div class="text-ellipsis">{{ trainingMessage }}</div>
-      <div>
-        <app-donut-chart
-          id="training-progress-spinner"
-          *ngIf="trainingPercentage < 100"
-          [colors]="['#b8d332', 'transparent']"
-          [data]="[trainingPercentage, 100 - trainingPercentage]"
-          backgroundColor="#ececec"
-          [animationDuration]="0"
-          [innerThicknessDelta]="0"
-          [thickness]="22"
-        ></app-donut-chart>
-        <mat-icon id="training-complete-icon" *ngIf="trainingPercentage === 100">check_circle_outline</mat-icon>
+  @if (showTrainingProgress) {
+    <div class="training-progress mat-card">
+      <div class="training-title" fxLayout="row" fxLayoutAlign="space-between center">
+        <div>{{ t("training") }}</div>
+        <button id="training-close-button" mat-icon-button type="button" (click)="closeTrainingProgress()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+      <div class="training-content" fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="5px">
+        <div class="text-ellipsis">{{ trainingMessage }}</div>
+        <div>
+          @if (trainingPercentage < 100) {
+            <app-donut-chart
+              id="training-progress-spinner"
+              [colors]="['#b8d332', 'transparent']"
+              [data]="[trainingPercentage, 100 - trainingPercentage]"
+              backgroundColor="#ececec"
+              [animationDuration]="0"
+              [innerThicknessDelta]="0"
+              [thickness]="22"
+            ></app-donut-chart>
+          }
+          @if (trainingPercentage === 100) {
+            <mat-icon id="training-complete-icon">check_circle_outline</mat-icon>
+          }
+        </div>
       </div>
     </div>
-  </div>
+  }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -1,7 +1,9 @@
 <ng-container *transloco="let t; read: 'translate_overview'">
   <div class="title mat-headline-4">{{ t("translate_overview") }}</div>
 
-  <app-font-unsupported-message *ngIf="isPTUser"></app-font-unsupported-message>
+  @if (isPTUser) {
+    <app-font-unsupported-message></app-font-unsupported-message>
+  }
 
   <div class="card-wrapper">
     <mat-card class="books-card">
@@ -20,70 +22,78 @@
         </mat-card-title>
       </mat-card-header>
       <mat-divider></mat-divider>
-      <mat-list *ngIf="texts != null" role="list">
-        <mat-list-item
-          role="listitem"
-          *ngFor="let textProgress of texts; trackBy: trackTextByBookNum"
-          [appRouterLink]="['./', getBookId(textProgress.text)]"
-        >
-          <mat-icon matListItemIcon class="mirror-rtl">book</mat-icon>
-          <span matListItemTitle>{{ getBookName(textProgress.text) }}</span>
-          <span matListItemLine>{{
-            t("translated_segments", { translatedSegments: textProgress.translated, total: textProgress.total })
-          }}</span>
-          <div class="progress" matListItemMeta [title]="textProgress.percentage + '%'">
-            <app-donut-chart
-              [colors]="['#b8d332', 'transparent']"
-              [data]="[textProgress.translated, textProgress.blank]"
-              backgroundColor="#ececec"
-              [innerThicknessDelta]="0"
-              [thickness]="22"
-            ></app-donut-chart>
-          </div>
-        </mat-list-item>
-      </mat-list>
+      @if (texts != null) {
+        <mat-list role="list">
+          @for (textProgress of texts; track trackTextByBookNum($index, textProgress)) {
+            <mat-list-item role="listitem" [appRouterLink]="['./', getBookId(textProgress.text)]">
+              <mat-icon matListItemIcon class="mirror-rtl">book</mat-icon>
+              <span matListItemTitle>{{ getBookName(textProgress.text) }}</span>
+              <span matListItemLine>{{
+                t("translated_segments", { translatedSegments: textProgress.translated, total: textProgress.total })
+              }}</span>
+              <div class="progress" matListItemMeta [title]="textProgress.percentage + '%'">
+                <app-donut-chart
+                  [colors]="['#b8d332', 'transparent']"
+                  [data]="[textProgress.translated, textProgress.blank]"
+                  backgroundColor="#ececec"
+                  [innerThicknessDelta]="0"
+                  [thickness]="22"
+                ></app-donut-chart>
+              </div>
+            </mat-list-item>
+          }
+        </mat-list>
+      }
     </mat-card>
 
-    <mat-card *ngIf="translationSuggestionsEnabled && canEditTexts" class="engine-card">
-      <mat-progress-bar
-        id="training-progress-bar"
-        [mode]="trainingPercentage > 0 ? 'determinate' : 'indeterminate'"
-        [class.mat-progress-bar--closed]="!isTraining"
-        [value]="trainingPercentage"
-      ></mat-progress-bar>
-      <mat-card-header>
-        <mat-card-title class="engine-card-title">{{ t("suggestion_engine") }}</mat-card-title>
-      </mat-card-header>
-      <mat-card-content class="engine-card-content">
-        <div class="engine-card-quality">
-          <div class="engine-card-quality-stars mirror-rtl" [title]="engineConfidence + ' BLEU'">
-            <mat-icon *ngFor="let star of engineQualityStars">{{
-              engineQuality >= star + 1 ? "star" : engineQuality === star + 0.5 ? "star_half" : "star_border"
-            }}</mat-icon>
+    @if (translationSuggestionsEnabled && canEditTexts) {
+      <mat-card class="engine-card">
+        <mat-progress-bar
+          id="training-progress-bar"
+          [mode]="trainingPercentage > 0 ? 'determinate' : 'indeterminate'"
+          [class.mat-progress-bar--closed]="!isTraining"
+          [value]="trainingPercentage"
+        ></mat-progress-bar>
+        <mat-card-header>
+          <mat-card-title class="engine-card-title">{{ t("suggestion_engine") }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content class="engine-card-content">
+          <div class="engine-card-quality">
+            <div class="engine-card-quality-stars mirror-rtl" [title]="engineConfidence + ' BLEU'">
+              @for (star of engineQualityStars; track star) {
+                <mat-icon>{{
+                  engineQuality >= star + 1 ? "star" : engineQuality === star + 0.5 ? "star_half" : "star_border"
+                }}</mat-icon>
+              }
+            </div>
+            <div class="engine-card-quality-subtitle">{{ t("quality") }}</div>
           </div>
-          <div class="engine-card-quality-subtitle">{{ t("quality") }}</div>
-        </div>
-        <div class="engine-card-segments">
-          <span class="engine-card-segments-count">{{ trainedSegmentCount }}</span
-          ><span>{{ t("trained_segments") }}</span>
-        </div>
-        <div *ngIf="showCannotTrainEngineMessage || !canTrainSuggestions" class="translation-suggestions-info">
-          {{ showCannotTrainEngineMessage ? t("cannot_train_suggestion_engine") : t("not_enough_verses_translated") }}
-        </div>
-      </mat-card-content>
-      <mat-divider></mat-divider>
-      <mat-card-actions>
-        <button
-          id="retrain-button"
-          mat-button
-          [disabled]="isTraining || !isOnline"
-          type="button"
-          (click)="startTraining()"
-        >
-          {{ isTraining ? t("training") : t("retrain") }}
-        </button>
-      </mat-card-actions>
-    </mat-card>
+          <div class="engine-card-segments">
+            <span class="engine-card-segments-count">{{ trainedSegmentCount }}</span
+            ><span>{{ t("trained_segments") }}</span>
+          </div>
+          @if (showCannotTrainEngineMessage || !canTrainSuggestions) {
+            <div class="translation-suggestions-info">
+              {{
+                showCannotTrainEngineMessage ? t("cannot_train_suggestion_engine") : t("not_enough_verses_translated")
+              }}
+            </div>
+          }
+        </mat-card-content>
+        <mat-divider></mat-divider>
+        <mat-card-actions>
+          <button
+            id="retrain-button"
+            mat-button
+            [disabled]="isTraining || !isOnline"
+            type="button"
+            (click)="startTraining()"
+          >
+            {{ isTraining ? t("training") : t("retrain") }}
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    }
   </div>
   <app-training-progress [projectId]="projectId"></app-training-progress>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -1,8 +1,8 @@
 <ng-container *transloco="let t; read: 'collaborators'">
   <div class="invite-user">
-    <span *ngIf="!isAppOnline" id="collaborators-offline-message" class="offline-text">{{
-      t("connect_network_to_manage_users")
-    }}</span>
+    @if (!isAppOnline) {
+      <span id="collaborators-offline-message" class="offline-text">{{ t("connect_network_to_manage_users") }}</span>
+    }
     <app-notice icon="live_help">
       <div class="help-message">
         {{ t("member_role_info") }}
@@ -28,103 +28,126 @@
         <input matInput formControlName="filter" (keyup)="updateSearchTerm($event.target)" />
       </mat-form-field>
     </div>
-    <div *ngIf="!isLoading">
-      <div *ngIf="filteredLength > 0">
-        <table mat-table fxFill id="project-users-table" [dataSource]="rowsToDisplay">
-          <ng-container matColumnDef="avatar">
-            <td mat-cell *matCellDef="let userRow; let i = index">
-              <div *ngIf="!userRow.isInvitee">
-                <app-avatar [user]="userRow.user" [size]="32"></app-avatar>
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="name">
-            <td mat-cell *matCellDef="let userRow">
-              <div *ngIf="!userRow.inviteeStatus" class="display-name-label">
-                {{ userRow.user?.displayName }}
-                <b *ngIf="isCurrentUser(userRow)" class="current-user-label">&nbsp;{{ t("me") }}</b>
-              </div>
-              <div
-                *ngIf="userRow.inviteeStatus"
-                [innerHtml]="
-                  userRow.inviteeStatus.expired
-                    ? i18n.translateAndInsertTags('collaborators.invitation_expired', { email: userRow.user?.email })
-                    : i18n.translateAndInsertTags('collaborators.awaiting_response_from', {
-                        email: userRow.user?.email
-                      })
-                "
-              ></div>
-              <div fxHide.gt-xs>
-                <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="info">
-            <td mat-cell *matCellDef="let userRow">
-              <div *ngIf="hasParatextRole(userRow)">
-                <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="questions_permission">
-            <td mat-cell *matCellDef="let userRow">
-              <div [matTooltip]="t('allow_add_edit_questions')" *ngIf="userRow.allowCreatingQuestions">
-                <mat-icon>post_add</mat-icon>
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="audio_permission">
-            <td mat-cell *matCellDef="let userRow">
-              <div [matTooltip]="t('allow_manage_audio')" *ngIf="userRow.canManageAudio">
-                <mat-icon class="shift-left material-icons-outlined">audio_file</mat-icon>
-              </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="role">
-            <td fxHide.xs mat-cell *matCellDef="let userRow">
-              <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="more">
-            <td mat-cell *matCellDef="let userRow">
-              <button mat-icon-button class="user-more-menu" [matMenuTriggerFor]="userOptions">
-                <mat-icon>more_vert</mat-icon>
-              </button>
-              <mat-menu #userOptions="matMenu" class="user-options">
-                <button
-                  *ngIf="!userRow.inviteeStatus && !isCurrentUser(userRow)"
-                  mat-menu-item
-                  class="remove-user"
-                  (click)="removeProjectUserClicked(userRow)"
-                  [disabled]="!isAppOnline"
-                >
-                  {{ t("remove_from_project") }}
-                </button>
-                <button
-                  *ngIf="userRow.inviteeStatus"
-                  mat-menu-item
-                  class="cancel-invite"
-                  (click)="uninviteProjectUser(userRow.user.email)"
-                  [disabled]="!isAppOnline"
-                >
-                  {{ t("cancel_invite") }}
-                </button>
-                <button
-                  mat-menu-item
-                  (click)="openRolesDialog(userRow)"
-                  [disabled]="isAdmin(userRow.role) || userRow.inviteeStatus"
-                  data-test-id="edit-roles-and-permissions"
-                >
-                  {{ t("edit_roles_and_permissions") }}
-                </button>
-              </mat-menu>
-            </td>
-          </ng-container>
-          <tr mat-row *matRowDef="let userRow; columns: tableColumns"></tr>
-        </table>
+    @if (!isLoading) {
+      <div>
+        @if (filteredLength > 0) {
+          <div>
+            <table mat-table fxFill id="project-users-table" [dataSource]="rowsToDisplay">
+              <ng-container matColumnDef="avatar">
+                <td mat-cell *matCellDef="let userRow; let i = index">
+                  @if (!userRow.isInvitee) {
+                    <div>
+                      <app-avatar [user]="userRow.user" [size]="32"></app-avatar>
+                    </div>
+                  }
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="name">
+                <td mat-cell *matCellDef="let userRow">
+                  @if (!userRow.inviteeStatus) {
+                    <div class="display-name-label">
+                      {{ userRow.user?.displayName }}
+                      @if (isCurrentUser(userRow)) {
+                        <b class="current-user-label">&nbsp;{{ t("me") }}</b>
+                      }
+                    </div>
+                  }
+                  @if (userRow.inviteeStatus) {
+                    <div
+                      [innerHtml]="
+                        userRow.inviteeStatus.expired
+                          ? i18n.translateAndInsertTags('collaborators.invitation_expired', {
+                              email: userRow.user?.email
+                            })
+                          : i18n.translateAndInsertTags('collaborators.awaiting_response_from', {
+                              email: userRow.user?.email
+                            })
+                      "
+                    ></div>
+                  }
+                  <div fxHide.gt-xs>
+                    <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
+                  </div>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="info">
+                <td mat-cell *matCellDef="let userRow">
+                  @if (hasParatextRole(userRow)) {
+                    <div>
+                      <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+                    </div>
+                  }
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="questions_permission">
+                <td mat-cell *matCellDef="let userRow">
+                  @if (userRow.allowCreatingQuestions) {
+                    <div [matTooltip]="t('allow_add_edit_questions')">
+                      <mat-icon>post_add</mat-icon>
+                    </div>
+                  }
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="audio_permission">
+                <td mat-cell *matCellDef="let userRow">
+                  @if (userRow.canManageAudio) {
+                    <div [matTooltip]="t('allow_manage_audio')">
+                      <mat-icon class="shift-left material-icons-outlined">audio_file</mat-icon>
+                    </div>
+                  }
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="role">
+                <td fxHide.xs mat-cell *matCellDef="let userRow">
+                  <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="more">
+                <td mat-cell *matCellDef="let userRow">
+                  <button mat-icon-button class="user-more-menu" [matMenuTriggerFor]="userOptions">
+                    <mat-icon>more_vert</mat-icon>
+                  </button>
+                  <mat-menu #userOptions="matMenu" class="user-options">
+                    @if (!userRow.inviteeStatus && !isCurrentUser(userRow)) {
+                      <button
+                        mat-menu-item
+                        class="remove-user"
+                        (click)="removeProjectUserClicked(userRow)"
+                        [disabled]="!isAppOnline"
+                      >
+                        {{ t("remove_from_project") }}
+                      </button>
+                    }
+                    @if (userRow.inviteeStatus) {
+                      <button
+                        mat-menu-item
+                        class="cancel-invite"
+                        (click)="uninviteProjectUser(userRow.user.email)"
+                        [disabled]="!isAppOnline"
+                      >
+                        {{ t("cancel_invite") }}
+                      </button>
+                    }
+                    <button
+                      mat-menu-item
+                      (click)="openRolesDialog(userRow)"
+                      [disabled]="isAdmin(userRow.role) || userRow.inviteeStatus"
+                      data-test-id="edit-roles-and-permissions"
+                    >
+                      {{ t("edit_roles_and_permissions") }}
+                    </button>
+                  </mat-menu>
+                </td>
+              </ng-container>
+              <tr mat-row *matRowDef="let userRow; columns: tableColumns"></tr>
+            </table>
+          </div>
+        }
+        @if (filteredLength === 0) {
+          <mat-hint class="no-users-label">{{ t("no_users_found") }}</mat-hint>
+        }
       </div>
-      <mat-hint *ngIf="filteredLength === 0" class="no-users-label">{{ t("no_users_found") }}</mat-hint>
-    </div>
+    }
     <app-share-control [projectId]="projectId" (invited)="onInvitationSent()"></app-share-control>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.component.html
@@ -4,31 +4,41 @@
     <div>
       <div class="userName">
         <span>{{ data.userProfile.displayName }}</span>
-        <img *ngIf="isParatextUser()" src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+        @if (isParatextUser()) {
+          <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+        }
       </div>
       <span class="userRole">{{ t(isParatextUser() ? "user_pt" : "user_sf") }}</span>
     </div>
   </div>
   <mat-dialog-content [formGroup]="form">
-    <app-notice *ngIf="isParatextUser()" icon="live_help">
-      <div class="help-message">
-        {{ t("roles_from_pt_cannot_be_changed") }}
-        <a mat-flat-button [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
-      </div>
-    </app-notice>
-    <span class="offline-text" *ngIf="form.disabled">{{ t("offline") }}</span>
+    @if (isParatextUser()) {
+      <app-notice icon="live_help">
+        <div class="help-message">
+          {{ t("roles_from_pt_cannot_be_changed") }}
+          <a mat-flat-button [href]="urls.rolesHelpPage" target="_blank">{{ t("learn_more") }}</a>
+        </div>
+      </app-notice>
+    }
+    @if (form.disabled) {
+      <span class="offline-text">{{ t("offline") }}</span>
+    }
     <h3>{{ t("roles") }}</h3>
     <mat-radio-group class="roleOptions" formControlName="roles">
-      <mat-radio-button class="roleButton" *ngFor="let role of roleOptions" [value]="role">
-        <span class="roleName">{{ i18n.localizeRole(role) }}</span>
-        <span class="roleDescription">{{ i18n.localizeRoleDescription(role) }}</span>
-      </mat-radio-button>
+      @for (role of roleOptions; track role) {
+        <mat-radio-button class="roleButton" [value]="role">
+          <span class="roleName">{{ i18n.localizeRole(role) }}</span>
+          <span class="roleDescription">{{ i18n.localizeRoleDescription(role) }}</span>
+        </mat-radio-button>
+      }
     </mat-radio-group>
-    <div *ngIf="isParatextUser()" class="permissions">
-      <h3>{{ t("permissions") }}</h3>
-      <mat-checkbox formControlName="canAddEditQuestions">{{ t("allow_add_edit_questions") }}</mat-checkbox>
-      <mat-checkbox formControlName="canManageAudio">{{ t("allow_manage_audio") }}</mat-checkbox>
-    </div>
+    @if (isParatextUser()) {
+      <div class="permissions">
+        <h3>{{ t("permissions") }}</h3>
+        <mat-checkbox formControlName="canAddEditQuestions">{{ t("allow_add_edit_questions") }}</mat-checkbox>
+        <mat-checkbox formControlName="canManageAudio">{{ t("allow_manage_audio") }}</mat-checkbox>
+      </div>
+    }
   </mat-dialog-content>
   <mat-dialog-actions [align]="'end'">
     <button mat-button mat-dialog-close type="button">

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
@@ -4,15 +4,20 @@
   [style.--avatar-color]="avatarColorFromDisplayName"
   [style.--avatar-border-color]="borderColor"
 >
-  <img
-    *ngIf="avatarUrl && mode === 'image'"
-    [src]="avatarUrl"
-    [alt]="name"
-    [width]="size"
-    [height]="size"
-    (error)="onImageError()"
-    referrerpolicy="no-referrer"
-  />
-  <mat-icon *ngIf="mode === 'user_icon'" class="user-icon">account_circle</mat-icon>
-  <div *ngIf="mode === 'initials'" class="initials">{{ initials }}</div>
+  @if (avatarUrl && mode === "image") {
+    <img
+      [src]="avatarUrl"
+      [alt]="name"
+      [width]="size"
+      [height]="size"
+      (error)="onImageError()"
+      referrerpolicy="no-referrer"
+    />
+  }
+  @if (mode === "user_icon") {
+    <mat-icon class="user-icon">account_circle</mat-icon>
+  }
+  @if (mode === "initials") {
+    <div class="initials">{{ initials }}</div>
+  }
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, Input, OnChanges } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
@@ -10,7 +9,7 @@ type AvatarMode = 'image' | 'initials' | 'user_icon';
   templateUrl: './avatar.component.html',
   styleUrls: ['./avatar.component.scss'],
   standalone: true,
-  imports: [CommonModule, MatIconModule]
+  imports: [MatIconModule]
 })
 export class AvatarComponent implements OnChanges {
   @Input() size: number = 32;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.html
@@ -7,15 +7,17 @@
     [attr.stroke]="backgroundColor"
     [attr.stroke-width]="thickness"
   ></circle>
-  <ng-container *ngFor="let v of data; let i = index">
-    <circle
-      #segmentCircle
-      [attr.r]="radius"
-      [attr.cx]="cx"
-      [attr.cy]="cy"
-      fill="transparent"
-      [attr.stroke]="colors[i]"
-      [attr.stroke-width]="segmentWidth"
-    ></circle>
-  </ng-container>
+  @for (v of data; track v; let i = $index) {
+    <ng-container>
+      <circle
+        #segmentCircle
+        [attr.r]="radius"
+        [attr.cx]="cx"
+        [attr.cy]="cy"
+        fill="transparent"
+        [attr.stroke]="colors[i]"
+        [attr.stroke-width]="segmentWidth"
+      ></circle>
+    </ng-container>
+  }
 </svg>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -1,11 +1,21 @@
 <ng-container *transloco="let t; read: 'edit_name_dialog'">
-  <h1 mat-dialog-title *ngIf="data.isConfirmation">{{ t("confirm_your_name") }}</h1>
-  <h1 mat-dialog-title *ngIf="!data.isConfirmation">{{ t("update_your_name") }}</h1>
+  @if (data.isConfirmation) {
+    <h1 mat-dialog-title>{{ t("confirm_your_name") }}</h1>
+  }
+  @if (!data.isConfirmation) {
+    <h1 mat-dialog-title>{{ t("update_your_name") }}</h1>
+  }
   <mat-dialog-content>
-    <span *ngIf="!isOnline" class="offline-text">{{ t("connect_to_edit_name") }}</span>
+    @if (!isOnline) {
+      <span class="offline-text">{{ t("connect_to_edit_name") }}</span>
+    }
     <form id="name-form">
-      <p *ngIf="data.isConfirmation">{{ t("confirm_name") }}</p>
-      <p *ngIf="!data.isConfirmation">{{ t("enter_name") }}</p>
+      @if (data.isConfirmation) {
+        <p>{{ t("confirm_name") }}</p>
+      }
+      @if (!data.isConfirmation) {
+        <p>{{ t("enter_name") }}</p>
+      }
       <mat-form-field appearance="fill">
         <mat-label>{{ t("your_name") }}</mat-label>
         <input matInput [formControl]="name" />
@@ -13,9 +23,11 @@
     </form>
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button mat-button type="button" [mat-dialog-close]="'close'" *ngIf="!data.isConfirmation" id="cancel-button">
-      {{ t("cancel") }}
-    </button>
+    @if (!data.isConfirmation) {
+      <button mat-button type="button" [mat-dialog-close]="'close'" id="cancel-button">
+        {{ t("cancel") }}
+      </button>
+    }
     <button mat-flat-button color="primary" type="submit" (click)="submitDialog()" id="submit-button">
       {{ data.isConfirmation ? t("confirm") : t("update") }}
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
@@ -3,18 +3,26 @@
   <mat-dialog-content>
     <p>{{ data.message }}</p>
     <p [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></p>
-    <p *ngIf="browserUnsupported" class="unsupported-browser" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
+    @if (browserUnsupported) {
+      <p class="unsupported-browser" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
+    }
     <p>
-      <ng-container *ngFor="let portion of i18n.interpolateVariables('error.error_id', { errorId: data.eventId })">
-        <ng-container *ngIf="portion.id == null">{{ portion.text }}</ng-container>
-        <span *ngIf="portion.id === 'errorId'" class="error-id">{{ portion.text }}</span>
-      </ng-container>
+      @for (portion of i18n.interpolateVariables("error.error_id", { errorId: data.eventId }); track portion) {
+        @if (portion.id == null) {
+          {{ portion.text }}
+        }
+        @if (portion.id === "errorId") {
+          <span class="error-id">{{ portion.text }}</span>
+        }
+      }
     </p>
 
-    <ng-container *ngIf="data.stack">
+    @if (data.stack) {
       <a (click)="this.showDetails = !this.showDetails">{{ showDetails ? t("hide_details") : t("show_details") }}</a>
-      <pre *ngIf="showDetails" dir="ltr">{{ data.stack }}</pre>
-    </ng-container>
+      @if (showDetails) {
+        <pre dir="ltr">{{ data.stack }}</pre>
+      }
+    }
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button mat-flat-button mat-dialog-close color="primary" cdkFocusRegionStart>{{ t("close") }}</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.spec.ts
@@ -4,18 +4,23 @@ import { NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { mock } from 'ts-mockito';
+import { anything, mock, when } from 'ts-mockito';
 import { FeatureFlagService } from '../feature-flags/feature-flag.service';
+import { I18nService } from '../i18n.service';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from '../test-utils';
 import { UICommonModule } from '../ui-common.module';
 import { ErrorAlertData, ErrorDialogComponent } from './error-dialog.component';
 
 const mockedFeatureFlagService = mock(FeatureFlagService);
+const mockedI18nService = mock(I18nService);
 
 describe('ErrorDialogComponent', () => {
   configureTestingModule(() => ({
     imports: [DialogTestModule],
-    providers: [{ provide: FeatureFlagService, useMock: mockedFeatureFlagService }]
+    providers: [
+      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
+      { provide: I18nService, useMock: mockedI18nService }
+    ]
   }));
 
   let overlayContainer: OverlayContainer;
@@ -86,6 +91,7 @@ class TestEnvironment {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     const viewContainerRef = this.fixture.componentInstance.childViewContainer;
 
+    when(mockedI18nService.interpolateVariables(anything(), anything())).thenReturn([{ text: '12345', id: 'errorId' }]);
     const config: MatDialogConfig<ErrorAlertData> = {
       data: dialogData,
       viewContainerRef

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.html
@@ -4,7 +4,9 @@
     These settings are for developers and testers of Scripture Forge. Do not use them for real projects. Doing so will
     cause unexpected problems and errors.
   </app-notice>
-  <mat-checkbox *ngFor="let flag of featureFlags.featureFlags" [(ngModel)]="flag.enabled" [disabled]="flag.readonly">
-    {{ flag.description }}
-  </mat-checkbox>
+  @for (flag of featureFlags.featureFlags; track flag) {
+    <mat-checkbox [(ngModel)]="flag.enabled" [disabled]="flag.readonly">
+      {{ flag.description }}
+    </mat-checkbox>
+  }
 </mat-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
@@ -1,10 +1,18 @@
-<h2 mat-dialog-title *ngIf="title$ | async as title">{{ title }}</h2>
-<div mat-dialog-content *ngIf="message$ | async as message">{{ message }}</div>
+@if (title$ | async; as title) {
+  <h2 mat-dialog-title>{{ title }}</h2>
+}
+@if (message$ | async; as message) {
+  <div mat-dialog-content>{{ message }}</div>
+}
 <div mat-dialog-actions align="end">
-  <ng-container *ngFor="let option of options">
-    <button *ngIf="option.highlight" mat-flat-button color="primary" [mat-dialog-close]="option.value">
-      {{ option.label | async }}
-    </button>
-    <button *ngIf="!option.highlight" mat-button [mat-dialog-close]="option.value">{{ option.label | async }}</button>
-  </ng-container>
+  @for (option of options; track option) {
+    @if (option.highlight) {
+      <button mat-flat-button color="primary" [mat-dialog-close]="option.value">
+        {{ option.label | async }}
+      </button>
+    }
+    @if (!option.highlight) {
+      <button mat-button [mat-dialog-close]="option.value">{{ option.label | async }}</button>
+    }
+  }
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { TranslocoService } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { CookieService } from 'ngx-cookie-service';
+import { of } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
@@ -111,18 +112,21 @@ describe('I18nService', () => {
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });
 
-  it('should interpolate translations around and within numbered template tags', () => {
-    when(mockedTranslocoService.translate<string>('app.settings', anything())).thenReturn(
-      'A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.'
+  it('should interpolate translations around and within numbered template tags', done => {
+    when(mockedTranslocoService.selectTranslate<string>('app.settings', anything())).thenReturn(
+      of('A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.')
     );
     const service = getI18nService();
-    expect(service.interpolate('app.settings')).toEqual([
-      { text: 'A quick brown ' },
-      { text: 'fox', id: 1 },
-      { text: ' jumps over the lazy ' },
-      { text: 'dog', id: 3 },
-      { text: '.' }
-    ]);
+    service.interpolate('app.settings').subscribe(value => {
+      expect(value).toEqual([
+        { text: 'A quick brown ' },
+        { text: 'fox', id: 1 },
+        { text: ' jumps over the lazy ' },
+        { text: 'dog', id: 3 },
+        { text: '.' }
+      ]);
+      done();
+    });
   });
 
   it('should interpolate translations around template variables', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -330,25 +330,27 @@ export class I18nService {
    * view, or a link for the text "fox" or "dog". This system has the advantage of being able to handle translations
    * that reorder "fox" and "dog".
    */
-  interpolate(key: I18nKey, params?: HashMap): { text: string; id?: number }[] {
-    const translation: string = this.transloco.translate(key, params);
-    // find instances of "{ 1 } text { 2 }"
-    const regex = /\{\s*\d+\s*\}(.*?)\{\s*\d+\s*\}/g;
+  interpolate(key: I18nKey, params?: HashMap): Observable<{ text: string; id?: number }[]> {
+    return this.transloco.selectTranslate(key, params).pipe(
+      map(translation => {
+        // find instances of "{ 1 } text { 2 }"
+        const regex = /\{\s*\d+\s*\}(.*?)\{\s*\d+\s*\}/g;
 
-    const sections: { text: string; id?: number }[] = [];
-    let i = 0;
-    for (const match of translation.matchAll(regex)) {
-      const fullMatchText = match[0];
-      const matchInnerText = match[1];
-      sections.push({ text: translation.substring(i, match.index) });
-      const id = Number.parseInt(fullMatchText.match(/\d+/)![0], 10);
-      sections.push({ text: matchInnerText, id });
-      // The index on a match can only be undefined when calling String.prototype.match with a non-global regex
-      i = match.index! + fullMatchText.length;
-    }
-    sections.push({ text: translation.substring(i) });
-
-    return sections;
+        const sections: { text: string; id?: number }[] = [];
+        let i = 0;
+        for (const match of translation.matchAll(regex)) {
+          const fullMatchText = match[0];
+          const matchInnerText = match[1];
+          sections.push({ text: translation.substring(i, match.index) });
+          const id = Number.parseInt(fullMatchText.match(/\d+/)![0], 10);
+          sections.push({ text: matchInnerText, id });
+          // The index on a match can only be undefined when calling String.prototype.match with a non-global regex
+          i = match.index! + fullMatchText.length;
+        }
+        sections.push({ text: translation.substring(i) });
+        return sections;
+      })
+    );
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.html
@@ -5,9 +5,13 @@
     'layout-inline': !layoutStacked
   }"
 >
-  <div class="avatar" *ngIf="includeAvatar"><app-avatar [user]="owner" [size]="32"></app-avatar></div>
+  @if (includeAvatar) {
+    <div class="avatar"><app-avatar [user]="owner" [size]="32"></app-avatar></div>
+  }
   <div class="owner-text">
     <div class="name">{{ name }}</div>
-    <small class="date-time" *ngIf="dateTime">{{ i18n.formatDate(date) }}</small>
+    @if (dateTime) {
+      <small class="date-time">{{ i18n.formatDate(date) }}</small>
+    }
   </div>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.html
@@ -4,15 +4,16 @@
     <input matInput (keyup)="updateSearchTerm($event.target)" id="project-filter" />
   </mat-form-field>
 </div>
-<ng-container *ngIf="!isLoading">
-  <ng-container *ngIf="length > 0">
+@if (!isLoading) {
+  @if (length > 0) {
     <table mat-table id="projects-table" [dataSource]="rows">
       <ng-container matColumnDef="name">
         <td mat-cell *matCellDef="let row">
-          <a *ngIf="row.isMember; else nonmember" [appRouterLink]="['/projects', row.id]">
+          @if (row.isMember) {
+            <a [appRouterLink]="['/projects', row.id]"> {{ row.shortName }} - {{ row.name }} </a>
+          } @else {
             {{ row.shortName }} - {{ row.name }}
-          </a>
-          <ng-template #nonmember>{{ row.shortName }} - {{ row.name }}</ng-template>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="tasks">
@@ -30,9 +31,11 @@
               (selectionChange)="updateRole(row, $event.value)"
               [hideSingleSelectionIndicator]="true"
             >
-              <mat-option *ngFor="let projectRole of projectRoles" [value]="projectRole">
-                {{ i18n.localizeRole(projectRole.role) }}
-              </mat-option>
+              @for (projectRole of projectRoles; track projectRole) {
+                <mat-option [value]="projectRole">
+                  {{ i18n.localizeRole(projectRole.role) }}
+                </mat-option>
+              }
             </mat-select>
           </mat-form-field>
         </td>
@@ -51,10 +54,8 @@
           </mat-checkbox>
         </td>
       </ng-container>
-
       <tr mat-row *matRowDef="let row; columns: ['name', 'tasks', 'role', 'syncDisabled', 'preTranslate']"></tr>
     </table>
-
     <mat-paginator
       [pageIndex]="pageIndex"
       [length]="length"
@@ -63,6 +64,8 @@
       (page)="updatePage($event.pageIndex, $event.pageSize)"
     >
     </mat-paginator>
-  </ng-container>
-  <div *ngIf="length === 0" class="no-projects-label">No projects found</div>
-</ng-container>
+  }
+  @if (length === 0) {
+    <div class="no-projects-label">No projects found</div>
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -4,8 +4,8 @@
     <input matInput id="user-filter" (input)="updateSearchTerm($event.target)" />
   </mat-form-field>
 </div>
-<ng-container *ngIf="!isLoading">
-  <ng-container *ngIf="totalRecordCount > 0">
+@if (!isLoading) {
+  @if (totalRecordCount > 0) {
     <table mat-table id="users-table" [dataSource]="userRows">
       <ng-container matColumnDef="avatar">
         <td mat-cell *matCellDef="let userRow; let i = index">
@@ -14,23 +14,31 @@
       </ng-container>
       <ng-container matColumnDef="name">
         <td mat-cell *matCellDef="let userRow">
-          <strong *ngIf="userRow.user.displayName !== userRow.user.email">{{ userRow.user.displayName }}</strong>
-          <div
-            *ngIf="userRow.user.name !== userRow.user.displayName && userRow.user.name !== userRow.user.email"
-            class="name-label"
-          >
-            {{ userRow.user.name }}
-          </div>
+          @if (userRow.user.displayName !== userRow.user.email) {
+            <strong>{{ userRow.user.displayName }}</strong>
+          }
+          @if (userRow.user.name !== userRow.user.displayName && userRow.user.name !== userRow.user.email) {
+            <div class="name-label">
+              {{ userRow.user.name }}
+            </div>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="projects">
         <td mat-cell *matCellDef="let userRow">
-          <span *ngIf="userRow.projects?.length > 0">
-            {{ userRow.projects?.length }} Projects -
-            <span class="projectsNames" *ngFor="let project of userRow.projects; last as isLast">
-              <a [appRouterLink]="['/projects', project.id]">{{ project.name }}</a> <span *ngIf="!isLast">, </span>
+          @if (userRow.projects?.length > 0) {
+            <span>
+              {{ userRow.projects?.length }} Projects -
+              @for (project of userRow.projects; track project; let isLast = $last) {
+                <span class="projectsNames">
+                  <a [appRouterLink]="['/projects', project.id]">{{ project.name }}</a>
+                  @if (!isLast) {
+                    <span>, </span>
+                  }
+                </span>
+              }
             </span>
-          </span>
+          }
         </td>
       </ng-container>
       <ng-container matColumnDef="remove">
@@ -42,10 +50,8 @@
           }
         </td>
       </ng-container>
-
       <tr mat-row *matRowDef="let userRow; columns: ['avatar', 'name', 'projects', 'remove']"></tr>
     </table>
-
     <mat-paginator
       [pageIndex]="pageIndex"
       [length]="totalRecordCount"
@@ -54,6 +60,8 @@
       (page)="updatePage($event.pageIndex, $event.pageSize)"
     >
     </mat-paginator>
-  </ng-container>
-  <div *ngIf="totalRecordCount === 0" id="no-users-label">No users found</div>
-</ng-container>
+  }
+  @if (totalRecordCount === 0) {
+    <div id="no-users-label">No users found</div>
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
@@ -1,8 +1,9 @@
-<mat-spinner
-  *ngIf="state === ElementState.Submitting && !formGroup?.errors"
-  diameter="15"
-  class="update-button-spinner"
-  aria-label="Update in progress"
-></mat-spinner>
-<mat-icon *ngIf="state === ElementState.Submitted && !formGroup?.errors" class="check-icon">done</mat-icon>
-<mat-icon *ngIf="state === ElementState.Error && !formGroup?.errors" class="error-icon" color="warn">error</mat-icon>
+@if (state === ElementState.Submitting && !formGroup?.errors) {
+  <mat-spinner diameter="15" class="update-button-spinner" aria-label="Update in progress"></mat-spinner>
+}
+@if (state === ElementState.Submitted && !formGroup?.errors) {
+  <mat-icon class="check-icon">done</mat-icon>
+}
+@if (state === ElementState.Error && !formGroup?.errors) {
+  <mat-icon class="error-icon" color="warn">error</mat-icon>
+}


### PR DESCRIPTION
The control flow template syntax is new in Angular 17. There is no immediate target for when the previous template structural directives will not supported. This PR used `ng g @angular/core:control-flow` as the starting point.
The upgrade to prettier 3.3.3 now supports this new format in the template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2617)
<!-- Reviewable:end -->
