### PR TITLE
SF-2995 Hide drafts tab from guest commenters

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project-rights.ts
@@ -15,7 +15,8 @@ export enum SFProjectDomain {
   SFNoteThreads = 'sf_note_threads',
   Notes = 'notes',
   TextAudio = 'text_audio',
-  TrainingData = 'training_data'
+  TrainingData = 'training_data',
+  Drafts = 'drafts'
 }
 
 // See https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
@@ -89,7 +90,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     sf_note_threads: ['view', 'create', 'edit', 'delete_own'],
     notes: ['view', 'create', 'edit_own', 'delete_own'],
     text_audio: ['view'],
-    training_data: ['view', 'create', 'edit_own', 'delete_own']
+    training_data: ['view', 'create', 'edit_own', 'delete_own'],
+    drafts: ['view']
   },
   pt_administrator: {
     project_user_configs: ['view_own', 'edit_own'],
@@ -105,7 +107,8 @@ const rightsByRole: Record<SFProjectRole, { [domain in `${SFProjectDomain}`]?: `
     sf_note_threads: ['view', 'create', 'edit', 'delete'],
     notes: ['view', 'create', 'edit_own', 'delete'],
     text_audio: ['view', 'edit', 'create', 'delete'],
-    training_data: ['view', 'create', 'edit', 'delete']
+    training_data: ['view', 'create', 'edit', 'delete'],
+    drafts: ['view']
   },
   none: {}
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-role-info.ts
@@ -21,5 +21,9 @@ export function roleCanAccessCommunityChecking(role: SFProjectRole): boolean {
   return SF_PROJECT_RIGHTS.roleHasRight(role, 'questions', Operation.View);
 }
 
+export function roleCanAccessDrafts(role: SFProjectRole): boolean {
+  return SF_PROJECT_RIGHTS.roleHasRight(role, 'drafts', Operation.View);
+}
+
 export const SF_DEFAULT_SHARE_ROLE: SFProjectRole = SFProjectRole.CommunityChecker;
 export const SF_DEFAULT_TRANSLATE_SHARE_ROLE: SFProjectRole = SFProjectRole.Viewer;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -49,6 +49,14 @@ describe('PermissionsService', () => {
     expect(env.service.canAccessTranslate(env.projectDoc, SFProjectRole.Commenter)).toBe(true);
   }));
 
+  it('does not allow commenters to access drafts', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedUserService.currentUserId).thenReturn(SFProjectRole.Commenter);
+
+    expect(env.service.canAccessDrafts(env.projectDoc)).toBe(false);
+    expect(env.service.canAccessDrafts(env.projectDoc, SFProjectRole.Commenter)).toBe(false);
+  }));
+
   it('allows checkers to access Community Checking if enabled', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedUserService.currentUserId).thenReturn(SFProjectRole.CommunityChecker);
@@ -57,7 +65,7 @@ describe('PermissionsService', () => {
     expect(env.service.canAccessCommunityChecking(env.projectDoc, SFProjectRole.CommunityChecker)).toBe(true);
   }));
 
-  it('allows admins to access both', fakeAsync(() => {
+  it('allows admins to access translate, checking, and drafts', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedUserService.currentUserId).thenReturn(SFProjectRole.ParatextAdministrator);
 
@@ -65,6 +73,8 @@ describe('PermissionsService', () => {
     expect(env.service.canAccessTranslate(env.projectDoc, SFProjectRole.ParatextAdministrator)).toBe(true);
     expect(env.service.canAccessCommunityChecking(env.projectDoc)).toBe(true);
     expect(env.service.canAccessCommunityChecking(env.projectDoc, SFProjectRole.ParatextAdministrator)).toBe(true);
+    expect(env.service.canAccessDrafts(env.projectDoc)).toBe(true);
+    expect(env.service.canAccessDrafts(env.projectDoc, SFProjectRole.ParatextAdministrator)).toBe(true);
   }));
 
   it('does not allow checkers to access Translate', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -7,7 +7,11 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { UserService } from 'xforge-common/user.service';
 import { environment } from '../../environments/environment';
 import { SFProjectProfileDoc } from './models/sf-project-profile-doc';
-import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from './models/sf-project-role-info';
+import {
+  roleCanAccessCommunityChecking,
+  roleCanAccessDrafts,
+  roleCanAccessTranslate
+} from './models/sf-project-role-info';
 import { TextDocId } from './models/text-doc';
 import { ParatextService } from './paratext.service';
 import { SFProjectService } from './sf-project.service';
@@ -34,6 +38,12 @@ export class PermissionsService {
     if (project.data == null) return false;
     const role = project.data.userRoles[userId ?? this.userService.currentUserId];
     return role != null && roleCanAccessTranslate(role as SFProjectRole);
+  }
+
+  canAccessDrafts(project?: SFProjectProfileDoc, userId?: string): boolean {
+    if (project?.data == null) return false;
+    const role = project.data.userRoles[userId ?? this.userService.currentUserId];
+    return role != null && roleCanAccessDrafts(role as SFProjectRole);
   }
 
   async isUserOnProject(projectId: string): Promise<boolean> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3870,6 +3870,7 @@ describe('EditorComponent', () => {
         const env = new TestEnvironment(env => {
           Object.defineProperty(env.component, 'showSource', { get: () => true });
         });
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.wait();
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
@@ -3887,6 +3888,7 @@ describe('EditorComponent', () => {
         const env = new TestEnvironment(env => {
           Object.defineProperty(env.component, 'showSource', { get: () => false });
         });
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.wait();
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
@@ -3904,6 +3906,7 @@ describe('EditorComponent', () => {
         const env = new TestEnvironment(env => {
           Object.defineProperty(env.component, 'showSource', { get: () => true });
         });
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
 
@@ -3920,10 +3923,26 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
+      it('should hide auto draft tab when user is commenter', fakeAsync(() => {
+        const env = new TestEnvironment(env => {
+          Object.defineProperty(env.component, 'showSource', { get: () => true });
+        });
+        env.setCommenterUser();
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        const targetTabGroup = env.component.tabState.getTabGroup('target');
+        expect(targetTabGroup?.tabs[1]).toBeUndefined();
+        expect(env.component.chapter).toBe(1);
+
+        env.dispose();
+      }));
+
       it('should hide target auto draft tab when switching to chapter with no draft', fakeAsync(() => {
         const env = new TestEnvironment(env => {
           Object.defineProperty(env.component, 'showSource', { get: () => false });
         });
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
 
@@ -3957,6 +3976,7 @@ describe('EditorComponent', () => {
       it('should select the draft tab if url query param is set', fakeAsync(() => {
         const env = new TestEnvironment();
         when(mockedActivatedRoute.snapshot).thenReturn({ queryParams: { 'draft-active': 'true' } } as any);
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.wait();
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
@@ -3970,6 +3990,7 @@ describe('EditorComponent', () => {
       it('should not select the draft tab if url query param is not set', fakeAsync(() => {
         const env = new TestEnvironment();
         when(mockedActivatedRoute.snapshot).thenReturn({ queryParams: {} } as any);
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         env.wait();
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1416,7 +1416,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.tabState.getFirstTabOfTypeIndex('draft');
 
     const urlDraftActive: boolean = this.activatedRoute.snapshot.queryParams['draft-active'] === 'true';
-    if (hasDraft && (!draftApplied || urlDraftActive)) {
+    const canViewDrafts: boolean = this.permissionsService.canAccessDrafts(
+      this.projectDoc,
+      this.userService.currentUserId
+    );
+    if (hasDraft && (!draftApplied || urlDraftActive) && canViewDrafts) {
       // URL may indicate to select the 'draft' tab (such as when coming from generate draft page)
       const groupIdToAddTo: EditorTabGroupType = this.showSource ? 'source' : 'target';
 


### PR DESCRIPTION
Guests commenters should not be able to view generated drafts in the editor, this is for any invited SF guests and PT observer and consultant roles. This change adds a `drafts` permission to PT translators and admins to only show the draft tab to users with those rights.

SF-3003 has changes in some of the same files as this PR which may require an updated PR to fix any merge issues (namely specs) that may arise.

`npm run build` will need to be run in `web-xforge\src\RealtimeServer` to pick up the changes made in `sf-project-rights.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2765)
<!-- Reviewable:end -->
