### PR TITLE
SF-2961 Skip getting draft build when project has no draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -4,7 +4,11 @@ import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { BiblicalTerm } from 'realtime-server/lib/esm/scriptureforge/models/biblical-term';
 import { getNoteThreadDocId, NoteStatus, NoteThread } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
-import { SF_PROJECTS_COLLECTION, SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import {
+  SF_PROJECTS_COLLECTION,
+  SFProject,
+  SFProjectProfile
+} from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { getSFProjectUserConfigDocId } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config';
@@ -45,6 +49,10 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     protected readonly retryingRequestService: RetryingRequestService
   ) {
     super(realtimeService, commandService, retryingRequestService, SF_PROJECT_ROLES);
+  }
+
+  static hasDraft(project: SFProjectProfile): boolean {
+    return project.texts.some(text => text.chapters.some(chapter => chapter.hasDraft));
   }
 
   async onlineCreate(settings: SFProjectCreateSettings): Promise<string> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -165,6 +165,24 @@ describe('ServalProjectComponent', () => {
       env.clickElement(env.downloadDraftButton);
       verify(mockNoticeService.showError(anything())).once();
     }));
+
+    describe('get last completed build', () => {
+      it('does not get last completed build if project does not have drafting enabled', fakeAsync(() => {
+        const env = new TestEnvironment(false);
+        verify(mockDraftGenerationService.getLastCompletedBuild(anything())).never();
+        verify(mockDraftGenerationService.getBuildProgress(anything())).never();
+        expect(env.component.translationBooks.length).toEqual(0);
+      }));
+
+      it('gets last completed build if drafting enabled and translation books selected', fakeAsync(() => {
+        const env = new TestEnvironment(true, {} as BuildDto);
+        tick();
+        env.fixture.detectChanges();
+        verify(mockDraftGenerationService.getLastCompletedBuild(anything())).once();
+        verify(mockDraftGenerationService.getBuildProgress(anything())).once();
+        expect(env.component.translationBooks.length).toEqual(2);
+      }));
+    });
   });
 
   class TestEnvironment {
@@ -198,7 +216,7 @@ describe('ServalProjectComponent', () => {
                 shortName: 'P4'
               },
               lastSelectedTrainingBooks: [1, 2],
-              lastSelectedTranslationBooks: [3, 4]
+              lastSelectedTranslationBooks: preTranslate ? [3, 4] : []
             },
             preTranslate: preTranslate,
             source: {
@@ -218,6 +236,7 @@ describe('ServalProjectComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(mockProjectDoc$);
 
       when(mockDraftGenerationService.getLastCompletedBuild(this.mockProjectId)).thenReturn(of(lastCompletedBuild));
+      when(mockDraftGenerationService.getBuildProgress(this.mockProjectId)).thenReturn(of(lastCompletedBuild));
       when(mockServalAdministrationService.downloadProject(anything())).thenReturn(of(new Blob()));
       when(mockAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
       when(mockDraftGenerationService.getBuildProgress(anything())).thenReturn(of({ additionalInfo: {} } as BuildDto));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -165,24 +165,26 @@ describe('ServalProjectComponent', () => {
       env.clickElement(env.downloadDraftButton);
       verify(mockNoticeService.showError(anything())).once();
     }));
+  });
 
-    describe('get last completed build', () => {
-      it('does not get last completed build if project does not have drafting enabled', fakeAsync(() => {
-        const env = new TestEnvironment(false);
-        verify(mockDraftGenerationService.getLastCompletedBuild(anything())).never();
-        verify(mockDraftGenerationService.getBuildProgress(anything())).never();
-        expect(env.component.translationBooks.length).toEqual(0);
-      }));
+  describe('get last completed build', () => {
+    it('does not get last completed build if project does not have draft books', fakeAsync(() => {
+      const env = new TestEnvironment(false);
+      tick();
+      env.fixture.detectChanges();
+      expect(env.component.preTranslate).toBe(false);
+      verify(mockDraftGenerationService.getLastCompletedBuild(anything())).never();
+      verify(mockDraftGenerationService.getBuildProgress(anything())).never();
+    }));
 
-      it('gets last completed build if drafting enabled and translation books selected', fakeAsync(() => {
-        const env = new TestEnvironment(true, {} as BuildDto);
-        tick();
-        env.fixture.detectChanges();
-        verify(mockDraftGenerationService.getLastCompletedBuild(anything())).once();
-        verify(mockDraftGenerationService.getBuildProgress(anything())).once();
-        expect(env.component.translationBooks.length).toEqual(2);
-      }));
-    });
+    it('gets last completed build if drafting enabled and draft books exist', fakeAsync(() => {
+      const env = new TestEnvironment(true, {} as BuildDto);
+      tick();
+      env.fixture.detectChanges();
+      expect(env.component.preTranslate).toBe(true);
+      verify(mockDraftGenerationService.getLastCompletedBuild(anything())).once();
+      verify(mockDraftGenerationService.getBuildProgress(anything())).once();
+    }));
   });
 
   class TestEnvironment {
@@ -201,6 +203,12 @@ describe('ServalProjectComponent', () => {
         data: createTestProjectProfile({
           name: 'Project 01',
           shortName: 'P1',
+          texts: [
+            { bookNum: 1, chapters: [{ number: 1, hasDraft: false }] },
+            { bookNum: 2, chapters: [{ number: 1, hasDraft: false }] },
+            { bookNum: 3, chapters: [{ number: 1, hasDraft: preTranslate }] },
+            { bookNum: 4, chapters: [{ number: 1, hasDraft: preTranslate }] }
+          ],
           translateConfig: {
             draftConfig: {
               alternateSource: {
@@ -215,10 +223,10 @@ describe('ServalProjectComponent', () => {
                 name: 'Project 04',
                 shortName: 'P4'
               },
-              lastSelectedTrainingBooks: [1, 2],
+              lastSelectedTrainingBooks: preTranslate ? [1, 2] : [],
               lastSelectedTranslationBooks: preTranslate ? [3, 4] : []
             },
-            preTranslate: preTranslate,
+            preTranslate,
             source: {
               paratextId: 'ptproject02',
               projectRef: 'project02',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -16,6 +16,7 @@ import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
 import { NoticeComponent } from '../shared/notice/notice.component';
 import { SharedModule } from '../shared/shared.module';
+import { projectLabel } from '../shared/utils';
 import { DraftZipProgress } from '../translate/draft-generation/draft-generation';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DraftInformationComponent } from '../translate/draft-generation/draft-information/draft-information.component';
@@ -84,7 +85,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           if (projectDoc.data == null) return of(undefined);
           const project: SFProjectProfile = projectDoc.data;
           this.preTranslate = project.translateConfig.preTranslate;
-          this.projectName = project.shortName + ' - ' + project.name;
+          this.projectName = projectLabel(project);
 
           // Setup the downloads table
           const rows: Row[] = [];
@@ -150,10 +151,10 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           );
 
           this.draftConfig = project.translateConfig.draftConfig;
-          this.draftJob$ = this.translationBooks.length > 0 ? this.getDraftJob(projectDoc.id) : of(undefined);
+          this.draftJob$ = SFProjectService.hasDraft(project) ? this.getDraftJob(projectDoc.id) : of(undefined);
 
           // Get the last completed build
-          if (this.isOnline && this.translationBooks.length > 0) {
+          if (this.isOnline && SFProjectService.hasDraft(project)) {
             return this.draftGenerationService.getLastCompletedBuild(projectDoc.id);
           } else {
             return of(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -4,7 +4,7 @@ import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { catchError, lastValueFrom, Observable, of, Subscription, switchMap, throwError } from 'rxjs';
+import { Observable, Subscription, catchError, lastValueFrom, of, switchMap, throwError } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -150,10 +150,10 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           );
 
           this.draftConfig = project.translateConfig.draftConfig;
-          this.draftJob$ = this.getDraftJob(projectDoc.id);
+          this.draftJob$ = this.translationBooks.length > 0 ? this.getDraftJob(projectDoc.id) : of(undefined);
 
           // Get the last completed build
-          if (this.isOnline) {
+          if (this.isOnline && this.translationBooks.length > 0) {
             return this.draftGenerationService.getLastCompletedBuild(projectDoc.id);
           } else {
             return of(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-menu.service.ts
@@ -5,7 +5,6 @@ export interface TabMenuItem {
   text: string;
   icon?: string;
   svgIcon?: string;
-  disabled?: boolean;
 }
 
 export abstract class TabMenuService<TGroupId extends string> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -48,12 +48,7 @@
   <mat-menu #newTabMenu>
     <!-- Migrating to control flow causes an "Expression changed after check" error when tabs are dragged -->
     <ng-container *ngIf="(menuItems$ | async)?.length; else emptyMenu">
-      <button
-        *ngFor="let item of menuItems$ | async"
-        mat-menu-item
-        [disabled]="item.disabled"
-        (click)="tabAddRequest.next(item.type)"
-      >
+      <button *ngFor="let item of menuItems$ | async" mat-menu-item (click)="tabAddRequest.next(item.type)">
         <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
         <mat-icon *ngIf="item.svgIcon" [svgIcon]="item.svgIcon"></mat-icon>
         <span>{{ item.text }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -155,9 +155,11 @@ describe('EditorTabMenuService', () => {
     service['canShowResource'] = () => false;
 
     service.getMenuItems().subscribe(items => {
-      expect(items.length).toBe(1);
+      expect(items.length).toBe(2);
       expect(items[0].type).toBe('biblical-terms');
       expect(items[0].disabled).toBeFalsy();
+      expect(items[1].type).toBe('draft');
+      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -150,7 +150,6 @@ describe('EditorTabMenuService', () => {
   it('should get "biblical terms" menu item', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([]);
-    env.setLastCompletedBuildExists(false);
     service['canShowBiblicalTerms'] = () => true;
     service['canShowHistory'] = () => false;
     service['canShowResource'] = () => false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -136,6 +136,27 @@ describe('EditorTabMenuService', () => {
     });
   });
 
+  it('should get "project-resources" and "history", and not "draft" when draft does not exist', done => {
+    const projectDoc = {
+      id: 'project-no-draft',
+      data: createTestProjectProfile({ translateConfig: { draftConfig: { lastSelectedTranslationBooks: [] } } })
+    } as SFProjectProfileDoc;
+    const env = new TestEnvironment(projectDoc);
+    env.setExistingTabs([]);
+    service['canShowHistory'] = () => true;
+    service['canShowResource'] = () => true;
+
+    verify(draftGenerationServiceMock.getLastCompletedBuild(anything())).never();
+    service.getMenuItems().subscribe(items => {
+      expect(items.length).toBe(2);
+      expect(items[0].type).toBe('history');
+      expect(items[0].disabled).toBeFalsy();
+      expect(items[1].type).toBe('project-resource');
+      expect(items[1].disabled).toBeFalsy();
+      done();
+    });
+  });
+
   it('should get "biblical terms" menu item', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([]);
@@ -255,7 +276,8 @@ class TestEnvironment {
     id: 'project1',
     data: createTestProjectProfile({
       translateConfig: {
-        preTranslate: true
+        preTranslate: true,
+        draftConfig: { lastSelectedTranslationBooks: [40] }
       },
       userRoles: TestEnvironment.rolesByUser
     })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -139,7 +139,7 @@ describe('EditorTabMenuService', () => {
   it('should get "project-resources" and "history", and not "draft" when draft does not exist', done => {
     const projectDoc = {
       id: 'project-no-draft',
-      data: createTestProjectProfile({ translateConfig: { draftConfig: { lastSelectedTranslationBooks: [] } } })
+      data: createTestProjectProfile({ translateConfig: { preTranslate: false } })
     } as SFProjectProfileDoc;
     const env = new TestEnvironment(projectDoc);
     env.setExistingTabs([]);
@@ -275,9 +275,13 @@ class TestEnvironment {
   readonly projectDoc = {
     id: 'project1',
     data: createTestProjectProfile({
+      texts: [
+        { bookNum: 40, chapters: [{ number: 1, hasDraft: false }] },
+        { bookNum: 41, chapters: [{ number: 1, hasDraft: true }] }
+      ],
       translateConfig: {
         preTranslate: true,
-        draftConfig: { lastSelectedTranslationBooks: [40] }
+        draftConfig: { lastSelectedTranslationBooks: [40], lastSelectedTrainingBooks: [41] }
       },
       userRoles: TestEnvironment.rolesByUser
     })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -25,7 +25,7 @@ const tabStateMock: TabStateService<any, any> = mock(TabStateService);
 const mockUserService = mock(UserService);
 const mockAuthService = mock(AuthService);
 
-fdescribe('EditorTabMenuService', () => {
+describe('EditorTabMenuService', () => {
   configureTestingModule(() => ({
     imports: [TestRealtimeModule.forRoot(SF_TYPE_REGISTRY), TestOnlineStatusModule.forRoot(), TestTranslocoModule],
     providers: [

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -48,11 +48,8 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(3);
       expect(items[0].type).toBe('history');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('draft');
-      expect(items[1].disabled).toBeFalsy();
       expect(items[2].type).toBe('project-resource');
-      expect(items[2].disabled).toBeFalsy();
       done();
     });
   });
@@ -70,9 +67,7 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('history');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('project-resource');
-      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });
@@ -86,7 +81,6 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(1);
       expect(items[0].type).toBe('history');
-      expect(items[0].disabled).toBeFalsy();
       done();
     });
   });
@@ -100,9 +94,7 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('draft');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('project-resource');
-      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });
@@ -120,9 +112,7 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('history');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('project-resource');
-      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });
@@ -140,9 +130,7 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('history');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('project-resource');
-      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });
@@ -157,9 +145,7 @@ describe('EditorTabMenuService', () => {
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
       expect(items[0].type).toBe('biblical-terms');
-      expect(items[0].disabled).toBeFalsy();
       expect(items[1].type).toBe('draft');
-      expect(items[1].disabled).toBeFalsy();
       done();
     });
   });
@@ -189,7 +175,6 @@ describe('EditorTabMenuService', () => {
       .subscribe(items => {
         expect(items.length).toBe(1);
         expect(items[0].type).toBe('history');
-        expect(items[0].disabled).toBeFalsy();
       });
 
     env.onlineStatus.setIsOnline(true);
@@ -199,11 +184,8 @@ describe('EditorTabMenuService', () => {
       .subscribe(items => {
         expect(items.length).toBe(3);
         expect(items[0].type).toBe('history');
-        expect(items[0].disabled).toBeFalsy();
         expect(items[1].type).toBe('draft');
-        expect(items[1].disabled).toBeFalsy();
         expect(items[2].type).toBe('project-resource');
-        expect(items[2].disabled).toBeFalsy();
         done();
       });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -6,7 +6,7 @@ import {
   editorTabTypes
 } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { combineLatest, forkJoin, map, Observable, of } from 'rxjs';
+import { Observable, combineLatest, forkJoin, map, of } from 'rxjs';
 import { shareReplay, switchMap, take } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -50,7 +50,10 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
         return combineLatest([
           of(projectDoc),
           of(isOnline),
-          !isOnline || projectDoc.data == null || ParatextService.isResource(projectDoc.data.paratextId)
+          !isOnline ||
+          projectDoc.data == null ||
+          projectDoc.data.translateConfig.draftConfig.lastSelectedTranslationBooks.length < 1 ||
+          ParatextService.isResource(projectDoc.data.paratextId)
             ? of(undefined)
             : this.draftGenerationService.getLastCompletedBuild(projectDoc.id),
           this.tabState.tabs$

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -16,6 +16,7 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { PermissionsService } from '../../../core/permissions.service';
+import { SFProjectService } from '../../../core/sf-project.service';
 import { TabMenuItem, TabMenuService, TabStateService } from '../../../shared/sf-tab-group';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { EditorTabInfo } from './editor-tabs.types';
@@ -52,7 +53,7 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
           of(isOnline),
           !isOnline ||
           projectDoc.data == null ||
-          projectDoc.data.translateConfig.draftConfig.lastSelectedTranslationBooks.length < 1 ||
+          !SFProjectService.hasDraft(projectDoc.data) ||
           ParatextService.isResource(projectDoc.data.paratextId)
             ? of(undefined)
             : this.draftGenerationService.getLastCompletedBuild(projectDoc.id),


### PR DESCRIPTION
Even when the project has no pre-translation build, the tab menu service would attempt to get the last pre-translation build. The error would be caught, but it would still log in the console that there was a 404 error. This change skips attempting to get the pre-translation build when the project's draft config has no last selected translation book (the most direct indication that no pre-translation build exists)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2713)
<!-- Reviewable:end -->
