### PR TITLE
Clean up migration to template control flow syntax

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -159,8 +159,7 @@
             @if (isAppOnline) {
               <mat-icon>cloud</mat-icon>
               {{ t("online") }}
-            }
-            @if (!isAppOnline) {
+            } @else {
               <mat-icon>cloud_off</mat-icon>
               {{ t("offline") }}
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.html
@@ -10,8 +10,7 @@
       <div class="wrapper wrapper-book-chapter valid">
         @if (!selectionHasAudioAlready || inEditState) {
           <mat-icon>book</mat-icon>
-        }
-        @if (selectionHasAudioAlready && !inEditState) {
+        } @else {
           <app-info [text]="t('audio_already_exists')" icon="warning" type="warning"></app-info>
         }
         <mat-select
@@ -53,13 +52,11 @@
           @if (hasAudioBeenUploaded) {
             <mat-icon (click)="deleteAudioData()" class="delete">delete</mat-icon>
           }
-        }
-        @if (!hasAudioBeenUploaded) {
+        } @else {
           <mat-icon>play_disabled</mat-icon>
           @if (!hasAudioDataError) {
             <span>{{ t("no_audio_file_uploaded") }}</span>
-          }
-          @if (hasAudioDataError) {
+          } @else {
             <span>{{ t(audioErrorMessageKey) }}</span>
           }
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -19,8 +19,6 @@
           >
             <mat-icon class="mirror-rtl">post_add</mat-icon> <span>{{ t("add_question") }}</span>
           </button>
-        }
-        @if (!isLoading) {
           <button
             class="add-question-button hide-gt-sm"
             mat-mini-fab

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -90,8 +90,7 @@
                   >
                     <mat-icon class="attach-icon">attach_file</mat-icon>
                   </button>
-                }
-                @if (selectedText) {
+                } @else {
                   <div class="answer-scripture">
                     <span class="answer-scripture-verse">{{ scriptureTextVerseRef(verseRef) }}</span>
                     <button mat-icon-button (click)="clearSelection()" class="answer-scripture-clear">
@@ -201,8 +200,6 @@
                       >
                         {{ t(isMarkedForExport(answer) ? "marked_for_export" : "mark_for_export") }}
                       </button>
-                    }
-                    @if (canChangeAnswerStatus(answer)) {
                       <button
                         mat-button
                         type="button"
@@ -222,8 +219,6 @@
                     }
                     @if (canDeleteAnswer(answer)) {
                       <div class="delete-divider">|</div>
-                    }
-                    @if (canDeleteAnswer(answer)) {
                       <button
                         mat-button
                         type="button"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.html
@@ -26,8 +26,7 @@
         <div id="noQuestionAudio" [class]="focusedText">
           <mat-icon class="mirror-rtl">question_answer</mat-icon>
         </div>
-      }
-      @if (questionAudioUrl) {
+      } @else {
         <app-single-button-audio-player
           #questionAudio
           id="questionAudio"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.html
@@ -7,8 +7,7 @@
             <button mat-icon-button type="button" (click)="play()" class="play">
               <mat-icon>play_arrow</mat-icon>
             </button>
-          }
-          @if (isPlaying()) {
+          } @else {
             <button mat-icon-button type="button" (click)="pause()" class="pause">
               <mat-icon>pause</mat-icon>
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.html
@@ -11,8 +11,7 @@
         >
           <mat-icon>mic</mat-icon>
         </button>
-      }
-      @if (isRecording) {
+      } @else {
         <button
           mat-button
           (click)="stopRecording()"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -33,8 +33,7 @@
     <div class="no-questions-found">
       @if (isFiltered) {
         {{ t("no_questions_found_filtered") }}
-      }
-      @if (!isFiltered) {
+      } @else {
         {{ t("no_questions_found_unfiltered") }}
       }
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -17,202 +17,200 @@
     }
 
     <div class="dialog-content-body" (scroll)="dialogScroll()" #dialogContentBody>
-      @if (status === "initial") {
-        <div class="initial-import-screen">
-          <div class="card-wrapper">
-            <mat-card>
-              <mat-card-title>{{ t("import_from_transcelerator") }}</mat-card-title>
-              <mat-card-content>
-                @for (i of transceleratorInfo | async; track i) {
-                  {{ i.id == null ? i.text : "" }}
-                  @if (i.id === 1) {
-                    <a [href]="urls.transcelerator" target="_blank">{{ i.text }}</a>
+      @switch (status) {
+        @case ("initial") {
+          <div class="initial-import-screen">
+            <div class="card-wrapper">
+              <mat-card>
+                <mat-card-title>{{ t("import_from_transcelerator") }}</mat-card-title>
+                <mat-card-content>
+                  @for (i of transceleratorInfo | async; track i) {
+                    {{ i.id == null ? i.text : "" }}
+                    @if (i.id === 1) {
+                      <a [href]="urls.transcelerator" target="_blank">{{ i.text }}</a>
+                    } @else if (i.id === 3) {
+                      <a [href]="urls.paratext" target="_blank">{{ i.text }}</a>
+                    }
                   }
-                  @if (i.id === 3) {
-                    <a [href]="urls.paratext" target="_blank">{{ i.text }}</a>
+                  <ol>
+                    @for (line of transceleratorInstructions; track line) {
+                      <li [innerHTML]="line"></li>
+                    }
+                  </ol>
+                </mat-card-content>
+                <mat-card-actions>
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    (click)="importFromTranscelerator()"
+                    [disabled]="transceleratorRequest.status !== 'complete'"
+                  >
+                    {{ t("import_from_transcelerator") }}
+                  </button>
+                  <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
+                  @if (transceleratorRequest.status === "offline") {
+                    <mat-error>
+                      {{ t("no_transcelerator_offline") }}
+                    </mat-error>
+                  } @else if (transceleratorRequest.status === "trying" && transceleratorRequest.failedAttempts > 0) {
+                    <mat-error>
+                      {{ t("network_error_transcelerator", { count: transceleratorRequest.failedAttempts }) }}
+                    </mat-error>
                   }
-                }
-                <ol>
-                  @for (line of transceleratorInstructions; track line) {
-                    <li [innerHTML]="line"></li>
-                  }
-                </ol>
-              </mat-card-content>
-              <mat-card-actions>
-                <button
-                  mat-flat-button
-                  color="primary"
-                  (click)="importFromTranscelerator()"
-                  [disabled]="transceleratorRequest.status !== 'complete'"
-                >
-                  {{ t("import_from_transcelerator") }}
-                </button>
-                <a mat-button [href]="urls.transceleratorImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
-                @if (transceleratorRequest.status === "offline") {
-                  <mat-error>
-                    {{ t("no_transcelerator_offline") }}
-                  </mat-error>
-                }
-                @if (transceleratorRequest.status === "trying" && transceleratorRequest.failedAttempts > 0) {
-                  <mat-error>
-                    {{ t("network_error_transcelerator", { count: transceleratorRequest.failedAttempts }) }}
-                  </mat-error>
-                }
-              </mat-card-actions>
-            </mat-card>
-            <mat-card>
-              <mat-card-title>{{ t("import_from_spreadsheet") }}</mat-card-title>
-              <mat-card-content>
-                <ol>
-                  <li>
-                    {{ csvInstructions[0] }}
-                    <table>
-                      <!-- TODO internationalize the references and headings, but only once we accept localized inputs -->
-                      <tr>
-                        <th>Reference</th>
-                        <th>Question</th>
-                      </tr>
-                      @for (verseNumber of [1, 2]; track verseNumber) {
+                </mat-card-actions>
+              </mat-card>
+              <mat-card>
+                <mat-card-title>{{ t("import_from_spreadsheet") }}</mat-card-title>
+                <mat-card-content>
+                  <ol>
+                    <li>
+                      {{ csvInstructions[0] }}
+                      <table>
+                        <!-- TODO internationalize the references and headings, but only once we accept localized inputs -->
                         <tr>
-                          <td>1JN 1:{{ verseNumber }}</td>
-                          <td>{{ t("question_for_verse", { number: verseNumber }) }}</td>
+                          <th>Reference</th>
+                          <th>Question</th>
                         </tr>
-                      }
-                    </table>
-                  </li>
-                  @for (line of csvInstructions.slice(1); track line) {
-                    <li [innerHTML]="line"></li>
-                  }
-                </ol>
-              </mat-card-content>
-              <mat-card-actions>
-                <button
-                  mat-flat-button
-                  color="primary"
-                  ngfSelect
-                  accept=".csv,.tsv"
-                  (fileChange)="fileSelected($event)"
-                >
-                  {{ t("import_from_csv_file") }}
-                </button>
-                <a mat-button [href]="urls.csvImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
-              </mat-card-actions>
-            </mat-card>
-          </div>
-          <div class="support-message">
-            @for (i of helpInstructions | async; track i) {
-              <!-- prettier-ignore -->
-              @if (i.id == null) {{{ i.text }}}
-              @if (i.id === 1) {
-                <a [href]="urls.communitySupport" target="_blank">{{ i.text }}</a>
+                        @for (verseNumber of [1, 2]; track verseNumber) {
+                          <tr>
+                            <td>1JN 1:{{ verseNumber }}</td>
+                            <td>{{ t("question_for_verse", { number: verseNumber }) }}</td>
+                          </tr>
+                        }
+                      </table>
+                    </li>
+                    @for (line of csvInstructions.slice(1); track line) {
+                      <li [innerHTML]="line"></li>
+                    }
+                  </ol>
+                </mat-card-content>
+                <mat-card-actions>
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    ngfSelect
+                    accept=".csv,.tsv"
+                    (fileChange)="fileSelected($event)"
+                  >
+                    {{ t("import_from_csv_file") }}
+                  </button>
+                  <a mat-button [href]="urls.csvImportHelpPage" target="_blank">{{ t("learn_more") }}</a>
+                </mat-card-actions>
+              </mat-card>
+            </div>
+            <div class="support-message">
+              @for (i of helpInstructions | async; track i) {
+                <!-- prettier-ignore -->
+                @if (i.id == null) {{{ i.text }}}
+                @else if (i.id === 1) {
+                  <a [href]="urls.communitySupport" target="_blank">{{ i.text }}</a>
+                } @else if (i.id === 3) {
+                  <a href="mailto:{{ issueEmail }}" target="_blank">{{ issueEmail }}</a>
+                }
               }
-              @if (i.id === 3) {
-                <a href="mailto:{{ issueEmail }}" target="_blank">{{ issueEmail }}</a>
-              }
-            }
-          </div>
-        </div>
-      }
-
-      @if (status === "loading") {
-        <div class="loading"><mat-spinner></mat-spinner></div>
-      }
-
-      @if (status === "file_import_errors") {
-        <div>
-          <table mat-table [dataSource]="invalidRowsForDisplay">
-            <ng-container matColumnDef="rowNumber">
-              <th mat-header-cell *matHeaderCellDef>{{ t("row") }}</th>
-              <td mat-cell *matCellDef="let element">{{ element[0] }}</td>
-            </ng-container>
-            <ng-container matColumnDef="reference">
-              <th mat-header-cell *matHeaderCellDef>{{ t("reference") }}</th>
-              <td mat-cell *matCellDef="let element">{{ element[1] }}</td>
-            </ng-container>
-            <ng-container matColumnDef="question">
-              <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
-              <td mat-cell *matCellDef="let element">{{ element[2] }}</td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="['rowNumber', 'reference', 'question']"></tr>
-            <tr mat-row *matRowDef="let row; columns: ['rowNumber', 'reference', 'question']"></tr>
-          </table>
-        </div>
-      }
-
-      @if (status === "filter") {
-        <form [formGroup]="filterForm" autocomplete="off">
-          <div class="filter-references">
-            <mat-form-field appearance="outline">
-              <mat-label>{{ t("reference_from") }}</mat-label>
-              <input matInput type="text" formControlName="from" />
-              <button mat-icon-button matSuffix #fromRef id="from-btn" (click)="openScriptureChooser(fromControl)">
-                <mat-icon>expand_more</mat-icon>
-              </button>
-              @if (fromControl.invalid) {
-                <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
-              }
-            </mat-form-field>
-            <mat-form-field appearance="outline">
-              <mat-label>{{ t("reference_to") }}</mat-label>
-              <input matInput type="text" formControlName="to" />
-              <button mat-icon-button matSuffix (click)="openScriptureChooser(toControl)">
-                <mat-icon>expand_more</mat-icon>
-              </button>
-              @if (toControl.invalid) {
-                <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
-              }
-            </mat-form-field>
-          </div>
-          <div colspan="2" class="filter-text">
-            <div>
-              <mat-form-field appearance="fill" subscriptSizing="dynamic">
-                <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
-              </mat-form-field>
-              <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
             </div>
           </div>
-          <table mat-table [dataSource]="questionsForDisplay" class="question-list">
-            <ng-container matColumnDef="verse">
-              <th mat-header-cell *matHeaderCellDef>
-                <mat-checkbox #selectAllCheckbox (change)="selectAllChanged($event.checked)">{{
-                  t("select_all")
-                }}</mat-checkbox>
-              </th>
-              <td mat-cell *matCellDef="let element">
-                <mat-checkbox
-                  [(ngModel)]="element.checked"
-                  (ngModelChange)="checkboxChanged(element)"
-                  [ngModelOptions]="{ standalone: true }"
-                  >{{ referenceForDisplay(element.question) }}</mat-checkbox
-                >
-              </td>
-            </ng-container>
-            <ng-container matColumnDef="question">
-              <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
-              <td mat-cell *matCellDef="let element">{{ element.question.text }}</td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="['verse', 'question']"></tr>
-            <tr mat-row *matRowDef="let row; columns: ['verse', 'question']"></tr>
-          </table>
-        </form>
-      }
+        }
 
-      @if (status === "no_questions") {
-        <div>{{ t("no_questions_available") }}</div>
-      }
+        @case ("loading") {
+          <div class="loading"><mat-spinner></mat-spinner></div>
+        }
+        @case ("file_import_errors") {
+          <div>
+            <table mat-table [dataSource]="invalidRowsForDisplay">
+              <ng-container matColumnDef="rowNumber">
+                <th mat-header-cell *matHeaderCellDef>{{ t("row") }}</th>
+                <td mat-cell *matCellDef="let element">{{ element[0] }}</td>
+              </ng-container>
+              <ng-container matColumnDef="reference">
+                <th mat-header-cell *matHeaderCellDef>{{ t("reference") }}</th>
+                <td mat-cell *matCellDef="let element">{{ element[1] }}</td>
+              </ng-container>
+              <ng-container matColumnDef="question">
+                <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
+                <td mat-cell *matCellDef="let element">{{ element[2] }}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="['rowNumber', 'reference', 'question']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['rowNumber', 'reference', 'question']"></tr>
+            </table>
+          </div>
+        }
 
-      @if (status === "update_transcelerator") {
-        <div>{{ t("update_transcelerator") }}</div>
-      }
+        @case ("filter") {
+          <form [formGroup]="filterForm" autocomplete="off">
+            <div class="filter-references">
+              <mat-form-field appearance="outline">
+                <mat-label>{{ t("reference_from") }}</mat-label>
+                <input matInput type="text" formControlName="from" />
+                <button mat-icon-button matSuffix #fromRef id="from-btn" (click)="openScriptureChooser(fromControl)">
+                  <mat-icon>expand_more</mat-icon>
+                </button>
+                @if (fromControl.invalid) {
+                  <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field appearance="outline">
+                <mat-label>{{ t("reference_to") }}</mat-label>
+                <input matInput type="text" formControlName="to" />
+                <button mat-icon-button matSuffix (click)="openScriptureChooser(toControl)">
+                  <mat-icon>expand_more</mat-icon>
+                </button>
+                @if (toControl.invalid) {
+                  <mat-error>{{ t("must_be_valid_reference") }}</mat-error>
+                }
+              </mat-form-field>
+            </div>
+            <div colspan="2" class="filter-text">
+              <div>
+                <mat-form-field appearance="fill" subscriptSizing="dynamic">
+                  <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
+                </mat-form-field>
+                <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
+              </div>
+            </div>
+            <table mat-table [dataSource]="questionsForDisplay" class="question-list">
+              <ng-container matColumnDef="verse">
+                <th mat-header-cell *matHeaderCellDef>
+                  <mat-checkbox #selectAllCheckbox (change)="selectAllChanged($event.checked)">{{
+                    t("select_all")
+                  }}</mat-checkbox>
+                </th>
+                <td mat-cell *matCellDef="let element">
+                  <mat-checkbox
+                    [(ngModel)]="element.checked"
+                    (ngModelChange)="checkboxChanged(element)"
+                    [ngModelOptions]="{ standalone: true }"
+                    >{{ referenceForDisplay(element.question) }}</mat-checkbox
+                  >
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="question">
+                <th mat-header-cell *matHeaderCellDef>{{ t("question") }}</th>
+                <td mat-cell *matCellDef="let element">{{ element.question.text }}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="['verse', 'question']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['verse', 'question']"></tr>
+            </table>
+          </form>
+        }
 
-      @if (status === "missing_header_row") {
-        <div [innerHTML]="i18n.translateAndInsertTags('import_questions_dialog.missing_header_row')"></div>
-      }
+        @case ("no_questions") {
+          <div>{{ t("no_questions_available") }}</div>
+        }
 
-      @if (status === "progress") {
-        <div>
-          <mat-progress-bar mode="determinate" [value]="(importedCount / toImportCount) * 100"></mat-progress-bar>
-        </div>
+        @case ("update_transcelerator") {
+          <div>{{ t("update_transcelerator") }}</div>
+        }
+
+        @case ("missing_header_row") {
+          <div [innerHTML]="i18n.translateAndInsertTags('import_questions_dialog.missing_header_row')"></div>
+        }
+
+        @case ("progress") {
+          <div>
+            <mat-progress-bar mode="determinate" [value]="(importedCount / toImportCount) * 100"></mat-progress-bar>
+          </div>
+        }
       }
     </div>
 
@@ -234,9 +232,7 @@
           </div>
         }
       </div>
-    }
-
-    @if (status === "progress") {
+    } @else if (status === "progress") {
       <div class="dialog-content-footer">
         {{ t("canceling_import_not_remove_questions") }}
         @if (importCanceled) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -52,8 +52,7 @@
             <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
               <mat-icon>mic</mat-icon>
             </button>
-          }
-          @if (input.audioAttachment.status === "recording") {
+          } @else if (input.audioAttachment.status === "recording") {
             <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
               <mat-icon class="stop-recording">stop</mat-icon>
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -32,8 +32,6 @@
       <div class="loading-project-description"></div>
       <div class="loading-action"></div>
     </mat-card>
-  }
-  @if (initialLoadingSFProjects) {
     <mat-card class="loading-card">
       <div class="loading-project-name"></div>
       <div class="loading-project-description"></div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -28,8 +28,7 @@
           <mat-icon class="mirror-rtl">list</mat-icon>
           {{ t("manage_questions") }}
         </a>
-      }
-      @if (!canManageQuestions) {
+      } @else {
         <a mat-list-item [appRouterLink]="getProjectLink('checking')">
           <mat-icon class="mirror-rtl">bar_chart</mat-icon>
           {{ t("my_progress") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -1,21 +1,32 @@
 <ng-container *transloco="let t; read: 'scripture_chooser_dialog'">
   <div class="dialog-container">
-    @if (showing === "books") {
-      <div id="bookPane">
-        <h1 mat-dialog-title>
-          <button
-            mat-icon-button
-            class="backout-button"
-            (click)="onClickBackoutButton()"
-            (focus)="onCloseFocus($event)"
-          >
-            <mat-icon>close</mat-icon>
-          </button>
-          <span>{{ t("choose_book") }}</span>
-        </h1>
-        <div mat-dialog-content>
-          <div class="upperBookSet">
-            @for (book of otBooks; track book) {
+    @switch (showing) {
+      @case ("books") {
+        <div id="bookPane">
+          <h1 mat-dialog-title>
+            <button
+              mat-icon-button
+              class="backout-button"
+              (click)="onClickBackoutButton()"
+              (focus)="onCloseFocus($event)"
+            >
+              <mat-icon>close</mat-icon>
+            </button>
+            <span>{{ t("choose_book") }}</span>
+          </h1>
+          <div mat-dialog-content>
+            <div class="upperBookSet">
+              @for (book of otBooks; track book) {
+                <button
+                  mat-button
+                  [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
+                  (click)="onClickBook(book)"
+                >
+                  {{ i18n.localizeBook(book) }}
+                </button>
+              }
+            </div>
+            @for (book of ntBooks; track book) {
               <button
                 mat-button
                 [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
@@ -25,100 +36,95 @@
               </button>
             }
           </div>
-          @for (book of ntBooks; track book) {
-            <button mat-button [ngClass]="{ 'mat-flat-button': data.input?.book === book }" (click)="onClickBook(book)">
-              {{ i18n.localizeBook(book) }}
-            </button>
-          }
         </div>
-      </div>
-    }
-    @if (showing === "chapters") {
-      <div id="chapterPane">
-        <h1 mat-dialog-title>
-          <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
-            <mat-icon>navigate_before</mat-icon>
-          </button>
-          <span>{{ t("choose_chapter") }}</span>
-        </h1>
-        <div mat-dialog-content>
-          <div class="reference">{{ getBookName(selection.book) }}</div>
-          @for (chapter of chaptersOf(selection.book); track chapter) {
+      }
+      @case ("chapters") {
+        <div id="chapterPane">
+          <h1 mat-dialog-title>
+            <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+              <mat-icon>navigate_before</mat-icon>
+            </button>
+            <span>{{ t("choose_chapter") }}</span>
+          </h1>
+          <div mat-dialog-content>
+            <div class="reference">{{ getBookName(selection.book) }}</div>
+            @for (chapter of chaptersOf(selection.book); track chapter) {
+              <button
+                mat-button
+                [ngClass]="{
+                  'mat-flat-button':
+                    data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter
+                }"
+                (click)="onClickChapter(chapter)"
+              >
+                {{ chapter }}
+              </button>
+            }
+          </div>
+        </div>
+      }
+      @case ("verses") {
+        <div id="versePane">
+          <h1 mat-dialog-title>
+            <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
+              <mat-icon>navigate_before</mat-icon>
+            </button>
+            <span>{{ t("choose_verse") }}</span>
+          </h1>
+          <div mat-dialog-content>
+            <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
+            @for (verse of versesOf(selection?.book, selection?.chapter); track verse) {
+              <button
+                mat-button
+                [ngClass]="{
+                  'mat-flat-button':
+                    data.input?.book === selection.book &&
+                    data.input?.chapter === selection.chapter &&
+                    getNumOrNaN(data.input?.verseNum) === +verse
+                }"
+                (click)="onClickVerse(verse)"
+              >
+                {{ verse }}
+              </button>
+            }
+          </div>
+        </div>
+      }
+      @case ("rangeEnd") {
+        <div id="rangeEndPane">
+          <div mat-dialog-title>
             <button
-              mat-button
-              [ngClass]="{
-                'mat-flat-button':
-                  data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter
-              }"
-              (click)="onClickChapter(chapter)"
+              mat-icon-button
+              class="backout-button"
+              (click)="onClickBackoutButton()"
+              (focus)="onCloseFocus($event)"
             >
-              {{ chapter }}
+              <mat-icon>close</mat-icon>
             </button>
-          }
+            <span>{{ t("choose_end_verse") }}</span>
+          </div>
+          <div mat-dialog-content>
+            <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
+            @for (
+              verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum);
+              track verse
+            ) {
+              <button
+                mat-button
+                [ngClass]="{
+                  'mat-flat-button':
+                    data.input?.book === data.rangeStart?.book &&
+                    data.input?.chapter === data.rangeStart?.chapter &&
+                    getNumOrNaN(data.input?.verseNum) === +verse
+                }"
+                (click)="onClickVerse(verse)"
+              >
+                {{ verse }}
+              </button>
+            }
+          </div>
         </div>
-      </div>
-    }
-    @if (showing === "verses") {
-      <div id="versePane">
-        <h1 mat-dialog-title>
-          <button mat-icon-button class="backout-button" (click)="onClickBackoutButton()">
-            <mat-icon>navigate_before</mat-icon>
-          </button>
-          <span>{{ t("choose_verse") }}</span>
-        </h1>
-        <div mat-dialog-content>
-          <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
-          @for (verse of versesOf(selection?.book, selection?.chapter); track verse) {
-            <button
-              mat-button
-              [ngClass]="{
-                'mat-flat-button':
-                  data.input?.book === selection.book &&
-                  data.input?.chapter === selection.chapter &&
-                  getNumOrNaN(data.input?.verseNum) === +verse
-              }"
-              (click)="onClickVerse(verse)"
-            >
-              {{ verse }}
-            </button>
-          }
-        </div>
-      </div>
-    }
-    @if (showing === "rangeEnd") {
-      <div id="rangeEndPane">
-        <div mat-dialog-title>
-          <button
-            mat-icon-button
-            class="backout-button"
-            (click)="onClickBackoutButton()"
-            (focus)="onCloseFocus($event)"
-          >
-            <mat-icon>close</mat-icon>
-          </button>
-          <span>{{ t("choose_end_verse") }}</span>
-        </div>
-        <div mat-dialog-content>
-          <div class="reference">{{ getBookName(data.rangeStart?.book) }} {{ data.rangeStart?.chapter }}</div>
-          @for (
-            verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum);
-            track verse
-          ) {
-            <button
-              mat-button
-              [ngClass]="{
-                'mat-flat-button':
-                  data.input?.book === data.rangeStart?.book &&
-                  data.input?.chapter === data.rangeStart?.chapter &&
-                  getNumOrNaN(data.input?.verseNum) === +verse
-              }"
-              (click)="onClickVerse(verse)"
-            >
-              {{ verse }}
-            </button>
-          }
-        </div>
-      </div>
+      }
     }
   </div>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -18,8 +18,7 @@
         <td mat-cell *matCellDef="let row">
           @if (row.preTranslate) {
             <strong>Enabled</strong>
-          }
-          @if (!row.preTranslate) {
+          } @else {
             <span>Disabled</span>
           }
         </td>
@@ -29,8 +28,7 @@
         <td mat-cell *matCellDef="let row">
           @if (row.sourceId != null) {
             <a [appRouterLink]="['/serval-administration', row.sourceId]">{{ row.source }}</a>
-          }
-          @if (row.sourceId == null) {
+          } @else {
             <span>{{ row.source }}</span>
           }
         </td>
@@ -40,8 +38,7 @@
         <td mat-cell *matCellDef="let row">
           @if (row.alternateSourceId != null) {
             <a [appRouterLink]="['/serval-administration', row.alternateSourceId]">{{ row.alternateSource }}</a>
-          }
-          @if (row.alternateSourceId == null) {
+          } @else {
             <span>{{ row.alternateSource }}</span>
           }
         </td>
@@ -53,8 +50,7 @@
             <a [appRouterLink]="['/serval-administration', row.alternateTrainingSourceId]">{{
               row.alternateTrainingSource
             }}</a>
-          }
-          @if (row.alternateTrainingSourceId == null) {
+          } @else {
             <span>{{ row.alternateTrainingSource }}</span>
           }
         </td>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -80,8 +80,7 @@
                     id="translation-suggestions-status"
                   ></app-write-status>
                 </div>
-              }
-              @if (!isBasedOnProjectSet) {
+              } @else {
                 <mat-hint>{{ t("translation_suggestions_require_source_text") }}</mat-hint>
               }
             </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player/audio-player.component.html
@@ -7,8 +7,7 @@
       </mat-slider>
       <div class="duration">{{ duration | audioTime }}</div>
     </div>
-  }
-  @if (hasProblem) {
+  } @else {
     <div class="audio-not-available">
       <mat-icon>volume_off</mat-icon>
       <span>{{ t("audio_unavailable") }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-button.component.html
@@ -3,8 +3,7 @@
     <button (click)="openDialog()" mat-icon-button [matTooltip]="t('share')" id="share-btn">
       <mat-icon class="mirror-rtl">person_add</mat-icon>
     </button>
-  }
-  @if (!iconOnlyButton) {
+  } @else {
     <button mat-flat-button (click)="openDialog()" color="primary" class="button-with-text">
       <mat-icon class="mirror-rtl">person_add</mat-icon> {{ t("share") }}
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -72,8 +72,7 @@
           {{ t("invitation_shared_in_language") }}
           @if (shareLocaleCode?.localName) {
             <b>{{ shareLocaleCode?.localName }}</b>
-          }
-          @if (!shareLocaleCode?.localName) {
+          } @else {
             <b class="empty-field" [ngClass]="{ error: error }"> ________________ </b>
           }
           <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}"> ({{ t("change") }}) </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -34,11 +34,7 @@
           }
           @if (syncActive) {
             <mat-hint id="sync-message">{{ t("your_project_is_being_synchronized") }}</mat-hint>
-          }
-          @if (syncActive) {
             <app-sync-progress [projectDoc]="projectDoc" (inProgress)="syncActive = $event"></app-sync-progress>
-          }
-          @if (syncActive) {
             <button
               mat-button
               type="button"
@@ -48,8 +44,7 @@
             >
               {{ t("cancel") }}
             </button>
-          }
-          @if (!syncActive) {
+          } @else {
             <mat-hint [title]="lastSyncDisplayDate" id="date-last-sync">
               {{ lastSyncNotice }}
             </mat-hint>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
@@ -11,8 +11,8 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
-  SFProjectUserConfig,
-  SF_PROJECT_USER_CONFIGS_COLLECTION
+  SF_PROJECT_USER_CONFIGS_COLLECTION,
+  SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { mock, when } from 'ts-mockito';
 import { I18nService } from 'xforge-common/i18n.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -18,20 +18,16 @@
         }
         @if (unusableTranslateSourceBooks.length) {
           <app-notice>
-            @if (unusableTranslateSourceBooks.length) {
-              <h4>
-                <transloco
-                  key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
-                  [params]="{ draftingSourceProjectName }"
-                ></transloco>
-              </h4>
-            }
-            @if (unusableTranslateSourceBooks.length) {
-              <app-book-multi-select
-                [availableBooks]="unusableTranslateSourceBooks"
-                [readonly]="true"
-              ></app-book-multi-select>
-            }
+            <h4>
+              <transloco
+                key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
+                [params]="{ draftingSourceProjectName }"
+              ></transloco>
+            </h4>
+            <app-book-multi-select
+              [availableBooks]="unusableTranslateSourceBooks"
+              [readonly]="true"
+            ></app-book-multi-select>
           </app-notice>
         }
         @if (showBookSelectionError) {
@@ -66,19 +62,15 @@
         @if (unusableTrainingSourceBooks.length) {
           <app-notice>
             <h4>
-              @if (unusableTrainingSourceBooks.length) {
-                <transloco
-                  key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
-                  [params]="{ trainingSourceProjectName }"
-                ></transloco>
-              }
+              <transloco
+                key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
+                [params]="{ trainingSourceProjectName }"
+              ></transloco>
             </h4>
-            @if (unusableTrainingSourceBooks.length) {
-              <app-book-multi-select
-                [availableBooks]="unusableTrainingSourceBooks"
-                [readonly]="true"
-              ></app-book-multi-select>
-            }
+            <app-book-multi-select
+              [availableBooks]="unusableTrainingSourceBooks"
+              [readonly]="true"
+            ></app-book-multi-select>
           </app-notice>
         }
         @if (showBookSelectionError) {
@@ -141,9 +133,7 @@
 
   @if (availableTranslateBooks && availableTranslateBooks.length <= 0) {
     <p>{{ t("no_available_books") }}</p>
-  }
-
-  @if (availableTranslateBooks == null) {
+  } @else if (availableTranslateBooks == null) {
     <div class="loading">
       <mat-spinner diameter="20" color="primary"></mat-spinner>
       <div>{{ t("loading") }}</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -1,8 +1,7 @@
 <ng-container *transloco="let t; read: 'draft_generation'">
   @if (isBackTranslationMode) {
     <h1 class="mat-headline-4">{{ t("generate_back_translation_drafts_header") }}</h1>
-  }
-  @if (!isBackTranslationMode) {
+  } @else {
     <h1 class="mat-headline-4">
       {{ t("generate_forward_translation_drafts_header") }}
     </h1>
@@ -19,8 +18,7 @@
               {{ t("instructions_scripture_forge_assist_back_translation_subtext") }}
             </p>
           </div>
-        }
-        @if (!isBackTranslationMode) {
+        } @else {
           <div>
             <p>
               <b>{{ t("instructions_scripture_forge_assist_forward_translation") }}</b>
@@ -86,8 +84,7 @@
             <transloco key="draft_generation.non_pa_info_alert_source_text_not_selected"></transloco>
           }
         </app-notice>
-      }
-      @if (isSourceProjectSet && !isSourceAndTargetDifferent) {
+      } @else if (!isSourceAndTargetDifferent) {
         <app-notice type="warning" icon="warning" data-test-id="warning-source-target-same">
           @if (isProjectAdmin) {
             <transloco
@@ -101,8 +98,7 @@
             ></transloco>
           }
         </app-notice>
-      }
-      @if (isSourceProjectSet && isSourceAndTargetDifferent && !isSourceAndTrainingSourceLanguageIdentical) {
+      } @else if (!isSourceAndTrainingSourceLanguageIdentical) {
         <app-notice type="warning" icon="warning" data-test-id="warning-source-training-different">
           @if (isProjectAdmin) {
             <transloco
@@ -123,13 +119,7 @@
             ></transloco>
           }
         </app-notice>
-      }
-      @if (
-        isSourceProjectSet &&
-        isSourceAndTargetDifferent &&
-        isSourceAndTrainingSourceLanguageIdentical &&
-        !isSourceAndAdditionalTrainingSourceLanguageIdentical
-      ) {
+      } @else if (!isSourceAndAdditionalTrainingSourceLanguageIdentical) {
         <app-notice type="warning" icon="warning" data-test-id="warning-mix-source-different">
           @if (isProjectAdmin) {
             <transloco
@@ -150,14 +140,7 @@
             ></transloco>
           }
         </app-notice>
-      }
-      @if (
-        isSourceProjectSet &&
-        isSourceAndTargetDifferent &&
-        isSourceAndTrainingSourceLanguageIdentical &&
-        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-        !canAccessDraftSourceIfAvailable(source)
-      ) {
+      } @else if (!canAccessDraftSourceIfAvailable(source)) {
         <app-notice type="warning" icon="warning" data-test-id="warning-source-no-access">
           <transloco
             key="draft_generation.info_alert_no_source_access"
@@ -167,15 +150,7 @@
             }"
           ></transloco>
         </app-notice>
-      }
-      @if (
-        isSourceProjectSet &&
-        isSourceAndTargetDifferent &&
-        isSourceAndTrainingSourceLanguageIdentical &&
-        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-        canAccessDraftSourceIfAvailable(source) &&
-        !canAccessDraftSourceIfAvailable(alternateSource)
-      ) {
+      } @else if (!canAccessDraftSourceIfAvailable(alternateSource)) {
         <app-notice type="warning" icon="warning" data-test-id="warning-alternate-source-no-access">
           <transloco
             key="draft_generation.info_alert_no_alternate_source_access"
@@ -185,16 +160,7 @@
             }"
           ></transloco>
         </app-notice>
-      }
-      @if (
-        isSourceProjectSet &&
-        isSourceAndTargetDifferent &&
-        isSourceAndTrainingSourceLanguageIdentical &&
-        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-        canAccessDraftSourceIfAvailable(source) &&
-        canAccessDraftSourceIfAvailable(alternateSource) &&
-        !canAccessDraftSourceIfAvailable(alternateTrainingSource)
-      ) {
+      } @else if (!canAccessDraftSourceIfAvailable(alternateTrainingSource)) {
         <app-notice type="warning" icon="warning" data-test-id="warning-alternate-training-source-no-access">
           <transloco
             key="draft_generation.info_alert_no_alternate_training_source_access"
@@ -204,17 +170,7 @@
             }"
           ></transloco>
         </app-notice>
-      }
-      @if (
-        isSourceProjectSet &&
-        isSourceAndTargetDifferent &&
-        isSourceAndTrainingSourceLanguageIdentical &&
-        isSourceAndAdditionalTrainingSourceLanguageIdentical &&
-        canAccessDraftSourceIfAvailable(source) &&
-        canAccessDraftSourceIfAvailable(alternateSource) &&
-        canAccessDraftSourceIfAvailable(alternateTrainingSource) &&
-        !canAccessDraftSourceIfAvailable(additionalTrainingSource)
-      ) {
+      } @else if (!canAccessDraftSourceIfAvailable(additionalTrainingSource)) {
         <app-notice type="warning" icon="warning" data-test-id="warning-mix-source-no-access">
           <transloco
             key="draft_generation.info_alert_no_additional_training_source_access"
@@ -241,9 +197,7 @@
     <section>
       <p class="offline-text">{{ t("offline_message") }}</p>
     </section>
-  }
-
-  @if (isOnline) {
+  } @else {
     <mat-tab-group>
       <mat-tab>
         @if (!this.isBackTranslationMode && !this.isPreTranslationApproved) {
@@ -306,8 +260,7 @@
                     <h3>{{ t("draft_queued_header") }}</h3>
                     @if (!hasDraftQueueDepth(draftJob)) {
                       <p>{{ t("draft_queued_detail") }}</p>
-                    }
-                    @if (hasDraftQueueDepth(draftJob)) {
+                    } @else {
                       <p>
                         {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
                       </p>
@@ -322,8 +275,7 @@
                       }
                     </div>
                   </section>
-                }
-                @if (isDraftActive(draftJob)) {
+                } @else if (isDraftActive(draftJob)) {
                   <section class="progress-active">
                     <h3>{{ t("draft_active_header") }}</h3>
                     <div class="progress-text">
@@ -366,8 +318,7 @@
                           >
                             @if (downloadProgress === 0) {
                               <mat-icon class="material-icons-outlined">cloud_download</mat-icon>
-                            }
-                            @if (downloadProgress > 0) {
+                            } @else if (downloadProgress > 0) {
                               <mat-icon>
                                 <mat-spinner
                                   diameter="18"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.html
@@ -19,8 +19,7 @@
           }
           <span>{{ trainingDataFilename }}</span>
           <mat-icon (click)="deleteTrainingData()" class="delete">delete</mat-icon>
-        }
-        @if (!hasBeenUploaded) {
+        } @else {
           <mat-icon>file_download_off</mat-icon>
           <span>{{ t("no_training_data_file_uploaded") }}</span>
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.html
@@ -2,10 +2,8 @@
   @if (historyChooser?.isLoading$ | async) {
     <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
   }
-} @else {
-  @if (!loadedRevision) {
-    <app-notice icon="warning" type="warning">{{ "editor_history_tab.offline_notice" | transloco }}</app-notice>
-  }
+} @else if (!loadedRevision) {
+  <app-notice icon="warning" type="warning">{{ "editor_history_tab.offline_notice" | transloco }}</app-notice>
 }
 
 <app-history-chooser

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -65,220 +65,222 @@
               }
               {{ tab.headerText }}
             </ng-template>
-            @if (tab.type === "project-resource") {
-              <app-editor-resource
-                [projectId]="tab.projectId"
-                [bookNum]="bookNum"
-                [chapter]="chapter"
-                [segmentRef]="target?.segmentRef"
-                [highlightSegment]="targetFocused"
-              ></app-editor-resource>
-            }
-            @if (tab.type === "project-source") {
-              <div class="project-tab-container">
-                @if (hasSourceCopyrightBanner) {
-                  <app-notice icon="copyright" type="warning" class="copyright-banner">
-                    <div>
-                      {{ sourceCopyrightBanner }}
-                      <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{
-                        t("more_info")
-                      }}</span>
-                    </div>
-                  </app-notice>
-                }
-                <div class="container-for-split">
-                  <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-                  <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
-                    <as-split-area [size]="75" [minSize]="20">
-                      <div class="text-container">
-                        <app-text
-                          #source
-                          [id]="visibleSourceProjectId | textDocId: bookNum : chapter"
-                          [isReadOnly]="true"
-                          [highlightSegment]="targetFocused"
-                          (loaded)="onTextLoaded('source')"
-                          (updated)="onSourceUpdated($event.delta != null)"
-                          [isRightToLeft]="isSourceRightToLeft"
-                          [fontSize]="sourceFontSize"
-                          [style.--project-font]="fontService.getFontFamilyFromProject(sourceProjectDoc)"
-                        ></app-text>
+            @switch (tab.type) {
+              @case ("project-resource") {
+                <app-editor-resource
+                  [projectId]="tab.projectId"
+                  [bookNum]="bookNum"
+                  [chapter]="chapter"
+                  [segmentRef]="target?.segmentRef"
+                  [highlightSegment]="targetFocused"
+                ></app-editor-resource>
+              }
+              @case ("project-source") {
+                <div class="project-tab-container">
+                  @if (hasSourceCopyrightBanner) {
+                    <app-notice icon="copyright" type="warning" class="copyright-banner">
+                      <div>
+                        {{ sourceCopyrightBanner }}
+                        <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{
+                          t("more_info")
+                        }}</span>
                       </div>
-                    </as-split-area>
-                    @if (biblicalTermsEnabledForSource) {
-                      <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
-                        <app-biblical-terms
-                          id="source-biblical-terms"
-                          [bookNum]="bookNum"
-                          [chapter]="chapter"
-                          [verse]="verse"
-                          [configProjectId]="projectId"
-                          [projectId]="sourceProjectId"
-                        ></app-biblical-terms>
+                    </app-notice>
+                  }
+                  <div class="container-for-split">
+                    <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+                    <as-split direction="vertical" [style.height]="sourceSplitHeight" [dir]="i18n.direction">
+                      <as-split-area [size]="75" [minSize]="20">
+                        <div class="text-container">
+                          <app-text
+                            #source
+                            [id]="visibleSourceProjectId | textDocId: bookNum : chapter"
+                            [isReadOnly]="true"
+                            [highlightSegment]="targetFocused"
+                            (loaded)="onTextLoaded('source')"
+                            (updated)="onSourceUpdated($event.delta != null)"
+                            [isRightToLeft]="isSourceRightToLeft"
+                            [fontSize]="sourceFontSize"
+                            [style.--project-font]="fontService.getFontFamilyFromProject(sourceProjectDoc)"
+                          ></app-text>
+                        </div>
                       </as-split-area>
-                    }
-                  </as-split>
+                      @if (biblicalTermsEnabledForSource) {
+                        <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
+                          <app-biblical-terms
+                            id="source-biblical-terms"
+                            [bookNum]="bookNum"
+                            [chapter]="chapter"
+                            [verse]="verse"
+                            [configProjectId]="projectId"
+                            [projectId]="sourceProjectId"
+                          ></app-biblical-terms>
+                        </as-split-area>
+                      }
+                    </as-split>
+                  </div>
                 </div>
-              </div>
-            }
-            @if (tab.type === "project-target") {
-              <div class="project-tab-container">
-                @if (hasTargetCopyrightBanner) {
-                  <app-notice icon="copyright" type="warning" class="copyright-banner">
-                    <div>
-                      {{ targetCopyrightBanner }}
-                      <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{
-                        t("more_info")
-                      }}</span>
-                    </div>
-                  </app-notice>
-                }
-                @if (!isUsfmValid && hasEditRight) {
-                  <app-notice type="warning" icon="warning" class="formatting-invalid-warning">
-                    {{ t("cannot_edit_chapter_formatting_invalid") }}
-                  </app-notice>
-                }
-                @if (!dataInSync && hasEditRight) {
-                  <app-notice type="warning" icon="warning" class="out-of-sync-warning">
-                    {{ t("project_data_out_of_sync") }}
-                  </app-notice>
-                }
-                @if (target.areOpsCorrupted && hasEditRight) {
-                  <app-notice type="error" icon="error" class="doc-corrupted-warning">
-                    {{ t("text_doc_corrupted") }}
-                    <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
-                  </app-notice>
-                }
-                @if (projectTextNotEditable && hasEditRight) {
-                  <app-notice type="info" icon="info" class="project-text-not-editable">
-                    {{ t("project_text_not_editable") }}
-                  </app-notice>
-                }
-                @if (showNoEditPermissionMessage) {
-                  <app-notice type="info" icon="info" class="no-edit-permission-message">
-                    {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
-                  </app-notice>
-                }
-                <div class="container-for-split">
-                  <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
-                  <as-split direction="vertical" [style.height]="targetSplitHeight">
-                    <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
-                      <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
-                        <app-text
-                          #target
-                          [id]="projectId | textDocId: bookNum : chapter"
-                          [isReadOnly]="!canEdit"
-                          (updated)="
-                            onTargetUpdated(
-                              $event.segment,
-                              $event.delta,
-                              $event.prevSegment,
-                              $event.affectedEmbeds,
-                              $event.isLocalUpdate
-                            )
-                          "
-                          (loaded)="onTextLoaded('target')"
-                          (focused)="targetFocused = $event"
-                          (segmentRefChange)="onSegmentRefChange($event)"
-                          (presenceChange)="onPresenceChange($event)"
-                          [highlightSegment]="targetFocused && canEdit"
-                          [enablePresence]="true"
-                          [markInvalid]="true"
-                          [isRightToLeft]="isTargetRightToLeft"
-                          [fontSize]="fontSize"
-                          [selectableVerses]="showAddCommentUI"
-                          [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
-                          [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
-                        ></app-text>
-                        <app-suggestions
-                          class="mat-elevation-z2"
-                          [show]="showSuggestions && translationSuggestionsEnabled"
-                          [suggestions]="suggestions"
-                          [text]="target"
-                          (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
-                          (showChange)="showSuggestions = $event"
-                        ></app-suggestions>
-                        <ng-template #fabBottomSheet>
-                          <div class="fab-bottom-sheet" [dir]="direction">
-                            <b>{{ currentSegmentReference }}</b>
-                            @if (!addingMobileNote && !hasEditRight) {
-                              <button mat-flat-button (click)="toggleAddingMobileNote()" color="accent">
-                                <mat-icon>add_comment</mat-icon>
-                                {{ t("add_comment") }}
-                              </button>
-                            }
-                            @if (addingMobileNote) {
-                              <form>
-                                <mat-form-field class="full-width" appearance="outline">
-                                  <mat-label>{{ t("your_comment") }}</mat-label>
-                                  <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
-                                </mat-form-field>
-                                <div class="fab-action-buttons">
-                                  <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
-                                    {{ t("cancel") }}
-                                  </button>
-                                  <button
-                                    mat-flat-button
-                                    class="save-button"
-                                    color="primary"
-                                    (click)="saveMobileNote()"
-                                  >
-                                    {{ t("save") }}
-                                  </button>
-                                </div>
-                              </form>
-                            }
-                          </div>
-                        </ng-template>
-                        @if (canInsertNote) {
-                          <button
-                            #fabButton
-                            class="insert-note-fab"
-                            mat-mini-fab
-                            title="{{ t('add_comment') }}"
-                            (click)="insertNote()"
-                          >
-                            <mat-icon>add_comment</mat-icon>
-                          </button>
-                        }
+              }
+              @case ("project-target") {
+                <div class="project-tab-container">
+                  @if (hasTargetCopyrightBanner) {
+                    <app-notice icon="copyright" type="warning" class="copyright-banner">
+                      <div>
+                        {{ targetCopyrightBanner }}
+                        <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{
+                          t("more_info")
+                        }}</span>
                       </div>
-                    </as-split-area>
-                    @if (biblicalTermsEnabledForTarget) {
-                      <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
-                        <app-biblical-terms
-                          id="target-biblical-terms"
-                          [bookNum]="bookNum"
-                          [chapter]="chapter"
-                          [verse]="verse"
-                          [configProjectId]="projectId"
-                          [projectId]="projectId"
-                        ></app-biblical-terms>
+                    </app-notice>
+                  }
+                  @if (!isUsfmValid && hasEditRight) {
+                    <app-notice type="warning" icon="warning" class="formatting-invalid-warning">
+                      {{ t("cannot_edit_chapter_formatting_invalid") }}
+                    </app-notice>
+                  }
+                  @if (!dataInSync && hasEditRight) {
+                    <app-notice type="warning" icon="warning" class="out-of-sync-warning">
+                      {{ t("project_data_out_of_sync") }}
+                    </app-notice>
+                  }
+                  @if (target.areOpsCorrupted && hasEditRight) {
+                    <app-notice type="error" icon="error" class="doc-corrupted-warning">
+                      {{ t("text_doc_corrupted") }}
+                      <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
+                    </app-notice>
+                  }
+                  @if (projectTextNotEditable && hasEditRight) {
+                    <app-notice type="info" icon="info" class="project-text-not-editable">
+                      {{ t("project_text_not_editable") }}
+                    </app-notice>
+                  }
+                  @if (showNoEditPermissionMessage) {
+                    <app-notice type="info" icon="info" class="no-edit-permission-message">
+                      {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
+                    </app-notice>
+                  }
+                  <div class="container-for-split">
+                    <!-- dir must be set on as-split-area because as-split is always set with dir=ltr -->
+                    <as-split direction="vertical" [style.height]="targetSplitHeight">
+                      <as-split-area [size]="75" [minSize]="20" [dir]="i18n.direction">
+                        <div class="text-container" [dir]="isTargetRightToLeft ? 'rtl' : 'ltr'">
+                          <app-text
+                            #target
+                            [id]="projectId | textDocId: bookNum : chapter"
+                            [isReadOnly]="!canEdit"
+                            (updated)="
+                              onTargetUpdated(
+                                $event.segment,
+                                $event.delta,
+                                $event.prevSegment,
+                                $event.affectedEmbeds,
+                                $event.isLocalUpdate
+                              )
+                            "
+                            (loaded)="onTextLoaded('target')"
+                            (focused)="targetFocused = $event"
+                            (segmentRefChange)="onSegmentRefChange($event)"
+                            (presenceChange)="onPresenceChange($event)"
+                            [highlightSegment]="targetFocused && canEdit"
+                            [enablePresence]="true"
+                            [markInvalid]="true"
+                            [isRightToLeft]="isTargetRightToLeft"
+                            [fontSize]="fontSize"
+                            [selectableVerses]="showAddCommentUI"
+                            [ngClass]="{ 'comment-enabled-editor': showAddCommentUI }"
+                            [style.--project-font]="fontService.getFontFamilyFromProject(projectDoc)"
+                          ></app-text>
+                          <app-suggestions
+                            class="mat-elevation-z2"
+                            [show]="showSuggestions && translationSuggestionsEnabled"
+                            [suggestions]="suggestions"
+                            [text]="target"
+                            (selected)="insertSuggestion($event.suggestionIndex, $event.wordIndex, $event.event)"
+                            (showChange)="showSuggestions = $event"
+                          ></app-suggestions>
+                          <ng-template #fabBottomSheet>
+                            <div class="fab-bottom-sheet" [dir]="direction">
+                              <b>{{ currentSegmentReference }}</b>
+                              @if (!addingMobileNote && !hasEditRight) {
+                                <button mat-flat-button (click)="toggleAddingMobileNote()" color="accent">
+                                  <mat-icon>add_comment</mat-icon>
+                                  {{ t("add_comment") }}
+                                </button>
+                              }
+                              @if (addingMobileNote) {
+                                <form>
+                                  <mat-form-field class="full-width" appearance="outline">
+                                    <mat-label>{{ t("your_comment") }}</mat-label>
+                                    <textarea #mobileNoteTextarea matInput [formControl]="mobileNoteControl"></textarea>
+                                  </mat-form-field>
+                                  <div class="fab-action-buttons">
+                                    <button mat-button class="close-button" (click)="toggleAddingMobileNote()">
+                                      {{ t("cancel") }}
+                                    </button>
+                                    <button
+                                      mat-flat-button
+                                      class="save-button"
+                                      color="primary"
+                                      (click)="saveMobileNote()"
+                                    >
+                                      {{ t("save") }}
+                                    </button>
+                                  </div>
+                                </form>
+                              }
+                            </div>
+                          </ng-template>
+                          @if (canInsertNote) {
+                            <button
+                              #fabButton
+                              class="insert-note-fab"
+                              mat-mini-fab
+                              title="{{ t('add_comment') }}"
+                              (click)="insertNote()"
+                            >
+                              <mat-icon>add_comment</mat-icon>
+                            </button>
+                          }
+                        </div>
                       </as-split-area>
-                    }
-                  </as-split>
+                      @if (biblicalTermsEnabledForTarget) {
+                        <as-split-area [size]="25" [dir]="i18n.direction" class="biblical-terms">
+                          <app-biblical-terms
+                            id="target-biblical-terms"
+                            [bookNum]="bookNum"
+                            [chapter]="chapter"
+                            [verse]="verse"
+                            [configProjectId]="projectId"
+                            [projectId]="projectId"
+                          ></app-biblical-terms>
+                        </as-split-area>
+                      }
+                    </as-split>
+                  </div>
                 </div>
-              </div>
-            }
-            @if (tab.type === "history") {
-              <app-editor-history
-                [projectId]="projectId"
-                [bookNum]="bookNum"
-                [chapter]="chapter"
-                [isRightToLeft]="isTargetRightToLeft"
-                [fontSize]="fontSize"
-                [diffText]="target"
-                (revisionSelect)="onHistoryTabRevisionSelect(tab, $event)"
-              >
-              </app-editor-history>
-            }
-            @if (tab.type === "draft") {
-              <app-editor-draft
-                [projectId]="projectId"
-                [bookNum]="bookNum"
-                [chapter]="chapter"
-                [isRightToLeft]="isTargetRightToLeft"
-                [fontSize]="fontSize"
-              >
-              </app-editor-draft>
+              }
+              @case ("history") {
+                <app-editor-history
+                  [projectId]="projectId"
+                  [bookNum]="bookNum"
+                  [chapter]="chapter"
+                  [isRightToLeft]="isTargetRightToLeft"
+                  [fontSize]="fontSize"
+                  [diffText]="target"
+                  (revisionSelect)="onHistoryTabRevisionSelect(tab, $event)"
+                >
+                </app-editor-history>
+              }
+              @case ("draft") {
+                <app-editor-draft
+                  [projectId]="projectId"
+                  [bookNum]="bookNum"
+                  [chapter]="chapter"
+                  [isRightToLeft]="isTargetRightToLeft"
+                  [fontSize]="fontSize"
+                >
+                </app-editor-draft>
+              }
             }
           </app-tab>
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -25,8 +25,7 @@
             }
             {{ viewers.length - maxAvatars + 1 }}</span
           >
-        }
-        @if (isMenuOpen) {
+        } @else {
           <mat-icon>arrow_drop_up</mat-icon>
         }
       </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -12,8 +12,7 @@
         <div class="text">
           @if (!isNewNote || isBiblicalTermNote) {
             <div class="note-text" [innerHTML]="getNoteContextText()"></div>
-          }
-          @if (isNewNote && !isBiblicalTermNote) {
+          } @else {
             <div class="note-text" [innerHTML]="segmentText"></div>
           }
           @if (showSegmentText) {
@@ -91,8 +90,7 @@
               <button mat-menu-item (click)="saveOption = 'save'">
                 <span>{{ t("save") }}</span>
               </button>
-            }
-            @if (saveOption === "save") {
+            } @else if (saveOption === "save") {
               <button mat-menu-item (click)="saveOption = 'resolve'">
                 <span>{{ t("resolve") }}</span>
               </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.spec.ts
@@ -12,8 +12,8 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import {
   getSFProjectUserConfigDocId,
-  SFProjectUserConfig,
-  SF_PROJECT_USER_CONFIGS_COLLECTION
+  SF_PROJECT_USER_CONFIGS_COLLECTION,
+  SFProjectUserConfig
 } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.html
@@ -1,7 +1,6 @@
 @if (isLoading) {
   <div class="loading-indicator"><span></span> <span></span> <span></span></div>
-}
-@if (!isLoading) {
+} @else {
   <mat-selection-list #list dense [multiple]="false" (click)="selectAll($event)" hideSingleSelectionIndicator>
     @for (suggestion of suggestions; track suggestion; let i = $index) {
       <mat-list-option [selected]="suggestion && i === 0">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
@@ -1,7 +1,6 @@
 @if (isLoading && !isSyncActive) {
   <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
-}
-@if (isSyncActive) {
+} @else if (isSyncActive) {
   <app-sync-progress [projectDoc]="selectedProjectDoc" (inProgress)="onSyncProgress($event)"></app-sync-progress>
 }
 
@@ -35,13 +34,11 @@
       <mat-error>
         {{ t("error_fetching_projects_resources") }}
       </mat-error>
-    }
-    @if (projectLoadingFailed && !resourceLoadingFailed) {
+    } @else if (projectLoadingFailed && !resourceLoadingFailed) {
       <mat-error>
         {{ t("error_fetching_projects") }}
       </mat-error>
-    }
-    @if (resourceLoadingFailed && !projectLoadingFailed) {
+    } @else if (resourceLoadingFailed && !projectLoadingFailed) {
       <mat-error>
         {{ t("error_fetching_resources") }}
       </mat-error>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
@@ -20,8 +20,7 @@
               [innerThicknessDelta]="0"
               [thickness]="22"
             ></app-donut-chart>
-          }
-          @if (trainingPercentage === 100) {
+          } @else if (trainingPercentage === 100) {
             <mat-icon id="training-complete-icon">check_circle_outline</mat-icon>
           }
         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -51,8 +51,7 @@
                         <b class="current-user-label">&nbsp;{{ t("me") }}</b>
                       }
                     </div>
-                  }
-                  @if (userRow.inviteeStatus) {
+                  } @else {
                     <div
                       [innerHtml]="
                         userRow.inviteeStatus.expired
@@ -117,8 +116,7 @@
                       >
                         {{ t("remove_from_project") }}
                       </button>
-                    }
-                    @if (userRow.inviteeStatus) {
+                    } @else if (userRow.inviteeStatus) {
                       <button
                         mat-menu-item
                         class="cancel-invite"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.component.html
@@ -13,11 +13,9 @@
       (error)="onImageError()"
       referrerpolicy="no-referrer"
     />
-  }
-  @if (mode === "user_icon") {
+  } @else if (mode === "user_icon") {
     <mat-icon class="user-icon">account_circle</mat-icon>
-  }
-  @if (mode === "initials") {
+  } @else if (mode === "initials") {
     <div class="initials">{{ initials }}</div>
   }
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.html
@@ -12,8 +12,7 @@
     <form id="name-form">
       @if (data.isConfirmation) {
         <p>{{ t("confirm_name") }}</p>
-      }
-      @if (!data.isConfirmation) {
+      } @else {
         <p>{{ t("enter_name") }}</p>
       }
       <mat-form-field appearance="fill">

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/generic-dialog/generic-dialog.component.html
@@ -10,8 +10,7 @@
       <button mat-flat-button color="primary" [mat-dialog-close]="option.value">
         {{ option.label | async }}
       </button>
-    }
-    @if (!option.highlight) {
+    } @else {
       <button mat-button [mat-dialog-close]="option.value">{{ option.label | async }}</button>
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/write-status/write-status.component.html
@@ -1,9 +1,7 @@
 @if (state === ElementState.Submitting && !formGroup?.errors) {
   <mat-spinner diameter="15" class="update-button-spinner" aria-label="Update in progress"></mat-spinner>
-}
-@if (state === ElementState.Submitted && !formGroup?.errors) {
+} @else if (state === ElementState.Submitted && !formGroup?.errors) {
   <mat-icon class="check-icon">done</mat-icon>
-}
-@if (state === ElementState.Error && !formGroup?.errors) {
+} @else if (state === ElementState.Error && !formGroup?.errors) {
   <mat-icon class="error-icon" color="warn">error</mat-icon>
 }


### PR DESCRIPTION
This PR cleans up the migration to the control flow syntax. These suggestions were made in PR#2617. Most of the changes make use of the `@else if` and `@else` branching tags.
The automated unit tests are passing locally so I do not think we will need to send this to testers since the changes have no logical difference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2664)
<!-- Reviewable:end -->
