### PR TITLE
SF-2968 Highlight all meaningful segments of a verse when selected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -2315,7 +2315,7 @@ describe('CheckingComponent', () => {
       expect(env.isSegmentHighlighted(1, 1)).toBe(false);
       expect(env.isSegmentHighlighted(1, 2)).toBe(false);
       expect(env.isSegmentHighlighted(1, 3)).toBe(false);
-      expect(env.isSegmentHighlighted(1, '4/p_1')).toBe(true);
+      expect(env.isSegmentHighlighted(1, '4/p_1')).toBe(false);
 
       env.component.highlightSegments('verse_1_5,6');
       env.waitForSliderUpdate();


### PR DESCRIPTION
This PR changes the behaviour of highlighting so that when a verse is selected in a target text, the entire verse of the source text is also highlighted. See the Jira issue for the discussion on this change.
Also remove the highlight on the final segment of a verse when it is blank (i.e. the blank segment at the start of the next paragraph).

Before
![Highlight verses before](https://github.com/user-attachments/assets/2784a8bb-83f4-4b54-932a-6f19b5e3e767)

After
![Highlight verses after](https://github.com/user-attachments/assets/9c48ec7a-cee8-4cdf-aea9-28e717a94d97)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2814)
<!-- Reviewable:end -->
