### PR TITLE
SF-3050 Fix audio visualization not displaying

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -31,9 +31,9 @@
       }
     </div>
     <div class="dialog-footer">
-      @if (showCanvas) {
+      @if (!hasAudioAttachment) {
         <canvas class="visualizer"></canvas>
-      } @else if (hasAudioAttachment) {
+      } @else {
         <div class="has-attachment">
           <button mat-button (click)="resetRecording()" class="remove-audio-file">
             <mat-icon>mic</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -63,7 +63,6 @@ describe('AudioRecorderDialogComponent', () => {
     const env = new TestEnvironment();
     expect(env.recordButton).toBeTruthy();
     expect(env.stopRecordingButton).toBeFalsy();
-    expect(env.recordingIndicator).toBeNull();
     env.clickButton(env.recordButton);
     // Record for more than 2 seconds in order to test the duration of blob files
     // which can fail with certain recording types

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -63,7 +63,6 @@ export class AudioRecorderDialogComponent
   showCountdown: boolean;
   countdownTimer: number = 0;
   mediaDevicesUnsupported: boolean = false;
-  showCanvas: boolean = false;
 
   private stream?: MediaStream;
   private mediaRecorder?: MediaRecorder;
@@ -182,7 +181,6 @@ export class AudioRecorderDialogComponent
       this.dialogService.openMatDialog(SupportedBrowsersDialogComponent, { data: BrowserIssue.AudioRecording });
       return;
     }
-    this.showCanvas = true;
     this.navigator.mediaDevices
       .getUserMedia(mediaConstraints)
       .then(this.successCallback.bind(this), this.errorCallback.bind(this));
@@ -193,7 +191,7 @@ export class AudioRecorderDialogComponent
       return;
     }
     this.refreshWaveformSub?.unsubscribe();
-    this.showCanvas = false;
+    this.canvasContext?.reset();
     this.mediaRecorder.stop();
     this.stream.getAudioTracks().forEach(track => track.stop());
     this.audio = { status: 'stopped' };


### PR DESCRIPTION
This PR fixes the audio dialog not always displaying the audio visualization bar. I have been able to reproduce this on Firefox and Safari for iOS (QA BrowserStack) but not on Chrome. This change loads the canvas element countdown/tap to record to ensure the context can be initialized when the recording starts. When the recording is stopped, the `canvasContext` is reset to a default state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2821)
<!-- Reviewable:end -->
