### PR TITLE
SF-3069 Fix audio visualization error in Safari iOS

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -191,7 +191,7 @@ export class AudioRecorderDialogComponent
       return;
     }
     this.refreshWaveformSub?.unsubscribe();
-    this.canvasContext?.reset();
+    this.canvasContext?.resetTransform();
     this.mediaRecorder.stop();
     this.stream.getAudioTracks().forEach(track => track.stop());
     this.audio = { status: 'stopped' };


### PR DESCRIPTION
This PR fixes the error that occurs when recording on iOS Safari version < 17.3. The canvas context `reset()` throws an error that prevents audio from being recorded on older mobile iOS devices in Safari. The `resetTransform()` function is compatible with older mobile iOS devices and resets the canvas to the initial identity matrix.