### PR TITLE
Sort locales by usage

### DIFF
--- a/mongodb/Users/SortLocalesByUsage.mongodb
+++ b/mongodb/Users/SortLocalesByUsage.mongodb
@@ -1,0 +1,39 @@
+use('xforge')
+
+// This script sorts locales by the number of users who have selected them as their interface language
+
+const locales = [] // Paste content of locales.json here. Unfortunately I couldn't find a good way to import JSON
+
+const languageCounts = db.users.aggregate([
+  {
+    $match: {
+      interfaceLanguage: { $exists: true }
+    }
+  },
+  {
+    $group: {
+      _id: '$interfaceLanguage',
+      count: { $sum: 1 }
+    }
+  },
+  { $sort: { count: -1 } }
+]).toArray()
+
+for (const locale of locales) {
+  locale.count = languageCounts.find(lc => locale.tags.includes(lc._id))?.count || 0
+}
+
+// Mark English locales as having an absurd number of users to ensure they are always at the top
+for (const locale of locales) {
+  if (locale.tags.includes('en') || locale.tags.includes('en-GB')) {
+    locale.count = 9e9;
+  }
+}
+
+locales.sort((a, b) => b.count - a.count)
+
+for (const locale of locales) {
+  delete locale.count
+}
+
+locales

--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -14,10 +14,11 @@
     "helps": ""
   },
   {
-    "localName": "简体中文",
-    "englishName": "Chinese (Simplified)",
-    "tags": ["zh-CN", "zh"],
-    "production": true
+    "localName": "français",
+    "englishName": "French",
+    "tags": ["fr", "fr-FR"],
+    "production": true,
+    "helps": "fr"
   },
   {
     "localName": "Español",
@@ -25,33 +26,6 @@
     "tags": ["es", "es-ES"],
     "production": true,
     "helps": "es"
-  },
-  {
-    "localName": "العربية",
-    "englishName": "Arabic",
-    "tags": ["ar", "ar-SA"],
-    "direction": "rtl",
-    "production": true
-  },
-  {
-    "localName": "Русский",
-    "englishName": "Russian",
-    "tags": ["ru", "ru-RU"],
-    "production": true
-  },
-  {
-    "localName": "Português",
-    "englishName": "Portuguese",
-    "tags": ["pt-BR"],
-    "production": true,
-    "helps": "pt-br"
-  },
-  {
-    "localName": "français",
-    "englishName": "French",
-    "tags": ["fr", "fr-FR"],
-    "production": true,
-    "helps": "fr"
   },
   {
     "localName": "Bahasa Indonesia",
@@ -66,21 +40,47 @@
     "production": true
   },
   {
+    "localName": "Português",
+    "englishName": "Portuguese",
+    "tags": ["pt-BR"],
+    "production": true,
+    "helps": "pt-br"
+  },
+  {
+    "localName": "简体中文",
+    "englishName": "Chinese (Simplified)",
+    "tags": ["zh-CN", "zh"],
+    "production": true
+  },
+  {
+    "localName": "العربية",
+    "englishName": "Arabic",
+    "tags": ["ar", "ar-SA"],
+    "direction": "rtl",
+    "production": true
+  },
+  {
     "localName": "Azərbaycanca",
     "englishName": "Azerbaijani",
     "tags": ["az", "az-AZ"],
     "production": true
   },
   {
-    "localName": "ພາສາລາວ",
-    "englishName": "Lao",
-    "tags": ["lo", "lo-LA"],
-    "production": true
-  },
-  {
     "localName": "ꤊꤢ꤬ꤛꤢ꤭ꤜꤟꤤ꤬ (W. Kayah Li)",
     "englishName": "Western Kayah Li",
     "tags": ["kyu", "kyu-Kali"],
+    "production": true
+  },
+  {
+    "localName": "Русский",
+    "englishName": "Russian",
+    "tags": ["ru", "ru-RU"],
+    "production": true
+  },
+  {
+    "localName": "ພາສາລາວ",
+    "englishName": "Lao",
+    "tags": ["lo", "lo-LA"],
     "production": true
   },
   {


### PR DESCRIPTION
Previously I tried to sort locales by total number of speakers globally, but it's hard to find good consistent data, and even harder to add a new locale and figure out where it fits in the list.

Instead, I think it makes more sense to sort the locales by popularity, and we can update it from time to time.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2634)
<!-- Reviewable:end -->
