### PR TITLE
SF-2867 Allow moving backwards via verse with SF note using left arrow

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1043,7 +1043,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (this.editor == null || this.segment == null) {
       return false;
     }
-    const selection = this.editor.getSelection();
+    const selection: RangeStatic | null = this.editor.getSelection();
     if (selection == null) {
       return false;
     }
@@ -1053,8 +1053,12 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return true;
     }
 
+    // Strip embeds from the segment range so we can get can an accurate index and length
+    const segmentRange: RangeStatic =
+      this.conformToValidSelectionForCurrentSegment(this.segment.range) ?? this.segment.range;
+
     const selectionEndIndex = selection.index + (end ? selection.length : 0);
-    const segmentEndIndex = this.segment.range.index + (end ? this.segment.range.length : 0);
+    const segmentEndIndex = segmentRange.index + (end ? segmentRange.length : 0);
     return selectionEndIndex === segmentEndIndex;
   }
 


### PR DESCRIPTION
This PR fixes moving to the previous verse with the arrow key, when the current verse has notes at the start of it (usually SF created notes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2653)
<!-- Reviewable:end -->
