### PR TITLE
SF-3038 Listen to project changes for ProgressService

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -19,10 +19,7 @@ describe('BookMultiSelectComponent', () => {
 
   configureTestingModule(() => ({
     imports: [MatChipsModule, TestTranslocoModule],
-    providers: [
-      { provide: ActivatedRoute, useMock: mockedActivatedRoute },
-      { provide: ProgressService, useMock: mockedProgressService }
-    ]
+    providers: [{ provide: ProgressService, useMock: mockedProgressService }]
   }));
 
   beforeEach(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -1,9 +1,8 @@
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { MatChipsModule } from '@angular/material/chips';
-import { ActivatedRoute } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
-import { filter, firstValueFrom, map } from 'rxjs';
+import { filter, firstValueFrom } from 'rxjs';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { ProgressService } from '../progress-service/progress.service';
@@ -24,7 +23,7 @@ type Scope = 'OT' | 'NT' | 'DC';
   imports: [UICommonModule, MatChipsModule, TranslocoModule],
   styleUrls: ['./book-multi-select.component.scss']
 })
-export class BookMultiSelectComponent extends SubscriptionDisposable implements OnInit, OnChanges {
+export class BookMultiSelectComponent extends SubscriptionDisposable implements OnChanges {
   @Input() availableBooks: number[] = [];
   @Input() selectedBooks: number[] = [];
   @Input() readonly: boolean = false;
@@ -46,17 +45,8 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
   selectedAllNT: boolean = false;
   selectedAllDC: boolean = false;
 
-  constructor(
-    private readonly activatedRoute: ActivatedRoute,
-    private readonly progressService: ProgressService
-  ) {
+  constructor(private readonly progressService: ProgressService) {
     super();
-  }
-
-  ngOnInit(): void {
-    this.subscribe(this.activatedRoute.params.pipe(map(params => params['projectId'])), async projectId => {
-      this.progressService.initialize(projectId);
-    });
   }
 
   async ngOnChanges(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
@@ -1,16 +1,18 @@
 import { NgZone } from '@angular/core';
 import { discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { OtJson0Op } from 'ot-json0';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { BehaviorSubject, of } from 'rxjs';
-import { anything, deepEqual, mock, when } from 'ts-mockito';
+import { anything, deepEqual, instance, mock, when } from 'ts-mockito';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
 import { TextDocId } from '../../core/models/text-doc';
@@ -21,6 +23,7 @@ import { ProgressService } from '../../shared/progress-service/progress.service'
 const mockSFProjectService = mock(SFProjectService);
 const mockNoticeService = mock(NoticeService);
 const mockPermissionService = mock(PermissionsService);
+const mockProjectService = mock(ActivatedProjectService);
 
 describe('progress service', () => {
   configureTestingModule(() => ({
@@ -30,15 +33,15 @@ describe('progress service', () => {
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: PermissionsService, useMock: mockPermissionService },
       { provide: SFProjectService, useMock: mockSFProjectService },
-      { provide: OnlineStatusService, useClass: TestOnlineStatusService }
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+      { provide: ActivatedProjectService, useMock: mockProjectService }
     ]
   }));
 
-  it('populates progress and texts on init', fakeAsync(() => {
+  it('populates progress and texts on construction', fakeAsync(() => {
     const env = new TestEnvironment(100, 50);
     const calculate = spyOn<any>(env.service, 'calculateProgress').and.callThrough();
 
-    env.service.initialize('project01');
     tick();
 
     expect(env.service.overallProgress.translated).toEqual(100);
@@ -60,6 +63,46 @@ describe('progress service', () => {
     discardPeriodicTasks();
   }));
 
+  it('re-initializes when switching projects', fakeAsync(() => {
+    const env = new TestEnvironment(100, 50);
+    tick();
+
+    const initialize = spyOn<any>(env.service, 'initialize').and.callThrough();
+
+    when(env.mockProject.id).thenReturn('project02');
+    env.project$.next(instance(env.mockProject));
+    tick();
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    discardPeriodicTasks();
+  }));
+
+  it('re-initializes for local project changes', fakeAsync(() => {
+    const env = new TestEnvironment(100, 50);
+    tick();
+
+    const initialize = spyOn<any>(env.service, 'initialize').and.callThrough();
+
+    tick(1000); // wait for the throttle time
+    env.projectChange$.next([]);
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    discardPeriodicTasks();
+  }));
+
+  it('re-initializes for remote project changes', fakeAsync(() => {
+    const env = new TestEnvironment(100, 50);
+    tick();
+
+    const initialize = spyOn<any>(env.service, 'initialize').and.callThrough();
+
+    tick(1000); // wait for the throttle time
+    env.projectRemoteChange$.next([]);
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    discardPeriodicTasks();
+  }));
+
   it('updates total progress when chapter content changes', fakeAsync(async () => {
     const env = new TestEnvironment();
     const changeEvent = new BehaviorSubject({});
@@ -73,7 +116,6 @@ describe('progress service', () => {
       };
     });
 
-    await env.service.initialize('project01');
     tick();
 
     // mock a change
@@ -93,27 +135,22 @@ describe('progress service', () => {
     changeEvent.next({});
 
     expect(env.service.overallProgress.translated).toEqual(originalProgress + 1);
-
     discardPeriodicTasks();
   }));
 
   it('can train suggestions', fakeAsync(async () => {
     const env = new TestEnvironment();
-    await env.service.initialize('project01');
     tick();
 
     expect(env.service.canTrainSuggestions).toBeTruthy();
-
     discardPeriodicTasks();
   }));
 
   it('cannot train suggestions if too few segments', fakeAsync(async () => {
     const env = new TestEnvironment(9);
-    await env.service.initialize('project01');
     tick();
 
     expect(env.service.canTrainSuggestions).toBeFalsy();
-
     discardPeriodicTasks();
   }));
 
@@ -122,43 +159,23 @@ describe('progress service', () => {
     when(
       mockPermissionService.canAccessText(deepEqual(new TextDocId('sourceId', anything(), anything(), 'target')))
     ).thenResolve(false);
-    await env.service.initialize('project01');
     tick();
 
     expect(env.service.canTrainSuggestions).toBeFalsy();
-
     discardPeriodicTasks();
   }));
 
   it('resets train suggestions flag when switching projects', fakeAsync(async () => {
     const env = new TestEnvironment();
-    await env.service.initialize('project01');
     tick();
 
     expect(env.service.canTrainSuggestions).toBeTruthy();
 
-    // set up blank project
-    const data = createTestProjectProfile({
-      texts: env.createTexts(),
-      translateConfig: {
-        translationSuggestionsEnabled: true,
-        source: {
-          projectRef: 'sourceId'
-        }
-      }
-    });
-    when(mockSFProjectService.getProfile('project02')).thenResolve({
-      data,
-      id: 'project02',
-      remoteChanges$: new BehaviorSubject([])
-    } as unknown as SFProjectProfileDoc);
-    env.setUpGetText('project02', 0, 1000);
-
-    await env.service.initialize('project02');
+    when(env.mockProject.id).thenReturn('project02');
+    env.project$.next(instance(env.mockProject));
     tick();
 
     expect(env.service.canTrainSuggestions).toBeFalsy();
-
     discardPeriodicTasks();
   }));
 });
@@ -169,12 +186,15 @@ class TestEnvironment {
   private readonly numBooks = 20;
   private readonly numChapters = 20;
 
+  readonly mockProject = mock(SFProjectProfileDoc);
+  readonly project$ = new BehaviorSubject(instance(this.mockProject));
+  readonly projectChange$ = new BehaviorSubject<OtJson0Op[]>([]);
+  readonly projectRemoteChange$ = new BehaviorSubject<OtJson0Op[]>([]);
+
   constructor(
     private readonly translatedSegments: number = 1000,
     private readonly blankSegments: number = 500
   ) {
-    this.service = TestBed.inject(ProgressService);
-
     const data = createTestProjectProfile({
       texts: this.createTexts(),
       translateConfig: {
@@ -185,6 +205,11 @@ class TestEnvironment {
       }
     });
 
+    when(this.mockProject.id).thenReturn('project01');
+    when(this.mockProject.changes$).thenReturn(this.projectChange$);
+    when(this.mockProject.remoteChanges$).thenReturn(this.projectRemoteChange$);
+    when(mockProjectService.projectDoc$).thenReturn(this.project$);
+
     when(mockPermissionService.canAccessText(anything())).thenResolve(true);
     when(mockSFProjectService.getProfile('project01')).thenResolve({
       data,
@@ -192,8 +217,18 @@ class TestEnvironment {
       remoteChanges$: new BehaviorSubject([])
     } as unknown as SFProjectProfileDoc);
 
+    // set up blank project
+    when(mockSFProjectService.getProfile('project02')).thenResolve({
+      data,
+      id: 'project02',
+      remoteChanges$: new BehaviorSubject([])
+    } as unknown as SFProjectProfileDoc);
+    this.setUpGetText('project02', 0, 1000);
+
     this.setUpGetText('sourceId', this.translatedSegments, this.blankSegments);
     this.setUpGetText('project01', this.translatedSegments, this.blankSegments);
+
+    this.service = TestBed.inject(ProgressService);
   }
 
   setUpGetText(projectId: string, translatedSegments: number, blankSegments: number): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -57,8 +57,9 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
       this.activatedProject.projectDoc$.pipe(
         filterNullish(),
         tap(async project => {
+          this.initialize(project.id);
           merge(project.remoteChanges$, project.changes$)
-            .pipe(throttleTime(1000, asyncScheduler, { leading: true, trailing: true }))
+            .pipe(throttleTime(1000, asyncScheduler, { leading: false, trailing: true }))
             .subscribe(() => {
               this.initialize(project.id);
             });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -54,23 +54,17 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
     super(noticeService);
 
     this.subscribe(
-      this.activatedProject.projectDoc$.pipe(
+      this.activatedProject.changes$.pipe(
         filterNullish(),
         tap(async project => {
           this.initialize(project.id);
-          merge(project.remoteChanges$, project.changes$)
-            .pipe(throttleTime(1000, asyncScheduler, { leading: false, trailing: true }))
-            .subscribe(() => {
-              this.initialize(project.id);
-            });
-        })
-      )
+        }),
+        throttleTime(1000, asyncScheduler, { leading: false, trailing: true })
+      ),
+      project => {
+        this.initialize(project.id);
+      }
     );
-  }
-
-  ngOnDestroy(): void {
-    super.ngOnDestroy();
-    this._allChaptersChangeSub?.unsubscribe();
   }
 
   get texts(): TextProgress[] {
@@ -80,6 +74,11 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
   // Whether or not we have the minimum number of segment pairs
   get canTrainSuggestions(): boolean {
     return this._canTrainSuggestions;
+  }
+
+  ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this._allChaptersChangeSub?.unsubscribe();
   }
 
   private async initialize(projectId: string): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -14,7 +14,6 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
-import { ProgressService } from '../../../shared/progress-service/progress.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { NllbLanguageService } from '../../nllb-language.service';
 import { DraftSource, DraftSourcesService } from '../draft-sources.service';
@@ -89,8 +88,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     private readonly draftSourcesService: DraftSourcesService,
     readonly featureFlags: FeatureFlagService,
     private readonly nllbLanguageService: NllbLanguageService,
-    private readonly trainingDataService: TrainingDataService,
-    private readonly progressService: ProgressService
+    private readonly trainingDataService: TrainingDataService
   ) {
     super();
   }
@@ -182,8 +180,6 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
       this.activatedProject.projectDoc$.pipe(
         filterNullish(),
         tap(async projectDoc => {
-          this.progressService.initialize(projectDoc.id);
-
           // Query for all training data files in the project
           this.trainingDataQuery?.dispose();
           this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -13,6 +13,7 @@ import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
+import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import * as RichText from 'rich-text';
 import { defer, of, Subject } from 'rxjs';
@@ -36,7 +37,7 @@ import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
-import { Progress, ProgressService } from '../../shared/progress-service/progress.service';
+import { Progress, ProgressService, TextProgress } from '../../shared/progress-service/progress.service';
 import { FontUnsupportedMessageComponent } from '../font-unsupported-message/font-unsupported-message.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 import { TranslateOverviewComponent } from './translate-overview.component';
@@ -285,10 +286,10 @@ class TestEnvironment {
     when(mockedProgressService.isLoaded$).thenReturn(of(true));
     when(mockedProgressService.overallProgress).thenReturn(new Progress());
     when(mockedProgressService.texts).thenReturn([
-      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 40 } as any } as any,
-      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 41 } as any } as any,
-      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 42 } as any } as any,
-      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 43 } as any } as any
+      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 40 } as TextInfo } as TextProgress,
+      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 41 } as TextInfo } as TextProgress,
+      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 42 } as TextInfo } as TextProgress,
+      { translated: 10, blank: 10, total: 20, percentage: 50, text: { bookNum: 43 } as TextInfo } as TextProgress
     ]);
 
     this.setCurrentUser();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -93,7 +93,6 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   ngOnInit(): void {
     this.subscribe(this.activatedRoute.params.pipe(map(params => params['projectId'])), async projectId => {
       this.projectDoc = await this.projectService.getProfile(projectId);
-      this.progressService.initialize(projectId);
 
       // Update the overview now if we are online, or when we are next online
       this.onlineStatusService.online.then(async () => {


### PR DESCRIPTION
Project changes can be adding books, for example. It now listens to the activated project to retrieve its project id, where beforehand it was waiting for the components to supply this.

Similarly, the initialize() call now can happen even when the project hasn't been switched (but it's private now). This accounts for the addition of books. It is on a 1s throttle, like the calculate() call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2810)
<!-- Reviewable:end -->
