### PR TITLE
Enable dev options as soon as version number is repeatedly clicked

### DIFF
--- a/scripts/db_tools/parse-version.ts
+++ b/scripts/db_tools/parse-version.ts
@@ -23,7 +23,7 @@ class ParseVersion {
 
   // This array is ordered based on the bit position of the feature flag
   featureFlags: string[] = [
-    'Show feature flags',
+    'Show developer tools',
     'Show non-published localizations',
     'Show NMT drafting',
     'Allow Forward Translation NMT drafting',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -70,19 +70,14 @@
           <a mat-menu-item target="_blank" href="/3rdpartylicenses.txt">
             <mat-icon>copyright</mat-icon> {{ t("open_source_licenses") }}
           </a>
-          @if (versionNumberClickCount >= 7 || featureFlags.showFeatureFlags.enabled) {
+          @if (featureFlags.showDeveloperTools.enabled) {
             <button mat-menu-item (click)="openFeatureFlagDialog()">
               <mat-icon>science</mat-icon>
               Developer settings
             </button>
           }
           <mat-divider></mat-divider>
-          <div
-            mat-menu-item
-            disabled="true"
-            (click)="versionNumberClickCount = versionNumberClickCount + 1"
-            id="version-number"
-          >
+          <div mat-menu-item disabled="true" (click)="versionNumberClicked()" id="version-number">
             {{ t("product_version", { version: version + this.featureFlags.versionSuffix }) }}
           </div>
         </mat-menu>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -662,7 +662,7 @@ class TestEnvironment {
     }
     when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
     when(mockedFeatureFlagService.allowForwardTranslationNmtDrafting).thenReturn(createTestFeatureFlag(false));
-    when(mockedFeatureFlagService.showFeatureFlags).thenReturn(createTestFeatureFlag(false));
+    when(mockedFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
     when(mockedFeatureFlagService.stillness).thenReturn(createTestFeatureFlag(false));
     when(mockedFeatureFlagService.showNonPublishedLocalizations).thenReturn(createTestFeatureFlag(false));
     when(mockedFileService.notifyUserIfStorageQuotaBelow(anything())).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -397,6 +397,13 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     this.dialogService.openMatDialog(FeatureFlagsDialogComponent);
   }
 
+  versionNumberClicked(): void {
+    this.versionNumberClickCount++;
+    if (this.versionNumberClickCount >= 7) {
+      this.featureFlags.showDeveloperTools.enabled = true;
+    }
+  }
+
   private async showProjectDeletedDialog(): Promise<void> {
     await this.userService.setCurrentProjectId(this.currentUserDoc!, undefined);
     await this.dialogService.message('app.project_has_been_deleted');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -209,9 +209,9 @@ export class FeatureFlagService {
   // Also, the position is important - this is the bit wise position of the feature flag in the version.
   // The position in the dialog is determined by the order in this class.
 
-  readonly showFeatureFlags: ObservableFeatureFlag = new FeatureFlagFromStorage(
-    'SHOW_FEATURE_FLAGS',
-    'Show feature flags',
+  readonly showDeveloperTools: ObservableFeatureFlag = new FeatureFlagFromStorage(
+    'SHOW_DEVELOPER_TOOLS',
+    'Show developer tools',
     0,
     this.featureFlagStore
   );


### PR DESCRIPTION
Android enables developer options as soon as the build number is tapped 7 times. Prior to this PR, SF only adds the "Developer settings" item to the menu, which then allows you to open the settings and enable the "show feature flags" setting. This is really a useless second step.

This PR changes it so that:
- The feature flag is immediately enabled upon clicking 7 times
- The flag is renamed to "Show developer tools"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2770)
<!-- Reviewable:end -->
