### PR TITLE
SF-2866 Update the avatar icon after the user's name changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, DoCheck, Input, OnChanges } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
 
@@ -11,7 +11,7 @@ type AvatarMode = 'image' | 'initials' | 'user_icon';
   standalone: true,
   imports: [MatIconModule]
 })
-export class AvatarComponent implements OnChanges {
+export class AvatarComponent implements DoCheck, OnChanges {
   @Input() size: number = 32;
   @Input() user?: UserProfile;
   @Input() borderColor: string = 'transparent';
@@ -22,6 +22,12 @@ export class AvatarComponent implements OnChanges {
   initials?: string;
   mode: AvatarMode = 'user_icon';
   imageLoadFailed: boolean = false;
+
+  ngDoCheck(): void {
+    if (this.name !== this.user?.displayName || this.avatarUrl !== this.user?.avatarUrl) {
+      this.ngOnChanges();
+    }
+  }
 
   ngOnChanges(): void {
     this.name = this.user?.displayName;


### PR DESCRIPTION
This PR ensures that the user's icon is updated if their name changes, and their icon is set to be their initials.

This was not taking place previously, because when the user's name did change, it was modifying a property in the `UserProfile` specified for the avatar, not changing the reference to the `UserProfile`. To resolve this, the `DoCheck` interface is implemented, which compares the two properties in the `UserProfile` for changes, and triggers the `OnChange` handler.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2657)
<!-- Reviewable:end -->
