### PR TITLE
Fix loading indicator diagnostics not working in production

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement, ErrorHandler } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
@@ -18,7 +18,7 @@ import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module'
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { ParatextProject } from '../core/models/paratext-project';
@@ -126,7 +126,7 @@ describe('ConnectProjectComponent', () => {
     env.fixture.detectChanges();
 
     expect(env.component.state).toEqual('input');
-    verify(mockedNoticeService.loadingStarted()).once();
+    verify(mockedNoticeService.loadingStarted(anything())).once();
     expect(env.component.showSettings).toBe(true);
     expect(env.component.projects.length).toEqual(0);
     expect(env.submitButton.nativeElement.disabled).toBe(true);
@@ -138,7 +138,7 @@ describe('ConnectProjectComponent', () => {
     expect(env.connectProjectForm).not.toBeNull();
     expect(env.component.projects.length).toEqual(env.paratextProjects.length);
     expect(env.submitButton.nativeElement.disabled).toBe(false);
-    verify(mockedNoticeService.loadingFinished()).once();
+    verify(mockedNoticeService.loadingFinished(anything())).once();
   }));
 
   it('disables page if offline', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.spec.ts
@@ -92,7 +92,7 @@ describe('MyProjectsComponent', () => {
     const resolve$: BehaviorSubject<boolean> = env.mockJoinProjectPromise('sf-cbntt');
 
     env.click(env.buttonForUnconnectedProject('pt-connButNotThisUser'));
-    verify(mockedNoticeService.loadingStarted()).once();
+    verify(mockedNoticeService.loadingStarted(anything())).once();
     verify(mockedSFProjectService.onlineAddCurrentUser('sf-cbntt')).once();
     expect(env.buttonForUnconnectedProject('pt-connButNotThisUser').nativeElement.disabled).toBe(true);
     expect(env.component.joiningProjects).toEqual(['sf-cbntt']);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -107,14 +107,14 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
 
   async joinProject(projectId: string): Promise<void> {
     try {
-      this.noticeService.loadingStarted();
+      this.noticeService.loadingStarted(this.constructor.name);
       this.joiningProjects.push(projectId);
       await this.projectService.onlineAddCurrentUser(projectId);
       this.router.navigate(['projects', projectId]);
     } catch (err) {
       this.noticeService.show(translate('my_projects.failed_to_join_project'));
     } finally {
-      this.noticeService.loadingFinished();
+      this.noticeService.loadingFinished(this.constructor.name);
       this.joiningProjects.pop();
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { DebugElement, ErrorHandler } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
@@ -18,7 +18,7 @@ import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module'
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
@@ -271,8 +271,8 @@ class TestEnvironment {
     when(mockedProjectService.onlineSync(anything()))
       .thenCall(id => this.setQueuedCount(id))
       .thenResolve();
-    when(mockedNoticeService.loadingStarted()).thenCall(() => (this.isLoading = true));
-    when(mockedNoticeService.loadingFinished()).thenCall(() => (this.isLoading = false));
+    when(mockedNoticeService.loadingStarted(anything())).thenCall(() => (this.isLoading = true));
+    when(mockedNoticeService.loadingFinished(anything())).thenCall(() => (this.isLoading = false));
     when(mockedNoticeService.isAppLoading).thenCall(() => this.isLoading);
     this.testOnlineStatusService.setIsOnline(isOnline);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
@@ -43,7 +43,7 @@ export abstract class DataLoadingComponent extends SubscriptionDisposable implem
 
   protected loadingStarted(): void {
     if (!this.isLoadingData) {
-      this.noticeService.loadingStarted();
+      this.noticeService.loadingStarted(this.constructor.name);
       this._isLoading$.next(true);
       this._isLoaded$.next(false);
     }
@@ -51,7 +51,7 @@ export abstract class DataLoadingComponent extends SubscriptionDisposable implem
 
   protected loadingFinished(): void {
     if (this.isLoadingData) {
-      this.noticeService.loadingFinished();
+      this.noticeService.loadingFinished(this.constructor.name);
       this._isLoading$.next(false);
       this._isLoaded$.next(true);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -24,9 +24,7 @@ export class NoticeService {
     return this._isAppLoading;
   }
 
-  loadingStarted(): void {
-    const callerId = this.getCallerClassName();
-
+  loadingStarted(callerId: string): void {
     if (this._loadingCountsByCallerId[callerId] === undefined) {
       this._loadingCountsByCallerId[callerId] = 0;
     }
@@ -35,9 +33,7 @@ export class NoticeService {
     this.setAppLoadingAsync(true);
   }
 
-  loadingFinished(): void {
-    const callerId = this.getCallerClassName();
-
+  loadingFinished(callerId: string): void {
     if (!(this._loadingCountsByCallerId[callerId] > 0)) {
       console.error(`loadingFinished called by ${callerId} without a corresponding loadingStarted call`);
       // Set it to 1 to avoid negative values
@@ -87,10 +83,6 @@ export class NoticeService {
     this.messageOnDisplay = message;
 
     firstValueFrom(snackBarRef.afterDismissed()).then(() => (this.messageOnDisplay = undefined));
-  }
-
-  private getCallerClassName(): string {
-    return new Error().stack?.split('\n')[3].match(/^\s*at (\w+)\./)?.[1] ?? 'unknown';
   }
 
   private setAppLoadingAsync(value: boolean): void {


### PR DESCRIPTION
On localhost, the component loading indicator diagnostics shows:

![](https://github.com/user-attachments/assets/c6bfe8a0-6568-4031-a1fd-9ea18b17ed87)

However, on QA and live, due to minification, we end up with this:

![](https://github.com/user-attachments/assets/5676d1be-82e1-47a4-9fb8-1684b9a3cfad)

I think this change will fix it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2808)
<!-- Reviewable:end -->
