### PR TITLE
SF-3023 Add System Admin Authorization Filter for Hangfire

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -132,6 +132,12 @@
               {{ t("serval_administration") }}
             </button>
           }
+          @if (isSystemAdmin) {
+            <button mat-menu-item id="hangfire-dashboard-btn" [disabled]="!isAppOnline" (click)="hangfireDashboard()">
+              <mat-icon>pending_actions</mat-icon>
+              {{ t("hangfire_dashboard") }}
+            </button>
+          }
           <button mat-menu-item appRouterLink="/projects" id="project-home-link">
             <mat-icon>home</mat-icon> {{ "my_projects.my_projects" | transloco }}
           </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -5,6 +5,7 @@ import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync, flush, tick
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Route, Router, RouterModule } from '@angular/router';
+import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
@@ -56,6 +57,7 @@ const mockedNmtDraftAuthGuard = mock(NmtDraftAuthGuard);
 const mockedUsersAuthGuard = mock(UsersAuthGuard);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedBugsnagService = mock(BugsnagService);
+const mockedCookieService = mock(CookieService);
 const mockedLocationService = mock(LocationService);
 const mockedNoticeService = mock(NoticeService);
 const mockedPwaService = mock(PwaService);
@@ -107,6 +109,7 @@ describe('AppComponent', () => {
       { provide: UsersAuthGuard, useMock: mockedUsersAuthGuard },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: BugsnagService, useMock: mockedBugsnagService },
+      { provide: CookieService, useMock: mockedCookieService },
       { provide: LocationService, useMock: mockedLocationService },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: PwaService, useMock: mockedPwaService },
@@ -447,6 +450,16 @@ describe('AppComponent', () => {
     expect(env.avatarIcon).not.toBeNull();
   }));
 
+  it('navigate to the hangfire dashboard and set the cookie', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    env.init();
+
+    await env.component.hangfireDashboard();
+    expect().nothing();
+    verify(mockedCookieService.set(anything(), anything(), anything(), anything())).once();
+    verify(mockedLocationService.go(anything())).once();
+  }));
+
   describe('Community Checking', () => {
     it('ensure local storage is cleared when removed from project', fakeAsync(() => {
       const env = new TestEnvironment();
@@ -517,6 +530,23 @@ describe('AppComponent', () => {
       // Hide the user menu
       env.showHideUserMenu();
     }));
+
+    it('does not show hangfire dashboard menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.showHideUserMenu();
+
+      // Verify the menu item is not visible
+      expect(env.component.isSystemAdmin).toBe(false);
+      expect(env.userMenu).not.toBeNull();
+      expect(env.hangfireDashboardButton).toBeNull();
+
+      // Hide the user menu
+      env.showHideUserMenu();
+    }));
   });
 
   describe('System Administrator', () => {
@@ -549,6 +579,23 @@ describe('AppComponent', () => {
       expect(env.component.isServalAdmin).toBe(false);
       expect(env.userMenu).not.toBeNull();
       expect(env.servalAdminButton).toBeNull();
+
+      // Hide the user menu
+      env.showHideUserMenu();
+    }));
+
+    it('shows hangfire dashboard menu item', fakeAsync(() => {
+      const env = new TestEnvironment('online');
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.SystemAdmin]);
+      env.init();
+
+      // Show the user menu
+      env.showHideUserMenu();
+
+      // Verify the menu item is visible
+      expect(env.component.isSystemAdmin).toBe(true);
+      expect(env.userMenu).not.toBeNull();
+      expect(env.hangfireDashboardButton).not.toBeNull();
 
       // Hide the user menu
       env.showHideUserMenu();
@@ -635,6 +682,7 @@ class TestEnvironment {
     when(mockedLocationService.pathname).thenReturn('/projects/project01/checking');
 
     when(mockedAuthService.currentUserRoles).thenReturn([]);
+    when(mockedAuthService.getAccessToken()).thenReturn(Promise.resolve('access_token'));
     when(mockedAuthService.isLoggedIn).thenCall(() => Promise.resolve(this.loggedInState$.getValue().loggedIn));
     when(mockedAuthService.loggedIn).thenCall(() =>
       firstValueFrom(this.loggedInState$.pipe(filter((state: any) => state.loggedIn)))
@@ -691,6 +739,10 @@ class TestEnvironment {
 
   get editNameButton(): DebugElement {
     return this.userMenu.query(By.css('#edit-name-btn'));
+  }
+
+  get hangfireDashboardButton(): DebugElement {
+    return this.userMenu.query(By.css('#hangfire-dashboard-btn'));
   }
 
   get servalAdminButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -457,7 +457,7 @@ describe('AppComponent', () => {
     await env.component.hangfireDashboard();
     expect().nothing();
     verify(mockedCookieService.set(anything(), anything(), anything(), anything())).once();
-    verify(mockedLocationService.go(anything())).once();
+    verify(mockedLocationService.openInNewTab(anything())).once();
   }));
 
   describe('Community Checking', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -375,7 +375,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       const expires = new Date();
       expires.setMinutes(expires.getMinutes() + 30);
       this.cookieService.set('Hangfire', accessToken, expires, '/hangfire');
-      this.locationService.go('/hangfire');
+      this.locationService.openInNewTab('/hangfire');
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import Bugsnag from '@bugsnag/js';
 import { translate } from '@ngneat/transloco';
 import { cloneDeep } from 'lodash-es';
+import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { AuthType, User, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -76,6 +77,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly locationService: LocationService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly breakpointService: MediaBreakpointService,
+    private readonly cookieService: CookieService,
     readonly noticeService: NoticeService,
     readonly i18n: I18nService,
     readonly urls: ExternalUrlService,
@@ -363,6 +365,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   dismissInstallIcon(): void {
     this.pwaService.setInstallPromptLastShownTime();
+  }
+
+  async hangfireDashboard(): Promise<void> {
+    // The access token will be undefined if offline
+    const accessToken: string | undefined = await this.authService.getAccessToken();
+    if (accessToken != null) {
+      // Grant 30 minutes access to the dashboard
+      const expires = new Date();
+      expires.setMinutes(expires.getMinutes() + 30);
+      this.cookieService.set('Hangfire', accessToken, expires, '/hangfire');
+      this.locationService.go('/hangfire');
+    }
   }
 
   installOnDevice(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -2,6 +2,7 @@
   "app": {
     "beta": "beta",
     "generate_draft": "Generate draft",
+    "hangfire_dashboard": "Hangfire Dashboard",
     "manage_questions": "Manage questions",
     "settings": "Settings",
     "synchronize": "Sync with Paratext",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/location.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/location.service.ts
@@ -40,6 +40,10 @@ export class LocationService {
     window.location.href = url;
   }
 
+  openInNewTab(url: string): void {
+    window.open(url, '_blank');
+  }
+
   reload(): void {
     window.location.reload();
   }

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
+using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -19,6 +20,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using SIL.XForge.Configuration;
 using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
 
 namespace SIL.XForge.Scripture;
 
@@ -262,6 +264,10 @@ public class Startup
             endpoints.MapControllers();
             endpoints.MapRazorPages();
             endpoints.MapHub<NotificationHub>(pattern: $"/{UrlConstants.ProjectNotifications}");
+            var authOptions = Configuration.GetOptions<AuthOptions>();
+            endpoints.MapHangfireDashboard(
+                new DashboardOptions { Authorization = [new HangfireDashboardAuthorizationFilter(authOptions)] }
+            );
         });
 
         // Map JSON-RPC controllers after MVC controllers, so that MVC controllers take precedence.

--- a/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Models;
@@ -7,12 +6,7 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class DataAccessApplicationBuilderExtensions
 {
-    public static void UseDataAccess(this IApplicationBuilder app)
-    {
-        app.UseHangfireDashboard();
-
-        app.InitRepository<UserSecret>();
-    }
+    public static void UseDataAccess(this IApplicationBuilder app) => app.InitRepository<UserSecret>();
 
     public static void InitRepository<T>(this IApplicationBuilder app)
         where T : IIdentifiable => app.ApplicationServices.GetService<IRepository<T>>().Init();

--- a/src/SIL.XForge/Services/HangfireDashboardAuthorizationFilter.cs
+++ b/src/SIL.XForge/Services/HangfireDashboardAuthorizationFilter.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using Hangfire.Dashboard;
+using Microsoft.IdentityModel.Tokens;
+using SIL.XForge.Configuration;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Services;
+
+[ExcludeFromCodeCoverage(Justification = "This logic will only work in the Hangfire context with a valid Auth0 token")]
+public class HangfireDashboardAuthorizationFilter(AuthOptions authOptions) : IDashboardAuthorizationFilter
+{
+    private readonly OpenIdConnectSigningKeyResolver _keyResolver = new OpenIdConnectSigningKeyResolver(
+        $"https://{authOptions.Domain}/"
+    );
+
+    public bool Authorize(DashboardContext context)
+    {
+        // Get the access token
+        string accessToken = context.GetHttpContext().Request.Cookies["Hangfire"];
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return false;
+        }
+
+        try
+        {
+            // Validate the token, as this request will not have passed through Microsoft.AspNetCore.Authentication.JwtBearer
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateAudience = true,
+                ValidAudience = authOptions.Audience,
+                ValidateIssuer = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = $"https://{authOptions.Domain}/",
+                ValidateLifetime = true,
+                IssuerSigningKeyResolver = (_, _, kid, _) => _keyResolver.GetSigningKey(kid),
+            };
+            var tokenHandler = new JwtSecurityTokenHandler();
+            tokenHandler.ValidateToken(accessToken, validationParameters, out SecurityToken validatedToken);
+            var token = (JwtSecurityToken)validatedToken;
+
+            // Get the roles from the token
+            var user = new ClaimsPrincipal(new ClaimsIdentity(token.Claims));
+            return UserAccessor.GetSystemRoles(user).Contains(SystemRole.SystemAdmin);
+        }
+        catch (SecurityTokenException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/SIL.XForge/Services/OpenIdConnectSigningKeyResolver.cs
+++ b/src/SIL.XForge/Services/OpenIdConnectSigningKeyResolver.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace SIL.XForge.Services;
+
+[ExcludeFromCodeCoverage(Justification = "This logic will only work with a live connection to an OpenId provider")]
+public class OpenIdConnectSigningKeyResolver(string authority)
+{
+    private readonly OpenIdConnectConfiguration _openIdConfig = new ConfigurationManager<OpenIdConnectConfiguration>(
+        $"{authority.TrimEnd('/')}/.well-known/openid-configuration",
+        new OpenIdConnectConfigurationRetriever()
+    )
+        .GetConfigurationAsync()
+        .GetAwaiter()
+        .GetResult();
+
+    public SecurityKey[] GetSigningKey(string kid) =>
+        [_openIdConfig.JsonWebKeySet.GetSigningKeys().FirstOrDefault(t => t.KeyId == kid)];
+}

--- a/src/SIL.XForge/Services/UserAccessor.cs
+++ b/src/SIL.XForge/Services/UserAccessor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Security.Claims;
 using IdentityModel;
@@ -7,13 +6,9 @@ using SIL.XForge.Utils;
 
 namespace SIL.XForge.Services;
 
-public class UserAccessor : IUserAccessor
+public class UserAccessor(IHttpContextAccessor httpContextAccessor) : IUserAccessor
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    public UserAccessor(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
-
-    private ClaimsPrincipal? User => _httpContextAccessor.HttpContext?.User;
+    private ClaimsPrincipal? User => httpContextAccessor.HttpContext?.User;
 
     public string AuthId => User?.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
     public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
@@ -28,7 +23,9 @@ public class UserAccessor : IUserAccessor
             return User?.FindFirst(JwtClaimTypes.Subject)?.Value ?? string.Empty;
         }
     }
-    public string[] SystemRoles =>
-        User?.FindAll(XFClaimTypes.Role).Select(c => c.Value).ToArray() ?? Array.Empty<string>();
+    public string[] SystemRoles => GetSystemRoles(User);
     public string UserId => User?.FindFirst(XFClaimTypes.UserId)?.Value ?? string.Empty;
+
+    public static string[] GetSystemRoles(ClaimsPrincipal? user) =>
+        user?.FindAll(XFClaimTypes.Role).Select(c => c.Value).ToArray() ?? [];
 }


### PR DESCRIPTION
This PR changes the Hangfire Dashboard so that it can only be accessed by a logged in System Administrator, and adds a Hangfire Dashboard menu item to the top right User menu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2773)
<!-- Reviewable:end -->
