### PR TITLE
SF-3012 Fix audio dialog recording after closing

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -46,6 +46,8 @@ export class AudioRecorderDialogComponent
   extends SubscriptionDisposable
   implements ControlValueAccessor, OnInit, OnDestroy
 {
+  destroyed = false;
+
   @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
   @Output() status = new EventEmitter<AudioAttachment>();
 
@@ -99,6 +101,8 @@ export class AudioRecorderDialogComponent
   }
 
   ngOnDestroy(): void {
+    this.destroyed = true;
+    super.ngOnDestroy();
     if (this.isRecording) {
       this.stopRecording();
     }
@@ -163,7 +167,7 @@ export class AudioRecorderDialogComponent
       },
       complete: () => {
         this.showCountdown = false;
-        this.startRecording();
+        if (!this.destroyed) this.startRecording();
       }
     });
   }


### PR DESCRIPTION
~The Jira issue for this hasn't been created yet but is coming.~

The cleanup code for this component is:
``` ts
    if (this.isRecording) {
      this.stopRecording();
    }
```

This looks like it's fully handling stopping recording, but there's a loophole. Because there's a countdown to start recording, the component can start recording *after* it's been closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2753)
<!-- Reviewable:end -->
