### PR TITLE
SF-3003 Fix Biblical Terms tab not showing in editor tabs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,5 +1,9 @@
 <ng-container *transloco="let t; read: 'editor'">
-  <div class="content" [class.reverse-columns]="!isTargetTextRight" [class.target-only]="!showSource">
+  <div
+    class="content"
+    [class.reverse-columns]="!isTargetTextRight"
+    [class.target-only]="!showSource && !persistentTabs"
+  >
     <div class="toolbar">
       <div class="toolbar-options">
         <app-book-chapter-chooser
@@ -69,6 +73,7 @@
             @switch (tab.type) {
               @case ("biblical-terms") {
                 <app-biblical-terms
+                  class="biblical-terms"
                   [bookNum]="bookNum"
                   [chapter]="chapter"
                   [verse]="verse"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -2,7 +2,7 @@
   <div
     class="content"
     [class.reverse-columns]="!isTargetTextRight"
-    [class.target-only]="!showSource && !persistentTabs"
+    [class.target-only]="!showSource && !showPersistentTabs"
   >
     <div class="toolbar">
       <div class="toolbar-options">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -2,7 +2,7 @@
   <div
     class="content"
     [class.reverse-columns]="!isTargetTextRight"
-    [class.target-only]="!showSource && !showPersistentTabs"
+    [class.target-only]="!showSource && !showPersistedTabsOnSource"
   >
     <div class="toolbar">
       <div class="toolbar-options">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4082,6 +4082,25 @@ describe('EditorComponent', () => {
 
         env.dispose();
       }));
+
+      it('should keep source pane open if biblical tab has been opened in it', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => false });
+        });
+        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
+        env.setProjectUserConfig({
+          biblicalTermsEnabled: true,
+          editorTabsOpen: [{ tabType: 'biblical-terms', groupId: 'source' }]
+        });
+        env.routeWithParams({ projectId: 'project01', bookId: 'GEN', chapter: '1' });
+        env.wait();
+
+        expect(env.component.showSource).toBe(false);
+        expect(env.component.hasPersistentTabs).toBe(true);
+        expect(env.fixture.debugElement.query(By.css('.biblical-terms'))).not.toBeNull();
+
+        env.dispose();
+      }));
     });
 
     describe('tab header tooltips', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4096,7 +4096,7 @@ describe('EditorComponent', () => {
         env.wait();
 
         expect(env.component.showSource).toBe(false);
-        expect(env.component.showPersistentTabs).toBe(true);
+        expect(env.component.showPersistedTabsOnSource).toBe(true);
         expect(env.fixture.debugElement.query(By.css('.biblical-terms'))).not.toBeNull();
 
         env.dispose();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4096,7 +4096,7 @@ describe('EditorComponent', () => {
         env.wait();
 
         expect(env.component.showSource).toBe(false);
-        expect(env.component.hasPersistentTabs).toBe(true);
+        expect(env.component.showPersistentTabs).toBe(true);
         expect(env.fixture.debugElement.query(By.css('.biblical-terms'))).not.toBeNull();
 
         env.dispose();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -413,7 +413,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.hasSource && this.hasSourceViewRight;
   }
 
-  get showPersistentTabs(): boolean {
+  get showPersistedTabsOnSource(): boolean {
     return this.tabState.getTabGroup('source')?.tabs.some(tab => tab.persist) ?? false;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -225,6 +225,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   mobileNoteControl: UntypedFormControl = new UntypedFormControl('');
   multiCursorViewers: MultiCursorViewer[] = [];
   target: TextComponent | undefined;
+  hasPersistentTabs: boolean = false;
 
   @ViewChild('source') source?: TextComponent;
   @ViewChild('fabButton', { read: ElementRef }) insertNoteFab?: ElementRef<HTMLElement>;
@@ -415,6 +416,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get hasEditRight(): boolean {
     return this.userHasGeneralEditRight && this.hasChapterEditPermission === true;
+  }
+
+  get persistentTabs(): boolean {
+    return this.hasPersistentTabs;
   }
 
   get userHasGeneralEditRight(): boolean {
@@ -813,6 +818,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.tabState.deconsolidateTabGroups();
         }
       });
+
+    this.editorTabPersistenceService.persistedTabs$.subscribe(tabs => {
+      const persistentTabTypes = ['biblical-terms', 'history', 'draft', 'project-resource'];
+      this.hasPersistentTabs = tabs.some(tab => persistentTabTypes.includes(tab.tabType));
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -225,7 +225,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   mobileNoteControl: UntypedFormControl = new UntypedFormControl('');
   multiCursorViewers: MultiCursorViewer[] = [];
   target: TextComponent | undefined;
-  hasPersistentTabs: boolean = false;
 
   @ViewChild('source') source?: TextComponent;
   @ViewChild('fabButton', { read: ElementRef }) insertNoteFab?: ElementRef<HTMLElement>;
@@ -414,12 +413,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.hasSource && this.hasSourceViewRight;
   }
 
-  get hasEditRight(): boolean {
-    return this.userHasGeneralEditRight && this.hasChapterEditPermission === true;
+  get showPersistentTabs(): boolean {
+    return this.tabState.getTabGroup('source')?.tabs.some(tab => tab.persist) ?? false;
   }
 
-  get persistentTabs(): boolean {
-    return this.hasPersistentTabs;
+  get hasEditRight(): boolean {
+    return this.userHasGeneralEditRight && this.hasChapterEditPermission === true;
   }
 
   get userHasGeneralEditRight(): boolean {
@@ -818,11 +817,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           this.tabState.deconsolidateTabGroups();
         }
       });
-
-    this.editorTabPersistenceService.persistedTabs$.subscribe(tabs => {
-      const persistentTabTypes = ['biblical-terms', 'history', 'draft', 'project-resource'];
-      this.hasPersistentTabs = tabs.some(tab => persistentTabTypes.includes(tab.tabType));
-    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
When editing with a source project and biblical terms the tab for Biblical terms can end up being hidden if they were opened in the source pane and the user navigates to a book that does not exist in the source. This change will keep the source pane open if a persistent tab (biblical terms, draft, resource, history) has been opened in it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2761)
<!-- Reviewable:end -->
