### PR TITLE
Fix language picker font not being used

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -147,7 +147,7 @@ header {
       visibility: hidden;
     }
 
-    .mat-mdc-menu-item {
+    .mat-mdc-menu-item .mat-mdc-menu-item-text {
       font-family: variables.$languageFonts;
     }
   }

--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -66,7 +66,7 @@
     "production": true
   },
   {
-    "localName": "ꤊꤢ꤬ꤛꤢ꤭ꤜꤟꤤ꤬ (W. Kayah Li)",
+    "localName": "ꤊꤢ꤬ꤛꤢ꤭ꤜꤟꤤ꤬",
     "englishName": "Western Kayah Li",
     "tags": ["kyu", "kyu-Kali"],
     "production": true


### PR DESCRIPTION
The font picker was not actually being used because Material has a rule that directly applied to `.mat-mdc-menu-item-text`, and our rule only applied it to `.mat-mdc-menu-item` (the parent element).

You can tell what font is being used by going to the "computed" tab of the element inspector and scrolling to the bottom. You can also look at the network tab and filter for fonts, and see that the language picker font wasn't even being loaded.

I also removed ` (W. Kayah Li)` because the text was originally added in https://github.com/sillsdev/web-xforge/pull/594 for font reasons.

Please note that not all locale names are being rendered with the language picker font, because we haven't been updating the language picker font. However, it does have the Western Kayah Li font, so I feel comfortable removing the English.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2802)
<!-- Reviewable:end -->
