### PR TITLE
SF-2934 Notify user when joining a project fails

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -87,6 +87,11 @@
           {{ t(errorMessage) }}
         </app-notice>
       }
+      @if ((isOnline | async) === false) {
+        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
+          {{ t("offline") }}
+        </app-notice>
+      }
       @for (ptProject of userUnconnectedParatextProjects; track ptProject) {
         <mat-card
           attr.data-pt-project-id="{{ ptProject.paratextId }}"
@@ -120,7 +125,7 @@
               mat-flat-button
               color="primary"
               (click)="joinProject(ptProject.projectId)"
-              [disabled]="joiningProjects.includes(ptProject.projectId)"
+              [disabled]="!(isOnline | async) || joiningProjects.includes(ptProject.projectId)"
             >
               {{ t("join") }}
             </button>
@@ -138,11 +143,6 @@
           <div class="loading-project-description"></div>
           <div class="loading-action"></div>
         </mat-card>
-      }
-      @if ((isOnline | async) === false) {
-        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
-          {{ t("offline") }}
-        </app-notice>
       }
     </div>
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -87,7 +87,7 @@
           {{ t(errorMessage) }}
         </app-notice>
       }
-      @if ((isOnline | async) === false) {
+      @if (!(isOnline | async)) {
         <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
           {{ t("offline") }}
         </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -114,11 +114,17 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
   }
 
   async joinProject(projectId: string): Promise<void> {
-    this.noticeService.loadingStarted();
-    this.joiningProjects.push(projectId);
-    await this.projectService.onlineAddCurrentUser(projectId);
-    this.noticeService.loadingFinished();
-    this.router.navigate(['projects', projectId]);
+    try {
+      this.noticeService.loadingStarted();
+      this.joiningProjects.push(projectId);
+      await this.projectService.onlineAddCurrentUser(projectId);
+      this.router.navigate(['projects', projectId]);
+    } catch (err) {
+      this.noticeService.show(translate('my_projects.failed_to_join_project'));
+    } finally {
+      this.noticeService.loadingFinished();
+      this.joiningProjects.pop();
+    }
   }
 
   private async loadUser(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -368,6 +368,7 @@
     "dbl_resources": "Digital Bible Library resources",
     "drafting": "Drafting",
     "failed_to_connect_to_pt_server": "There was a problem connecting to Paratext to get your projects. Please try again later. If the problem persists after several hours, please report the issue for help.",
+    "failed_to_join_project": "Failed to join the project. Please check your internet connection and try again later.",
     "join": "Join",
     "loading_more_pt_projects": "Loading additional Paratext projects ...",
     "looking_for_another_project": "Looking for another project?",


### PR DESCRIPTION
Users cannot join a project while they are offline because it requires hitting an endpoint on the server. This change will allow the error to be caught while the user is not online and notify the user that they failed to join the project.

![My projects failed to join](https://github.com/user-attachments/assets/e1fbdd10-8245-4e22-ac96-3f248f430fd4)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2708)
<!-- Reviewable:end -->
