### PR TITLE
SF-2910 Add script to duplicate text audio docs in mongodb

### DIFF
--- a/scripts/db_tools/duplicate-doc.js
+++ b/scripts/db_tools/duplicate-doc.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// This file can be used to duplicate documents in a collection with new IDs. This can be
+// useful for migrating documents to have a new ID format.
+const utils = require('./utils.js');
+const ShareDB = require('sharedb/lib/client');
+const Scr = require('@sillsdev/scripture');
+const OTJson0 = require('ot-json0');
+
+// Edit these settings to specify which docs to duplicate
+const connectionConfig = utils.devConfig;
+const collection = 'text_audio';
+const docIds = ['doc-ids-to-duplicate'];
+
+ShareDB.types.register(OTJson0.type);
+
+async function run() {
+  const ws = utils.createWS(connectionConfig);
+  const conn = new ShareDB.Connection(ws);
+  for (const docId of docIds) {
+    const document = conn.get(collection, docId);
+    await utils.fetchDoc(document);
+    const docParts = docId.split(':');
+    // Convert the book number part to book ID
+    const bookId = Scr.Canon.bookNumberToId(parseInt(docParts[1]));
+    const newDocId = `${docParts[0]}:${bookId}:${docParts[2]}:target`;
+    const newDoc = conn.get(collection, newDocId);
+    const newData = document.data;
+    newData.dataId = newDocId;
+    await utils.createDoc(newDoc, newData, OTJson0.type.name);
+  }
+  conn.close();
+}
+
+run();

--- a/src/RealtimeServer/scriptureforge/models/text-audio.ts
+++ b/src/RealtimeServer/scriptureforge/models/text-audio.ts
@@ -1,11 +1,12 @@
-import { ProjectData, PROJECT_DATA_INDEX_PATHS } from '../../common/models/project-data';
+import { Canon } from '@sillsdev/scripture';
+import { PROJECT_DATA_INDEX_PATHS, ProjectData } from '../../common/models/project-data';
 import { AudioTiming } from './audio-timing';
 
 export const TEXT_AUDIO_COLLECTION = 'text_audio';
 export const TEXT_AUDIO_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
 
 export function getTextAudioId(projectId: string, bookNum: number, chapterNum: number): string {
-  return `${projectId}:${bookNum}:${chapterNum}:target`;
+  return `${projectId}:${Canon.bookNumberToId(bookNum)}:${chapterNum}:target`;
 }
 
 export interface TextAudio extends ProjectData {

--- a/src/SIL.XForge.Scripture/Models/TextAudio.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAudio.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
+using SIL.Scripture;
 using SIL.XForge.Models;
 
 namespace SIL.XForge.Scripture.Models;
 
 public class TextAudio : ProjectData
 {
-    public static string GetDocId(string projectId, int book, int chapter) => $"{projectId}:{book}:{chapter}:target";
+    public static string GetDocId(string projectId, int book, int chapter) =>
+        $"{projectId}:{Canon.BookNumberToId(book)}:{chapter}:target";
 
     public string DataId { get; set; }
     public List<AudioTiming> Timings { get; set; } = new List<AudioTiming>();


### PR DESCRIPTION
The previous doc ids for text audio docs incorrectly used the book number instead of the book ID. This PR updates how we calculate the text audio IDs and provides a script to update the mongoDB with docs with the updated text audio IDs by duplicating the docs.
Currently there are roughly 15 documents on live to update the doc ID for. It is important to update the mongo DB before shipping this code.

Developer testing will be sufficient. Once this gets to QA, regression tests will catch any errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2722)
<!-- Reviewable:end -->
