### PR TITLE
Fix SemaphoreFullException from incorrect use of SemaphoreSlim

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -3342,9 +3342,9 @@ public class ParatextService : DisposableBase, IParatextService
     private async Task<UserSecret> GetUserSecretWithCurrentParatextTokens(string sfUserId, CancellationToken token)
     {
         SemaphoreSlim semaphore = _tokenRefreshSemaphores.GetOrAdd(sfUserId, _ => new SemaphoreSlim(1, 1));
+        await semaphore.WaitAsync(token);
         try
         {
-            await semaphore.WaitAsync(token);
             Attempt<UserSecret> attempt = await _userSecretRepository.TryGetAsync(sfUserId);
             if (!attempt.TryResult(out UserSecret userSecret))
             {


### PR DESCRIPTION
This PR fixes `SemaphoreFullException` crashes that have been occurring on sync, due `ReleaseAsync()` being called before `WaitAsync()` had completed. This can happen if the token is cancelled.

The solution to this is to follow the correct design pattern by having `WaitAsync()` called before try/catch block.

This PR does not require testing, as the only confirmation necessary is that a sync is successful.