### PR TITLE
SF-3033 SMT Training Status is not correct when connecting to project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -68,19 +68,7 @@ import {
   of,
   timer
 } from 'rxjs';
-import {
-  debounceTime,
-  delayWhen,
-  filter,
-  first,
-  map,
-  repeat,
-  retryWhen,
-  switchMap,
-  take,
-  tap,
-  throttleTime
-} from 'rxjs/operators';
+import { debounceTime, filter, first, map, repeat, retry, switchMap, take, tap, throttleTime } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -1640,7 +1628,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         }),
         repeat(),
         filter(progress => progress.percentCompleted > 0),
-        retryWhen(errors => errors.pipe(delayWhen(() => timer(30000))))
+        retry({ delay: () => timer(30000) })
       )
       .subscribe();
     this.interactiveTranslatorFactory = this.translationEngineService.createInteractiveTranslatorFactory(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -3,7 +3,7 @@ import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { BehaviorSubject, Subscription, timer } from 'rxjs';
-import { delayWhen, filter, repeat, retryWhen, tap } from 'rxjs/operators';
+import { filter, repeat, retry, tap } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
@@ -151,7 +151,7 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
         }),
         repeat(),
         filter(progress => progress.percentCompleted > 0),
-        retryWhen(errors => errors.pipe(delayWhen(() => timer(30000))))
+        retry({ delay: () => timer(30000) })
       )
       .subscribe(progress => {
         if (this.trainingCompletedTimeout != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -10,7 +10,7 @@ import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scri
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { Subscription, asyncScheduler, firstValueFrom, timer } from 'rxjs';
-import { delayWhen, filter, map, repeat, retryWhen, tap, throttleTime } from 'rxjs/operators';
+import { filter, map, repeat, retry, tap, throttleTime } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -215,8 +215,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
           }
         }),
         repeat(),
-        filter(progress => progress.percentCompleted > 0),
-        retryWhen(errors => errors.pipe(delayWhen(() => timer(30000))))
+        retry({ delay: () => timer(30000) })
       )
       .subscribe(progress => {
         this.trainingPercentage = Math.round(progress.percentCompleted * 100);

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -665,7 +665,7 @@ public class MachineApiService(
         // We use project service, as it provides permission and token checks
         string syncJobId = await projectService.SyncAsync(curUserId, sfProjectId);
 
-        // Run the training after the sync has completed
+        // Run the training after the sync has completed. If the sync failed or stopped, retrain anyway
         string buildJobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
             syncJobId,
             r =>
@@ -674,7 +674,9 @@ public class MachineApiService(
                     new BuildConfig { ProjectId = sfProjectId },
                     false,
                     CancellationToken.None
-                )
+                ),
+            null,
+            JobContinuationOptions.OnAnyFinishedState
         );
 
         // Set the translation queued date and time, and hang fire job id

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -205,8 +205,16 @@ public class SyncService(
                         JobContinuationOptions.OnAnyFinishedState
                     );
 
-                    // Store the build job id, so we can cancel the job later if needed
-                    await projectSecrets.UpdateAsync(projectSecret.Id, u => u.Add(p => p.JobIds, buildJobId));
+                    // Set the translation queued date and time, and hang fire job id
+                    await projectSecrets.UpdateAsync(
+                        projectSecret.Id,
+                        u =>
+                        {
+                            u.Set(p => p.ServalData.TranslationJobId, buildJobId);
+                            u.Set(p => p.ServalData.TranslationQueuedAt, DateTime.UtcNow);
+                            u.Unset(p => p.ServalData.TranslationErrorMessage);
+                        }
+                    );
 
                     // Return the build job id as it is the last in the chain
                     return buildJobId;


### PR DESCRIPTION
This PR enables the training overview section of the Translate Overview page to display status accurately when the project is being uploaded to Serval before the SMT build has stated.

I also took the opportunity to update use of `retryWhen` to `retry`, as `retryWhen` is deprecated.