### PR TITLE
SF-2908 Fix crash when syncing specific Paratext Resources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -27,6 +27,7 @@ using Newtonsoft.Json.Linq;
 using Paratext.Data;
 using Paratext.Data.Languages;
 using Paratext.Data.ProjectComments;
+using Paratext.Data.ProjectFileAccess;
 using Paratext.Data.ProjectSettingsAccess;
 using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
@@ -2355,6 +2356,13 @@ public class ParatextService : DisposableBase, IParatextService
     {
         if (resource.InstallableResource != null)
         {
+            // Correct the language code for old resources
+            LanguageId? overrideLanguageId = null;
+            if (DetermineBestLanguageForResource(resource.InstallableResource.ExistingScrText))
+            {
+                overrideLanguageId = resource.InstallableResource.ExistingScrText?.Settings.LanguageID;
+            }
+
             // Install the resource if it is missing or out of date
             if (
                 !resource.IsInstalled
@@ -2364,6 +2372,12 @@ public class ParatextService : DisposableBase, IParatextService
             {
                 resource.InstallableResource.Install();
                 needsToBeCloned = true;
+
+                // On first install, we will now have an existing ScrText, so check the language is OK
+                if (DetermineBestLanguageForResource(resource.InstallableResource.ExistingScrText))
+                {
+                    overrideLanguageId = resource.InstallableResource.ExistingScrText?.Settings.LanguageID;
+                }
             }
 
             // Extract the resource to the source directory
@@ -2372,7 +2386,7 @@ public class ParatextService : DisposableBase, IParatextService
                 string path = LocalProjectDir(targetParatextId);
                 _fileSystemService.CreateDirectory(path);
                 resource.InstallableResource.ExtractToDirectory(path);
-                MigrateResourceIfRequired(username, targetParatextId);
+                MigrateResourceIfRequired(username, targetParatextId, overrideLanguageId);
             }
         }
         else
@@ -2382,18 +2396,72 @@ public class ParatextService : DisposableBase, IParatextService
     }
 
     /// <summary>
+    /// Determines the best language for a resource project
+    /// </summary>
+    /// <param name="scrText">The scripture text for the resource.</param>
+    /// <returns><c>true</c> if the project language was overridden by the DBL; otherwise, <c>false</c>.</returns>
+    /// <remarks>
+    /// <para>
+    /// This is reimplemented from <c>Paratext.Migration.MigrateLanguage.DetermineBestLangIdToUseForResource()</c>.
+    /// </para>
+    /// <para>
+    /// Because resources are not written to (as they are readonly), this should be run before using the LanguageID.
+    /// </para>
+    /// </remarks>
+    private static bool DetermineBestLanguageForResource(ScrText? scrText)
+    {
+        // If we do not have a ScrText, or this is not a resource, do not determine the language
+        if (scrText is null || !scrText.IsResourceProject)
+        {
+            return false;
+        }
+
+        // Get the language identifier from the .SSF file
+        string? languageIdLDML = scrText.Settings.LanguageID?.Id;
+
+        // Get the language identifier embedded in the .P8Z folder structure: .dbl\language\iso
+        string languageIdDBL = ((ZippedProjectFileManagerBase)scrText.FileManager).DBLResourceSettings.LanguageIso639_3;
+        LanguageId langIdDBL = LanguageId.FromEthnologueCode(languageIdDBL);
+        if (string.IsNullOrEmpty(languageIdLDML))
+        {
+            scrText.Settings.LanguageID = langIdDBL;
+            return true;
+        }
+
+        LanguageId langIdLDML = LanguageId.FromEthnologueCode(languageIdLDML);
+        if (langIdLDML.Code == langIdDBL.Code)
+        {
+            scrText.Settings.LanguageID = langIdLDML;
+            return false;
+        }
+
+        scrText.Settings.LanguageID = langIdDBL;
+        return true;
+    }
+
+    /// <summary>
     /// Migrates a Paratext Resource, if required.
     /// </summary>
     /// <param name="username">The username.</param>
     /// <param name="paratextId">The paratext project identifier.</param>
+    /// <param name="overrideLanguage">The language to override, if the project's language is incorrect.</param>
     /// <remarks>This only performs one basic migration. Full migration can only be performed by Paratext.</remarks>
-    private void MigrateResourceIfRequired(string username, string paratextId)
+    private void MigrateResourceIfRequired(string username, string paratextId, LanguageId? overrideLanguage)
     {
         // Ensure that we have the ScrText to migrate
         using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
         if (scrText is null)
         {
             return;
+        }
+
+        // Migrate the language id if it is missing. It will be missing as the project has changed from a resource (p8z)
+        // to a project (directory based), and we did not write to the p8z file as Paratext does in its migrators.
+        // The ScrText created above will not have the values defined in DetermineBestLanguageForResource() above, so
+        // we will need to override them again before migrating the LDML (an action which requires the LanguageID).
+        if (overrideLanguage is not null)
+        {
+            scrText.Settings.LanguageID = overrideLanguage;
         }
 
         // Perform a simple migration of the Paratext 7 LDML file to the new Paratext 8+ location.


### PR DESCRIPTION
This PR fixes a crash when connecting to or syncing older DBL Resources, such as the SBLGNT.

This crash occurs because the .SSF file does not contain the language identifier. Paratext usually works around this by running an migrator on the project, which only changes the project in memory.

To resolve the crash, I have reimplemented the migrator in a way that works with Scripture Forge.

If you wish to test this on your developer machine, use the resource "apw - The New Testament of our Lord and Saviour Jesus Christ" which suffers from the same bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2669)
<!-- Reviewable:end -->
