### PR TITLE
Allow downloading resources from Serval admin page, and other fixups

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -1,5 +1,6 @@
-<h1>{{ projectName }}</h1>
-<a mat-raised-button color="primary" [appRouterLink]="'/serval-administration'">Back to Projects</a>
+@if (showProjectTitle) {
+  <h1>{{ projectName }}</h1>
+}
 
 <h2>Pre-Translation Configuration</h2>
 <div class="admin-tool">
@@ -11,7 +12,7 @@
   <div class="admin-tool-control">
     <button
       id="run-webhook"
-      mat-raised-button
+      mat-flat-button
       color="primary"
       (click)="retrievePreTranslationStatus()"
       [disabled]="!isOnline"
@@ -26,7 +27,12 @@
 
 <h2>Downloads</h2>
 <app-notice icon="info">
-  The Zip archives contain the Paratext files for the project at the time of last sync.
+  <p>The Zip archives contain the Paratext files for the project at the time of last sync.</p>
+  <p>
+    Source projects may be listed here even if they are not currently being used for drafting. For example, if a user
+    selects an alternate source, but then unselects "Use a different source for drafting," the source will still be
+    listed here even though it is not currently set to be used for drafting.
+  </p>
 </app-notice>
 <div class="table-container">
   <table mat-table [dataSource]="rows">
@@ -41,11 +47,12 @@
       <th mat-header-cell *matHeaderCellDef></th>
       <td mat-cell *matCellDef="let row">
         <button
-          mat-raised-button
+          mat-flat-button
           color="primary"
           (click)="downloadProject(row['id'], row['fileName'])"
           [disabled]="!isOnline"
         >
+          <mat-icon>download</mat-icon>
           Download
         </button>
       </td>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -97,7 +97,7 @@ describe('ServalProjectComponent', () => {
     it('should disable the download button when offline', fakeAsync(() => {
       const env = new TestEnvironment(true);
       env.onlineStatus = false;
-      expect(env.firstDownloadButton.innerText).toBe('Download');
+      expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(true);
     }));
 
@@ -106,7 +106,7 @@ describe('ServalProjectComponent', () => {
       when(mockServalAdministrationService.downloadProject(anything())).thenReturn(
         throwError(() => new HttpErrorResponse({ status: 404 }))
       );
-      expect(env.firstDownloadButton.innerText).toBe('Download');
+      expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(false);
       env.clickElement(env.firstDownloadButton);
       verify(mockNoticeService.showError(anything())).once();
@@ -114,13 +114,13 @@ describe('ServalProjectComponent', () => {
 
     it('should have a download button', fakeAsync(() => {
       const env = new TestEnvironment(true);
-      expect(env.firstDownloadButton.innerText).toBe('Download');
+      expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(false);
     }));
 
     it('should allow clicking of the button to download', fakeAsync(() => {
       const env = new TestEnvironment(true);
-      expect(env.firstDownloadButton.innerText).toBe('Download');
+      expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(false);
       env.clickElement(env.firstDownloadButton);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -10,7 +10,6 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
 import { NoticeComponent } from '../shared/notice/notice.component';
@@ -34,6 +33,7 @@ interface Row {
   standalone: true
 })
 export class ServalProjectComponent extends DataLoadingComponent implements OnInit {
+  @Input() showProjectTitle = true;
   preTranslate = false;
   projectName = '';
 
@@ -85,10 +85,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           });
 
           // Add the source
-          if (
-            project.translateConfig.source != null &&
-            !ParatextService.isResource(project.translateConfig.source.paratextId)
-          ) {
+          if (project.translateConfig.source != null) {
             rows.push({
               id: project.translateConfig.source.projectRef,
               name: project.translateConfig.source.shortName + ' - ' + project.translateConfig.source.name,
@@ -98,10 +95,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           }
 
           // Add the alternate source
-          if (
-            project.translateConfig.draftConfig.alternateSource != null &&
-            !ParatextService.isResource(project.translateConfig.draftConfig.alternateSource.paratextId)
-          ) {
+          if (project.translateConfig.draftConfig.alternateSource != null) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateSource.projectRef,
               name:
@@ -114,10 +108,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           }
 
           // Add the alternate training source
-          if (
-            project.translateConfig.draftConfig.alternateTrainingSource != null &&
-            !ParatextService.isResource(project.translateConfig.draftConfig.alternateTrainingSource.paratextId)
-          ) {
+          if (project.translateConfig.draftConfig.alternateTrainingSource != null) {
             rows.push({
               id: project.translateConfig.draftConfig.alternateTrainingSource.projectRef,
               name:

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -375,7 +375,7 @@
     <mat-expansion-panel class="serval-administration">
       <mat-expansion-panel-header><h3>Serval Administration</h3></mat-expansion-panel-header>
       <ng-template matExpansionPanelContent>
-        <app-serval-project></app-serval-project>
+        <app-serval-project [showProjectTitle]="false"></app-serval-project>
       </ng-template>
     </mat-expansion-panel>
   </section>


### PR DESCRIPTION
- Hide project title when component is shown on the generate draft page
- Use flat Material buttons for consistency with rest of app
- Clarify that not all sources projects shown are necessarily in use
- Add download icon to download buttons

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2701)
<!-- Reviewable:end -->
