### PR TITLE
hotfix: SF-2884 Fix sync problem when a note has no content

### DIFF
--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -27,7 +27,7 @@ public class Note : Comment
     /// Content of note. Contains XML. Corresponds to `Contents` element, which is not always present in the
     /// Notes XML file.
     /// </summary>
-    public string Content { get; set; }
+    public string? Content { get; set; }
 
     /// <summary>
     /// Change difference accepted from a conflict, if any. Contains encoded XML. Not always present, in

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2869,7 +2869,8 @@ public class ParatextService : DisposableBase, IParatextService
         out string xml
     )
     {
-        string equivalentCommentContent = GetCommentContentsFromNote(note, displayNames, ptProjectUsers);
+        string equivalentCommentContent =
+            GetCommentContentsFromNote(note, displayNames, ptProjectUsers) ?? string.Empty;
         string contents = comment.Contents?.InnerXml ?? string.Empty;
         string updatedContent = GetUpdatedContentIfChanged(contents, equivalentCommentContent);
         if (updatedContent is not null)
@@ -2885,12 +2886,14 @@ public class ParatextService : DisposableBase, IParatextService
     /// Convert the note content to its comment equivalent. The primary use case
     /// is to add the SF user label to the content.
     /// </summary>
-    private string GetCommentContentsFromNote(
+    private string? GetCommentContentsFromNote(
         Note note,
         IReadOnlyDictionary<string, string> displayNames,
         Dictionary<string, ParatextUserProfile> ptProjectUsers
     )
     {
+        if (note.Content == null)
+            return null;
         string ownerId = note.OwnerRef;
         // if the user is a paratext user, keep the note content as is
         if (


### PR DESCRIPTION
This is the hotfix for #2626

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2636)
<!-- Reviewable:end -->
