### PR TITLE
SF-2858 Fix position of unread count icon in RTL

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -16,14 +16,9 @@
         <div class="question-meta">
           <span class="question-verse">{{ questionVerseRef(questionDoc) }}</span>
           <a *ngIf="getUnreadAnswers(questionDoc) > 0" class="view-answers" title="{{ t('view_answers') }}">
-            <mat-icon
-              aria-hidden="false"
-              class="mirror-rtl"
-              [matBadge]="getUnreadAnswers(questionDoc)"
-              matBadgePosition="before"
-              matBadgeSize="small"
-              >forum</mat-icon
-            >
+            <div [matBadge]="getUnreadAnswers(questionDoc)" matBadgePosition="before" matBadgeSize="small">
+              <mat-icon aria-hidden="false" class="mirror-rtl">forum</mat-icon>
+            </div>
           </a>
         </div>
       </div>


### PR DESCRIPTION
* Moved the unread answers badge out of the icon container which was being mirrored in RTL

**Before**
![image](https://github.com/user-attachments/assets/215eab79-7400-4ea0-8069-359ba102f000)


**After**
![image](https://github.com/user-attachments/assets/01767e08-3e3e-4b7f-98d5-4e01570593ff)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2646)
<!-- Reviewable:end -->
