### PR TITLE
SF-2964 Update isValid when restoring a history snapshot

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -1,11 +1,10 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
-import { firstValueFrom, Observable } from 'rxjs';
+import { Observable, firstValueFrom } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
-import { Snapshot } from 'xforge-common/models/snapshot';
 import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
+import { TextSnapshot } from '../../xforge-common/models/textsnapshot';
 import { ParatextProject } from './models/paratext-project';
 import { TextDocSource } from './models/text-doc';
 
@@ -103,9 +102,9 @@ export class ParatextService {
     book: string,
     chapter: number,
     timestamp: string
-  ): Promise<Snapshot<TextData> | undefined> {
+  ): Promise<TextSnapshot | undefined> {
     return await firstValueFrom(
-      this.http.get<Snapshot<TextData>>(
+      this.http.get<TextSnapshot>(
         `${PARATEXT_API_NAMESPACE}/history/snapshot/${projectId}_${book}_${chapter}_target?timestamp=${timestamp}`,
         {
           headers: this.headers

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -3,8 +3,8 @@ import { Injectable } from '@angular/core';
 import { Observable, firstValueFrom } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
+import { TextSnapshot } from 'xforge-common/models/textsnapshot';
 import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
-import { TextSnapshot } from '../../xforge-common/models/textsnapshot';
 import { ParatextProject } from './models/paratext-project';
 import { TextDocSource } from './models/text-doc';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
@@ -160,6 +160,7 @@ describe('HistoryChooserComponent', () => {
     env.clickRevertHistoryButton();
     verify(mockedDialogService.confirm(anything(), anything())).once();
     verify(mockedTextDocService.overwrite(anything(), anything(), anything())).once();
+    verify(mockedProjectService.onlineSetIsValid(anything(), anything(), anything(), env.isSnapshotValid)).once();
   }));
 
   class TestEnvironment {
@@ -167,6 +168,7 @@ describe('HistoryChooserComponent', () => {
     readonly fixture: ComponentFixture<HistoryChooserComponent>;
     readonly realtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
     readonly testOnlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
+    isSnapshotValid = true;
 
     constructor() {
       this.fixture = TestBed.createComponent(HistoryChooserComponent);
@@ -185,7 +187,8 @@ describe('HistoryChooserComponent', () => {
         data: { ops: [] },
         id: 'id',
         type: '',
-        v: 1
+        v: 1,
+        isValid: this.isSnapshotValid
       });
       when(mockedI18nService.locale).thenReturn({
         localName: 'English',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -5,20 +5,21 @@ import { Canon } from '@sillsdev/scripture';
 import { DeltaStatic } from 'quill';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import {
-  asyncScheduler,
   BehaviorSubject,
+  Observable,
+  Subject,
+  asyncScheduler,
   combineLatest,
   map,
-  Observable,
   observeOn,
   startWith,
-  Subject,
   tap
 } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TextSnapshot } from '../../../../../xforge-common/models/textsnapshot';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { Delta, TextDocId } from '../../../../core/models/text-doc';
 import { ParatextService, Revision } from '../../../../core/paratext.service';
@@ -45,7 +46,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
 
   historyRevisions: Revision[] = [];
   selectedRevision: Revision | undefined;
-  selectedSnapshot: Snapshot<TextData> | undefined;
+  selectedSnapshot: TextSnapshot | undefined;
 
   // 'asyncScheduler' prevents ExpressionChangedAfterItHasBeenCheckedError
   private loading$ = new BehaviorSubject<boolean>(false);
@@ -155,6 +156,12 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
     const delta: DeltaStatic = new Delta(this.selectedSnapshot.data.ops);
     const textDocId = new TextDocId(this.projectId, this.bookNum, this.chapter, 'target');
     await this.textDocService.overwrite(textDocId, delta, 'History');
+    await this.projectService.onlineSetIsValid(
+      textDocId.projectId,
+      textDocId.bookNum,
+      textDocId.chapterNum,
+      this.selectedSnapshot.isValid
+    );
 
     // Force the history editor to reload
     this.revisionSelect.emit({ revision: this.selectedRevision, snapshot: this.selectedSnapshot });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -17,9 +17,9 @@ import {
 } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
+import { TextSnapshot } from 'xforge-common/models/textsnapshot';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { TextSnapshot } from '../../../../../xforge-common/models/textsnapshot';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { Delta, TextDocId } from '../../../../core/models/text-doc';
 import { ParatextService, Revision } from '../../../../core/paratext.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/textsnapshot.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/textsnapshot.ts
@@ -1,0 +1,5 @@
+import { Snapshot } from './snapshot';
+
+export interface TextSnapshot extends Snapshot {
+  isValid: boolean;
+}

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc;
 using Paratext.Data;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
-using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Scripture.Services;
 using SIL.XForge.Services;
@@ -136,7 +135,7 @@ public class ParatextController : ControllerBase
     /// <response code="403">The user does not have permission to access the document.</response>
     /// <response code="404">The document does not exist.</response>
     [HttpGet("history/snapshot/{projectId}_{book}_{chapter:int}_target")]
-    public async Task<ActionResult<Snapshot<TextData>>> GetSnapshotAsync(
+    public async Task<ActionResult<TextSnapshot>> GetSnapshotAsync(
         string projectId,
         string book,
         int chapter,

--- a/src/SIL.XForge.Scripture/Models/TextSnapshot.cs
+++ b/src/SIL.XForge.Scripture/Models/TextSnapshot.cs
@@ -1,0 +1,11 @@
+using SIL.XForge.Realtime;
+
+namespace SIL.XForge.Scripture.Models;
+
+public class TextSnapshot : Snapshot<TextData>
+{
+    /// <summary>
+    /// Whether the TextData is valid or not.
+    /// </summary>
+    public bool IsValid { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -80,7 +80,7 @@ public interface IParatextService
     void ClearParatextDataCaches(UserSecret userSecret, string paratextId);
     void InitializeCommentManager(UserSecret userSecret, string paratextId);
 
-    Task<Snapshot<TextData>> GetSnapshotAsync(
+    Task<TextSnapshot> GetSnapshotAsync(
         UserSecret userSecret,
         string sfProjectId,
         string book,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1902,7 +1902,7 @@ public class ParatextService : DisposableBase, IParatextService
             // Retrieve the USFM for the chapter, and convert to USX, then to deltas
             IGetText version = versionedText.GetVersion(revision.Id);
             string usfm = version.GetText(verseRef, true, false);
-            var chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
+            ChapterDelta chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
             ret = new TextSnapshot
             {
                 Id = id,
@@ -1915,7 +1915,7 @@ public class ParatextService : DisposableBase, IParatextService
         {
             // We have the snapshot, but we need to determine if it's valid
             var usfm = scrText.GetText(verseRef.BookNum);
-            var chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
+            ChapterDelta chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
             ret = new TextSnapshot
             {
                 Id = snapshot.Id,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1841,7 +1841,7 @@ public class ParatextService : DisposableBase, IParatextService
         }
     }
 
-    public async Task<Snapshot<TextData>> GetSnapshotAsync(
+    public async Task<TextSnapshot> GetSnapshotAsync(
         UserSecret userSecret,
         string sfProjectId,
         string book,
@@ -1870,16 +1870,19 @@ public class ParatextService : DisposableBase, IParatextService
         // Ensure that the timestamp is UTC
         timestamp = DateTime.SpecifyKind(timestamp, DateTimeKind.Utc);
 
+        // Load the Paratext project
+        string ptProjectId = projectDoc.Data.ParatextId;
+        using ScrText scrText = GetScrText(userSecret, ptProjectId);
+        VerseRef verseRef = new VerseRef($"{book} {chapter}:0");
+
+        TextSnapshot ret = null;
         string id = $"{sfProjectId}:{book}:{chapter}:target";
         Snapshot<TextData> snapshot = await connection.FetchSnapshotAsync<TextData>(id, timestamp);
 
-        // We do not have a snapshot, so retrieve the data from Paratext
-        // Note: The following code is not testable due to ParatextData limitations
         if (snapshot.Data is null)
         {
-            // Load the Paratext project
-            string ptProjectId = projectDoc.Data.ParatextId;
-            using ScrText scrText = GetScrText(userSecret, ptProjectId);
+            // We do not have a snapshot, so retrieve the data from Paratext
+            // Note: The following code is not testable due to ParatextData limitations
 
             // Retrieve the first revision before or at the timestamp
             VersionedText versionedText = VersioningManager.Get(scrText);
@@ -1898,17 +1901,31 @@ public class ParatextService : DisposableBase, IParatextService
 
             // Retrieve the USFM for the chapter, and convert to USX, then to deltas
             IGetText version = versionedText.GetVersion(revision.Id);
-            VerseRef verseRef = new VerseRef($"{book} {chapter}:0");
             string usfm = version.GetText(verseRef, true, false);
-            snapshot = new Snapshot<TextData>
+            var chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
+            ret = new TextSnapshot
             {
                 Id = id,
                 Version = 0,
-                Data = new TextData(GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm)),
+                Data = new TextData(chapterDelta.Delta),
+                IsValid = chapterDelta.IsValid
+            };
+        }
+        else
+        {
+            // We have the snapshot, but we need to determine if it's valid
+            var usfm = scrText.GetText(verseRef.BookNum);
+            var chapterDelta = GetDeltaFromUsfm(scrText, verseRef.BookNum, usfm);
+            ret = new TextSnapshot
+            {
+                Id = snapshot.Id,
+                Version = snapshot.Version,
+                Data = snapshot.Data,
+                IsValid = chapterDelta.IsValid
             };
         }
 
-        return snapshot;
+        return ret;
     }
 
     public async IAsyncEnumerable<DocumentRevision> GetRevisionHistoryAsync(
@@ -2075,7 +2092,7 @@ public class ParatextService : DisposableBase, IParatextService
         using ScrText scrText = GetScrText(userSecret, projectDoc.Data.ParatextId);
 
         // Get the USFM as a Delta
-        return GetDeltaFromUsfm(scrText, bookNum, usfm);
+        return GetDeltaFromUsfm(scrText, bookNum, usfm).Delta;
     }
 
     protected override void DisposeManagedResources()
@@ -2091,11 +2108,11 @@ public class ParatextService : DisposableBase, IParatextService
     /// <param name="bookNum">The book number</param>
     /// <param name="usfm">The USFM data</param>
     /// <returns>The delta.</returns>
-    private Delta GetDeltaFromUsfm(ScrText scrText, int bookNum, string usfm)
+    private ChapterDelta GetDeltaFromUsfm(ScrText scrText, int bookNum, string usfm)
     {
         string usx = UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
         XDocument usxDoc = XDocument.Parse(usx);
-        return _deltaUsxMapper.ToChapterDeltas(usxDoc).First().Delta;
+        return _deltaUsxMapper.ToChapterDeltas(usxDoc).First();
     }
 
     private ScrText GetScrText(UserSecret userSecret, string paratextId)

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -250,7 +250,7 @@ public class ParatextControllerTests
             .Throws(new ForbiddenException());
 
         // SUT
-        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
+        ActionResult<TextSnapshot> actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
@@ -263,7 +263,7 @@ public class ParatextControllerTests
         env.UserAccessor.UserId.Returns("invalid_user");
 
         // SUT
-        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
+        ActionResult<TextSnapshot> actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
@@ -277,7 +277,7 @@ public class ParatextControllerTests
             .Throws(new DataNotFoundException("Not Found"));
 
         // SUT
-        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
+        ActionResult<TextSnapshot> actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<NotFoundResult>(actual.Result);
     }
@@ -289,7 +289,7 @@ public class ParatextControllerTests
         var env = new TestEnvironment();
 
         // SUT
-        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
+        ActionResult<TextSnapshot> actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
         var snapshot = (Snapshot<TextData>)((OkObjectResult)actual.Result!).Value!;

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -250,12 +250,7 @@ public class ParatextControllerTests
             .Throws(new ForbiddenException());
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetSnapshotAsync(
-            Project01,
-            Book,
-            Chapter,
-            Timestamp
-        );
+        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
@@ -268,12 +263,7 @@ public class ParatextControllerTests
         env.UserAccessor.UserId.Returns("invalid_user");
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetSnapshotAsync(
-            Project01,
-            Book,
-            Chapter,
-            Timestamp
-        );
+        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
@@ -287,12 +277,7 @@ public class ParatextControllerTests
             .Throws(new DataNotFoundException("Not Found"));
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetSnapshotAsync(
-            Project01,
-            Book,
-            Chapter,
-            Timestamp
-        );
+        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<NotFoundResult>(actual.Result);
     }
@@ -304,12 +289,7 @@ public class ParatextControllerTests
         var env = new TestEnvironment();
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetSnapshotAsync(
-            Project01,
-            Book,
-            Chapter,
-            Timestamp
-        );
+        var actual = await env.Controller.GetSnapshotAsync(Project01, Book, Chapter, Timestamp);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
         var snapshot = (Snapshot<TextData>)((OkObjectResult)actual.Result!).Value!;
@@ -404,11 +384,12 @@ public class ParatextControllerTests
             Source = OpSource.History,
         };
 
-        public readonly Snapshot<TextData> TestSnapshot = new Snapshot<TextData>
+        public readonly TextSnapshot TestSnapshot = new TextSnapshot
         {
             Data = new TextData(),
             Id = "textId",
             Version = 1,
+            IsValid = true
         };
 
         public readonly byte[] ZipHeader = [80, 75, 05, 06];

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -469,7 +469,7 @@ public class ParatextServiceTests
         string ptProjectId = env.PTProjectIds[env.Project01].Id;
         UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         env.SetSharedRepositorySource(user01Secret, UserRoles.Administrator);
-        env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(i => null);
+        env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(_ => null);
 
         // SUT
         Assert.Throws<DataNotFoundException>(() => env.Service.GetBookText(user01Secret, ptProjectId, 8));
@@ -5217,7 +5217,7 @@ public class ParatextServiceTests
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
         ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
 
-        env.MockScrTextCollection.FindById(Arg.Any<string>(), Arg.Any<string>()).Returns(i => scrText);
+        env.MockScrTextCollection.FindById(Arg.Any<string>(), Arg.Any<string>()).Returns(_ => scrText);
         env.MockDeltaUsxMapper.ToChapterDeltas(Arg.Any<XDocument>())
             .Returns([new ChapterDelta(chapter, 1, false, textData)]);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -5214,8 +5214,6 @@ public class ParatextServiceTests
         TextData textData = env.AddTextDoc(Canon.BookIdToNumber(book), chapter);
 
         var associatedPtUser = new SFParatextUser(env.Username01);
-        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
         ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -503,10 +503,13 @@ public class ParatextServiceTests
 
         TextData data = new TextData(new Delta(new[] { token1, token2, token3, token4, token5 }));
         XDocument oldDocUsx = XDocument.Parse(ruthBookUsx);
-        var newDocUsx = env.DeltaUsxMapper.ToUsx(
-            oldDocUsx,
-            new List<ChapterDelta> { new ChapterDelta(1, 2, true, data) }
+        var mapper = new DeltaUsxMapper(
+            new TestGuidService(),
+            Substitute.For<ILogger<DeltaUsxMapper>>(),
+            Substitute.For<IExceptionHandler>()
         );
+        var newDocUsx = mapper.ToUsx(oldDocUsx, new List<ChapterDelta> { new ChapterDelta(1, 2, true, data) });
+
         int booksUpdated = await env.Service.PutBookText(userSecret, ptProjectId, ruthBookNum, newDocUsx);
         env.ProjectFileManager.Received(1).WriteFileCreatingBackup(Arg.Any<string>(), Arg.Any<Action<string>>());
         Assert.That(booksUpdated, Is.EqualTo(1));
@@ -5210,11 +5213,22 @@ public class ParatextServiceTests
         const int chapter = 1;
         TextData textData = env.AddTextDoc(Canon.BookIdToNumber(book), chapter);
 
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        ScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
+
+        env.MockScrTextCollection.FindById(Arg.Any<string>(), Arg.Any<string>()).Returns(i => scrText);
+        env.MockDeltaUsxMapper.ToChapterDeltas(Arg.Any<XDocument>())
+            .Returns([new ChapterDelta(chapter, 1, false, textData)]);
+
         // SUT
         var actual = await env.Service.GetSnapshotAsync(userSecret, project.Id, book, chapter, DateTime.UtcNow);
         Assert.AreEqual(textData.Ops.First(), actual.Data.Ops.First());
         Assert.AreEqual(textData.Id, actual.Id);
         Assert.AreEqual(0, actual.Version);
+        Assert.AreEqual(false, actual.IsValid);
     }
 
     [Test]
@@ -5310,6 +5324,9 @@ public class ParatextServiceTests
         );
         JToken token6 = JToken.Parse("{\"insert\": \"\n\" }");
         Delta expected = new Delta([token1, token2, token3, token4, token5, token6]);
+
+        env.MockDeltaUsxMapper.ToChapterDeltas(Arg.Any<XDocument>())
+            .Returns([new ChapterDelta(-1, -1, false, expected)]);
 
         // SUT
         var delta = await env.Service.GetDeltaFromUsfmAsync(env.User01, project.Id, env.RuthBookUsfm, 8);
@@ -5720,7 +5737,7 @@ public class ParatextServiceTests
         public readonly IGuidService MockGuidService;
         public readonly ParatextService Service;
         public readonly HttpClient MockRegistryHttpClient;
-        public readonly IDeltaUsxMapper DeltaUsxMapper;
+        public readonly IDeltaUsxMapper MockDeltaUsxMapper;
         public readonly IAuthService MockAuthService;
         public readonly Dictionary<string, string> usernames;
         private bool disposed;
@@ -5742,11 +5759,7 @@ public class ParatextServiceTests
             MockRestClientFactory = Substitute.For<ISFRestClientFactory>();
             MockGuidService = Substitute.For<IGuidService>();
             MockRegistryHttpClient = Substitute.For<HttpClient>();
-            DeltaUsxMapper = new DeltaUsxMapper(
-                new TestGuidService(),
-                Substitute.For<ILogger<DeltaUsxMapper>>(),
-                Substitute.For<IExceptionHandler>()
-            );
+            MockDeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
             MockAuthService = Substitute.For<IAuthService>();
 
             DateTime aSecondAgo = DateTime.Now - TimeSpan.FromSeconds(1);
@@ -5817,7 +5830,7 @@ public class ParatextServiceTests
                 MockGuidService,
                 MockRestClientFactory,
                 MockHgWrapper,
-                DeltaUsxMapper,
+                MockDeltaUsxMapper,
                 MockAuthService
             )
             {


### PR DESCRIPTION
This involved subclassing Snapshot to add the IsValid property. It also involved processing, via DeltaUsxMapper, the snapshot from the RealtimeServer when a snapshot is requested from there. This is new behavior, as before it would only process a snapshot if it didn't exist on the RealtimeServer, and therefore was fetched from PT. The processing supplies IsValid. We opted to subclass Snapshot to avoid overhauling RealtimeServer etc.

Now that IsValid is updated when restoring, I wonder if it's safe to allow restoring when the current text is invalid. This is currently disabled, maybe due to the deficiency I'm addressing?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2743)
<!-- Reviewable:end -->
