### PR TITLE
SF-2604 Update history tab when the language changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.spec.ts
@@ -4,6 +4,7 @@ import Quill from 'quill';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { Subject } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
@@ -22,6 +23,7 @@ describe('EditorHistoryComponent', () => {
   let component: EditorHistoryComponent;
   let fixture: ComponentFixture<EditorHistoryComponent>;
   const mockSFProjectService = mock(SFProjectService);
+  const mockI18nService = mock(I18nService);
   const mockEditorHistoryService = mock(EditorHistoryService);
   const mockHistoryChooserComponent = mock(HistoryChooserComponent);
 
@@ -35,6 +37,7 @@ describe('EditorHistoryComponent', () => {
     providers: [
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: SFProjectService, useMock: mockSFProjectService },
+      { provide: I18nService, useMock: mockI18nService },
       { provide: EditorHistoryService, useMock: mockEditorHistoryService },
       { provide: HistoryChooserComponent, useMock: mockHistoryChooserComponent }
     ]

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
@@ -1,8 +1,19 @@
-import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DeltaStatic } from 'quill';
 import { combineLatest, startWith, tap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { Delta, TextDoc } from '../../../core/models/text-doc';
@@ -17,7 +28,7 @@ import { HistoryChooserComponent, RevisionSelectEvent } from './history-chooser/
   templateUrl: './editor-history.component.html',
   styleUrls: ['./editor-history.component.scss']
 })
-export class EditorHistoryComponent implements OnChanges, AfterViewInit {
+export class EditorHistoryComponent implements OnChanges, OnInit, AfterViewInit {
   @Input() projectId?: string;
   @Input() bookNum?: number;
   @Input() chapter?: number;
@@ -35,10 +46,11 @@ export class EditorHistoryComponent implements OnChanges, AfterViewInit {
 
   constructor(
     private readonly destroyRef: DestroyRef,
-    private readonly projectService: SFProjectService,
     private readonly editorHistoryService: EditorHistoryService,
     readonly fontService: FontService,
-    readonly onlineStatusService: OnlineStatusService
+    private readonly i18nService: I18nService,
+    readonly onlineStatusService: OnlineStatusService,
+    private readonly projectService: SFProjectService
   ) {}
 
   ngOnChanges(): void {
@@ -49,6 +61,13 @@ export class EditorHistoryComponent implements OnChanges, AfterViewInit {
     if (this.isViewInitialized) {
       this.revisionSelect.emit(undefined);
     }
+  }
+
+  ngOnInit(): void {
+    // When the locale changes, emit the loaded Revision again, as the date formatting will need to update
+    this.i18nService.locale$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.revisionSelect.emit(this.loadedRevision));
   }
 
   ngAfterViewInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
@@ -3,7 +3,8 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { Revision } from '../../../../core/paratext.service';
 
 @Pipe({
-  name: 'revisionFormat'
+  name: 'revisionFormat',
+  pure: false
 })
 export class HistoryRevisionFormatPipe implements PipeTransform {
   constructor(private readonly i18n: I18nService) {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1164,7 +1164,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     });
   }
 
-  onHistoryTabRevisionSelect(tab: EditorTabInfo, revision: Revision | undefined): void {
+  async onHistoryTabRevisionSelect(tab: EditorTabInfo, revision: Revision | undefined): Promise<void> {
     if (revision != null) {
       const separator: string = this.i18n.isRtl ? `${RIGHT_TO_LEFT_MARK} - ` : ' - ';
       tab.headerText = `${this.targetLabel}${separator}${this.editorHistoryService.formatTimestamp(revision.timestamp)}`;
@@ -1173,13 +1173,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         true
       )}`;
     } else {
-      tab.headerText = `${this.targetLabel} - History`;
-      tab.tooltip = `${this.projectDoc?.data?.name} - History`;
+      const historyDefaultTabHeader: string = await firstValueFrom(
+        this.i18n.translate('editor_tab_factory.default_history_tab_header')
+      );
+      tab.headerText = `${this.targetLabel} - ${historyDefaultTabHeader}`;
+      tab.tooltip = `${this.projectDoc?.data?.name} - ${historyDefaultTabHeader}`;
     }
 
     this.changeDetector.detectChanges();
-
-    // TODO: Respond to locale changes
   }
 
   /**


### PR DESCRIPTION
This PR fixes the remaining localization bugs with the view history component, particularly updating the tab title and dropdown dates when the locale changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2658)
<!-- Reviewable:end -->
