### PR TITLE
SF-2927 Fix incorrect escaping of XML characters in notes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.spec.ts
@@ -38,6 +38,7 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { SFProjectService } from '../../core/sf-project.service';
+import { XmlUtils } from '../../shared/utils';
 import { MockNoteDialogRef } from '../editor/editor.component.spec';
 import { NoteDialogComponent } from '../editor/note-dialog/note-dialog.component';
 import { BiblicalTermDialogIcon, BiblicalTermNoteIcon, BiblicalTermsComponent } from './biblical-terms.component';
@@ -215,7 +216,7 @@ describe('BiblicalTermsComponent', () => {
     env.biblicalTermsNotesButton.click();
     env.wait();
 
-    const noteContent: string = 'content in the thread';
+    const noteContent: string = 'content in the thread & with an ampersand';
     env.mockNoteDialogRef.close({ noteContent });
     env.wait();
 
@@ -232,7 +233,7 @@ describe('BiblicalTermsComponent', () => {
     expect(noteThread.originalSelectedText).toEqual('');
     expect(noteThread.publishedToSF).toBe(true);
     expect(noteThread.notes[0].ownerRef).toEqual('user01');
-    expect(noteThread.notes[0].content).toEqual(noteContent);
+    expect(noteThread.notes[0].content).toEqual(XmlUtils.encodeForXml(noteContent));
     expect(noteThread.notes[0].tagId).toEqual(BIBLICAL_TERM_TAG_ID);
     const projectUserConfigDoc: SFProjectUserConfigDoc = env.getProjectUserConfigDoc('project01', 'user01');
     expect(projectUserConfigDoc.data!.noteRefsRead).not.toContain(noteThread.notes[0].dataId);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
@@ -12,7 +12,7 @@ import {
   NoteThread,
   NoteType
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { BehaviorSubject, firstValueFrom, merge, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -29,7 +29,7 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
-import { getVerseNumbers } from '../../shared/utils';
+import { getVerseNumbers, XmlUtils } from '../../shared/utils';
 import { SaveNoteParameters } from '../editor/editor.component';
 import { NoteDialogComponent, NoteDialogData, NoteDialogResult } from '../editor/note-dialog/note-dialog.component';
 import { BiblicalTermDialogComponent, BiblicalTermDialogData } from './biblical-term-dialog.component';
@@ -468,6 +468,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
 
     const currentDate: string = new Date().toJSON();
     const threadId = `BT_${biblicalTermDoc.data.termId}`;
+    const noteContent: string | undefined = params.content == null ? undefined : XmlUtils.encodeForXml(params.content);
     // Configure the note
     const note: Note = {
       dateCreated: currentDate,
@@ -476,7 +477,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
       threadId,
       tagId: BIBLICAL_TERM_TAG_ID,
       ownerRef: this.userService.currentUserId,
-      content: params.content,
+      content: noteContent,
       conflictType: NoteConflictType.DefaultValue,
       type: NoteType.Normal,
       status: params.status ?? NoteStatus.Todo,
@@ -516,7 +517,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
       const noteIndex: number = threadDoc.data!.notes.findIndex(n => n.dataId === params.dataId);
       if (noteIndex >= 0) {
         await threadDoc!.submitJson0Op(op => {
-          op.set(t => t.notes[noteIndex].content, params.content);
+          op.set(t => t.notes[noteIndex].content, noteContent);
           op.set(t => t.notes[noteIndex].dateModified, currentDate);
         });
       } else {

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2920,15 +2920,17 @@ public class ParatextService : DisposableBase, IParatextService
         string label = $"[{displayName} - {_siteOptions.Value.Name}]";
         var labelElement = new XElement("p", label, new XAttribute("sf-user-label", "true"));
         contentElem.Add(labelElement);
+
+        XDocument commentDoc = XDocument.Parse($"<root>{note.Content}</root>");
         if (!note.Content.StartsWith("<p>"))
         {
             // add the note content in a paragraph tag
-            XElement commentNode = new XElement("p", note.Content);
-            contentElem.Add(commentNode);
+            XElement paragraph = new XElement("p");
+            paragraph.Add(commentDoc.Root.Nodes());
+            contentElem.Add(paragraph);
         }
         else
         {
-            XDocument commentDoc = XDocument.Parse($"<root>{note.Content}</root>");
             // add the note content paragraph by paragraph
             foreach (XElement paragraphElems in commentDoc.Root.Descendants("p"))
                 contentElem.Add(paragraphElems);
@@ -2981,7 +2983,7 @@ public class ParatextService : DisposableBase, IParatextService
                 continue;
             // If there is only one paragraph node other than the SF user label then omit the paragraph tags
             if (isReviewer && paragraphNodeCount <= 2)
-                sb.Append(element.Value);
+                sb.Append(string.Concat(element.Elements()));
             else
                 sb.Append(node);
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2983,7 +2983,7 @@ public class ParatextService : DisposableBase, IParatextService
                 continue;
             // If there is only one paragraph node other than the SF user label then omit the paragraph tags
             if (isReviewer && paragraphNodeCount <= 2)
-                sb.Append(string.Concat(element.Elements()));
+                sb.AppendJoin(string.Empty, element.Nodes());
             else
                 sb.Append(node);
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -1160,31 +1161,34 @@ public class ParatextServiceTests
         string paratextId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-        string formattedContent = "Text with <bold>bold</bold> and <italics>italics</italics> styles.";
-        string nonFormattedContent = "Text without formatting";
-        string formattedContentInParagraph =
+        const string formattedContent = "Text with <bold>bold</bold> and <italics>italics</italics> styles.";
+        const string nonFormattedContent = "Text without formatting";
+        const string formattedContentInParagraph =
             "<p>Text with <bold>bold</bold> style.</p><p>Text with<italics>italics</italics> style.</p>";
-        string nonFormattedContentInParagraph = "<p>Text without formatting.</p><p>Second paragraph.</p>";
-        string whitespaceInContent = "<p>First paragraph.</p>\n<p>Second paragraph.</p>";
+        const string nonFormattedContentInParagraph = "<p>Text without formatting.</p><p>Second paragraph.</p>";
+        const string whitespaceInContent = "<p>First paragraph.</p>\n<p>Second paragraph.</p>";
+        const string reviewerAuthorParagraph = "<p sf-user-label=\"true\">[testuser - Scripture Forge]</p>";
+        const string reviewerContentParagraph = "<p>Test <bold>entity parsing</bold> with 1&amp;2 John!</p>";
+        const string reviewerContent = reviewerAuthorParagraph + reviewerContentParagraph;
         var note1 = new ThreadNoteComponents { content = formattedContent };
         var note2 = new ThreadNoteComponents { content = nonFormattedContent };
         var note3 = new ThreadNoteComponents { content = formattedContentInParagraph };
         var note4 = new ThreadNoteComponents { content = nonFormattedContentInParagraph };
         var note5 = new ThreadNoteComponents { content = whitespaceInContent };
+        var note6 = new ThreadNoteComponents { content = reviewerContent };
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
-                    noteCount = 5,
+                    noteCount = 6,
                     username = env.Username01,
-                    notes = new[] { note1, note2, note3, note4, note5 }
-                }
-            }
+                    notes = [note1, note2, note3, note4, note5, note6],
+                },
+            ]
         );
 
-        var noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
+        IDocument<NoteThread>[] noteThreadDocs = [];
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
@@ -1194,9 +1198,9 @@ public class ParatextServiceTests
                 {
                     SFUserId = env.User01,
                     OpaqueUserId = "syncuser01",
-                    Username = env.Username01
+                    Username = env.Username01,
                 }
-            }
+            },
         };
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
             userSecret,
@@ -1208,17 +1212,19 @@ public class ParatextServiceTests
         );
         Assert.That(changes.Count, Is.EqualTo(1));
         NoteThreadChange change1 = changes.Single();
-        string expected1 = $"thread1-syncuser01-{formattedContent}";
+        const string expected1 = $"thread1-syncuser01-{formattedContent}";
         Assert.That(change1.NotesAdded[0].NoteToString(), Is.EqualTo(expected1));
-        string expected2 = $"thread1-syncuser01-{nonFormattedContent}";
+        const string expected2 = $"thread1-syncuser01-{nonFormattedContent}";
         Assert.That(change1.NotesAdded[1].NoteToString(), Is.EqualTo(expected2));
-        string expected3 = $"thread1-syncuser01-{formattedContentInParagraph}";
+        const string expected3 = $"thread1-syncuser01-{formattedContentInParagraph}";
         Assert.That(change1.NotesAdded[2].NoteToString(), Is.EqualTo(expected3));
-        string expected4 = $"thread1-syncuser01-{nonFormattedContentInParagraph}";
+        const string expected4 = $"thread1-syncuser01-{nonFormattedContentInParagraph}";
         Assert.That(change1.NotesAdded[3].NoteToString(), Is.EqualTo(expected4));
         // whitespace does not get processed as a node in xml, so it gets omitted from note content
-        string expected5 = $"thread1-syncuser01-{whitespaceInContent}".Replace("\n", "");
+        string expected5 = $"thread1-syncuser01-{whitespaceInContent.Replace("\n", string.Empty)}";
         Assert.That(change1.NotesAdded[4].NoteToString(), Is.EqualTo(expected5));
+        string expected6 = $"thread1-syncuser01-{Regex.Replace(reviewerContentParagraph, "</?p>", string.Empty)}";
+        Assert.That(change1.NotesAdded[5].NoteToString(), Is.EqualTo(expected6));
     }
 
     [Test]
@@ -2625,80 +2631,78 @@ public class ParatextServiceTests
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-        string dataId1 = "dataId1";
-        string dataId2 = "dataId2";
-        string dataId3 = "dataId3";
-        string thread1 = "thread1";
-        string thread2 = "thread2";
-        string thread3 = "thread3";
-        var thread1Notes = new[]
-        {
+        const string dataId1 = "dataId1";
+        const string dataId2 = "dataId2";
+        const string dataId3 = "dataId3";
+        const string thread1 = "thread1";
+        const string thread2 = "thread2";
+        const string thread3 = "thread3";
+        ThreadNoteComponents[] thread1Notes =
+        [
             new ThreadNoteComponents
             {
                 ownerRef = env.User01,
-                tagsAdded = new[] { "1" },
+                tagsAdded = ["1"],
                 editable = true,
                 versionNumber = 1,
                 status = NoteStatus.Todo,
-            }
-        };
-        var thread2Notes = new[]
-        {
+            },
+        ];
+        ThreadNoteComponents[] thread2Notes =
+        [
             new ThreadNoteComponents
             {
                 ownerRef = env.User05,
-                tagsAdded = new[] { "1" },
+                tagsAdded = ["1"],
                 editable = true,
                 versionNumber = 1,
-            }
-        };
+                content = "See 1&amp;2 John",
+            },
+        ];
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     isNew = true,
-                    notes = thread1Notes
+                    notes = thread1Notes,
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
                     isNew = true,
-                    notes = thread2Notes
+                    notes = thread2Notes,
                 },
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 2,
-                    deletedNotes = new[] { false, true },
-                    versionNumber = 1
-                }
-            }
+                    deletedNotes = [false, true],
+                    versionNumber = 1,
+                },
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 1,
                     username = env.Username01,
-                    deletedNotes = new[] { false },
-                    versionNumber = 1
-                }
-            }
+                    deletedNotes = [false],
+                    versionNumber = 1,
+                },
+            ]
         );
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         CommentThread thread = env.ProjectCommentManager.FindThread(thread1);
         Assert.That(thread, Is.Null);
-        string[] noteThreadDataIds = new[] { dataId1, dataId2, dataId3 };
-        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
-            conn,
-            noteThreadDataIds
-        );
+        string[] noteThreadDataIds = [dataId1, dataId2, dataId3];
+        List<IDocument<NoteThread>> noteThreadDocs = (
+            await TestEnvironment.GetNoteThreadDocsAsync(conn, noteThreadDataIds)
+        ).ToList();
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
             {
@@ -2707,9 +2711,9 @@ public class ParatextServiceTests
                 {
                     Username = env.Username01,
                     OpaqueUserId = "syncuser01",
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
-            }
+            },
         };
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -2739,7 +2743,7 @@ public class ParatextServiceTests
         expected =
             "thread2/User 01/2019-01-01T08:00:00.0000000+00:00-"
             + "MAT 1:2-"
-            + "<p sf-user-label=\"true\">[User 05 - xForge]</p><p>thread2 note 1.</p>-"
+            + $"<p sf-user-label=\"true\">[User 05 - xForge]</p><p>{thread2Notes[0].content}</p>-"
             + "Start:0-"
             + "user05-"
             + "Tag:1-"
@@ -2757,7 +2761,7 @@ public class ParatextServiceTests
         Assert.That(syncMetricInfo, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 0, updated: 0)));
 
         // PT username is not written to server logs
-        env.MockLogger.AssertNoEvent((LogEvent logEvent) => logEvent.Message.Contains(env.Username02));
+        env.MockLogger.AssertNoEvent(logEvent => logEvent.Message!.Contains(env.Username02));
     }
 
     [Test]


### PR DESCRIPTION
This error was caused by attempting to parse `1&2` as XML (when the `&` should have been escaped).

It is not clear to me exactly how the situation was created, but what I did observe is:
1. A Paratext user commented on a key term
2. That comment ended up having the user's name added to the comment *as thought the user was a reviewer, even though the user was not*. Perhaps joining/leaving the project, or changing names, somehow confused SF. I'm not sure.

The partially redacted XML looked like this:

``` XML
  <Comment Thread="BT_Δαυίδ" User="John Doe" VerseRef="MAT 1:1" Language="" Date="2024-08-05T04:00:02.6700000+00:00">
    <SelectedText />
    <StartPosition>0</StartPosition>
    <ContextBefore />
    <ContextAfter />
    <Status>todo</Status>
    <Type></Type>
    <ConflictType>unknownConflictType</ConflictType>
    <Verse />
    <ExtraHeadingInfo>Δαυίδ￼greek￼David David</ExtraHeadingInfo>
    <HideInTextWindow>false</HideInTextWindow>
    <Field Name="versionNumber">1</Field>
    <Contents>
      <p sf-user-label="true">[John Doe - Scripture Forge]</p>
      <p>there was some text here 1&amp;2 more text
</p>
    </Contents>
    <BiblicalTermId>Δαυίδ</BiblicalTermId>
    <TagAdded>-3</TagAdded>
  </Comment>
```

As you can see, the ampersand is escaped, as expected. However, the SF UI showed this error when trying to view the thread:

![](https://github.com/user-attachments/assets/2b83b7a2-6adc-4f7c-9671-a3cfc0e9bfcf)

This is because in Mongo the ampersand was not escaped.

Testing showed that if you add a comment as a reviewer in SF and include an ampersand, it is stored in the XML escaped twice, and shows in the PT UI escaped once.

The rest of the explanation of the problem will be on the changed lines themselves.

I have not written tests, though I think they should be added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2675)
<!-- Reviewable:end -->
