### PR TITLE
SF-3002 Fix bug where pre-translation jobs are not cancelled

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -72,9 +72,6 @@ public class MachineApiService(
         // Ensure that the user has permission
         await EnsureProjectPermissionAsync(curUserId, sfProjectId);
 
-        // Get the translation engine id
-        string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: true);
-
         // If we have pre-translation job information
         if (
             (await projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret)
@@ -100,6 +97,9 @@ public class MachineApiService(
                 }
             );
         }
+
+        // Get the translation engine id
+        string translationEngineId = await GetTranslationIdAsync(sfProjectId, preTranslate: true);
 
         try
         {


### PR DESCRIPTION
This PR fixes a bug where draft generation jobs were not being cancelled if the cancel button was clicked soon after the build was started for the first time for that project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2742)
<!-- Reviewable:end -->
