### PR TITLE
Fix checking app cut off on medium-sized viewport

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -85,7 +85,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   ) {
     super(noticeService);
     this.subscribe(
-      this.breakpointObserver.observe(this.breakpointService.width('>', Breakpoint.MD)),
+      this.breakpointObserver.observe(this.breakpointService.width('>', Breakpoint.LG)),
       (value: BreakpointState) => (this.isDrawerPermanent = value.matches)
     );
 


### PR DESCRIPTION
I noticed that when I moved the screen size close to the medium value (768px) the scripture viewer is cut off. I've updated the hiding of the side bar to get pinned only when the viewport size is large (992px) to better use of the screen on medium sized devices.

Before
![checking app cut off before](https://github.com/user-attachments/assets/cd7c6cb1-3449-4122-9914-c0dd5b6f1cb0)

After
![Checking app cut off after](https://github.com/user-attachments/assets/01a50864-49ea-4c8f-a198-96b72425fbf2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2726)
<!-- Reviewable:end -->
