### PR TITLE
Remove unneeded optional chaining in templates

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.html
@@ -2,7 +2,7 @@
   @for (comment of getSortedComments(); track comment; let i = $index) {
     <div>
       @if (
-        (activeComment == null || (commentFormVisible && activeComment?.dataId !== comment.dataId)) &&
+        (activeComment == null || (commentFormVisible && activeComment.dataId !== comment.dataId)) &&
         (i + 1 < maxCommentsToShow || commentCount === maxCommentsToShow || showAllComments)
       ) {
         <div class="comment" [ngClass]="{ 'comment-unread': !hasUserReadComment(comment) }">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -73,7 +73,7 @@
           </h1>
           <div mat-dialog-content>
             <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
-            @for (verse of versesOf(selection?.book, selection?.chapter); track verse) {
+            @for (verse of versesOf(selection.book, selection.chapter); track verse) {
               <button
                 mat-button
                 [ngClass]="{


### PR DESCRIPTION
This fixes warnings that are shown when running `npm run build:stats`

My guess is that the previous template syntax resulted in a situation where you couldn't

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2705)
<!-- Reviewable:end -->
