### PR TITLE
SF-2959 Remove fxShow and fxHide from component templates

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -50,10 +50,10 @@
             <mat-expansion-panel-header>
               <mat-panel-title>
                 <span fxFlex>{{ getBookName(text) }}</span>
-                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
+                <span fxFlex="110px" fxLayoutAlign="end center" class="questions-count hide-lt-sm">
                   {{ questionCountLabel(bookQuestionCount(text)) }}
                 </span>
-                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
                   {{ answerCountLabel(bookAnswerCount(text)) }}
                 </span>
                 <span fxFlex="64px" fxLayoutAlign="end center">
@@ -91,10 +91,10 @@
                               >
                             }
                           </span>
-                          <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="questions-count">
+                          <span fxFlex="110px" fxLayoutAlign="end center" class="questions-count hide-lt-sm">
                             {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
                           </span>
-                          <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                          <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
                             {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
                           </span>
                           <span fxFlex="64px" fxLayoutAlign="end center">
@@ -177,7 +177,7 @@
                                     <span>{{ questionDoc.data?.text }}</span>
                                   }
                                 </span>
-                                <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center">
+                                <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
                                   {{ answerCountLabel(questionDoc.getAnswers().length) }}
                                 </span>
                                 <span fxFlex="64px" fxLayoutAlign="end center">
@@ -305,7 +305,7 @@
               <mat-panel-title>
                 <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
                   <span fxFlex>{{ getBookName(text) }}</span>
-                  <span fxFlex="110px" fxShow fxHide.xs fxLayoutAlign="end center" class="archived-questions-count">
+                  <span fxFlex="110px" fxLayoutAlign="end center" class="archived-questions-count hide-lt-sm">
                     {{ questionCountLabel(bookQuestionCount(text, true)) }}
                   </span>
                   <span fxFlex="64px" fxLayoutAlign="end center">
@@ -330,13 +330,7 @@
                       <mat-panel-title>
                         <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
                           <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
-                          <span
-                            fxFlex="110px"
-                            fxShow
-                            fxHide.xs
-                            fxLayoutAlign="end center"
-                            class="archived-questions-count"
-                          >
+                          <span fxFlex="110px" fxLayoutAlign="end center" class="archived-questions-count hide-lt-sm">
                             {{ questionCountLabel(questionCount(text.bookNum, chapter.number, true)) }}
                           </span>
                           <span fxFlex="64px" fxLayoutAlign="end center">
@@ -372,7 +366,7 @@
                                   <span>{{ questionDoc.data?.text }}</span>
                                 }
                               </span>
-                              <span fxFlex="260px" fxHide.lt-sm fxLayoutAlign="end center" class="date-archived">{{
+                              <span fxFlex="260px" fxLayoutAlign="end center" class="date-archived hide-lt-sm">{{
                                 timeArchivedStamp(questionDoc.data?.dateArchived)
                               }}</span>
                               <span fxFlex="64px" fxLayoutAlign="end center">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -260,8 +260,8 @@
       }
       @if (status === "filter") {
         <button id="import-button" mat-flat-button color="primary" (click)="importQuestions()">
-          <span fxShow fxHide.xs>{{ t("import_count_questions", { count: selectedCount }) }}</span>
-          <span fxHide fxShow.xs>{{ t("import") }}</span>
+          <span class="hide-lt-sm">{{ t("import_count_questions", { count: selectedCount }) }}</span>
+          <span class="hide-gt-sm">{{ t("import") }}</span>
         </button>
       }
       @if (status === "progress") {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -16,6 +16,8 @@
       </button>
     </form>
     <a (click)="logIn()" [innerHtml]="i18nService.translateAndInsertTags('join.login_existing_account')"></a>
-    <mat-spinner diameter="50" color="#fff" [ngClass]="{ visible: isJoining }"></mat-spinner>
+    @if (isJoining) {
+      <mat-spinner diameter="50" color="#fff"></mat-spinner>
+    }
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -16,6 +16,6 @@
       </button>
     </form>
     <a (click)="logIn()" [innerHtml]="i18nService.translateAndInsertTags('join.login_existing_account')"></a>
-    <mat-spinner diameter="50" color="#fff" [fxHide]="!isJoining"></mat-spinner>
+    <mat-spinner diameter="50" color="#fff" [ngClass]="{ visible: isJoining }"></mat-spinner>
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
@@ -46,3 +46,10 @@ a {
     }
   }
 }
+
+mat-spinner {
+  visibility: hidden;
+  &.visible {
+    visibility: visible;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.scss
@@ -46,10 +46,3 @@ a {
     }
   }
 }
-
-mat-spinner {
-  visibility: hidden;
-  &.visible {
-    visibility: visible;
-  }
-}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/delete-project-dialog/delete-project-dialog.component.html
@@ -25,8 +25,8 @@
         [mat-dialog-close]="'accept'"
         [disabled]="deleteDisabled"
       >
-        <span fxHide.lt-sm>{{ t("i_understand_the_consequences") }}</span>
-        <span fxHide fxShow.xs>{{ t("delete_this_project") }}</span>
+        <span class="hide-lt-sm">{{ t("i_understand_the_consequences") }}</span>
+        <span class="hide-gt-sm">{{ t("delete_this_project") }}</span>
       </button>
     </mat-dialog-actions>
   </mat-dialog>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -10,7 +10,7 @@
           [chapters]="chapters"
         ></app-book-chapter-chooser>
         @if (showSource || suggestionsSettingsEnabled) {
-          <div class="toolbar-separator" [fxHide.xs]="!suggestionsSettingsEnabled">&nbsp;</div>
+          <div class="toolbar-separator" [ngClass]="{ 'hide-lt-sm': !suggestionsSettingsEnabled }">&nbsp;</div>
           @if (showSource) {
             <button
               mat-icon-button
@@ -18,7 +18,7 @@
               type="button"
               (click)="isTargetTextRight = !isTargetTextRight"
               title="{{ t('swap_source_and_target') }}"
-              fxHide.xs
+              class="hide-lt-sm"
             >
               <mat-icon>swap_horiz</mat-icon>
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -64,7 +64,7 @@
                       "
                     ></div>
                   }
-                  <div fxHide.gt-xs>
+                  <div class="hide-gt-sm">
                     <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
                   </div>
                 </td>
@@ -97,7 +97,7 @@
                 </td>
               </ng-container>
               <ng-container matColumnDef="role">
-                <td fxHide.xs mat-cell *matCellDef="let userRow">
+                <td class="hide-lt-sm" mat-cell *matCellDef="let userRow">
                   <em>{{ userRow.role ? i18n.localizeRole(userRow.role) : "" }}</em>
                 </td>
               </ng-container>


### PR DESCRIPTION
The fxShow and fxHide attributes have been removed in favor of the classes in styles.scss. Developer testing will be sufficient to merge this PR as it is a simple change-over.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2718)
<!-- Reviewable:end -->
