### PR TITLE
SF-2905 Fix crash when syncing a book with invalid chapters

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -549,6 +549,11 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     }
                 }
 
+                if (i >= chapterDeltaArray.Length)
+                {
+                    return newUsxDoc;
+                }
+
                 if (
                     chapterDeltaArray[i].Number == curChapter
                     && chapterDeltaArray[i].IsValid


### PR DESCRIPTION
This PR fixes a crash that affects a project on production which contains invalid chapters. Details on the crash are in the JIRA ticket.

A test has been added that recreates the crash (and confirms that it no longer crashes), while an old test that expected the crash to occur has been removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2660)
<!-- Reviewable:end -->
