### PR TITLE
SF-3021 Warn the user when applying a draft and the book does not exist

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -13,14 +13,14 @@
         (projectSelect)="projectSelectedAsync($event.paratextId)"
         formControlName="targetParatextId"
       ></app-project-select>
-      @if (!canEditProject && isAppOnline) {
-        <mat-error class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</mat-error>
-      }
-      @if (projectLoadingFailed && isAppOnline) {
-        <mat-error class="fetch-projects-failed-message">{{ t("error_fetching_projects") }}</mat-error>
-      }
       @if (!isAppOnline) {
         <mat-error class="offline-message">{{ t("connect_to_the_internet") }}</mat-error>
+      } @else if (projectLoadingFailed) {
+        <mat-error class="fetch-projects-failed-message">{{ t("error_fetching_projects") }}</mat-error>
+      } @else if (!bookExistsInProject) {
+        <mat-error class="book-does-not-exist-message mat-hint">{{ t("book_does_not_exist") }}</mat-error>
+      } @else if (!canEditProject) {
+        <mat-error class="cannot-edit-message mat-hint">{{ t("no_write_permission") }}</mat-error>
       }
       @if (connectOtherProject != null) {
         <div class="unlisted-project-message">

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -142,6 +142,7 @@
   },
   "draft_apply_dialog": {
     "add_to_project": "Add to project",
+    "book_does_not_exist": "This book does not exist in the selected project.",
     "book_is_empty": "{{ bookName }} in {{ projectName }} project is empty",
     "cancel": "Cancel",
     "connect_to_the_internet": "Please connect to the internet to add the draft to your project",


### PR DESCRIPTION
This PR updates the apply draft dialog to warn the user when they are about to apply a draft and the draft book does not exist in the selected project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2775)
<!-- Reviewable:end -->
