### PR TITLE
SF-3029 Hide bottom bar while answering or commenting

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
@@ -32,8 +32,8 @@ import { QuestionDialogData } from '../../question-dialog/question-dialog.compon
 import { QuestionDialogService } from '../../question-dialog/question-dialog.service';
 import { AudioAttachment } from '../checking-audio-recorder/checking-audio-recorder.component';
 import { CheckingTextComponent } from '../checking-text/checking-text.component';
-import { CommentAction } from './checking-comments/checking-comments.component';
-import { CheckingInput } from './checking-input-form/checking-input-form.component';
+import { CheckingCommentsComponent, CommentAction } from './checking-comments/checking-comments.component';
+import { CheckingInput, CheckingInputFormComponent } from './checking-input-form/checking-input-form.component';
 import { CheckingQuestionComponent } from './checking-question/checking-question.component';
 
 export interface AnswerAction {
@@ -81,6 +81,8 @@ enum LikeAnswerResponse {
   styleUrls: ['./checking-answers.component.scss']
 })
 export class CheckingAnswersComponent extends SubscriptionDisposable implements OnInit {
+  @ViewChild(CheckingInputFormComponent) answerInput?: CheckingInputFormComponent;
+  @ViewChildren(CheckingCommentsComponent) allComments?: QueryList<CheckingCommentsComponent>;
   @ViewChild(CheckingQuestionComponent) questionComponent?: CheckingQuestionComponent;
   @Input() projectUserConfigDoc?: SFProjectUserConfigDoc;
   @Input() textsByBookId?: TextsByBookId;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import cloneDeep from 'lodash-es/cloneDeep';
 import sortBy from 'lodash-es/sortBy';
@@ -14,6 +14,7 @@ import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
 import { AudioAttachment } from '../../checking-audio-recorder/checking-audio-recorder.component';
+import { CheckingInputFormComponent } from '../checking-input-form/checking-input-form.component';
 
 export interface CommentAction {
   action: 'delete' | 'save' | 'show-form' | 'hide-form' | 'show-comments';
@@ -29,6 +30,7 @@ export interface CommentAction {
   styleUrls: ['./checking-comments.component.scss']
 })
 export class CheckingCommentsComponent extends SubscriptionDisposable implements OnInit {
+  @ViewChild(CheckingInputFormComponent) inputComponent?: CheckingInputFormComponent;
   @Input() project?: SFProjectProfile;
   @Input() projectUserConfigDoc?: SFProjectUserConfigDoc;
   @Input() questionDoc?: QuestionDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -199,7 +199,7 @@
         </div>
       </div>
       @if (projectDoc) {
-        <div id="question-nav">
+        <div id="question-nav" [ngClass]="{ hide: textHasFocus }">
           @if (!this.isQuestionListPermanent) {
             <button mat-button type="button" (click)="setQuestionsOverlayVisibility(true)">
               {{ t("view_questions") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -258,6 +258,10 @@ header {
       margin-bottom: -10px;
       margin-inline: -10px;
     }
+
+    &.hide {
+      display: none;
+    }
   }
 
   #project-summary {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1073,6 +1073,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     }
   }
 
+  get textHasFocus(): boolean {
+    const isAnswering = this.answersPanel?.answerInput != null;
+    const isCommenting = this.answersPanel?.allComments?.find(c => c.inputComponent != null) != null;
+    return isAnswering || isCommenting;
+  }
+
   /**
    * Retrieves the adjacent question based on the active question and the direction.
    * Adjacent question might be outside the current filtered scope.


### PR DESCRIPTION
This helps the user focus on their immediate task and frees up vertical space. It is based off the presence of the CheckingInputComponent, which contains the textarea for keyboard entry. However, we don't want to base it off of having the textarea focused, since audio would cause it to reappear. It is better to rely solely on the presence of this component.

When this property is set, it will in turn set a class which disables the display of the question-nav. This was necessary, as opposed to putting the textHasFocus check in the surrounding @if condition, to avoid "changed after checked" errors.

I also experimented with animating the show/hide, but it didn't look good with all the other resizing (splitter + keyboard).