### PR TITLE
SF-2916 Change display name label on join component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -3,8 +3,9 @@
     <h1 [innerHTML]="inviteText"></h1>
     @if (!isOnline) {
       <app-notice type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>
+    } @else {
+      <span>{{ t("explain_your_name") }}</span>
     }
-    <span>{{ t("explain_your_name") }}</span>
     <form>
       <mat-form-field appearance="fill">
         <mat-label>{{ t("your_name") }}</mat-label>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -5,6 +5,7 @@
     @if (!isOnline) {
       <app-notice type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>
     }
+    <span>{{ t("explain_your_name") }}</span>
     <form>
       <mat-form-field appearance="fill">
         <mat-label>{{ t("your_name") }}</mat-label>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -1,7 +1,6 @@
 <ng-container *transloco="let t; read: 'join'">
   @if (!isLoading) {
-    <h1>{{ t("join_a_project") }}</h1>
-    <p [innerHTML]="inviteText"></p>
+    <h1 [innerHTML]="inviteText"></h1>
     @if (!isOnline) {
       <app-notice type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
@@ -6,8 +6,17 @@
   flex-direction: column;
   align-items: center;
 }
-p {
+h1 {
   text-align: center;
+  font-size: 20px;
+  line-height: 1.25;
+  font-weight: normal;
+  margin-bottom: 40px;
+  ::ng-deep strong {
+    font-size: 32px;
+    font-weight: bold;
+    display: block;
+  }
 }
 form {
   padding-top: 20px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -310,7 +310,7 @@ class TestEnvironment {
   }
 
   get joiningText(): DebugElement {
-    return this.fixture.debugElement.query(By.css('p'));
+    return this.fixture.debugElement.query(By.css('h1'));
   }
 
   get displayName(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -87,11 +87,8 @@ export class JoinComponent extends DataLoadingComponent {
   }
 
   get inviteText(): string {
-    if (this.joiningResponse == null) {
-      return '';
-    }
     return this.i18nService.translateAndInsertTags('join.invited_to_join', {
-      projectName: this.joiningResponse.projectName
+      projectName: this.joiningResponse?.projectName
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -336,6 +336,7 @@
   },
   "join": {
     "error_occurred_login": "An error occurred trying to join the project",
+    "explain_your_name": "Enter the name you want other people to see",
     "invited_to_join": "You've been invited to join {{ boldStart }}{{ projectName }}{{ boldEnd }} project",
     "join": "Join",
     "join_a_project": "Join a project",
@@ -346,7 +347,7 @@
     "please_connect_to_use_link": "Please connect to the internet to join a project using a link.",
     "project_link_is_invalid": "The project link is invalid. Please contact the person who sent you the link and ask for a new one.",
     "role_not_found": "The role you were assigned on this project is no longer available. Please contact the person who sent you the link and ask for a new one.",
-    "your_name": "Enter your name"
+    "your_name": "Your name"
   },
   "dialog": {
     "cancel": "Cancel",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -293,7 +293,7 @@
     "enter_name": "Enter the name you want other people to see",
     "update_your_name": "Update your name",
     "update": "Update",
-    "your_name": "Your display name"
+    "your_name": "Name"
   },
   "error": {
     "chrome": "Chrome",
@@ -346,7 +346,7 @@
     "please_connect_to_use_link": "Please connect to the internet to join a project using a link.",
     "project_link_is_invalid": "The project link is invalid. Please contact the person who sent you the link and ask for a new one.",
     "role_not_found": "The role you were assigned on this project is no longer available. Please contact the person who sent you the link and ask for a new one.",
-    "your_name": "Your display name"
+    "your_name": "Name"
   },
   "dialog": {
     "cancel": "Cancel",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -286,11 +286,11 @@
   },
   "edit_name_dialog": {
     "cancel": "Cancel",
-    "confirm_name": "Confirm the name that other people on this project will see when you post answers and comments",
+    "confirm_name": "Confirm the name that other people will see when you post answers and comments",
     "confirm_your_name": "Confirm your name",
     "confirm": "Confirm",
     "connect_to_edit_name": "Please connect to the internet to edit your name",
-    "enter_name": "Please enter your name",
+    "enter_name": "Enter the name you want other people to see",
     "update_your_name": "Update your name",
     "update": "Update",
     "your_name": "Your name"

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -293,7 +293,7 @@
     "enter_name": "Enter the name you want other people to see",
     "update_your_name": "Update your name",
     "update": "Update",
-    "your_name": "Your name"
+    "your_name": "Your display name"
   },
   "error": {
     "chrome": "Chrome",
@@ -337,9 +337,8 @@
   "join": {
     "error_occurred_login": "An error occurred trying to join the project",
     "explain_your_name": "Enter the name you want other people to see",
-    "invited_to_join": "You've been invited to join {{ boldStart }}{{ projectName }}{{ boldEnd }} project",
+    "invited_to_join": "You've been invited to join {{ boldStart }}{{ projectName }}{{ boldEnd }}",
     "join": "Join",
-    "join_a_project": "Join a project",
     "key_already_used": "The project link has already been used by another user. Please contact the person who sent you the link and ask for a new one.",
     "key_expired": "The project link expired. Please contact the person who sent you the link and ask for a new one.",
     "login_existing_account": "or {{ underlineStart }}Log in{{ underlineEnd }} to an existing account",
@@ -347,7 +346,7 @@
     "please_connect_to_use_link": "Please connect to the internet to join a project using a link.",
     "project_link_is_invalid": "The project link is invalid. Please contact the person who sent you the link and ask for a new one.",
     "role_not_found": "The role you were assigned on this project is no longer available. Please contact the person who sent you the link and ask for a new one.",
-    "your_name": "Your name"
+    "your_name": "Your display name"
   },
   "dialog": {
     "cancel": "Cancel",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.spec.ts
@@ -94,7 +94,7 @@ describe('EditNameDialogComponent', () => {
     env.component.isConfirmContext = true;
     env.openDialog();
     expect(env.title.textContent).toBe('Confirm your name');
-    expect(env.description.textContent).toContain('Confirm the name that other people on this project will see');
+    expect(env.description.textContent).toContain('Confirm the name that other people will see');
     env.clickSubmit();
     expect(env.component.confirmedName).toBe('Simon Says');
   }));


### PR DESCRIPTION
Settled on option one as it gave more room for the text to grow in other languages.

**Option One**
![Screenshot 2024-08-13 151557](https://github.com/user-attachments/assets/4d0e0d61-68c6-4518-a02f-192abfb9522f)

**Option Two**
![Screenshot 2024-08-13 151614](https://github.com/user-attachments/assets/28d85455-c16d-4aa9-9e37-a3afd1a760dc)

**Option Three**
![Screenshot 2024-08-13 151638](https://github.com/user-attachments/assets/c0789952-5c81-456d-93f1-572abcd9c43e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2672)
<!-- Reviewable:end -->
