### PR TITLE
SF-2911 Support syncing notes when user has changed PT username

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -18,6 +18,8 @@ public interface IParatextService
     Task<bool> CanUserAuthenticateToPTArchivesAsync(string userSFId);
     Task<IReadOnlyList<ParatextProject>> GetProjectsAsync(UserSecret userSecret);
     string? GetParatextUsername(UserSecret userSecret);
+    void ForceParatextUsername(string username, string forcedUsername);
+    void ClearForcedUsernames();
     Task<Attempt<string>> TryGetProjectRoleAsync(UserSecret userSecret, string paratextId, CancellationToken token);
     ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -562,7 +562,11 @@ public class ParatextService : DisposableBase, IParatextService
     }
 
     /// <summary> Get the Paratext username from the UserSecret. </summary>
-    public string? GetParatextUsername(UserSecret userSecret) => _jwtTokenHelper.GetParatextUsername(userSecret);
+    public string? GetParatextUsername(UserSecret userSecret)
+    {
+        string? username = _jwtTokenHelper.GetParatextUsername(userSecret);
+        return UserSecret.ParatextUsername(username);
+    }
 
     /// <summary>
     /// Gets the permission a user has to access a resource, according to a DBL server.

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -81,6 +81,7 @@ public class ParatextService : DisposableBase, IParatextService
     private readonly DotNetCoreAlert _alertSystem;
     private readonly IDeltaUsxMapper _deltaUsxMapper;
     private readonly IAuthService _authService;
+    private readonly Dictionary<string, string> _forcedUsernames = [];
 
     public ParatextService(
         IWebHostEnvironment env,
@@ -565,8 +566,21 @@ public class ParatextService : DisposableBase, IParatextService
     public string? GetParatextUsername(UserSecret userSecret)
     {
         string? username = _jwtTokenHelper.GetParatextUsername(userSecret);
-        return UserSecret.ParatextUsername(username);
+        if (username is not null && _forcedUsernames.TryGetValue(username, out string forcedUsername))
+            return forcedUsername;
+        return username;
     }
+
+    /// <summary> Force a Paratext username for a given user. </summary>
+    /// <remarks>
+    /// It is crucial to clear the forced usernames before or after synchronizing with Paratext.
+    /// Since ParatextService is a singleton, forced usernames that not cleared will remain for subsequent syncs.
+    /// </remarks>
+    public void ForceParatextUsername(string username, string forcedUsername) =>
+        _forcedUsernames.Add(username, forcedUsername);
+
+    /// <summary> Clear forced usernames. </summary>
+    public void ClearForcedUsernames() => _forcedUsernames.Clear();
 
     /// <summary>
     /// Gets the permission a user has to access a resource, according to a DBL server.

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1833,13 +1833,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
         {
             await _projectDoc.SubmitJson0OpAsync(op =>
             {
+                List<string> userIdsAdded = [];
                 foreach (ParatextUserProfile activePtSyncUser in _currentPtSyncUsers.Values)
                 {
                     ParatextUserProfile existingUser = _projectDoc.Data.ParatextUsers.SingleOrDefault(u =>
                         u.Username == activePtSyncUser.Username
                     );
                     if (existingUser == null)
+                    {
+                        // Ensure the PT user gets the up-to-date SF user ID
+                        activePtSyncUser.SFUserId = _paratextUsers
+                            .SingleOrDefault(u => u.Username == activePtSyncUser.Username)
+                            ?.Id;
                         op.Add(pd => pd.ParatextUsers, activePtSyncUser);
+                        if (!string.IsNullOrEmpty(activePtSyncUser.SFUserId))
+                            userIdsAdded.Add(activePtSyncUser.SFUserId);
+                    }
                     else if (existingUser.SFUserId == null)
                     {
                         int index = _projectDoc.Data.ParatextUsers.FindIndex(u =>
@@ -1848,6 +1857,15 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         string userId = _currentPtSyncUsers[existingUser.Username].SFUserId;
                         if (!string.IsNullOrEmpty(userId))
                             op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
+                    }
+                }
+                foreach (string userId in userIdsAdded)
+                {
+                    int index = _projectDoc.Data.ParatextUsers.FindIndex(u => u.SFUserId == userId);
+                    if (index > -1)
+                    {
+                        // Unset the old user that had the same ID
+                        op.Unset(pd => pd.ParatextUsers[index].SFUserId);
                     }
                 }
             });
@@ -1957,6 +1975,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
         // Free the comment manager and versioning manager for this project from memory
         _paratextService.ClearParatextDataCaches(_userSecret, _projectDoc.Data.ParatextId);
+        UserSecret.RemoveForcedUsernames();
 
         await NotifySyncProgress(SyncPhase.Phase9, 100.0);
         Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
@@ -1987,20 +2006,32 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
     private Dictionary<string, ParatextUserProfile> GetCurrentProjectPtUsers()
     {
-        Dictionary<string, ParatextUserProfile> paratextUsers = _projectDoc.Data.ParatextUsers.ToDictionary(p =>
+        UserSecret.RemoveForcedUsernames();
+        Dictionary<string, ParatextUserProfile> savedPtUsers = _projectDoc.Data.ParatextUsers.ToDictionary(p =>
             p.Username
         );
         foreach (ParatextProjectUser paratextUser in _paratextUsers)
         {
-            if (!paratextUsers.TryGetValue(paratextUser.Username, out ParatextUserProfile profile))
+            if (!savedPtUsers.TryGetValue(paratextUser.Username, out ParatextUserProfile profile))
             {
+                string sfUserId = paratextUser.Id;
+                if (!string.IsNullOrEmpty(sfUserId))
+                {
+                    // Detect if the SF user ID is already attached to a Paratext user. Force the old PT username
+                    ParatextUserProfile oldPtUser = savedPtUsers.Values.SingleOrDefault(u => u.SFUserId == sfUserId);
+                    if (oldPtUser != null)
+                    {
+                        sfUserId = null;
+                        UserSecret.ForceUsername(paratextUser.Username, oldPtUser.Username);
+                    }
+                }
                 ParatextUserProfile userProfile = new ParatextUserProfile
                 {
                     Username = paratextUser.Username,
-                    SFUserId = paratextUser.Id,
+                    SFUserId = sfUserId,
                     OpaqueUserId = _guidService.NewObjectId(),
                 };
-                paratextUsers.TryAdd(paratextUser.Username, userProfile);
+                savedPtUsers.TryAdd(paratextUser.Username, userProfile);
             }
             else
             {
@@ -2008,7 +2039,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 // We create a new object to so that the logic in projectDoc.SubmitJson0OpAsync() will see the change.
                 if (profile.SFUserId is null)
                 {
-                    paratextUsers[paratextUser.Username] = new ParatextUserProfile
+                    savedPtUsers[paratextUser.Username] = new ParatextUserProfile
                     {
                         Username = profile.Username,
                         SFUserId = paratextUser.Id,
@@ -2017,7 +2048,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 }
             }
         }
-        return paratextUsers;
+        return savedPtUsers;
     }
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1849,14 +1849,19 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         if (!string.IsNullOrEmpty(activePtSyncUser.SFUserId))
                             userIdsAdded.Add(activePtSyncUser.SFUserId);
                     }
-                    else if (existingUser.SFUserId == null)
+                    else if (string.IsNullOrEmpty(existingUser.SFUserId))
                     {
                         int index = _projectDoc.Data.ParatextUsers.FindIndex(u =>
                             u.Username == activePtSyncUser.Username
                         );
-                        string userId = _currentPtSyncUsers[existingUser.Username].SFUserId;
+                        string? userId = _paratextUsers
+                            .SingleOrDefault(u => u.Username == activePtSyncUser.Username)
+                            ?.Id;
                         if (!string.IsNullOrEmpty(userId))
+                        {
                             op.Set(pd => pd.ParatextUsers[index].SFUserId, userId);
+                            userIdsAdded.Add(userId);
+                        }
                     }
                 }
                 foreach (string userId in userIdsAdded)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1980,7 +1980,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
         // Free the comment manager and versioning manager for this project from memory
         _paratextService.ClearParatextDataCaches(_userSecret, _projectDoc.Data.ParatextId);
-        UserSecret.RemoveForcedUsernames();
+        _paratextService.ClearForcedUsernames();
 
         await NotifySyncProgress(SyncPhase.Phase9, 100.0);
         Log($"CompleteSync: Finished. Sync was {(successful ? "successful" : "unsuccessful")}.");
@@ -2011,7 +2011,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
     private Dictionary<string, ParatextUserProfile> GetCurrentProjectPtUsers()
     {
-        UserSecret.RemoveForcedUsernames();
+        _paratextService.ClearForcedUsernames();
         Dictionary<string, ParatextUserProfile> availablePtUsers = _projectDoc.Data.ParatextUsers.ToDictionary(p =>
             p.Username
         );
@@ -2049,7 +2049,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 if (oldPtUser is not null)
                 {
                     userProfileToAdd.SFUserId = null;
-                    UserSecret.ForceUsername(paratextUser.Username, oldPtUser.Username);
+                    _paratextService.ForceParatextUsername(paratextUser.Username, oldPtUser.Username);
                 }
             }
             if (userProfileToAdd is not null)

--- a/src/SIL.XForge/Models/UserSecret.cs
+++ b/src/SIL.XForge/Models/UserSecret.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace SIL.XForge.Models;
 
 /// <summary>
@@ -8,10 +6,6 @@ namespace SIL.XForge.Models;
 /// </summary>
 public class UserSecret : IIdentifiable
 {
-    // Stores a mapping of usernames to the forced usernames for a user secret to allow specifying an
-    // alternate username. This is needed to persist data created by a user prior changing PT names
-    private static Dictionary<string, string> _forcedUsernameMap = [];
-
     /// <summary>
     /// SF user ID of the user that these secrets pertain to. (This is not a different set of IDs for
     /// specifically user secrets.)
@@ -19,16 +13,4 @@ public class UserSecret : IIdentifiable
     public string Id { get; set; }
 
     public Tokens ParatextTokens { get; set; }
-
-    public static string ParatextUsername(string username)
-    {
-        if (_forcedUsernameMap.TryGetValue(username, out string forcedUsername))
-            return forcedUsername;
-        return username;
-    }
-
-    public static void RemoveForcedUsernames() => _forcedUsernameMap.Clear();
-
-    public static bool ForceUsername(string username, string forcedUsername) =>
-        _forcedUsernameMap.TryAdd(username, forcedUsername);
 }

--- a/src/SIL.XForge/Models/UserSecret.cs
+++ b/src/SIL.XForge/Models/UserSecret.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SIL.XForge.Models;
 
 /// <summary>
@@ -6,6 +8,10 @@ namespace SIL.XForge.Models;
 /// </summary>
 public class UserSecret : IIdentifiable
 {
+    // Stores a mapping of usernames to the forced usernames for a user secret to allow specifying an
+    // alternate username. This is needed to persist data created by a user prior changing PT names
+    private static Dictionary<string, string> _forcedUsernameMap = [];
+
     /// <summary>
     /// SF user ID of the user that these secrets pertain to. (This is not a different set of IDs for
     /// specifically user secrets.)
@@ -13,4 +19,16 @@ public class UserSecret : IIdentifiable
     public string Id { get; set; }
 
     public Tokens ParatextTokens { get; set; }
+
+    public static string ParatextUsername(string username)
+    {
+        if (_forcedUsernameMap.TryGetValue(username, out string forcedUsername))
+            return forcedUsername;
+        return username;
+    }
+
+    public static void RemoveForcedUsernames() => _forcedUsernameMap.Clear();
+
+    public static bool ForceUsername(string username, string forcedUsername) =>
+        _forcedUsernameMap.TryAdd(username, forcedUsername);
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -2919,7 +2919,7 @@ public class ParatextServiceTests
         // Update the username
         string newUsername = "New User 1";
         env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(newUsername);
-        UserSecret.ForceUsername(newUsername, env.Username01);
+        env.Service.ForceParatextUsername(newUsername, env.Username01);
 
         ThreadNoteComponents note1 = new ThreadNoteComponents
         {
@@ -3004,7 +3004,6 @@ public class ParatextServiceTests
         CommentThread thread2 = env.ProjectCommentManager.FindThread("thread2");
         Assert.That(thread2.Comments.Count, Is.EqualTo(1));
         Assert.That(thread2.Comments[0].User, Is.EqualTo(env.Username01));
-        UserSecret.RemoveForcedUsernames();
     }
 
     [Test]
@@ -5775,11 +5774,11 @@ public class ParatextServiceTests
         Assert.AreEqual(env.Username01, username);
 
         string forcedUsername = "Forced Username";
-        UserSecret.ForceUsername(env.Username01, forcedUsername);
+        env.Service.ForceParatextUsername(env.Username01, forcedUsername);
 
         username = env.Service.GetParatextUsername(userSecret);
         Assert.AreEqual(forcedUsername, username);
-        UserSecret.RemoveForcedUsernames();
+        env.Service.ClearForcedUsernames();
     }
 
     private class TestEnvironment : IDisposable


### PR DESCRIPTION
This PR updates our current Paratext users records for a project prior to attempting to synchronize the notes. It was important to retain the records of users that have had their Paratext name changed, but the SF user ID would be removed from old records and moved to the new record for a Paratext user.

We do not expect too many users to need to update their usernames, but this allows it to happen and for a sync to continue to work. It would be critical to ensure that old notes created by the user before changing their name continues to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2747)
<!-- Reviewable:end -->
