### PR TITLE
Add draft configuration information to Serval admin page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -55,3 +55,17 @@
     <tr mat-row *matRowDef="let myRowData; columns: columnsToDisplay"></tr>
   </table>
 </div>
+
+<h2>Last Draft settings</h2>
+<h3>Training books</h3>
+{{ trainingBooks.join(", ") || "None" }}
+<h3>Training data files</h3>
+{{ trainingFiles.join(", ") || "None" }}
+<h3>Translation books</h3>
+{{ translationBooks.join(", ") || "None" }}
+
+<h2>Raw draft config</h2>
+<pre class="raw-draft-config">
+@for (key of keys(draftConfig ?? {}); track key) {{{ key }}: <strong>{{ stringify(draftConfig![key]) }}</strong>
+}
+</pre>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
@@ -9,3 +9,7 @@
     column-gap: 10px;
   }
 }
+
+.raw-draft-config {
+  font-family: monospace;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { catchError, lastValueFrom, of, tap, throwError } from 'rxjs';
@@ -36,6 +37,12 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   headingsToDisplay = { category: 'Category', name: 'Project', id: '' };
   columnsToDisplay = ['category', 'name', 'id'];
   rows: Row[] = [];
+
+  trainingBooks: string[] = [];
+  trainingFiles: string[] = [];
+  translationBooks: string[] = [];
+
+  draftConfig: Object | undefined;
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
@@ -119,6 +126,17 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
           // We have to set the rows this way to trigger the update
           this.rows = rows;
+
+          // Setup the books
+          this.trainingBooks = project.translateConfig.draftConfig.lastSelectedTrainingBooks.map(bookNum =>
+            Canon.bookNumberToEnglishName(bookNum)
+          );
+          this.trainingFiles = project.translateConfig.draftConfig.lastSelectedTrainingDataFiles;
+          this.translationBooks = project.translateConfig.draftConfig.lastSelectedTranslationBooks.map(bookNum =>
+            Canon.bookNumberToEnglishName(bookNum)
+          );
+
+          this.draftConfig = project.translateConfig.draftConfig;
         })
       )
     );
@@ -161,5 +179,20 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   async retrievePreTranslationStatus(): Promise<void> {
     await this.servalAdministrationService.onlineRetrievePreTranslationStatus(this.activatedProjectService.projectId!);
     await this.noticeService.show('Webhook job started.');
+  }
+
+  keys(obj: Object): string[] {
+    return Object.keys(obj);
+  }
+
+  stringify(value: any): string {
+    if (Array.isArray(value)) {
+      return this.arrayToString(value);
+    }
+    return JSON.stringify(value, (_key, value) => (Array.isArray(value) ? this.arrayToString(value) : value), 2);
+  }
+
+  arrayToString(value: any): string {
+    return '[' + value.join(', ') + ']';
   }
 }


### PR DESCRIPTION
Right now it can be difficult to determine what settings a project used to generate its last draft if not an actual member of the project. 

This isn't an ideal solution, but it provides a bunch of contextual information for Serval admins. Ideally at some point in the future this will be presented better, but I expect there to be changes to how configuration is done that could make any work here obsolete.

![](https://github.com/user-attachments/assets/a4d70c4e-c706-44f6-89ef-a6f5363b9d5a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2681)
<!-- Reviewable:end -->
