### PR TITLE
Fix @for track expression in error dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.html
@@ -7,7 +7,7 @@
       <p class="unsupported-browser" [innerHTML]="t('unsupported_browser', browserLinks)"></p>
     }
     <p>
-      @for (portion of i18n.interpolateVariables("error.error_id", { errorId: data.eventId }); track portion) {
+      @for (portion of i18n.interpolateVariables("error.error_id", { errorId: data.eventId }); track portion.text) {
         @if (portion.id == null) {
           {{ portion.text }}
         }


### PR DESCRIPTION
If you select the error ID in the error dialog and press Ctrl, it clears the selection (there's probably a bunch of other ways to trigger this bug, but this is one). You can see this even in Storybook.

I think the reason is because it would trigger change detection, and the `track` option was wrong. The object it specifies changes each time, and so it would result in always creating new elements, which results in clearing the user's selection. Tracking by the text ensures that Angular understands nothing actually changed, and it doesn't need to re-render the elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2700)
<!-- Reviewable:end -->
