### PR TITLE
SF-2516 Remove project selector from connect project page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -11,16 +11,14 @@
     </div>
     <mat-card *ngSwitchCase="'connecting'" class="progress-container card-outline">
       <mat-card-content>
-        <div class="progress-label">{{ t("connecting_to_project", { projectName: connectProjectName }) }}</div>
+        <div class="progress-label">{{ t("connecting_to_project", { projectName: projectTitle }) }}</div>
         <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
       </mat-card-content>
     </mat-card>
-    <ng-container *ngIf="projects.length > 0">
-      <div class="project-title">
-        <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
-        {{ projectTitle }}
-      </div>
-    </ng-container>
+    <div class="project-title" *ngIf="state !== 'connecting'">
+      <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+      {{ projectTitle }}
+    </div>
     <form *ngSwitchDefault [formGroup]="connectProjectForm" (ngSubmit)="submit()">
       <mat-card id="settings-card" *ngIf="showSettings" class="card-outline" formGroupName="settings">
         <mat-card-title>{{ t("project_settings") }}</mat-card-title>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -1,106 +1,68 @@
 <ng-container *transloco="let t; read: 'connect_project'">
   <div class="title mat-headline-4">{{ t("connect_paratext_project") }}</div>
-  @if (!isAppOnline) {
-    <span class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
-  }
-  <div class="content">
-    @switch (state) {
-      @case ("login") {
-        <div class="paratext-login-container">
-          <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
-          <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
-            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-            {{ t("log_in_with_paratext") }}
-          </button>
-        </div>
-      }
-      @case ("connecting") {
-        <mat-card class="progress-container card-outline">
-          <mat-card-content>
-            <div class="progress-label">{{ t("connecting_to_project", { projectName: connectProjectName }) }}</div>
-            <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
-          </mat-card-content>
-        </mat-card>
-      }
-      @default {
-        <form [formGroup]="connectProjectForm" (ngSubmit)="submit()">
-          @if (projects.length > 0 || state === "offline") {
-            @if (hasNonAdministratorProject && !showSettings && isAppOnline) {
-              <p id="connect-non-admin-msg">
-                {{ t("only_paratext_admins_can_start") }}
-              </p>
-            }
-            <mat-form-field appearance="outline">
-              <mat-label>{{ t("paratext_project") }}</mat-label>
-              <mat-select #projectSelect id="project-select" disableOptionCentering formControlName="paratextId">
-                @for (project of projects; track project) {
-                  <mat-option [value]="project.paratextId" [disabled]="!project.isConnectable">
-                    {{ projectLabel(project) }}
-                    @if (!project.isConnectable && project.isConnected) {
-                      &nbsp;{{ t("already_connected") }}
-                    }
-                    @if (!project.isConnectable && !project.isConnected) {
-                      &nbsp;**
-                    }
-                  </mat-option>
-                }
-              </mat-select>
-            </mat-form-field>
-          } @else {
-            @if (state !== "loading") {
-              <p
-                id="no-projects-msg"
-                [innerHtml]="i18n.translateAndInsertTags('connect_project.no_connectable_projects')"
-              ></p>
-            }
-          }
-          @if (showSettings) {
-            <mat-card id="settings-card" class="card-outline" formGroupName="settings">
-              <mat-card-title>{{ t("project_settings") }}</mat-card-title>
-              <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
-              <mat-card-content class="card-content">
-                <p>{{ t("select_project_or_resource") }}</p>
-                <p>{{ t("translation_suggestions_require_source_text") }}</p>
-                <app-project-select
-                  formControlName="sourceParatextId"
-                  placeholder="{{ t('source_text_placeholder') }}"
-                  [projects]="projects"
-                  [resources]="resources"
-                  [hiddenParatextIds]="[paratextIdControl.value]"
-                ></app-project-select>
-                @if (showResourcesLoadingFailedMessage) {
-                  <mat-error>{{ t("error_fetching_resources") }}</mat-error>
-                }
-                @if (isBasedOnProjectSet) {
-                  <div fxLayout="row" fxLayoutAlign="start center">
-                    <div fxLayout="column" fxFlex="grow">
-                      <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                        {{ t("enable_translation_suggestions") }}
-                      </mat-checkbox>
-                      <p
-                        class="helper-text"
-                        [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                      ></p>
-                    </div>
-                  </div>
-                }
-              </mat-card-content>
-              <mat-divider></mat-divider>
-              <mat-card-content class="card-content">
-                <div>
-                  <mat-checkbox formControlName="checking" id="checking-checkbox">
-                    {{ t("enable_community_checking") }}
-                  </mat-checkbox>
-                </div>
-                <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
-              </mat-card-content>
-            </mat-card>
-          }
-          <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
-            {{ t("connect") }}
-          </button>
-        </form>
-      }
-    }
+  <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
+  <div class="content" [ngSwitch]="state">
+    <div *ngSwitchCase="'login'" class="paratext-login-container">
+      <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
+      <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
+        <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+        {{ t("log_in_with_paratext") }}
+      </button>
+    </div>
+    <mat-card *ngSwitchCase="'connecting'" class="progress-container card-outline">
+      <mat-card-content>
+        <div class="progress-label">{{ t("connecting_to_project", { projectName: connectProjectName }) }}</div>
+        <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
+      </mat-card-content>
+    </mat-card>
+    <ng-container *ngIf="projects.length > 0">
+      <div class="project-title">
+        <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+        {{ projectTitle }}
+      </div>
+    </ng-container>
+    <form *ngSwitchDefault [formGroup]="connectProjectForm" (ngSubmit)="submit()">
+      <mat-card id="settings-card" *ngIf="showSettings" class="card-outline" formGroupName="settings">
+        <mat-card-title>{{ t("project_settings") }}</mat-card-title>
+        <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
+        <mat-card-content class="card-content">
+          <p>{{ t("select_project_or_resource") }}</p>
+          <p>{{ t("translation_suggestions_require_source_text") }}</p>
+          <app-project-select
+            formControlName="sourceParatextId"
+            placeholder="{{ t('source_text_placeholder') }}"
+            [projects]="projects"
+            [resources]="resources"
+            [hiddenParatextIds]="[ptProjectId]"
+          ></app-project-select>
+          <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
+          <ng-container *ngIf="isBasedOnProjectSet">
+            <div fxLayout="row" fxLayoutAlign="start center">
+              <div fxLayout="column" fxFlex="grow">
+                <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
+                  {{ t("enable_translation_suggestions") }}
+                </mat-checkbox>
+                <p
+                  class="helper-text"
+                  [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
+                ></p>
+              </div>
+            </div>
+          </ng-container>
+        </mat-card-content>
+        <mat-divider></mat-divider>
+        <mat-card-content class="card-content">
+          <div>
+            <mat-checkbox formControlName="checking" id="checking-checkbox">
+              {{ t("enable_community_checking") }}
+            </mat-checkbox>
+          </div>
+          <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
+        </mat-card-content>
+      </mat-card>
+      <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
+        {{ t("connect") }}
+      </button>
+    </form>
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -32,6 +32,7 @@
             [projects]="projects"
             [resources]="resources"
             [hiddenParatextIds]="[ptProjectId]"
+            [isDisabled]="projects.length === 0"
           ></app-project-select>
           <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
           <ng-container *ngIf="isBasedOnProjectSet">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -1,67 +1,81 @@
 <ng-container *transloco="let t; read: 'connect_project'">
   <div class="title mat-headline-4">{{ t("connect_paratext_project") }}</div>
-  <span *ngIf="!isAppOnline" class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
-  <div class="content" [ngSwitch]="state">
-    <div *ngSwitchCase="'login'" class="paratext-login-container">
-      <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
-      <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
-        <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-        {{ t("log_in_with_paratext") }}
-      </button>
-    </div>
-    <mat-card *ngSwitchCase="'connecting'" class="progress-container card-outline">
-      <mat-card-content>
-        <div class="progress-label">{{ t("connecting_to_project", { projectName: projectTitle }) }}</div>
-        <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
-      </mat-card-content>
-    </mat-card>
-    <div class="project-title" *ngIf="state !== 'connecting'">
-      <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
-      {{ projectTitle }}
-    </div>
-    <form *ngSwitchDefault [formGroup]="connectProjectForm" (ngSubmit)="submit()">
-      <mat-card id="settings-card" *ngIf="showSettings" class="card-outline" formGroupName="settings">
-        <mat-card-title>{{ t("project_settings") }}</mat-card-title>
-        <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
-        <mat-card-content class="card-content">
-          <p>{{ t("select_project_or_resource") }}</p>
-          <p>{{ t("translation_suggestions_require_source_text") }}</p>
-          <app-project-select
-            formControlName="sourceParatextId"
-            placeholder="{{ t('source_text_placeholder') }}"
-            [projects]="projects"
-            [resources]="resources"
-            [hiddenParatextIds]="[ptProjectId]"
-            [isDisabled]="projects.length === 0"
-          ></app-project-select>
-          <mat-error *ngIf="showResourcesLoadingFailedMessage">{{ t("error_fetching_resources") }}</mat-error>
-          <ng-container *ngIf="isBasedOnProjectSet">
-            <div fxLayout="row" fxLayoutAlign="start center">
-              <div fxLayout="column" fxFlex="grow">
-                <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                  {{ t("enable_translation_suggestions") }}
-                </mat-checkbox>
-                <p
-                  class="helper-text"
-                  [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                ></p>
-              </div>
-            </div>
-          </ng-container>
-        </mat-card-content>
-        <mat-divider></mat-divider>
-        <mat-card-content class="card-content">
-          <div>
-            <mat-checkbox formControlName="checking" id="checking-checkbox">
-              {{ t("enable_community_checking") }}
-            </mat-checkbox>
-          </div>
-          <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
-        </mat-card-content>
-      </mat-card>
-      <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
-        {{ t("connect") }}
-      </button>
-    </form>
+  @if (!isAppOnline) {
+    <span class="offline-text"> {{ t("connect_network_to_connect_project") }} </span>
+  }
+  <div class="content">
+    @switch (state) {
+      @case ("login") {
+        <div class="paratext-login-container">
+          <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
+          <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
+            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
+            {{ t("log_in_with_paratext") }}
+          </button>
+        </div>
+      }
+      @case ("connecting") {
+        <mat-card class="progress-container card-outline">
+          <mat-card-content>
+            <div class="progress-label">{{ t("connecting_to_project", { projectName: projectTitle }) }}</div>
+            <app-sync-progress [projectDoc]="projectDoc" (inProgress)="updateStatus($event)"></app-sync-progress>
+          </mat-card-content>
+        </mat-card>
+      }
+      @default {
+        <div class="project-title">
+          <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
+          {{ projectTitle }}
+        </div>
+        <form [formGroup]="connectProjectForm" (ngSubmit)="submit()">
+          @if (showSettings) {
+            <mat-card id="settings-card" class="card-outline" formGroupName="settings">
+              <mat-card-title>{{ t("project_settings") }}</mat-card-title>
+              <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
+              <mat-card-content class="card-content">
+                <p>{{ t("select_project_or_resource") }}</p>
+                <p>{{ t("translation_suggestions_require_source_text") }}</p>
+                <app-project-select
+                  formControlName="sourceParatextId"
+                  placeholder="{{ t('source_text_placeholder') }}"
+                  [projects]="projects"
+                  [resources]="resources"
+                  [hiddenParatextIds]="[ptProjectId]"
+                  [isDisabled]="projects.length === 0"
+                ></app-project-select>
+                @if (showResourcesLoadingFailedMessage) {
+                  <mat-error>{{ t("error_fetching_resources") }}</mat-error>
+                }
+                @if (isBasedOnProjectSet) {
+                  <div fxLayout="row" fxLayoutAlign="start center">
+                    <div fxLayout="column" fxFlex="grow">
+                      <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
+                        {{ t("enable_translation_suggestions") }}
+                      </mat-checkbox>
+                      <p
+                        class="helper-text"
+                        [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
+                      ></p>
+                    </div>
+                  </div>
+                }
+              </mat-card-content>
+              <mat-divider></mat-divider>
+              <mat-card-content class="card-content">
+                <div>
+                  <mat-checkbox formControlName="checking" id="checking-checkbox">
+                    {{ t("enable_community_checking") }}
+                  </mat-checkbox>
+                </div>
+                <p class="helper-text">{{ t("engage_the_wider_community_to_check_scripture") }}</p>
+              </mat-card-content>
+            </mat-card>
+          }
+          <button mat-flat-button type="submit" id="connect-submit-button" [disabled]="submitDisabled">
+            {{ t("connect") }}
+          </button>
+        </form>
+      }
+    }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -10,6 +10,20 @@
   margin-bottom: 32px;
 }
 
+.project-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  column-gap: 8px;
+  color: $pt-button-green;
+  font-size: 26px;
+
+  img {
+    width: 40px;
+    height: 40px;
+  }
+}
+
 .offline-text {
   padding-bottom: 16px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -50,7 +50,7 @@ const mockedNoticeService = mock(NoticeService);
 const mockedI18nService = mock(I18nService);
 const mockedErrorHandler = mock(ErrorHandler);
 
-fdescribe('ConnectProjectComponent', () => {
+describe('ConnectProjectComponent', () => {
   configureTestingModule(() => ({
     imports: [
       HttpClientTestingModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -123,13 +123,15 @@ describe('ConnectProjectComponent', () => {
     verify(mockedRouter.navigate(deepEqual(['/projects']))).once();
   }));
 
-  it('should display loading when getting PT projects', fakeAsync(() => {
+  it('page is instantly available without waiting for projects', fakeAsync(() => {
     const env = new TestEnvironment();
-    env.setupProjectsResources([], []);
+    env.setupProjectsResources(env.paratextProjects, []);
     env.fixture.detectChanges();
 
-    expect(env.component.state).toEqual('loading');
+    expect(env.component.state).toEqual('input');
     verify(mockedNoticeService.loadingStarted()).once();
+    expect(env.component.showSettings).toBe(true);
+    expect(env.component.projects.length).toEqual(0);
     expect(env.submitButton.nativeElement.disabled).toBe(true);
 
     tick();
@@ -137,6 +139,8 @@ describe('ConnectProjectComponent', () => {
 
     expect(env.component.state).toEqual('input');
     expect(env.connectProjectForm).not.toBeNull();
+    expect(env.component.projects.length).toEqual(env.paratextProjects.length);
+    expect(env.submitButton.nativeElement.disabled).toBe(false);
     verify(mockedNoticeService.loadingFinished()).once();
   }));
 
@@ -317,7 +321,7 @@ describe('ConnectProjectComponent', () => {
 
     verify(mockedParatextService.getProjects()).once();
     verify(mockedAuthService.requestParatextCredentialUpdate(anything())).once();
-    expect(env.component.state).toEqual('loading');
+    expect(env.component.state).toEqual('input');
   }));
 });
 
@@ -328,8 +332,7 @@ class TestEnvironment {
     OnlineStatusService
   ) as TestOnlineStatusService;
 
-  private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
-  private paratextProjects: ParatextProject[] = [
+  paratextProjects: ParatextProject[] = [
     {
       paratextId: 'pt01',
       name: 'English',
@@ -375,6 +378,7 @@ class TestEnvironment {
     },
     { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895', shortName: 'RVA' }
   ];
+  private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor(params: TestEnvironmentParams = {}) {
     when(mockedSFProjectService.onlineCreate(anything())).thenCall((settings: SFProjectCreateSettings) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -47,7 +47,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
   });
   resources?: SelectableProject[];
   showResourcesLoadingFailedMessage = false;
-  state: 'connecting' | 'loading' | 'input' | 'login' | 'offline' = 'loading';
+  state: 'connecting' | 'input' | 'login' | 'offline' = 'input';
   projectDoc?: SFProjectDoc;
 
   projectLabel = projectLabel;
@@ -87,14 +87,11 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
   }
 
   get showSettings(): boolean {
-    if (this.state !== 'input' || this.projectsFromParatext == null) {
-      return false;
-    }
-    return this.projectToConnect != null;
+    return this.state === 'input' && this.projectMetadata?.projectId == null;
   }
 
   get submitDisabled(): boolean {
-    return this.state !== 'input' || !this.isAppOnline;
+    return (this.projectsFromParatext == null && this.projectMetadata?.projectId == null) || !this.isAppOnline;
   }
 
   get isBasedOnProjectSet(): boolean {
@@ -122,12 +119,8 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
     return `${this.projectMetadata.shortName} - ${this.projectMetadata.name}`;
   }
 
-  private get projectToConnect(): ParatextProject | undefined {
-    return this.projectsFromParatext?.find(p => p.paratextId === this.ptProjectId);
-  }
-
   ngOnInit(): void {
-    this.state = 'loading';
+    this.state = 'input';
     if (this.ptProjectId === '') {
       this.router.navigate(['/projects']);
     }
@@ -206,7 +199,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
   }
 
   private async populateProjectList(): Promise<void> {
-    this.state = 'loading';
+    this.state = 'input';
     this.loadingStarted();
 
     try {
@@ -217,7 +210,6 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
         this.state = 'login';
       } else {
         this.projectsFromParatext = projects.sort(compareProjectsForSorting);
-        this.state = 'input';
         if (this.projectMetadata?.projectId == null) {
           // do not wait for resources to load
           this.fetchResources();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -74,7 +74,7 @@
         problemGettingPTProjects ||
         (isOnline | async) === false
       ) {
-        <h2 id="header-unconnected-projects">
+        <h2 id="header-not-connected-projects">
           {{
             loadingPTProjects
               ? t("loading_more_pt_projects")
@@ -84,68 +84,68 @@
           }}
         </h2>
       }
-      <app-notice
-        id="message-trouble-getting-pt-project-list"
-        icon="error"
-        type="error"
-        *ngIf="problemGettingPTProjects"
-      >
-        {{ t(errorMessage) }}
-      </app-notice>
-
-      <mat-card
-        *ngFor="let ptProject of userUnconnectedParatextProjects"
-        attr.data-pt-project-id="{{ ptProject.paratextId }}"
-        data-project-type="user-unconnected-project"
-        [class.cannot-connect]="!ptProject.isConnectable"
-      >
-        <span class="project-name">
-          <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
-        </span>
-        <span *ngIf="!ptProject.isConnectable" class="project-description">
-          {{ t("not_admin_cannot_connect_project") }}
-        </span>
-        <a
-          *ngIf="ptProject.isConnectable && ptProject.projectId == null"
-          appRouterLink="/connect-project"
-          [state]="{
-            paratextId: ptProject.paratextId,
-            name: ptProject.name,
-            shortName: ptProject.shortName
-          }"
-          mat-flat-button
-          color="primary"
+      @if (problemGettingPTProjects) {
+        <app-notice id="message-trouble-getting-pt-project-list" icon="error" type="error">
+          {{ t(errorMessage) }}
+        </app-notice>
+      }
+      @for (ptProject of userUnconnectedParatextProjects; track ptProject) {
+        <mat-card
+          attr.data-pt-project-id="{{ ptProject.paratextId }}"
+          data-project-type="user-unconnected-project"
+          [class.cannot-connect]="!ptProject.isConnectable"
         >
-          {{ "connect_project.connect" | transloco }}
-        </a>
-        <button
-          *ngIf="ptProject.isConnectable && ptProject.projectId != null"
-          mat-flat-button
-          color="primary"
-          (click)="joinProject(ptProject.projectId)"
-          [disabled]="joinDisabledProjects.includes(ptProject.projectId)"
-        >
-          {{ t("join") }}
-        </button>
-      </mat-card>
-      <mat-card id="pt-loading-card" *ngIf="loadingPTProjects" class="loading-card">
-        <div class="loading-project-name"></div>
-        <div class="loading-project-description"></div>
-        <div class="loading-action"></div>
-      </mat-card>
-      <mat-card class="loading-card" *ngIf="loadingPTProjects">
-        <div class="loading-project-name"></div>
-        <div class="loading-project-description"></div>
-        <div class="loading-action"></div>
-      </mat-card>
-      <app-notice
-        id="message-offline"
-        icon="cloud_off"
-        [type]="userHasProjects ? 'info' : 'error'"
-        *ngIf="(isOnline | async) === false"
-      >
-        {{ t("offline") }}
-      </app-notice>
+          <span class="project-name">
+            <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
+          </span>
+          @if (!ptProject.isConnectable) {
+            <span class="project-description">
+              {{ t("not_admin_cannot_connect_project") }}
+            </span>
+          }
+          @if (ptProject.isConnectable && ptProject.projectId == null) {
+            <a
+              appRouterLink="/connect-project"
+              [state]="{
+                paratextId: ptProject.paratextId,
+                name: ptProject.name,
+                shortName: ptProject.shortName
+              }"
+              mat-flat-button
+              color="primary"
+            >
+              {{ "connect_project.connect" | transloco }}
+            </a>
+          }
+          @if (ptProject.isConnectable && ptProject.projectId != null) {
+            <button
+              mat-flat-button
+              color="primary"
+              (click)="joinProject(ptProject.projectId)"
+              [disabled]="joiningProjects.includes(ptProject.projectId)"
+            >
+              {{ t("join") }}
+            </button>
+          }
+        </mat-card>
+      }
+      @if (loadingPTProjects) {
+        <mat-card id="pt-loading-card" class="loading-card">
+          <div class="loading-project-name"></div>
+          <div class="loading-project-description"></div>
+          <div class="loading-action"></div>
+        </mat-card>
+        <mat-card class="loading-card">
+          <div class="loading-project-name"></div>
+          <div class="loading-project-description"></div>
+          <div class="loading-action"></div>
+        </mat-card>
+      }
+      @if ((isOnline | async) === false) {
+        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
+          {{ t("offline") }}
+        </app-notice>
+      }
     </div>
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -106,7 +106,12 @@
           @if (ptProject.isConnectable) {
             <a
               appRouterLink="/connect-project"
-              [state]="{ ptProjectId: ptProject.paratextId }"
+              [state]="{
+                ptProjectId: ptProject.paratextId,
+                projectId: ptProject.projectId,
+                name: ptProject.name,
+                shortName: ptProject.shortName
+              }"
               mat-flat-button
               color="primary"
             >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -74,7 +74,7 @@
         problemGettingPTProjects ||
         (isOnline | async) === false
       ) {
-        <h2 id="header-not-connected-projects">
+        <h2 id="header-unconnected-projects">
           {{
             loadingPTProjects
               ? t("loading_more_pt_projects")
@@ -84,63 +84,68 @@
           }}
         </h2>
       }
-      @if (problemGettingPTProjects) {
-        <app-notice id="message-trouble-getting-pt-project-list" icon="error" type="error">
-          {{ t(errorMessage) }}
-        </app-notice>
-      }
-      @for (ptProject of userUnconnectedParatextProjects; track ptProject) {
-        <mat-card
-          attr.data-pt-project-id="{{ ptProject.paratextId }}"
-          data-project-type="user-unconnected-project"
-          [class.cannot-connect]="!ptProject.isConnectable"
+      <app-notice
+        id="message-trouble-getting-pt-project-list"
+        icon="error"
+        type="error"
+        *ngIf="problemGettingPTProjects"
+      >
+        {{ t(errorMessage) }}
+      </app-notice>
+
+      <mat-card
+        *ngFor="let ptProject of userUnconnectedParatextProjects"
+        attr.data-pt-project-id="{{ ptProject.paratextId }}"
+        data-project-type="user-unconnected-project"
+        [class.cannot-connect]="!ptProject.isConnectable"
+      >
+        <span class="project-name">
+          <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
+        </span>
+        <span *ngIf="!ptProject.isConnectable" class="project-description">
+          {{ t("not_admin_cannot_connect_project") }}
+        </span>
+        <a
+          *ngIf="ptProject.isConnectable && ptProject.projectId == null"
+          appRouterLink="/connect-project"
+          [state]="{
+            paratextId: ptProject.paratextId,
+            name: ptProject.name,
+            shortName: ptProject.shortName
+          }"
+          mat-flat-button
+          color="primary"
         >
-          <span class="project-name">
-            <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
-          </span>
-          @if (!ptProject.isConnectable) {
-            <span class="project-description">
-              {{ t("not_admin_cannot_connect_project") }}
-            </span>
-          }
-          @if (ptProject.isConnectable) {
-            <a
-              appRouterLink="/connect-project"
-              [state]="{
-                ptProjectId: ptProject.paratextId,
-                projectId: ptProject.projectId,
-                name: ptProject.name,
-                shortName: ptProject.shortName
-              }"
-              mat-flat-button
-              color="primary"
-            >
-              {{
-                paratextService.isParatextProjectInSF(ptProject) ? t("join") : ("connect_project.connect" | transloco)
-              }}
-            </a>
-          }
-        </mat-card>
-      }
-      @if (loadingPTProjects) {
-        <mat-card id="pt-loading-card" class="loading-card">
-          <div class="loading-project-name"></div>
-          <div class="loading-project-description"></div>
-          <div class="loading-action"></div>
-        </mat-card>
-      }
-      @if (loadingPTProjects) {
-        <mat-card class="loading-card">
-          <div class="loading-project-name"></div>
-          <div class="loading-project-description"></div>
-          <div class="loading-action"></div>
-        </mat-card>
-      }
-      @if ((isOnline | async) === false) {
-        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
-          {{ t("offline") }}
-        </app-notice>
-      }
+          {{ "connect_project.connect" | transloco }}
+        </a>
+        <button
+          *ngIf="ptProject.isConnectable && ptProject.projectId != null"
+          mat-flat-button
+          color="primary"
+          (click)="joinProject(ptProject.projectId)"
+          [disabled]="joinDisabledProjects.includes(ptProject.projectId)"
+        >
+          {{ t("join") }}
+        </button>
+      </mat-card>
+      <mat-card id="pt-loading-card" *ngIf="loadingPTProjects" class="loading-card">
+        <div class="loading-project-name"></div>
+        <div class="loading-project-description"></div>
+        <div class="loading-action"></div>
+      </mat-card>
+      <mat-card class="loading-card" *ngIf="loadingPTProjects">
+        <div class="loading-project-name"></div>
+        <div class="loading-project-description"></div>
+        <div class="loading-action"></div>
+      </mat-card>
+      <app-notice
+        id="message-offline"
+        icon="cloud_off"
+        [type]="userHasProjects ? 'info' : 'error'"
+        *ngIf="(isOnline | async) === false"
+      >
+        {{ t("offline") }}
+      </app-notice>
     </div>
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -85,7 +85,7 @@ describe('MyProjectsComponent', () => {
     expect(env.router.lastSuccessfulNavigation?.extras.state?.shortName).toEqual('NCAA');
   }));
 
-  it('click Join, passes PT project id and SF project id', fakeAsync(() => {
+  it('click Join, user added to the project', fakeAsync(() => {
     const env = new TestEnvironment();
     env.waitUntilLoaded();
 
@@ -93,6 +93,7 @@ describe('MyProjectsComponent', () => {
     verify(mockedNoticeService.loadingStarted()).once();
     verify(mockedSFProjectService.onlineAddCurrentUser('sf-cbntt')).once();
     expect(env.joinButtonForProject('pt-connButNotThisUser').nativeElement.disabled).toBe(true);
+    expect(env.component.joiningProjects).toEqual(['sf-cbntt']);
     // Navigates to the connect project component.
     expect(env.router.url).toEqual('/projects/sf-cbntt');
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -75,6 +75,23 @@ describe('MyProjectsComponent', () => {
     expect(env.router.url).toEqual('/connect-project');
     // Passes PT project id to connect project component.
     expect(env.router.lastSuccessfulNavigation?.extras.state?.ptProjectId).toEqual('pt-notConnToSF');
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.projectId).toBeUndefined();
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.name).toEqual('Not connected at all to SF');
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.shortName).toEqual('NCAA');
+  }));
+
+  it('click Join, passes PT project id and SF project id', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.waitUntilLoaded();
+
+    env.click(env.goButtonForProject('pt-connButNotThisUser'));
+    // Navigates to the connect project component.
+    expect(env.router.url).toEqual('/connect-project');
+    // Passes PT project id to connect project component.
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.ptProjectId).toEqual('pt-connButNotThisUser');
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.projectId).toEqual('sf-cbntt');
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.name).toEqual('Connected but not to this SF user');
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.shortName).toEqual('CBNTT');
   }));
 
   it('lists my connected projects', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -9,8 +9,9 @@ import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { of } from 'rxjs';
-import { mock, objectContaining, verify, when } from 'ts-mockito';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { UserDoc } from 'xforge-common/models/user-doc';
+import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
@@ -21,15 +22,18 @@ import { UserService } from 'xforge-common/user.service';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { ParatextService } from '../core/paratext.service';
+import { SFProjectService } from '../core/sf-project.service';
 import { SharedModule } from '../shared/shared.module';
 import { MyProjectsComponent } from './my-projects.component';
 
 @Component({ template: '' })
 class EmptyComponent {}
 
+const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedUserProjectsService = mock(SFUserProjectsService);
 const mockedParatextService = mock(ParatextService);
+const mockedNoticeService = mock(NoticeService);
 
 describe('MyProjectsComponent', () => {
   configureTestingModule(() => ({
@@ -47,10 +51,12 @@ describe('MyProjectsComponent', () => {
     ],
     providers: [
       provideAnimations(),
+      { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService },
       { provide: ParatextService, useMock: mockedParatextService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: SFUserProjectsService, useMock: mockedUserProjectsService }
+      { provide: SFUserProjectsService, useMock: mockedUserProjectsService },
+      { provide: NoticeService, useMock: mockedNoticeService }
     ]
   }));
 
@@ -74,8 +80,7 @@ describe('MyProjectsComponent', () => {
     // Navigates to the connect project component.
     expect(env.router.url).toEqual('/connect-project');
     // Passes PT project id to connect project component.
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.ptProjectId).toEqual('pt-notConnToSF');
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.projectId).toBeUndefined();
+    expect(env.router.lastSuccessfulNavigation?.extras.state?.paratextId).toEqual('pt-notConnToSF');
     expect(env.router.lastSuccessfulNavigation?.extras.state?.name).toEqual('Not connected at all to SF');
     expect(env.router.lastSuccessfulNavigation?.extras.state?.shortName).toEqual('NCAA');
   }));
@@ -84,14 +89,12 @@ describe('MyProjectsComponent', () => {
     const env = new TestEnvironment();
     env.waitUntilLoaded();
 
-    env.click(env.goButtonForProject('pt-connButNotThisUser'));
+    env.click(env.joinButtonForProject('pt-connButNotThisUser'));
+    verify(mockedNoticeService.loadingStarted()).once();
+    verify(mockedSFProjectService.onlineAddCurrentUser('sf-cbntt')).once();
+    expect(env.joinButtonForProject('pt-connButNotThisUser').nativeElement.disabled).toBe(true);
     // Navigates to the connect project component.
-    expect(env.router.url).toEqual('/connect-project');
-    // Passes PT project id to connect project component.
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.ptProjectId).toEqual('pt-connButNotThisUser');
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.projectId).toEqual('sf-cbntt');
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.name).toEqual('Connected but not to this SF user');
-    expect(env.router.lastSuccessfulNavigation?.extras.state?.shortName).toEqual('CBNTT');
+    expect(env.router.url).toEqual('/projects/sf-cbntt');
   }));
 
   it('lists my connected projects', fakeAsync(() => {
@@ -151,7 +154,8 @@ describe('MyProjectsComponent', () => {
     const env = new TestEnvironment();
     env.waitUntilLoaded();
 
-    expect(env.goButtonForProject('pt-connButNotThisUser').nativeElement.textContent).toContain('Join');
+    expect(env.joinButtonForProject('pt-connButNotThisUser')).not.toBeNull();
+    expect(env.goButtonForProject('pt-connButNotThisUser')).toBeNull();
   }));
 
   it('a project that is not on SF shows Connect button', fakeAsync(() => {
@@ -497,16 +501,6 @@ class TestEnvironment {
         }
       ] as ParatextProject[];
 
-      when(mockedParatextService.isParatextProjectInSF(objectContaining({ paratextId: 'pt-notConnToSF' }))).thenReturn(
-        false
-      );
-      when(
-        mockedParatextService.isParatextProjectInSF(objectContaining({ paratextId: 'pt-connButNotThisUser' }))
-      ).thenReturn(true);
-      when(
-        mockedParatextService.isParatextProjectInSF(objectContaining({ paratextId: 'pt-notConnToSFAndUserIsTran' }))
-      ).thenReturn(false);
-
       this.projectProfileDocs.forEach((projectProfileDoc: SFProjectProfileDoc) => {
         this.userParatextProjects.push({
           projectId: projectProfileDoc.id,
@@ -516,17 +510,12 @@ class TestEnvironment {
           isConnectable: true,
           isConnected: true
         } as ParatextProject);
-
-        when(
-          mockedParatextService.isParatextProjectInSF(
-            objectContaining({ paratextId: projectProfileDoc.data!.paratextId })
-          )
-        ).thenReturn(true);
       });
     }
 
     when(mockedParatextService.getProjects()).thenResolve(this.userParatextProjects);
     when(mockedUserProjectsService.projectDocs$).thenReturn(of(this.projectProfileDocs));
+    when(mockedSFProjectService.onlineAddCurrentUser(anything())).thenResolve();
 
     const user: User = createTestUser({
       paratextId: isKnownPTUser ? 'pt-user-id' : undefined,
@@ -591,6 +580,10 @@ class TestEnvironment {
   /** Main button on card, like Open, Connect, or Join. */
   goButtonForProject(ptProjectId: string): DebugElement {
     return this.getElement(`mat-card[data-pt-project-id=${ptProjectId}] > a`);
+  }
+
+  joinButtonForProject(ptProjectId: string): DebugElement {
+    return this.getElement(`mat-card[data-pt-project-id=${ptProjectId}] > button`);
   }
 
   cardForUserConnectedProject(ptProjectId: string): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -38,7 +38,7 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
   loadingPTProjects: boolean = false;
   initialLoadingSFProjects: boolean = true;
   userIsPTUser: boolean = false;
-  joinDisabledProjects: string[] = [];
+  joiningProjects: string[] = [];
 
   constructor(
     private readonly projectService: SFProjectService,
@@ -68,7 +68,9 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
   async ngOnInit(): Promise<void> {
     this.subscribe(this.userProjectsService.projectDocs$, (projects?: SFProjectProfileDoc[]) => {
       if (projects == null) return;
-      this.userConnectedProjects = projects.filter(project => project.data != null && !isResource(project.data));
+      this.userConnectedProjects = projects.filter(
+        project => project.data != null && !isResource(project.data) && !this.joiningProjects.includes(project.id)
+      );
       this.userConnectedResources = projects.filter(project => project.data != null && isResource(project.data));
       this.initialLoadingSFProjects = false;
     });
@@ -91,7 +93,7 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
 
   async joinProject(projectId: string): Promise<void> {
     this.noticeService.loadingStarted();
-    this.joinDisabledProjects.push(projectId);
+    this.joiningProjects.push(projectId);
     await this.projectService.onlineAddCurrentUser(projectId);
     this.noticeService.loadingFinished();
     this.router.navigate(['projects', projectId]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.stories.ts
@@ -10,6 +10,7 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { delay, of } from 'rxjs';
 import { instance, mock, objectContaining, when } from 'ts-mockito';
 import { UserDoc } from 'xforge-common/models/user-doc';
+import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
@@ -19,6 +20,7 @@ import { UserService } from 'xforge-common/user.service';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { ParatextService } from '../core/paratext.service';
+import { SFProjectService } from '../core/sf-project.service';
 import { SharedModule } from '../shared/shared.module';
 import { MyProjectsComponent } from './my-projects.component';
 
@@ -27,9 +29,11 @@ class EmptyComponent {}
 
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedUserService = mock(UserService);
+const mockedSFProjectService = mock(SFProjectService);
 const mockedUserProjectsService = mock(SFUserProjectsService);
 const mockedParatextService = mock(ParatextService);
 const mockedOnlineStatusService = mock(OnlineStatusService);
+const mockedNoticeService = mock(NoticeService);
 
 interface ProjectScenario {
   code: string;
@@ -184,11 +188,13 @@ const meta: Meta = {
       declarations: [MyProjectsComponent],
       providers: [
         provideAnimations(),
+        { provide: SFProjectService, useValue: instance(mockedSFProjectService) },
         { provide: ActivatedRoute, useValue: instance(mockedActivatedRoute) },
         { provide: UserService, useValue: instance(mockedUserService) },
         { provide: ParatextService, useValue: instance(mockedParatextService) },
         { provide: OnlineStatusService, useValue: instance(mockedOnlineStatusService) },
-        { provide: SFUserProjectsService, useValue: instance(mockedUserProjectsService) }
+        { provide: SFUserProjectsService, useValue: instance(mockedUserProjectsService) },
+        { provide: NoticeService, useValue: instance(mockedNoticeService) }
       ]
     }),
     (story, context) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -96,7 +96,6 @@
     "share_with_others": "Share with others"
   },
   "connect_project": {
-    "already_connected": "(already connected)",
     "connect_network_to_connect_project": "Please connect to the internet to enable connecting to a project",
     "connect_paratext_project": "Connect Paratext Project",
     "connect": "Connect",
@@ -106,10 +105,7 @@
     "engage_the_wider_community_to_check_scripture": "Engage the wider community to ensure that the translation is clear, accurate, and natural. Select verses, ask targeted questions, allow discussion of answers.",
     "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
     "log_in_with_paratext": "Log in with Paratext",
-    "no_connectable_projects": "Looks like there are no connectable projects for you.{{ newLine }}Please go to Paratext to register a project to connect to.",
-    "only_paratext_admins_can_start": "** You must be the Paratext Administrator of a project to start it here. Ask your Administrator to connect to your project then you can also connect to it here after that.",
     "paratext_account_linked_to_another_user": "You have logged into a Paratext account that is already linked to a user with the email {{ email }}. You will be logged out of your current account and proceed as the Paratext user.",
-    "paratext_project": "Paratext Project",
     "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
     "proceed": "Proceed",
     "project_settings": "Project Settings",


### PR DESCRIPTION
This change removes the project selector from the connect project page since it is no longer expected that users will be updating which project they intend to connect to.
![Connect project connect](https://github.com/user-attachments/assets/886621bb-9345-47bb-91b3-d38713eb1c0a)
![Connect project join](https://github.com/user-attachments/assets/4551df9c-e015-430d-bdeb-54599fc21181)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2635)
<!-- Reviewable:end -->
