### PR TITLE
deploy: use python script from workflow commit

### DIFF
--- a/.github/workflows/compute-next-version.yml
+++ b/.github/workflows/compute-next-version.yml
@@ -3,10 +3,6 @@ name: "Compute next version"
 on:
   workflow_call:
     inputs:
-      app_commit:
-        description: "The commit from which to run the computation code. (Since the release branch may not have the latest or best version of compute-next-version.py.)"
-        required: true
-        type: string
       release_branch:
         description: "The release branch on which to look for prior tags."
         required: true
@@ -39,7 +35,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.app_commit }}
+          # Use the python code from the same commit that the workflow files are being used from, when the workflow is
+          # triggered from schedule or workflow_dispatch. Then workflow file expectations can more easily match the
+          # python code.
+          ref: ${{ github.sha }}
           fetch-depth: "0"
       - name: Compute next version
         id: compute_next_version

--- a/.github/workflows/release-live.yml
+++ b/.github/workflows/release-live.yml
@@ -55,7 +55,6 @@ jobs:
     needs: determine_build_commit
     uses: ./.github/workflows/compute-next-version.yml
     with:
-      app_commit: "${{ needs.determine_build_commit.outputs.build_commit }}"
       versioning-system: "production"
       release-level: ${{ github.event.inputs.release-level }}
       tag_prefix: "SFv"

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -78,7 +78,6 @@ jobs:
     if: ${{ needs.stop_if_already_built.outputs.already_built == 'false' || github.event.inputs.re-release == 'true' }}
     uses: ./.github/workflows/compute-next-version.yml
     with:
-      app_commit: ${{ needs.determine_build_commit.outputs.build_commit }}
       versioning-system: "staging"
       tag_prefix: "SF-QAv"
       release_branch: "sf-qa"


### PR DESCRIPTION
---

This lets the compute_next_version.py and workflow .yml files be conceptually grouped together.

This uses [github.sha](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), which seems to be the right thing. 

When a scheduled workflow runs, it uses workflow files from the default branch (master).
When a workflow_dispatch'ed workflow runs, my understanding is that it uses workflow files from the "Use workflow from" branch. 
When the compute_next_version.py script runs, we first _checkout_ the repository to run it. Checking out the repository at  `github.sha`, as the commit from which to use the python script, will mean that the python script will also be used from the same branch that the workflow files are being used from.

Preliminary testing shows that it should be working.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2632)
<!-- Reviewable:end -->
