### PR TITLE
SF-2915 Fix crash when retrieving Paratext tokens for deleted users

### DIFF
--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -47,7 +47,16 @@ public class AuthService : DisposableBase, IAuthService
 
     public async Task<Tokens?> GetParatextTokensAsync(string authId, CancellationToken token)
     {
-        string userProfileJson = await CallApiAsync(HttpMethod.Get, $"users/{authId}", content: null, token);
+        string userProfileJson;
+        try
+        {
+            userProfileJson = await CallApiAsync(HttpMethod.Get, $"users/{authId}", content: null, token);
+        }
+        catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
+        {
+            // The users API returns 404 if the user was removed from Auth0
+            return null;
+        }
 
         JObject userProfile = JObject.Parse(userProfileJson);
         JArray identities = userProfile["identities"] as JArray;

--- a/test/SIL.XForge.Tests/Services/MockHttpMessageHandler.cs
+++ b/test/SIL.XForge.Tests/Services/MockHttpMessageHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace SIL.XForge.Services;
 
-public class MockHttpMessageHandler(Dictionary<string, string> responses, HttpStatusCode statusCode)
+public class MockHttpMessageHandler((string url, string message, HttpStatusCode statusCode)[] responses)
     : HttpMessageHandler
 {
     public string? LastInput { get; private set; }
@@ -23,15 +22,15 @@ public class MockHttpMessageHandler(Dictionary<string, string> responses, HttpSt
         LastInput = request.Content is not null ? await request.Content.ReadAsStringAsync(cancellationToken) : null;
 
         foreach (
-            KeyValuePair<string, string> response in responses.Where(response =>
-                request.RequestUri!.PathAndQuery.Contains(response.Key)
+            (string _, string message, HttpStatusCode statusCode) in responses.Where(response =>
+                request.RequestUri!.PathAndQuery.Contains(response.url)
             )
         )
         {
             return new HttpResponseMessage
             {
                 StatusCode = statusCode,
-                Content = new StringContent(response.Value),
+                Content = new StringContent(message),
                 RequestMessage = request,
             };
         }


### PR DESCRIPTION
This PR fixes a crash that occurs on production when syncing some resources that contain users who have had their account removed from Paratext.

Due to the destructive nature of the Acceptance Test, I have marked this Pull Request as Testing Not Required. If you disagree, please change the PR label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2692)
<!-- Reviewable:end -->
