### PR TITLE
SF-2950 Fix authentication failure when joining a project with a link

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -262,6 +262,8 @@ export class AuthService {
       appState: JSON.stringify(state)
     };
     this.unscheduleRenewal();
+    console.log(returnUrl);
+    console.log(auth0Parameters);
     await this.auth0.loginWithRedirect(authOptions);
   }
 
@@ -425,10 +427,20 @@ export class AuthService {
           // Auth0 as they may still have a valid refresh token
           // Connections to Auth0 from Scripture Forge use the Auth0 API which has different expiry timestamps on tokens
           // compared with the tokens used directly in the Auth0 website application
+          console.log('Joining with share key');
           if (this.idToken != null) {
-            await this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
-            // Return a NEVER promise to graceful wait for the redirection to complete without showing the join page
-            return new Promise<never>(() => {});
+            console.log('User may be logged in - renew tokens');
+            // Attempt to renew tokens first otherwise send them to Auth0
+            await this.renewTokens();
+            if (await this.hasExpired()) {
+              console.log('Tokens have expired - send to Auth0');
+              // Return a NEVER promise to graceful wait for the redirection to complete from renewTokens
+              // without showing the join page
+              return new Promise<never>(() => {});
+            }
+            console.log('Tokens have been renewed');
+            await this.remoteStore.init(() => this.getAccessToken());
+            return { loggedIn: true, newlyLoggedIn: true, anonymousUser: true };
           } else if (await this.tryTransparentAuthentication()) {
             return { loggedIn: true, newlyLoggedIn: true, anonymousUser: true };
           }
@@ -592,6 +604,7 @@ export class AuthService {
   }
 
   private async renewTokens(): Promise<void> {
+    console.log('Renewing tokens');
     if (this.renewTokenPromise == null) {
       this.renewTokenPromise = new Promise<void>(async (resolve, reject) => {
         let success = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -262,8 +262,6 @@ export class AuthService {
       appState: JSON.stringify(state)
     };
     this.unscheduleRenewal();
-    console.log(returnUrl);
-    console.log(auth0Parameters);
     await this.auth0.loginWithRedirect(authOptions);
   }
 
@@ -427,18 +425,14 @@ export class AuthService {
           // Auth0 as they may still have a valid refresh token
           // Connections to Auth0 from Scripture Forge use the Auth0 API which has different expiry timestamps on tokens
           // compared with the tokens used directly in the Auth0 website application
-          console.log('Joining with share key');
           if (this.idToken != null) {
-            console.log('User may be logged in - renew tokens');
             // Attempt to renew tokens first otherwise send them to Auth0
             await this.renewTokens();
             if (await this.hasExpired()) {
-              console.log('Tokens have expired - send to Auth0');
               // Return a NEVER promise to graceful wait for the redirection to complete from renewTokens
               // without showing the join page
               return new Promise<never>(() => {});
             }
-            console.log('Tokens have been renewed');
             await this.remoteStore.init(() => this.getAccessToken());
             return { loggedIn: true, newlyLoggedIn: true, anonymousUser: true };
           } else if (await this.tryTransparentAuthentication()) {
@@ -604,7 +598,6 @@ export class AuthService {
   }
 
   private async renewTokens(): Promise<void> {
-    console.log('Renewing tokens');
     if (this.renewTokenPromise == null) {
       this.renewTokenPromise = new Promise<void>(async (resolve, reject) => {
         let success = false;


### PR DESCRIPTION
I've added comments to the Jira card explaining the situation as well as some to our `auth.service`.

TLDR: Tokens had expired in Scripture Forge but were still valid when on the Auth0 website login page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2709)
<!-- Reviewable:end -->
