### PR TITLE
SF-2885 Fix project deleted message being shown after deleting project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -173,7 +173,9 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   get appIconLink(): string[] {
-    return this.router.url === '/projects' ? ['/projects', this.lastSelectedProjectId ?? ''] : ['/projects'];
+    return this.router.url === '/projects' && this.lastSelectedProjectId != null
+      ? ['/projects', this.lastSelectedProjectId]
+      : ['/projects'];
   }
 
   get isLoggedIn(): Observable<boolean> {
@@ -276,7 +278,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       }
       this.selectedProjectDeleteSub = this._selectedProjectDoc.delete$.subscribe(() => {
         // handle remotely deleted project
-        if (this.userService.currentProjectId != null) {
+        const userDoc = this.currentUserDoc;
+        if (userDoc != null && this.userService.currentProjectId(userDoc) != null) {
           this.showProjectDeletedDialog();
         }
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.spec.ts
@@ -14,6 +14,7 @@ import {
 import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { of } from 'rxjs';
 import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
@@ -35,6 +36,7 @@ const mockedSFProjectService = mock(SFProjectService);
 const mockedTranslocoService = mock(TranslocoService);
 const mockedPermissions = mock(PermissionsService);
 const mockResumeCheckingService = mock(ResumeCheckingService);
+const mockedDialogService = mock(DialogService);
 
 describe('ProjectComponent', () => {
   configureTestingModule(() => ({
@@ -47,7 +49,8 @@ describe('ProjectComponent', () => {
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: TranslocoService, useMock: mockedTranslocoService },
       { provide: PermissionsService, useMock: mockedPermissions },
-      { provide: ResumeCheckingService, useMock: mockResumeCheckingService }
+      { provide: ResumeCheckingService, useMock: mockResumeCheckingService },
+      { provide: DialogService, useMock: mockedDialogService }
     ]
   }));
 
@@ -207,6 +210,8 @@ class TestEnvironment {
 
     // Just mock the response.  Testing of the actual service functionality can be in the service spec.
     when(mockResumeCheckingService.checkingLink$).thenReturn(of(['projects', 'project1', 'checking', 'JHN', '1']));
+
+    when(mockedDialogService.message(anything())).thenResolve();
 
     this.fixture = TestBed.createComponent(ProjectComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -6,6 +6,7 @@ import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/mode
 import { Observable } from 'rxjs';
 import { distinctUntilChanged, filter, first, map } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
 import { environment } from '../../environments/environment';
@@ -28,6 +29,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     private readonly userService: UserService,
     private readonly permissions: PermissionsService,
     private readonly resumeCheckingService: ResumeCheckingService,
+    private readonly dialogService: DialogService,
     noticeService: NoticeService
   ) {
     super(noticeService);
@@ -60,11 +62,13 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
       });
     });
 
-    this.subscribe(navigateToProject$, projectId => {
-      if (!userDoc.data?.sites[environment.siteId].projects?.includes(projectId)) {
-        return;
+    this.subscribe(navigateToProject$, async projectId => {
+      if (userDoc.data?.sites[environment.siteId].projects?.includes(projectId)) {
+        this.navigateToProject(projectId);
+      } else {
+        await this.dialogService.message('app.project_has_been_deleted');
+        this.router.navigateByUrl('/projects', { replaceUrl: true });
       }
-      this.navigateToProject(projectId);
     });
   }
 


### PR DESCRIPTION
This is supposed to be an error message, not a confirmation message.

![](https://github.com/user-attachments/assets/ae1ba1cb-7cf4-4d94-a26c-dbbead9191a1)

This was broken in 28553e5451ed003cc25d85a505290033f387f5d3 when UserService.currentProjectId was changed from a gettter to a method that requires an argument, and AppComponent was not correctly updated. The result was that this dialog was shown after a user deletes a project. It should only be shown for _other_ users on a project, when the project is deleted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2625)
<!-- Reviewable:end -->
