### PR TITLE
SF-3045 Fix audio being trimmed on mobile iOS browsers

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -137,7 +137,7 @@ export class AudioRecorderDialogComponent
       url: URL.createObjectURL(blob),
       status: 'processed',
       blob: blob,
-      fileName: objectId() + '.webm'
+      fileName: objectId() + '.wav'
     };
     this._onTouched.emit();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/manifest.json
@@ -6,6 +6,7 @@
   "display": "standalone",
   "scope": "/",
   "start_url": "/projects",
+  "permissions": ["storage", "microphone"],
   "icons": [
     {
       "src": "assets/icons/sf-72x72.png",


### PR DESCRIPTION
This PR adds permissions to our manifest.json file for storage and microphone usage. Additionally, changes the audio files from `.webm` to `.wav` as mobile iOS browsers do not natively support `.webm` files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2831)
<!-- Reviewable:end -->
