### PR TITLE
SF-2881 Redirect users to projects page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -191,8 +191,13 @@ export class JoinComponent extends DataLoadingComponent {
 
     if (error instanceof HttpErrorResponse && isKnownJoinError(error.error)) {
       await this.showJoinError(error.error);
-    } else if (error instanceof CommandError && isKnownJoinError(error.message)) {
-      await this.showJoinError(error.message);
+    } else if (error instanceof CommandError) {
+      let errorMessage = error.message.split(' ').at(-1);
+      if (isKnownJoinError(errorMessage)) {
+        await this.showJoinError(errorMessage);
+      } else {
+        await this.errorHandler.handleError(error);
+      }
     } else {
       await this.errorHandler.handleError(error);
     }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -864,6 +864,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string projectId = projectSecret.Id;
         ShareKey projectSecretShareKey = projectSecret.ShareKeys.FirstOrDefault(sk => sk.Key == shareKey);
 
+        IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
+        SFProject project = projectDoc.Data;
+        if (project.UserRoles.ContainsKey(curUserId))
+            return projectId;
+
         if (projectSecretShareKey.RecipientUserId != null)
         {
             if (projectSecretShareKey.RecipientUserId == curUserId)
@@ -872,11 +877,6 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             }
             throw new DataNotFoundException("key_already_used");
         }
-
-        IDocument<SFProject> projectDoc = await GetProjectDocAsync(projectId, conn);
-        SFProject project = projectDoc.Data;
-        if (project.UserRoles.ContainsKey(curUserId))
-            return projectId;
 
         IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
         // Attempt to get the role for the user from the Paratext registry


### PR DESCRIPTION
Fixed error handling to display correct error messages for one-time use access links.
Fixed redirection issue by checking if user is on project before validating share key.