### PR TITLE
Fix the notes dialog title for Study Bible footnotes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.spec.ts
@@ -29,16 +29,30 @@ describe('TextNoteDialogComponent', () => {
     expect(env.text).toBe(text);
   }));
 
-  it('Displays cross-references', fakeAsync(() => {
+  it('Displays extended footnotes', fakeAsync(() => {
+    const text = 'Footnote text';
+    env = new TestEnvironment({ type: TextNoteType.ExtendedFootnote, text, isRightToLeft: false });
+    expect(env.title).toBe('text_note_dialog.footnote');
+    expect(env.text).toBe(text);
+  }));
+
+  it('Displays end notes', fakeAsync(() => {
     const text = 'End note text';
     env = new TestEnvironment({ type: TextNoteType.EndNote, text, isRightToLeft: false });
     expect(env.title).toBe('text_note_dialog.end_note');
     expect(env.text).toBe(text);
   }));
 
-  it('Displays end notes', fakeAsync(() => {
+  it('Displays cross-references', fakeAsync(() => {
     const text = 'Cross-reference text';
     env = new TestEnvironment({ type: TextNoteType.CrossReference, text, isRightToLeft: false });
+    expect(env.title).toBe('text_note_dialog.cross_reference');
+    expect(env.text).toBe(text);
+  }));
+
+  it('Displays extended cross-references', fakeAsync(() => {
+    const text = 'Cross-reference text';
+    env = new TestEnvironment({ type: TextNoteType.ExtendedCrossReference, text, isRightToLeft: false });
     expect(env.title).toBe('text_note_dialog.cross_reference');
     expect(env.text).toBe(text);
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-note-dialog/text-note-dialog.component.ts
@@ -5,8 +5,10 @@ import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 
 export enum TextNoteType {
   Footnote = 'f',
+  ExtendedFootnote = 'ef',
   EndNote = 'fe',
-  CrossReference = 'x'
+  CrossReference = 'x',
+  ExtendedCrossReference = 'ex'
 }
 
 export interface NoteDialogData {
@@ -37,12 +39,14 @@ export class TextNoteDialogComponent {
     let translateKey = this.data.type.toString();
     switch (this.data.type) {
       case TextNoteType.Footnote:
+      case TextNoteType.ExtendedFootnote:
         translateKey = 'footnote';
         break;
       case TextNoteType.EndNote:
         translateKey = 'end_note';
         break;
       case TextNoteType.CrossReference:
+      case TextNoteType.ExtendedCrossReference:
         translateKey = 'cross_reference';
     }
     return this.translocoService.translate(`text_note_dialog.${translateKey}`);


### PR DESCRIPTION
This PR fixes a bug I noticed for the Telegu Study Bible, where the notes dialog had a missing translation string:
![image](https://github.com/user-attachments/assets/c4e9260c-0bdf-43c1-b1e9-8f71d7529fd1)

This PR fixes that by using "Footnote" or "Cross-Reference" as the dialog title for `\ef` and `\ex` notes:
![image](https://github.com/user-attachments/assets/425b8b1e-4819-4f80-92fd-10a7e7bbcc36)

I also corrected two incorrectly named unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2659)
<!-- Reviewable:end -->
