### PR TITLE
Remove unneeded interpolation from attribute bindings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -33,7 +33,7 @@
         }
         <span class="toolbar-spacer"></span>
         @if (isAppOnline) {
-          <button mat-icon-button title="{{ t('language') }}" [matMenuTriggerFor]="localeMenu">
+          <button mat-icon-button [title]="t('language')" [matMenuTriggerFor]="localeMenu">
             <mat-icon>translate</mat-icon>
           </button>
         }
@@ -50,7 +50,7 @@
           }
         </mat-menu>
 
-        <button mat-icon-button title="{{ t('help') }}" [matMenuTriggerFor]="helpMenu">
+        <button mat-icon-button [title]="t('help')" [matMenuTriggerFor]="helpMenu">
           <mat-icon class="mirror-rtl">help</mat-icon>
         </button>
         <mat-menu #helpMenu="matMenu" class="help-menu">
@@ -90,7 +90,7 @@
         @if (currentUser) {
           <button
             mat-icon-button
-            title="{{ currentUser.displayName }}"
+            [title]="currentUser.displayName"
             [matMenuTriggerFor]="userMenu"
             (click)="dismissInstallIcon()"
             class="user-menu-btn"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -86,7 +86,7 @@
                           <span fxFlex fxLayout class="book-chapter-heading"
                             >{{ getBookName(text) + " " + chapter?.number }}
                             @if (chapter.hasAudio) {
-                              <mat-icon title="{{ t('chapter_audio_attached') }}" class="material-icons-outlined"
+                              <mat-icon [title]="t('chapter_audio_attached')" class="material-icons-outlined"
                                 >audio_file</mat-icon
                               >
                             }
@@ -184,7 +184,7 @@
                                   <button
                                     mat-icon-button
                                     (click)="setQuestionArchiveStatus(questionDoc, true)"
-                                    title="{{ t('archive') }}"
+                                    [title]="t('archive')"
                                     class="archive-btn"
                                   >
                                     <mat-icon>archive</mat-icon>
@@ -373,7 +373,7 @@
                                 <button
                                   mat-icon-button
                                   (click)="setQuestionArchiveStatus(questionDoc, false)"
-                                  title="{{ t('republish') }}"
+                                  [title]="t('republish')"
                                   class="publish-btn"
                                 >
                                   <mat-icon>public</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.html
@@ -17,7 +17,7 @@
             <div class="question-meta">
               <span class="question-verse">{{ questionVerseRef(questionDoc) }}</span>
               @if (getUnreadAnswers(questionDoc) > 0) {
-                <a class="view-answers" title="{{ t('view_answers') }}">
+                <a class="view-answers" [title]="t('view_answers')">
                   <div [matBadge]="getUnreadAnswers(questionDoc)" matBadgePosition="before" matBadgeSize="small">
                     <mat-icon aria-hidden="false" class="mirror-rtl">forum</mat-icon>
                   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.html
@@ -163,7 +163,7 @@
             <div colspan="2" class="filter-text">
               <div>
                 <mat-form-field appearance="fill" subscriptSizing="dynamic">
-                  <input matInput type="text" formControlName="filter" placeholder="{{ t('filter_questions') }}" />
+                  <input matInput type="text" formControlName="filter" [placeholder]="t('filter_questions')" />
                 </mat-form-field>
                 <button mat-button type="button" (click)="clearFilters()">{{ t("show_all") }}</button>
               </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -39,7 +39,7 @@
       <div class="text-container">
         <app-checking-text
           [id]="textDocId"
-          placeholder="{{ t('enter_a_reference_to_load_text') }}"
+          [placeholder]="t('enter_a_reference_to_load_text')"
           [activeVerse]="selection"
           [isRightToLeft]="isTextRightToLeft"
           [projectDoc]="projectDoc"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -37,7 +37,7 @@
                 <p>{{ t("translation_suggestions_require_source_text") }}</p>
                 <app-project-select
                   formControlName="sourceParatextId"
-                  placeholder="{{ t('source_text_placeholder') }}"
+                  [placeholder]="t('source_text_placeholder')"
                   [projects]="projects"
                   [resources]="resources"
                   [hiddenParatextIds]="[ptProjectId]"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -15,7 +15,7 @@
       <mat-card
         [class.active-project]="isLastSelectedProject(projectDoc)"
         id="user-connected-project-card-{{ projectDoc.data?.paratextId }}"
-        attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
+        [attr.data-pt-project-id]="projectDoc.data?.paratextId"
         class="user-connected-project mat-elevation-z4"
         appRouterLink="/projects/{{ projectDoc.id }}"
         matRipple
@@ -55,7 +55,7 @@
     @for (projectDoc of userConnectedResources; track projectDoc) {
       <mat-card
         [class.active-project]="isLastSelectedProject(projectDoc)"
-        attr.data-pt-project-id="{{ projectDoc.data?.paratextId }}"
+        [attr.data-pt-project-id]="projectDoc.data?.paratextId"
         appRouterLink="/projects/{{ projectDoc.id }}"
         class="user-connected-resource mat-elevation-z4"
       >
@@ -97,7 +97,7 @@
         }
         @for (ptProject of userUnconnectedParatextProjects; track ptProject) {
           <div
-            attr.data-pt-project-id="{{ ptProject.paratextId }}"
+            [attr.data-pt-project-id]="ptProject.paratextId"
             class="user-unconnected-project"
             [class.cannot-connect]="!ptProject.isConnectable"
           >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -17,14 +17,14 @@
       class="project-select"
     >
       @if (nullableLength(projects$ | async) > 0) {
-        <mat-optgroup label="{{ t('projects') }}">
+        <mat-optgroup [label]="t('projects')">
           @for (project of projects$ | async; track project) {
             <mat-option [value]="project">{{ projectLabel(project) }}</mat-option>
           }
         </mat-optgroup>
       }
       @if (nullableLength(resources$ | async) > 0) {
-        <mat-optgroup label="{{ t('resources') }}">
+        <mat-optgroup [label]="t('resources')">
           @for (resource of resources$ | async; track resource) {
             <mat-option [value]="resource">{{ projectLabel(resource) }}</mat-option>
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.html
@@ -32,7 +32,7 @@
       mat-icon-button
       (click)="prevChapter()"
       [disabled]="isPrevChapterDisabled()"
-      title="{{ t('previous_chapter') }}"
+      [title]="t('previous_chapter')"
       class="hide-lt-sm"
     >
       <mat-icon>keyboard_arrow_{{ i18n.backwardDirectionWord }}</mat-icon>
@@ -41,7 +41,7 @@
       mat-icon-button
       (click)="nextChapter()"
       [disabled]="isNextChapterDisabled()"
-      title="{{ t('next_chapter') }}"
+      [title]="t('next_chapter')"
       class="hide-lt-sm"
     >
       <mat-icon>keyboard_arrow_{{ i18n.forwardDirectionWord }}</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.html
@@ -55,7 +55,7 @@
         (click)="tabAddRequest.next(item.type)"
       >
         <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
-        <mat-icon *ngIf="item.svgIcon" svgIcon="{{ item.svgIcon }}"></mat-icon>
+        <mat-icon *ngIf="item.svgIcon" [svgIcon]="item.svgIcon"></mat-icon>
         <span>{{ item.text }}</span>
       </button>
     </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.html
@@ -9,7 +9,7 @@
       <div>
         {{ t(shareLinkType + "_can") }} <b>{{ i18n.localizeRoleDescription(shareRole) }}</b>
         @if (canUserChangeRole) {
-          <a [matMenuTriggerFor]="roleMenu" title="{{ t('invitation_role') }}">({{ t("change") }})</a>
+          <a [matMenuTriggerFor]="roleMenu" [title]="t('invitation_role')">({{ t("change") }})</a>
         }
       </div>
       <mat-menu #roleMenu>
@@ -29,7 +29,7 @@
         <div>
           {{ t("link_can_be_used_by") }} <b>{{ t(shareLinkType) }}</b>
           @if (shareLinkUsageOptions.length > 1) {
-            <a [matMenuTriggerFor]="linkUsageMenu" title="{{ t('invitation_link_type') }}">({{ t("change") }})</a>
+            <a [matMenuTriggerFor]="linkUsageMenu" [title]="t('invitation_link_type')">({{ t("change") }})</a>
           }
         </div>
         <mat-menu #linkUsageMenu>
@@ -49,7 +49,7 @@
         <div>
           <transloco key="share_dialog.will_expire_in" [params]="{ count: shareExpiration }"></transloco>
           @if (linkExpirationOptions.length > 1) {
-            <a [matMenuTriggerFor]="expireMenu" title="{{ t('expiration_description') }}"> ({{ t("change") }}) </a>
+            <a [matMenuTriggerFor]="expireMenu" [title]="t('expiration_description')"> ({{ t("change") }}) </a>
           }
         </div>
         <mat-menu #expireMenu>
@@ -75,7 +75,7 @@
           } @else {
             <b class="empty-field" [ngClass]="{ error: error }"> ________________ </b>
           }
-          <a [matMenuTriggerFor]="langMenu" title="{{ t('invitation_language') }}"> ({{ t("change") }}) </a>
+          <a [matMenuTriggerFor]="langMenu" [title]="t('invitation_language')"> ({{ t("change") }}) </a>
         </div>
         <span class="error help-text" [ngClass]="{ hidden: !error }">{{ t("error_language") }}</span>
       </div>
@@ -106,7 +106,7 @@
       mat-flat-button
       (click)="copyLink()"
       [disabled]="!isLinkReady"
-      color="{{ !supportsShareAPI ? 'primary' : '' }}"
+      [color]="!supportsShareAPI ? 'primary' : ''"
     >
       <mat-icon>content_copy</mat-icon>{{ t("copy_link") }}
     </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.html
@@ -30,7 +30,7 @@
         appBlurOnClick
         type="button"
         (click)="toggleDiff()"
-        matTooltip="{{ !showDiff ? t('show_diff') : t('hide_diff') }}"
+        [matTooltip]="!showDiff ? t('show_diff') : t('hide_diff')"
       >
         <mat-icon [ngClass]="{ 'material-icons-outlined': !showDiff }">difference</mat-icon>
         {{ showDiff ? t("hide_changes") : t("show_changes") }}
@@ -41,7 +41,7 @@
           mat-button
           type="button"
           (click)="revertToSnapshot()"
-          matTooltip="{{ t('revert_details') }}"
+          [matTooltip]="t('revert_details')"
         >
           <mat-icon class="material-icons-outlined">undo</mat-icon>
           {{ t("revert") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -17,7 +17,7 @@
               appBlurOnClick
               type="button"
               (click)="isTargetTextRight = !isTargetTextRight"
-              title="{{ t('swap_source_and_target') }}"
+              [title]="t('swap_source_and_target')"
               class="hide-lt-sm"
             >
               <mat-icon>swap_horiz</mat-icon>
@@ -30,7 +30,7 @@
               type="button"
               id="settings-btn"
               (click)="openSuggestionsSettings()"
-              title="{{ t('configure_translation_suggestions') }}"
+              [title]="t('configure_translation_suggestions')"
             >
               <mat-icon>settings</mat-icon>
             </button>
@@ -60,7 +60,7 @@
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable" [tooltip]="tab.tooltip">
             <ng-template sf-tab-header>
               @if (tab.svgIcon) {
-                <mat-icon svgIcon="{{ tab.svgIcon }}"></mat-icon>
+                <mat-icon [svgIcon]="tab.svgIcon"></mat-icon>
               } @else if (tab.icon) {
                 <mat-icon>{{ tab.icon }}</mat-icon>
               }
@@ -223,7 +223,7 @@
                         #fabButton
                         class="insert-note-fab"
                         mat-mini-fab
-                        title="{{ t('add_comment') }}"
+                        [title]="t('add_comment')"
                         (click)="insertNote()"
                       >
                         <mat-icon>add_comment</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.html
@@ -18,9 +18,9 @@
       tab text jumps a few pixels when navigating between tabs. -->
       <div class="tab-selector">
         <mat-tab-group [mat-stretch-tabs]="false" (selectedIndexChange)="currentTabIndex = $event">
-          <mat-tab label="{{ t('all') }}"></mat-tab>
-          <mat-tab label="{{ t('paratext_members') }}"></mat-tab>
-          <mat-tab label="{{ t('project_guests') }}"></mat-tab>
+          <mat-tab [label]="t('all')"></mat-tab>
+          <mat-tab [label]="t('paratext_members')"></mat-tab>
+          <mat-tab [label]="t('project_guests')"></mat-tab>
         </mat-tab-group>
       </div>
       <mat-form-field [formGroup]="filterForm" appearance="outline" id="project-user-filter">


### PR DESCRIPTION
This was done using a global find and replace using this regex: `([^\s]+)="\{\{\s*(.*?)\s*\}\}"`
Matches were replaced with:
`[$1]="$2"`
The search was limited to files matching:
`*.html`

See https://angular.dev/guide/templates/binding for documentation

The before and after are not exactly equivalent. Using interpolation implicitly converts values to strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2762)
<!-- Reviewable:end -->
