### PR TITLE
SF-2998 Revert Biblical Terms migration

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-user-config.ts
@@ -17,6 +17,7 @@ export interface SFProjectUserConfig extends ProjectData {
   selectedBiblicalTermsFilter?: string;
   isTargetTextRight: boolean;
   confidenceThreshold: number;
+  biblicalTermsEnabled?: boolean;
   transliterateBiblicalTerms: boolean;
   translationSuggestionsEnabled: boolean;
   numSuggestions: number;

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.spec.ts
@@ -103,107 +103,19 @@ describe('SFProjectUserConfigMigrations', () => {
   });
 
   describe('version 7', () => {
-    it('creates the tab in the source if there are source tabs', async () => {
+    it('does not modify the document', async () => {
       const env = new TestEnvironment(6);
       const conn = env.server.connect();
       await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {
-        biblicalTermsEnabled: true,
-        editorTabsOpen: [{ groupId: 'source' }]
+        biblicalTermsEnabled: true
       });
       let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(1);
-      expect(userConfigDoc.data.biblicalTermsEnabled).toBeDefined();
-
-      await env.server.migrateIfNecessary();
-
-      userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(2);
-      expect(userConfigDoc.data.editorTabsOpen[1]).toEqual({
-        tabType: 'biblical-terms',
-        groupId: 'source',
-        isSelected: false
-      });
-    });
-
-    it('creates the tab in the target if there are no source tabs', async () => {
-      const env = new TestEnvironment(6);
-      const conn = env.server.connect();
-      await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {
-        biblicalTermsEnabled: true,
-        editorTabsOpen: []
-      });
-      let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(0);
-      expect(userConfigDoc.data.biblicalTermsEnabled).toBeDefined();
-
-      await env.server.migrateIfNecessary();
-
-      userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(1);
-      expect(userConfigDoc.data.editorTabsOpen[0]).toEqual({
-        tabType: 'biblical-terms',
-        groupId: 'target',
-        isSelected: false
-      });
-    });
-
-    it('does not create a tab if one already exists', async () => {
-      const env = new TestEnvironment(6);
-      const conn = env.server.connect();
-      await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {
-        biblicalTermsEnabled: true,
-        editorTabsOpen: [
-          {
-            tabType: 'biblical-terms',
-            groupId: 'target',
-            isSelected: false
-          }
-        ]
-      });
-      let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(1);
-      expect(userConfigDoc.data.biblicalTermsEnabled).toBeDefined();
-
-      await env.server.migrateIfNecessary();
-
-      userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(1);
-    });
-
-    it('does not migrate if already migrated', async () => {
-      const env = new TestEnvironment(6);
-      const conn = env.server.connect();
-      await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {});
-      let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
       expect(userConfigDoc.version).toBe(1);
 
       await env.server.migrateIfNecessary();
 
       userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
       expect(userConfigDoc.version).toBe(1);
-    });
-
-    it('removes the biblicalTermsEnabled property', async () => {
-      const env = new TestEnvironment(6);
-      const conn = env.server.connect();
-      await createDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01', {
-        biblicalTermsEnabled: false,
-        editorTabsOpen: []
-      });
-      let userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(0);
-      expect(userConfigDoc.data.biblicalTermsEnabled).toBeDefined();
-
-      await env.server.migrateIfNecessary();
-
-      userConfigDoc = await fetchDoc(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, 'project01:user01');
-      expect(userConfigDoc.data.editorTabsOpen.length).toBe(0);
-      expect(userConfigDoc.data.biblicalTermsEnabled).not.toBeDefined();
     });
   });
 });

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
@@ -79,7 +79,9 @@ class SFProjectUserConfigMigration7 extends DocMigration {
   static readonly VERSION = 7;
 
   async migrateDoc(_: Doc): Promise<void> {
-    // This migration has been removed
+    // This migration has been removed.
+    // The migration that was here added the Biblical Terms tab, and removed the setting from project-user-config.
+    // This migration was run on QA but not live.
   }
 }
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
@@ -1,4 +1,4 @@
-import { Doc, ListInsertOp, ObjectDeleteOp, ObjectInsertOp, Op } from 'sharedb/lib/client';
+import { Doc, ObjectDeleteOp, ObjectInsertOp } from 'sharedb/lib/client';
 import { DocMigration, MigrationConstructor } from '../../common/migration';
 import { submitMigrationOp } from '../../common/realtime-server';
 
@@ -78,46 +78,8 @@ class SFProjectUserConfigMigration6 extends DocMigration {
 class SFProjectUserConfigMigration7 extends DocMigration {
   static readonly VERSION = 7;
 
-  async migrateDoc(doc: Doc): Promise<void> {
-    const biblicalTermsEnabled: boolean | undefined = doc.data.biblicalTermsEnabled;
-    if (biblicalTermsEnabled !== undefined) {
-      const ops: Op[] = [];
-      if (biblicalTermsEnabled) {
-        // Determine whether to show the biblical terms tab in the source or target
-        let createTab: boolean = true;
-        let groupId: string = 'target';
-        for (const editorTab of doc.data.editorTabsOpen) {
-          // If a tab is in the source, we can show the tab in the source
-          if (editorTab.groupId === 'source') {
-            groupId = 'source';
-          }
-
-          // If we already have a biblical terms tab, do not recreate it
-          if (editorTab.tabType === 'biblical-terms') {
-            createTab = false;
-          }
-        }
-
-        // Add a biblical terms tab
-        if (createTab) {
-          const i: number = doc.data.editorTabsOpen.length;
-          const liOp: ListInsertOp = {
-            p: ['editorTabsOpen', i],
-            li: {
-              tabType: 'biblical-terms',
-              groupId,
-              isSelected: false
-            }
-          };
-          ops.push(liOp);
-        }
-      }
-
-      // Remove the old biblical terms enabled property
-      const odOp: ObjectDeleteOp = { p: ['biblicalTermsEnabled'], od: biblicalTermsEnabled };
-      ops.push(odOp);
-      await submitMigrationOp(SFProjectUserConfigMigration7.VERSION, doc, ops);
-    }
+  async migrateDoc(_: Doc): Promise<void> {
+    // This migration has been removed
   }
 }
 

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-service.ts
@@ -49,6 +49,9 @@ export class SFProjectUserConfigService extends SFProjectDataService<SFProjectUs
       confidenceThreshold: {
         bsonType: 'number'
       },
+      biblicalTermsEnabled: {
+        bsonType: 'bool'
+      },
       transliterateBiblicalTerms: {
         bsonType: 'bool'
       },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3938,6 +3938,76 @@ describe('EditorComponent', () => {
       }));
     });
 
+    describe('updateBiblicalTermsTabVisibility', () => {
+      it('should add biblical terms tab to source when enabled and "showSource" is true', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => true });
+        });
+        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
+        env.setProjectUserConfig({ biblicalTermsEnabled: true });
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+
+        const tabGroup = env.component.tabState.getTabGroup('source');
+        expect(tabGroup?.tabs[1].type).toEqual('biblical-terms');
+
+        const targetTabGroup = env.component.tabState.getTabGroup('target');
+        expect(targetTabGroup?.tabs[1]).toBeUndefined();
+
+        env.dispose();
+      }));
+
+      it('should add biblical terms tab to target when available and "showSource" is false', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => false });
+        });
+        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
+        env.setProjectUserConfig({ biblicalTermsEnabled: true });
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+
+        const targetTabGroup = env.component.tabState.getTabGroup('target');
+        expect(targetTabGroup?.tabs[1].type).toEqual('biblical-terms');
+
+        const sourceTabGroup = env.component.tabState.getTabGroup('source');
+        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
+
+        env.dispose();
+      }));
+
+      it('should not add the biblical terms tab when opening project with biblical terms disabled', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => true });
+        });
+        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: false } });
+        env.setProjectUserConfig({ biblicalTermsEnabled: true });
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+
+        const sourceTabGroup = env.component.tabState.getTabGroup('source');
+        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
+        expect(env.component.chapter).toBe(1);
+
+        env.dispose();
+      }));
+
+      it('should not add the biblical terms tab when if the user had biblical terms disabled', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => true });
+        });
+        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
+        env.setProjectUserConfig({ biblicalTermsEnabled: false });
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+
+        const sourceTabGroup = env.component.tabState.getTabGroup('source');
+        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
+        expect(env.component.chapter).toBe(1);
+
+        env.dispose();
+      }));
+    });
+
     describe('tab header tooltips', () => {
       it('should show source tab header tooltip', fakeAsync(async () => {
         const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3948,8 +3948,8 @@ describe('EditorComponent', () => {
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
         env.wait();
 
-        const tabGroup = env.component.tabState.getTabGroup('source');
-        expect(tabGroup?.tabs[1].type).toEqual('biblical-terms');
+        const sourceTabGroup = env.component.tabState.getTabGroup('source');
+        expect(sourceTabGroup?.tabs[1].type).toEqual('biblical-terms');
 
         const targetTabGroup = env.component.tabState.getTabGroup('target');
         expect(targetTabGroup?.tabs[1]).toBeUndefined();
@@ -3991,7 +3991,7 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should not add the biblical terms tab when if the user had biblical terms disabled', fakeAsync(() => {
+      it('should not add the biblical terms tab if the user had biblical terms disabled', fakeAsync(() => {
         const env = new TestEnvironment(env => {
           Object.defineProperty(env.component, 'showSource', { get: () => true });
         });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1412,6 +1412,22 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
   }
 
+  private async updateBiblicalTermsTabVisibility(): Promise<void> {
+    // If the user does not have an existing Biblical Terms tab, and BT is enabled in their project and project-user
+    // configuration, show the Biblical Terms tab then remove that setting from their project-user configuration.
+    const existingDraftTab: { groupId: EditorTabGroupType; index: number } | undefined =
+      this.tabState.getFirstTabOfTypeIndex('biblical-terms');
+    if (
+      existingDraftTab == null &&
+      this.projectDoc?.data?.biblicalTermsConfig?.biblicalTermsEnabled === true &&
+      this.projectUserConfigDoc?.data?.biblicalTermsEnabled === true
+    ) {
+      const groupIdToAddTo: EditorTabGroupType = this.showSource ? 'source' : 'target';
+      this.tabState.addTab(groupIdToAddTo, await this.editorTabFactory.createTab('biblical-terms'), false);
+      await this.projectUserConfigDoc?.submitJson0Op(op => op.unset(p => p.biblicalTermsEnabled));
+    }
+  }
+
   /** Insert or remove note thread embeds into the quill editor. */
   private toggleNoteThreadVerses(toggleOn: boolean): void {
     if (
@@ -1891,6 +1907,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.changeText();
     this.toggleNoteThreadVerses(true);
     this.updateAutoDraftTabVisibility();
+    this.updateBiblicalTermsTabVisibility();
   }
 
   private loadTranslateSuggesterConfidence(): void {

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
@@ -28,6 +29,9 @@ public class SFProjectUserConfig : ProjectData
     public List<string> CommentRefsRead { get; set; } = [];
     public List<EditorTabPersistData> EditorTabsOpen { get; set; } = [];
     public string? SelectedQuestionRef { get; set; }
+
+    [Obsolete("For backwards compatibility with older frontend clients. Deprecated September 2024.")]
+    public bool? BiblicalTermsEnabled { get; set; }
     public bool TransliterateBiblicalTerms { get; set; }
     public string? SelectedBiblicalTermsCategory { get; set; }
     public string? SelectedBiblicalTermsFilter { get; set; }


### PR DESCRIPTION
A bug was discovered on QA when a user had Biblical Terms enabled for their project and visible, the following error displays if the user has not yet updated SF to the latest version.

This PR fixes this by removing the migration, and restoring the `biblicalTermsEnabled` property in `SFProjectUserConfig` and making it nullable.

The downside of this PR is that users who previously had the Biblical Terms panel open will no longer have it open when the update their Scripture Forge PWA.

**Question**

Should we have Biblical Terms auto appear, like we do for Auto Draft if Biblical Terms is enabled for the project?

**Implementation Notes**

- The `biblicalTermsEnabled` property was restored and marked nullable because older clients will be able to set this value via their older version of the Translation Settings dialog.
- This PR is labelled as testing not required, as it is only testable on QA.
- I have kept the `SFProjectUserConfigMigration7` class and cleared its contents because this migration has already been run on all developer workstations, and deployed to QA. Any future migrations for ``SFProjectUserConfig` should begin with version 8.

**Error**

![image](https://github.com/user-attachments/assets/8121869e-4ae5-4666-9925-d8ea85fc98bc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2740)
<!-- Reviewable:end -->
