### PR TITLE
SF-2978 Limit chapter and book chapter select height for mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -15,7 +15,7 @@
 ::ng-deep .mat-mdc-select-panel {
   &.book-select-menu,
   &.chapter-select-menu {
-    max-height: 85vh;
+    max-height: 70vh;
   }
 }
 


### PR DESCRIPTION
This change allows the book chapter select menu to fit on screen, especially on smartphone devices where there may be overlays that take up vertical screen space. Since this is difficult to test for the test team on localhost, we should merge this code and have it shipped to QA for the test team.

Before
![Book Chapter Chooser Before](https://github.com/user-attachments/assets/6530af4c-9125-4208-b8e5-2e7e0059ee7c)

After
![Book Chapter Chooser After](https://github.com/user-attachments/assets/53db49e6-dfbc-444e-9bc7-de6b2e69d026)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2772)
<!-- Reviewable:end -->
