### PR TITLE
Disable Chromatic snapshots that produce inconsistent results

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -1,21 +1,21 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
-import { NAVIGATOR } from 'xforge-common/browser-globals';
-import { NoticeService } from 'xforge-common/notice.service';
-import { I18nStoryModule } from 'xforge-common/i18n-story.module';
-import { DialogService } from 'xforge-common/dialog.service';
 import { expect, userEvent } from '@storybook/test';
 import { instance, mock, when } from 'ts-mockito';
-import {
-  AudioAttachment,
-  AudioRecorderDialogComponent,
-  AudioRecorderDialogData
-} from './audio-recorder-dialog.component';
+import { NAVIGATOR } from 'xforge-common/browser-globals';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nStoryModule } from 'xforge-common/i18n-story.module';
+import { NoticeService } from 'xforge-common/notice.service';
 import {
   MatDialogLaunchComponent,
   matDialogStory,
   MatDialogStoryConfig
 } from '../../../../.storybook/util/mat-dialog-launch';
 import { createMockMediaStream } from '../test-utils';
+import {
+  AudioAttachment,
+  AudioRecorderDialogComponent,
+  AudioRecorderDialogData
+} from './audio-recorder-dialog.component';
 
 const mockedNavigator = mock(Navigator);
 
@@ -119,6 +119,7 @@ Countdown.play = async ({ canvasElement }) => {
   expect(stopButton).toHaveClass('stop');
   expect(stopButton).toBeVisible();
 };
+Countdown.parameters = { chromatic: { disableSnapshot: true } };
 
 export const ExistingAudio = matDialogStory(AudioRecorderDialogComponent, dialogStoryConfig);
 ExistingAudio.args = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.stories.ts
@@ -57,3 +57,4 @@ export const DraftApplyDialog = matDialogStory(DraftApplyDialogComponent, {
   ]
 });
 DraftApplyDialog.args = { data: { bookNum: 1 } };
+DraftApplyDialog.parameters = { chromatic: { disableSnapshot: true } };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.stories.ts
@@ -137,6 +137,7 @@ const dialogStoryConfig: MatDialogStoryConfig = {
 // The dialog opens for the user and successfully fetches projects and resources.
 export const Loaded = matDialogStory(EditorTabAddResourceDialogComponent, dialogStoryConfig);
 Loaded.args = {};
+Loaded.parameters = { chromatic: { disableSnapshot: true } };
 
 // The dialog opens for the user and has not yet finished fetching projects or resources.
 export const Loading = matDialogStory(EditorTabAddResourceDialogComponent, dialogStoryConfig);


### PR DESCRIPTION
A snapshot that is not consistently reproducible has almost no value, so we're not losing much by turning these off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2834)
<!-- Reviewable:end -->
