### PR TITLE
SF-2947 Only update interface language via UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -235,18 +235,44 @@ describe('AppComponent', () => {
 
   it('sets user locale when stored locale does not match the browsing session', fakeAsync(() => {
     const env = new TestEnvironment();
+    when(mockedAuthService.isNewlyLoggedIn).thenResolve(true);
     when(mockedI18nService.localeCode).thenReturn('es');
     env.navigate(['/projects', 'project01']);
     env.init();
 
     tick();
     env.fixture.detectChanges();
-    verify(mockedAuthService.updateInterfaceLanguage('es')).once();
+    verify(mockedI18nService.setLocale('en')).once();
 
     env.component.setLocale('pt-BR');
     tick();
     env.fixture.detectChanges();
-    verify(mockedI18nService.setLocale('pt-BR', anything())).once();
+    verify(mockedI18nService.setLocale('pt-BR')).once();
+  }));
+
+  it('should not set user locale when not newly logged in and stored locale does not match the browsing session', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedAuthService.isNewlyLoggedIn).thenResolve(false);
+    when(mockedI18nService.localeCode).thenReturn('es');
+    env.navigate(['/projects', 'project01']);
+    env.init();
+
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedI18nService.setLocale('en')).never();
+  }));
+
+  it('set interface language when specifically setting locale', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.navigate(['/projects', 'project01']);
+    env.init();
+
+    tick();
+    env.fixture.detectChanges();
+
+    env.component.setLocale('pt-BR');
+    verify(mockedI18nService.setLocale('pt-BR')).once();
+    verify(mockedAuthService.updateInterfaceLanguage('pt-BR')).once();
   }));
 
   it('response to remote project deletion', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -240,12 +240,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       if (Bugsnag.isStarted()) Bugsnag.setUser(this.currentUserDoc.id);
     }
 
-    // Set the locale in the Auth0 user profile to the current browsing session based on the cookie
-    const languageTag: string | undefined = this.currentUserDoc.data!.interfaceLanguage;
-    if (languageTag != null && I18nService.getLocale(languageTag)?.canonicalTag !== this.i18n.localeCode) {
-      this.authService.updateInterfaceLanguage(this.i18n.localeCode);
-    }
-
     const isNewlyLoggedIn = await this.authService.isNewlyLoggedIn;
     this.isLoggedInUserAnonymous = await this.authService.isLoggedInUserAnonymous;
     const isBrowserSupported = supportedBrowser();
@@ -254,6 +248,16 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       this.dialogService.openMatDialog(SupportedBrowsersDialogComponent, {
         data: BrowserIssue.Upgrade
       });
+    }
+
+    // Set the locale to the Auth0 user profile on first login
+    const languageTag: string | undefined = this.currentUserDoc.data!.interfaceLanguage;
+    if (
+      isNewlyLoggedIn &&
+      languageTag != null &&
+      I18nService.getLocale(languageTag)?.canonicalTag !== this.i18n.localeCode
+    ) {
+      this.i18n.setLocale(languageTag);
     }
 
     // Monitor current project
@@ -328,7 +332,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   setLocale(locale: string): void {
-    this.i18n.setLocale(locale, this.authService);
+    this.i18n.setLocale(locale);
+    this.authService.updateInterfaceLanguage(locale);
   }
 
   changePassword(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.spec.ts
@@ -112,19 +112,19 @@ describe('JoinComponent', () => {
 
   it('sets locale when not logged in', fakeAsync(() => {
     new TestEnvironment({ isLoggedIn: false, locale: 'fr' });
-    verify(mockedI18nService.setLocale('fr', anything())).once();
+    verify(mockedI18nService.setLocale('fr')).once();
     expect().nothing();
   }));
 
   it('sets locale when not logged in and locale not supplied', fakeAsync(() => {
     new TestEnvironment({ isLoggedIn: false });
-    verify(mockedI18nService.setLocale('en', anything())).once();
+    verify(mockedI18nService.setLocale('en')).once();
     expect().nothing();
   }));
 
   it('does not set locale when logged in', fakeAsync(() => {
     new TestEnvironment({ isLoggedIn: true });
-    verify(mockedI18nService.setLocale(anything(), anything())).never();
+    verify(mockedI18nService.setLocale(anything())).never();
     expect().nothing();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -75,7 +75,7 @@ export class JoinComponent extends DataLoadingComponent {
     this.subscribe(checkLinkSharing$, joining => {
       // Set locale only if not logged in
       if (this.authService.currentUserId == null) {
-        this.i18nService.setLocale(joining.locale, this.authService);
+        this.i18nService.setLocale(joining.locale);
       }
       this.initialize(joining.shareKey);
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -48,7 +48,7 @@ describe('I18nService', () => {
     expect(service).toBeTruthy();
     service.setLocale('zh-CN', instance(mockedAuthService));
     verify(mockedTranslocoService.setActiveLang('zh-CN')).called();
-    verify(mockedAuthService.updateInterfaceLanguage('zh-CN')).called();
+    verify(mockedAuthService.updateInterfaceLanguage(anything())).never();
     expect(service.localeCode).toEqual('zh-CN');
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -46,7 +46,7 @@ describe('I18nService', () => {
   it('should set locale', () => {
     const service = getI18nService();
     expect(service).toBeTruthy();
-    service.setLocale('zh-CN', instance(mockedAuthService));
+    service.setLocale('zh-CN');
     verify(mockedTranslocoService.setActiveLang('zh-CN')).called();
     verify(mockedAuthService.updateInterfaceLanguage(anything())).never();
     expect(service.localeCode).toEqual('zh-CN');
@@ -100,15 +100,15 @@ describe('I18nService', () => {
     // Test for any white space character for maximum compatibility
     expect(service.formatDate(date)).toMatch(/Nov 25, 1991, 5:28\sPM/);
 
-    service.setLocale('en-GB', mockedAuthService);
+    service.setLocale('en-GB');
     expect(service.formatDate(date)).toMatch(/25 Nov 1991, 5:28\spm/);
 
     // As of Chromium 98 for zh-CN it's changed from using characters to indicate AM/PM, to using a 24 hour clock. It's
     // unclear whether the cause is Chromium itself or a localization library. The tests should pass with either version
-    service.setLocale('zh-CN', mockedAuthService);
+    service.setLocale('zh-CN');
     expect(['1991/11/25 17:28', '1991/11/25下午5:28']).toContain(service.formatDate(date));
 
-    service.setLocale('az', mockedAuthService);
+    service.setLocale('az');
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });
 
@@ -145,9 +145,9 @@ describe('I18nService', () => {
   it('should set text direction on the body element', () => {
     const service = getI18nService();
     verify(mockedDocumentBody.setAttribute('dir', 'ltr')).never();
-    service.setLocale('zh-CN', mockedAuthService);
+    service.setLocale('zh-CN');
     verify(mockedDocumentBody.setAttribute('dir', 'ltr')).once();
-    service.setLocale('ar', mockedAuthService);
+    service.setLocale('ar');
     verify(mockedDocumentBody.setAttribute('dir', 'rtl')).once();
     expect().nothing();
   });
@@ -156,7 +156,7 @@ describe('I18nService', () => {
     when(mockedTranslocoService.translate<string>('canon.book_names.GEN')).thenReturn('Genesis');
     const service = getI18nService();
     expect(service.localizeReference(new VerseRef('GEN 1:2-3'))).toBe('Genesis 1:2-3');
-    service.setLocale('ar', mockedAuthService);
+    service.setLocale('ar');
     // Expect right-to-left mark before chapter num, ':', and '-' characters
     expect(service.localizeReference(new VerseRef('GEN 1:2-3'))).toBe('Genesis \u200F1\u200F:2\u200F-3');
   });
@@ -164,19 +164,19 @@ describe('I18nService', () => {
   describe('getLanguageDisplayName', () => {
     it('should return the display name for a valid language code', () => {
       const service = getI18nService();
-      service.setLocale('en', instance(mockedAuthService));
+      service.setLocale('en');
       expect(service.getLanguageDisplayName('en')).toBe('English');
     });
 
     it('should return undefined for an undefined language code', () => {
       const service = getI18nService();
-      service.setLocale('en', instance(mockedAuthService));
+      service.setLocale('en');
       expect(service.getLanguageDisplayName(undefined)).toBeUndefined();
     });
 
     it('should return language code for an unknown language code', () => {
       const service = getI18nService();
-      service.setLocale('en', instance(mockedAuthService));
+      service.setLocale('en');
       expect(service.getLanguageDisplayName('123')).toBe('123');
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -7,7 +7,6 @@ import { of } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { AuthService } from './auth.service';
 import { DOCUMENT } from './browser-globals';
 import { BugsnagService } from './bugsnag.service';
 import { I18nService } from './i18n.service';
@@ -15,7 +14,6 @@ import { LocationService } from './location.service';
 
 const mockedLocationService = mock(LocationService);
 const mockedBugsnagService = mock(BugsnagService);
-const mockedAuthService = mock(AuthService);
 const mockedTranslocoService = mock(TranslocoService);
 const mockedCookieService = mock(CookieService);
 const mockedErrorReportingService = mock(ErrorReportingService);
@@ -29,7 +27,6 @@ describe('I18nService', () => {
     providers: [
       { provide: LocationService, useMock: mockedLocationService },
       { provide: BugsnagService, useMock: mockedBugsnagService },
-      { provide: AuthService, useMock: mockedAuthService },
       { provide: TranslocoService, useMock: mockedTranslocoService },
       { provide: CookieService, useMock: mockedCookieService },
       { provide: ErrorReportingService, useMock: mockedErrorReportingService },
@@ -48,7 +45,6 @@ describe('I18nService', () => {
     expect(service).toBeTruthy();
     service.setLocale('zh-CN');
     verify(mockedTranslocoService.setActiveLang('zh-CN')).called();
-    verify(mockedAuthService.updateInterfaceLanguage(anything())).never();
     expect(service.localeCode).toEqual('zh-CN');
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -10,7 +10,6 @@ import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { ObjectPaths } from '../type-utils';
-import { AuthService } from './auth.service';
 import { DOCUMENT } from './browser-globals';
 import { BugsnagService } from './bugsnag.service';
 import { FeatureFlagService } from './feature-flags/feature-flag.service';
@@ -154,12 +153,12 @@ export class I18nService {
     );
   }
 
-  setLocale(tag: string, authService: AuthService): void {
+  setLocale(tag: string): void {
     const locale = I18nService.getLocale(tag);
     if (locale == null) {
       throw new Error(`Cannot set locale to non-existent locale ${tag}`);
     }
-    this.trySetLocale(tag, authService);
+    this.trySetLocale(tag);
   }
 
   /**
@@ -169,10 +168,9 @@ export class I18nService {
    * supplied, it will also be written the locale to the user profile.
    * @param tag The locale code of the locale to activate. I18nService.locales lists the locales, and each locale has a
    * canonicalTag. This parameter must be one of those tags, or similar to it, by a case-insensitive comparison.
-   * @param authService (optional) The AuthService, which can be used to update the interfaceLanguage on the user. If
    * this is not supplied, the user profile will not be updated.
    */
-  trySetLocale(tag: string, authService?: AuthService): void {
+  trySetLocale(tag: string): void {
     const locale = I18nService.getLocale(tag);
     if (locale == null) {
       this.reportingService.silentError(`Failed attempt to set locale to unsupported locale ${tag}`);
@@ -192,9 +190,6 @@ export class I18nService {
       true,
       'Strict'
     );
-    if (authService != null) {
-      authService.updateInterfaceLanguage(locale.canonicalTag);
-    }
     this.bugsnagService.leaveBreadcrumb(
       'Set Locale',
       {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -164,11 +164,9 @@ export class I18nService {
   /**
    * Attempts to set the locale to the specified locale tag. If the specified locale is not available this will not
    * throw an exception but will report the failure to Bugsnag. If it is available, this will set the active local of
-   * the I18nService, write to the ASP .NET Core culture cookie, and log to Bugsnag. If the authService parameter is
-   * supplied, it will also be written the locale to the user profile.
+   * the I18nService, write to the ASP .NET Core culture cookie, and log to Bugsnag.
    * @param tag The locale code of the locale to activate. I18nService.locales lists the locales, and each locale has a
    * canonicalTag. This parameter must be one of those tags, or similar to it, by a case-insensitive comparison.
-   * this is not supplied, the user profile will not be updated.
    */
   trySetLocale(tag: string): void {
     const locale = I18nService.getLocale(tag);


### PR DESCRIPTION
Updating the interface language in Auth0 only only occurs on login or if the user specifically changes it via the UI.

It is still possible to have the same user logged in via different browsers and have them in different languages based on a cookie.

Logging in will now update the UI to what is in Auth0 and not what is in a cookie from the Razor home page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2696)
<!-- Reviewable:end -->
