### PR TITLE
SF-3049 Fix sync error when user no longer on back translation

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -804,6 +804,11 @@ public class ParatextService : DisposableBase, IParatextService
                 }
             }
 
+            // if the project is a back translation, we want to check if user is still
+            // on project with permission to sync or return an error to UI
+            if (!users.Select(u => u.Id).ToList().Contains(userSecret.Id))
+                throw new ForbiddenException();
+
             return users;
         }
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4391,6 +4391,21 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public async Task GetParatextUsersAsync_UserNoLongerOnBackTranslationError()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User03, env.Username03, env.ParatextUserId03);
+        env.SetSharedRepositorySource(userSecret, UserRoles.Administrator);
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+        Assert.That(project.UserRoles.Count, Is.EqualTo(3), "setup");
+        env.MakeRegistryClientReturn(env.NotFoundHttpResponseMessage);
+        Assert.ThrowsAsync<ForbiddenException>(
+            async () => await env.Service.GetParatextUsersAsync(userSecret, project, CancellationToken.None)
+        );
+    }
+
+    [Test]
     public async Task GetParatextUsersAsync_UsesTheRepositoryForUnregisteredProjects()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
This PR checks that a user is still on a back translation project before continuing the Sync process. If the user is no longer found on the project an error will be thrown and dialog message displayed to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2822)
<!-- Reviewable:end -->
