### PR TITLE
SF-2960 Remove flex-layout dependency

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -13,7 +13,6 @@
         "@angular/cdk": "^17.3.10",
         "@angular/common": "^17.3.7",
         "@angular/core": "^17.3.7",
-        "@angular/flex-layout": "^15.0.0-beta.42",
         "@angular/forms": "^17.3.7",
         "@angular/material": "^17.3.10",
         "@angular/platform-browser": "^17.3.7",
@@ -2092,22 +2091,6 @@
       "peerDependencies": {
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.14.0"
-      }
-    },
-    "node_modules/@angular/flex-layout": {
-      "version": "15.0.0-beta.42",
-      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-15.0.0-beta.42.tgz",
-      "integrity": "sha512-cTAPVMMxnyIFwpZwdq0PL5mdP9Qh+R8MB7ZBezVaN3Rz2fRrkagzKpLvPX3TFzepXrvHBdpKsU4b8u+NxEC/6g==",
-      "deprecated": "This package has been deprecated. Please see https://blog.angular.io/modern-css-in-angular-layouts-4a259dca9127",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": ">=15.0.0",
-        "@angular/common": ">=15.0.2",
-        "@angular/core": ">=15.0.2",
-        "@angular/platform-browser": ">=15.0.2",
-        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/forms": {

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -34,7 +34,6 @@
     "@angular/cdk": "^17.3.10",
     "@angular/common": "^17.3.7",
     "@angular/core": "^17.3.7",
-    "@angular/flex-layout": "^15.0.0-beta.42",
     "@angular/forms": "^17.3.7",
     "@angular/material": "^17.3.10",
     "@angular/platform-browser": "^17.3.7",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -38,7 +38,7 @@
   </div>
 
   @if (canEditQuestion) {
-    <div class="flex-column" id="text-with-questions-list">
+    <div id="text-with-questions-list">
       @if (!isOnline && (canCreateScriptureAudio || canDeleteScriptureAudio)) {
         <app-notice id="warning-some-actions-unavailable-offline" icon="cloud_off" type="warning">{{
           t("some_actions_unavailable_offline")
@@ -297,7 +297,7 @@
   }
 
   @if (canEditQuestion) {
-    <div class="flex-column" id="text-with-archived-questions">
+    <div id="text-with-archived-questions">
       @for (text of texts; track text) {
         @if (bookQuestionCount(text, true) > 0) {
           <mat-expansion-panel [togglePosition]="'before'" class="book-expander mat-elevation-z0">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -38,7 +38,7 @@
   </div>
 
   @if (canEditQuestion) {
-    <div fxLayout="column" fxLayoutAlign="space-around" id="text-with-questions-list">
+    <div class="flex-column" id="text-with-questions-list">
       @if (!isOnline && (canCreateScriptureAudio || canDeleteScriptureAudio)) {
         <app-notice id="warning-some-actions-unavailable-offline" icon="cloud_off" type="warning">{{
           t("some_actions_unavailable_offline")
@@ -49,14 +49,14 @@
           <mat-expansion-panel [togglePosition]="'before'" class="book-expander mat-elevation-z0">
             <mat-expansion-panel-header>
               <mat-panel-title>
-                <span fxFlex>{{ getBookName(text) }}</span>
-                <span fxFlex="110px" fxLayoutAlign="end center" class="questions-count hide-lt-sm">
+                <span class="flex">{{ getBookName(text) }}</span>
+                <span class="questions-count hide-lt-sm flex-info-end">
                   {{ questionCountLabel(bookQuestionCount(text)) }}
                 </span>
-                <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
+                <span class="hide-lt-sm flex-info-end">
                   {{ answerCountLabel(bookAnswerCount(text)) }}
                 </span>
-                <span fxFlex="64px" fxLayoutAlign="end center">
+                <span class="flex-icon">
                   <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
                   @if (bookQuestionCount(text) > 0) {
                     <button
@@ -82,8 +82,8 @@
                       class="mat-elevation-z0"
                     >
                       <mat-expansion-panel-header>
-                        <mat-panel-title fxLayoutAlign="start center">
-                          <span fxFlex fxLayout class="book-chapter-heading"
+                        <mat-panel-title>
+                          <span class="book-chapter-heading flex"
                             >{{ getBookName(text) + " " + chapter?.number }}
                             @if (chapter.hasAudio) {
                               <mat-icon [title]="t('chapter_audio_attached')" class="material-icons-outlined"
@@ -91,13 +91,13 @@
                               >
                             }
                           </span>
-                          <span fxFlex="110px" fxLayoutAlign="end center" class="questions-count hide-lt-sm">
+                          <span class="questions-count hide-lt-sm flex-info-end">
                             {{ questionCountLabel(questionCount(text.bookNum, chapter.number)) }}
                           </span>
-                          <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
+                          <span class="hide-lt-sm flex-info-end">
                             {{ answerCountLabel(chapterAnswerCount(text.bookNum, chapter.number)) }}
                           </span>
-                          <span fxFlex="64px" fxLayoutAlign="end center">
+                          <span class="flex-icon">
                             <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
                             <button
                               class="chapter-menu-button"
@@ -158,7 +158,7 @@
                             track questionDoc
                           ) {
                             <mat-list-item disableRipple>
-                              <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                              <div class="flex">
                                 <button
                                   mat-icon-button
                                   (click)="questionDialog(questionDoc)"
@@ -172,15 +172,15 @@
                                 @if (questionDoc.data?.audioUrl) {
                                   <mat-icon class="audio-icon material-icons-outlined"> audio_file </mat-icon>
                                 }
-                                <span fxFlex class="no-overflow-ellipsis">
+                                <span class="no-overflow-ellipsis flex">
                                   @if (questionDoc.data?.text) {
                                     <span>{{ questionDoc.data?.text }}</span>
                                   }
                                 </span>
-                                <span fxFlex="110px" class="hide-lt-sm" fxLayoutAlign="end center">
+                                <span class="hide-lt-sm flex-info-end">
                                   {{ answerCountLabel(questionDoc.getAnswers().length) }}
                                 </span>
-                                <span fxFlex="64px" fxLayoutAlign="end center">
+                                <span class="flex-icon">
                                   <button
                                     mat-icon-button
                                     (click)="setQuestionArchiveStatus(questionDoc, true)"
@@ -205,13 +205,13 @@
       }
     </div>
   } @else {
-    <div fxLayout="column" fxLayoutAlign="space-around" class="reviewer-panels" id="reviewer-question-panel">
+    <div class="reviewer-panels" id="reviewer-question-panel">
       <mat-list dense id="reviewer-questions-list">
         @for (text of texts; track text) {
           @if (bookQuestionCount(text) > 0) {
             <mat-list-item [appRouterLink]="getRouterLink(getBookId(text))">
-              <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                <span fxFlex>{{ getBookName(text) }}</span>
+              <div class="flex">
+                <span class="flex">{{ getBookName(text) }}</span>
                 <span>
                   <app-donut-chart
                     [colors]="['#3a3a3a', '#edecec', '#B8D332']"
@@ -227,7 +227,7 @@
   }
 
   @if (showNoQuestionsMessage) {
-    <div fxLayout="row" fxLayoutAlign="space-around" class="reviewer-panels" id="no-questions-label">
+    <div class="reviewer-panels flex" id="no-questions-label">
       <p>
         {{ t("no_questions") }}
         @if (canCreateQuestion) {
@@ -246,44 +246,44 @@
     <h2>{{ t(canCreateQuestion ? "project_stats" : "my_contributions") }}</h2>
   </div>
 
-  <div fxLayout="row wrap" fxLayoutAlign="space-between" class="reviewer-panels stat-panels">
+  <div class="reviewer-panels stat-panels">
     @if (canCreateQuestion) {
       <mat-card class="card card-content-question mat-elevation-z2">
         <mat-card-content>
-          <span fxFlex>
+          <span class="flex">
             <div class="stat-total">{{ allQuestionsCount }}</div>
             <div class="stat-label">{{ t("questions") }}</div>
           </span>
-          <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">help</mat-icon> </span>
+          <span class="vertical-center"> <mat-icon class="mirror-rtl">help</mat-icon> </span>
         </mat-card-content>
       </mat-card>
     }
     <mat-card class="card card-content-answer">
       <mat-card-content>
-        <span fxFlex>
+        <span class="flex">
           <div class="stat-total">{{ myAnswerCount }}</div>
           <div class="stat-label">{{ t("answers") }}</div>
         </span>
-        <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">question_answer</mat-icon> </span>
+        <span class="vertical-center"> <mat-icon class="mirror-rtl">question_answer</mat-icon> </span>
       </mat-card-content>
     </mat-card>
     <mat-card class="card card-content-comment">
       <mat-card-content>
-        <span fxFlex>
+        <span class="flex">
           <div class="stat-total">{{ myCommentCount }}</div>
           <div class="stat-label">{{ t("comments") }}</div>
         </span>
-        <span fxLayoutAlign="start center"> <mat-icon class="mirror-rtl">comment</mat-icon> </span>
+        <span class="vertical-center"> <mat-icon class="mirror-rtl">comment</mat-icon> </span>
       </mat-card-content>
     </mat-card>
     @if (canSeeOtherUserResponses) {
       <mat-card class="card card-content-like">
         <mat-card-content>
-          <span fxFlex>
+          <span class="flex">
             <div class="stat-total">{{ myLikeCount }}</div>
             <div class="stat-label">{{ t("likes") }}</div>
           </span>
-          <span fxLayoutAlign="start center"> <mat-icon>thumb_up</mat-icon> </span>
+          <span class="vertical-center"> <mat-icon>thumb_up</mat-icon> </span>
         </mat-card-content>
       </mat-card>
     }
@@ -297,18 +297,18 @@
   }
 
   @if (canEditQuestion) {
-    <div fxLayout="column" id="text-with-archived-questions">
+    <div class="flex-column" id="text-with-archived-questions">
       @for (text of texts; track text) {
         @if (bookQuestionCount(text, true) > 0) {
           <mat-expansion-panel [togglePosition]="'before'" class="book-expander mat-elevation-z0">
             <mat-expansion-panel-header>
               <mat-panel-title>
-                <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                  <span fxFlex>{{ getBookName(text) }}</span>
-                  <span fxFlex="110px" fxLayoutAlign="end center" class="archived-questions-count hide-lt-sm">
+                <div class="flex">
+                  <span class="flex">{{ getBookName(text) }}</span>
+                  <span class="archived-questions-count hide-lt-sm flex-info-end">
                     {{ questionCountLabel(bookQuestionCount(text, true)) }}
                   </span>
-                  <span fxFlex="64px" fxLayoutAlign="end center">
+                  <span class="flex-icon">
                     <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
                     <button
                       mat-icon-button
@@ -328,12 +328,12 @@
                   <mat-expansion-panel [togglePosition]="'before'" class="mat-elevation-z0">
                     <mat-expansion-panel-header>
                       <mat-panel-title>
-                        <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
-                          <span fxFlex>{{ getBookName(text) + " " + chapter?.number }}</span>
-                          <span fxFlex="110px" fxLayoutAlign="end center" class="archived-questions-count hide-lt-sm">
+                        <div class="flex">
+                          <span class="flex">{{ getBookName(text) + " " + chapter?.number }}</span>
+                          <span class="archived-questions-count hide-lt-sm flex-info-end">
                             {{ questionCountLabel(questionCount(text.bookNum, chapter.number, true)) }}
                           </span>
-                          <span fxFlex="64px" fxLayoutAlign="end center">
+                          <span class="flex-icon">
                             <!-- $event.stopPropagation() is needed because the button is within a row that is listening for clicks -->
                             <button
                               mat-icon-button
@@ -356,20 +356,20 @@
                           track questionDoc
                         ) {
                           <mat-list-item disableRipple>
-                            <div fxFlex="grow" fxLayout="row" fxLayoutAlign="start center">
+                            <div class="flex">
                               v{{ questionDoc.data?.verseRef?.verseNum }} -&nbsp;
                               @if (questionDoc.data?.audioUrl) {
                                 <mat-icon class="audio-icon material-icons-outlined"> audio_file </mat-icon>
                               }
-                              <span fxFlex class="no-overflow-ellipsis">
+                              <span class="no-overflow-ellipsis flex">
                                 @if (questionDoc.data?.text) {
                                   <span>{{ questionDoc.data?.text }}</span>
                                 }
                               </span>
-                              <span fxFlex="260px" fxLayoutAlign="end center" class="date-archived hide-lt-sm">{{
+                              <span class="date-archived hide-lt-sm flex-timestamp">{{
                                 timeArchivedStamp(questionDoc.data?.dateArchived)
                               }}</span>
-                              <span fxFlex="64px" fxLayoutAlign="end center">
+                              <span class="flex-icon">
                                 <button
                                   mat-icon-button
                                   (click)="setQuestionArchiveStatus(questionDoc, false)"
@@ -392,7 +392,7 @@
         }
       }
       @if (showNoArchivedQuestionsMessage) {
-        <div fxLayout="row" fxLayoutAlign="space-around" class="reviewer-panels" id="no-archived-questions-label">
+        <div class="reviewer-panels" id="no-archived-questions-label">
           <p>{{ t("no_archived_questions") }}</p>
         </div>
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -11,6 +11,31 @@
   }
 }
 
+.flex {
+  display: flex;
+  flex: 1;
+  flex-flow: wrap;
+  align-items: center;
+}
+
+.flex-info-end {
+  display: flex;
+  place-content: center flex-end;
+  width: 110px;
+}
+
+.flex-icon {
+  display: flex;
+  place-content: center flex-end;
+  width: 64px;
+}
+
+.flex-timestamp {
+  display: flex;
+  place-content: center flex-end;
+  width: 260px;
+}
+
 .add-question-button.hide-gt-sm {
   padding-inline-start: 1px;
   z-index: 1;
@@ -48,6 +73,8 @@ app-donut-chart {
 }
 
 #reviewer-questions-list {
+  flex: 1;
+
   .mat-mdc-list-item {
     cursor: pointer;
     height: 50px;
@@ -79,11 +106,15 @@ app-donut-chart {
 #loading-questions-message,
 #loading-archived-questions-message {
   text-align: center;
+  justify-content: center;
   color: variables.$text-hint-on-background;
 }
 
 .reviewer-panels {
   max-width: 800px;
+  flex-flow: wrap;
+  display: flex;
+  place-content: stretch space-between;
 }
 
 .stat-panels {
@@ -93,10 +124,21 @@ app-donut-chart {
 .card {
   margin: 8px 0;
   width: 130px;
+
+  .mat-mdc-card-content {
+    display: flex;
+    height: 100%;
+
+    .vertical-center {
+      display: flex;
+      align-items: center;
+    }
+  }
 }
 
 .stat-total {
   font-size: x-large;
+  width: 100%;
 }
 
 .stat-label {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -47,8 +47,8 @@
                   <mat-error>{{ t("error_fetching_resources") }}</mat-error>
                 }
                 @if (isBasedOnProjectSet) {
-                  <div fxLayout="row" fxLayoutAlign="start center">
-                    <div fxLayout="column" fxFlex="grow">
+                  <div>
+                    <div class="flex-column">
                       <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
                         {{ t("enable_translation_suggestions") }}
                       </mat-checkbox>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -48,15 +48,13 @@
                 }
                 @if (isBasedOnProjectSet) {
                   <div>
-                    <div class="flex-column">
-                      <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                        {{ t("enable_translation_suggestions") }}
-                      </mat-checkbox>
-                      <p
-                        class="helper-text"
-                        [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                      ></p>
-                    </div>
+                    <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
+                      {{ t("enable_translation_suggestions") }}
+                    </mat-checkbox>
+                    <p
+                      class="helper-text"
+                      [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
+                    ></p>
                   </div>
                 }
               </mat-card-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'settings'">
-  <div fxLayout="column" fxLayoutGap="2rem" class="container">
+  <div class="container flex-column">
     <div class="mat-headline-4">{{ t("settings") }}</div>
     @if (!isAppOnline) {
       <span class="offline-text"> {{ t("connect_network_to_change_settings") }} </span>
@@ -384,7 +384,7 @@
             <span>{{ synchronizeWarning?.after }}</span>
           </p>
         }
-        <div fxLayout="row" fxLayoutAlign="end stretch">
+        <div class="delete-btn-container">
           <button
             id="delete-btn"
             mat-flat-button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'settings'">
-  <div class="container flex-column">
+  <div class="container">
     <div class="mat-headline-4">{{ t("settings") }}</div>
     @if (!isAppOnline) {
       <span class="offline-text"> {{ t("connect_network_to_change_settings") }} </span>
@@ -384,19 +384,17 @@
             <span>{{ synchronizeWarning?.after }}</span>
           </p>
         }
-        <div class="delete-btn-container">
-          <button
-            id="delete-btn"
-            mat-flat-button
-            type="button"
-            color="warn"
-            (click)="openDeleteProjectDialog()"
-            [class.enabled]="!deleteButtonDisabled"
-            [disabled]="deleteButtonDisabled"
-          >
-            {{ t("delete_this_project") }}
-          </button>
-        </div>
+        <button
+          id="delete-btn"
+          mat-flat-button
+          type="button"
+          color="warn"
+          (click)="openDeleteProjectDialog()"
+          [class.enabled]="!deleteButtonDisabled"
+          [disabled]="deleteButtonDisabled"
+        >
+          {{ t("delete_this_project") }}
+        </button>
       </mat-card>
     </div>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -6,6 +6,10 @@
   padding: 0;
   max-width: 800px;
   padding-block-end: 10px;
+
+  .mat-headline-4 {
+    margin-bottom: 32px;
+  }
 }
 
 .mat-mdc-card {
@@ -160,7 +164,10 @@ mat-radio-group.tool-setting {
   }
 }
 
-.delete-btn-container {
-  display: flex;
-  justify-content: flex-end;
+#danger-zone {
+  margin-top: 32px;
+
+  button {
+    align-self: end;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -159,3 +159,8 @@ mat-radio-group.tool-setting {
     margin-block-start: 0;
   }
 }
+
+.delete-btn-container {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -5,10 +5,10 @@
   @if (!isAppOnline) {
     <div class="offline-text">{{ t("share_not_available_offline") }}</div>
   }
-  <div fxLayout="column" fxLayoutGap="20px">
+  <div class="flex-column">
     <div class="invite-by-email">
       <h3>{{ t("send_a_link") }}</h3>
-      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+      <div class="flex-row">
         <form id="email-form" [formGroup]="sendInviteForm" #form="ngForm">
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -5,10 +5,10 @@
   @if (!isAppOnline) {
     <div class="offline-text">{{ t("share_not_available_offline") }}</div>
   }
-  <div class="flex-column">
+  <div class="invite-forms">
     <div class="invite-by-email">
       <h3>{{ t("send_a_link") }}</h3>
-      <div class="flex-row">
+      <div>
         <form id="email-form" [formGroup]="sendInviteForm" #form="ngForm">
           <mat-form-field id="email">
             <mat-label>{{ t("email") }}</mat-label>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -2,6 +2,12 @@
 
 @import 'src/variables';
 
+.invite-forms {
+  display: flex;
+  flex-direction: column;
+  row-gap: 20px;
+}
+
 form {
   display: flex;
   width: 100%;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'editor'">
   <div class="content" [class.reverse-columns]="!isTargetTextRight" [class.target-only]="!showSource">
-    <div class="toolbar" fxLayout="row" fxLayoutAlign="start center">
-      <div fxFlex fxLayout="row wrap">
+    <div class="toolbar">
+      <div class="toolbar-options">
         <app-book-chapter-chooser
           [book]="bookNum"
           (bookChange)="setBook($event)"
@@ -42,7 +42,7 @@
         }
       </div>
       @if (showMultiViewers) {
-        <div fxFlexAlign="end" class="avatar-padding">
+        <div class="avatar-padding">
           <app-multi-viewer [viewers]="multiCursorViewers" (viewerClick)="onViewerClicked($event)"></app-multi-viewer>
         </div>
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -59,11 +59,19 @@
   border-color: vars.$border-color;
   padding: 5px 10px;
   grid-column: 1 / span 2;
+  display: flex;
+  align-items: center;
 
   @include media-breakpoint('<', sm) {
     margin-top: 0;
     margin-bottom: 0;
     border-bottom-width: 0;
+  }
+
+  .toolbar-options {
+    display: flex;
+    flex-flow: wrap;
+    flex: 1;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row" fxLayoutAlign="start center">
+<div class="multi-viewer-container">
   @for (viewer of avatarViewers; track viewer) {
     <div class="app-avatar-container" [title]="viewer.displayName">
       <app-avatar
@@ -32,9 +32,9 @@
       <mat-menu #menu="matMenu" (closed)="closeMenu()">
         <button mat-menu-item disabled>{{ otherViewersLabel }}</button>
         @for (viewer of viewers; track viewer) {
-          <button mat-menu-item (click)="closeMenu(); clickAvatar(viewer)">
+          <button mat-menu-item class="other-viewer" (click)="closeMenu(); clickAvatar(viewer)">
             <app-avatar [user]="viewer" [size]="32" [borderColor]="viewer.cursorColor"></app-avatar>
-            <span fxFlex>{{ viewer.displayName }}</span>
+            <span>{{ viewer.displayName }}</span>
           </button>
         }
       </mat-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -24,7 +24,7 @@ app-avatar {
   cursor: pointer;
 }
 
-::ng-deep .other-viewer {
+.other-viewer ::ng-deep {
   > span {
     display: flex;
     align-items: center;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.scss
@@ -1,3 +1,7 @@
+.multi-viewer-container {
+  display: flex;
+}
+
 .app-avatar-container {
   border-radius: 50%;
   border: 2px solid white;
@@ -18,4 +22,12 @@
 
 app-avatar {
   cursor: pointer;
+}
+
+::ng-deep .other-viewer {
+  > span {
+    display: flex;
+    align-items: center;
+    column-gap: 4px;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -73,7 +73,7 @@
         </mat-form-field>
       }
     </mat-dialog-content>
-    <mat-dialog-actions fxLayoutAlign="end">
+    <mat-dialog-actions align="end">
       <button mat-button class="close-button" [mat-dialog-close]="undefined">{{ t("close") }}</button>
       @if (canInsertNote) {
         <mat-button-toggle-group hideSingleSelectionIndicator="true">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="training-content">
-        <div class="text-ellipsis">A message to be added</div>
+        <div class="text-ellipsis">{{ trainingMessage }}</div>
         <div>
           @if (trainingPercentage < 100) {
             <app-donut-chart

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.html
@@ -1,14 +1,14 @@
 <ng-container *transloco="let t; read: 'training_progress'">
   @if (showTrainingProgress) {
     <div class="training-progress mat-card">
-      <div class="training-title" fxLayout="row" fxLayoutAlign="space-between center">
+      <div class="training-title">
         <div>{{ t("training") }}</div>
         <button id="training-close-button" mat-icon-button type="button" (click)="closeTrainingProgress()">
           <mat-icon>close</mat-icon>
         </button>
       </div>
-      <div class="training-content" fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="5px">
-        <div class="text-ellipsis">{{ trainingMessage }}</div>
+      <div class="training-content">
+        <div class="text-ellipsis">A message to be added</div>
         <div>
           @if (trainingPercentage < 100) {
             <app-donut-chart

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
@@ -17,7 +17,7 @@
     padding: 2px;
     padding-inline-start: 10px;
     display: flex;
-    place-content: space-between;
+    justify-content: space-between;
     align-items: center;
 
     > div {
@@ -30,7 +30,7 @@
     padding: 10px;
     height: 44px;
     display: flex;
-    place-content: space-between;
+    justify-content: space-between;
     column-gap: 5px;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.scss
@@ -16,6 +16,9 @@
   > .training-title {
     padding: 2px;
     padding-inline-start: 10px;
+    display: flex;
+    place-content: space-between;
+    align-items: center;
 
     > div {
       color: white;
@@ -26,6 +29,9 @@
   > .training-content {
     padding: 10px;
     height: 44px;
+    display: flex;
+    place-content: space-between;
+    column-gap: 5px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -8,7 +8,7 @@
   <div class="card-wrapper">
     <mat-card class="books-card">
       <mat-card-header id="translate-overview-title" class="books-card-title">
-        <mat-card-title fxLayout="row" fxLayoutAlign="space-between center"
+        <mat-card-title class="progress-header"
           >{{ t("progress") }}
           <div class="progress" [title]="progressService.overallProgress.percentage">
             <app-donut-chart

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -28,6 +28,11 @@ mat-card {
 .books-card {
   width: 18rem;
 
+  .progress-header {
+    display: flex;
+    place-content: center space-between;
+  }
+
   .books-card-title ::ng-deep {
     margin-top: 4px;
     padding: 0 16px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -12,7 +12,7 @@
       </div>
     </app-notice>
 
-    <div fxLayout="row" fxLayoutAlign="start center" class="users-controls">
+    <div class="users-controls">
       <!-- The tab group component sets the currentTabIndex which filters the list of users.
       This is a non-standard way to use the component and causes a slight UI glitch where the
       tab text jumps a few pixels when navigating between tabs. -->

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.scss
@@ -44,6 +44,8 @@ h3 {
 .users-controls {
   margin-top: 16px;
   flex-wrap: wrap-reverse;
+  display: flex;
+  align-items: center;
 }
 
 .tab-selector {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
@@ -1,4 +1,4 @@
-<div class="body-content flex-start">
+<div class="body-content">
   <h1>System Administration</h1>
 
   <mat-tab-group>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutAlign="center start" class="body-content">
+<div class="body-content flex-start">
   <h1>System Administration</h1>
 
   <mat-tab-group>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -82,61 +82,6 @@ const modules = [
   NgCircleProgressModule
 ];
 
-const appFlexLayoutBreakPoints = [
-  {
-    alias: 'xs',
-    mediaQuery: 'screen and (min-width: 1px) and (max-width: 575px)'
-  },
-  {
-    alias: 'sm',
-    mediaQuery: 'screen and (min-width: 576px) and (max-width: 767px)'
-  },
-  {
-    alias: 'md',
-    mediaQuery: 'screen and (min-width: 768px) and (max-width: 991px)'
-  },
-  {
-    alias: 'lg',
-    mediaQuery: 'screen and (min-width: 992px) and (max-width: 1199px)'
-  },
-  {
-    alias: 'xl',
-    mediaQuery: 'screen and (min-width: 1200px) and (max-width: 5000px)'
-  },
-  {
-    alias: 'lt-sm',
-    mediaQuery: 'screen and (max-width: 575px)'
-  },
-  {
-    alias: 'lt-md',
-    mediaQuery: 'screen and (max-width: 767px)'
-  },
-  {
-    alias: 'lt-lg',
-    mediaQuery: 'screen and (max-width: 991px)'
-  },
-  {
-    alias: 'lt-xl',
-    mediaQuery: 'screen and (max-width: 1199px)'
-  },
-  {
-    alias: 'gt-xs',
-    mediaQuery: 'screen and (min-width: 576px)'
-  },
-  {
-    alias: 'gt-sm',
-    mediaQuery: 'screen and (min-width: 768px)'
-  },
-  {
-    alias: 'gt-md',
-    mediaQuery: 'screen and (min-width: 992px)'
-  },
-  {
-    alias: 'gt-lg',
-    mediaQuery: 'screen and (min-width: 1200px)'
-  }
-];
-
 @NgModule({
   declarations: [BlurOnClickDirective, AutofocusDirective, ScrollIntoViewDirective, RouterLinkDirective],
   imports: modules,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -1,6 +1,5 @@
 import { BidiModule } from '@angular/cdk/bidi';
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { BREAKPOINT, FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatBadgeModule } from '@angular/material/badge';
@@ -45,7 +44,6 @@ import { ScrollIntoViewDirective } from './scroll-into-view';
 
 const modules = [
   DonutChartModule,
-  FlexLayoutModule,
   FormsModule,
   BidiModule,
   MatAutocompleteModule,
@@ -144,7 +142,6 @@ const appFlexLayoutBreakPoints = [
   imports: modules,
   exports: [...modules, BlurOnClickDirective, AutofocusDirective, ScrollIntoViewDirective, RouterLinkDirective],
   providers: [
-    { provide: BREAKPOINT, useValue: appFlexLayoutBreakPoints, multi: true },
     {
       provide: MatPaginatorIntl,
       useClass: Paginator,


### PR DESCRIPTION
This PR removes the angular flex-layout dependency and converts the component template files to work without using flex layout api. The best way to ensure that the conversion is adequate is by having 2 windows open, one on QA and one on this branch and check that each component still behaves as expected.

It would be good to check the layout of each component by varying the screen size and checking right-to-left interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2729)
<!-- Reviewable:end -->
