### PR TITLE
SF-2877 Show correct date format for history tab

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -124,6 +124,7 @@ import {
   canInsertNote,
   formatFontSizeToRems,
   getVerseRefFromSegmentRef,
+  RIGHT_TO_LEFT_MARK,
   threadIdFromMouseEvent,
   VERSE_REGEX,
   verseRefFromMouseEvent,
@@ -1158,8 +1159,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onHistoryTabRevisionSelect(tab: EditorTabInfo, revision: Revision | undefined): void {
     if (revision != null) {
-      tab.headerText = `${this.targetLabel} - ${this.editorHistoryService.formatTimestamp(revision.timestamp)}`;
-      tab.tooltip = `${this.projectDoc?.data?.name} - ${this.editorHistoryService.formatTimestamp(
+      const separator: string = this.i18n.isRtl ? `${RIGHT_TO_LEFT_MARK} - ` : ' - ';
+      tab.headerText = `${this.targetLabel}${separator}${this.editorHistoryService.formatTimestamp(revision.timestamp)}`;
+      tab.tooltip = `${this.projectDoc?.data?.name}${separator}${this.editorHistoryService.formatTimestamp(
         revision.timestamp,
         true
       )}`;


### PR DESCRIPTION
This PR fixes the date format when an a project has a short name that contains the numbers 1-12, and the UI language is set to Arabic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2639)
<!-- Reviewable:end -->
