### PR TITLE
Improve layout of notice on feature flag dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -71,8 +71,8 @@
             mat-menu-item
             (click)="openFeatureFlagDialog()"
           >
-            <mat-icon>flag</mat-icon>
-            Feature flags
+            <mat-icon>science</mat-icon>
+            Developer settings
           </button>
           <mat-divider></mat-divider>
           <div

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flags-dialog.component.scss
@@ -10,6 +10,7 @@
 }
 
 app-notice {
-  max-width: 25em;
+  width: 25em;
+  min-width: 100%;
   margin: 1em 0;
 }


### PR DESCRIPTION
The weirdness of this layout has been bugging me:

Before | After
-------|------
![](https://github.com/user-attachments/assets/b4c1abd8-f88c-4e07-8775-83c0e3137eb8) | ![](https://github.com/user-attachments/assets/f0ac9890-6272-44a0-90d6-39df8ffe824d)

The wording and the icon has not been consistent with the dialog:

Before | After
-------|------
![](https://github.com/user-attachments/assets/cc1aaa26-09b6-46c3-b138-205e6cf854c6) | ![](https://github.com/user-attachments/assets/12c59de0-1bab-41e0-8282-568ade4cce56)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2654)
<!-- Reviewable:end -->
