### PR TITLE
SF-3016 Fix loading console error on collaborators component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -9,7 +9,7 @@
             {{ t("import_questions") }}
           </button>
         }
-        @if (!isLoading) {
+        @if (!isLoadingData) {
           <button
             class="add-question-button hide-lt-sm"
             mat-flat-button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'join'">
-  @if (!isLoading) {
+  @if (!isLoadingData) {
     <h1 [innerHTML]="inviteText"></h1>
     @if (!isOnline) {
       <app-notice type="error" icon="cloud_off">{{ t("please_connect_to_use_link") }}</app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -10,7 +10,7 @@
           <mat-card-content>
             <mat-card-title>{{ t("translate") }}</mat-card-title>
             <div class="tool-setting">
-              @if (!isLoading && !isLoggedInToParatext && isAppOnline) {
+              @if (!isLoadingData && !isLoggedInToParatext && isAppOnline) {
                 <div class="paratext-login-container">
                   <button
                     class="action-button"
@@ -41,7 +41,7 @@
                     [resources]="resources"
                     [nonSelectableProjects]="nonSelectableProjects"
                     [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                    [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                    [isDisabled]="!isAppOnline || isLoadingData || (projectLoadingFailed && resourceLoadingFailed)"
                   ></app-project-select>
                   <app-write-status
                     [state]="getControlState('sourceParatextId')"
@@ -134,7 +134,7 @@
                         [resources]="resources"
                         [nonSelectableProjects]="nonSelectableProjects"
                         [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                        [isDisabled]="!isAppOnline || isLoadingData || (projectLoadingFailed && resourceLoadingFailed)"
                       ></app-project-select>
                       <app-write-status
                         [state]="getControlState('alternateSourceParatextId')"
@@ -168,7 +168,7 @@
                         [resources]="resources"
                         [nonSelectableProjects]="nonSelectableProjects"
                         [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                        [isDisabled]="!isAppOnline || isLoadingData || (projectLoadingFailed && resourceLoadingFailed)"
                       ></app-project-select>
                       <app-write-status
                         [state]="getControlState('alternateTrainingSourceParatextId')"
@@ -204,7 +204,7 @@
                         [resources]="resources"
                         [nonSelectableProjects]="nonSelectableProjects"
                         [hiddenParatextIds]="projectParatextId ? [projectParatextId] : []"
-                        [isDisabled]="!isAppOnline || isLoading || (projectLoadingFailed && resourceLoadingFailed)"
+                        [isDisabled]="!isAppOnline || isLoadingData || (projectLoadingFailed && resourceLoadingFailed)"
                       ></app-project-select>
                       <app-write-status
                         [state]="getControlState('additionalTrainingSourceParatextId')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -18,14 +18,14 @@
             {{ t("log_in_to_paratext") }}
           </button>
         }
-        @if (isLoggedIntoParatext || isLoading || !isAppOnline) {
+        @if (isLoggedIntoParatext || isLoadingData || !isAppOnline) {
           @if (!syncActive) {
             <button
               mat-flat-button
               color="primary"
               type="button"
               (click)="syncProject()"
-              [disabled]="isLoading || !isAppOnline || syncDisabled"
+              [disabled]="isLoadingData || !isAppOnline || syncDisabled"
               id="btn-sync"
             >
               <mat-icon>sync</mat-icon>
@@ -39,7 +39,7 @@
               mat-button
               type="button"
               (click)="cancelSync()"
-              [disabled]="isLoading || !isAppOnline || syncDisabled"
+              [disabled]="isLoadingData || !isAppOnline || syncDisabled"
               id="btn-cancel-sync"
             >
               {{ t("cancel") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
@@ -20,11 +20,11 @@ export abstract class DataLoadingComponent extends SubscriptionDisposable implem
     super();
   }
 
-  get isLoading$(): Observable<boolean> {
+  get isLoadingData$(): Observable<boolean> {
     return this._isLoading$.asObservable();
   }
 
-  get isLoading(): boolean {
+  get isLoadingData(): boolean {
     return this._isLoading$.value;
   }
 
@@ -42,7 +42,7 @@ export abstract class DataLoadingComponent extends SubscriptionDisposable implem
   }
 
   protected loadingStarted(): void {
-    if (!this.isLoading) {
+    if (!this.isLoadingData) {
       this.noticeService.loadingStarted();
       this._isLoading$.next(true);
       this._isLoaded$.next(false);
@@ -50,7 +50,7 @@ export abstract class DataLoadingComponent extends SubscriptionDisposable implem
   }
 
   protected loadingFinished(): void {
-    if (this.isLoading) {
+    if (this.isLoadingData) {
       this.noticeService.loadingFinished();
       this._isLoading$.next(false);
       this._isLoaded$.next(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.html
@@ -4,7 +4,7 @@
     <input matInput id="user-filter" (input)="updateSearchTerm($event.target)" />
   </mat-form-field>
 </div>
-@if (!isLoading) {
+@if (!isLoadingData) {
   @if (totalRecordCount > 0) {
     <table mat-table id="users-table" [dataSource]="userRows">
       <ng-container matColumnDef="avatar">


### PR DESCRIPTION
The collaborator component had its own definition of the `isLoading` getter which was overriding the definition in the parent class. Changing the getter's name in the DataLoadingComponent fixed the console warning.
Developer testing will be sufficient to merge this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2771)
<!-- Reviewable:end -->
