### PR TITLE
Update locales.json by sorting by locale usage

### DIFF
--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -21,17 +21,17 @@
     "helps": "fr"
   },
   {
+    "localName": "Bahasa Indonesia",
+    "englishName": "Indonesian",
+    "tags": ["id", "id-ID"],
+    "production": true
+  },
+  {
     "localName": "Español",
     "englishName": "Spanish",
     "tags": ["es", "es-ES"],
     "production": true,
     "helps": "es"
-  },
-  {
-    "localName": "Bahasa Indonesia",
-    "englishName": "Indonesian",
-    "tags": ["id", "id-ID"],
-    "production": true
   },
   {
     "localName": "Română",
@@ -78,6 +78,13 @@
     "production": true
   },
   {
+    "localName": "Deutsch",
+    "englishName": "German",
+    "tags": ["de", "de-DE"],
+    "production": true,
+    "helps": "de"
+  },
+  {
     "localName": "नेपाली",
     "englishName": "Nepali",
     "tags": ["npi", "npi-NP"],
@@ -88,13 +95,6 @@
     "englishName": "Lao",
     "tags": ["lo", "lo-LA"],
     "production": true
-  },
-  {
-    "localName": "Deutsch",
-    "englishName": "German",
-    "tags": ["de", "de-DE"],
-    "production": true,
-    "helps": "de"
   },
   {
     "localName": "ខ្មែរ",


### PR DESCRIPTION
Sorted locales by using `mongodb/Users/SortLocalesByUsage.mongodb`.

I also removed ` (W. Kayah Li)` from a locale name, since we don't have that for any of the others.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2801)
<!-- Reviewable:end -->
