### PR TITLE
SF-2958 Remove dependency on MediaObserver

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -1,11 +1,11 @@
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { NavigationEnd, Router } from '@angular/router';
 import Bugsnag from '@bugsnag/js';
 import { translate } from '@ngneat/transloco';
 import { cloneDeep } from 'lodash-es';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
-import { AuthType, getAuthType, User } from 'realtime-server/lib/esm/common/models/user';
+import { AuthType, User, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { Observable, Subscription } from 'rxjs';
@@ -21,6 +21,7 @@ import { FeatureFlagsDialogComponent } from 'xforge-common/feature-flags/feature
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
+import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -73,9 +74,10 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly reportingService: ErrorReportingService,
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly locationService: LocationService,
+    private readonly breakpointObserver: BreakpointObserver,
+    private readonly breakpointService: MediaBreakpointService,
     readonly noticeService: NoticeService,
     readonly i18n: I18nService,
-    readonly media: MediaObserver,
     readonly urls: ExternalUrlService,
     readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService,
@@ -83,13 +85,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   ) {
     super(noticeService);
     this.subscribe(
-      media.asObservable().pipe(
-        filter((changes: MediaChange[]) => changes.length > 0),
-        map((changes: MediaChange[]) => changes[0])
-      ),
-      (change: MediaChange) => {
-        this.isDrawerPermanent = ['xl', 'lt-xl', 'lg', 'lt-lg'].includes(change.mqAlias);
-      }
+      this.breakpointObserver.observe(this.breakpointService.width('>', Breakpoint.MD)),
+      (value: BreakpointState) => (this.isDrawerPermanent = value.matches)
     );
 
     // Check full online status changes

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -15,7 +15,6 @@ import {
   ViewChildren
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MediaObserver } from '@angular/flex-layout';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
@@ -259,7 +258,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     noticeService: NoticeService,
     private readonly dialogService: DialogService,
     private readonly changeDetector: ChangeDetectorRef,
-    private readonly mediaObserver: MediaObserver,
+
     private readonly onlineStatusService: OnlineStatusService,
     private readonly translationEngineService: TranslationEngineService,
     readonly i18n: I18nService,
@@ -574,7 +573,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private get isCommenterOnMobileDevice(): boolean {
-    return !this.hasEditRight && this.mediaObserver.isActive('lt-lg');
+    return (
+      !this.hasEditRight && this.breakpointObserver.isMatched(this.mediaBreakpointService.width('<', Breakpoint.LG))
+    );
   }
 
   private get canShowInsertNoteFab(): boolean {
@@ -1099,7 +1100,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       verseRef = getVerseRefFromSegmentRef(this.bookNum, defaultSegmentRef);
     }
     // Mobile users can use the bottom sheet to add new notes
-    if (this.mediaObserver.isActive('lt-lg')) {
+    if (this.breakpointObserver.isMatched(this.mediaBreakpointService.width('<', Breakpoint.LG))) {
       this.toggleAddingMobileNote();
       this.setNoteFabVisibility('hidden');
       this.bottomSheetRef = this.bottomSheet.open(this.TemplateBottomSheet, { hasBackdrop: false });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.spec.ts
@@ -1,15 +1,17 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBreakpointObserver } from 'xforge-common/test-breakpoint-observer';
+import { configureTestingModule } from 'xforge-common/test-utils';
 import { MultiViewerComponent } from './multi-viewer.component';
 
 describe('MultiViewerComponent', () => {
   let component: MultiViewerComponent;
   let fixture: ComponentFixture<MultiViewerComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [MultiViewerComponent]
-    }).compileComponents();
-  });
+  configureTestingModule(() => ({
+    declarations: [MultiViewerComponent],
+    providers: [{ provide: BreakpointObserver, useClass: TestBreakpointObserver }]
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MultiViewerComponent);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -47,10 +47,8 @@ export class MultiViewerComponent extends SubscriptionDisposable implements OnIn
         this.breakpointObserver.observe(this.breakpointService.width('<=', Breakpoint.XS))
       ]),
       ([bigger, xs]) => {
-        const isViewportBigger: boolean = bigger.matches;
-        this.maxAvatars = isViewportBigger ? 6 : 3;
-        const isViewportXS: boolean = xs.matches;
-        this.maxAvatars = isViewportXS ? 1 : this.maxAvatars;
+        // initialize to 3, but if > SM then set to 6, else if <= XS then set to 1
+        this.maxAvatars = bigger.matches ? 6 : xs.matches ? 1 : 3;
       }
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-breakpoint-observer.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-breakpoint-observer.ts
@@ -1,0 +1,28 @@
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+/** This class is a helper for tests. */
+@Injectable({
+  providedIn: 'root'
+})
+export class TestBreakpointObserver extends BreakpointObserver {
+  private observe$: Subject<BreakpointState> = new Subject<BreakpointState>();
+  private isMatchedResult: boolean = true;
+
+  set matchedResult(value: boolean) {
+    this.isMatchedResult = value;
+  }
+
+  observe(): Observable<BreakpointState> {
+    return this.observe$;
+  }
+
+  isMatched(_: string | readonly string[]): boolean {
+    return this.isMatchedResult;
+  }
+
+  emitObserveValue(result: boolean): void {
+    this.observe$.next({ matches: result } as BreakpointState);
+  }
+}


### PR DESCRIPTION
This PR removes the dependency for the MediaObserver from the angular/flex-layout library and replaces it with the BreakpointObserver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2711)
<!-- Reviewable:end -->
