### PR TITLE
SF-2936b Make draft info component show basic info

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -65,6 +65,7 @@
 <p>{{ translationBooks.join(", ") || "None" }}</p>
 
 <!-- @if (draftJob$ | async; as draftJob) {
+  <h3>Diagnostic Information</h3>
   <app-draft-information [draftJob]="draftJob"></app-draft-information>
 } -->
 <h2>Raw draft config</h2>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -360,16 +360,23 @@
     </mat-tab-group>
   }
 </ng-container>
-<div class="flex-column">
-  <app-draft-information [draftJob]="draftJob"></app-draft-information>
-  @if (this.isServalAdmin()) {
-    <section>
-      <mat-expansion-panel class="serval-administration">
-        <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent>
-          <app-serval-project></app-serval-project>
-        </ng-template>
-      </mat-expansion-panel>
-    </section>
-  }
-</div>
+@if (this.canShowAdditionalInfo(draftJob)) {
+  <section>
+    <mat-expansion-panel class="diagnostics-info">
+      <mat-expansion-panel-header><h3>Diagnostics Information</h3></mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <app-draft-information [draftJob]="draftJob"></app-draft-information>
+      </ng-template>
+    </mat-expansion-panel>
+  </section>
+}
+@if (this.isServalAdmin()) {
+  <section>
+    <mat-expansion-panel class="serval-administration">
+      <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <app-serval-project></app-serval-project>
+      </ng-template>
+    </mat-expansion-panel>
+  </section>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -28,11 +28,6 @@ h3 {
   gap: 10px;
 }
 
-.flex-column {
-  margin-top: 10px;
-  row-gap: 10px;
-}
-
 .requirements {
   p {
     margin: 0 0 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -538,6 +538,10 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
   }
 
+  canShowAdditionalInfo(job?: BuildDto): boolean {
+    return job?.additionalInfo != null && this.authService.currentUserRoles.includes(SystemRole.ServalAdmin);
+  }
+
   canCancel(job?: BuildDto): boolean {
     return job == null || this.isDraftInProgress(job);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.html
@@ -1,17 +1,14 @@
 @if (this.canShowAdditionalInfo) {
-  <mat-expansion-panel class="diagnostic-info">
-    <mat-expansion-panel-header><h3>Diagnostic Information</h3></mat-expansion-panel-header>
-    <ng-template matExpansionPanelContent>
-      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
-      <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
-      <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
-      <div><strong>Message:</strong> {{ draftJob?.message }}</div>
-      <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
-      <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
-      <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
-      <div><strong>State:</strong> {{ draftJob?.state }}</div>
-      <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
-      <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
-    </ng-template>
-  </mat-expansion-panel>
+  <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId }}</div>
+  <div><strong>Corpora Ids:</strong> {{ draftJob?.additionalInfo?.corporaIds?.join(", ") }}</div>
+  <div><strong>Date Finished:</strong> {{ draftJob?.additionalInfo?.dateFinished?.toLocaleString() }}</div>
+  <div><strong>Message:</strong> {{ draftJob?.message }}</div>
+  <div><strong>Percent Completed:</strong> {{ draftJob?.percentCompleted }}</div>
+  <div><strong>Revision:</strong> {{ draftJob?.revision }}</div>
+  <div><strong>Queue Depth:</strong> {{ draftJob?.queueDepth }}</div>
+  <div><strong>State:</strong> {{ draftJob?.state }}</div>
+  <div><strong>Step:</strong> {{ draftJob?.additionalInfo?.step }}</div>
+  <div><strong>Translation Engine Id:</strong> {{ draftJob?.additionalInfo?.translationEngineId }}</div>
+} @else {
+  <p class="info-unavailable">The latest draft information is unavailable</p>
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.scss
@@ -1,6 +1,0 @@
-h3 {
-  font-size: 20px;
-  font-weight: 500;
-  display: flex;
-  gap: 10px;
-}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.spec.ts
@@ -20,7 +20,9 @@ describe('DraftInformationComponent', () => {
       when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
     });
     env.component.draftJob = { additionalInfo: {} } as BuildDto;
+    env.fixture.detectChanges();
     expect(env.component.canShowAdditionalInfo).toBe(true);
+    expect(env.infoUnavailableMessage).toBeNull();
   });
 
   it('should return false if the draft build has no additional info', () => {
@@ -28,13 +30,17 @@ describe('DraftInformationComponent', () => {
       when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
     });
     env.component.draftJob = {} as BuildDto;
+    env.fixture.detectChanges();
     expect(env.component.canShowAdditionalInfo).toBe(false);
+    expect(env.infoUnavailableMessage).not.toBeNull();
   });
 
   it('should return false if the user is not system admin', () => {
     const env = new TestEnvironment();
     env.component.draftJob = { additionalInfo: {} } as BuildDto;
+    env.fixture.detectChanges();
     expect(env.component.canShowAdditionalInfo).toBe(false);
+    expect(env.infoUnavailableMessage).not.toBeNull();
   });
 });
 
@@ -51,5 +57,9 @@ class TestEnvironment {
     this.fixture = TestBed.createComponent(DraftInformationComponent);
     this.component = this.fixture.componentInstance;
     this.fixture.detectChanges();
+  }
+
+  get infoUnavailableMessage(): HTMLElement {
+    return this.fixture.nativeElement.querySelector('.info-unavailable');
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-information/draft-information.component.ts
@@ -9,8 +9,7 @@ import { BuildDto } from '../../../machine-api/build-dto';
   selector: 'app-draft-information',
   standalone: true,
   imports: [UICommonModule, CommonModule],
-  templateUrl: './draft-information.component.html',
-  styleUrl: './draft-information.component.scss'
+  templateUrl: './draft-information.component.html'
 })
 export class DraftInformationComponent {
   @Input() draftJob?: BuildDto;


### PR DESCRIPTION
It was mentioned that the draft information component should have minimal formatting, and the parent component should have the job of adding additional display elements (i.e. expansion panel). This change removes the expansion panel element from the draft information component.

![Draft Diagnostic Info](https://github.com/user-attachments/assets/1176c7b6-4e35-4c68-bb81-56f46b96c483)
