### PR TITLE
SF-3052 Add interactive-widget setting to viewport meta tag

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/index.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/index.html
@@ -17,7 +17,7 @@
     <title>Scripture Forge</title>
     <base href="/" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="assets/icons/sf-192x192.png" />
     <link rel="manifest" href="manifest.json" />


### PR DESCRIPTION
Chrome 108 (Nov '22) added support for this new tag, which resizes the visual viewport to the visible space. It does not appear after brief investigation that Safari supports this, and Firefox has been documented to resize with or without this setting.

Note that if we choose to hide the bottom bar in the future (which is currently the case), it may not be quite necessary to use "resizes-content" as compared to the other accepted values. It may be that, given that bar will go away, the value "overlays-content" may also suffice. However, the default (resizes-visual for Chrome) likely would cause buggy behavior, given that it currently hides the top bar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2820)
<!-- Reviewable:end -->
