### PR TITLE
SF-2974 Add highlight to selected step in material stepper

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -69,6 +69,11 @@ as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {
   }
 }
 
+.mat-step-icon.mat-step-icon-selected {
+  --mat-stepper-header-selected-state-icon-background-color: #{variables.$greenLight};
+  --mat-stepper-header-selected-state-icon-foreground-color: #{variables.$sf_grey};
+}
+
 .offline-text {
   color: variables.$errorColor;
 }


### PR DESCRIPTION
The material stepper component was not highlighting the selected step for the draft generation stepper component. It looks like the reasoning is that our primary colour for our colour palette is grey, which look a lot like the default stepper icon colour.
To add the highlight colour, I specified the colours used on the mat stepper component, using the accent colour as the colour for the selected step.

![image](https://github.com/user-attachments/assets/1257ac30-a348-4d72-b4df-972a612de6b3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2719)
<!-- Reviewable:end -->
