### PR TITLE
SF-2894 Create new record dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
@@ -21,7 +21,7 @@ export function getOverlay(element: HTMLElement): HTMLElement {
 export const COMPONENT_UNDER_TEST = new InjectionToken<any>('COMPONENT_UNDER_TEST');
 export const COMPONENT_PROPS = new InjectionToken<any>('COMPONENT_PROPS');
 
-interface MatDialogStoryConfig {
+export interface MatDialogStoryConfig {
   imports?: any[];
   declarations?: any[];
   providers?: Provider[];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -1,0 +1,48 @@
+<ng-container *transloco="let t; read: 'checking_audio_recorder'">
+  <mat-dialog-content>
+    <div class="countdown" [ngClass]="{ animate: countdown > 0 }">{{ countdown }}</div>
+    @if (!hasAudioAttachment) {
+      <div class="no-attachment">
+        @if (!isRecording) {
+          <button
+            mat-button
+            (click)="startRecording()"
+            class="record"
+            [matTooltip]="t('record_audio')"
+            matTooltipPosition="before"
+          >
+            <mat-icon>mic</mat-icon>
+          </button>
+        } @else {
+          <button
+            mat-button
+            (click)="stopRecording()"
+            class="stop"
+            [matTooltip]="t('stop_recording')"
+            matTooltipPosition="before"
+          >
+            <mat-icon>stop</mat-icon>
+          </button>
+        }
+      </div>
+    }
+    @if (hasAudioAttachment) {
+      <div class="has-attachment">
+        @if (!!audio.url) {
+          <app-single-button-audio-player [source]="audio.url" (click)="toggleAudio()">
+            <mat-icon>{{ audioPlayer?.playing ? "stop" : "play_arrow" }}</mat-icon>
+          </app-single-button-audio-player>
+        }
+        <button
+          mat-button
+          (click)="resetRecording()"
+          [matTooltip]="t('delete')"
+          class="remove-audio-file"
+          matTooltipPosition="before"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    }
+  </mat-dialog-content>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -23,8 +23,7 @@
               [matTooltip]="t('stop_recording')"
               matTooltipPosition="below"
             >
-              <mat-icon class="mic-icon">mic</mat-icon>
-              <mat-icon class="stop-icon">stop</mat-icon>
+              <mat-icon>stop</mat-icon>
             </button>
           }
         </div>
@@ -39,9 +38,12 @@
     </div>
     <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
       <button mat-flat-button color="primary" (click)="resetRecording()" class="remove-audio-file">
-        <mat-icon>mic</mat-icon> Re-record
+        <mat-icon>mic</mat-icon>
+        {{ t("re_record") }}
       </button>
-      <button mat-button (click)="saveRecording()" class="save-audio-file"><mat-icon>check</mat-icon> Save</button>
+      <button mat-button (click)="saveRecording()" class="save-audio-file">
+        <mat-icon>check</mat-icon> {{ t("save") }}
+      </button>
     </div>
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -10,7 +10,7 @@
               (click)="startRecording()"
               class="record"
               [matTooltip]="t('record_audio')"
-              matTooltipPosition="before"
+              matTooltipPosition="below"
             >
               <mat-icon>mic</mat-icon>
             </button>
@@ -21,7 +21,7 @@
               (click)="stopRecording()"
               class="stop"
               [matTooltip]="t('stop_recording')"
-              matTooltipPosition="before"
+              matTooltipPosition="below"
             >
               <mat-icon class="mic-icon">mic</mat-icon>
               <mat-icon class="stop-icon">stop</mat-icon>
@@ -38,25 +38,10 @@
       }
     </div>
     <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
-      <button
-        mat-flat-button
-        color="primary"
-        (click)="resetRecording()"
-        [matTooltip]="t('delete')"
-        class="remove-audio-file"
-        matTooltipPosition="before"
-      >
+      <button mat-flat-button color="primary" (click)="resetRecording()" class="remove-audio-file">
         <mat-icon>mic</mat-icon> Re-record
       </button>
-      <button
-        mat-button
-        (click)="saveRecording()"
-        [matTooltip]="t('save')"
-        class="save-audio-file"
-        matTooltipPosition="before"
-      >
-        <mat-icon>check</mat-icon> Save
-      </button>
+      <button mat-button (click)="saveRecording()" class="save-audio-file"><mat-icon>check</mat-icon> Save</button>
     </div>
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -1,48 +1,62 @@
-<ng-container *transloco="let t; read: 'checking_audio_recorder'">
+<ng-container *transloco="let t; read: 'audio_recorder_dialog'">
   <mat-dialog-content>
-    <div class="countdown" [ngClass]="{ animate: countdown > 0 }">{{ countdown }}</div>
-    @if (!hasAudioAttachment) {
-      <div class="no-attachment">
-        @if (!isRecording) {
-          <button
-            mat-button
-            (click)="startRecording()"
-            class="record"
-            [matTooltip]="t('record_audio')"
-            matTooltipPosition="before"
-          >
-            <mat-icon>mic</mat-icon>
-          </button>
-        } @else {
-          <button
-            mat-button
-            (click)="stopRecording()"
-            class="stop"
-            [matTooltip]="t('stop_recording')"
-            matTooltipPosition="before"
-          >
-            <mat-icon>stop</mat-icon>
-          </button>
-        }
-      </div>
-    }
-    @if (hasAudioAttachment) {
-      <div class="has-attachment">
-        @if (!!audio.url) {
+    <div class="container">
+      <div class="countdown" [ngClass]="{ animate: countdownTimer > 0 }">{{ countdownTimer }}</div>
+      @if (!hasAudioAttachment) {
+        <div class="no-attachment">
+          @if (!isRecording && !showCountdown) {
+            <button
+              mat-icon-button
+              (click)="startRecording()"
+              class="record"
+              [matTooltip]="t('record_audio')"
+              matTooltipPosition="before"
+            >
+              <mat-icon>mic</mat-icon>
+            </button>
+          }
+          @if (isRecording) {
+            <button
+              mat-icon-button
+              (click)="stopRecording()"
+              class="stop"
+              [matTooltip]="t('stop_recording')"
+              matTooltipPosition="before"
+            >
+              <mat-icon class="mic-icon">mic</mat-icon>
+              <mat-icon class="stop-icon">stop</mat-icon>
+            </button>
+          }
+        </div>
+      }
+      @if (hasAudioAttachment && !!audio.url) {
+        <div class="has-attachment">
           <app-single-button-audio-player [source]="audio.url" (click)="toggleAudio()">
             <mat-icon>{{ audioPlayer?.playing ? "stop" : "play_arrow" }}</mat-icon>
           </app-single-button-audio-player>
-        }
-        <button
-          mat-button
-          (click)="resetRecording()"
-          [matTooltip]="t('delete')"
-          class="remove-audio-file"
-          matTooltipPosition="before"
-        >
-          <mat-icon>close</mat-icon>
-        </button>
-      </div>
-    }
+        </div>
+      }
+    </div>
+    <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
+      <button
+        mat-flat-button
+        color="primary"
+        (click)="resetRecording()"
+        [matTooltip]="t('delete')"
+        class="remove-audio-file"
+        matTooltipPosition="before"
+      >
+        <mat-icon>mic</mat-icon> Re-record
+      </button>
+      <button
+        mat-button
+        (click)="saveRecording()"
+        [matTooltip]="t('save')"
+        class="save-audio-file"
+        matTooltipPosition="before"
+      >
+        <mat-icon>check</mat-icon> Save
+      </button>
+    </div>
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -1,0 +1,25 @@
+.countdown {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  height: 100px;
+  width: 100px;
+  &.animate {
+    animation: countdown 1s 3;
+  }
+  &:not(.animate) {
+    opacity: 0;
+  }
+}
+
+@keyframes countdown {
+  0% {
+    font-size: 100px;
+    transform: scale(1.2);
+  }
+  100% {
+    font-size: 90px;
+    transform: scale(1);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -31,7 +31,7 @@
     color: #fff;
     transition: color 0.3s;
     &:hover {
-      color: variables.$greyDark;
+      color: #fff;
       .stop-icon {
         display: block;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -32,15 +32,6 @@
     transition: color 0.3s;
     &:hover {
       color: #fff;
-      .stop-icon {
-        display: block;
-      }
-      .mic-icon {
-        display: none;
-      }
-    }
-    .stop-icon {
-      display: none;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -1,15 +1,57 @@
-.countdown {
+@use 'src/variables';
+
+.container {
   display: flex;
   align-items: center;
   justify-content: center;
-  line-height: 1;
-  height: 100px;
-  width: 100px;
-  &.animate {
-    animation: countdown 1s 3;
+  height: 150px;
+  width: 150px;
+
+  .countdown {
+    line-height: 1;
+    font-weight: bold;
+
+    &.animate {
+      animation: countdown 1s 3;
+    }
+
+    &:not(.animate) {
+      opacity: 0;
+      display: none;
+    }
   }
-  &:not(.animate) {
-    opacity: 0;
+
+  .record,
+  .stop,
+  .has-attachment {
+    transform: scale(2);
+  }
+  .stop {
+    animation: pulse 0.75s infinite;
+    color: #fff;
+    transition: color 0.3s;
+    &:hover {
+      color: variables.$greyDark;
+      .stop-icon {
+        display: block;
+      }
+      .mic-icon {
+        display: none;
+      }
+    }
+    .stop-icon {
+      display: none;
+    }
+  }
+}
+
+.has-attachment {
+  transform: scale(0);
+  display: flex;
+  gap: 30px;
+
+  &.visible {
+    transform: scale(1);
   }
 }
 
@@ -21,5 +63,17 @@
   100% {
     font-size: 90px;
     transform: scale(1);
+  }
+}
+
+@keyframes pulse {
+  0% {
+    background-color: variables.$red;
+  }
+  50% {
+    background-color: lighten(variables.$red, 10%);
+  }
+  100% {
+    background-color: variables.$red;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -1,6 +1,5 @@
-import { DebugElement, NgZone } from '@angular/core';
+import { NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AudioRecorderDialogComponent } from './audio-recorder-dialog.component';
+
+describe('AudioRecorderComponent', () => {
+  let component: AudioRecorderDialogComponent;
+  let fixture: ComponentFixture<AudioRecorderDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AudioRecorderDialogComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AudioRecorderDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -1,22 +1,183 @@
+import { DebugElement, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { anything, mock, verify, when } from 'ts-mockito';
+import { NAVIGATOR } from 'xforge-common/browser-globals';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { MockConsole } from 'xforge-common/mock-console';
+import { UserDoc } from 'xforge-common/models/user-doc';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { SupportedBrowsersDialogComponent } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
+import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
+import { AudioPlayer } from '../audio/audio-player';
+import { AudioRecorderDialogComponent, AudioRecorderDialogData } from './audio-recorder-dialog.component';
 
-import { AudioRecorderDialogComponent } from './audio-recorder-dialog.component';
+const mockedNoticeService = mock(NoticeService);
+const mockedNavigator = mock(Navigator);
+const mockedDialog = mock(DialogService);
+const mockedI18nService = mock(I18nService);
+const mockedConsole: MockConsole = MockConsole.install();
 
-describe('AudioRecorderComponent', () => {
-  let component: AudioRecorderDialogComponent;
-  let fixture: ComponentFixture<AudioRecorderDialogComponent>;
+describe('AudioRecorderDialogComponent', () => {
+  configureTestingModule(() => ({
+    imports: [
+      UICommonModule,
+      TestTranslocoModule,
+      TestOnlineStatusModule.forRoot(),
+      TestRealtimeModule.forRoot(SF_TYPE_REGISTRY)
+    ],
+    providers: [
+      { provide: NoticeService, useMock: mockedNoticeService },
+      { provide: NAVIGATOR, useMock: mockedNavigator },
+      { provide: OnlineStatusService, useclass: TestOnlineStatusService },
+      { provide: DialogService, useMock: mockedDialog },
+      { provide: I18nService, useMock: mockedI18nService }
+    ]
+  }));
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AudioRecorderDialogComponent]
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AudioRecorderDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  let overlayContainer: OverlayContainer;
+  beforeEach(() => {
+    overlayContainer = TestBed.inject(OverlayContainer);
+  });
+  afterEach(() => {
+    // Prevents 'Error: Test did not clean up its overlay container content.'
+    overlayContainer.ngOnDestroy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('can record', async () => {
+    const env = new TestEnvironment();
+    expect(env.recordButton).toBeTruthy();
+    expect(env.stopRecordingButton).toBeFalsy();
+    env.clickButton(env.recordButton);
+    // Record for more than 2 seconds in order to test the duration of blob files
+    // which can fail with certain recording types
+    await env.waitForRecorder(2400);
+    expect(env.recordButton).toBeFalsy();
+    expect(env.stopRecordingButton).toBeTruthy();
+    env.clickButton(env.stopRecordingButton);
+    await env.waitForRecorder(100);
+    // The actual duration is slightly less than the length recorded so rounding is sufficient
+    // If the duration fails it will return zero
+    expect(Math.floor(await env.getAudioDuration())).toEqual(2);
+    expect(env.component.hasAudioAttachment).toBe(true);
+  });
+
+  it('can restart', async () => {
+    const env = new TestEnvironment();
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(1000);
+    env.clickButton(env.stopRecordingButton);
+    await env.waitForRecorder(100);
+    env.clickButton(env.tryAgainButton);
+    expect(env.recordButton).toBeTruthy();
+  });
+
+  it('should display message if microphone not accessible', async () => {
+    const env = new TestEnvironment();
+    mockedConsole.expectAndHide(/No microphone/);
+    env.rejectUserMedia = true;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(100);
+    verify(mockedNoticeService.show(anything())).once();
+    mockedConsole.verify();
+    mockedConsole.reset();
+    env.rejectUserMedia = false;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(1000);
+    expect(env.recordButton).toBeFalsy();
+    expect(env.stopRecordingButton).toBeTruthy();
+    env.clickButton(env.stopRecordingButton);
+    await env.waitForRecorder(100);
+    expect(env.component.hasAudioAttachment).toBe(true);
+  });
+
+  it('should show browser unsupported dialog', async () => {
+    const env = new TestEnvironment();
+    env.component.mediaDevicesUnsupported = true;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(100);
+    verify(mockedDialog.openMatDialog(SupportedBrowsersDialogComponent, anything())).once();
+    env.component.mediaDevicesUnsupported = false;
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(100);
+    verify(mockedDialog.openMatDialog(SupportedBrowsersDialogComponent, anything())).once();
+    expect().nothing();
   });
 });
+
+class TestEnvironment {
+  rejectUserMedia = false;
+  readonly ngZone: NgZone = TestBed.inject(NgZone);
+  readonly component: AudioRecorderDialogComponent;
+  readonly fixture: ComponentFixture<ChildViewContainerComponent>;
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
+  dialogRef: MatDialogRef<AudioRecorderDialogComponent>;
+
+  private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
+
+  constructor(countdown: boolean = false) {
+    this.fixture = TestBed.createComponent(ChildViewContainerComponent);
+    this.dialogRef = TestBed.inject(MatDialog).open(AudioRecorderDialogComponent, {
+      data: { countdown } as AudioRecorderDialogData
+    });
+    this.component = this.dialogRef.componentInstance;
+
+    this.realtimeService.addSnapshot(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: { name: 'user' }
+    });
+    when(mockedNavigator.mediaDevices).thenReturn({
+      getUserMedia: (mediaConstraints: MediaStreamConstraints) =>
+        this.rejectUserMedia ? Promise.reject('No microphone') : navigator.mediaDevices.getUserMedia(mediaConstraints)
+    } as MediaDevices);
+    this.fixture.detectChanges();
+  }
+
+  async getAudioDuration(): Promise<number> {
+    const audio = new AudioPlayer(this.component.audio.url!, this.testOnlineStatusService);
+    await this.waitForRecorder(100);
+    return audio.duration;
+  }
+
+  get countdown(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.countdown.animate') as HTMLElement;
+  }
+
+  get overlayContainerElement(): HTMLElement {
+    return this.fixture.nativeElement.parentElement.querySelector('.cdk-overlay-container');
+  }
+
+  get recordButton(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.record') as HTMLElement;
+  }
+
+  get stopRecordingButton(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.stop') as HTMLElement;
+  }
+
+  get tryAgainButton(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.remove-audio-file') as HTMLElement;
+  }
+
+  clickButton(button: HTMLElement): void {
+    button.click();
+    this.fixture.detectChanges();
+  }
+
+  async waitForRecorder(ms: number): Promise<any> {
+    await new Promise(resolve => this.ngZone.runOutsideAngular(() => setTimeout(resolve, ms)));
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -26,8 +26,8 @@ export interface AudioAttachment {
 }
 
 export interface AudioRecorderDialogData {
-  countdown: boolean;
-  audio: AudioAttachment;
+  countdown?: boolean;
+  audio?: AudioAttachment;
 }
 
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ControlValueAccessor } from '@angular/forms';
 import { translate, TranslocoModule } from '@ngneat/transloco';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -35,14 +35,7 @@ export interface AudioRecorderDialogData {
   selector: 'app-audio-recorder-dialog',
   templateUrl: './audio-recorder-dialog.component.html',
   styleUrl: './audio-recorder-dialog.component.scss',
-  imports: [UICommonModule, CommonModule, SharedModule, TranslocoModule],
-  providers: [
-    {
-      provide: NG_VALUE_ACCESSOR,
-      multi: true,
-      useExisting: AudioRecorderDialogComponent
-    }
-  ]
+  imports: [UICommonModule, CommonModule, SharedModule, TranslocoModule]
 })
 /* eslint-disable brace-style */
 export class AudioRecorderDialogComponent
@@ -86,18 +79,6 @@ export class AudioRecorderDialogComponent
     }
   }
 
-  writeValue(obj: AudioAttachment): void {
-    this.audio = obj;
-  }
-
-  registerOnChange(fn: ((value: AudioAttachment) => void) | undefined): void {
-    this.subscribe(this.status, fn);
-  }
-
-  registerOnTouched(fn: ((value: AudioAttachment) => void) | undefined): void {
-    this.subscribe(this._onTouched, fn);
-  }
-
   get hasAudioAttachment(): boolean {
     return this.audio.url !== undefined;
   }
@@ -115,6 +96,18 @@ export class AudioRecorderDialogComponent
   async ngOnInit(): Promise<void> {
     this.mediaDevicesUnsupported =
       this.navigator.mediaDevices?.getUserMedia == null || typeof MediaRecorder === 'undefined';
+  }
+
+  writeValue(obj: AudioAttachment): void {
+    this.audio = obj;
+  }
+
+  registerOnChange(fn: ((value: AudioAttachment) => void) | undefined): void {
+    this.subscribe(this.status, fn);
+  }
+
+  registerOnTouched(fn: ((value: AudioAttachment) => void) | undefined): void {
+    this.subscribe(this._onTouched, fn);
   }
 
   processAudio(): void {
@@ -188,8 +181,8 @@ export class AudioRecorderDialogComponent
     await new Promise<void>(resolve => {
       const statusPromise = this.status.subscribe((status: AudioAttachment) => {
         if (status.status === 'processed') {
-          resolve();
           statusPromise.unsubscribe();
+          resolve();
         }
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -1,0 +1,215 @@
+import { Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { translate, TranslocoModule } from '@ngneat/transloco';
+import { NAVIGATOR } from 'xforge-common/browser-globals';
+import { DialogService } from 'xforge-common/dialog.service';
+import { NoticeService } from 'xforge-common/notice.service';
+import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
+import {
+  BrowserIssue,
+  SupportedBrowsersDialogComponent
+} from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
+import { isGecko, objectId } from 'xforge-common/utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { interval } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { CommonModule } from '@angular/common';
+import { SingleButtonAudioPlayerComponent } from '../../checking/checking/single-button-audio-player/single-button-audio-player.component';
+import { SharedModule } from '../shared.module';
+
+export interface AudioAttachment {
+  status?: 'denied' | 'processed' | 'recording' | 'reset' | 'stopped' | 'uploaded';
+  url?: string;
+  fileName?: string;
+  blob?: Blob;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-audio-recorder-dialog',
+  templateUrl: './audio-recorder-dialog.component.html',
+  styleUrl: './audio-recorder-dialog.component.scss',
+  imports: [UICommonModule, CommonModule, SharedModule, TranslocoModule],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: AudioRecorderDialogComponent
+    }
+  ]
+})
+/* eslint-disable brace-style */
+export class AudioRecorderDialogComponent
+  extends SubscriptionDisposable
+  implements ControlValueAccessor, OnInit, OnDestroy
+{
+  @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
+  @Output() status = new EventEmitter<AudioAttachment>();
+
+  get audio(): AudioAttachment {
+    return this._audio;
+  }
+  @Input() set audio(audio: AudioAttachment) {
+    this._audio = audio;
+    this.status.emit(audio);
+  }
+
+  countdown: number = 0;
+  mediaDevicesUnsupported: boolean = false;
+  private stream?: MediaStream;
+  private mediaRecorder?: MediaRecorder;
+  private recordedChunks: Blob[] = [];
+  private _audio: AudioAttachment = {};
+  private _onTouched = new EventEmitter();
+
+  constructor(
+    private readonly noticeService: NoticeService,
+    @Inject(NAVIGATOR) private readonly navigator: Navigator,
+    private readonly dialogService: DialogService
+  ) {
+    super();
+    this.startCountdown();
+  }
+
+  writeValue(obj: AudioAttachment): void {
+    this.audio = obj;
+  }
+
+  registerOnChange(fn: ((value: AudioAttachment) => void) | undefined): void {
+    this.subscribe(this.status, fn);
+  }
+
+  registerOnTouched(fn: ((value: AudioAttachment) => void) | undefined): void {
+    this.subscribe(this._onTouched, fn);
+  }
+
+  get hasAudioAttachment(): boolean {
+    return this.audio.url !== undefined;
+  }
+
+  get isRecording(): boolean {
+    return this.mediaRecorder != null && this.mediaRecorder.state === 'recording';
+  }
+
+  ngOnDestroy(): void {
+    if (this.isRecording) {
+      this.stopRecording();
+    }
+  }
+
+  async ngOnInit(): Promise<void> {
+    this.mediaDevicesUnsupported =
+      this.navigator.mediaDevices?.getUserMedia == null || typeof MediaRecorder === 'undefined';
+  }
+
+  processAudio(): void {
+    if (this.mediaRecorder == null) {
+      return;
+    }
+
+    const blob = new Blob(this.recordedChunks, { type: this.mimeType });
+    this.audio = {
+      url: URL.createObjectURL(blob),
+      status: 'processed',
+      blob: blob,
+      fileName: objectId() + '.webm'
+    };
+    this._onTouched.emit();
+  }
+
+  resetRecording(): void {
+    this.audio = { status: 'reset' };
+    this.recordedChunks = [];
+    this._onTouched.emit();
+  }
+
+  startCountdown(): void {
+    // Start a countdown timer from 3 seconds to zero and then start recording
+    const seconds = 3;
+    const countdown$ = interval(1000).pipe(
+      take(seconds + 1),
+      map(countown => seconds - countown)
+    );
+
+    countdown$.subscribe({
+      next: value => {
+        this.countdown = value;
+      },
+      complete: () => {
+        this.startRecording();
+      }
+    });
+  }
+
+  startRecording(): void {
+    const mediaConstraints: MediaStreamConstraints = { audio: true };
+    if (this.mediaDevicesUnsupported) {
+      this.audio = { status: 'denied' };
+      this.dialogService.openMatDialog(SupportedBrowsersDialogComponent, { data: BrowserIssue.AudioRecording });
+      return;
+    }
+    this.navigator.mediaDevices
+      .getUserMedia(mediaConstraints)
+      .then(this.successCallback.bind(this), this.errorCallback.bind(this));
+  }
+
+  async stopRecording(): Promise<void> {
+    if (this.mediaRecorder == null || this.stream == null) {
+      return;
+    }
+
+    this.mediaRecorder.stop();
+    this.stream.getAudioTracks().forEach(track => track.stop());
+    this.audio = { status: 'stopped' };
+    // Additional promise for when the audio has been processed and is available
+    await new Promise<void>(resolve => {
+      const statusPromise = this.status.subscribe((status: AudioAttachment) => {
+        if (status.status === 'processed') {
+          resolve();
+          statusPromise.unsubscribe();
+        }
+      });
+    });
+  }
+
+  toggleAudio(): void {
+    this.audioPlayer?.playing ? this.audioPlayer?.stop() : this.audioPlayer?.play();
+    this._onTouched.emit();
+  }
+
+  private get mimeType(): string {
+    // If OGG is not used on Firefox, recording does not work correctly.
+    // See https://github.com/muaz-khan/RecordRTC/issues/166#issuecomment-242942400
+    return isGecko() ? 'audio/ogg' : 'audio/webm';
+  }
+
+  private errorCallback(error: any): void {
+    console.error(error);
+    this.audio = { status: 'denied' };
+
+    if (error.code === DOMException.NOT_FOUND_ERR) {
+      this.noticeService.show(translate('checking_audio_recorder.mic_not_found'));
+    } else {
+      this.noticeService.show(translate('checking_audio_recorder.mic_access_denied'));
+    }
+  }
+
+  private dataAvailableCallback(event: BlobEvent): void {
+    if (event.data.size > 0) {
+      this.recordedChunks.push(event.data);
+    }
+  }
+
+  private successCallback(stream: MediaStream): void {
+    const options: MediaRecorderOptions = {
+      mimeType: this.mimeType
+    };
+    this.stream = stream;
+    this.recordedChunks = [];
+    this.mediaRecorder = new MediaRecorder(stream, options);
+    this.mediaRecorder.ondataavailable = event => this.dataAvailableCallback(event);
+    this.mediaRecorder.onstop = () => this.processAudio();
+    this.mediaRecorder.start();
+    this.audio = { status: 'recording' };
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -11,8 +11,8 @@ import {
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { isGecko, objectId } from 'xforge-common/utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { interval, timer } from 'rxjs';
-import { map, startWith, take } from 'rxjs/operators';
+import { timer } from 'rxjs';
+import { map, take } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { SingleButtonAudioPlayerComponent } from '../../checking/checking/single-button-audio-player/single-button-audio-player.component';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -16,21 +16,9 @@ import {
   matDialogStory,
   MatDialogStoryConfig
 } from '../../../../.storybook/util/mat-dialog-launch';
+import { createMockMediaStream } from '../test-utils';
 
 const mockedNavigator = mock(Navigator);
-
-// Function to create a mock MediaStream with an audio track
-const createMockMediaStream = (): MediaStream => {
-  // Use the MediaStream constructor to simulate a stream with an audio track
-  const audioContext = new window.AudioContext();
-  const oscillator = audioContext.createOscillator();
-  const destination = audioContext.createMediaStreamDestination();
-
-  oscillator.connect(destination);
-  oscillator.start();
-
-  return destination.stream;
-};
 
 interface StoryAppState {
   audio: AudioAttachment;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -2,16 +2,47 @@ import { Meta } from '@storybook/angular';
 import { NoticeService } from 'xforge-common/notice.service';
 import { I18nStoryModule } from 'xforge-common/i18n-story.module';
 import { DialogService } from 'xforge-common/dialog.service';
+import { expect } from '@storybook/jest';
 import { AudioRecorderDialogComponent } from './audio-recorder-dialog.component';
-import { MatDialogLaunchComponent, matDialogStory } from '../../../../.storybook/util/mat-dialog-launch';
+import {
+  MatDialogLaunchComponent,
+  matDialogStory,
+  MatDialogStoryConfig
+} from '../../../../.storybook/util/mat-dialog-launch';
 
 export default {
   title: 'Shared/Audio Recorder',
   component: MatDialogLaunchComponent
 } as Meta;
 
-export const Default = matDialogStory(AudioRecorderDialogComponent, {
+const dialogStoryConfig: MatDialogStoryConfig = {
   imports: [I18nStoryModule],
   providers: [DialogService, NoticeService],
   standaloneComponent: true
-});
+};
+
+export const ReadyToRecord = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
+
+export const Countdown = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
+Countdown.args = {
+  data: { countdown: true }
+};
+Countdown.play = async ({ canvasElement }) => {
+  // Countdown should be visible
+  await new Promise(resolve => setTimeout(resolve, 1));
+  const countdownElement = canvasElement.querySelector('.countdown');
+  expect(countdownElement).toHaveClass('animate');
+
+  // The timer is only 3 seconds but give storybook enough time to process the media devices
+  await new Promise(resolve => setTimeout(resolve, 4000));
+
+  // Recording should have started
+  const stopButton = canvasElement.querySelector('.no-attachment .stop');
+  expect(stopButton).toHaveClass('stop');
+  expect(stopButton).toBeVisible();
+};
+
+export const ExistingAudio = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
+ExistingAudio.args = {
+  data: { audio: { status: 'processed', url: './test-audio-player.webm' } }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -1,23 +1,109 @@
-import { Meta } from '@storybook/angular';
+import { Meta, moduleMetadata } from '@storybook/angular';
 import { NoticeService } from 'xforge-common/notice.service';
 import { I18nStoryModule } from 'xforge-common/i18n-story.module';
 import { DialogService } from 'xforge-common/dialog.service';
 import { expect } from '@storybook/jest';
-import { AudioRecorderDialogComponent } from './audio-recorder-dialog.component';
+import { instance, mock, when } from 'ts-mockito';
+import { NAVIGATOR } from 'xforge-common/browser-globals';
+import { userEvent } from '@storybook/testing-library';
+import {
+  AudioAttachment,
+  AudioRecorderDialogComponent,
+  AudioRecorderDialogData
+} from './audio-recorder-dialog.component';
 import {
   MatDialogLaunchComponent,
   matDialogStory,
   MatDialogStoryConfig
 } from '../../../../.storybook/util/mat-dialog-launch';
 
+const mockedNavigator = mock(Navigator);
+
+// Function to create a mock MediaStream with an audio track
+const createMockMediaStream = (): MediaStream => {
+  // Use the MediaStream constructor to simulate a stream with an audio track
+  const audioContext = new window.AudioContext();
+  const oscillator = audioContext.createOscillator();
+  const destination = audioContext.createMediaStreamDestination();
+
+  oscillator.connect(destination);
+  oscillator.start();
+
+  return destination.stream;
+};
+
+interface StoryAppState {
+  audio: AudioAttachment;
+  micAvailable: boolean;
+  micPermission: boolean;
+  countdown: boolean;
+  data: AudioRecorderDialogData;
+}
+
+const defaultArgs: StoryAppState = {
+  audio: {},
+  micAvailable: true,
+  micPermission: true,
+  countdown: false,
+  data: {}
+};
+
 export default {
   title: 'Shared/Audio Recorder',
-  component: MatDialogLaunchComponent
+  component: MatDialogLaunchComponent,
+  argTypes: {
+    audio: {
+      description: 'Existing audio attachment',
+      table: { category: 'Dialog data', type: { summary: 'AudioAttachment' } }
+    },
+    countdown: {
+      control: { type: 'boolean' },
+      description: 'Initiate with a countdown',
+      table: { category: 'Dialog data' }
+    },
+    data: {
+      description: 'Data to pass to the dialog',
+      table: { category: 'Dialog data', type: { summary: 'AudioRecorderDialogData' } }
+    },
+    micAvailable: {
+      control: { type: 'boolean' },
+      description: 'Device has a microphone available for use',
+      table: { category: 'App state' }
+    },
+    micPermission: {
+      control: { type: 'boolean' },
+      description: 'Permission to access the microphone',
+      table: { category: 'App state' }
+    }
+  },
+  decorators: [
+    moduleMetadata({}),
+    (story, context) => {
+      context.args.data = { countdown: context.args.countdown } as AudioRecorderDialogData;
+      when(mockedNavigator.mediaDevices).thenReturn({
+        getUserMedia: (_: MediaStreamConstraints): Promise<MediaStream> => {
+          return context.args.micPermission && context.args.micAvailable
+            ? Promise.resolve(createMockMediaStream())
+            : context.args.micAvailable
+              ? Promise.reject('No microphone')
+              : Promise.reject({ code: DOMException.NOT_FOUND_ERR });
+        }
+      } as MediaDevices);
+      return story();
+    }
+  ],
+  parameters: {
+    controls: {
+      expanded: true,
+      include: Object.keys(defaultArgs)
+    }
+  },
+  args: defaultArgs
 } as Meta;
 
 const dialogStoryConfig: MatDialogStoryConfig = {
   imports: [I18nStoryModule],
-  providers: [DialogService, NoticeService],
+  providers: [DialogService, NoticeService, { provide: NAVIGATOR, useValue: instance(mockedNavigator) }],
   standaloneComponent: true
 };
 
@@ -25,7 +111,7 @@ export const ReadyToRecord = matDialogStory(AudioRecorderDialogComponent, dialog
 
 export const Countdown = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
 Countdown.args = {
-  data: { countdown: true }
+  countdown: true
 };
 Countdown.play = async ({ canvasElement }) => {
   // Countdown should be visible
@@ -44,5 +130,27 @@ Countdown.play = async ({ canvasElement }) => {
 
 export const ExistingAudio = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
 ExistingAudio.args = {
-  data: { audio: { status: 'processed', url: './test-audio-player.webm' } }
+  audio: { status: 'processed', url: './test-audio-player.webm' }
+};
+
+export const PermissionDenied = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
+PermissionDenied.args = {
+  micPermission: false
+};
+PermissionDenied.play = async ({ canvasElement }) => {
+  const recordButton = canvasElement.querySelector('.record');
+  await userEvent.click(recordButton!);
+  const notice = canvasElement.querySelector('simple-snack-bar');
+  expect(notice?.textContent?.includes('Access to your microphone was denied')).toBeTruthy();
+};
+
+export const MicNotFound = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
+MicNotFound.args = {
+  micAvailable: false
+};
+MicNotFound.play = async ({ canvasElement }) => {
+  const recordButton = canvasElement.querySelector('.record');
+  await userEvent.click(recordButton!);
+  const notice = canvasElement.querySelector('simple-snack-bar');
+  expect(notice?.textContent?.includes('No microphone was found')).toBeTruthy();
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/angular';
+import { NoticeService } from 'xforge-common/notice.service';
+import { I18nStoryModule } from 'xforge-common/i18n-story.module';
+import { DialogService } from 'xforge-common/dialog.service';
+import { AudioRecorderDialogComponent } from './audio-recorder-dialog.component';
+import { MatDialogLaunchComponent, matDialogStory } from '../../../../.storybook/util/mat-dialog-launch';
+
+export default {
+  title: 'Shared/Audio Recorder',
+  component: MatDialogLaunchComponent
+} as Meta;
+
+export const Default = matDialogStory(AudioRecorderDialogComponent, {
+  imports: [I18nStoryModule],
+  providers: [DialogService, NoticeService],
+  standaloneComponent: true
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/test-utils.ts
@@ -113,3 +113,16 @@ export function paratextUsersFromRoles(userRoles: { [id: string]: string }): Par
     .filter(u => isParatextRole(userRoles[u]))
     .map(u => ({ sfUserId: u, username: `pt${u}`, opaqueUserId: `opaque${u}` }));
 }
+
+// Function to create a mock MediaStream with an audio track
+export const createMockMediaStream = (): MediaStream => {
+  // Use the MediaStream constructor to simulate a stream with an audio track
+  const audioContext: AudioContext = new window.AudioContext();
+  const oscillator: OscillatorNode = audioContext.createOscillator();
+  const destination: MediaStreamAudioDestinationNode = audioContext.createMediaStreamDestination();
+
+  oscillator.connect(destination);
+  oscillator.start();
+
+  return destination.stream;
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -1,11 +1,8 @@
 {
   "audio_recorder_dialog": {
-    "delete": "Delete Recording",
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
-    "not_available": "Your browser currently does not support audio recording. Please try using another supported browser.",
     "record_audio": "Record Audio",
-    "save": "Save",
     "stop_recording": "Stop Recording"
   },
   "app": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -1,4 +1,13 @@
 {
+  "audio_recorder_dialog": {
+    "delete": "Delete Recording",
+    "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
+    "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
+    "not_available": "Your browser currently does not support audio recording. Please try using another supported browser.",
+    "record_audio": "Record Audio",
+    "save": "Save",
+    "stop_recording": "Stop Recording"
+  },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",
     "all_questions": "All Questions",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -3,6 +3,8 @@
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
     "record_audio": "Record Audio",
+    "re_record": "Re-record",
+    "save": "Save",
     "stop_recording": "Stop Recording"
   },
   "app": {


### PR DESCRIPTION
This functionality is NOT in use within the app. 

The intention of this new component is to provide a consistent way of recording audio anywhere in SF. It has been heavily based off the current `CheckingAudioRecorderComponent` component.

Stories have been created to show the intention of the different states. The main new flow is when this dialog opens it immediately starts a countdown for the user and then starts recording.

New Jira tasks can be created to integrate it into the Community Checking components to replace the existing `CheckingAudioRecorderComponent`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2676)
<!-- Reviewable:end -->
