### PR TITLE
Remove unneeded trailing padding from nav menu items

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.scss
@@ -3,7 +3,7 @@
 mat-nav-list .mdc-list-item {
   font-weight: 500;
   font-size: 14px;
-  padding-inline: 12px;
+  padding-inline: 12px 0;
 
   mat-icon {
     color: variables.$purpleMedium;
@@ -100,4 +100,5 @@ mat-nav-list .mdc-list-item {
   font-size: 0.95em;
   background: #4678d6;
   margin-inline-start: auto;
+  margin-inline-end: 12px;
 }


### PR DESCRIPTION
The menu items in the main navigation have leading and trailing padding of 12px.

The leading padding is needed in order to give the items a consistent layout, but the trailing padding has no effect other than to cut off long menu items.

This is the padding I'm referring to:

![](https://github.com/user-attachments/assets/3b29e276-a8c7-48ba-a5d1-f1b071bac943)

This PR removes the trailing padding so that longer strings are not cut off.

Before | After
-------|------
![](https://github.com/user-attachments/assets/ad20d911-9ab6-4971-b9e5-2d7c6f9e6768) | ![](https://github.com/user-attachments/assets/abf90987-fc69-4f16-875c-d24a547bd999)

I am marking this as "testing not required" since there is comprehensive test coverage of visual changes to this component.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2666)
<!-- Reviewable:end -->
