### PR TITLE
Remove obsolete scripture audio feature flag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -74,10 +74,7 @@
             <ng-template matExpansionPanelContent>
               <mat-selection-list>
                 @for (chapter of text.chapters; track chapter) {
-                  @if (
-                    questionCount(text.bookNum, chapter.number) > 0 ||
-                    (chapter.hasAudio && featureFlagsService.scriptureAudio.enabled)
-                  ) {
+                  @if (questionCount(text.bookNum, chapter.number) > 0 || chapter.hasAudio) {
                     <mat-expansion-panel
                       [disabled]="!questionCount(text.bookNum, chapter.number)"
                       dense
@@ -88,7 +85,7 @@
                         <mat-panel-title fxLayoutAlign="start center">
                           <span fxFlex fxLayout class="book-chapter-heading"
                             >{{ getBookName(text) + " " + chapter?.number }}
-                            @if (featureFlagsService.scriptureAudio.enabled && chapter.hasAudio) {
+                            @if (chapter.hasAudio) {
                               <mat-icon title="{{ t('chapter_audio_attached') }}" class="material-icons-outlined"
                                 >audio_file</mat-icon
                               >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -31,7 +31,6 @@ import { anything, capture, instance, mock, reset, resetCalls, verify, when } fr
 import { AuthService } from 'xforge-common/auth.service';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
@@ -65,7 +64,6 @@ const mockedAuthService = mock(AuthService);
 const mockedQuestionDialogService = mock(QuestionDialogService);
 const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedPermissions = mock(PermissionsService);
 const mockedChapterAudioDialogService = mock(ChapterAudioDialogService);
 
@@ -96,7 +94,6 @@ describe('CheckingOverviewComponent', () => {
       { provide: BugsnagService, useMock: mockedBugsnagService },
       { provide: CookieService, useMock: mockedCookieService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
       { provide: PermissionsService, useMock: mockedPermissions },
       { provide: ChapterAudioDialogService, useMock: mockedChapterAudioDialogService }
     ]
@@ -1032,8 +1029,6 @@ class TestEnvironment {
       }
     );
     this.setCurrentUser(this.adminUser);
-
-    when(mockedFeatureFlagService.scriptureAudio).thenReturn(createTestFeatureFlag(true));
 
     this.fixture = TestBed.createComponent(CheckingOverviewComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -60,11 +60,9 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     private readonly checkingQuestionsService: CheckingQuestionsService,
     private readonly userService: UserService,
     private readonly questionDialogService: QuestionDialogService,
-    private readonly router: Router,
     private readonly permissions: PermissionsService,
     private readonly chapterAudioDialogService: ChapterAudioDialogService,
-    private readonly onlineStatusService: OnlineStatusService,
-    readonly featureFlagsService: FeatureFlagService
+    private readonly onlineStatusService: OnlineStatusService
   ) {
     super(noticeService);
   }
@@ -169,18 +167,12 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   get canCreateScriptureAudio(): boolean {
-    if (!this.featureFlags.scriptureAudio.enabled) {
-      return false;
-    }
     const project: Readonly<SFProjectProfile | undefined> = this.projectDoc?.data;
     const userId: string = this.userService.currentUserId;
     return project != null && SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.TextAudio, Operation.Create);
   }
 
   get canDeleteScriptureAudio(): boolean {
-    if (!this.featureFlags.scriptureAudio.enabled) {
-      return false;
-    }
     const project = this.projectDoc?.data;
     const userId = this.userService.currentUserId;
     return project != null && SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.TextAudio, Operation.Delete);
@@ -410,9 +402,6 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   bookHasChapterAudio(text: TextInfo): boolean {
-    if (!this.featureFlagsService.scriptureAudio.enabled) {
-      return false;
-    }
     return text.chapters.filter((c: Chapter) => c.hasAudio).length > 0;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -1,19 +1,15 @@
 <ng-container *transloco="let t; read: 'checking_answers'">
   <div class="answers-component">
     <div class="answers-component-scrollable-content">
-      @if (featureFlags.scriptureAudio.enabled) {
-        <app-checking-question [questionDoc]="questionDoc" (audioPlayed)="playAudio()"> </app-checking-question>
-      }
+      <app-checking-question [questionDoc]="questionDoc" (audioPlayed)="playAudio()"> </app-checking-question>
       <div class="answer-question">
         <div class="question">
-          @if (!featureFlags.scriptureAudio.enabled) {
-            <div class="question-text">{{ questionDoc?.data?.text }}</div>
-            @if (questionDoc?.data?.audioUrl) {
-              <div class="question-audio">
-                <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
-                </app-checking-audio-player>
-              </div>
-            }
+          <div class="question-text">{{ questionDoc?.data?.text }}</div>
+          @if (questionDoc?.data?.audioUrl) {
+            <div class="question-audio">
+              <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
+              </app-checking-audio-player>
+            </div>
           }
           @if (canEditQuestion) {
             <div class="question-footer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -6,11 +6,10 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { Answer, AnswerStatus } from 'realtime-server/lib/esm/scriptureforge/models/answer';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { fromVerseRef, toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { Subscription } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
@@ -124,7 +123,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
     private readonly fileService: FileService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    public featureFlags: FeatureFlagService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly mediaBreakpointService: MediaBreakpointService
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -1,9 +1,7 @@
 <ng-container *transloco="let t; read: 'checking'">
   <div id="checking-app-container">
     <div id="questions-panel" #questionsPanel [ngClass]="{ 'overlay-visible': isQuestionsOverlayVisible }">
-      @if (
-        hideChapterText && hasQuestionWithoutAudio && featureFlags.scriptureAudio.enabled && canCreateScriptureAudio
-      ) {
+      @if (hideChapterText && hasQuestionWithoutAudio && canCreateScriptureAudio) {
         <span class="audio-checking-warning">{{ t("questions_on_chapters_no_audio") }}</span>
       }
       <header [ngClass]="{ 'filter-applied': isQuestionFilterApplied }">
@@ -106,7 +104,7 @@
                   <mat-icon class="material-icons-outlined">audio_file</mat-icon>
                 </button>
               }
-              @if (featureFlags.scriptureAudio.enabled && chapterHasAudio) {
+              @if (chapterHasAudio) {
                 <button
                   type="button"
                   mat-icon-button
@@ -124,7 +122,7 @@
             </div>
           </div>
         </header>
-        @if (!chapterHasAudio && hideChapterText && featureFlags.scriptureAudio.enabled) {
+        @if (!chapterHasAudio && hideChapterText) {
           <span class="no-audio-message">{{ t("question_does_not_have_audio") }}</span>
         }
         <div id="split-container" #splitContainer>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -42,7 +42,6 @@ import { AuthService } from 'xforge-common/auth.service';
 import { AvatarComponent } from 'xforge-common/avatar/avatar.component';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FileService } from 'xforge-common/file.service';
 import { createStorageFileData, FileOfflineData, FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
@@ -107,7 +106,6 @@ const mockedChapterAudioDialogService = mock(ChapterAudioDialogService);
 const mockedBugsnagService = mock(BugsnagService);
 const mockedCookieService = mock(CookieService);
 const mockedFileService = mock(FileService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedPermissions = mock(PermissionsService);
 
 function createUser(idSuffix: number, role: string, nameConfirmed: boolean = true): UserInfo {
@@ -184,7 +182,6 @@ describe('CheckingComponent', () => {
       { provide: CookieService, useMock: mockedCookieService },
       { provide: FileService, useMock: mockedFileService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
       { provide: PermissionsService, useMock: mockedPermissions }
     ]
   }));
@@ -276,14 +273,14 @@ describe('CheckingComponent', () => {
     }));
 
     it('hides add audio button for community checker', fakeAsync(() => {
-      const env = new TestEnvironment({ user: CHECKER_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: CHECKER_USER });
       expect(env.addAudioButton).toBeNull();
       flush();
       discardPeriodicTasks();
     }));
 
     it('shows add audio and shows add question button for paratext administrator', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       expect(env.addAudioButton).not.toBeNull();
       expect(env.addQuestionButton).not.toBeNull();
       flush();
@@ -291,7 +288,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('shows add audio and hides add question button for paratext translator (includes consultant, reviewer, archivist, and typesetter) based on user permissions', fakeAsync(() => {
-      const env = new TestEnvironment({ user: TRANSLATOR_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: TRANSLATOR_USER });
       env.fixture.detectChanges();
       expect(env.addAudioButton).not.toBeNull();
       expect(env.addQuestionButton).toBeNull();
@@ -300,7 +297,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('hides add audio and shows add question button for paratext consultant (includes translator, reviewer, archivist, and typesetter) based on user permissions', fakeAsync(() => {
-      const env = new TestEnvironment({ user: CONSULTANT_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: CONSULTANT_USER });
       env.fixture.detectChanges();
       expect(env.addAudioButton).toBeNull();
       expect(env.addQuestionButton).not.toBeNull();
@@ -2104,7 +2101,7 @@ describe('CheckingComponent', () => {
 
   describe('Chapter Audio', () => {
     it('can open chapter audio', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.fixture.detectChanges();
 
       expect(env.component.showScriptureAudioPlayer).toBe(false);
@@ -2120,7 +2117,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('can close chapter audio', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -2135,7 +2132,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('stops audio when changing chapter', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const audio = env.mockScriptureAudioAndPlay();
 
       env.component.chapter = 2;
@@ -2147,7 +2144,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('audio stops when changing question on the same chapter', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const audio = env.mockScriptureAudioAndPlay();
 
       env.selectQuestion(4);
@@ -2158,7 +2155,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('pauses chapter audio when adding a question', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const audio = env.mockScriptureAudioAndPlay();
 
       env.clickButton(env.addQuestionButton);
@@ -2168,7 +2165,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('pauses audio when question is archived', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       const audio = env.mockScriptureAudioAndPlay();
 
       env.selectQuestion(1);
@@ -2185,7 +2182,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('hides chapter audio if chapter audio is absent', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -2200,7 +2197,7 @@ describe('CheckingComponent', () => {
     }));
 
     it('keeps chapter audio if chapter audio is present', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -2217,7 +2214,6 @@ describe('CheckingComponent', () => {
     it('notifies admin if chapter audio is absent and hide scripture text is enabled', fakeAsync(() => {
       const env = new TestEnvironment({
         user: ADMIN_USER,
-        scriptureAudio: true,
         projectBookRoute: 'MAT',
         questionScope: 'book'
       });
@@ -2247,7 +2243,6 @@ describe('CheckingComponent', () => {
     it('notifies community checker if chapter audio is absent and hide scripture text is enabled', fakeAsync(() => {
       const env = new TestEnvironment({
         user: CHECKER_USER,
-        scriptureAudio: true,
         projectBookRoute: 'MAT',
         questionScope: 'book'
       });
@@ -2263,8 +2258,7 @@ describe('CheckingComponent', () => {
 
     it('can highlight segments of varying formats', fakeAsync(() => {
       const env = new TestEnvironment({
-        user: CHECKER_USER,
-        scriptureAudio: true
+        user: CHECKER_USER
       });
       env.selectQuestion(1);
 
@@ -2301,7 +2295,7 @@ describe('CheckingComponent', () => {
 
     // TODO: Get this test working
     xit('pauses audio on reload (changing book)', fakeAsync(() => {
-      const env = new TestEnvironment({ user: ADMIN_USER, questionScope: 'book', scriptureAudio: true });
+      const env = new TestEnvironment({ user: ADMIN_USER, questionScope: 'book' });
       env.component.toggleAudio();
       env.fixture.detectChanges();
 
@@ -2388,7 +2382,6 @@ class TestEnvironment {
     projectChapterRoute = 1,
     questionScope = 'book',
     hasConnection = true,
-    scriptureAudio = false,
     testProject = undefined
   }: {
     user: UserInfo;
@@ -2396,7 +2389,6 @@ class TestEnvironment {
     projectChapterRoute?: number;
     questionScope?: QuestionScope;
     hasConnection?: boolean;
-    scriptureAudio?: boolean;
     testProject?: SFProject;
   }) {
     this.params$ = new BehaviorSubject<Params>({
@@ -2423,7 +2415,6 @@ class TestEnvironment {
       mockedFileService.findOrUpdateCache(FileType.Audio, QuestionDoc.COLLECTION, anything(), undefined)
     ).thenResolve(undefined);
     when(mockedFileService.fileSyncComplete$).thenReturn(this.fileSyncComplete);
-    when(mockedFeatureFlagService.scriptureAudio).thenReturn(createTestFeatureFlag(scriptureAudio));
 
     const query = mock(RealtimeQuery<TextAudioDoc>) as RealtimeQuery<TextAudioDoc>;
     when(query.remoteChanges$).thenReturn(new BehaviorSubject<void>(undefined));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -19,7 +19,6 @@ import { toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge
 import { asyncScheduler, combineLatest, merge, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, throttleTime } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
@@ -171,7 +170,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     private readonly permissions: PermissionsService,
     private readonly questionDialogService: QuestionDialogService,
     readonly i18n: I18nService,
-    readonly featureFlags: FeatureFlagService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly chapterAudioDialogService: ChapterAudioDialogService
   ) {
@@ -236,9 +234,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   }
 
   get canCreateScriptureAudio(): boolean {
-    if (!this.featureFlags.scriptureAudio.enabled) {
-      return false;
-    }
     const project: Readonly<SFProjectProfile | undefined> = this.projectDoc?.data;
     const userId: string = this.userService.currentUserId;
     return project != null && SF_PROJECT_RIGHTS.hasRight(project, userId, SFProjectDomain.TextAudio, Operation.Create);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -281,24 +281,19 @@
                   ></app-write-status>
                 </div>
               </div>
-              @if (featureFlags.scriptureAudio.enabled) {
-                <div class="tool-setting">
-                  <div class="tool-setting-field checkbox-field">
-                    <mat-checkbox
-                      formControlName="hideCommunityCheckingText"
-                      id="checkbox-hide-community-checking-text"
-                    >
-                      {{ t("hide_community_checking_text") }}
-                    </mat-checkbox>
-                    <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
-                    <app-write-status
-                      [state]="getControlState('hideCommunityCheckingText')"
-                      [formGroup]="form"
-                      id="hide-community-checking-text-status"
-                    ></app-write-status>
-                  </div>
+              <div class="tool-setting">
+                <div class="tool-setting-field checkbox-field">
+                  <mat-checkbox formControlName="hideCommunityCheckingText" id="checkbox-hide-community-checking-text">
+                    {{ t("hide_community_checking_text") }}
+                  </mat-checkbox>
+                  <app-info [text]="t('checkers_listen_to_scripture_audio')"></app-info>
+                  <app-write-status
+                    [state]="getControlState('hideCommunityCheckingText')"
+                    [formGroup]="form"
+                    id="hide-community-checking-text-status"
+                  ></app-write-status>
                 </div>
-              }
+              </div>
               <div>
                 <p class="helper-text">{{ t("export_checking_answers") }}</p>
                 <div class="tool-setting">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -1294,7 +1294,6 @@ class TestEnvironment {
       },
       { paratextId: '9bb76cd3e5a7f9b4', name: 'Revised Version with Apocrypha 1885, 1895', shortName: 'RVA' }
     ]);
-    when(mockedFeatureFlagService.scriptureAudio).thenReturn(createTestFeatureFlag(true));
     when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(true));
     when(mockedFeatureFlagService.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(true));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -204,7 +204,7 @@ export class FeatureFlagService {
 
   // Before you add a new feature flag:
   //
-  // NOTE: Be sure when adding new feature flags that you update /src/db_tools/parse-version.ts
+  // NOTE: Be sure when adding new feature flags that you update /scripts/db_tools/parse-version.ts
   //
   // Also, the position is important - this is the bit wise position of the feature flag in the version.
   // The position in the dialog is determined by the order in this class.
@@ -237,7 +237,7 @@ export class FeatureFlagService {
     new StaticFeatureFlagStore(true, { readonly: true })
   );
 
-  readonly scriptureAudio: ObservableFeatureFlag = new FeatureFlagFromStorage(
+  private readonly scriptureAudio: ObservableFeatureFlag = new FeatureFlagFromStorage(
     'SCRIPTURE_AUDIO',
     'Scripture audio',
     4,


### PR DESCRIPTION
This PR removes the obsolete dependency on the scripture audio feature flag. If desired, I can also remove the other unused feature flags (NMT Drafting, Forward drafting).
Developer testing will be sufficient, so I marked this as testing not required. If desired, we can move this to testers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2694)
<!-- Reviewable:end -->
