### PR TITLE
SF-2955 Fix checking question layout

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -1,52 +1,41 @@
 <ng-container *transloco="let t; read: 'checking_answers'">
   <div class="answers-component">
     <div class="answers-component-scrollable-content">
-      <div>
+      <div class="answer-question">
         <app-checking-question [questionDoc]="questionDoc" (audioPlayed)="playAudio()"> </app-checking-question>
-        <div class="answer-question">
-          <div class="question">
-            <div class="question-text">{{ questionDoc?.data?.text }}</div>
-            @if (questionDoc?.data?.audioUrl) {
-              <div class="question-audio">
-                <app-checking-audio-player [source]="getFileSource(questionDoc?.data?.audioUrl)">
-                </app-checking-audio-player>
-              </div>
-            }
-            @if (canEditQuestion) {
-              <div class="question-footer">
-                <div class="actions">
-                  <button
-                    mat-icon-button
-                    type="button"
-                    (click)="questionDialog()"
-                    class="edit-question-button"
-                    [matTooltip]="t('edit')"
-                  >
-                    <mat-icon>edit</mat-icon>
-                  </button>
-                  <button
-                    mat-icon-button
-                    type="button"
-                    (click)="archiveQuestion()"
-                    class="archive-question-button"
-                    [matTooltip]="t('archive')"
-                  >
-                    <mat-icon>archive</mat-icon>
-                  </button>
-                </div>
-              </div>
+        @if (canEditQuestion) {
+          <div class="question-footer">
+            <div class="actions">
+              <button
+                mat-icon-button
+                type="button"
+                (click)="questionDialog()"
+                class="edit-question-button"
+                [matTooltip]="t('edit')"
+              >
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button
+                mat-icon-button
+                type="button"
+                (click)="archiveQuestion()"
+                class="archive-question-button"
+                [matTooltip]="t('archive')"
+              >
+                <mat-icon>archive</mat-icon>
+              </button>
+            </div>
+          </div>
+        }
+        @if (!answerFormVisible) {
+          <div class="actions">
+            @if (currentUserTotalAnswers === 0 && canAddAnswer) {
+              <button mat-flat-button color="primary" (click)="showAnswerForm()" id="add-answer">
+                {{ t("add_answer") }}
+              </button>
             }
           </div>
-          @if (!answerFormVisible) {
-            <div class="actions">
-              @if (currentUserTotalAnswers === 0 && canAddAnswer) {
-                <button mat-flat-button color="primary" (click)="showAnswerForm()" id="add-answer">
-                  {{ t("add_answer") }}
-                </button>
-              }
-            </div>
-          }
-        </div>
+        }
       </div>
       @if (answerFormVisible) {
         <div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -26,10 +26,6 @@
   flex-direction: column;
   row-gap: 4px;
 
-  .question-text {
-    font-weight: bold;
-  }
-
   .question-footer {
     margin-inline-start: 30px;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2493,7 +2493,7 @@ class TestEnvironment {
   }
 
   get audioPlayerOnQuestion(): DebugElement {
-    return this.answerPanel.query(By.css('.question-audio'));
+    return this.answerPanel.query(By.css('#questionAudio'));
   }
 
   get chapterAudio(): DebugElement {


### PR DESCRIPTION
A layout bug was introduced in PR #2694 which resulted in duplicate questions shown on the checking app. This removed the obsolete question layout code and fixes the tests that depended on the obsolete question audio element.

![Checking question layout](https://github.com/user-attachments/assets/11358d62-f295-4275-8534-63f152304cfd)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2703)
<!-- Reviewable:end -->
