### PR TITLE
SF-3048 Hide unusable books details on draft generation stepper

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -89,6 +89,10 @@ $colors: (
     border-color: var(--notice-color-outline);
     color: var(--notice-color-outline-text);
   }
+  &.mode-basic {
+    background-color: var(--notice-color);
+    border-color: var(--notice-color);
+  }
 
   // Style buttons inside notices
   ::ng-deep .mat-mdc-button-base {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.types.ts
@@ -1,5 +1,5 @@
 export const noticeTypes = ['primary', 'secondary', 'success', 'warning', 'error', 'info', 'light', 'dark'] as const;
 export type NoticeType = (typeof noticeTypes)[number];
 
-export const noticeModes = ['fill-light', 'fill-dark', 'fill-extra-dark', 'outline'] as const;
+export const noticeModes = ['fill-light', 'fill-dark', 'fill-extra-dark', 'outline', 'basic'] as const;
 export type NoticeMode = (typeof noticeModes)[number];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -21,17 +21,32 @@
           </app-notice>
         }
         @if (unusableTranslateSourceBooks.length) {
-          <app-notice>
-            <h4>
-              <transloco
-                key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
-                [params]="{ draftingSourceProjectName }"
-              ></transloco>
-            </h4>
-            <app-book-multi-select
-              [availableBooks]="unusableTranslateSourceBooks"
-              [readonly]="true"
-            ></app-book-multi-select>
+          <app-notice icon="info" class="unusable-translate-books">
+            <div class="notice-container">
+              <span
+                class="books-hidden-message"
+                (click)="expandUnusableTranslateBooks = !expandUnusableTranslateBooks"
+                [innerHtml]="
+                  !expandUnusableTranslateBooks
+                    ? i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_show_why', {
+                        numBooks: unusableTranslateSourceBooks.length
+                      })
+                    : i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_hide_explanation', {
+                        numBooks: unusableTranslateSourceBooks.length
+                      })
+                "
+              >
+              </span>
+              @if (expandUnusableTranslateBooks) {
+                <h4 class="explanation">
+                  <transloco
+                    key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"
+                    [params]="{ draftingSourceProjectName }"
+                  ></transloco>
+                </h4>
+                <span class="book-names">{{ bookNames(unusableTranslateSourceBooks) }}</span>
+              }
+            </div>
           </app-notice>
         }
         @if (showBookSelectionError) {
@@ -65,17 +80,32 @@
           </app-notice>
         }
         @if (unusableTrainingSourceBooks.length) {
-          <app-notice>
-            <h4>
-              <transloco
-                key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
-                [params]="{ trainingSourceProjectName }"
-              ></transloco>
-            </h4>
-            <app-book-multi-select
-              [availableBooks]="unusableTrainingSourceBooks"
-              [readonly]="true"
-            ></app-book-multi-select>
+          <app-notice icon="info" class="unusable-training-books">
+            <div class="notice-container">
+              <span
+                class="books-hidden-message"
+                (click)="expandUnusableTrainingBooks = !expandUnusableTrainingBooks"
+                [innerHtml]="
+                  !expandUnusableTrainingBooks
+                    ? i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_show_why', {
+                        numBooks: unusableTrainingSourceBooks.length
+                      })
+                    : i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_hide_explanation', {
+                        numBooks: unusableTrainingSourceBooks.length
+                      })
+                "
+              >
+              </span>
+              @if (expandUnusableTrainingBooks) {
+                <h4 class="explanation">
+                  <transloco
+                    key="draft_generation_steps.these_source_books_cannot_be_used_for_training"
+                    [params]="{ trainingSourceProjectName }"
+                  ></transloco>
+                </h4>
+                <span class="book-names">{{ bookNames(unusableTrainingSourceBooks) }}</span>
+              }
+            </div>
           </app-notice>
         }
         @if (showBookSelectionError) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -15,13 +15,8 @@
           (bookSelect)="onTranslateBookSelect($event)"
           data-test-id="draft-stepper-translate-books"
         ></app-book-multi-select>
-        @if (unusableTranslateTargetBooks.length) {
-          <app-notice>
-            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-          </app-notice>
-        }
         @if (unusableTranslateSourceBooks.length) {
-          <app-notice icon="info" class="unusable-translate-books">
+          <app-notice icon="info" mode="basic" type="light" class="unusable-translate-books">
             <div class="notice-container">
               <span
                 class="books-hidden-message"
@@ -49,6 +44,11 @@
             </div>
           </app-notice>
         }
+        @if (unusableTranslateTargetBooks.length) {
+          <app-notice>
+            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
+          </app-notice>
+        }
         @if (showBookSelectionError) {
           <app-notice type="error">
             {{ t("choose_books_to_translate_error") }}
@@ -74,13 +74,8 @@
           (bookSelect)="onTrainingBookSelect($event)"
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
-        @if (unusableTranslateTargetBooks.length) {
-          <app-notice>
-            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-          </app-notice>
-        }
         @if (unusableTrainingSourceBooks.length) {
-          <app-notice icon="info" class="unusable-training-books">
+          <app-notice icon="info" mode="basic" type="light" class="unusable-training-books">
             <div class="notice-container">
               <span
                 class="books-hidden-message"
@@ -106,6 +101,11 @@
                 <span class="book-names">{{ bookNames(unusableTrainingSourceBooks) }}</span>
               }
             </div>
+          </app-notice>
+        }
+        @if (unusableTranslateTargetBooks.length) {
+          <app-notice>
+            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
           </app-notice>
         }
         @if (showBookSelectionError) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -46,7 +46,18 @@ app-notice {
   h4 {
     font-style: italic;
     font-weight: 400;
-    margin: 0 0 16px;
+    font-size: 0.9em;
+    margin: 0;
+  }
+
+  .notice-container {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+  }
+
+  .books-hidden-message {
+    cursor: pointer;
   }
 
   &.warning {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -1,4 +1,5 @@
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
+@use 'src/variables';
 
 h1 {
   margin: 12px 0;
@@ -58,10 +59,27 @@ app-notice {
 
   .books-hidden-message {
     cursor: pointer;
+    padding: 3px 0;
+
+    ::ng-deep u {
+      &:hover {
+        color: variables.$theme-secondary;
+      }
+    }
   }
 
   &.warning {
     display: flex;
+  }
+
+  &.unusable-translate-books,
+  &.unusable-training-books {
+    align-items: start;
+  }
+
+  .book-names {
+    font-weight: 500;
+    padding: 8px;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -183,8 +183,26 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should set "unusableTranslateSourceBooks" and "unusableTrainingSourceBooks" correctly', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
       expect(component.unusableTranslateSourceBooks).toEqual([6, 7]);
       expect(component.unusableTrainingSourceBooks).toEqual([6, 7]);
+
+      // interact with unusable books notice
+      const unusableTranslateBooks = fixture.nativeElement.querySelector('.unusable-translate-books');
+      expect(unusableTranslateBooks).not.toBeNull();
+      expect(unusableTranslateBooks.querySelector('.explanation')).toBeNull();
+      unusableTranslateBooks.querySelector('.books-hidden-message')!.click();
+      tick();
+      fixture.detectChanges();
+      expect(unusableTranslateBooks.querySelector('.explanation')).not.toBeNull();
+      const unusableTrainingBooks = fixture.nativeElement.querySelector('.unusable-training-books');
+      expect(unusableTrainingBooks).not.toBeNull();
+      expect(unusableTrainingBooks.querySelector('.explanation')).toBeNull();
+      unusableTrainingBooks.querySelector('.books-hidden-message')!.click();
+      tick();
+      fixture.detectChanges();
+      expect(unusableTrainingBooks.querySelector('.explanation')).not.toBeNull();
     }));
 
     it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -8,6 +8,7 @@ import { Subscription, merge } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
@@ -80,6 +81,9 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   trainingDataFilesAvailable = false;
   fastTraining: boolean = false;
 
+  expandUnusableTranslateBooks = false;
+  expandUnusableTrainingBooks = false;
+
   private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
   private trainingDataSub?: Subscription;
 
@@ -88,7 +92,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     private readonly draftSourcesService: DraftSourcesService,
     readonly featureFlags: FeatureFlagService,
     private readonly nllbLanguageService: NllbLanguageService,
-    private readonly trainingDataService: TrainingDataService
+    private readonly trainingDataService: TrainingDataService,
+    readonly i18n: I18nService
   ) {
     super();
   }
@@ -268,6 +273,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
     this.initialSelectedTrainingBooks = newSelectedTrainingBooks;
     this.userSelectedTrainingBooks = newSelectedTrainingBooks;
+  }
+
+  bookNames(books: number[]): string {
+    return books.map(bookNum => this.i18n.localizeBook(bookNum)).join(', ');
   }
 
   private validateCurrentStep(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -214,6 +214,8 @@
   },
   "draft_generation_steps": {
     "back": "Back",
+    "books_are_hidden_show_why": "{{ numBooks }} books are hidden. {{ underlineStart }}Show why{{ underlineEnd }}",
+    "books_are_hidden_hide_explanation": "{{ numBooks }} books are hidden. {{ underlineStart }}Hide explanation{{ underlineEnd }}",
     "choose_additional_training_data_files_label": "Additional training",
     "choose_additional_training_data_files": "Choose additional files for training the language model",
     "choose_books_for_training_error": "No books selected. Select training books to continue.",


### PR DESCRIPTION
Please reference the [balsamiq](https://balsamiq.cloud/sghq53/pejrlz8/r49DC) for the mock up of this change.

This PR add a way to hide the info for unusable translate and training books on the draft generation stepper.

Collapsed:
![Unusable books message initial](https://github.com/user-attachments/assets/be39a04b-bb4c-48ef-88b5-a7fb3eb8b6dd)

Expanded:
![unusable books message](https://github.com/user-attachments/assets/447cf872-604f-41ed-b4ee-f932b319965a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2817)
<!-- Reviewable:end -->
