### PR TITLE
Move checking strings that were in the wrong file

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -165,6 +165,10 @@
       "LAO": "Laodiceans"
     }
   },
+  "chapter_nav": {
+    "previous_chapter": "Previous chapter",
+    "next_chapter": "Next chapter"
+  },
   "checking": {
     "filter_questions": "Filter questions",
     "input_required_before_saving": "Provide text or audio before saving",
@@ -381,6 +385,12 @@
     "offline-accessible": "Offline Access",
     "open": "Open",
     "problem_getting_pt_list": "There was a problem getting the list of available Paratext projects to connect to. If this continues to happen, and logging out and back in does not fix the problem, please report the issue for help."
+  },
+  "roles": {
+    "sf_community_checker": "Community Checker"
+  },
+  "role_descriptions": {
+    "sf_community_checker": "Answer questions - comment on answers"
   },
   "scripture_chooser_dialog": {
     "choose_book": "Choose book",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -49,10 +49,6 @@
     "old_testament": "OT",
     "select": "Select"
   },
-  "chapter_nav": {
-    "previous_chapter": "Previous chapter",
-    "next_chapter": "Next chapter"
-  },
   "checking": {
     "add_question": "Add question"
   },
@@ -429,7 +425,6 @@
     "roles": "Roles",
     "roles_from_pt_cannot_be_changed": "Roles can only be changed in Paratext",
     "save": "Save",
-    "sf_community_checker": "Community Checker",
     "sf_commenter": "Commenter",
     "sf_observer": "Viewer",
     "user_pt": "Paratext User",
@@ -440,7 +435,6 @@
     "pt_consultant": "View translation - view questions & answers - add notes",
     "pt_observer": "View translation - view questions & answers - view notes",
     "pt_translator": "Edit translations - view questions - add answers - add notes - sync with Paratext",
-    "sf_community_checker": "Answer questions - comment on answers",
     "sf_commenter": "View translation - add notes",
     "sf_observer": "View translation - view notes"
   },


### PR DESCRIPTION
These strings can be accessed by community checkers, and therefore should be in the community checking file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2738)
<!-- Reviewable:end -->
