### PR TITLE
SF-2936 Show diagnostic information to serval admins

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -58,12 +58,15 @@
 
 <h2>Last Draft settings</h2>
 <h3>Training books</h3>
-{{ trainingBooks.join(", ") || "None" }}
+<p>{{ trainingBooks.join(", ") || "None" }}</p>
 <h3>Training data files</h3>
-{{ trainingFiles.join(", ") || "None" }}
+<p>{{ trainingFiles.join(", ") || "None" }}</p>
 <h3>Translation books</h3>
-{{ translationBooks.join(", ") || "None" }}
+<p>{{ translationBooks.join(", ") || "None" }}</p>
 
+@if (draftJob$ | async; as draftJob) {
+  <app-draft-information [draftJob]="draftJob"></app-draft-information>
+}
 <h2>Raw draft config</h2>
 <pre class="raw-draft-config">
 @for (key of keys(draftConfig ?? {}); track key) {{{ key }}: <strong>{{ stringify(draftConfig![key]) }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -64,9 +64,9 @@
 <h3>Translation books</h3>
 <p>{{ translationBooks.join(", ") || "None" }}</p>
 
-@if (draftJob$ | async; as draftJob) {
+<!-- @if (draftJob$ | async; as draftJob) {
   <app-draft-information [draftJob]="draftJob"></app-draft-information>
-}
+} -->
 <h2>Raw draft config</h2>
 <pre class="raw-draft-config">
 @for (key of keys(draftConfig ?? {}); track key) {{{ key }}: <strong>{{ stringify(draftConfig![key]) }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import FileSaver from 'file-saver';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
@@ -18,6 +19,8 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
 import { SFProjectService } from '../core/sf-project.service';
+import { BuildDto } from '../machine-api/build-dto';
+import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { ServalAdministrationService } from './serval-administration.service';
 import { ServalProjectComponent } from './serval-project.component';
 
@@ -27,6 +30,7 @@ const mockNoticeService = mock(NoticeService);
 const mockSFProjectService = mock(SFProjectService);
 const mockServalAdministrationService = mock(ServalAdministrationService);
 const mockAuthService = mock(AuthService);
+const mockDraftGenerationService = mock(DraftGenerationService);
 
 describe('ServalProjectComponent', () => {
   configureTestingModule(() => ({
@@ -44,7 +48,8 @@ describe('ServalProjectComponent', () => {
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: ServalAdministrationService, useMock: mockServalAdministrationService },
       { provide: SFProjectService, useMock: mockSFProjectService },
-      { provide: AuthService, useMock: mockAuthService }
+      { provide: AuthService, useMock: mockAuthService },
+      { provide: DraftGenerationService, useMock: mockDraftGenerationService }
     ]
   }));
 
@@ -174,6 +179,8 @@ describe('ServalProjectComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(mockProjectDoc$);
 
       when(mockServalAdministrationService.downloadProject(anything())).thenReturn(of(new Blob()));
+      when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+      when(mockDraftGenerationService.getBuildProgress(anything())).thenReturn(of({ additionalInfo: {} } as BuildDto));
 
       // NOTE: The FileSaver namespace shares its signature with the FileSaver function, which has a deprecation warning
       // eslint-disable-next-line deprecation/deprecation

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -360,34 +360,16 @@
     </mat-tab-group>
   }
 </ng-container>
-
-@if (this.canShowAdditionalInfo(draftJob)) {
-  <section>
-    <mat-expansion-panel class="diagnostic-info">
-      <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
-      <ng-template matExpansionPanelContent>
-        <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
-        <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
-        <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
-        <div><strong>Message:</strong> {{ draftJob?.message }}</div>
-        <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
-        <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
-        <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
-        <div><strong>State:</strong> {{ draftJob?.state }}</div>
-        <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
-        <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
-      </ng-template>
-    </mat-expansion-panel>
-  </section>
-}
-
-@if (this.isServalAdmin()) {
-  <section>
-    <mat-expansion-panel class="serval-administration">
-      <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
-      <ng-template matExpansionPanelContent>
-        <app-serval-project></app-serval-project>
-      </ng-template>
-    </mat-expansion-panel>
-  </section>
-}
+<div class="flex-column">
+  <app-draft-information [draftJob]="draftJob"></app-draft-information>
+  @if (this.isServalAdmin()) {
+    <section>
+      <mat-expansion-panel class="serval-administration">
+        <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
+        <ng-template matExpansionPanelContent>
+          <app-serval-project></app-serval-project>
+        </ng-template>
+      </mat-expansion-panel>
+    </section>
+  }
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -28,6 +28,11 @@ h3 {
   gap: 10px;
 }
 
+.flex-column {
+  margin-top: 10px;
+  row-gap: 10px;
+}
+
 .requirements {
   p {
     margin: 0 0 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -2017,27 +2017,6 @@ describe('DraftGenerationComponent', () => {
     });
   });
 
-  describe('canShowAdditionalInfo', () => {
-    it('should return true if the user is serval admin, and build has additional info', () => {
-      let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.ServalAdmin] });
-      });
-      expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(true);
-    });
-
-    it('should return false if the draft build has no additional info', () => {
-      let env = new TestEnvironment(() => {
-        mockAuthService = jasmine.createSpyObj<AuthService>([], { currentUserRoles: [SystemRole.ServalAdmin] });
-      });
-      expect(env.component.canShowAdditionalInfo({} as BuildDto)).toBe(false);
-    });
-
-    it('should return false if the user is not system admin', () => {
-      let env = new TestEnvironment();
-      expect(env.component.canShowAdditionalInfo({ additionalInfo: {} } as BuildDto)).toBe(false);
-    });
-  });
-
   describe('downloadProgress', () => {
     it('should show number between 0 and 100', () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -40,6 +40,7 @@ import {
   DraftGenerationStepsResult
 } from './draft-generation-steps/draft-generation-steps.component';
 import { DraftGenerationService } from './draft-generation.service';
+import { DraftInformationComponent } from './draft-information/draft-information.component';
 import { DraftPreviewBooksComponent } from './draft-preview-books/draft-preview-books.component';
 import { DraftSource, DraftSourcesService } from './draft-sources.service';
 import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
@@ -59,6 +60,7 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
     SharedModule,
     WorkingAnimatedIndicatorComponent,
     DraftGenerationStepsComponent,
+    DraftInformationComponent,
     SupportedBackTranslationLanguagesDialogComponent,
     ServalProjectComponent,
     DraftPreviewBooksComponent
@@ -534,10 +536,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
 
   isServalAdmin(): boolean {
     return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
-  }
-
-  canShowAdditionalInfo(job?: BuildDto): boolean {
-    return job?.additionalInfo != null && this.isServalAdmin();
   }
 
   canCancel(job?: BuildDto): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.html
@@ -1,0 +1,17 @@
+@if (this.canShowAdditionalInfo) {
+  <mat-expansion-panel class="diagnostic-info">
+    <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
+    <ng-template matExpansionPanelContent>
+      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
+      <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+      <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
+      <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+      <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
+      <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
+      <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
+      <div><strong>State:</strong> {{ draftJob?.state }}</div>
+      <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
+      <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
+    </ng-template>
+  </mat-expansion-panel>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.scss
@@ -1,0 +1,6 @@
+h3 {
+  font-size: 20px;
+  font-weight: 500;
+  display: flex;
+  gap: 10px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.spec.ts
@@ -1,0 +1,55 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { mock, when } from 'ts-mockito';
+import { AuthService } from 'xforge-common/auth.service';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { BuildDto } from '../../../machine-api/build-dto';
+import { DraftInformationComponent } from './draft-information.component';
+
+const mockAuthService = mock(AuthService);
+
+describe('DraftInformationComponent', () => {
+  configureTestingModule(() => ({
+    imports: [UICommonModule],
+    providers: [{ provide: AuthService, useMock: mockAuthService }]
+  }));
+
+  it('should return true if the user is serval admin, and build has additional info', () => {
+    const env = new TestEnvironment(() => {
+      when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+    });
+    env.component.draftJob = { additionalInfo: {} } as BuildDto;
+    expect(env.component.canShowAdditionalInfo).toBe(true);
+  });
+
+  it('should return false if the draft build has no additional info', () => {
+    const env = new TestEnvironment(() => {
+      when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+    });
+    env.component.draftJob = {} as BuildDto;
+    expect(env.component.canShowAdditionalInfo).toBe(false);
+  });
+
+  it('should return false if the user is not system admin', () => {
+    const env = new TestEnvironment();
+    env.component.draftJob = { additionalInfo: {} } as BuildDto;
+    expect(env.component.canShowAdditionalInfo).toBe(false);
+  });
+});
+
+class TestEnvironment {
+  component: DraftInformationComponent;
+  fixture: ComponentFixture<DraftInformationComponent>;
+  currentUserId: string = 'user01';
+
+  constructor(setup?: () => void) {
+    when(mockAuthService.currentUserRoles).thenReturn([SystemRole.User]);
+    if (setup != null) {
+      setup();
+    }
+    this.fixture = TestBed.createComponent(DraftInformationComponent);
+    this.component = this.fixture.componentInstance;
+    this.fixture.detectChanges();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { AuthService } from 'xforge-common/auth.service';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { BuildDto } from '../../../machine-api/build-dto';
+
+@Component({
+  selector: 'app-draft-information',
+  standalone: true,
+  imports: [UICommonModule, CommonModule],
+  templateUrl: './draft-information.component.html',
+  styleUrl: './draft-information.component.scss'
+})
+export class DraftInformationComponent {
+  @Input() draftJob?: BuildDto;
+
+  constructor(private readonly authService: AuthService) {}
+
+  get isServalAdmin(): boolean {
+    return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+  }
+
+  get canShowAdditionalInfo(): boolean {
+    return this.draftJob?.additionalInfo != null && this.isServalAdmin;
+  }
+}


### PR DESCRIPTION
This PR moves the diagnostics info that was in a panel in the draft generation page and makes it its own component. Then this component was added to the serval administration page on projects so Serval admins can get access to the build information of the draft.

I set this one as Testing Not Required since this is visible only to serval admins and not normal users.

![Additional Info on serval Admin](https://github.com/user-attachments/assets/9c0ed6b1-cfd7-4229-a676-f42bf30d9d33)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2687)
<!-- Reviewable:end -->
