### PR TITLE
SF-2886 Allow adding a draft book to a different project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -13,11 +13,14 @@
         (projectSelect)="projectSelectedAsync($event.paratextId)"
         formControlName="targetParatextId"
       ></app-project-select>
-      @if (!canEditProject) {
+      @if (!canEditProject && isAppOnline) {
         <mat-error class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</mat-error>
       }
-      @if (projectLoadingFailed) {
+      @if (projectLoadingFailed && isAppOnline) {
         <mat-error class="fetch-projects-failed-message">{{ t("error_fetching_projects") }}</mat-error>
+      }
+      @if (!isAppOnline) {
+        <mat-error class="offline-message">{{ t("connect_to_the_internet") }}</mat-error>
       }
       @if (connectOtherProject != null) {
         <div class="unlisted-project-message">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -9,6 +9,7 @@
       <app-project-select
         [projects]="projects"
         [placeholder]="t('choose_project')"
+        [isDisabled]="projects.length === 0"
         (projectSelect)="projectSelectedAsync($event.paratextId)"
       ></app-project-select>
       @if (!canEditProject) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -11,30 +11,30 @@
         [placeholder]="t('choose_project')"
         [isDisabled]="projects.length === 0"
         (projectSelect)="projectSelectedAsync($event.paratextId)"
+        formControlName="targetParatextId"
       ></app-project-select>
       @if (!canEditProject) {
         <div class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</div>
       }
-      <div class="unlisted-project-message">
-        <p>
-          <span [innerHTML]="connectOtherProject?.before"></span>
-          <!-- TODO: Get page to open in new tab -->
-          <a target="_blank" [appRouterLink]="['projects']">{{ connectOtherProject?.templateTagText }}</a>
-          <span>{{ connectOtherProject?.after }}</span>
-        </p>
-      </div>
+      @if (connectOtherProject != null) {
+        <div class="unlisted-project-message">
+          <p>
+            <span [innerHTML]="connectOtherProject.before"></span>
+            <a [appRouterLink]="['projects']">{{ connectOtherProject.templateTagText }}</a>
+            <span>{{ connectOtherProject.after }}</span>
+          </p>
+        </div>
+      }
       @if (targetProject$ | async; as project) {
-        @if (targetChapters$ | async; as chapters) {
-          <div class="target-project-content">
-            @if (chapters === 0) {
-              <mat-icon>check</mat-icon>
-              {{ t("book_is_empty", { bookName, projectName: project.name }) }}
-            } @else {
-              <mat-icon>warning</mat-icon>
-              {{ t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name }) }}
-            }
-          </div>
-        }
+        <div class="target-project-content">
+          @if (targetChapters$ | async; as chapters) {
+            <mat-icon>warning</mat-icon>
+            {{ t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name }) }}
+          } @else {
+            <mat-icon>verified</mat-icon>
+            {{ t("book_is_empty", { bookName, projectName: project.name }) }}
+          }
+        </div>
         <mat-checkbox class="overwrite-content" formControlName="overwrite">{{
           t("i_understand_overwrite_book", { projectName: project.name, bookName })
         }}</mat-checkbox>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -1,0 +1,49 @@
+@if (isLoading) {
+  <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
+}
+
+<ng-container *transloco="let t; read: 'draft_apply_dialog'">
+  <div mat-dialog-content>
+    <form [formGroup]="addToProjectForm">
+      <p>{{ t("select_alternate_project") }}</p>
+      <app-project-select
+        [projects]="projects"
+        [placeholder]="t('choose_project')"
+        (projectSelect)="projectSelectedAsync($event.paratextId)"
+      ></app-project-select>
+      @if (!canEditProject) {
+        <div class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</div>
+      }
+      <div class="unlisted-project-message">
+        <p>
+          <span [innerHTML]="connectOtherProject?.before"></span>
+          <!-- TODO: Get page to open in new tab -->
+          <a target="_blank" [appRouterLink]="['projects']">{{ connectOtherProject?.templateTagText }}</a>
+          <span>{{ connectOtherProject?.after }}</span>
+        </p>
+      </div>
+      @if (targetProject$ | async; as project) {
+        @if (targetChapters$ | async; as chapters) {
+          <div class="target-project-content">
+            @if (chapters === 0) {
+              <mat-icon>check</mat-icon>
+              {{ t("book_is_empty", { bookName, projectName: project.name }) }}
+            } @else {
+              <mat-icon>warning</mat-icon>
+              {{ t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name }) }}
+            }
+          </div>
+        }
+        <mat-checkbox class="overwrite-content" formControlName="overwrite">{{
+          t("i_understand_overwrite_book", { projectName: project.name, bookName })
+        }}</mat-checkbox>
+      }
+    </form>
+  </div>
+  <div mat-dialog-actions>
+    <button mat-button class="cancel-button" [mat-dialog-close]="false">{{ t("cancel") }}</button>
+    <button mat-raised-button class="add-button" color="primary" (click)="addToProject()" [disabled]="addDisabled">
+      {{ t("add_to_project") }}
+    </button>
+  </div>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -14,13 +14,16 @@
         formControlName="targetParatextId"
       ></app-project-select>
       @if (!canEditProject) {
-        <div class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</div>
+        <mat-error class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</mat-error>
+      }
+      @if (projectLoadingFailed) {
+        <mat-error class="fetch-projects-failed-message">{{ t("error_fetching_projects") }}</mat-error>
       }
       @if (connectOtherProject != null) {
         <div class="unlisted-project-message">
           <p>
             <span [innerHTML]="connectOtherProject.before"></span>
-            <a [appRouterLink]="['projects']">{{ connectOtherProject.templateTagText }}</a>
+            <a [appRouterLink]="['projects']" (click)="close()">{{ connectOtherProject.templateTagText }}</a>
             <span>{{ connectOtherProject.after }}</span>
           </p>
         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
@@ -1,0 +1,16 @@
+@use 'src/variables' as var;
+
+.mat-mdc-dialog-actions {
+  justify-content: flex-end;
+}
+
+.cannot-edit-message {
+  color: var.$errorColor;
+}
+
+.target-project-content {
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
+  padding: 8px 0;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
@@ -1,11 +1,5 @@
-@use 'src/variables' as var;
-
 .mat-mdc-dialog-actions {
   justify-content: flex-end;
-}
-
-.cannot-edit-message {
-  color: var.$errorColor;
 }
 
 .target-project-content {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.scss
@@ -14,3 +14,7 @@
   column-gap: 8px;
   padding: 8px 0;
 }
+
+.overwrite-content {
+  inset-inline-start: -8px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
@@ -29,8 +29,7 @@ const mockedTextDocService = mock(TextDocService);
 const mockedI18nService = mock(I18nService);
 let env: TestEnvironment;
 
-// TODO: Get tests to pass
-xdescribe('DraftApplyDialogComponent', () => {
+fdescribe('DraftApplyDialogComponent', () => {
   configureTestingModule(() => ({
     imports: [UICommonModule, DraftApplyDialogComponent, TestTranslocoModule, NoopAnimationsModule],
     providers: [
@@ -67,12 +66,13 @@ xdescribe('DraftApplyDialogComponent', () => {
     expect(env.targetProjectContent).toBeNull();
   }));
 
-  it('add button is disabled until project is selected', fakeAsync(async () => {
+  fit('add button is disabled until project is selected', fakeAsync(async () => {
     expect(env.addButton).toBeTruthy();
     expect(env.addButton.attributes['disabled']).toBeDefined();
     env.component.targetProjectId = 'project01';
     tick();
     env.fixture.detectChanges();
+    /*
     expect(env.addButton.attributes['disabled']).toBeDefined();
     const harness = await env.checkboxHarnessAsync();
     harness.check();
@@ -82,6 +82,7 @@ xdescribe('DraftApplyDialogComponent', () => {
     env.cancelButton.click();
     tick();
     env.fixture.detectChanges();
+    */
   }));
 
   it('can add draft to project when project selected', fakeAsync(async () => {
@@ -168,6 +169,8 @@ class TestEnvironment {
   constructor() {
     when(mockedParatextService.getProjects()).thenReturn(Promise.resolve(this.projects));
     when(mockedUserService.currentUserId).thenReturn('user01');
+    when(mockedI18nService.localizeBook(anything())).thenReturn('Genesis');
+    when(mockedI18nService.translateTextAroundTemplateTags(anything())).thenReturn(undefined);
     this.setupProject();
 
     this.fixture = TestBed.createComponent(DraftApplyDialogComponent);
@@ -224,6 +227,10 @@ class TestEnvironment {
         })
       } as SFProjectProfileDoc;
       when(mockedProjectService.getProfile(id)).thenReturn(Promise.resolve(mockedProject));
+      // const mockedTextDoc = {
+      //   getNonEmptyVerses: () => 0
+      // } as unknown as TextDoc;
+      // when(mockedProjectService.getText(anything())).thenResolve(mockedTextDoc);
     }
     when(mockedTextDocService.userHasGeneralEditRight(anything())).thenReturn(true);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
@@ -82,11 +82,21 @@ describe('DraftApplyDialogComponent', () => {
     expect(env.unlistedProjectMessage).not.toBeNull();
     expect(env.overwriteContentMessage).toBeNull();
     expect(env.targetProjectContent).toBeNull();
+    expect(env.getProjectsFailedMessage).toBeNull();
+  }));
+
+  it('shows error when loading project fails', fakeAsync(() => {
+    env.component.projectLoadingFailed = true;
+    verify(mockedParatextService.getProjects()).once();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.getProjectsFailedMessage).not.toBeNull();
   }));
 
   it('add button is disabled until project is selected', fakeAsync(async () => {
     expect(env.addButton).toBeTruthy();
     expect(env.addButton.attributes['disabled']).toBeDefined();
+    env.component.addToProjectForm.controls.targetParatextId.setValue('pt01');
     env.component.projectSelectedAsync('pt01');
     tick();
     env.fixture.detectChanges();
@@ -102,6 +112,7 @@ describe('DraftApplyDialogComponent', () => {
   }));
 
   it('can add draft to project when project selected', fakeAsync(async () => {
+    env.component.addToProjectForm.controls.targetParatextId.setValue('pt01');
     env.component.projectSelectedAsync('pt01');
     tick();
     env.fixture.detectChanges();
@@ -117,6 +128,7 @@ describe('DraftApplyDialogComponent', () => {
   }));
 
   it('checks if the user has edit permissions', fakeAsync(async () => {
+    env.component.addToProjectForm.controls.targetParatextId.setValue('pt01');
     env.component.projectSelectedAsync('pt01');
     tick();
     env.fixture.detectChanges();
@@ -184,7 +196,7 @@ class TestEnvironment {
   ];
 
   constructor() {
-    when(mockedParatextService.getProjects()).thenReturn(Promise.resolve(this.projects));
+    when(mockedParatextService.getProjects()).thenResolve(this.projects);
     when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedI18nService.localizeBook(anything())).thenReturn('Genesis');
     when(mockedI18nService.translateTextAroundTemplateTags(anything())).thenReturn({
@@ -222,6 +234,10 @@ class TestEnvironment {
 
   get unlistedProjectMessage(): HTMLElement {
     return this.fixture.nativeElement.querySelector('.unlisted-project-message');
+  }
+
+  get getProjectsFailedMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.fetch-projects-failed-message');
   }
 
   async checkboxHarnessAsync(): Promise<MatCheckboxHarness> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
@@ -1,0 +1,230 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
+import { anything, mock, verify, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { UserService } from 'xforge-common/user.service';
+import { ParatextProject } from '../../../core/models/paratext-project';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { ParatextService } from '../../../core/paratext.service';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDocService } from '../../../core/text-doc.service';
+import { DraftHandlingService } from '../draft-handling.service';
+import { DraftApplyDialogComponent } from './draft-apply-dialog.component';
+
+const mockedDraftHandlingService = mock(DraftHandlingService);
+const mockedParatextService = mock(ParatextService);
+const mockedProjectService = mock(SFProjectService);
+const mockedUserService = mock(UserService);
+const mockedDialogRef = mock(MatDialogRef);
+const mockedTextDocService = mock(TextDocService);
+const mockedI18nService = mock(I18nService);
+let env: TestEnvironment;
+
+// TODO: Get tests to pass
+xdescribe('DraftApplyDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [UICommonModule, DraftApplyDialogComponent, TestTranslocoModule, NoopAnimationsModule],
+    providers: [
+      { provide: DraftHandlingService, useMock: mockedDraftHandlingService },
+      { provide: ParatextService, useMock: mockedParatextService },
+      { provide: SFProjectService, useMock: mockedProjectService },
+      { provide: UserService, useMock: mockedUserService },
+      { provide: TextDocService, useMock: mockedTextDocService },
+      { provide: I18nService, useMock: mockedI18nService },
+      { provide: MatDialogRef, useMock: mockedDialogRef },
+      { provide: MAT_DIALOG_DATA, useValue: { bookNum: 1 } }
+    ]
+  }));
+
+  beforeEach(async () => {
+    env = new TestEnvironment();
+  });
+
+  it('can get projects', fakeAsync(() => {
+    expect(env.cancelButton).toBeTruthy();
+    verify(mockedParatextService.getProjects()).once();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.component.projects).toEqual(env.projects);
+    verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).never();
+    env.cancelButton.click();
+    tick();
+    env.fixture.detectChanges();
+  }));
+
+  it('shows additional information to users', fakeAsync(() => {
+    expect(env.unlistedProjectMessage).not.toBeNull();
+    expect(env.overwriteContentMessage).not.toBeNull();
+    expect(env.targetProjectContent).toBeNull();
+  }));
+
+  it('add button is disabled until project is selected', fakeAsync(async () => {
+    expect(env.addButton).toBeTruthy();
+    expect(env.addButton.attributes['disabled']).toBeDefined();
+    env.component.targetProjectId = 'project01';
+    tick();
+    env.fixture.detectChanges();
+    expect(env.addButton.attributes['disabled']).toBeDefined();
+    const harness = await env.checkboxHarnessAsync();
+    harness.check();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.addButton.attributes['disabled']).toBeUndefined();
+    env.cancelButton.click();
+    tick();
+    env.fixture.detectChanges();
+  }));
+
+  it('can add draft to project when project selected', fakeAsync(async () => {
+    env.component.targetProjectId = 'project01';
+    const harness = await env.checkboxHarnessAsync();
+    harness.check();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.addButton.attributes['disabled']).toBeUndefined();
+    env.component.addToProject();
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedDialogRef.close(anything())).once();
+  }));
+
+  it('checks if the user has edit permissions', fakeAsync(async () => {
+    env.component.projectSelectedAsync('pt01');
+    const harness = await env.checkboxHarnessAsync();
+    harness.check();
+    tick(100);
+    env.fixture.detectChanges();
+    tick(100);
+    env.fixture.detectChanges();
+    console.log('checking content');
+    expect(env.targetProjectContent).not.toBeNull();
+    expect(env.component.targetProjectId).toBe('project01');
+    verify(mockedProjectService.getProfile(anything())).once();
+    verify(mockedTextDocService.userHasGeneralEditRight(anything())).once();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.addButton.attributes['disabled']).toBeUndefined();
+    expect(env.cannotEditMessage).toBeNull();
+  }));
+
+  it('notifies user if no edit permissions', fakeAsync(() => {
+    env.component.projectSelectedAsync('pt02');
+    tick();
+    env.fixture.detectChanges();
+    expect(env.component.targetProjectId).toBe('project02');
+    verify(mockedProjectService.getProfile(anything())).once();
+    verify(mockedTextDocService.userHasGeneralEditRight(anything())).once();
+    tick();
+    env.fixture.detectChanges();
+    expect(env.addButton.attributes['disabled']).toBeDefined();
+    expect(env.cannotEditMessage).not.toBeNull();
+  }));
+});
+
+class TestEnvironment {
+  component: DraftApplyDialogComponent;
+  fixture: ComponentFixture<DraftApplyDialogComponent>;
+  loader: HarnessLoader;
+
+  projects: ParatextProject[] = [
+    {
+      paratextId: 'pt01',
+      projectId: 'project01',
+      name: 'Project 01',
+      shortName: 'P01',
+      languageTag: 'en',
+      isConnectable: true,
+      isConnected: true
+    },
+    {
+      paratextId: 'pt02',
+      projectId: 'project02',
+      name: 'Project 02',
+      shortName: 'P02',
+      languageTag: 'fr',
+      isConnectable: true,
+      isConnected: true
+    },
+    {
+      paratextId: 'pt03',
+      projectId: 'project03',
+      name: 'Project 03',
+      shortName: 'P03',
+      languageTag: 'es',
+      isConnectable: true,
+      isConnected: false
+    }
+  ];
+
+  constructor() {
+    when(mockedParatextService.getProjects()).thenReturn(Promise.resolve(this.projects));
+    when(mockedUserService.currentUserId).thenReturn('user01');
+    this.setupProject();
+
+    this.fixture = TestBed.createComponent(DraftApplyDialogComponent);
+    this.loader = TestbedHarnessEnvironment.loader(this.fixture);
+    this.component = this.fixture.componentInstance;
+    this.fixture.detectChanges();
+  }
+
+  get addButton(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.add-button');
+  }
+
+  get cancelButton(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.cancel-button');
+  }
+
+  get cannotEditMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.cannot-edit-message');
+  }
+
+  get targetProjectContent(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.target-project-content');
+  }
+
+  get overwriteContentMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.overwrite-content');
+  }
+
+  get unlistedProjectMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.unlisted-project-message');
+  }
+
+  async checkboxHarnessAsync(): Promise<MatCheckboxHarness> {
+    return await this.loader.getHarness(MatCheckboxHarness.with({ selector: '.overwrite-content' }));
+  }
+
+  private setupProject(): void {
+    const projectPermissions = [
+      { id: 'project01', permission: TextInfoPermission.Write },
+      { id: 'project02', permission: TextInfoPermission.Read }
+    ];
+    for (const { id, permission } of projectPermissions) {
+      const mockedProject = {
+        id,
+        data: createTestProjectProfile({
+          userRoles: { user01: SFProjectRole.ParatextAdministrator },
+          texts: [
+            {
+              bookNum: 1,
+              chapters: [{ number: 1, permissions: { user01: permission } }],
+              permissions: { user01: permission }
+            }
+          ]
+        })
+      } as SFProjectProfileDoc;
+      when(mockedProjectService.getProfile(id)).thenReturn(Promise.resolve(mockedProject));
+    }
+    when(mockedTextDocService.userHasGeneralEditRight(anything())).thenReturn(true);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -12,6 +12,7 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { OnlineStatusService } from '../../../../xforge-common/online-status.service';
 import { ParatextProject } from '../../../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../../core/models/text-doc';
@@ -57,7 +58,8 @@ export class DraftApplyDialogComponent implements OnInit {
     private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
     private readonly i18n: I18nService,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    private readonly onlineStatusService: OnlineStatusService
   ) {
     this.targetProject$.pipe(filterNullish()).subscribe(async project => {
       const chapters: number = await this.chaptersWithTextAsync(project);
@@ -70,7 +72,7 @@ export class DraftApplyDialogComponent implements OnInit {
   }
 
   get addDisabled(): boolean {
-    return this.targetProjectId == null || !this.canEditProject || this.addToProjectForm.invalid;
+    return this.targetProjectId == null || !this.canEditProject || this.addToProjectForm.invalid || !this.isAppOnline;
   }
 
   get bookName(): string {
@@ -80,6 +82,10 @@ export class DraftApplyDialogComponent implements OnInit {
   /** An observable that emits the target project profile if the user has permission to write to the specified book. */
   get targetProject$(): Observable<SFProjectProfile | undefined> {
     return this.targetProjectDoc$.pipe(map(p => p?.data));
+  }
+
+  get isAppOnline(): boolean {
+    return this.onlineStatusService.isOnline;
   }
 
   ngOnInit(): void {
@@ -129,6 +135,8 @@ export class DraftApplyDialogComponent implements OnInit {
     // emit the project profile document
     if (this.canEditProject) {
       this.targetProjectDoc$.next(projectDoc);
+    } else {
+      this.targetProjectDoc$.next(undefined);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -1,0 +1,134 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { TranslocoModule } from '@ngneat/transloco';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
+import { BehaviorSubject, filter, map, Observable } from 'rxjs';
+import { I18nService } from 'xforge-common/i18n.service';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { UserService } from 'xforge-common/user.service';
+import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { ParatextProject } from '../../../core/models/paratext-project';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { TextDoc, TextDocId } from '../../../core/models/text-doc';
+import { ParatextService } from '../../../core/paratext.service';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDocService } from '../../../core/text-doc.service';
+import { compareProjectsForSorting } from '../../../shared/utils';
+
+export interface DraftApplyDialogResult {
+  projectId: string;
+}
+
+@Component({
+  selector: 'app-draft-apply-dialog',
+  standalone: true,
+  imports: [UICommonModule, XForgeCommonModule, TranslocoModule, CommonModule],
+  templateUrl: './draft-apply-dialog.component.html',
+  styleUrl: './draft-apply-dialog.component.scss'
+})
+export class DraftApplyDialogComponent implements OnInit {
+  _projects?: ParatextProject[];
+  // the project to add the draft to
+  targetProjectId?: string;
+  isLoading: boolean = false;
+  canEditProject: boolean = true;
+  addToProjectForm = new FormGroup({
+    overwrite: new FormControl(false, Validators.requiredTrue)
+  });
+  connectOtherProject = this.i18n.translateTextAroundTemplateTags('draft_apply_dialog.looking_for_unlisted_project');
+  /** An observable that emits the number of chapters in the target project that have some text. */
+  targetChapters$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
+
+  private targetProjectDoc$: BehaviorSubject<SFProjectProfileDoc | undefined> = new BehaviorSubject<
+    SFProjectProfileDoc | undefined
+  >(undefined);
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private data: { bookNum: number },
+    @Inject(MatDialogRef) private dialogRef: MatDialogRef<DraftApplyDialogComponent, DraftApplyDialogResult>,
+    private readonly paratextService: ParatextService,
+    private readonly projectService: SFProjectService,
+    private readonly textDocService: TextDocService,
+    private readonly i18n: I18nService,
+    private readonly userService: UserService
+  ) {
+    this.targetProject$.pipe(filterNullish()).subscribe(async project => {
+      const chapters: number = await this.chaptersWithTextAsync(project);
+      this.targetChapters$.next(chapters);
+    });
+  }
+
+  get projects(): ParatextProject[] {
+    return this._projects ?? [];
+  }
+
+  get addDisabled(): boolean {
+    return this.targetProjectId == null || !this.canEditProject || this.addToProjectForm.invalid;
+  }
+
+  get bookName(): string {
+    return this.i18n.localizeBook(this.data.bookNum);
+  }
+
+  /** An observable that emits the target project profile if the user has permission to write to the specified book. */
+  get targetProject$(): Observable<SFProjectProfile | undefined> {
+    return this.targetProjectDoc$.pipe(
+      filter(() => this.canEditProject),
+      filterNullish(),
+      map(p => p.data)
+    );
+  }
+
+  async ngOnInit(): Promise<void> {
+    this.isLoading = true;
+    const projects: ParatextProject[] | undefined = await this.paratextService.getProjects();
+    this._projects = projects?.sort(compareProjectsForSorting);
+    this.isLoading = false;
+  }
+
+  addToProject(): void {
+    if (this.targetProjectId == null || !this.canEditProject) {
+      this.dialogRef.close();
+      return;
+    }
+    this.dialogRef.close({ projectId: this.targetProjectId });
+  }
+
+  async projectSelectedAsync(paratextId: string): Promise<void> {
+    this.targetProjectId = this.projects?.find(p => p.paratextId === paratextId)?.projectId;
+    if (this.targetProjectId == null) return;
+    const projectDoc: SFProjectProfileDoc = await this.projectService.getProfile(this.targetProjectId);
+    if (projectDoc.data == null) {
+      this.canEditProject = false;
+      return;
+    }
+
+    // emit the project profile document
+    this.targetProjectDoc$.next(projectDoc);
+    this.canEditProject =
+      this.textDocService.userHasGeneralEditRight(projectDoc.data) &&
+      projectDoc.data.texts.find(t => t.bookNum === this.data.bookNum)?.permissions[this.userService.currentUserId] ===
+        TextInfoPermission.Write;
+  }
+
+  private async chaptersWithTextAsync(project: SFProjectProfile): Promise<number> {
+    if (this.targetProjectId == null) return 0;
+    const chapters = project.texts.find(t => t.bookNum === this.data.bookNum)?.chapters;
+    if (chapters == null) return 0;
+    const textPromises: Promise<boolean>[] = [];
+    for (const chapter of chapters) {
+      const textDocId = new TextDocId(this.targetProjectId, this.data.bookNum, chapter.number);
+      textPromises.push(this.isNotEmpty(textDocId));
+    }
+    return (await Promise.all(textPromises)).filter(hasText => hasText).length;
+  }
+
+  private async isNotEmpty(textDocId: TextDocId): Promise<boolean> {
+    const textDoc: TextDoc = await this.projectService.getText(textDocId);
+    return textDoc.getNonEmptyVerses().length > 0;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -4,8 +4,9 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { Chapter } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
-import { BehaviorSubject, filter, map, Observable } from 'rxjs';
+import { BehaviorSubject, map, Observable } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
@@ -13,7 +14,7 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { ParatextProject } from '../../../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { TextDocId } from '../../../core/models/text-doc';
+import { TextDoc, TextDocId } from '../../../core/models/text-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextDocService } from '../../../core/text-doc.service';
@@ -33,16 +34,17 @@ export interface DraftApplyDialogResult {
 export class DraftApplyDialogComponent implements OnInit {
   _projects?: ParatextProject[];
   // the project to add the draft to
-  targetProjectId?: string;
   isLoading: boolean = false;
-  canEditProject: boolean = true;
   addToProjectForm = new FormGroup({
+    targetParatextId: new FormControl<string | undefined>(undefined),
     overwrite: new FormControl(false, Validators.requiredTrue)
   });
   connectOtherProject = this.i18n.translateTextAroundTemplateTags('draft_apply_dialog.looking_for_unlisted_project');
   /** An observable that emits the number of chapters in the target project that have some text. */
   targetChapters$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
+  canEditProject: boolean = true;
 
+  private targetProjectId?: string;
   private targetProjectDoc$: BehaviorSubject<SFProjectProfileDoc | undefined> = new BehaviorSubject<
     SFProjectProfileDoc | undefined
   >(undefined);
@@ -76,17 +78,13 @@ export class DraftApplyDialogComponent implements OnInit {
 
   /** An observable that emits the target project profile if the user has permission to write to the specified book. */
   get targetProject$(): Observable<SFProjectProfile | undefined> {
-    return this.targetProjectDoc$.pipe(
-      filter(() => this.canEditProject),
-      filterNullish(),
-      map(p => p.data)
-    );
+    return this.targetProjectDoc$.pipe(map(p => p?.data));
   }
 
   async ngOnInit(): Promise<void> {
     this.isLoading = true;
     const projects: ParatextProject[] | undefined = await this.paratextService.getProjects();
-    this._projects = projects?.sort(compareProjectsForSorting);
+    this._projects = projects?.filter(p => p.projectId != null).sort(compareProjectsForSorting);
     this.isLoading = false;
   }
 
@@ -99,38 +97,44 @@ export class DraftApplyDialogComponent implements OnInit {
   }
 
   async projectSelectedAsync(paratextId: string): Promise<void> {
+    if (paratextId == null) {
+      this.targetProjectDoc$.next(undefined);
+      return;
+    }
     this.targetProjectId = this.projects?.find(p => p.paratextId === paratextId)?.projectId;
     if (this.targetProjectId == null) return;
     const projectDoc: SFProjectProfileDoc = await this.projectService.getProfile(this.targetProjectId);
     if (projectDoc.data == null) {
       this.canEditProject = false;
+      this.targetProjectDoc$.next(undefined);
       return;
     }
 
-    // emit the project profile document
-    this.targetProjectDoc$.next(projectDoc);
     this.canEditProject =
       this.textDocService.userHasGeneralEditRight(projectDoc.data) &&
       projectDoc.data.texts.find(t => t.bookNum === this.data.bookNum)?.permissions[this.userService.currentUserId] ===
         TextInfoPermission.Write;
+
+    // emit the project profile document
+    if (this.canEditProject) {
+      this.targetProjectDoc$.next(projectDoc);
+    }
   }
 
   private async chaptersWithTextAsync(project: SFProjectProfile): Promise<number> {
     if (this.targetProjectId == null) return 0;
-    const chapters = project.texts.find(t => t.bookNum === this.data.bookNum)?.chapters;
+    const chapters: Chapter[] | undefined = project.texts.find(t => t.bookNum === this.data.bookNum)?.chapters;
     if (chapters == null) return 0;
     const textPromises: Promise<boolean>[] = [];
-    // for (const chapter of chapters) {
-    //   const textDocId = new TextDocId(this.targetProjectId, this.data.bookNum, chapter.number);
-    //   textPromises.push(this.isNotEmpty(textDocId));
-    // }
-    // return (await Promise.all(textPromises)).filter(hasText => hasText).length;
-    return 0;
+    for (const chapter of chapters) {
+      const textDocId = new TextDocId(this.targetProjectId, this.data.bookNum, chapter.number);
+      textPromises.push(this.isNotEmpty(textDocId));
+    }
+    return (await Promise.all(textPromises)).filter(hasText => hasText).length;
   }
 
   private async isNotEmpty(textDocId: TextDocId): Promise<boolean> {
-    return true;
-    // const textDoc: TextDoc = await this.projectService.getText(textDocId);
-    // return textDoc.getNonEmptyVerses().length > 0;
+    const textDoc: TextDoc = await this.projectService.getText(textDocId);
+    return textDoc.getNonEmptyVerses().length > 0;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -13,7 +13,7 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { ParatextProject } from '../../../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { TextDoc, TextDocId } from '../../../core/models/text-doc';
+import { TextDocId } from '../../../core/models/text-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextDocService } from '../../../core/text-doc.service';
@@ -120,15 +120,17 @@ export class DraftApplyDialogComponent implements OnInit {
     const chapters = project.texts.find(t => t.bookNum === this.data.bookNum)?.chapters;
     if (chapters == null) return 0;
     const textPromises: Promise<boolean>[] = [];
-    for (const chapter of chapters) {
-      const textDocId = new TextDocId(this.targetProjectId, this.data.bookNum, chapter.number);
-      textPromises.push(this.isNotEmpty(textDocId));
-    }
-    return (await Promise.all(textPromises)).filter(hasText => hasText).length;
+    // for (const chapter of chapters) {
+    //   const textDocId = new TextDocId(this.targetProjectId, this.data.bookNum, chapter.number);
+    //   textPromises.push(this.isNotEmpty(textDocId));
+    // }
+    // return (await Promise.all(textPromises)).filter(hasText => hasText).length;
+    return 0;
   }
 
   private async isNotEmpty(textDocId: TextDocId): Promise<boolean> {
-    const textDoc: TextDoc = await this.projectService.getText(textDocId);
-    return textDoc.getNonEmptyVerses().length > 0;
+    return true;
+    // const textDoc: TextDoc = await this.projectService.getText(textDocId);
+    // return textDoc.getNonEmptyVerses().length > 0;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.stories.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { Meta } from '@storybook/angular';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
+import { UserService } from 'xforge-common/user.service';
+import { MatDialogLaunchComponent, matDialogStory } from '../../../../../.storybook/util/mat-dialog-launch';
+import { ParatextService } from '../../../core/paratext.service';
+import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDocService } from '../../../core/text-doc.service';
+import { DraftApplyDialogComponent } from './draft-apply-dialog.component';
+
+@Component({ template: '' })
+class EmptyComponent {}
+
+const mockedParatextService = mock(ParatextService);
+const mockedI18nService = mock(I18nService);
+const mockedDialogRef = mock(MatDialogRef);
+const mockedProjectService = mock(SFProjectService);
+const mockedTextDocService = mock(TextDocService);
+const mockedUserService = mock(UserService);
+const mockActivatedRoute = mock(ActivatedRoute);
+
+when(mockedParatextService.getProjects()).thenResolve([
+  {
+    paratextId: 'pt01',
+    name: 'Project 01',
+    shortName: 'P01',
+    isConnectable: true,
+    isConnected: true,
+    languageTag: 'fr'
+  }
+]);
+when(mockedI18nService.translateTextAroundTemplateTags(anything())).thenReturn({
+  before: 'Looking for a project that is not listed? Connect it on ',
+  templateTagText: 'the projects page',
+  after: ' first'
+});
+
+const meta: Meta = {
+  title: 'Misc/Dialogs/Draft Apply Dialog',
+  component: MatDialogLaunchComponent
+};
+export default meta;
+
+export const DraftApplyDialog = matDialogStory(DraftApplyDialogComponent, {
+  standaloneComponent: true,
+  imports: [RouterModule.forChild([{ path: 'projects', component: EmptyComponent }])],
+  providers: [
+    { provide: ActivatedRoute, useValue: instance(mockActivatedRoute) },
+    { provide: ParatextService, useValue: instance(mockedParatextService) },
+    { provide: I18nService, useValue: instance(mockedI18nService) },
+    { provide: MatDialogRef, useValue: instance(mockedDialogRef) },
+    { provide: SFProjectService, useValue: instance(mockedProjectService) },
+    { provide: TextDocService, useValue: instance(mockedTextDocService) },
+    { provide: UserService, useValue: instance(mockedUserService) }
+  ]
+});
+DraftApplyDialog.args = { data: { bookNum: 1 } };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -270,7 +270,7 @@ describe('DraftHandlingService', () => {
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations(anything(), anything(), anything())
       ).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
-      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId);
+      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId, textDocId);
       expect(result).toBe(true);
       verify(mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1)).once();
       verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).once();
@@ -286,7 +286,7 @@ describe('DraftHandlingService', () => {
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations(anything(), anything(), anything())
       ).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(false);
-      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId);
+      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId, textDocId);
       expect(result).toBe(false);
       verify(mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1)).never();
       verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).never();
@@ -300,7 +300,7 @@ describe('DraftHandlingService', () => {
       ).thenReturn(throwError(() => ({ status: 405 })));
       when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
-      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId);
+      const result: boolean = await service.getAndApplyDraftAsync(mockedSFProject.data!, textDocId, textDocId);
       expect(result).toBe(false);
       verify(mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1)).once();
       verify(mockedDraftGenerationService.getGeneratedDraft('project01', 1, 1)).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -179,7 +179,9 @@ export class DraftHandlingService {
 
   /**
    * Retrieves and applies the draft to the text document.
-   * @param draftTextDocId The text doc identifier.
+   * @param project The project profile.
+   * @param draftTextDocId The text doc identifier of the draft of a chapter.
+   * @param targetTextDocId The text doc identifier to apply the draft to.
    * @returns True if the draft was successfully applied, false if the draft was not applied i.e. the draft
    * was in the legacy USFM format.
    */
@@ -204,7 +206,7 @@ export class DraftHandlingService {
           ops = draft;
         }
         const draftDelta: DeltaStatic = new Delta(ops);
-        await this.applyChapterDraftAsync(targetTextDocId ?? draftTextDocId, draftDelta);
+        await this.applyChapterDraftAsync(targetTextDocId, draftDelta);
         resolve(true);
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -206,7 +206,7 @@ export class DraftHandlingService {
           ops = draft;
         }
         const draftDelta: DeltaStatic = new Delta(ops);
-        await this.applyChapterDraftAsync(targetTextDocId, draftDelta);
+        await this.applyChapterDraftAsync(targetTextDocId, draftDelta).catch(() => resolve(false));
         resolve(true);
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -179,17 +179,21 @@ export class DraftHandlingService {
 
   /**
    * Retrieves and applies the draft to the text document.
-   * @param textDocId The text doc identifier.
+   * @param draftTextDocId The text doc identifier.
    * @returns True if the draft was successfully applied, false if the draft was not applied i.e. the draft
    * was in the legacy USFM format.
    */
-  async getAndApplyDraftAsync(project: SFProjectProfile, textDocId: TextDocId): Promise<boolean> {
-    if (!this.textDocService.canEdit(project, textDocId.bookNum, textDocId.chapterNum)) {
+  async getAndApplyDraftAsync(
+    project: SFProjectProfile,
+    draftTextDocId: TextDocId,
+    targetTextDocId: TextDocId
+  ): Promise<boolean> {
+    if (!this.textDocService.canEdit(project, draftTextDocId.bookNum, draftTextDocId.chapterNum)) {
       return false;
     }
 
     return await new Promise<boolean>(resolve => {
-      this.getDraft(textDocId, { isDraftLegacy: false }).subscribe(async draft => {
+      this.getDraft(draftTextDocId, { isDraftLegacy: false }).subscribe(async draft => {
         let ops: DeltaOperation[] = [];
         if (this.isDraftSegmentMap(draft)) {
           // Do not support applying drafts for the legacy segment map format.
@@ -200,7 +204,7 @@ export class DraftHandlingService {
           ops = draft;
         }
         const draftDelta: DeltaStatic = new Delta(ops);
-        await this.applyChapterDraftAsync(textDocId, draftDelta);
+        await this.applyChapterDraftAsync(targetTextDocId ?? draftTextDocId, draftDelta);
         resolve(true);
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -12,6 +12,7 @@
       <button mat-menu-item (click)="applyBookDraftAsync(book)">
         <mat-icon>input</mat-icon>{{ book.draftApplied ? t("readd_to_project") : t("add_to_project") }}
       </button>
+      <button mat-menu-item><mat-icon>input</mat-icon>{{ t("add_to_different_project") }}</button>
     </mat-menu>
   } @empty {
     <strong>{{ t("no_books_have_drafts") }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -9,10 +9,14 @@
       </mat-button-toggle>
     </mat-button-toggle-group>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="applyBookDraftAsync(book)">
+      <button mat-menu-item (click)="confirmAndAddToProjectAsync(book)">
         <mat-icon>input</mat-icon>{{ book.draftApplied ? t("readd_to_project") : t("add_to_project") }}
       </button>
-      <button mat-menu-item><mat-icon>input</mat-icon>{{ t("add_to_different_project") }}</button>
+      @if ((isProjectAdmin$ | async) === true) {
+        <button mat-menu-item (click)="chooseAlternateProjectToAddDraft(book)">
+          <mat-icon>input</mat-icon>{{ t("add_to_different_project") }}
+        </button>
+      }
     </mat-menu>
   } @empty {
     <strong>{{ t("no_books_have_drafts") }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -14,7 +14,7 @@
       </button>
       @if ((isProjectAdmin$ | async) === true) {
         <button mat-menu-item (click)="chooseAlternateProjectToAddDraft(book)">
-          <mat-icon>input</mat-icon>{{ t("add_to_different_project") }}
+          <mat-icon>output</mat-icon>{{ t("add_to_different_project") }}
         </button>
       }
     </mat-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -1,4 +1,7 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatMenuHarness } from '@angular/material/menu/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -58,6 +61,20 @@ describe('DraftPreviewBooks', () => {
     expect(extras).toEqual({
       queryParams: { 'draft-active': true }
     });
+  }));
+
+  it('opens more menu with options', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    const moreButton: HTMLElement = env.getBookButtonAtIndex(0).querySelector('.book-more')!;
+    moreButton.click();
+    tick();
+    env.fixture.detectChanges();
+    const harness: MatMenuHarness = await env.moreMenuHarness();
+    const items = await harness.getItems();
+    expect(items.length).toEqual(2);
+    harness.close();
+    tick();
+    env.fixture.detectChanges();
   }));
 
   it('does not apply draft if user cancels', fakeAsync(() => {
@@ -151,6 +168,7 @@ describe('DraftPreviewBooks', () => {
 class TestEnvironment {
   component: DraftPreviewBooksComponent;
   fixture: ComponentFixture<DraftPreviewBooksComponent>;
+  loader: HarnessLoader;
   mockProjectDoc: SFProjectProfileDoc = {
     data: createTestProjectProfile({
       texts: [
@@ -204,6 +222,7 @@ class TestEnvironment {
     when(mockedUserService.currentUserId).thenReturn('user01');
     this.fixture = TestBed.createComponent(DraftPreviewBooksComponent);
     this.component = this.fixture.componentInstance;
+    this.loader = TestbedHarnessEnvironment.loader(this.fixture);
     tick();
     this.fixture.detectChanges();
   }
@@ -214,5 +233,9 @@ class TestEnvironment {
 
   getBookButtonAtIndex(index: number): HTMLElement {
     return this.fixture.nativeElement.querySelectorAll('.draft-book-option')[index];
+  }
+
+  async moreMenuHarness(): Promise<MatMenuHarness> {
+    return await this.loader.getHarness(MatMenuHarness.with({ selector: '.book-more' }));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -132,6 +132,17 @@
     "readd_book_to_project": "Re-add {{ bookName }} to project",
     "readd_to_project": "Re-add to project"
   },
+  "draft_apply_dialog": {
+    "add_to_project": "Add to project",
+    "book_is_empty": "{{ bookName }} in {{ projectName }} project is empty",
+    "cancel": "Cancel",
+    "choose_project": "Choose project",
+    "i_understand_overwrite_book": "I understand the draft will overwrite {{ bookName }} in {{ projectName }} project",
+    "looking_for_unlisted_project": "Looking for a project that is not listed? Connect it on {{ templateTagBoundary }}the projects page{{ templateTagBoundary }} first",
+    "no_write_permission": "You do not have permission to write to this book on this project. Contact the project's administrator to get permission.",
+    "project_has_text_in_chapters": "{{ bookName }} in {{ projectName }} has text in {{ numChapters }} chapters",
+    "select_alternate_project": "Select the project you want to add the draft to"
+  },
   "draft_generation": {
     "back_from_stepper_button": "Back",
     "back_translation_requirement": "Back translation drafts can only be generated into the roughly 200 [link:supportedLanguagesUrl]supported languages[/link].",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -136,6 +136,7 @@
     "add_to_project": "Add to project",
     "book_is_empty": "{{ bookName }} in {{ projectName }} project is empty",
     "cancel": "Cancel",
+    "connect_to_the_internet": "Please connect to the internet to add the draft to your project",
     "choose_project": "Choose project",
     "error_fetching_projects": "There was an error fetching projects.",
     "i_understand_overwrite_book": "I understand the draft will overwrite {{ bookName }} in {{ projectName }} project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -213,6 +213,7 @@
   },
   "draft_preview_books": {
     "add_to_project": "Add to project",
+    "add_to_different_project": "Add to a different project",
     "draft_successfully_applied": "The draft for {{ bookName }} has been successfully applied to your project.",
     "one_or_more_drafts_failed": "Drafts of one or more chapters failed to be applied. View the chapters in the book to see which chapters had drafts applied successfully.",
     "no_books_have_drafts": "No books have any drafts.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -137,6 +137,7 @@
     "book_is_empty": "{{ bookName }} in {{ projectName }} project is empty",
     "cancel": "Cancel",
     "choose_project": "Choose project",
+    "error_fetching_projects": "There was an error fetching projects.",
     "i_understand_overwrite_book": "I understand the draft will overwrite {{ bookName }} in {{ projectName }} project",
     "looking_for_unlisted_project": "Looking for a project that is not listed? Connect it on {{ templateTagBoundary }}the projects page{{ templateTagBoundary }} first",
     "no_write_permission": "You do not have permission to write to this book on this project. Contact the project's administrator to get permission.",


### PR DESCRIPTION
This change introduces the ability to add a draft to a different project. Tests need to be fixed, but I wanted to get this under review before I can fully get the tests to work.
See the [balsamiq mockup](https://balsamiq.cloud/sghq53/pejrlz8/r1550)

![Add draft to alternate project dialog](https://github.com/user-attachments/assets/afae464a-67b9-4581-b216-95062dd7dce7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2667)
<!-- Reviewable:end -->
