### PR TITLE
Fix diagnostic overlay position strategy

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/diagnostic-overlay/diagnostic-overlay.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/diagnostic-overlay/diagnostic-overlay.component.html
@@ -1,60 +1,58 @@
-<ng-template cdkConnectedOverlay [cdkConnectedOverlayOpen]="isOpen">
-  <div class="diagnostic-overlay mat-elevation-z4" [class.collapsed]="!isExpanded">
-    <div class="header">
-      @if (isExpanded) {
-        <h2>Developer Diagnostics</h2>
-      }
-      <button mat-icon-button class="toggle-button" [class.collapsed]="!isExpanded" (click)="toggle()">
-        @if (isExpanded) {
-          <mat-icon>chevron_right</mat-icon>
-        } @else {
-          <mat-icon>chevron_left</mat-icon>
-        }
-      </button>
-      <button mat-icon-button class="close-button" (click)="close()">
-        <mat-icon>close</mat-icon>
-      </button>
-    </div>
+<div class="wrapper" [class.collapsed]="!isExpanded">
+  <div class="header">
     @if (isExpanded) {
-      <h3>Total documents {{ totalDocsCount | l10nNumber }} tracked by realtime service</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Collection</th>
-            <th>Documents</th>
-            <th>Subscribers</th>
-            <th>Queries</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (docType of docCountsByCollection | keyvalue; track docType.key) {
-            <tr>
-              <td>{{ docType.key }}</td>
-              <td>{{ docType.value.docs | l10nNumber }}</td>
-              <td>{{ docType.value.subscribers | l10nNumber }}</td>
-              <td>{{ docType.value.queries | l10nNumber }}</td>
-            </tr>
-          }
-        </tbody>
-      </table>
-
-      <h3>Components affecting loading indicator</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Component</th>
-            <th>Count</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (component of noticeService.loadingCountsByCallerId | keyvalue; track component.key) {
-            <tr [class.bold]="component.value > 0">
-              <td>{{ component.key }}</td>
-              <td>{{ component.value | l10nNumber }}</td>
-            </tr>
-          }
-        </tbody>
-      </table>
+      <h2>Developer Diagnostics</h2>
     }
+    <button mat-icon-button class="toggle-button" [class.collapsed]="!isExpanded" (click)="toggle()">
+      @if (isExpanded) {
+        <mat-icon>chevron_right</mat-icon>
+      } @else {
+        <mat-icon>chevron_left</mat-icon>
+      }
+    </button>
+    <button mat-icon-button class="close-button" (click)="close()">
+      <mat-icon>close</mat-icon>
+    </button>
   </div>
-</ng-template>
+  @if (isExpanded) {
+    <h3>{{ totalDocsCount | l10nNumber }} documents tracked by realtime service</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Collection</th>
+          <th>Docs</th>
+          <th>Subscribers</th>
+          <th>Queries</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (docType of docCountsByCollection | keyvalue; track docType.key) {
+          <tr>
+            <td>{{ docType.key }}</td>
+            <td>{{ docType.value.docs | l10nNumber }}</td>
+            <td>{{ docType.value.subscribers | l10nNumber }}</td>
+            <td>{{ docType.value.queries | l10nNumber }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    <h3>Components affecting loading indicator</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Component</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (component of noticeService.loadingCountsByCallerId | keyvalue; track component.key) {
+          <tr [class.bold]="component.value > 0">
+            <td>{{ component.key }}</td>
+            <td>{{ component.value | l10nNumber }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/diagnostic-overlay/diagnostic-overlay.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/diagnostic-overlay/diagnostic-overlay.component.scss
@@ -1,29 +1,28 @@
-$toolbar-height: 56px;
 $background-color: #282828;
 $foreground-color: #ddd;
 $table-border-color: #404040;
 
-.diagnostic-overlay {
-  position: fixed;
-  top: $toolbar-height;
-  right: 0;
-  bottom: 0;
+::ng-deep .diagnostic-overlay-panel {
+  height: 100%;
+}
 
+:host {
   background-color: $background-color;
   color: $foreground-color;
+
   font-size: 12px;
   overflow-y: auto;
+}
 
-  &.collapsed {
-    width: 44px;
-    padding: 2px;
-  }
+.wrapper:not(.collapsed) {
+  padding: 4px 12px;
+  width: 25vw;
+  min-width: 300px;
+}
 
-  &:not(.collapsed) {
-    padding: 4px 12px;
-    width: 25vw;
-    min-width: 300px;
-  }
+.wrapper.collapsed {
+  width: 44px;
+  padding: 2px;
 }
 
 table {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/diagnostic-overlay.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/diagnostic-overlay.service.ts
@@ -24,7 +24,11 @@ export class DiagnosticOverlayService {
   open(): void {
     if (this.overlayRef != null) return;
 
-    this.overlayRef = this.overlay.create({ direction: this.i18n.direction });
+    this.overlayRef = this.overlay.create({
+      positionStrategy: this.overlay.position().global().end('0').top('56px'),
+      direction: this.i18n.direction,
+      panelClass: 'diagnostic-overlay-panel'
+    });
     const portal = new ComponentPortal(DiagnosticOverlayComponent);
     this.overlayRef.attach(portal);
     this.localSettings.set(diagnosticOverlayOpenKey, true);


### PR DESCRIPTION
If you open the diagnostics panel on master and look at the console, this error is present:

![](https://github.com/user-attachments/assets/86a86db6-7412-43ae-a4b0-1651b9fa0885)

If you use the element inspector to look at the position of the `.cdk-overlay-pane`, it's at position `0, 0` on the page. The only reason the panel shows up in the correct place is because an element within it has `position: fixed;`.

We're not really using any of the built-in positioning logic, and instead have a overlay with zero size in the top left corner, that contains a positioned element.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2809)
<!-- Reviewable:end -->
