### PR TITLE
SF-2972 Improve drafting bulk-book selection UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -2,6 +2,7 @@
   @if (availableBooks.length > 0 && !readonly) {
     <div>
       <mat-checkbox
+        class="ot-checkbox"
         value="OT"
         [checked]="selectedAllOT"
         [disabled]="!isOldTestamentAvailable()"
@@ -11,6 +12,7 @@
         {{ t("old_testament") }}
       </mat-checkbox>
       <mat-checkbox
+        class="nt-checkbox"
         value="NT"
         [checked]="selectedAllNT"
         [(indeterminate)]="partialNT"
@@ -22,6 +24,7 @@
 
       @if (isDeuterocanonAvailable()) {
         <mat-checkbox
+          class="dc-checkbox"
           value="DC"
           [checked]="selectedAllDC"
           (change)="select($event.checked ? 'DC' : 'clearDC')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -4,20 +4,20 @@
       <mat-checkbox
         class="ot-checkbox"
         value="OT"
-        [checked]="selectedAllOT"
         [disabled]="!isOldTestamentAvailable()"
-        [(indeterminate)]="partialOT"
-        (change)="select($event.checked ? 'OT' : 'clearOT')"
+        [checked]="selectedAllOT"
+        [indeterminate]="partialOT"
+        (change)="select('OT', $event.checked)"
       >
         {{ t("old_testament") }}
       </mat-checkbox>
       <mat-checkbox
         class="nt-checkbox"
         value="NT"
-        [checked]="selectedAllNT"
-        [(indeterminate)]="partialNT"
         [disabled]="!isNewTestamentAvailable()"
-        (change)="select($event.checked ? 'NT' : 'clearNT')"
+        [checked]="selectedAllNT"
+        [indeterminate]="partialNT"
+        (change)="select('NT', $event.checked)"
       >
         {{ t("new_testament") }}
       </mat-checkbox>
@@ -27,8 +27,8 @@
           class="dc-checkbox"
           value="DC"
           [checked]="selectedAllDC"
-          (change)="select($event.checked ? 'DC' : 'clearDC')"
-          [(indeterminate)]="partialDC"
+          [indeterminate]="partialDC"
+          (change)="select('DC', $event.checked)"
         >
           {{ t("deuterocanon") }}
         </mat-checkbox>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,33 +1,35 @@
 <ng-container *transloco="let t; read: 'book_select'">
   @if (availableBooks.length > 0 && !readonly) {
     <div>
-      <mat-card class="bulk-select">
-        <mat-card-content>
-          <div>
-            <span>{{ t("select") }}:</span>
-            <mat-button-toggle-group
-              (change)="select($event.value)"
-              [(ngModel)]="selection"
-              hideSingleSelectionIndicator="true"
-            >
-              <mat-button-toggle value="OT" [disabled]="!isOldTestamentAvailable()">
-                {{ t("old_testament") }}
-              </mat-button-toggle>
-              <mat-button-toggle value="NT" [disabled]="!isNewTestamentAvailable()">
-                {{ t("new_testament") }}
-              </mat-button-toggle>
-              @if (isDeuterocanonAvailable()) {
-                <mat-button-toggle value="DC">
-                  {{ t("deuterocanon") }}
-                </mat-button-toggle>
-              }
-            </mat-button-toggle-group>
-            @if (selectedBooks.length > 0) {
-              <button mat-button (click)="clear()">{{ t("clear") }}</button>
-            }
-          </div>
-        </mat-card-content>
-      </mat-card>
+      <mat-checkbox
+        value="OT"
+        [checked]="selectedAllOT"
+        [disabled]="!isOldTestamentAvailable()"
+        [(indeterminate)]="partialOT"
+        (change)="select($event.checked ? 'OT' : 'clearOT')"
+      >
+        {{ t("old_testament") }}
+      </mat-checkbox>
+      <mat-checkbox
+        value="NT"
+        [checked]="selectedAllNT"
+        [(indeterminate)]="partialNT"
+        [disabled]="!isNewTestamentAvailable()"
+        (change)="select($event.checked ? 'NT' : 'clearNT')"
+      >
+        {{ t("new_testament") }}
+      </mat-checkbox>
+
+      @if (isDeuterocanonAvailable()) {
+        <mat-checkbox
+          value="DC"
+          [checked]="selectedAllDC"
+          (change)="select($event.checked ? 'DC' : 'clearDC')"
+          [(indeterminate)]="partialDC"
+        >
+          {{ t("deuterocanon") }}
+        </mat-checkbox>
+      }
     </div>
   }
   <div class="flex-row">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -64,35 +64,35 @@ describe('BookMultiSelectComponent', () => {
   it('can select all OT books and clear all OT books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
-    await component.select('OT');
+    await component.select('OT', true);
     expect(component.selectedBooks.length).toEqual(3);
 
-    await component.select('clearOT');
+    await component.select('OT', false);
     expect(component.selectedBooks.length).toEqual(0);
   });
 
   it('can select all NT books and clear all NT books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
-    await component.select('NT');
+    await component.select('NT', true);
     expect(component.selectedBooks.length).toEqual(4);
 
-    await component.select('clearNT');
+    await component.select('NT', false);
     expect(component.selectedBooks.length).toEqual(2);
   });
 
   it('can select all DC books and clear all DC books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
-    await component.select('DC');
+    await component.select('DC', true);
     expect(component.selectedBooks.length).toEqual(4);
 
-    await component.select('clearDC');
+    await component.select('DC', false);
     expect(component.selectedBooks.length).toEqual(2);
   });
 
   it('should show checkboxes for OT, NT, and DC as indeterminate when only some books from that category are selected', async () => {
-    await component.select('clearOT');
+    await component.select('OT', false);
     component.selectedBooks = [1];
     await component.ngOnChanges();
     fixture.detectChanges();
@@ -101,7 +101,7 @@ describe('BookMultiSelectComponent', () => {
     expect(component.partialNT).toBe(false);
     expect(component.partialDC).toBe(false);
 
-    await component.select('clearOT');
+    await component.select('OT', false);
     component.selectedBooks = [40];
     await component.ngOnChanges();
     fixture.detectChanges();
@@ -110,7 +110,7 @@ describe('BookMultiSelectComponent', () => {
     expect(component.partialNT).toBe(true);
     expect(component.partialDC).toBe(false);
 
-    await component.select('clearNT');
+    await component.select('NT', false);
     component.selectedBooks = [67];
     await component.ngOnChanges();
     fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -26,15 +26,17 @@ describe('BookMultiSelectComponent', () => {
   }));
 
   beforeEach(() => {
-    mockBooks = [1, 2, 3, 42, 70];
+    mockBooks = [1, 2, 3, 40, 42, 67, 70];
     mockSelectedBooks = [1, 3];
     when(mockedActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockedProgressService.isLoaded$).thenReturn(of(true));
     when(mockedProgressService.texts).thenReturn([
       { text: { bookNum: 1 }, percentage: 0 } as TextProgress,
-      { text: { bookNum: 2 }, percentage: 20 } as TextProgress,
-      { text: { bookNum: 3 }, percentage: 40 } as TextProgress,
-      { text: { bookNum: 42 }, percentage: 70 } as TextProgress,
+      { text: { bookNum: 2 }, percentage: 15 } as TextProgress,
+      { text: { bookNum: 3 }, percentage: 30 } as TextProgress,
+      { text: { bookNum: 40 }, percentage: 45 } as TextProgress,
+      { text: { bookNum: 42 }, percentage: 60 } as TextProgress,
+      { text: { bookNum: 67 }, percentage: 80 } as TextProgress,
       { text: { bookNum: 70 }, percentage: 100 } as TextProgress
     ]);
 
@@ -50,42 +52,71 @@ describe('BookMultiSelectComponent', () => {
 
     expect(component.bookOptions).toEqual([
       { bookNum: 1, bookId: 'GEN', selected: true, progressPercentage: 0 },
-      { bookNum: 2, bookId: 'EXO', selected: false, progressPercentage: 20 },
-      { bookNum: 3, bookId: 'LEV', selected: true, progressPercentage: 40 },
-      { bookNum: 42, bookId: 'LUK', selected: false, progressPercentage: 70 },
+      { bookNum: 2, bookId: 'EXO', selected: false, progressPercentage: 15 },
+      { bookNum: 3, bookId: 'LEV', selected: true, progressPercentage: 30 },
+      { bookNum: 40, bookId: 'MAT', selected: false, progressPercentage: 45 },
+      { bookNum: 42, bookId: 'LUK', selected: false, progressPercentage: 60 },
+      { bookNum: 67, bookId: 'TOB', selected: false, progressPercentage: 80 },
       { bookNum: 70, bookId: 'WIS', selected: false, progressPercentage: 100 }
     ]);
   });
 
-  it('can select all OT books', async () => {
+  it('can select all OT books and clear all OT books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
     await component.select('OT');
-
     expect(component.selectedBooks.length).toEqual(3);
+
+    await component.select('clearOT');
+    expect(component.selectedBooks.length).toEqual(0);
   });
 
-  it('can select all NT books', async () => {
+  it('can select all NT books and clear all NT books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
     await component.select('NT');
+    expect(component.selectedBooks.length).toEqual(4);
 
-    expect(component.selectedBooks.length).toEqual(3);
+    await component.select('clearNT');
+    expect(component.selectedBooks.length).toEqual(2);
   });
 
-  it('can select all DC books', async () => {
+  it('can select all DC books and clear all DC books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 
     await component.select('DC');
+    expect(component.selectedBooks.length).toEqual(4);
 
-    expect(component.selectedBooks.length).toEqual(3);
+    await component.select('clearDC');
+    expect(component.selectedBooks.length).toEqual(2);
   });
 
-  it('can reset book selection', async () => {
-    expect(component.selectedBooks.length).toEqual(2);
+  it('should show checkboxes for OT, NT, and DC as indeterminate when only some books from that category are selected', async () => {
+    await component.select('clearOT');
+    component.selectedBooks = [1];
+    await component.ngOnChanges();
+    fixture.detectChanges();
 
-    await component.clear();
+    expect(component.partialOT).toBe(true);
+    expect(component.partialNT).toBe(false);
+    expect(component.partialDC).toBe(false);
 
-    expect(component.selectedBooks.length).toEqual(0);
+    await component.select('clearOT');
+    component.selectedBooks = [40];
+    await component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(component.partialOT).toBe(false);
+    expect(component.partialNT).toBe(true);
+    expect(component.partialDC).toBe(false);
+
+    await component.select('clearNT');
+    component.selectedBooks = [67];
+    await component.ngOnChanges();
+    fixture.detectChanges();
+
+    expect(component.partialOT).toBe(false);
+    expect(component.partialOT).toBe(false);
+    expect(component.partialDC).toBe(true);
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -30,7 +30,19 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
 
   bookOptions: BookOption[] = [];
 
-  selection: any = '';
+  booksOT: number[] = [];
+  availableBooksOT: number[] = [];
+  booksNT: number[] = [];
+  availableBooksNT: number[] = [];
+  booksDC: number[] = [];
+  availableBooksDC: number[] = [];
+
+  partialOT: boolean = false;
+  partialNT: boolean = false;
+  partialDC: boolean = false;
+  selectedAllOT: boolean = false;
+  selectedAllNT: boolean = false;
+  selectedAllDC: boolean = false;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -61,15 +73,29 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
       selected: selectedSet.has(bookNum),
       progressPercentage: progress.find(p => p.text.bookNum === bookNum)!.percentage
     }));
+
+    this.booksOT = this.selectedBooks.filter(n => Canon.isBookOT(n));
+    this.availableBooksOT = this.availableBooks.filter(n => Canon.isBookOT(n));
+    this.booksNT = this.selectedBooks.filter(n => Canon.isBookNT(n));
+    this.availableBooksNT = this.availableBooks.filter(n => Canon.isBookNT(n));
+    this.booksDC = this.selectedBooks.filter(n => Canon.isBookDC(n));
+    this.availableBooksDC = this.availableBooks.filter(n => Canon.isBookDC(n));
+
+    this.selectedAllOT = this.booksOT.length > 0 && this.booksOT.length === this.availableBooksOT.length;
+    this.selectedAllNT = this.booksNT.length > 0 && this.booksNT.length === this.availableBooksNT.length;
+    this.selectedAllDC = this.booksDC.length > 0 && this.booksDC.length === this.availableBooksDC.length;
+
+    this.partialOT = !this.selectedAllOT && this.booksOT.length > 0;
+    this.partialNT = !this.selectedAllNT && this.booksNT.length > 0;
+    this.partialDC = !this.selectedAllDC && this.booksDC.length > 0;
   }
 
   onChipListChange(book: BookOption): void {
     const bookIndex: number = this.bookOptions.findIndex(n => n.bookId === book.bookId);
     this.bookOptions[bookIndex].selected = !this.bookOptions[bookIndex].selected;
     this.selectedBooks = this.bookOptions.filter(n => n.selected).map(n => n.bookNum);
-
-    this.selection = undefined;
     this.bookSelect.emit(this.selectedBooks);
+    this.initBookOptions();
   }
 
   async select(eventValue: string): Promise<void> {
@@ -77,22 +103,24 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
       this.selectedBooks.push(
         ...this.availableBooks.filter(n => Canon.isBookOT(n) && this.selectedBooks.indexOf(n) === -1)
       );
+    } else if (eventValue === 'clearOT') {
+      const booksOT = this.selectedBooks.filter(n => Canon.isBookOT(n));
+      this.selectedBooks = this.selectedBooks.filter(n => !booksOT.includes(n));
     } else if (eventValue === 'NT') {
       this.selectedBooks.push(
         ...this.availableBooks.filter(n => Canon.isBookNT(n) && this.selectedBooks.indexOf(n) === -1)
       );
+    } else if (eventValue === 'clearNT') {
+      const booksNT = this.selectedBooks.filter(n => Canon.isBookNT(n));
+      this.selectedBooks = this.selectedBooks.filter(n => !booksNT.includes(n));
     } else if (eventValue === 'DC') {
       this.selectedBooks.push(
         ...this.availableBooks.filter(n => Canon.isBookDC(n) && this.selectedBooks.indexOf(n) === -1)
       );
+    } else if (eventValue === 'clearDC') {
+      const booksDC = this.selectedBooks.filter(n => Canon.isBookDC(n));
+      this.selectedBooks = this.selectedBooks.filter(n => !booksDC.includes(n));
     }
-    await this.initBookOptions();
-    this.bookSelect.emit(this.selectedBooks);
-  }
-
-  async clear(): Promise<void> {
-    this.selectedBooks.length = 0;
-    this.selection = undefined;
     await this.initBookOptions();
     this.bookSelect.emit(this.selectedBooks);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -15,6 +15,8 @@ export interface BookOption {
   progressPercentage: number;
 }
 
+type Scope = 'OT' | 'NT' | 'DC';
+
 @Component({
   selector: 'app-book-multi-select',
   templateUrl: './book-multi-select.component.html',
@@ -98,28 +100,20 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
     this.initBookOptions();
   }
 
-  async select(eventValue: string): Promise<void> {
-    if (eventValue === 'OT') {
+  isBookInScope(bookNum: number, scope: Scope): boolean {
+    if (scope === 'OT') return Canon.isBookOT(bookNum);
+    else if (scope === 'NT') return Canon.isBookNT(bookNum);
+    else if (scope === 'DC') return Canon.isBookDC(bookNum);
+    throw new Error('Invalid scope');
+  }
+
+  async select(scope: Scope, value: boolean): Promise<void> {
+    if (value) {
       this.selectedBooks.push(
-        ...this.availableBooks.filter(n => Canon.isBookOT(n) && this.selectedBooks.indexOf(n) === -1)
+        ...this.availableBooks.filter(n => this.isBookInScope(n, scope) && !this.selectedBooks.includes(n))
       );
-    } else if (eventValue === 'clearOT') {
-      const booksOT = this.selectedBooks.filter(n => Canon.isBookOT(n));
-      this.selectedBooks = this.selectedBooks.filter(n => !booksOT.includes(n));
-    } else if (eventValue === 'NT') {
-      this.selectedBooks.push(
-        ...this.availableBooks.filter(n => Canon.isBookNT(n) && this.selectedBooks.indexOf(n) === -1)
-      );
-    } else if (eventValue === 'clearNT') {
-      const booksNT = this.selectedBooks.filter(n => Canon.isBookNT(n));
-      this.selectedBooks = this.selectedBooks.filter(n => !booksNT.includes(n));
-    } else if (eventValue === 'DC') {
-      this.selectedBooks.push(
-        ...this.availableBooks.filter(n => Canon.isBookDC(n) && this.selectedBooks.indexOf(n) === -1)
-      );
-    } else if (eventValue === 'clearDC') {
-      const booksDC = this.selectedBooks.filter(n => Canon.isBookDC(n));
-      this.selectedBooks = this.selectedBooks.filter(n => !booksDC.includes(n));
+    } else {
+      this.selectedBooks = this.selectedBooks.filter(n => !this.isBookInScope(n, scope));
     }
     await this.initBookOptions();
     this.bookSelect.emit(this.selectedBooks);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -115,7 +115,7 @@
             </div>
           </ng-template>
           <div>
-            <mat-checkbox [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
+            <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
           </div>
           @if (fastTraining) {
             <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -290,7 +290,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.tryAdvanceStep();
 
       // Tick the checkbox
-      const fastTrainingCheckbox = fixture.nativeElement.querySelector('mat-checkbox input');
+      const fastTrainingCheckbox = fixture.nativeElement.querySelector('mat-checkbox.fast-training input');
       fastTrainingCheckbox.click();
 
       // Click next on the final step to generate the draft

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -45,9 +45,9 @@
   },
   "book_select": {
     "clear": "Clear",
-    "deuterocanon": "DC",
-    "new_testament": "NT",
-    "old_testament": "OT",
+    "deuterocanon": "Deuerocanon",
+    "new_testament": "New Testament",
+    "old_testament": "Old Testament",
     "select": "Select"
   },
   "checking": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -44,11 +44,9 @@
     "view_renderings": "View Renderings"
   },
   "book_select": {
-    "clear": "Clear",
-    "deuterocanon": "Deuerocanon",
+    "deuterocanon": "Deuterocanon",
     "new_testament": "New Testament",
-    "old_testament": "Old Testament",
-    "select": "Select"
+    "old_testament": "Old Testament"
   },
   "checking": {
     "add_question": "Add question"


### PR DESCRIPTION
Improves the visualization and functionality of the bulk-book selection when the user is setting up a new draft. Using an indeterminant checkbox allows the user to see if None/Some/All of the Old Testament, New Testament, or Deuterocanon books have been selected. The checkbox will change from None/Some to All or from All to None. When selecting individual books the checkbox will show an indeterminant state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2748)
<!-- Reviewable:end -->
