### PR TITLE
SF-2844 Notify user resource failed to load due to being offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AbortError, HubConnection, HubConnectionBuilder, IHttpConnectionOptions } from '@microsoft/signalr';
 import { AuthService } from 'xforge-common/auth.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 
 @Injectable({
   providedIn: 'root'
@@ -11,8 +12,15 @@ export class ProjectNotificationService {
     accessTokenFactory: async () => (await this.authService.getAccessToken()) ?? ''
   };
 
-  constructor(private authService: AuthService) {
+  constructor(
+    private authService: AuthService,
+    private readonly onlineService: OnlineStatusService
+  ) {
     this.connection = new HubConnectionBuilder().withUrl('/project-notifications', this.options).build();
+  }
+
+  get appOnline(): boolean {
+    return this.onlineService.isOnline && this.onlineService.isBrowserOnline;
   }
 
   setNotifySyncProgressHandler(handler: any): void {
@@ -22,8 +30,9 @@ export class ProjectNotificationService {
   async start(): Promise<void> {
     await this.connection.start().catch(err => {
       // Suppress AbortErrors, as they are not caused by server error, but the SignalR connection state
-      // These will be thrown if a user navigates away quickly after starting the sync
-      if (err instanceof AbortError) {
+      // These will be thrown if a user navigates away quickly after
+      // starting the sync or the app loses internet connection
+      if (err instanceof AbortError || !this.appOnline) {
         return;
       } else {
         throw err;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -57,6 +57,7 @@ describe('SyncProgressComponent', () => {
 
   it('does not initialize if app is offline', fakeAsync(async () => {
     const env = new TestEnvironment({ userId: 'user01' });
+    env.setupProjectDoc();
     env.onlineStatus = false;
     verify(mockedProjectService.get('sourceProject02')).never();
     expect(await env.getMode()).toBe('indeterminate');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
@@ -10,6 +11,9 @@ import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -28,22 +32,32 @@ describe('SyncProgressComponent', () => {
   configureTestingModule(() => ({
     declarations: [HostComponent, SyncProgressComponent],
     imports: [
+      TestOnlineStatusModule.forRoot(),
       UICommonModule,
       TestTranslocoModule,
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
       HttpClientTestingModule
     ],
     providers: [
+      provideAnimations(),
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: ProjectNotificationService, useMock: mockedProjectNotificationService },
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: ErrorReportingService, useMock: mockedErrorReportingService }
+      { provide: ErrorReportingService, useMock: mockedErrorReportingService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
   }));
 
   it('does not initialize if projectDoc is undefined', fakeAsync(async () => {
     const env = new TestEnvironment({ userId: 'user01' });
     expect(env.host.projectDoc).toBeUndefined();
+    verify(mockedProjectService.get('sourceProject02')).never();
+    expect(await env.getMode()).toBe('indeterminate');
+  }));
+
+  it('does not initialize if app is offline', fakeAsync(async () => {
+    const env = new TestEnvironment({ userId: 'user01' });
+    env.onlineStatus = false;
     verify(mockedProjectService.get('sourceProject02')).never();
     expect(await env.getMode()).toBe('indeterminate');
   }));
@@ -144,6 +158,9 @@ interface TestEnvArgs {
 }
 
 class TestEnvironment {
+  readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
+    OnlineStatusService
+  ) as TestOnlineStatusService;
   readonly fixture: ComponentFixture<HostComponent>;
   readonly host: HostComponent;
 
@@ -209,6 +226,12 @@ class TestEnvironment {
 
   get progressBar(): HTMLElement | null {
     return this.fixture.nativeElement.querySelector('mat-progress-bar');
+  }
+
+  set onlineStatus(isOnline: boolean) {
+    this.testOnlineStatusService.setIsOnline(isOnline);
+    tick();
+    this.fixture.detectChanges();
   }
 
   updateSyncProgress(percentCompleted: number, projectId: string): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -5,6 +5,7 @@ import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf
 import { BehaviorSubject, Observable, map, merge } from 'rxjs';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { ProjectNotificationService } from '../../core/project-notification.service';
@@ -46,13 +47,18 @@ export class SyncProgressComponent extends SubscriptionDisposable {
     private readonly projectService: SFProjectService,
     private readonly projectNotificationService: ProjectNotificationService,
     private readonly featureFlags: FeatureFlagService,
-    private readonly errorReportingService: ErrorReportingService
+    private readonly errorReportingService: ErrorReportingService,
+    private readonly onlineStatus: OnlineStatusService
   ) {
     super();
 
     this.projectNotificationService.setNotifySyncProgressHandler((projectId: string, progressState: ProgressState) => {
       this.updateProgressState(projectId, progressState);
     });
+  }
+
+  get appOnline(): boolean {
+    return this.onlineStatus.isOnline && this.onlineStatus.isBrowserOnline;
   }
 
   @Input() set projectDoc(doc: SFProjectDoc | undefined) {
@@ -64,7 +70,7 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   }
 
   async initialize(): Promise<void> {
-    if (this._projectDoc?.data == null) {
+    if (this._projectDoc?.data == null || !this.appOnline) {
       return;
     }
     await this.projectNotificationService.start();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
@@ -31,20 +31,26 @@
     }
 
     @if (projectLoadingFailed && resourceLoadingFailed) {
-      <mat-error>
+      <mat-error id="project-resources-error">
         {{ t("error_fetching_projects_resources") }}
       </mat-error>
     } @else if (projectLoadingFailed && !resourceLoadingFailed) {
-      <mat-error>
+      <mat-error id="project-error">
         {{ t("error_fetching_projects") }}
       </mat-error>
     } @else if (resourceLoadingFailed && !projectLoadingFailed) {
-      <mat-error>
+      <mat-error id="resource-error">
         {{ t("error_fetching_resources") }}
       </mat-error>
     }
+    @if (!appOnline) {
+      <mat-error id="offline-error">
+        {{ t("error_offline") }}
+      </mat-error>
+    }
+
     @if (projectFetchFailed || syncFailed) {
-      <mat-error>
+      <mat-error id="fetch-sync-error">
         {{ t("error_loading_resource") }}
       </mat-error>
     }
@@ -55,7 +61,7 @@
     <button
       mat-flat-button
       color="primary"
-      [disabled]="!form.valid || isLoading || isSyncActive || projectFetchFailed || syncFailed"
+      [disabled]="!form.valid || isLoading || isSyncActive || !appOnline"
       (click)="confirmSelection()"
     >
       {{ t("select") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -83,7 +83,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
         }
         if (project?.projectId != null) {
           // Add the user to the project if they are not already connected to it
-          if (!project.isConnected && this.appOnline) {
+          if (!project.isConnected) {
             await this.projectService.onlineAddCurrentUser(project.projectId);
           }
           this.selectedProjectDoc =
@@ -99,11 +99,13 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
 
         if (this.selectedProjectDoc != null) {
           if (this.permissionsService.canSync(this.selectedProjectDoc)) {
-            if (!this.selectedProjectDoc?.data?.texts?.length) {
+            if (!this.selectedProjectDoc.data?.texts.length) {
               this.isSyncActive = true;
               await this.projectService.onlineSync(this.selectedProjectDoc.id);
             } else {
-              this.projectService.onlineSync(this.selectedProjectDoc.id);
+              this.projectService
+                .onlineSync(this.selectedProjectDoc.id)
+                .catch(_ => console.warn('Syncing to resource project failed'));
               this.dialogRef.close(this.selectedProjectDoc);
             }
           } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -56,6 +56,10 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) readonly dialogData: EditorTabAddResourceDialogData
   ) {}
 
+  get appOnline(): boolean {
+    return this.onlineStatus.isOnline && this.onlineStatus.isBrowserOnline;
+  }
+
   async ngOnInit(): Promise<void> {
     await this.getProjectsAndResources();
   }
@@ -65,6 +69,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
   }
 
   async confirmSelection(): Promise<void> {
+    this.resetErrors();
     const paratextId: string | null | undefined = this.form.value.sourceParatextId;
 
     try {
@@ -73,27 +78,32 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
 
         // If the Paratext project has a SF project id, add the user to that project if they are not already
         const project = this.projects?.find(p => p.paratextId === paratextId);
+        if (!this.appOnline) {
+          return;
+        }
         if (project?.projectId != null) {
           // Add the user to the project if they are not already connected to it
-          if (!project.isConnected) {
+          if (!project.isConnected && this.appOnline) {
             await this.projectService.onlineAddCurrentUser(project.projectId);
           }
-          this.selectedProjectDoc = await this.projectService.get(project.projectId);
+          this.selectedProjectDoc =
+            project?.projectId != null ? await this.projectService.get(project.projectId) : undefined;
         } else {
           // Load the project or resource, creating it if it is not present
-          const projectId: string | undefined = await this.projectService.onlineCreateResourceProject(paratextId);
-          this.selectedProjectDoc = projectId != null ? await this.projectService.get(projectId) : undefined;
+          const projectId: string | undefined = this.appOnline
+            ? await this.projectService.onlineCreateResourceProject(paratextId)
+            : undefined;
+          this.selectedProjectDoc =
+            projectId != null && this.appOnline ? await this.projectService.get(projectId) : undefined;
         }
 
         if (this.selectedProjectDoc != null) {
           if (this.permissionsService.canSync(this.selectedProjectDoc)) {
-            // Wait for sync if no texts
-            if (!this.selectedProjectDoc.data?.texts.length) {
+            if (!this.selectedProjectDoc?.data?.texts?.length) {
               this.isSyncActive = true;
-              await this.syncProject(this.selectedProjectDoc.id);
+              await this.projectService.onlineSync(this.selectedProjectDoc.id);
             } else {
-              // Otherwise, start a sync in the background and close dialog
-              this.syncProject(this.selectedProjectDoc.id);
+              this.projectService.onlineSync(this.selectedProjectDoc.id);
               this.dialogRef.close(this.selectedProjectDoc);
             }
           } else {
@@ -104,11 +114,19 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
         }
       }
     } catch (e) {
-      this.syncFailed = true;
       try {
-        this.cancelSync();
+        if (this.appOnline) {
+          this.isSyncActive = false;
+          this.syncFailed = true;
+          this.cancelSync();
+        }
       } catch {}
     } finally {
+      if (!this.appOnline) {
+        this.syncFailed = true;
+        this.isSyncActive = false;
+      }
+
       this.isLoading = false;
     }
   }
@@ -124,7 +142,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
     this.isSyncActive = isActive;
 
     // Wait for sync to complete before closing dialog
-    if (!isActive) {
+    if (!isActive && this.selectedProjectDoc?.data?.texts?.length) {
       this.dialogRef.close(this.selectedProjectDoc);
     }
   }
@@ -165,10 +183,6 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
     this.resourceLoadingFailed = false;
     this.projectFetchFailed = false;
     this.syncFailed = false;
-  }
-
-  private async syncProject(projectId: string): Promise<void> {
-    await this.projectService.onlineSync(projectId);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -492,6 +492,7 @@
     "error_fetching_projects": "There was an error fetching projects. You will only be able to select resources from Digital Bible Library.",
     "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
     "error_loading_resource": "There was an error loading the selected resource.",
+    "error_offline": "You are offline. Please connect to the internet to load this resource.",
     "loading": "Loading",
     "placeholder_loading": "{{ editor_add_tab_resource_dialog.loading }}...",
     "placeholder_ready": "Select paratext project or DBL resource",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -5,6 +5,7 @@ import { v1 as uuidv1 } from 'uuid';
 import { hasNumberProp, hasObjectProp, hasStringProp } from '../type-utils';
 import { BugsnagService } from './bugsnag.service';
 import { COMMAND_API_NAMESPACE } from './url-constants';
+import { OnlineStatusService } from './online-status.service';
 
 /** See also C# enum EdjCase.JsonRpc.Common.RpcErrorCode, which this somewhat matches. */
 export enum CommandErrorCode {
@@ -61,8 +62,13 @@ export class CommandError extends Error {
 export class CommandService {
   constructor(
     private readonly http: HttpClient,
-    private readonly bugsnagService: BugsnagService
+    private readonly bugsnagService: BugsnagService,
+    private readonly onlineStatus: OnlineStatusService
   ) {}
+
+  get appOnline(): boolean {
+    return this.onlineStatus.isOnline && this.onlineStatus.isBrowserOnline;
+  }
 
   async onlineInvoke<T>(url: string, method: string, params: any = {}): Promise<T | undefined> {
     url = `${COMMAND_API_NAMESPACE}/${url}`;
@@ -83,13 +89,17 @@ export class CommandService {
       'request'
     );
     try {
-      const response = await lastValueFrom(
-        this.http.post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
-      );
-      if (response.error != null) {
-        throw response.error;
+      if (!this.appOnline) {
+        return Promise.resolve(undefined);
+      } else {
+        const response = await lastValueFrom(
+          this.http.post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
+        );
+        if (response.error != null) {
+          throw response.error;
+        }
+        return response.result;
       }
-      return response.result;
     } catch (error) {
       // Transform the various kinds of errors into a CommandError.
 
@@ -119,7 +129,11 @@ export class CommandService {
         moreInformation = `Unexpected error type: ${error}`;
       }
       const message = `Error invoking ${method}: ${moreInformation}`;
-      throw new CommandError(code, message, data);
+      if (this.appOnline) {
+        throw new CommandError(code, message, data);
+      }
+      console.error(`${code} ${message} ${data}`);
+      return undefined;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling-service.ts
@@ -233,7 +233,7 @@ export class ExceptionHandlingService {
     try {
       const eventId = objectId();
       try {
-        // Don't show a dialog if this is a silent error that we just want sent to Bugsnag
+        // Don't show a dialog if this is a silent error or that we just want sent to Bugsnag
         if (!silently) {
           const stack = hasStringProp(error, 'stack') ? error.stack : undefined;
           await this.handleAlert(ngZone, dialogService, { message, stack, eventId });


### PR DESCRIPTION
When a user attempts to load a resource but losses internet connection they could receive a variety of Error Dialog popups as a result.

One minor change has to do with background loading the resource if it already exists in the IndexedDB. The dialog will stay open can close once the resource is sync.

Added additional error messages to be displayed in `editor-tab-add-resource-dialog`:
- User will be notified if loading resource failed due to being offline.
- User will be notified if loading project failed due to not being authorized.

Added offline checks to `realtime-service`, this may not be what we want in the long run. But this is an issue when we attempt to subscribe to anything with the realtime server that has not been loaded for offline access (Line 264 in the `realtime-doc.ts` appears to be the culprit). This also seems to be one of the reasons why we see the infinite loading bar at the top of the screen when offline.

Updated `exception-handling-service` to not show errors when user is offline. I'm not sure this how we want to handle this but in testing this issue I would sometimes see 2-3 error dialogs appear for both server http and angular errors. These will still be logged to the console but as the user is offline they would not be reported to bugsnag.

EDIT: Looks like I forgot to run all tests and have a large amount failing due adding the OnlineStatusService in the `exception-handling-service`. Converted this to a draft for feedback on that portion of the pull request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2684)
<!-- Reviewable:end -->
