### PR TITLE
SF-3036 Add attach audio component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
@@ -1,0 +1,29 @@
+<ng-container *transloco="let t; read: 'attach_audio'">
+  <div class="add-audio">
+    @if (!textAndAudio?.input?.audioUrl && textAndAudio?.audioAttachment?.status !== "recording") {
+      <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
+        <mat-icon>mic</mat-icon>
+      </button>
+    }
+    @if (textAndAudio?.audioAttachment?.status === "recording") {
+      <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
+        <mat-icon class="stop-recording">stop</mat-icon>
+      </button>
+    }
+  </div>
+  @if (textAndAudio?.input?.audioUrl) {
+    <div class="audio-added">
+      <app-single-button-audio-player
+        #audio
+        [source]="textAndAudio?.input?.audioUrl"
+        (click)="toggleAudio()"
+        theme="secondary"
+      >
+        <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
+      </app-single-button-audio-player>
+      <button mat-icon-button (click)="deleteAudio()" class="clear">
+        <mat-icon>clear</mat-icon>
+      </button>
+    </div>
+  }
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.scss
@@ -1,0 +1,18 @@
+@use 'src/variables';
+
+.audio-added {
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.05);
+  padding-inline-start: 6px;
+  border-radius: 4px;
+  margin-inline-end: 2px;
+}
+
+.stop-recording {
+  color: variables.$red;
+}
+
+.clear {
+  color: variables.$greenDark;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
@@ -1,0 +1,68 @@
+import { CommonModule } from '@angular/common';
+import { DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { instance, mock, when } from 'ts-mockito';
+import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
+import { UICommonModule } from 'xforge-common/ui-common.module';
+import { OnlineStatusService } from '../../../xforge-common/online-status.service';
+import { TestOnlineStatusModule } from '../../../xforge-common/test-online-status.module';
+import { TestOnlineStatusService } from '../../../xforge-common/test-online-status.service';
+import { SharedModule } from '../../shared/shared.module';
+import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.component';
+import { AttachAudioComponent } from './attach-audio.component';
+
+describe('AttachAudioComponent', () => {
+  let env: TestEnvironment;
+
+  configureTestingModule(() => ({
+    imports: [CommonModule, UICommonModule, SharedModule, TestTranslocoModule, TestOnlineStatusModule.forRoot()],
+    declarations: [AttachAudioComponent],
+    providers: [
+      {
+        provide: OnlineStatusService,
+        useClass: TestOnlineStatusService
+      }
+    ]
+  }));
+
+  beforeEach(async () => {
+    env = new TestEnvironment();
+  });
+
+  it('should show mic when not audio attached', () => {
+    expect(env.iconButton.nativeElement.textContent).toBe('mic');
+  });
+
+  it('should show stop when recording', () => {
+    const mockTextAndAudio = mock(TextAndAudioComponent);
+    when(mockTextAndAudio.audioAttachment).thenReturn({ status: 'recording' });
+    env.component.textAndAudio = instance(mockTextAndAudio);
+    env.fixture.detectChanges();
+    expect(env.iconButton.nativeElement.textContent).toBe('stop');
+  });
+
+  it('should show play when audio is attached', () => {
+    const mockTextAndAudio = mock(TextAndAudioComponent);
+    when(mockTextAndAudio.audioAttachment).thenReturn({ status: 'processed' });
+    when(mockTextAndAudio.input).thenReturn({ audioUrl: 'blob://audio' });
+    env.component.textAndAudio = instance(mockTextAndAudio);
+    env.fixture.detectChanges();
+    expect(env.component.audioPlayer).not.toBeNull();
+    expect(env.iconButton.nativeElement.textContent).toBe('clear');
+  });
+});
+
+class TestEnvironment {
+  component: AttachAudioComponent;
+  fixture: ComponentFixture<AttachAudioComponent>;
+  constructor() {
+    this.fixture = TestBed.createComponent(AttachAudioComponent);
+    this.component = this.fixture.componentInstance;
+    this.fixture.detectChanges();
+  }
+
+  get iconButton(): DebugElement {
+    return this.fixture.debugElement.query(By.css('button .mat-icon'));
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
@@ -34,8 +34,10 @@ describe('AttachAudioComponent', () => {
     env = new TestEnvironment();
   });
 
-  it('should show mic when not audio attached', () => {
+  it('should show mic when no audio attached', () => {
     when(mockTextAndAudio.input).thenReturn({});
+    when(mockTextAndAudio.audioAttachment).thenReturn({ status: 'reset' });
+    env.fixture.detectChanges();
     expect(env.iconButton.nativeElement.textContent).toBe('mic');
     env.iconButton.nativeElement.click();
     env.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { SingleButtonAudioPlayerComponent } from '../checking/single-button-audio-player/single-button-audio-player.component';
+import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.component';
+
+@Component({
+  selector: 'app-attach-audio',
+  templateUrl: './attach-audio.component.html',
+  styleUrl: './attach-audio.component.scss'
+})
+export class AttachAudioComponent {
+  @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
+  @Input() textAndAudio?: TextAndAudioComponent;
+
+  constructor() {}
+
+  startRecording(): void {
+    this.textAndAudio?.audioComponent?.startRecording();
+  }
+
+  stopRecording(): void {
+    this.textAndAudio?.audioComponent?.stopRecording();
+  }
+
+  deleteAudio(): void {
+    this.textAndAudio?.audioComponent?.resetRecording();
+  }
+
+  toggleAudio(): void {
+    this.audioPlayer?.playing ? this.audioPlayer?.stop() : this.audioPlayer?.play();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking.module.ts
@@ -9,6 +9,7 @@ import { AudioPlayerComponent } from '../shared/audio/audio-player/audio-player.
 import { AudioTimePipe } from '../shared/audio/audio-time-pipe';
 import { SharedModule } from '../shared/shared.module';
 import { TextChooserDialogComponent } from '../text-chooser-dialog/text-chooser-dialog.component';
+import { AttachAudioComponent } from './attach-audio/attach-audio.component';
 import { ChapterAudioDialogComponent } from './chapter-audio-dialog/chapter-audio-dialog.component';
 import { CheckingOverviewComponent } from './checking-overview/checking-overview.component';
 import { CheckingRoutingModule } from './checking-routing.module';
@@ -35,6 +36,7 @@ import { TextAndAudioComponent } from './text-and-audio/text-and-audio.component
     CheckingTextComponent,
     CheckingAnswersComponent,
     TextAndAudioComponent,
+    AttachAudioComponent,
     QuestionDialogComponent,
     ImportQuestionsDialogComponent,
     ImportQuestionsConfirmationDialogComponent,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.html
@@ -58,33 +58,7 @@
             ></app-text-and-audio>
             <div class="bottom-row">
               <div class="attachments">
-                <div class="add-audio">
-                  @if (!answer.input?.audioUrl && answer.audioAttachment.status !== "recording") {
-                    <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
-                      <mat-icon>mic</mat-icon>
-                    </button>
-                  }
-                  @if (answer.audioAttachment.status === "recording") {
-                    <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
-                      <mat-icon class="stop-recording">stop</mat-icon>
-                    </button>
-                  }
-                </div>
-                @if (answer.input?.audioUrl) {
-                  <div class="audio-added">
-                    <app-single-button-audio-player
-                      #audio
-                      [source]="answer.input?.audioUrl"
-                      (click)="toggleAudio()"
-                      theme="secondary"
-                    >
-                      <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
-                    </app-single-button-audio-player>
-                    <button mat-icon-button (click)="deleteAudio()" class="clear">
-                      <mat-icon>clear</mat-icon>
-                    </button>
-                  </div>
-                }
+                <app-attach-audio [textAndAudio]="answer"></app-attach-audio>
                 @if (!selectedText) {
                   <button
                     mat-icon-button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -51,9 +51,6 @@
     align-items: center;
     column-gap: 8px;
   }
-  .stop-recording {
-    color: variables.$red;
-  }
 }
 
 .answers-container {
@@ -166,17 +163,12 @@
 }
 
 .answer-scripture,
-.scripture-text,
-.audio-added {
+.scripture-text {
   display: flex;
   align-items: center;
   background: rgba(0, 0, 0, 0.05);
   padding-inline-start: 6px;
   border-radius: 4px;
-}
-
-.audio-added {
-  margin-inline-end: 2px;
 }
 
 .answer-scripture-text {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -39,7 +39,6 @@ import { QuestionDialogService } from '../../question-dialog/question-dialog.ser
 import { TextAndAudioComponent } from '../../text-and-audio/text-and-audio.component';
 import { AudioAttachment } from '../checking-audio-recorder/checking-audio-recorder.component';
 import { CheckingTextComponent } from '../checking-text/checking-text.component';
-import { SingleButtonAudioPlayerComponent } from '../single-button-audio-player/single-button-audio-player.component';
 import { CommentAction } from './checking-comments/checking-comments.component';
 import { CheckingQuestionComponent } from './checking-question/checking-question.component';
 
@@ -90,7 +89,6 @@ enum LikeAnswerResponse {
 export class CheckingAnswersComponent extends SubscriptionDisposable implements OnInit, AfterViewInit {
   @ViewChild(TextAndAudioComponent) textAndAudio?: TextAndAudioComponent;
   @ViewChild(CheckingQuestionComponent) questionComponent?: CheckingQuestionComponent;
-  @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
   @Input() projectUserConfigDoc?: SFProjectUserConfigDoc;
   @Input() textsByBookId?: TextsByBookId;
   @Input() checkingTextComponent?: CheckingTextComponent;
@@ -409,22 +407,6 @@ export class CheckingAnswersComponent extends SubscriptionDisposable implements 
         this.questionDoc.submitJson0Op(op => op.set(q => q.audioUrl, urlResult));
       }
     }
-  }
-
-  startRecording(): void {
-    this.textAndAudio?.audioComponent?.startRecording();
-  }
-
-  stopRecording(): void {
-    this.textAndAudio?.audioComponent?.stopRecording();
-  }
-
-  deleteAudio(): void {
-    this.textAndAudio?.audioComponent?.resetRecording();
-  }
-
-  toggleAudio(): void {
-    this.audioPlayer?.playing ? this.audioPlayer?.stop() : this.audioPlayer?.play();
   }
 
   selectScripture(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -74,6 +74,7 @@ import { AudioPlayerComponent } from '../../shared/audio/audio-player/audio-play
 import { AudioTimePipe } from '../../shared/audio/audio-time-pipe';
 import { SharedModule } from '../../shared/shared.module';
 import { TextChooserDialogComponent, TextSelection } from '../../text-chooser-dialog/text-chooser-dialog.component';
+import { AttachAudioComponent } from '../attach-audio/attach-audio.component';
 import { ChapterAudioDialogService } from '../chapter-audio-dialog/chapter-audio-dialog.service';
 import { QuestionScope } from '../checking.utils';
 import { QuestionDialogData } from '../question-dialog/question-dialog.component';
@@ -154,7 +155,8 @@ describe('CheckingComponent', () => {
       CheckingQuestionsComponent,
       CheckingTextComponent,
       TextAndAudioComponent,
-      FontSizeComponent
+      FontSizeComponent,
+      AttachAudioComponent
     ],
     imports: [
       AngularSplitModule,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -47,32 +47,7 @@
       </div>
       <app-text-and-audio #input [input]="question" [textLabel]="t('question')"></app-text-and-audio>
       <div class="attachments">
-        <div class="add-audio">
-          @if (!input.input?.audioUrl && input.audioAttachment.status !== "recording") {
-            <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
-              <mat-icon>mic</mat-icon>
-            </button>
-          } @else if (input.audioAttachment.status === "recording") {
-            <button mat-icon-button (click)="stopRecording()" [matTooltip]="t('tooltip_stop')">
-              <mat-icon class="stop-recording">stop</mat-icon>
-            </button>
-          }
-        </div>
-        @if (input.input?.audioUrl) {
-          <div class="audio-added">
-            <app-single-button-audio-player
-              #audio
-              [source]="input.input?.audioUrl"
-              (click)="toggleAudio()"
-              theme="secondary"
-            >
-              <mat-icon>{{ audio.playing ? "stop" : "play_arrow" }}</mat-icon>
-            </app-single-button-audio-player>
-            <button mat-icon-button (click)="deleteAudio()" class="clear">
-              <mat-icon>clear</mat-icon>
-            </button>
-          </div>
-        }
+        <app-attach-audio [textAndAudio]="input"></app-attach-audio>
       </div>
     </mat-dialog-content>
     <mat-dialog-actions [align]="'end'">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.scss
@@ -1,6 +1,5 @@
 @use 'src/variables';
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
-@use '../checking/checking-global-vars' as checking-vars;
 
 .mat-mdc-dialog-content.content-padding {
   padding-top: 0.5em;
@@ -48,24 +47,4 @@ mat-form-field {
   flex-direction: row;
   margin-top: 2px;
   min-height: 40px;
-}
-
-.audio-added {
-  display: flex;
-  align-items: center;
-  color: checking-vars.$greenDark;
-  background: rgba(0, 0, 0, 0.05);
-  padding-inline-start: 6px;
-  border-radius: 4px;
-  font-size: 0.9em;
-}
-
-.clear {
-  width: 36px;
-  height: 36px;
-  line-height: 24px;
-}
-
-.stop-recording {
-  color: variables.$red;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -21,7 +21,6 @@ import {
 import { ParentAndStartErrorStateMatcher, SFValidators } from '../../shared/sfvalidators';
 import { combineVerseRefStrs } from '../../shared/utils';
 import { AudioAttachment } from '../checking/checking-audio-recorder/checking-audio-recorder.component';
-import { SingleButtonAudioPlayerComponent } from '../checking/single-button-audio-player/single-button-audio-player.component';
 import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.component';
 
 export interface QuestionDialogData {
@@ -45,7 +44,6 @@ export interface QuestionDialogResult {
 })
 export class QuestionDialogComponent extends SubscriptionDisposable implements OnInit {
   @ViewChild(TextAndAudioComponent) textAndAudio?: TextAndAudioComponent;
-  @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
   modeLabel =
     this.data && this.data.questionDoc != null
       ? translate('question_dialog.edit_question')
@@ -166,22 +164,6 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
 
   updateScriptureEndEnabled(): void {
     this.scriptureStart.valid ? this.scriptureEnd.enable() : this.scriptureEnd.disable();
-  }
-
-  startRecording(): void {
-    this.textAndAudio?.audioComponent?.startRecording();
-  }
-
-  stopRecording(): void {
-    this.textAndAudio?.audioComponent?.stopRecording();
-  }
-
-  deleteAudio(): void {
-    this.textAndAudio?.audioComponent?.resetRecording();
-  }
-
-  toggleAudio(): void {
-    this.audioPlayer?.playing ? this.audioPlayer?.stop() : this.audioPlayer?.play();
   }
 
   async submit(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -38,6 +38,10 @@
     "scripture_checking_not_available": "Scripture checking is not available in this project.",
     "update_is_available": "An update is available. Please refresh the page."
   },
+  "attach_audio": {
+    "tooltip_record": "Record audio",
+    "tooltip_stop": "Stop recording"
+  },
   "canon": {
     "book_names": {
       "GEN": "Genesis",
@@ -216,8 +220,6 @@
     "select_verses": "Select verses",
     "show_more_unread": "Show {{ count }} more unread answers",
     "tooltip_attach": "Attach scripture",
-    "tooltip_record": "Record audio",
-    "tooltip_stop": "Stop recording",
     "tooltip_status_export": "Export to Paratext if configured in Settings",
     "tooltip_status_resolve": "Mark answer as resolved",
     "your_answer": "Your answer"

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -407,9 +407,7 @@
     "recording_stopped": "The recording for your question was automatically stopped.",
     "required_with_asterisk": "*Required",
     "save": "Save",
-    "scripture_reference": "Scripture reference",
-    "tooltip_record": "Record audio",
-    "tooltip_stop": "Stop recording"
+    "scripture_reference": "Scripture reference"
   },
   "roles": {
     "allow_add_edit_questions": "Can add & edit questions",


### PR DESCRIPTION
The attach audio feature is in multiple places. This PR creates an attach audio component that can be reused for recording questions, answers and the coming-soon audio comment feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2795)
<!-- Reviewable:end -->
