### PR TITLE
SF-2999 Silently hide unknown tab types without error

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -29,6 +29,7 @@ import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import Quill, { DeltaOperation, DeltaStatic, RangeStatic, Sources, StringMap } from 'quill';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
+import { WritingSystem } from 'realtime-server/lib/esm/common/models/writing-system';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { RecursivePartial } from 'realtime-server/lib/esm/common/utils/type-utils';
 import { BiblicalTerm } from 'realtime-server/lib/esm/scriptureforge/models/biblical-term';
@@ -77,7 +78,6 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { WritingSystem } from 'realtime-server/lib/esm/common/models/writing-system';
 import { BiblicalTermDoc } from '../../core/models/biblical-term-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
@@ -4659,6 +4659,7 @@ class TestEnvironment {
   }
 
   setProjectUserConfig(userConfig: Partial<SFProjectUserConfig> = {}): void {
+    userConfig.editorTabsOpen = userConfig.editorTabsOpen ?? [];
     userConfig.noteRefsRead = userConfig.noteRefsRead ?? [];
     const user1Config = cloneDeep(userConfig);
     user1Config.ownerRef = 'user01';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { cloneDeep } from 'lodash-es';
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
-import { of, Subject } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserService } from 'xforge-common/user.service';
@@ -45,6 +45,17 @@ describe('EditorTabPersistenceService', () => {
       { a: 1, b: 2 },
       { a: 3, b: 4 }
     ] as any);
+  }));
+
+  it('should not return invalid persisted tabs', fakeAsync(() => {
+    const tabs = [{ tabType: 'invalid' }, { tabType: 'biblical-terms' }] as unknown as EditorTabPersistData[];
+    const env = new TestEnvironment(tabs);
+    let persistedTabs = [];
+    env.service.persistedTabs$.subscribe(tabs => {
+      persistedTabs = tabs;
+    });
+    tick();
+    expect(persistedTabs.length).toBe(1);
   }));
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { isEqual, isUndefined, omitBy } from 'lodash-es';
+import { editorTabTypes } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
-import { combineLatest, firstValueFrom, Observable, of, startWith, Subject, Subscription, switchMap, tap } from 'rxjs';
+import { Observable, Subject, Subscription, combineLatest, firstValueFrom, of, startWith, switchMap, tap } from 'rxjs';
 import { distinctUntilChanged, finalize, shareReplay } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserService } from 'xforge-common/user.service';
@@ -19,7 +20,7 @@ export class EditorTabPersistenceService {
    * Observable list of open editor tabs.
    */
   readonly persistedTabs$: Observable<EditorTabPersistData[]> = this.projectUserConfigDoc$.pipe(
-    switchMap(configDoc => of(configDoc.data?.editorTabsOpen ?? [])),
+    switchMap(configDoc => of(configDoc.data?.editorTabsOpen.filter(t => editorTabTypes.includes(t.tabType)) ?? [])),
     distinctUntilChanged(isEqual)
   );
 


### PR DESCRIPTION
This PR stops invalid tabs from causing an error when they are present in a user's configuration.

Testing should be done by a developer because it requires getting ids from MongoDB and running a custom script in the browser console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2781)
<!-- Reviewable:end -->
