### PR TITLE
SF-2991 Display informative error message when sync fails due to permissions issue

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sync.ts
+++ b/src/RealtimeServer/scriptureforge/models/sync.ts
@@ -5,4 +5,5 @@ export interface Sync {
   syncedToRepositoryVersion?: string;
   /** Indicates if PT project data from the last send/receive operation was incorporated into the SF project docs */
   dataInSync?: boolean;
+  lastSyncErrorCode?: number;
 }

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -428,6 +428,9 @@ export class SFProjectService extends ProjectService<SFProject> {
           },
           dataInSync: {
             bsonType: 'bool'
+          },
+          lastSyncErrorCode: {
+            bsonType: 'int'
           }
         },
         additionalProperties: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -7,6 +7,11 @@
     @if (syncDisabled) {
       <span id="sync-disabled-message" [innerHTML]="syncDisabledMessage"> </span>
     }
+    @if (showSyncUserPermissionsFailureMessage) {
+      <app-notice id="sync-user-permission-failure-message" type="error" icon="error">
+        {{ t("sync_user_permissions_failure_message") }}
+      </app-notice>
+    }
     @if (showSyncFailureSupportMessage) {
       <span id="sync-failure-support-message" [innerHTML]="syncFailureSupportMessage"></span>
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -15,6 +15,10 @@ import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 
+enum SyncErrorCodes {
+  UserPermission = -1
+}
+
 @Component({
   selector: 'app-sync',
   templateUrl: './sync.component.html',
@@ -72,6 +76,10 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     return this.lastSyncDate?.toLocaleString() || '';
   }
 
+  get lastSyncErrorCode(): number | undefined {
+    return this.projectDoc?.data?.sync.lastSyncErrorCode;
+  }
+
   get projectName(): string {
     return this.projectDoc?.data == null ? '' : this.projectDoc.data.name;
   }
@@ -93,6 +101,8 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
         if (this.projectDoc.data.sync.lastSyncSuccessful) {
           this.noticeService.show(translate('sync.successfully_synchronized_with_paratext', { projectName }));
           this.previousLastSyncDate = this.lastSyncDate;
+        } else if (this.showSyncUserPermissionsFailureMessage) {
+          this.dialogService.message(this.i18n.translate('sync.user_permissions_failure_dialog_message'));
         } else {
           this.dialogService.message(
             this.i18n.translate('sync.something_went_wrong_synchronizing_this_project', { projectName })
@@ -108,6 +118,10 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     return this.i18n.translateAndInsertTags('sync.sync_is_disabled', {
       email: `<a target="_blank" href="mailto:${environment.issueEmail}">${environment.issueEmail}</a>`
     });
+  }
+
+  get showSyncUserPermissionsFailureMessage(): boolean {
+    return this.lastSyncErrorCode === SyncErrorCodes.UserPermission;
   }
 
   get showSyncFailureSupportMessage(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -538,7 +538,9 @@
     "synchronize_project": "Synchronize {{ projectName }} with Paratext",
     "your_project_is_being_synchronized": "Your project is being synchronized...",
     "sync_is_disabled": "Synchronization for this project needed to be disabled, so it is not available at this time. Please contact {{ email }} to discuss what needs to be done so project synchronization can be enabled again.",
-    "sync_failure_support_message": "Something went wrong the last time Scripture Forge attempted to synchronize the project with Paratext. If it still doesn't work after you try again, please report the problem by writing to {{email}}."
+    "sync_failure_support_message": "Something went wrong the last time Scripture Forge attempted to synchronize the project with Paratext. If it still doesn't work after you try again, please report the problem by writing to {{email}}.",
+    "sync_user_permissions_failure_message": "The last user to synchronize this project no longer has permission to sync. Please contact the project administrator.",
+    "user_permissions_failure_dialog_message": "You no longer have permission to synchronize this project with Paratext. Please contact the project administrator."
   },
   "tab_group_header": {
     "no_tabs_available": "No tabs available."

--- a/src/SIL.XForge.Scripture/Models/Sync.cs
+++ b/src/SIL.XForge.Scripture/Models/Sync.cs
@@ -33,4 +33,5 @@ public class Sync
     /// record of successfully importing all local PT repo data into SF DB at the new commit id.
     /// </summary>
     public bool? DataInSync { get; set; }
+    public int? LastSyncErrorCode { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/SyncErrorCodes.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncErrorCodes.cs
@@ -1,0 +1,9 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The error codes for returning errors to front end via LastSyncErrorCode <see cref="Sync"/>.
+/// </summary>
+public enum SyncErrorCodes
+{
+    UserPermissionError = -1,
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -78,6 +78,28 @@ public class ParatextSyncRunnerTests
     }
 
     [Test]
+    public async Task SyncAsync_UserPermissionError()
+    {
+        var env = new TestEnvironment();
+        env.SetupSFData(true, true, false, false);
+        env.ParatextService.GetParatextUsersAsync(
+                Arg.Any<UserSecret>(),
+                Arg.Any<SFProject>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Throws(new ForbiddenException());
+
+        await env.Runner.RunAsync("project01", "user02", "project01", false, CancellationToken.None);
+
+        SFProject project = env.VerifyProjectSync(false, projectSFId: "project01");
+        Assert.That(project.Sync.LastSyncSuccessful, Is.False);
+        Assert.That(project.Sync.LastSyncErrorCode, Is.EqualTo((int)SyncErrorCodes.UserPermissionError));
+
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.Status, Is.EqualTo(SyncStatus.Failed));
+    }
+
+    [Test]
     public async Task SyncAsync_KeepsErrorStateWhenRunningAgain()
     {
         var env = new TestEnvironment();
@@ -1578,7 +1600,7 @@ public class ParatextSyncRunnerTests
                     string.Join('.', new ObjectPath(ex).Items) == "Sync.LastSyncSuccessful"
                 )
             );
-        env.Connection.Received(3).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
+        env.Connection.Received(4).ExcludePropertyFromTransaction(Arg.Any<Expression<Func<SFProject, object>>>());
     }
 
     [Test]
@@ -3826,7 +3848,7 @@ public class ParatextSyncRunnerTests
                         // No SyncedToRepositoryVersion
                     },
                     NoteTags = new List<NoteTag>()
-                },
+                }
             };
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));


### PR DESCRIPTION
In the event a sync fails due to a user who no longer has permission to sync a project we want to inform the user to contact the project administrator. This change passes an error code that can be read by the front-end when the notification of the sync completes. It will display a different sync error message and dialog message than the default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2794)
<!-- Reviewable:end -->
