### PR TITLE
SF-3017 Hide biblical terms tab item for users without permission

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -191,6 +191,28 @@ describe('PermissionsService', () => {
         expect(env.service.canSync(env.projectDoc, role)).toBe(false);
       });
     });
+
+    describe('canAccessBiblicalTerms', () => {
+      it('returns true if user has permissions', () => {
+        const env = new TestEnvironment();
+        env.setCurrentUser(SFProjectRole.ParatextTranslator);
+        expect(env.service.canAccessBiblicalTerms(env.projectDoc)).toBe(true);
+      });
+
+      it('returns false if biblical terms enabled is false', () => {
+        const env = new TestEnvironment();
+        env.setCurrentUser(SFProjectRole.ParatextAdministrator);
+
+        env.setProjectProfile({ biblicalTermsConfig: { biblicalTermsEnabled: false } });
+        expect(env.service.canAccessBiblicalTerms(env.projectDoc)).toBe(false);
+      });
+
+      it('returns false if user does not has permissions', () => {
+        const env = new TestEnvironment();
+        env.setCurrentUser(SFProjectRole.Commenter);
+        expect(env.service.canAccessBiblicalTerms(env.projectDoc)).toBe(false);
+      });
+    });
   });
 });
 class TestEnvironment {
@@ -273,6 +295,7 @@ class TestEnvironment {
       checkingConfig: {
         checkingEnabled: this.checkingEnabled
       },
+      biblicalTermsConfig: { biblicalTermsEnabled: true },
       ...overrides
     };
     const data = createTestProjectProfile(config);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -82,4 +82,10 @@ export class PermissionsService {
     // Only PT admin and PT translator can sync non-resource projects
     return role === SFProjectRole.ParatextAdministrator || role === SFProjectRole.ParatextTranslator;
   }
+
+  canAccessBiblicalTerms(projectDoc: SFProjectProfileDoc): boolean {
+    if (projectDoc?.data?.biblicalTermsConfig?.biblicalTermsEnabled !== true) return false;
+    const role: string = projectDoc.data.userRoles[this.userService.currentUserId];
+    return SF_PROJECT_RIGHTS.roleHasRight(role, SFProjectDomain.BiblicalTerms, Operation.View);
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -85,7 +85,11 @@ export class PermissionsService {
 
   canAccessBiblicalTerms(projectDoc: SFProjectProfileDoc): boolean {
     if (projectDoc?.data?.biblicalTermsConfig?.biblicalTermsEnabled !== true) return false;
-    const role: string = projectDoc.data.userRoles[this.userService.currentUserId];
-    return SF_PROJECT_RIGHTS.roleHasRight(role, SFProjectDomain.BiblicalTerms, Operation.View);
+    return SF_PROJECT_RIGHTS.hasRight(
+      projectDoc.data,
+      this.userService.currentUserId,
+      SFProjectDomain.BiblicalTerms,
+      Operation.View
+    );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -44,6 +44,7 @@ describe('EditorTabMenuService', () => {
     env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
+    service['canShowBiblicalTerms'] = () => false;
 
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(3);
@@ -63,6 +64,7 @@ describe('EditorTabMenuService', () => {
     ]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
+    service['canShowBiblicalTerms'] = () => false;
 
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
@@ -77,6 +79,7 @@ describe('EditorTabMenuService', () => {
     env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => false;
+    service['canShowBiblicalTerms'] = () => false;
 
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(1);
@@ -90,6 +93,7 @@ describe('EditorTabMenuService', () => {
     env.setExistingTabs([]);
     service['canShowHistory'] = () => false;
     service['canShowResource'] = () => true;
+    service['canShowBiblicalTerms'] = () => false;
 
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(2);
@@ -138,7 +142,6 @@ describe('EditorTabMenuService', () => {
   it('should get "biblical terms" menu item', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([]);
-    service['canShowBiblicalTerms'] = () => true;
     service['canShowHistory'] = () => false;
     service['canShowResource'] = () => false;
 
@@ -150,11 +153,24 @@ describe('EditorTabMenuService', () => {
     });
   });
 
+  it('should not get "biblical terms" menu item', done => {
+    const env = new TestEnvironment();
+    env.setExistingTabs([]);
+    service['canShowHistory'] = () => false;
+    service['canShowResource'] = () => false;
+    service['canShowBiblicalTerms'] = () => false;
+    service.getMenuItems().subscribe(items => {
+      expect(items.length).toBe(0);
+      done();
+    });
+  });
+
   it('should get no menu items', done => {
     const env = new TestEnvironment(TestEnvironment.projectDocNoDraft);
     env.setExistingTabs([]);
     service['canShowHistory'] = () => false;
     service['canShowResource'] = () => false;
+    service['canShowBiblicalTerms'] = () => false;
 
     service.getMenuItems().subscribe(items => {
       expect(items.length).toBe(0);
@@ -167,6 +183,7 @@ describe('EditorTabMenuService', () => {
     env.setExistingTabs([]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
+    service['canShowBiblicalTerms'] = () => false;
 
     env.onlineStatus.setIsOnline(false);
     service
@@ -263,7 +280,8 @@ class TestEnvironment {
         preTranslate: true,
         draftConfig: { lastSelectedTranslationBooks: [40], lastSelectedTrainingBooks: [41] }
       },
-      userRoles: TestEnvironment.rolesByUser
+      userRoles: TestEnvironment.rolesByUser,
+      biblicalTermsConfig: { biblicalTermsEnabled: true }
     })
   } as SFProjectProfileDoc;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -153,18 +153,6 @@ describe('EditorTabMenuService', () => {
     });
   });
 
-  it('should not get "biblical terms" menu item', done => {
-    const env = new TestEnvironment();
-    env.setExistingTabs([]);
-    service['canShowHistory'] = () => false;
-    service['canShowResource'] = () => false;
-    service['canShowBiblicalTerms'] = () => false;
-    service.getMenuItems().subscribe(items => {
-      expect(items.length).toBe(0);
-      done();
-    });
-  });
-
   it('should get no menu items', done => {
     const env = new TestEnvironment(TestEnvironment.projectDocNoDraft);
     env.setExistingTabs([]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -139,7 +139,7 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
   }
 
   private canShowBiblicalTerms(projectDoc: SFProjectProfileDoc): boolean {
-    return projectDoc?.data?.biblicalTermsConfig?.biblicalTermsEnabled === true;
+    return this.permissionsService.canAccessBiblicalTerms(projectDoc);
   }
 
   private canShowHistory(projectDoc: SFProjectProfileDoc): boolean {


### PR DESCRIPTION
Biblical terms would visible as a menu item for any user who can view the translate app if it was enabled, but only Paratext users had permission to view it. This change adds a check in permissions service for whether the user had permission and uses the permission service when initializing tab menu items for a user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2768)
<!-- Reviewable:end -->
