### PR TITLE
SF-3061 Include last blank segment when previewing question verses

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -83,7 +83,15 @@ describe('CheckingTextComponent', () => {
     expect(env.segmentHasQuestion(1, 4)).toBe(false);
     expect(env.isSegmentHighlighted('verse_1_4')).toBe(false);
 
-    // change 2nd question from v3 to v4 and make it active
+    // change 1st question to include verse 2 (empty)
+    const verseRefWithBlank = VerseRef.tryParse('MAT 1:1-2');
+    env.component.activeVerse = verseRefWithBlank.verseRef;
+    env.component.questionVerses = [verseRefWithBlank.verseRef];
+    env.wait();
+    expect(env.isSegmentHighlighted('verse_1_1')).toBe(true);
+    expect(env.isSegmentHighlighted('verse_1_2')).toBe(true);
+
+    // // change 2nd question from v3 to v4 and make it active
     const activeVerse = new VerseRef(40, 1, 4);
     env.component.activeVerse = activeVerse;
     env.component.questionVerses = [new VerseRef(40, 1, 1), activeVerse];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1418,9 +1418,11 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   private filterBlankFinalSegment(segmentRefs: string[]): string[] {
+    if (segmentRefs.length <= 1) return segmentRefs;
     const lastSegment: string = segmentRefs[segmentRefs.length - 1];
-    if (segmentRefs.length > 1 && this.isSegmentBlank(lastSegment)) {
-      // remove the last segment if it is blank
+    const newLineSegment: boolean = lastSegment.includes('/');
+    if (newLineSegment && this.isSegmentBlank(lastSegment)) {
+      // remove the last segment if it is blank and is on a new line
       segmentRefs.pop();
     }
     return segmentRefs;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -588,7 +588,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     for (const verseRef of chapterFeaturedVerseRefs) {
       let featuredVerseSegments: string[] =
         featureName === 'question' ? this.getVerseSegmentsNoHeadings(verseRef) : this.getVerseSegments(verseRef);
-      featuredVerseSegments = this.filterBlankFinalSegment(featuredVerseSegments);
+      featuredVerseSegments = this.filterBlankNewlineSegment(featuredVerseSegments);
       if (featuredVerseSegments.length === 0) {
         continue;
       }
@@ -724,7 +724,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
 
   toggleVerseSelection(verseRef: VerseRef): boolean {
     if (this.editor == null) return false;
-    const verseSegments: string[] = this.filterBlankFinalSegment(this.getCompatibleSegments(verseRef));
+    const verseSegments: string[] = this.filterBlankNewlineSegment(this.getCompatibleSegments(verseRef));
     const verseRange: RangeStatic | undefined = this.getSegmentRange(verseSegments[0]);
     let selectionValue: true | null = true;
     if (verseRange != null) {
@@ -786,7 +786,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
 
-    segmentRefs = this.filterBlankFinalSegment(segmentRefs);
+    segmentRefs = this.filterBlankNewlineSegment(segmentRefs);
     // this changes the underlying HTML, which can mess up some Quill events, so defer this call
     Promise.resolve(segmentRefs).then(refs => {
       this.viewModel.highlight(refs);
@@ -1417,15 +1417,18 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     this._segment.update(text, segmentRange);
   }
 
-  private filterBlankFinalSegment(segmentRefs: string[]): string[] {
+  /** Filter the final segment if it is blank and a new line segment (i.e. verse_2_4/p_1) */
+  private filterBlankNewlineSegment(segmentRefs: string[]): string[] {
+    // do nothing if there is one or less segments
     if (segmentRefs.length <= 1) return segmentRefs;
-    const lastSegment: string = segmentRefs[segmentRefs.length - 1];
+    const filteredSegments: string[] = [...segmentRefs];
+    const lastSegment: string = filteredSegments[segmentRefs.length - 1];
     const newLineSegment: boolean = lastSegment.includes('/');
     if (newLineSegment && this.isSegmentBlank(lastSegment)) {
       // remove the last segment if it is blank and is on a new line
-      segmentRefs.pop();
+      filteredSegments.pop();
     }
-    return segmentRefs;
+    return filteredSegments;
   }
 
   /** Gets the embeds affected */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1423,7 +1423,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (segmentRefs.length <= 1) return segmentRefs;
     const filteredSegments: string[] = [...segmentRefs];
     const lastSegment: string = filteredSegments[segmentRefs.length - 1];
-    const newLineSegment: boolean = lastSegment.includes('/');
+    const newLineSegment: boolean = lastSegment.includes('/p');
     if (newLineSegment && this.isSegmentBlank(lastSegment)) {
       // remove the last segment if it is blank and is on a new line
       filteredSegments.pop();


### PR DESCRIPTION
This PR updates the logic to only filter the last blank segment when it is a segment that begins on a new line and is blank. Previously, the final blank segment was not being highlighted when creating a question in the question dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2833)
<!-- Reviewable:end -->
