### PR TITLE
SF-2975 Fix Flagged for review button with long captions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -204,5 +204,6 @@
 
 .short-button {
   line-height: unset;
-  height: 20px;
+  min-height: 20px;
+  height: auto;
 }


### PR DESCRIPTION
This PR fixes the Flagged for review button height when the text is broken onto multiple lines due to window size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2774)
<!-- Reviewable:end -->
