### PR TITLE
SF-2942 Display warning message when editor does not support translation language

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -113,6 +113,13 @@
               }
               @case ("project-target") {
                 <div class="project-tab-container">
+                  @if (showBrowserWarningBanner) {
+                    <app-notice icon="warning" type="warning" class="browser-warning-banner">
+                      <div>
+                        <span [innerHtml]="browserWarningMessage"></span>
+                      </div>
+                    </app-notice>
+                  }
                   @if (hasTargetCopyrightBanner) {
                     <app-notice icon="copyright" type="warning" class="copyright-banner">
                       <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -113,10 +113,10 @@
               }
               @case ("project-target") {
                 <div class="project-tab-container">
-                  @if (showBrowserWarningBanner) {
-                    <app-notice icon="warning" type="warning" class="browser-warning-banner">
+                  @if (writingSystemWarningBanner) {
+                    <app-notice icon="warning" type="warning" class="writing-system-warning-banner">
                       <div>
-                        <span [innerHtml]="browserWarningMessage"></span>
+                        <span [innerHtml]="writingSystemWarningMessage"></span>
                       </div>
                     </app-notice>
                   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -115,9 +115,7 @@
                 <div class="project-tab-container">
                   @if (writingSystemWarningBanner) {
                     <app-notice icon="warning" type="warning" class="writing-system-warning-banner">
-                      <div>
-                        <span [innerHtml]="writingSystemWarningMessage"></span>
-                      </div>
+                      <span [innerHtml]="writingSystemWarningMessage"></span>
                     </app-notice>
                   }
                   @if (hasTargetCopyrightBanner) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -275,10 +275,10 @@ describe('EditorComponent', () => {
     expect(env.component.writingSystemWarningBanner).toBe(false);
     expect(env.showWritingSystemWarningBanner).toBeNull();
     expect(env.component.userHasGeneralEditRight).toBe(true);
-    expect(env.component.hasChapterEditPermission).toBe(false); // undefined
+    expect(env.component.hasChapterEditPermission).toBe(false);
     expect(env.component.canEdit).toBe(false);
-    expect(env.component.showNoEditPermissionMessage).toBe(true); //false
-    expect(env.noChapterEditPermissionMessage).not.toBeNull(); // null
+    expect(env.component.showNoEditPermissionMessage).toBe(true);
+    expect(env.noChapterEditPermissionMessage).not.toBeNull();
 
     discardPeriodicTasks();
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -77,6 +77,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
+import { WritingSystem } from 'realtime-server/lib/esm/common/models/writing-system';
 import { BiblicalTermDoc } from '../../core/models/biblical-term-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -226,6 +227,19 @@ describe('EditorComponent', () => {
     expect(env.component.target!.segmentRef).toEqual('verse_2_1');
 
     env.dispose();
+  }));
+
+  it('shows warning to users when translation is Korean, Japanese, or Chinese', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProject({
+      writingSystem: { tag: 'ko' }
+    });
+    env.wait();
+    expect(env.component.browserEngine).not.toEqual('gecko');
+    expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('ko');
+    expect(env.component.showBrowserWarningBanner).toBe(true);
+    expect(env.browserWarningBanner).not.toBeNull();
+    discardPeriodicTasks();
   }));
 
   describe('Translation Suggestions enabled', () => {
@@ -4458,6 +4472,10 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('.copyright-banner'));
   }
 
+  get browserWarningBanner(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.browser-warning-banner'));
+  }
+
   get copyrightMoreInfo(): DebugElement {
     return this.fixture.debugElement.query(By.css('.copyright-banner .copyright-more-info'));
   }
@@ -4536,6 +4554,9 @@ class TestEnvironment {
       ...this.testProjectProfile,
       paratextUsers: this.paratextUsersOnProject
     });
+    if (data.writingSystem != null) {
+      projectProfileData.writingSystem = data.writingSystem as WritingSystem;
+    }
     if (data.translateConfig?.translationSuggestionsEnabled != null) {
       projectProfileData.translateConfig.translationSuggestionsEnabled =
         data.translateConfig.translationSuggestionsEnabled;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -257,20 +257,29 @@ describe('EditorComponent', () => {
     discardPeriodicTasks();
   }));
 
-  it('does not show warning to users if they cannot edit', fakeAsync(() => {
+  it('does not show warning to users if they do not have edit permissions on the selected book', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setupProject({
       writingSystem: { tag: 'ko' },
       translateConfig: defaultTranslateConfig
     });
-    env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 3 });
+    // user03 only has read permissions on Luke 1
+    // As the editor is disabled, we do not need to show the writing system warning
+    // The no_permission_edit_chapter message will be displayed instead
+    env.setCurrentUser('user03');
+    env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 1 });
     env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
     env.wait();
 
-    expect(env.component.canEdit).toBe(false);
     expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('ko');
     expect(env.component.writingSystemWarningBanner).toBe(false);
     expect(env.showWritingSystemWarningBanner).toBeNull();
+    expect(env.component.userHasGeneralEditRight).toBe(true);
+    expect(env.component.hasChapterEditPermission).toBe(false); // undefined
+    expect(env.component.canEdit).toBe(false);
+    expect(env.component.showNoEditPermissionMessage).toBe(true); //false
+    expect(env.noChapterEditPermissionMessage).not.toBeNull(); // null
+
     discardPeriodicTasks();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -235,9 +235,42 @@ describe('EditorComponent', () => {
       writingSystem: { tag: 'ko' }
     });
     env.wait();
+
+    expect(env.component.canEdit).toBe(true);
     expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('ko');
     expect(env.component.writingSystemWarningBanner).toBe(true);
     expect(env.showWritingSystemWarningBanner).not.toBeNull();
+    discardPeriodicTasks();
+  }));
+
+  it('does not show warning to users when translation is not Korean, Japanese, or Chinese', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProject({
+      writingSystem: { tag: 'en' }
+    });
+    env.wait();
+
+    expect(env.component.canEdit).toBe(true);
+    expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('en');
+    expect(env.component.writingSystemWarningBanner).toBe(false);
+    expect(env.showWritingSystemWarningBanner).toBeNull();
+    discardPeriodicTasks();
+  }));
+
+  it('does not show warning to users if they cannot edit', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProject({
+      writingSystem: { tag: 'ko' },
+      translateConfig: defaultTranslateConfig
+    });
+    env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 3 });
+    env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
+    env.wait();
+
+    expect(env.component.canEdit).toBe(false);
+    expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('ko');
+    expect(env.component.writingSystemWarningBanner).toBe(false);
+    expect(env.showWritingSystemWarningBanner).toBeNull();
     discardPeriodicTasks();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -235,10 +235,9 @@ describe('EditorComponent', () => {
       writingSystem: { tag: 'ko' }
     });
     env.wait();
-    expect(env.component.browserEngine).not.toEqual('gecko');
     expect(env.component.projectDoc?.data?.writingSystem.tag).toEqual('ko');
-    expect(env.component.showBrowserWarningBanner).toBe(true);
-    expect(env.browserWarningBanner).not.toBeNull();
+    expect(env.component.writingSystemWarningBanner).toBe(true);
+    expect(env.showWritingSystemWarningBanner).not.toBeNull();
     discardPeriodicTasks();
   }));
 
@@ -4472,8 +4471,8 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('.copyright-banner'));
   }
 
-  get browserWarningBanner(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.browser-warning-banner'));
+  get showWritingSystemWarningBanner(): DebugElement {
+    return this.fixture.debugElement.query(By.css('.writing-system-warning-banner'));
   }
 
   get copyrightMoreInfo(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -96,7 +96,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { getBrowserEngine, getLinkHTML, issuesEmailTemplate, objectId } from 'xforge-common/utils';
+import { getLinkHTML, issuesEmailTemplate, objectId, browserLinks, isGecko } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon, defaultNoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -249,8 +249,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private tabStateInitialized$ = new BehaviorSubject<boolean>(false);
   private readonly fabDiameter = 40;
   readonly fabVerticalCushion = 5;
-  readonly browserEngine: string = getBrowserEngine();
-  readonly translationWarningLanguages = ['ko', 'ja', 'cmn'];
+  readonly writingSystemWarningRegex = /^(ko|cmn|ja)_?$/;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -502,8 +501,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return getLinkHTML(environment.issueEmail, issuesEmailTemplate());
   }
 
-  get browserWarningMessage(): string {
-    return translate('editor.browser_warning_banner', { firefoxLink: getLinkHTML('Firefox', 'https://firefox.com') });
+  get writingSystemWarningMessage(): string {
+    return translate('editor.browser_warning_banner', { firefoxLink: browserLinks().firefoxLink });
   }
 
   get showMultiViewers(): boolean {
@@ -587,13 +586,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.projectDoc?.data?.shortName;
   }
 
-  get showBrowserWarningBanner(): boolean {
+  get writingSystemWarningBanner(): boolean {
     const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
-    return (
-      writingSystemTag != null &&
-      this.translationWarningLanguages.includes(writingSystemTag) &&
-      this.browserEngine !== 'gecko'
-    );
+    return !isGecko() && writingSystemTag != null && this.writingSystemWarningRegex.test(writingSystemTag);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -161,7 +161,35 @@ export interface SaveNoteParameters {
 }
 
 const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
-const WRITING_SYSTEM_WARNING_REGEX = /^(ja|ko|cmn)(?![a-z])/;
+const UNSUPPORTED_LANGUAGE_CODES = [
+  'ko',
+  'kor',
+  'ja',
+  'jpn',
+  'cmn',
+  'czh',
+  'cdo',
+  'cjy',
+  'cmn',
+  'cpx',
+  'czh',
+  'czo',
+  'gan',
+  'hak',
+  'hsn',
+  'lzh',
+  'mnp',
+  'nan',
+  'quu',
+  'yue',
+  'cnp',
+  'csp',
+  'cpi',
+  'lzh',
+  'lpz',
+  'wuu',
+  'zh'
+];
 /** Scripture editing area. Used for Translate task.
  * ```
  * ┌─────────────────────────────────────┐
@@ -587,9 +615,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get writingSystemWarningBanner(): boolean {
     const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
-    return (
-      !isGecko() && writingSystemTag != null && WRITING_SYSTEM_WARNING_REGEX.test(writingSystemTag) && this.canEdit
-    );
+    const languageCode = writingSystemTag?.split('-')[0] ?? '';
+    const unsupportedLanguageCode = UNSUPPORTED_LANGUAGE_CODES.includes(languageCode);
+    return !isGecko() && writingSystemTag != null && unsupportedLanguageCode && this.canEdit;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -96,7 +96,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { getLinkHTML, issuesEmailTemplate, objectId } from 'xforge-common/utils';
+import { getBrowserEngine, getLinkHTML, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon, defaultNoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -249,6 +249,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private tabStateInitialized$ = new BehaviorSubject<boolean>(false);
   private readonly fabDiameter = 40;
   readonly fabVerticalCushion = 5;
+  readonly browserEngine: string = getBrowserEngine();
+  readonly translationWarningLanguages = ['ko', 'ja', 'cmn'];
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -500,6 +502,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return getLinkHTML(environment.issueEmail, issuesEmailTemplate());
   }
 
+  get browserWarningMessage(): string {
+    return translate('editor.browser_warning_banner', { firefoxLink: getLinkHTML('Firefox', 'https://firefox.com') });
+  }
+
   get showMultiViewers(): boolean {
     return this.onlineStatusService.isOnline && this.multiCursorViewers.length > 0;
   }
@@ -579,6 +585,15 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
   get targetLabel(): string | undefined {
     return this.projectDoc?.data?.shortName;
+  }
+
+  get showBrowserWarningBanner(): boolean {
+    const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
+    return (
+      writingSystemTag != null &&
+      this.translationWarningLanguages.includes(writingSystemTag) &&
+      this.browserEngine !== 'gecko'
+    );
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -96,7 +96,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { getLinkHTML, issuesEmailTemplate, objectId, browserLinks, isGecko } from 'xforge-common/utils';
+import { browserLinks, getLinkHTML, isGecko, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon, defaultNoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -161,7 +161,7 @@ export interface SaveNoteParameters {
 }
 
 const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
-
+const WRITING_SYSTEM_WARNING_REGEX = /^(ko|cmn|ja)$/;
 /** Scripture editing area. Used for Translate task.
  * ```
  * ┌─────────────────────────────────────┐
@@ -249,7 +249,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private tabStateInitialized$ = new BehaviorSubject<boolean>(false);
   private readonly fabDiameter = 40;
   readonly fabVerticalCushion = 5;
-  readonly writingSystemWarningRegex = /^(ko|cmn|ja)_?$/;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -588,7 +587,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get writingSystemWarningBanner(): boolean {
     const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
-    return !isGecko() && writingSystemTag != null && this.writingSystemWarningRegex.test(writingSystemTag);
+    return !isGecko() && writingSystemTag != null && WRITING_SYSTEM_WARNING_REGEX.test(writingSystemTag);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -615,7 +615,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get writingSystemWarningBanner(): boolean {
     const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
-    const languageCode = writingSystemTag?.split('-')[0] ?? '';
+    /*
+      We only want the beginning part of the language code identifier from Paratext.
+      Standard format is with a hyphen, checking for an underscore in the off
+      chance a SF project has saved the writing system tag with one.
+    */
+    const languageCode = writingSystemTag?.split(/-_/)[0] ?? '';
     const unsupportedLanguageCode = UNSUPPORTED_LANGUAGE_CODES.includes(languageCode);
     return !isGecko() && writingSystemTag != null && unsupportedLanguageCode && this.canEdit;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -161,7 +161,7 @@ export interface SaveNoteParameters {
 }
 
 const PUNCT_SPACE_REGEX = /^(?:\p{P}|\p{S}|\p{Cc}|\p{Z})+$/u;
-const WRITING_SYSTEM_WARNING_REGEX = /^(ko|cmn|ja)$/;
+const WRITING_SYSTEM_WARNING_REGEX = /^(ja|ko|cmn)(?![a-z])/;
 /** Scripture editing area. Used for Translate task.
  * ```
  * ┌─────────────────────────────────────┐

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -96,7 +96,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { browserLinks, getLinkHTML, isGecko, issuesEmailTemplate, objectId } from 'xforge-common/utils';
+import { browserLinks, getLinkHTML, isBlink, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { environment } from '../../../environments/environment';
 import { NoteThreadDoc, NoteThreadIcon, defaultNoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -529,7 +529,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get writingSystemWarningMessage(): string {
-    return translate('editor.browser_warning_banner', { firefoxLink: browserLinks().firefoxLink });
+    return translate('editor.browser_warning_banner', {
+      firefoxLink: browserLinks().firefoxLink,
+      safari: browserLinks().safariLink
+    });
   }
 
   get showMultiViewers(): boolean {
@@ -622,7 +625,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     */
     const languageCode = writingSystemTag?.split(/-_/)[0] ?? '';
     const unsupportedLanguageCode = UNSUPPORTED_LANGUAGE_CODES.includes(languageCode);
-    return !isGecko() && writingSystemTag != null && unsupportedLanguageCode && this.canEdit;
+    return isBlink() && writingSystemTag != null && unsupportedLanguageCode && this.canEdit;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -587,7 +587,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get writingSystemWarningBanner(): boolean {
     const writingSystemTag = this.projectDoc?.data?.writingSystem.tag;
-    return !isGecko() && writingSystemTag != null && WRITING_SYSTEM_WARNING_REGEX.test(writingSystemTag);
+    return (
+      !isGecko() && writingSystemTag != null && WRITING_SYSTEM_WARNING_REGEX.test(writingSystemTag) && this.canEdit
+    );
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,7 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
-    "browser_warning_banner": "The editor is not compatible with the current browser for the projects language. We recommend translating this project in {{ firefoxLink }} or {{ safari }}.",
+    "browser_warning_banner": "The editor is not compatible with the current browser for the project language. We recommend translating this project in {{ firefoxLink }} or {{ safari }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,7 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
-    "browser_warning_banner": "Translating to this language in Chrome could result in errors displaying in the editor. We recommend using {{ firefoxLink }}.",
+    "browser_warning_banner": "Your browser does not support editing in this language. We recommend using firefox. {{ firefoxLink }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,7 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
-    "browser_warning_banner": "The editor is not compatible with the current browser for the project language. We recommend translating this project in {{ firefoxLink }} or {{ safari }}.",
+    "browser_warning_banner": "The editor is not compatible with the current browser for the project language. We recommend editing this project in {{ firefoxLink }} or {{ safari }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,7 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
-    "browser_warning_banner": "Your browser does not support editing in this language. We recommend using {{ firefoxLink }}.",
+    "browser_warning_banner": "The editor is not compatible with the current browser for the projects language. We recommend translating this project in {{ firefoxLink }} or {{ safari }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,6 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
+    "browser_warning_banner": "Translating to this language in Chrome could result in errors displaying in the editor. We recommend using {{ firefoxLink }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -244,7 +244,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
-    "browser_warning_banner": "Your browser does not support editing in this language. We recommend using firefox. {{ firefoxLink }}.",
+    "browser_warning_banner": "Your browser does not support editing in this language. We recommend using {{ firefoxLink }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -62,8 +62,16 @@ export function getBrowserEngine(): string {
   return engine == null ? '' : engine.toLowerCase();
 }
 
+export function isBlink(): boolean {
+  return getBrowserEngine() === 'blink';
+}
+
 export function isGecko(): boolean {
   return getBrowserEngine() === 'gecko';
+}
+
+export function isWebkit(): boolean {
+  return getBrowserEngine() === 'webkit';
 }
 
 export function audioRecordingMimeType(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -70,10 +70,6 @@ export function isGecko(): boolean {
   return getBrowserEngine() === 'gecko';
 }
 
-export function isWebkit(): boolean {
-  return getBrowserEngine() === 'webkit';
-}
-
 export function audioRecordingMimeType(): string {
   // MediaRecorder.isTypeSupported('audio/webm') will erroneously return true on Firefox,
   // and so we must use browser sniffing in this case.


### PR DESCRIPTION
Added `app-notice` to `editor.component.html` to notify users to use Firefox if translation language is Korean, Japanese, or Chinese and the browser they are using is not Firefox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2699)
<!-- Reviewable:end -->
