### PR TITLE
SF-2892 Fix error when Serval admin enables drafting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -280,6 +280,15 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       this.permissionsChangedSub?.unsubscribe();
       this.permissionsChangedSub = this._selectedProjectDoc.remoteChanges$.subscribe(() => {
         if (this._selectedProjectDoc?.data != null && this.currentUserDoc != null) {
+          // If the user is in the Serval administration page, do not check access,
+          // as they will be modifying the project's properties
+          if (
+            this.locationService.pathname.includes('serval-administration') &&
+            this.currentUser?.roles.includes(SystemRole.ServalAdmin)
+          ) {
+            return;
+          }
+          // See if the user was removed from the project
           if (!(this.currentUserDoc.id in this._selectedProjectDoc.data.userRoles)) {
             // The user has been removed from the project
             this.showProjectDeletedDialog();


### PR DESCRIPTION
This PR fixes the "The project has been deleted or is no longer accessible." dialog appearing when a serval admin enables or disables pre-translation drafting for a project that the user does not have access to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2637)
<!-- Reviewable:end -->
