### PR TITLE
Add message to tap button in audio recorder dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -20,9 +20,11 @@
             </button>
           }
         </div>
-        <p class="record-message" [ngClass]="{ visible: !isRecording }">{{ t("tap_to_record") }}</p>
+        <div class="record-message" [class.visible]="!isRecording">
+          <p>{{ tapToRecordText!.before }}<mat-icon>mic</mat-icon>{{ tapToRecordText!.after }}</p>
+        </div>
       }
-      @if (hasAudioAttachment && !!audio.url) {
+      @if (hasAudioAttachment) {
         <div class="has-attachment">
           <app-single-button-audio-player [source]="audio.url" (click)="toggleAudio()">
             <mat-icon>{{ audioPlayer?.playing ? "stop" : "play_arrow" }}</mat-icon>
@@ -33,16 +35,17 @@
     <div class="dialog-footer">
       @if (showCanvas) {
         <canvas class="visualizer"></canvas>
+      } @else if (hasAudioAttachment) {
+        <div class="has-attachment">
+          <button mat-button (click)="resetRecording()" class="remove-audio-file">
+            <mat-icon>mic</mat-icon>
+            {{ t("re_record") }}
+          </button>
+          <button mat-flat-button color="primary" (click)="saveRecording()" class="save-audio-file">
+            <mat-icon>check</mat-icon> {{ t("save") }}
+          </button>
+        </div>
       }
-      <div class="has-attachment" [ngClass]="{ visible: hasAudioAttachment }">
-        <button mat-button (click)="resetRecording()" class="remove-audio-file">
-          <mat-icon>mic</mat-icon>
-          {{ t("re_record") }}
-        </button>
-        <button mat-flat-button color="primary" (click)="saveRecording()" class="save-audio-file">
-          <mat-icon>check</mat-icon> {{ t("save") }}
-        </button>
-      </div>
     </div>
   </mat-dialog-content>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -5,9 +5,10 @@
       @if (!hasAudioAttachment && !showCountdown) {
         <div class="no-attachment" id="audioRecordContainer">
           @if (!isRecording) {
-            <button mat-icon-button (click)="startRecording()" class="record">
-              <mat-icon>mic</mat-icon>
-            </button>
+            <div (click)="startRecording()" class="record">
+              <mat-icon class="record-button">mic</mat-icon>
+              <span class="record-message">{{ t("tap_to_record") }}</span>
+            </div>
           } @else {
             <button
               mat-icon-button
@@ -19,9 +20,6 @@
               <mat-icon>stop</mat-icon>
             </button>
           }
-        </div>
-        <div class="record-message" [class.visible]="!isRecording">
-          <p>{{ tapToRecordText!.before }}<mat-icon>mic</mat-icon>{{ tapToRecordText!.after }}</p>
         </div>
       }
       @if (hasAudioAttachment) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -6,8 +6,8 @@
         <div class="no-attachment" id="audioRecordContainer">
           @if (!isRecording) {
             <div (click)="startRecording()" class="record">
-              <mat-icon class="record-button">mic</mat-icon>
-              <span class="record-message">{{ t("tap_to_record") }}</span>
+              <mat-icon class="record-icon">mic</mat-icon>
+              <span class="record-message">{{ t("record") }}</span>
             </div>
           } @else {
             <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -5,13 +5,7 @@
       @if (!hasAudioAttachment && !showCountdown) {
         <div class="no-attachment" id="audioRecordContainer">
           @if (!isRecording) {
-            <button
-              mat-icon-button
-              (click)="startRecording()"
-              class="record"
-              [matTooltip]="t('record_audio')"
-              matTooltipPosition="below"
-            >
+            <button mat-icon-button (click)="startRecording()" class="record">
               <mat-icon>mic</mat-icon>
             </button>
           } @else {
@@ -26,6 +20,7 @@
             </button>
           }
         </div>
+        <p class="record-message" [ngClass]="{ visible: !isRecording }">{{ t("tap_to_record") }}</p>
       }
       @if (hasAudioAttachment && !!audio.url) {
         <div class="has-attachment">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -36,7 +36,6 @@
     right: 0;
     left: 0;
     margin: auto;
-    animation: fadein 0.5s;
   }
 
   .stop {
@@ -59,6 +58,7 @@
     cursor: pointer;
     background-color: rgba(0, 0, 0, 0.08);
     box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.15);
+    animation: fadein 0.5s;
     transition:
       color 0.15s,
       background-color 0.15s;
@@ -77,6 +77,7 @@
     height: 100%;
     width: 100%;
     position: relative;
+    animation: fadein 0.5s;
 
     // the div elements with the animate class are created dynamically and the
     // ng-deep was needed for these styles to apply
@@ -153,6 +154,9 @@
 
 @keyframes fadein {
   0% {
+    opacity: 0%;
+  }
+  50% {
     opacity: 0%;
   }
   100% {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -22,7 +22,6 @@
     }
   }
 
-  .record,
   .stop,
   .has-attachment {
     transform: scale(2);
@@ -49,6 +48,24 @@
     }
   }
 
+  .record {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+    align-items: center;
+    justify-content: center;
+    height: 120px;
+    border-radius: 50%;
+    cursor: pointer;
+    background-color: rgba(0, 0, 0, 0.1);
+    box-shadow: 2px 2px variables.$greyLight;
+    animation: fadein 0.5s;
+
+    .record-button {
+      transform: scale(2);
+    }
+  }
+
   .no-attachment {
     height: 100%;
     width: 100%;
@@ -68,21 +85,6 @@
       left: 0;
       margin: auto;
       animation: growshrink 1s forwards;
-    }
-  }
-
-  .record-message {
-    position: absolute;
-    bottom: 70px;
-    opacity: 0%;
-    &.visible {
-      animation: fadein 0.5s;
-      opacity: 100%;
-    }
-
-    p {
-      display: flex;
-      align-items: center;
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -70,6 +70,16 @@
       animation: growshrink 1s forwards;
     }
   }
+
+  .record-message {
+    position: absolute;
+    bottom: 70px;
+    opacity: 0%;
+    &.visible {
+      animation: fadein 0.5s;
+      opacity: 100%;
+    }
+  }
 }
 
 .dialog-footer {
@@ -128,5 +138,14 @@
     width: 120px;
     height: 120px;
     background-color: white;
+  }
+}
+
+@keyframes fadein {
+  0% {
+    opacity: 0%;
+  }
+  100% {
+    opacity: 100%;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -79,12 +79,18 @@
       animation: fadein 0.5s;
       opacity: 100%;
     }
+
+    p {
+      display: flex;
+      align-items: center;
+    }
   }
 }
 
 .dialog-footer {
   height: 50px;
   position: relative;
+  min-width: 220px;
   canvas {
     position: absolute;
   }
@@ -96,14 +102,9 @@
 }
 
 .has-attachment {
-  transform: scale(0);
   display: flex;
-  justify-content: space-between;
-  gap: 10px;
-
-  &.visible {
-    transform: scale(1);
-  }
+  justify-content: space-evenly;
+  column-gap: 8px;
 }
 
 @keyframes countdown {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -36,6 +36,7 @@
     right: 0;
     left: 0;
     margin: auto;
+    animation: fadein 0.5s;
   }
 
   .stop {
@@ -54,15 +55,21 @@
     row-gap: 8px;
     align-items: center;
     justify-content: center;
-    height: 120px;
     border-radius: 50%;
     cursor: pointer;
-    background-color: rgba(0, 0, 0, 0.1);
-    box-shadow: 2px 2px variables.$greyLight;
-    animation: fadein 0.5s;
+    background-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 3px 4px 4px rgba(0, 0, 0, 0.15);
+    transition:
+      color 0.15s,
+      background-color 0.15s;
 
-    .record-button {
+    .record-icon {
       transform: scale(2);
+    }
+
+    &:hover {
+      background-color: variables.$greenLight;
+      color: variables.$sf_grey;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.scss
@@ -68,7 +68,7 @@
     }
 
     &:hover {
-      background-color: variables.$greenLight;
+      background-color: rgba(0, 0, 0, 0.15);
       color: variables.$sf_grey;
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -151,6 +151,11 @@ class TestEnvironment {
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
   constructor(countdown: boolean = false) {
+    when(mockedI18nService.translateTextAroundTemplateTags(anything())).thenReturn({
+      before: 'before ',
+      templateTagText: '',
+      after: ' after'
+    });
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     this.dialogRef = TestBed.inject(MatDialog).open(AudioRecorderDialogComponent, {
       data: { countdown } as AudioRecorderDialogData

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -7,7 +7,7 @@ import { Observable, Subscription, interval, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
-import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import {
@@ -64,9 +64,6 @@ export class AudioRecorderDialogComponent
   countdownTimer: number = 0;
   mediaDevicesUnsupported: boolean = false;
   showCanvas: boolean = false;
-  tapToRecordText?: TextAroundTemplate = this.i18n.translateTextAroundTemplateTags(
-    'audio_recorder_dialog.tap_to_record'
-  );
 
   private stream?: MediaStream;
   private mediaRecorder?: MediaRecorder;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -7,6 +7,7 @@ import { Observable, Subscription, interval, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import {
@@ -63,6 +64,10 @@ export class AudioRecorderDialogComponent
   countdownTimer: number = 0;
   mediaDevicesUnsupported: boolean = false;
   showCanvas: boolean = false;
+  tapToRecordText?: TextAroundTemplate = this.i18n.translateTextAroundTemplateTags(
+    'audio_recorder_dialog.tap_to_record'
+  );
+
   private stream?: MediaStream;
   private mediaRecorder?: MediaRecorder;
   private recordedChunks: Blob[] = [];
@@ -80,7 +85,8 @@ export class AudioRecorderDialogComponent
     @Inject(MAT_DIALOG_DATA) public data: AudioRecorderDialogData,
     private readonly noticeService: NoticeService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
-    private readonly dialogService: DialogService
+    private readonly dialogService: DialogService,
+    private i18n: I18nService
   ) {
     super();
     this.showCountdown = data?.countdown ?? false;
@@ -93,7 +99,7 @@ export class AudioRecorderDialogComponent
   }
 
   get hasAudioAttachment(): boolean {
-    return this.audio.url !== undefined;
+    return !!this.audio.url;
   }
 
   get isRecording(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -2,10 +2,10 @@
   "audio_recorder_dialog": {
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
-    "record_audio": "Record Audio",
     "re_record": "Re-record",
     "save": "Save",
-    "stop_recording": "Stop Recording"
+    "stop_recording": "Stop Recording",
+    "tap_to_record": "Tap to record"
   },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -5,7 +5,7 @@
     "re_record": "Re-record",
     "save": "Save",
     "stop_recording": "Stop Recording",
-    "tap_to_record": "Tap to record"
+    "tap_to_record": "Tap the icon to record"
   },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -5,7 +5,7 @@
     "re_record": "Re-record",
     "save": "Save",
     "stop_recording": "Stop Recording",
-    "tap_to_record": "Tap {{ templateTagBoundary }}{{ templateTagBoundary }} to record"
+    "tap_to_record": "Tap to record"
   },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -2,10 +2,10 @@
   "audio_recorder_dialog": {
     "mic_access_denied": "Access to your microphone was denied. Please enable the microphone from your browser.",
     "mic_not_found": "No microphone was found. Please connect a microphone to your device.",
+    "record": "Record",
     "re_record": "Re-record",
     "save": "Save",
-    "stop_recording": "Stop Recording",
-    "tap_to_record": "Tap to record"
+    "stop_recording": "Stop Recording"
   },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -5,7 +5,7 @@
     "re_record": "Re-record",
     "save": "Save",
     "stop_recording": "Stop Recording",
-    "tap_to_record": "Tap the icon to record"
+    "tap_to_record": "Tap {{ templateTagBoundary }}{{ templateTagBoundary }} to record"
   },
   "app": {
     "action_not_available_offline": "This action isn't available while you are offline.",


### PR DESCRIPTION
A user may not recognize that to start a recording, they need to click the button. The tooltip partially fixed the problem, but not for users on mobile devices. This was suggested by the test team.

![Record button final](https://github.com/user-attachments/assets/cc62ea98-0d70-4264-b085-3ca67656dcf2)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2777)
<!-- Reviewable:end -->
