### PR TITLE
SF-2952 Fix resource tab not displaying right-to-left correctly

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
@@ -1,10 +1,10 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Subject } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { FontService } from 'xforge-common/font.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { SFProjectDoc } from '../../../core/models/sf-project-doc';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { EditorResourceComponent } from './editor-resource.component';
 
@@ -15,8 +15,8 @@ describe('EditorResourceComponent', () => {
   const mockFontService = mock(FontService);
   const projectDoc = {
     id: 'projectId',
-    data: createTestProject()
-  } as SFProjectDoc;
+    data: createTestProjectProfile()
+  } as SFProjectProfileDoc;
 
   configureTestingModule(() => ({
     providers: [
@@ -66,5 +66,21 @@ describe('EditorResourceComponent', () => {
     tick();
     verify(mockSFProjectService.getProfile(projectId)).once();
     verify(mockFontService.getFontFamilyFromProject(projectDoc)).once();
+  }));
+
+  it('can determine if a resource should display right-to-left', fakeAsync(() => {
+    const projectId = 'rtl-project';
+    component.projectId = projectId;
+    component.bookNum = 1;
+    component.chapter = 1;
+    const rtlProjectDoc: SFProjectProfileDoc = {
+      id: projectId,
+      data: createTestProjectProfile({ isRightToLeft: true })
+    } as SFProjectProfileDoc;
+    when(mockSFProjectService.getProfile(projectId)).thenReturn(Promise.resolve(rtlProjectDoc));
+    component['initProjectDetails']();
+    component.resourceText.editorCreated.next();
+    tick();
+    expect(component.isRightToLeft).toBe(true);
   }));
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, DestroyRef, Input, OnChanges, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { combineLatest, EMPTY, startWith, Subject, switchMap } from 'rxjs';
+import { EMPTY, Subject, combineLatest, startWith, switchMap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -53,7 +53,7 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
         })
       )
       .subscribe((projectDoc: SFProjectProfileDoc) => {
-        this.isRightToLeft = projectDoc.data?.translateConfig?.source?.isRightToLeft ?? false;
+        this.isRightToLeft = projectDoc.data?.isRightToLeft ?? false;
         this.fontSize = formatFontSizeToRems(projectDoc.data?.defaultFontSize);
         this.font = this.fontService.getFontFamilyFromProject(projectDoc);
       });


### PR DESCRIPTION
The editor resource component was incorrectly determining the right to left property from the resource's source project when it should be directly from the resource project. This PR updates the calculation to come from the resource project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2727)
<!-- Reviewable:end -->
