### PR TITLE
dev: fix frontend debug vscode source mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,8 @@
       "port": 9977,
       "request": "attach",
       "type": "pwa-chrome",
-      "webRoot": "${workspaceRoot}/src/SIL.XForge.Scripture/ClientApp"
+      "webRoot": "${workspaceRoot}/src/SIL.XForge.Scripture/ClientApp",
+      "sourceMaps": true
     },
     {
       // Attach to and debug the running backend


### PR DESCRIPTION
This restores VSCode's behaviour of showing the source mapped .ts
files when attached to a running Chromium.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2813)
<!-- Reviewable:end -->
