### PR TITLE
SF-2966 Fix support for audio recording on iOS and Safari

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-recorder/checking-audio-recorder.component.ts
@@ -9,7 +9,7 @@ import {
   BrowserIssue,
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
-import { isGecko, objectId } from 'xforge-common/utils';
+import { audioRecordingMimeType, objectId } from 'xforge-common/utils';
 import { SingleButtonAudioPlayerComponent } from '../single-button-audio-player/single-button-audio-player.component';
 
 export interface AudioAttachment {
@@ -97,7 +97,7 @@ export class CheckingAudioRecorderComponent
       return;
     }
 
-    const blob = new Blob(this.recordedChunks, { type: this.mimeType });
+    const blob = new Blob(this.recordedChunks, { type: audioRecordingMimeType() });
     this.audio = {
       url: URL.createObjectURL(blob),
       status: 'processed',
@@ -149,12 +149,6 @@ export class CheckingAudioRecorderComponent
     this._onTouched.emit();
   }
 
-  private get mimeType(): string {
-    // If OGG is not used on Firefox, recording does not work correctly.
-    // See https://github.com/muaz-khan/RecordRTC/issues/166#issuecomment-242942400
-    return isGecko() ? 'audio/ogg' : 'audio/webm';
-  }
-
   private errorCallback(error: any): void {
     console.error(error);
     this.audio = { status: 'denied' };
@@ -174,7 +168,7 @@ export class CheckingAudioRecorderComponent
 
   private successCallback(stream: MediaStream): void {
     const options: MediaRecorderOptions = {
-      mimeType: this.mimeType
+      mimeType: audioRecordingMimeType()
     };
     this.stream = stream;
     this.recordedChunks = [];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -14,7 +14,7 @@ import {
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { isGecko, objectId } from 'xforge-common/utils';
+import { audioRecordingMimeType, objectId } from 'xforge-common/utils';
 import { SingleButtonAudioPlayerComponent } from '../../checking/checking/single-button-audio-player/single-button-audio-player.component';
 import { SharedModule } from '../shared.module';
 
@@ -122,7 +122,7 @@ export class AudioRecorderDialogComponent
       return;
     }
 
-    const blob = new Blob(this.recordedChunks, { type: this.mimeType });
+    const blob = new Blob(this.recordedChunks, { type: audioRecordingMimeType() });
     this.audio = {
       url: URL.createObjectURL(blob),
       status: 'processed',
@@ -202,12 +202,6 @@ export class AudioRecorderDialogComponent
     this._onTouched.emit();
   }
 
-  private get mimeType(): string {
-    // If OGG is not used on Firefox, recording does not work correctly.
-    // See https://github.com/muaz-khan/RecordRTC/issues/166#issuecomment-242942400
-    return isGecko() ? 'audio/ogg' : 'audio/webm';
-  }
-
   private errorCallback(error: any): void {
     console.error(error);
     this.audio = { status: 'denied' };
@@ -227,7 +221,7 @@ export class AudioRecorderDialogComponent
 
   private successCallback(stream: MediaStream): void {
     const options: MediaRecorderOptions = {
-      mimeType: this.mimeType
+      mimeType: audioRecordingMimeType()
     };
     this.stream = stream;
     this.recordedChunks = [];

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -66,6 +66,22 @@ export function isGecko(): boolean {
   return getBrowserEngine() === 'gecko';
 }
 
+export function audioRecordingMimeType(): string {
+  // MediaRecorder.isTypeSupported('audio/webm') will erroneously return true on Firefox,
+  // and so we must use browser sniffing in this case.
+  if (isGecko()) {
+    // If OGG is not used on Firefox, recording does not work correctly.
+    // See https://github.com/muaz-khan/RecordRTC/issues/166#issuecomment-242942400
+    return 'audio/ogg';
+  } else if (MediaRecorder.isTypeSupported('audio/webm')) {
+    // This is the default format for Chromium based browsers
+    return 'audio/webm';
+  } else {
+    // Safari on iOS/macOS does not support audio/webm
+    return 'audio/mp4';
+  }
+}
+
 export function issuesEmailTemplate(errorId?: string): string {
   const bowser = Bowser.getParser(window.navigator.userAgent);
 


### PR DESCRIPTION
This Pull Request fixes support for recording audio for all browsers on iOS, and for Safari for macOS.

I was able to test this on the iOS simulator using a mac via the instructions at https://github.com/sillsdev/web-xforge/wiki/Debugging-on-another-computer.

I have marked this as testing not required, as the test team will need to test this on QA when this is deployed to QA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2731)
<!-- Reviewable:end -->
