### PR TITLE
SF-2906 Fix crash when syncing and notes with duplicate ids are incoming

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1263,7 +1263,9 @@ public class ParatextService : DisposableBase, IParatextService
             IEnumerable<string> newCommentIds = ptCommentIds.Except(matchedCommentIds);
             foreach (string commentId in newCommentIds)
             {
-                Paratext.Data.ProjectComments.Comment comment = existingThread.Comments.Single(c => c.Id == commentId);
+                // If there are duplicates, we only retrieve the first, although Paratext displays both
+                // Actions (like Delete) performed on duplicates in Paratext affect both duplicates.
+                Paratext.Data.ProjectComments.Comment comment = existingThread.Comments.First(c => c.Id == commentId);
                 CommentTag commentIconTag = GetCommentTag(existingThread, comment, commentTags);
                 threadChange.AddChange(
                     CreateNoteFromComment(_guidService.NewObjectId(), comment, commentIconTag, ptProjectUsers),


### PR DESCRIPTION
This PR fixes a crash noticed in production syncs when notes were incoming that had duplicate ids

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2662)
<!-- Reviewable:end -->
