### PR TITLE
Wrap long lines in draft config on Serval project page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.scss
@@ -18,3 +18,7 @@
   display: flex;
   align-items: center;
 }
+
+pre {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Long lines in the draft config (e.g. when the user selected a lot of books) could flow off the page but didn't wrap.

This change causes new line characters to continue be respected, but long lines can still be wrapped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2702)
<!-- Reviewable:end -->
