### PR TITLE
SF-3051 Fix error in drafting wizard when texts have not yet loaded

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -58,6 +58,21 @@ describe('BookMultiSelectComponent', () => {
     ]);
   });
 
+  it('should not crash when texts have not yet loaded', async () => {
+    when(mockedProgressService.texts).thenReturn([]);
+    await component.ngOnChanges();
+
+    expect(component.bookOptions).toEqual([
+      { bookNum: 1, bookId: 'GEN', selected: true, progressPercentage: 0 },
+      { bookNum: 2, bookId: 'EXO', selected: false, progressPercentage: 0 },
+      { bookNum: 3, bookId: 'LEV', selected: true, progressPercentage: 0 },
+      { bookNum: 40, bookId: 'MAT', selected: false, progressPercentage: 0 },
+      { bookNum: 42, bookId: 'LUK', selected: false, progressPercentage: 0 },
+      { bookNum: 67, bookId: 'TOB', selected: false, progressPercentage: 0 },
+      { bookNum: 70, bookId: 'WIS', selected: false, progressPercentage: 0 }
+    ]);
+  });
+
   it('can select all OT books and clear all OT books', async () => {
     expect(component.selectedBooks.length).toEqual(2);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -66,7 +66,7 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
       bookNum,
       bookId: Canon.bookNumberToId(bookNum),
       selected: selectedSet.has(bookNum),
-      progressPercentage: progress.find(p => p.text.bookNum === bookNum)!.percentage
+      progressPercentage: progress.find(p => p.text.bookNum === bookNum)?.percentage ?? 0
     }));
 
     this.booksOT = this.selectedBooks.filter(n => Canon.isBookOT(n));


### PR DESCRIPTION
This PR fixes the `Cannot read properties of undefined (reading 'percentage')` error in the generate draft wizard that can occur when the connection is interrupted while loading the progress of the texts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2845)
<!-- Reviewable:end -->
