### PR TITLE
SF-2929 Add missing unit tests in ParatextService

### DIFF
--- a/src/SIL.XForge.Scripture/Models/BiblicalTermsChanges.cs
+++ b/src/SIL.XForge.Scripture/Models/BiblicalTermsChanges.cs
@@ -8,6 +8,15 @@ namespace SIL.XForge.Scripture.Models;
 public class BiblicalTermsChanges
 {
     public List<BiblicalTerm> BiblicalTerms { get; } = [];
+    public BiblicalTermErrorCode ErrorCode { get; init; } = BiblicalTermErrorCode.None;
     public string ErrorMessage { get; init; } = string.Empty;
     public bool HasRenderings { get; init; }
+}
+
+public enum BiblicalTermErrorCode
+{
+    None,
+    NotAccessible,
+    NotSynced,
+    NoPermission,
 }

--- a/src/SIL.XForge.Scripture/Models/BiblicalTermsChanges.cs
+++ b/src/SIL.XForge.Scripture/Models/BiblicalTermsChanges.cs
@@ -5,9 +5,9 @@ namespace SIL.XForge.Scripture.Models;
 /// <summary>
 /// The changes in the Biblical Terms from Paratext
 /// </summary>
-public record BiblicalTermsChanges
+public class BiblicalTermsChanges
 {
-    public List<BiblicalTerm> BiblicalTerms = new List<BiblicalTerm>();
-    public string ErrorMessage { get; set; } = string.Empty;
-    public bool HasRenderings { get; set; }
+    public List<BiblicalTerm> BiblicalTerms { get; } = [];
+    public string ErrorMessage { get; init; } = string.Empty;
+    public bool HasRenderings { get; init; }
 }

--- a/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
@@ -1,4 +1,5 @@
 using Paratext.Data;
+using Paratext.Data.ProjectFileAccess;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -6,4 +7,10 @@ public interface IScrTextCollection
 {
     void Initialize(string settingsDir = null);
     ScrText? FindById(string username, string projectId);
+
+    ResourceScrText CreateResourceScrText(
+        string ptUsername,
+        ProjectName projectName,
+        IZippedResourcePasswordProvider passwordProvider
+    );
 }

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Paratext.Data;
+using Paratext.Data.ProjectFileAccess;
 using Paratext.Data.ProjectSettingsAccess;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
@@ -69,6 +70,16 @@ public class LazyScrTextCollection : IScrTextCollection
         }
 
         return null;
+    }
+
+    public virtual ResourceScrText CreateResourceScrText(
+        string ptUsername,
+        ProjectName projectName,
+        IZippedResourcePasswordProvider passwordProvider
+    )
+    {
+        var associatedUser = new SFParatextUser(ptUsername);
+        return new ResourceScrText(projectName, associatedUser, passwordProvider);
     }
 
     protected virtual ScrText CreateScrText(string ptUsername, ProjectName projectName)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -596,6 +596,7 @@ public class ParatextService : DisposableBase, IParatextService
                 _restClientFactory,
                 _fileSystemService,
                 _jwtTokenHelper,
+                ScrTextCollection,
                 _exceptionHandler,
                 _dblServerUri
             );
@@ -2717,6 +2718,7 @@ public class ParatextService : DisposableBase, IParatextService
             _restClientFactory,
             _fileSystemService,
             _jwtTokenHelper,
+            ScrTextCollection,
             _exceptionHandler,
             _dblServerUri
         );

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1398,7 +1398,7 @@ public class ParatextService : DisposableBase, IParatextService
             // Log the error and return the empty biblical terms collection. Biblical Terms will be disabled.
             const string message = "The Paratext Project is not accessible from Scripture Forge.";
             _logger.LogError(message);
-            return new BiblicalTermsChanges { ErrorMessage = message };
+            return new BiblicalTermsChanges { ErrorCode = BiblicalTermErrorCode.NotAccessible, ErrorMessage = message };
         }
 
         // The biblical terms ScrText, if defined, must be disposed properly
@@ -1424,7 +1424,11 @@ public class ParatextService : DisposableBase, IParatextService
                         $"The Biblical Terms project ({biblicalTermsListParts[1]}) has not been synced to "
                         + "Scripture Forge.";
                     _logger.LogError(message);
-                    return new BiblicalTermsChanges { ErrorMessage = message };
+                    return new BiblicalTermsChanges
+                    {
+                        ErrorCode = BiblicalTermErrorCode.NotSynced,
+                        ErrorMessage = message
+                    };
                 }
 
                 // Load the biblical terms project
@@ -1440,7 +1444,11 @@ public class ParatextService : DisposableBase, IParatextService
                         + $"{GetParatextUsername(userSecret)} does not have permission to read the Biblical Terms "
                         + "project defined in Paratext.";
                     _logger.LogError(message);
-                    return new BiblicalTermsChanges { ErrorMessage = message };
+                    return new BiblicalTermsChanges
+                    {
+                        ErrorCode = BiblicalTermErrorCode.NoPermission,
+                        ErrorMessage = message
+                    };
                 }
 
                 Enum<BiblicalTermsListType> listType = string.IsNullOrEmpty(biblicalTermsListParts[0])

--- a/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockLazyScrTextCollection.cs
@@ -1,13 +1,17 @@
 using Paratext.Data;
+using Paratext.Data.ProjectFileAccess;
 using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
 public class MockLazyScrTextCollection : LazyScrTextCollection
 {
-    protected override ScrText CreateScrText(string ptUsername, ProjectName projectName)
-    {
-        var associatedPtUser = new SFParatextUser(ptUsername);
-        return new MockScrText(associatedPtUser, projectName);
-    }
+    protected override ScrText CreateScrText(string ptUsername, ProjectName projectName) =>
+        new MockScrText(new SFParatextUser(ptUsername), projectName);
+
+    public override ResourceScrText CreateResourceScrText(
+        string ptUsername,
+        ProjectName projectName,
+        IZippedResourcePasswordProvider passwordProvider
+    ) => new MockResourceScrText(projectName, new SFParatextUser(ptUsername), new MockZippedResourcePasswordProvider());
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockResourceScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockResourceScrText.cs
@@ -1,0 +1,65 @@
+using System.Text;
+using Ionic.Zip;
+using Paratext.Data;
+using Paratext.Data.Languages;
+using Paratext.Data.ProjectFileAccess;
+using Paratext.Data.ProjectSettingsAccess;
+using Paratext.Data.Users;
+
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Mocks a resource in a zip file.
+/// </summary>
+public class MockResourceScrText : ResourceScrText
+{
+    private readonly ScrLanguage _language;
+    private readonly ProjectSettings _settings;
+
+    public MockResourceScrText(
+        ProjectName name,
+        ParatextUser associatedUser,
+        IZippedResourcePasswordProvider passwordProvider
+    )
+        : base(name, associatedUser, passwordProvider)
+    {
+        _settings = new MockProjectSettings(this);
+        // ScrText sets its cachedGuid from the settings Guid. Here we are doing it the other way around.
+        // Some tests may need both MockScrText.Guid and MockScrText.Settings.Guid to be set.
+        _language = new MockScrLanguage(this);
+    }
+
+    public HexId CachedGuid
+    {
+        set
+        {
+            cachedGuid = value;
+            Settings.Guid = value;
+        }
+    }
+
+    public ZipFile ZipFile { get; } = new ZipFile(new UTF8Encoding());
+
+    protected override ProjectFileManager CreateFileManager() =>
+        new MockZippedProjectFileManager(ZipFile, loadDblSettings: true, Name);
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing)
+        {
+            ZipFile.Dispose();
+        }
+    }
+
+    protected override void Load(bool ignoreLoadErrors = false)
+    {
+        // We should not load anything from disk
+    }
+
+    public override ProjectSettings Settings => _settings;
+    public override ScrStylesheet DefaultStylesheet => new MockScrStylesheet("./usfm.sty");
+    public override string Directory => projectName.ProjectPath;
+    public override string Name => projectName.ShortName;
+    public override ScrLanguage Language => _language;
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrLanguage.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrLanguage.cs
@@ -1,0 +1,18 @@
+using Paratext.Data;
+using Paratext.Data.Languages;
+using PtxUtils;
+using SIL.WritingSystems;
+
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// Replaces a ScrLanguage for use in testing. Does not use the file system to save/load data.
+/// </summary>
+class MockScrLanguage : ScrLanguage
+{
+    internal MockScrLanguage(ScrText scrText)
+        : base(null, ProjectNormalization.Undefined, scrText) { }
+
+    // Don't load anything from disk for testing and just return the one we already have
+    protected override WritingSystemDefinition LoadWsDef(ScrText scrText) => wsDef;
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -5,9 +5,7 @@ using Paratext.Data.Languages;
 using Paratext.Data.ProjectFileAccess;
 using Paratext.Data.ProjectSettingsAccess;
 using Paratext.Data.Users;
-using PtxUtils;
 using SIL.Scripture;
-using SIL.WritingSystems;
 
 namespace SIL.XForge.Scripture.Services;
 
@@ -35,7 +33,7 @@ public class MockScrText : ScrText
         }
     }
 
-    public Dictionary<string, string> Data = new Dictionary<string, string>();
+    public Dictionary<string, string> Data { get; } = new Dictionary<string, string>();
 
     /// <summary>
     /// Return text of specified chapter or book.
@@ -64,17 +62,4 @@ public class MockScrText : ScrText
     public override ScrLanguage Language => _language;
     private readonly ScrLanguage _language;
     private readonly ProjectSettings _settings;
-}
-
-/// <summary>
-/// Replaces a ScrLanguage for use in testing. Does not use the file system to save/load data.
-/// </summary>
-class MockScrLanguage : ScrLanguage
-{
-    internal MockScrLanguage(ScrText scrText)
-        : base(null, ProjectNormalization.Undefined, scrText) { }
-
-    protected override WritingSystemDefinition LoadWsDef(ScrText scrText) =>
-        // Don't load anything from disk for testing and just return the one we already have
-        wsDef;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MockZippedProjectFileManager.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockZippedProjectFileManager.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Text;
+using Ionic.Zip;
+using Paratext.Data.ProjectFileAccess;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class MockZippedProjectFileManager(ZipFile zipFile, bool loadDblSettings, string projectName)
+    : ZippedProjectFileManagerBase(zipFile, loadDblSettings, projectName, null)
+{
+    public override void Delete(string relFilePath) => throw new NotImplementedException();
+
+    public override void DeleteDirectory(string relDirPath) => throw new NotImplementedException();
+
+    public override void MoveFile(string relFilePath, string newRelPath) => throw new NotImplementedException();
+
+    public override void CopyFile(string absSourceFilePath, string dstRelPath) => throw new NotImplementedException();
+
+    public override void WriteFileCreatingBackup(
+        string relFilePath,
+        Action<string> writeFile,
+        Action<string> validateFile = null
+    ) => throw new NotImplementedException();
+
+    public override TextWriter OpenFileForWrite(string relFilePath, Encoding encoding = null) =>
+        throw new NotImplementedException();
+
+    public override BinaryWriter OpenFileForByteWrite(string relFilePath) => throw new NotImplementedException();
+
+    public override void SetXml<T>(T obj, string relFilePath) => throw new NotImplementedException();
+
+    public override void CreateDirIfNotExist(string relDirPath) => throw new NotImplementedException();
+
+    public override string MakeSureFigureIsAccessible(string fileName) => throw new NotImplementedException();
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MockZippedResourcePasswordProvider.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockZippedResourcePasswordProvider.cs
@@ -1,0 +1,8 @@
+using Paratext.Data.ProjectFileAccess;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class MockZippedResourcePasswordProvider : IZippedResourcePasswordProvider
+{
+    public string GetPassword() => "password";
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -22,8 +22,10 @@ using Paratext.Data;
 using Paratext.Data.Languages;
 using Paratext.Data.ProjectComments;
 using Paratext.Data.ProjectFileAccess;
+using Paratext.Data.ProjectSettingsAccess;
 using Paratext.Data.RegistryServerAccess;
 using Paratext.Data.Repository;
+using Paratext.Data.Terms;
 using Paratext.Data.Users;
 using PtxUtils;
 using SIL.Scripture;
@@ -5200,6 +5202,314 @@ public class ParatextServiceTests
         Assert.IsTrue(delta.DeepEquals(expected));
     }
 
+    [Test]
+    public async Task GetBiblicalTermsAsync_AllBiblicalTerms()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup Biblical Terms
+        string settingValue = $"{BiblicalTermsListType.All}::BiblicalTerms.xml";
+        env.ProjectScrText.Settings.SetSetting(Setting.BiblicalTermsListSetting, settingValue);
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: [40]
+        );
+
+        // There are 1587 All Biblical Terms in Matthew
+        Assert.AreEqual(actual.BiblicalTerms.Count, 1587);
+        Assert.IsEmpty(actual.ErrorMessage);
+        Assert.IsFalse(actual.HasRenderings);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_InvalidProjectBiblicalTermsConfiguration()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        SFProject project = env.NewSFProject();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup Biblical Terms
+        string settingValue = $":{project.ShortName}:BiblicalTerms.xml";
+        env.ProjectScrText.Settings.SetSetting(Setting.BiblicalTermsListSetting, settingValue);
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            project.ParatextId,
+            books: [40]
+        );
+
+        // Code will fall back to Major Biblical Terms.
+        // There are 580 Major Biblical Terms in Matthew
+        Assert.AreEqual(actual.BiblicalTerms.Count, 580);
+        Assert.IsEmpty(actual.ErrorMessage);
+        Assert.IsFalse(actual.HasRenderings);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_MajorBiblicalTerms()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup term rendering
+        const string termId = "Ἀβιά-1";
+        const string rendering = "Abijah";
+        env.ProjectFileManager.GetXml<TermRenderingsList>(Arg.Any<string>())
+            .Returns(
+                new TermRenderingsList
+                {
+                    RenderingsInternal = [new TermRendering { Id = termId, RenderingsInternal = rendering }],
+                }
+            );
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: [40]
+        );
+
+        // Confirm there is only one rendering, and that rendering is our rendering
+        Assert.AreEqual(actual.BiblicalTerms.First().TermId, termId);
+        Assert.AreEqual(actual.BiblicalTerms.First().Renderings.Single(), rendering);
+        Assert.AreEqual(actual.BiblicalTerms.SelectMany(bt => bt.Renderings).Count(), 1);
+        Assert.IsEmpty(actual.ErrorMessage);
+        Assert.IsTrue(actual.HasRenderings);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_MissingBiblicalTermsParatextProject()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        SFProject project = env.NewSFProject();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project02, new SFParatextUser(env.Username01));
+
+        // Setup Biblical Terms
+        string settingValue = $"Project:{project.ShortName}:ProjectBiblicalTerms.xml";
+        env.ProjectScrText.Settings.SetSetting(Setting.BiblicalTermsListSetting, settingValue);
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project02].Id,
+            books: []
+        );
+
+        string message =
+            $"Biblical Terms could not be retrieved during Sync because the user {env.Username01} does not have "
+            + "permission to read the Biblical Terms project defined in Paratext.";
+        Assert.AreEqual(actual.ErrorMessage, message);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_MissingBiblicalTermsProject()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup Biblical Terms
+        const string btShortName = "AnotherProjectShortName";
+        const string settingValue = $"Project:{btShortName}:ProjectBiblicalTerms.xml";
+        env.ProjectScrText.Settings.SetSetting(Setting.BiblicalTermsListSetting, settingValue);
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: []
+        );
+
+        const string message = $"The Biblical Terms project ({btShortName}) has not been synced to Scripture Forge.";
+        Assert.AreEqual(actual.ErrorMessage, message);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_MissingParatextProject()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: []
+        );
+
+        const string message = "The Paratext Project is not accessible from Scripture Forge.";
+        Assert.AreEqual(actual.ErrorMessage, message);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_NoTermRenderings()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: [40]
+        );
+
+        // There are 580 Major Biblical Terms in Matthew
+        Assert.AreEqual(actual.BiblicalTerms.Count, 580);
+        Assert.IsEmpty(actual.ErrorMessage);
+        Assert.IsFalse(actual.HasRenderings);
+    }
+
+    [Test]
+    public async Task GetBiblicalTermsAsync_ProjectBiblicalTerms()
+    {
+        // Setup the test environment
+        var env = new TestEnvironment();
+        SFProject project = env.NewSFProject();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup Biblical Terms
+        string settingValue = $"Project:{project.ShortName}:ProjectBiblicalTerms.xml";
+        env.ProjectScrText.Settings.SetSetting(Setting.BiblicalTermsListSetting, settingValue);
+        Term term = new Term
+        {
+            CategoryIds = ["AT"],
+            Id = "my_term_id",
+            Index = 0,
+            Language = "greek",
+            LinkString = "my_links",
+            LocalGloss = "my_gloss",
+            References = [new Verse { VerseText = new VerseRef(40, 1, 1).BBBCCCVVVS }],
+            SemanticDomain = "animals",
+            Transliteration = "my_transliteration",
+        };
+        TermRendering termRendering = new TermRendering
+        {
+            Id = term.Id,
+            RenderingsInternal = "my_rendering",
+            Notes = "my_notes",
+        };
+        BiblicalTermsList biblicalTermsList = new BiblicalTermsList();
+        biblicalTermsList.AddTerm(term);
+        env.ProjectFileManager.GetXml<BiblicalTermsList>(Arg.Any<string>()).Returns(biblicalTermsList);
+
+        env.ProjectFileManager.GetXml<TermRenderingsList>(Arg.Any<string>())
+            .Returns(new TermRenderingsList { RenderingsInternal = [termRendering] });
+
+        // SUT
+        BiblicalTermsChanges actual = await env.Service.GetBiblicalTermsAsync(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            books: [40]
+        );
+
+        Assert.IsEmpty(actual.BiblicalTerms.Single().DataId);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Definitions["en"].Categories.Single(), "Attributes");
+        Assert.AreEqual(actual.BiblicalTerms.Single().Definitions["en"].Domains.Single(), term.SemanticDomain);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Definitions["en"].Gloss, term.Gloss);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Description, termRendering.Notes);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Transliteration, term.Transliteration);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Language, term.Language);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Links.Single(), term.Links.Single());
+        Assert.AreEqual(actual.BiblicalTerms.Single().TermId, term.Id);
+        Assert.AreEqual(actual.BiblicalTerms.Single().References.Single(), term.References.Single().VerseRef.BBBCCCVVV);
+        Assert.AreEqual(actual.BiblicalTerms.Single().Renderings.Single(), termRendering.RenderingsEntries.Single());
+        Assert.IsEmpty(actual.ErrorMessage);
+        Assert.IsTrue(actual.HasRenderings);
+    }
+
+    [Test]
+    public void UpdateBiblicalTerms_MissingParatextProject()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        IReadOnlyList<BiblicalTerm> biblicalTerms = [new BiblicalTerm()];
+
+        // SUT
+        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        env.MockScrTextCollection.Received(1).FindById(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public void UpdateBiblicalTerms_NoBiblicalTerms()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        IReadOnlyList<BiblicalTerm> biblicalTerms = [];
+
+        // SUT
+        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        env.MockScrTextCollection.DidNotReceive().FindById(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Test]
+    public void UpdateBiblicalTerms_UpdatesTermRenderings()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup term rendering
+        const string termId = "Ἀβιά-1";
+        env.ProjectFileManager.GetXml<TermRenderingsList>(Arg.Any<string>())
+            .Returns(
+                new TermRenderingsList
+                {
+                    RenderingsInternal =
+                    [
+                        new TermRendering
+                        {
+                            Id = termId,
+                            RenderingsInternal = "Old Abijah",
+                            Notes = "Old Notes",
+                        },
+                    ],
+                }
+            );
+
+        const string newRendering = "New Abijah";
+        const string newNotes = "New Notes";
+        IReadOnlyList<BiblicalTerm> biblicalTerms =
+        [
+            new BiblicalTerm
+            {
+                TermId = termId,
+                Renderings = [newRendering],
+                Description = newNotes,
+            },
+        ];
+
+        // SUT
+        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        env.ProjectFileManager.Received(1)
+            .SetXml(
+                Arg.Is<TermRenderingsList>(r =>
+                    r.Renderings.Single().Id == termId
+                    && r.Renderings.Single().RenderingsEntries.Single() == newRendering
+                    && r.Renderings.Single().Notes == newNotes
+                ),
+                "TermRenderings.xml"
+            );
+    }
+
     private class TestEnvironment : IDisposable
     {
         public readonly string ParatextUserId01 = "paratext01";
@@ -5347,7 +5657,7 @@ public class ParatextServiceTests
             {
                 { User01, "User 01 Display" },
                 { User02, Username02 },
-                { User05, "User 05" }
+                { User05, "User 05" },
             };
 
             Service = new ParatextService(
@@ -5566,25 +5876,25 @@ public class ParatextServiceTests
             {
                 SendReceiveId = PTProjectIds[Project01],
                 ScrTextName = "P01",
-                SourceUsers = sourceUsers
+                SourceUsers = sourceUsers,
             };
             SharedRepository repo2 = new SharedRepository
             {
                 SendReceiveId = PTProjectIds[Project02],
                 ScrTextName = "P02",
-                SourceUsers = sourceUsers
+                SourceUsers = sourceUsers,
             };
             SharedRepository repo3 = new SharedRepository
             {
                 SendReceiveId = PTProjectIds[Project03],
                 ScrTextName = "P03",
-                SourceUsers = sourceUsers
+                SourceUsers = sourceUsers,
             };
             SharedRepository repo4 = new SharedRepository
             {
                 SendReceiveId = PTProjectIds[Project04],
                 ScrTextName = "P04",
-                SourceUsers = sourceUsers
+                SourceUsers = sourceUsers,
             };
 
             ProjectMetadata projMeta1 = GetMetadata(PTProjectIds[Project01].Id, "Full Name " + Project01);
@@ -5665,7 +5975,7 @@ public class ParatextServiceTests
                         Name = "Source",
                         ShortName = "SRC",
                         WritingSystem = new WritingSystem { Tag = "qaa" },
-                    }
+                    },
                 },
                 CheckingConfig = new CheckingConfig { ShareEnabled = false },
                 UserRoles = new Dictionary<string, string>
@@ -5803,9 +6113,9 @@ public class ParatextServiceTests
                         : new TextAnchor { Start = ContextBefore.Length, Length = text.Length },
                     OriginalContextAfter = comp.appliesToVerse ? "" : ContextAfter,
                     Status = NoteStatus.Todo.InternalValue,
-                    Assignment = GetAssignedUserStr(comp.notes)
+                    Assignment = GetAssignedUserStr(comp.notes),
                 };
-                List<Note> notes = new List<Note>();
+                List<Note> notes = [];
                 for (int i = 1; i <= comp.noteCount; i++)
                 {
                     ThreadNoteComponents noteComponent = new ThreadNoteComponents
@@ -5904,7 +6214,7 @@ public class ParatextServiceTests
         )
         {
             Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
-            int numVersesInChapter = 10;
+            const int numVersesInChapter = 10;
             for (int i = 1; i <= chapters; i++)
             {
                 Delta delta = GetChapterDelta(
@@ -6136,7 +6446,7 @@ public class ParatextServiceTests
             CommentTags.CommentTagList list = new CommentTags.CommentTagList
             {
                 SerializedData = tags.ToArray(),
-                SerializedLastUsedId = TagCount
+                SerializedLastUsedId = TagCount,
             };
             scrText.FileManager.GetXml<CommentTags.CommentTagList>(Arg.Any<string>()).Returns(list);
         }
@@ -6171,20 +6481,20 @@ public class ParatextServiceTests
                 selectedText = ReattachedSelectedText,
                 startPos = startPos,
                 contextBefore = AlternateBefore,
-                contextAfter = AlternateAfter
+                contextAfter = AlternateAfter,
             };
         }
 
-        public static string ReattachedThreadInfoStr(ReattachedThreadInfo rnt)
+        private static string ReattachedThreadInfoStr(ReattachedThreadInfo rnt)
         {
-            string[] reattachParts = new[]
-            {
+            string[] reattachParts =
+            [
                 rnt.verseStr,
                 rnt.selectedText,
                 rnt.startPos,
                 rnt.contextBefore,
-                rnt.contextAfter
-            };
+                rnt.contextAfter,
+            ];
             return string.Join(StringUtils.orcCharacter, reattachParts);
         }
 
@@ -6195,7 +6505,7 @@ public class ParatextServiceTests
         /// </summary>
         public async Task<IEnumerable<NoteThreadChange>> PrepareChangeOnSingleCommentAsync(
             Action<Paratext.Data.ProjectComments.Comment> modifyComment,
-            Action<NoteThread> modifyNoteThread = null
+            Action<NoteThread>? modifyNoteThread = null
         )
         {
             var env = this;
@@ -6241,7 +6551,7 @@ public class ParatextServiceTests
                         Deleted = false,
                         Status = NoteStatus.Todo.InternalValue,
                         Assignment = CommentThread.unassignedUser,
-                        Content = $"<p>Note content.</p>",
+                        Content = "<p>Note content.</p>",
                         AcceptedChangeXml = null,
                     }
                 }
@@ -6263,7 +6573,7 @@ public class ParatextServiceTests
                 ContextBefore = "",
                 ContextAfter = "",
                 StartPosition = 0,
-                Date = $"2019-12-31T08:00:00.0000000+00:00",
+                Date = "2019-12-31T08:00:00.0000000+00:00",
                 Deleted = false,
                 Status = NoteStatus.Todo,
                 Type = NoteType.Normal,
@@ -6276,10 +6586,7 @@ public class ParatextServiceTests
             env.AddParatextComment(comment);
 
             await using IConnection conn = await env.RealtimeService.ConnectAsync();
-            IEnumerable<IDocument<NoteThread>> noteThreadDocs = await GetNoteThreadDocsAsync(
-                conn,
-                new[] { "dataId01" }
-            );
+            IEnumerable<IDocument<NoteThread>> noteThreadDocs = await GetNoteThreadDocsAsync(conn, ["dataId01"]);
             Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
             {
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -5338,6 +5338,7 @@ public class ParatextServiceTests
         // There are 1587 All Biblical Terms in Matthew
         Assert.AreEqual(actual.BiblicalTerms.Count, 1587);
         Assert.IsEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.None);
         Assert.IsFalse(actual.HasRenderings);
     }
 
@@ -5365,6 +5366,7 @@ public class ParatextServiceTests
         // There are 580 Major Biblical Terms in Matthew
         Assert.AreEqual(actual.BiblicalTerms.Count, 580);
         Assert.IsEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.None);
         Assert.IsFalse(actual.HasRenderings);
     }
 
@@ -5399,6 +5401,7 @@ public class ParatextServiceTests
         Assert.AreEqual(actual.BiblicalTerms.First().Renderings.Single(), rendering);
         Assert.AreEqual(actual.BiblicalTerms.SelectMany(bt => bt.Renderings).Count(), 1);
         Assert.IsEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.None);
         Assert.IsTrue(actual.HasRenderings);
     }
 
@@ -5421,11 +5424,8 @@ public class ParatextServiceTests
             env.PTProjectIds[env.Project02].Id,
             books: []
         );
-
-        string message =
-            $"Biblical Terms could not be retrieved during Sync because the user {env.Username01} does not have "
-            + "permission to read the Biblical Terms project defined in Paratext.";
-        Assert.AreEqual(actual.ErrorMessage, message);
+        Assert.IsNotEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.NoPermission);
     }
 
     [Test]
@@ -5447,9 +5447,8 @@ public class ParatextServiceTests
             env.PTProjectIds[env.Project01].Id,
             books: []
         );
-
-        const string message = $"The Biblical Terms project ({btShortName}) has not been synced to Scripture Forge.";
-        Assert.AreEqual(actual.ErrorMessage, message);
+        Assert.IsNotEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.NotSynced);
     }
 
     [Test]
@@ -5465,9 +5464,8 @@ public class ParatextServiceTests
             env.PTProjectIds[env.Project01].Id,
             books: []
         );
-
-        const string message = "The Paratext Project is not accessible from Scripture Forge.";
-        Assert.AreEqual(actual.ErrorMessage, message);
+        Assert.IsNotEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.NotAccessible);
     }
 
     [Test]
@@ -5488,6 +5486,7 @@ public class ParatextServiceTests
         // There are 580 Major Biblical Terms in Matthew
         Assert.AreEqual(actual.BiblicalTerms.Count, 580);
         Assert.IsEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.None);
         Assert.IsFalse(actual.HasRenderings);
     }
 
@@ -5547,6 +5546,7 @@ public class ParatextServiceTests
         Assert.AreEqual(actual.BiblicalTerms.Single().References.Single(), term.References.Single().VerseRef.BBBCCCVVV);
         Assert.AreEqual(actual.BiblicalTerms.Single().Renderings.Single(), termRendering.RenderingsEntries.Single());
         Assert.IsEmpty(actual.ErrorMessage);
+        Assert.AreEqual(actual.ErrorCode, BiblicalTermErrorCode.None);
         Assert.IsTrue(actual.HasRenderings);
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -5510,6 +5510,34 @@ public class ParatextServiceTests
             );
     }
 
+    [Test]
+    public void InitializeCommentManager_MissingParatextProject()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.ProjectFileManager = Substitute.For<ProjectFileManager>(null, null);
+
+        // SUT
+        env.Service.InitializeCommentManager(userSecret, env.PTProjectIds[env.Project01].Id);
+        env.ProjectFileManager.DidNotReceive().ProjectFiles("Notes_*.xml");
+        env.ProjectFileManager.DidNotReceive().GetXml<CommentList>(Arg.Any<string>());
+    }
+
+    [Test]
+    public void InitializeCommentManager_Success()
+    {
+        var env = new TestEnvironment();
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        const string fileName = "Notes_User 01.xml";
+        env.ProjectFileManager.ProjectFiles("Notes_*.xml").Returns([fileName]);
+
+        // SUT
+        env.Service.InitializeCommentManager(userSecret, env.PTProjectIds[env.Project01].Id);
+        env.ProjectFileManager.Received().ProjectFiles("Notes_*.xml");
+        env.ProjectFileManager.Received().GetXml<CommentList>(Arg.Any<string>());
+    }
+
     private class TestEnvironment : IDisposable
     {
         public readonly string ParatextUserId01 = "paratext01";


### PR DESCRIPTION
This PR adds missing unit tests in ParatextService for:

 * GetBiblicalTermsAsync()
 * UpdateBiblicalTerms()
 * InitializeCommentManager()
 * LanguageId migration logic in the functions
     * DetermineBestLanguageForResource()
     * InstallResource()
     * MigrateResourceIfRequired()

I have also fixed a bug for Biblical Terms where the Biblical Term's local gloss was not loaded when it should have been, corrected a bug in `BiblicalTermsChanges` where a property was incorrectly a field, and performed minor code formatting cleanups to the `ParatextServiceTests`.

The unit tests for language id migration required a reworking of how `ResourceScrText` objects are created to allow mocking. This has not changed what code is called, just where the code resides that is called. A usual QA regression test will be sufficient to cover the changes.

**Note:** It is not possible to test the new logic in `LazyScrTextCollection`, because this code directly interfaces with the ParatextData logic, hence the `MockLazyScrTextCollection` class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2695)
<!-- Reviewable:end -->
