### PR TITLE
WIP SF-2911 Fix sync failures caused by Paratext username changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -432,11 +432,14 @@ export class NoteDialogComponent implements OnInit {
 
     // If the user is not a PT user, or the note was created in SF, or the user created the note
     if (
-      syncUser == null || // There is no sync user, i.e. the note is not synced yet or the current user is not a PT user
-      note.editable || // Only notes created in SF are editable, so display the SF owner, falling back to the sync user
-      syncUser.sfUserId === ownerDoc.id // The note is not editable, but the sync user is the owner, so use the SF owner
+      // There is no sync user, i.e. the note is not synced yet or the current user is not a PT user
+      syncUser == null ||
+      // Only notes created in SF are editable, so display the SF owner, falling back to the sync user
+      note.editable ||
+      // The note is not editable, but the sync user is the owner, so use the SF owner
+      syncUser.sfUserId === note.ownerRef
     ) {
-      return this.userService.currentUserId === ownerDoc.id
+      return this.userService.currentUserId === note.ownerRef
         ? translate('checking.me') // "Me", i.e. the current user
         : (ownerDoc.data?.displayName ?? // Another user
             syncUser?.username ?? // Fallback to the sync user

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2823,8 +2823,7 @@ public class ParatextService : DisposableBase, IParatextService
 
                     // We can only update a note if the comment and note have the same version number.
                     // Or if the note is authored by a commenter, set the comment content to be the SF note content
-                    bool isCommenterNote =
-                        ptProjectUsers.Values.SingleOrDefault(p => p.SFUserId == note.OwnerRef) == null;
+                    bool isCommenterNote = !ptProjectUsers.Values.Any(p => p.SFUserId == note.OwnerRef);
                     if (note.VersionNumber == comment.VersionNumber || isCommenterNote)
                     {
                         bool commentUpdated = false;
@@ -2986,10 +2985,11 @@ public class ParatextService : DisposableBase, IParatextService
     {
         if (note.Content == null)
             return null;
+        string syncUser = note.SyncUserRef;
         string ownerId = note.OwnerRef;
         // if the user is a paratext user, keep the note content as is
         if (
-            ptProjectUsers.Values.SingleOrDefault(u => u.SFUserId == ownerId) != null
+            ptProjectUsers.Values.Any(u => u.SFUserId == ownerId)
             || !displayNames.TryGetValue(ownerId, out string displayName)
         )
             return note.Content;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2823,7 +2823,7 @@ public class ParatextService : DisposableBase, IParatextService
 
                     // We can only update a note if the comment and note have the same version number.
                     // Or if the note is authored by a commenter, set the comment content to be the SF note content
-                    bool isCommenterNote = !ptProjectUsers.Values.Any(p => p.SFUserId == note.OwnerRef);
+                    bool isCommenterNote = !ptProjectUsers.Values.Any(u => u.SFUserId == note.OwnerRef);
                     if (note.VersionNumber == comment.VersionNumber || isCommenterNote)
                     {
                         bool commentUpdated = false;
@@ -2985,13 +2985,10 @@ public class ParatextService : DisposableBase, IParatextService
     {
         if (note.Content == null)
             return null;
-        string syncUser = note.SyncUserRef;
-        string ownerId = note.OwnerRef;
+
         // if the user is a paratext user, keep the note content as is
-        if (
-            ptProjectUsers.Values.Any(u => u.SFUserId == ownerId)
-            || !displayNames.TryGetValue(ownerId, out string displayName)
-        )
+        bool isParatextUser = ptProjectUsers.Any(u => u.Value.SFUserId == note.OwnerRef);
+        if (isParatextUser || !displayNames.TryGetValue(note.OwnerRef, out string displayName))
             return note.Content;
 
         var contentElem = new XElement("Contents");

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1837,6 +1837,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 {
                     ParatextUserProfile existingUser = _projectDoc.Data.ParatextUsers.SingleOrDefault(u =>
                         u.Username == activePtSyncUser.Username
+                        || (!string.IsNullOrEmpty(u.SFUserId) && string.Equals(u.SFUserId, activePtSyncUser.SFUserId))
                     );
                     if (existingUser == null)
                         op.Add(pd => pd.ParatextUsers, activePtSyncUser);
@@ -1848,6 +1849,11 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         string userId = _currentPtSyncUsers[existingUser.Username].SFUserId;
                         if (!string.IsNullOrEmpty(userId))
                             op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
+                    }
+                    else if (!string.Equals(existingUser.Username, activePtSyncUser.Username))
+                    {
+                        int index = _projectDoc.Data.ParatextUsers.FindIndex(u => u.SFUserId == existingUser.SFUserId);
+                        op.Set(pd => pd.ParatextUsers[index].Username, activePtSyncUser.Username);
                     }
                 }
             });

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -615,7 +615,7 @@ public class ParatextSyncRunnerTests
 
         SFProject project = env.VerifyProjectSync(true);
 
-        List<ParatextUserProfile> afterParatextUsers = env.GetProject().ParatextUsers;
+        List<ParatextUserProfile> afterParatextUsers = project.ParatextUsers;
         Assert.That(afterParatextUsers.Count, Is.EqualTo(2));
         Assert.That(afterParatextUsers[0].Username, Is.EqualTo("User 1"));
         Assert.That(afterParatextUsers[1].Username, Is.EqualTo("User 2 Changed"));

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -587,7 +587,9 @@ public class ParatextSyncRunnerTests
         List<ParatextUserProfile> beforeParatextUsers = env.GetProject().ParatextUsers;
         Assert.That(beforeParatextUsers.Count, Is.EqualTo(2));
         Assert.That(beforeParatextUsers[0].Username, Is.EqualTo("User 1"));
+        Assert.That(beforeParatextUsers[0].SFUserId, Is.EqualTo("pt01"));
         Assert.That(beforeParatextUsers[1].Username, Is.EqualTo("User 2"));
+        Assert.That(beforeParatextUsers[1].SFUserId, Is.EqualTo("pt02"));
 
         env.ParatextService.GetParatextUsersAsync(
                 Arg.Any<UserSecret>(),
@@ -598,14 +600,16 @@ public class ParatextSyncRunnerTests
                 [
                     TestEnvironment.ParatextProjectUser01 with
                     {
-                        Id = "user01",
-                        ParatextId = "pt01",
+                        Id = "pt01",
+                        ParatextId = "user01",
                         Role = SFProjectRole.Administrator,
                         Username = "User 1"
                     },
                     TestEnvironment.ParatextProjectUser02 with
                     {
                         Id = "pt02",
+                        ParatextId = "user02",
+                        Role = SFProjectRole.Administrator,
                         Username = "User 2 Changed"
                     }
                 ]
@@ -616,9 +620,13 @@ public class ParatextSyncRunnerTests
         SFProject project = env.VerifyProjectSync(true);
 
         List<ParatextUserProfile> afterParatextUsers = project.ParatextUsers;
-        Assert.That(afterParatextUsers.Count, Is.EqualTo(2));
+        Assert.That(afterParatextUsers.Count, Is.EqualTo(3));
         Assert.That(afterParatextUsers[0].Username, Is.EqualTo("User 1"));
-        Assert.That(afterParatextUsers[1].Username, Is.EqualTo("User 2 Changed"));
+        Assert.That(afterParatextUsers[0].SFUserId, Is.EqualTo("pt01"));
+        Assert.That(afterParatextUsers[1].Username, Is.EqualTo("User 2"));
+        Assert.That(afterParatextUsers[2].Username, Is.EqualTo("User 2 Changed"));
+        Assert.That(afterParatextUsers[2].OpaqueUserId, Is.Not.EqualTo(afterParatextUsers[1].OpaqueUserId));
+        Assert.That(afterParatextUsers[2].SFUserId, Is.EqualTo("pt02"));
     }
 
     [Test]


### PR DESCRIPTION
Updated `existingUsers` to check the Projects Paratext users by `SFUserId` rather than just on `username`.
Added conditional to compare on `Username` and update `existingUser` if it has changed.

Updated tests to include optional `SFUserId` for user name changes or other future tests when setting the SF Data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2710)
<!-- Reviewable:end -->
