### PR TITLE
SF-3063 Specify updated learning rate for Serval

### DIFF
--- a/scripts/db_tools/parse-version.ts
+++ b/scripts/db_tools/parse-version.ts
@@ -36,7 +36,8 @@ class ParseVersion {
     'Use Echo for Pre-Translation Drafting',
     'Allow Fast Pre-Translation Training',
     'Upload Paratext Zip Files for Pre-Translation Drafting',
-    'Allow mixing in an additional training source'
+    'Allow mixing in an additional training source',
+    'Updated Learning Rate For Serval'
   ];
 
   constructor() {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -306,6 +306,13 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
+  private readonly updatedLearningRateForServal: FeatureFlag = new ServerOnlyFeatureFlag(
+    'UpdatedLearningRateForServal',
+    'Updated Learning Rate For Serval',
+    14,
+    this.featureFlagStore
+  );
+
   get featureFlags(): FeatureFlag[] {
     return Object.values(this).filter(value => value instanceof FeatureFlagFromStorage);
   }

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -5,5 +5,6 @@ namespace SIL.XForge.Scripture.Models;
 /// </summary>
 public static class FeatureFlags
 {
+    public const string UpdatedLearningRateForServal = "UpdatedLearningRateForServal";
     public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
 }

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -63,6 +63,7 @@
     "Serval": true,
     "MachineInProcess": false,
     "UploadParatextZipForPreTranslation": false,
-    "UseEchoForPreTranslation": false
+    "UseEchoForPreTranslation": false,
+    "UpdatedLearningRateForServal": true
   }
 }


### PR DESCRIPTION
This PR adds support for the updated learning rate for Serval.

I have placed this behind a feature flag so we may disable it when Serval implements this rate as the default, or if the new rate proves problematic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2829)
<!-- Reviewable:end -->
