### PR TITLE
Add missing project type Transliteration

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -4,6 +4,7 @@ export enum ProjectType {
   Standard = 'Standard',
   BackTranslation = 'BackTranslation',
   Daughter = 'Daughter',
+  Transliteration = 'Transliteration',
   TransliterationManual = 'TransliterationManual',
   TransliterationWithEncoder = 'TransliterationWithEncoder',
   StudyBible = 'StudyBible',

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -258,6 +258,7 @@ export class SFProjectService extends ProjectService<SFProject> {
               'Standard',
               'BackTranslation',
               'Daughter',
+              'Transliteration',
               'TransliterationManual',
               'TransliterationWithEncoder',
               'StudyBible',


### PR DESCRIPTION
This PR adds a missing project type "Transliteration" to the validation schema, which I discovered in our Mongo database after running `validate-data.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2846)
<!-- Reviewable:end -->
