### PR TITLE
Remove biblical terms tab top border

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
@@ -79,7 +79,6 @@
   align-items: center;
   justify-content: flex-start;
   padding: 1em 0.5em 0.75em 0.5em;
-  border-top: 1px solid var(--sf-tab-group-border-color);
   background: #fff;
 }
 


### PR DESCRIPTION
Remove erroneous border on biblical terms page

Before
![biblical terms border before](https://github.com/user-attachments/assets/ada61998-11f2-46e1-99ad-010c9e0cbc89)

After
![Biblical terms border after](https://github.com/user-attachments/assets/a67d124f-9738-4191-a240-f961626ced74)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2736)
<!-- Reviewable:end -->
