### PR TITLE
SF-2895 Add recording visualizer to the audio recorder dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -36,6 +36,9 @@
         </div>
       }
     </div>
+    <div class="visualizer-container">
+      <canvas class="visualizer" [ngClass]="{ visible: isRecording }"></canvas>
+    </div>
     <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
       <button mat-flat-button color="primary" (click)="resetRecording()" class="remove-audio-file">
         <mat-icon>mic</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -3,7 +3,7 @@
     <div class="container">
       <div class="countdown" [ngClass]="{ animate: countdownTimer > 0 }">{{ countdownTimer }}</div>
       @if (!hasAudioAttachment) {
-        <div class="no-attachment">
+        <div class="no-attachment" id="audioRecordContainer">
           @if (!isRecording && !showCountdown) {
             <button
               mat-icon-button
@@ -16,17 +16,15 @@
             </button>
           }
           @if (isRecording) {
-            <div class="stop-background">
-              <button
-                mat-icon-button
-                (click)="stopRecording()"
-                class="stop"
-                [matTooltip]="t('stop_recording')"
-                matTooltipPosition="below"
-              >
-                <mat-icon>stop</mat-icon>
-              </button>
-            </div>
+            <button
+              mat-icon-button
+              (click)="stopRecording()"
+              class="stop"
+              [matTooltip]="t('stop_recording')"
+              matTooltipPosition="below"
+            >
+              <mat-icon>stop</mat-icon>
+            </button>
           }
         </div>
       }
@@ -38,17 +36,20 @@
         </div>
       }
     </div>
-    <div class="visualizer-container">
-      <canvas class="visualizer" [ngClass]="{ visible: isRecording }"></canvas>
-    </div>
-    <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
-      <button mat-flat-button color="primary" (click)="resetRecording()" class="remove-audio-file">
-        <mat-icon>mic</mat-icon>
-        {{ t("re_record") }}
-      </button>
-      <button mat-button (click)="saveRecording()" class="save-audio-file">
-        <mat-icon>check</mat-icon> {{ t("save") }}
-      </button>
+    <div class="dialog-footer">
+      @if (showCanvas) {
+        <canvas class="visualizer"></canvas>
+      } @else {
+        <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
+          <button mat-flat-button color="primary" (click)="resetRecording()" class="remove-audio-file">
+            <mat-icon>mic</mat-icon>
+            {{ t("re_record") }}
+          </button>
+          <button mat-button (click)="saveRecording()" class="save-audio-file">
+            <mat-icon>check</mat-icon> {{ t("save") }}
+          </button>
+        </div>
+      }
     </div>
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -16,15 +16,17 @@
             </button>
           }
           @if (isRecording) {
-            <button
-              mat-icon-button
-              (click)="stopRecording()"
-              class="stop"
-              [matTooltip]="t('stop_recording')"
-              matTooltipPosition="below"
-            >
-              <mat-icon>stop</mat-icon>
-            </button>
+            <div class="stop-background">
+              <button
+                mat-icon-button
+                (click)="stopRecording()"
+                class="stop"
+                [matTooltip]="t('stop_recording')"
+                matTooltipPosition="below"
+              >
+                <mat-icon>stop</mat-icon>
+              </button>
+            </div>
           }
         </div>
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -27,48 +27,66 @@
     transform: scale(2);
   }
 
-  .stop-background {
-    background-color: variables.$red;
-    height: 80px;
-    width: 80px;
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  .record,
+  .stop {
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    margin: auto;
+  }
 
-    &.animate {
-      animation: 1s growshrink;
-    }
+  .stop {
+    animation: pulse 0.75s infinite;
+    color: #fff;
+    transition: color 0.3s;
 
-    .stop {
-      animation: pulse 0.75s infinite;
+    &:hover {
       color: #fff;
-      transition: color 0.3s;
-      &:hover {
-        color: #fff;
-      }
+    }
+  }
+
+  .no-attachment {
+    height: 100%;
+    width: 100%;
+    position: relative;
+
+    ::ng-deep .animate {
+      content: '';
+      background-color: variables.$red;
+      height: 80px;
+      width: 80px;
+      border-radius: 50%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      left: 0;
+      margin: auto;
+      animation: growshrink 1s forwards;
     }
   }
 }
 
-.visualizer-container {
-  display: flex;
-  justify-content: flex-end;
+.dialog-footer {
+  height: 50px;
+  width: 220px;
+}
 
-  .visualizer {
-    width: 100%;
-    height: 50px;
-    transform: scale(0);
-    &.visible {
-      transform: scale(1);
-    }
-  }
+.visualizer {
+  width: 100%;
+  height: 100%;
 }
 
 .has-attachment {
   transform: scale(0);
   display: flex;
-  gap: 30px;
+  justify-content: space-between;
 
   &.visible {
     transform: scale(1);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -26,12 +26,27 @@
   .has-attachment {
     transform: scale(2);
   }
-  .stop {
-    animation: pulse 0.75s infinite;
-    color: #fff;
-    transition: color 0.3s;
-    &:hover {
+
+  .stop-background {
+    background-color: variables.$red;
+    height: 80px;
+    width: 80px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &.animate {
+      animation: 1s growshrink;
+    }
+
+    .stop {
+      animation: pulse 0.75s infinite;
       color: #fff;
+      transition: color 0.3s;
+      &:hover {
+        color: #fff;
+      }
     }
   }
 }
@@ -80,5 +95,17 @@
   }
   100% {
     background-color: variables.$red;
+  }
+}
+
+@keyframes growshrink {
+  0% {
+    width: 80px;
+    height: 80px;
+  }
+  100% {
+    width: 120px;
+    height: 120px;
+    background-color: white;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -36,6 +36,20 @@
   }
 }
 
+.visualizer-container {
+  display: flex;
+  justify-content: flex-end;
+
+  .visualizer {
+    width: 20px;
+    height: 50px;
+    transform: scale(0);
+    &.visible {
+      transform: scale(1);
+    }
+  }
+}
+
 .has-attachment {
   transform: scale(0);
   display: flex;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -41,7 +41,7 @@
   justify-content: flex-end;
 
   .visualizer {
-    width: 20px;
+    width: 100%;
     height: 50px;
     transform: scale(0);
     &.visible {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -53,15 +53,13 @@
     width: 100%;
     position: relative;
 
+    // the div elements with the animate class are created dynamically and the
+    // ng-deep was needed for these styles to apply
     ::ng-deep .animate {
-      content: '';
       background-color: variables.$red;
       height: 80px;
       width: 80px;
       border-radius: 50%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
       position: absolute;
       top: 0;
       bottom: 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -1,5 +1,8 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
 import { NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -15,17 +18,14 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { ChildViewContainerComponent, configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { firstValueFrom } from 'rxjs';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { AudioPlayer } from '../audio/audio-player';
+import { createMockMediaStream } from '../test-utils';
 import {
   AudioAttachment,
   AudioRecorderDialogComponent,
   AudioRecorderDialogData
 } from './audio-recorder-dialog.component';
-import { createMockMediaStream } from '../test-utils';
 
 const mockedNoticeService = mock(NoticeService);
 const mockedNavigator = mock(Navigator);
@@ -63,6 +63,7 @@ describe('AudioRecorderDialogComponent', () => {
     const env = new TestEnvironment();
     expect(env.recordButton).toBeTruthy();
     expect(env.stopRecordingButton).toBeFalsy();
+    expect(env.recordingIndicator.classList.contains('visible')).toBe(false);
     env.clickButton(env.recordButton);
     // Record for more than 2 seconds in order to test the duration of blob files
     // which can fail with certain recording types
@@ -70,6 +71,7 @@ describe('AudioRecorderDialogComponent', () => {
     expect(env.recordButton).toBeFalsy();
     expect(env.stopRecordingButton).toBeTruthy();
     expect(env.component.audio.status).toEqual('recording');
+    expect(env.recordingIndicator.classList.contains('visible')).toBe(true);
     env.clickButton(env.stopRecordingButton);
     await env.waitForRecorder(100);
     expect(env.component.audio.status).toEqual('processed');
@@ -188,6 +190,10 @@ class TestEnvironment {
 
   get tryAgainButton(): HTMLElement {
     return this.overlayContainerElement.querySelector('.remove-audio-file') as HTMLElement;
+  }
+
+  get recordingIndicator(): HTMLElement {
+    return this.overlayContainerElement.querySelector('.visualizer') as HTMLElement;
   }
 
   clickButton(button: HTMLElement): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -63,7 +63,7 @@ describe('AudioRecorderDialogComponent', () => {
     const env = new TestEnvironment();
     expect(env.recordButton).toBeTruthy();
     expect(env.stopRecordingButton).toBeFalsy();
-    expect(env.recordingIndicator.classList.contains('visible')).toBe(false);
+    expect(env.recordingIndicator).toBeNull();
     env.clickButton(env.recordButton);
     // Record for more than 2 seconds in order to test the duration of blob files
     // which can fail with certain recording types
@@ -71,7 +71,7 @@ describe('AudioRecorderDialogComponent', () => {
     expect(env.recordButton).toBeFalsy();
     expect(env.stopRecordingButton).toBeTruthy();
     expect(env.component.audio.status).toEqual('recording');
-    expect(env.recordingIndicator.classList.contains('visible')).toBe(true);
+    expect(env.recordingIndicator).not.toBeNull();
     env.clickButton(env.stopRecordingButton);
     await env.waitForRecorder(100);
     expect(env.component.audio.status).toEqual('processed');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -2,8 +2,8 @@ import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { translate, TranslocoModule } from '@ngneat/transloco';
-import { interval, Observable, Subscription, timer } from 'rxjs';
+import { TranslocoModule, translate } from '@ngneat/transloco';
+import { Observable, Subscription, interval, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -305,8 +305,8 @@ export class AudioRecorderDialogComponent
     const rippleContainerElement: HTMLElement | null = document.querySelector('#audioRecordContainer');
     if (rippleContainerElement == null) return;
 
-    const waveformThreshold = 1.3;
-    if (dataArray.some(v => v / this.audioWaveformBase > waveformThreshold)) {
+    const waveformThreshold = 1.2;
+    if (dataArray.some(v => Math.abs(v / this.audioWaveformBase) > waveformThreshold)) {
       // show the ripple animation when the waveform reaches the threshold
       const rippleElement: HTMLElement = document.createElement('div');
       rippleElement.classList.add('animate');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -62,7 +62,7 @@ export class AudioRecorderDialogComponent
   private recordedChunks: Blob[] = [];
   private _audio: AudioAttachment = {};
   private _onTouched = new EventEmitter();
-  private rippleSubscription?: Subscription;
+  private refreshWaveformSub?: Subscription;
   private canvasContext: CanvasRenderingContext2D | null = null;
   // height and width are calculated when the canvas is initialized
   private visualizerHeight = 150;
@@ -181,7 +181,7 @@ export class AudioRecorderDialogComponent
     if (this.mediaRecorder == null || this.stream == null) {
       return;
     }
-    this.rippleSubscription?.unsubscribe();
+    this.refreshWaveformSub?.unsubscribe();
     this.showCanvas = false;
     this.mediaRecorder.stop();
     this.stream.getAudioTracks().forEach(track => track.stop());
@@ -257,7 +257,7 @@ export class AudioRecorderDialogComponent
     };
 
     const refreshRate: Observable<number> = interval(150);
-    this.rippleSubscription = this.subscribe(refreshRate, _ => drawWaveForm());
+    this.refreshWaveformSub = this.subscribe(refreshRate, _ => drawWaveForm());
   }
 
   private initCanvasContext(): void {


### PR DESCRIPTION
This change adds the visualization of the active audio recording. See the Jira issue for the link to the tutorial for creating a frequency bar visualization of an audio recording.
Please feel free to make suggestions for improving the layout of the bar.

![Visualize Recording](https://github.com/user-attachments/assets/b6bbdc64-fd94-4394-87f9-3f6d18dcced8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2691)
<!-- Reviewable:end -->
