### PR TITLE
Add API key to health check endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
           SERVAL_CLIENT_ID: ${{secrets.serval_client_id}}
           AUTH_BACKEND_SECRET: ${{secrets.auth_backend_secret}}
           AUTH_WEBHOOK_PASSWORD: ${{secrets.auth_webhook_password}}
+          AUTH_HEALTH_CHECK_API_KEY: ${{secrets.auth_health_check_api_key}
           PARATEXT_API_TOKEN: ${{secrets.paratext_api_token}}
           PARATEXT_RESOURCE_PASSWORD_BASE64: ${{secrets.paratext_resource_password_base64}}
           PARATEXT_RESOURCE_PASSWORD_HASH: ${{secrets.paratext_resource_password_hash}}

--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -31,7 +31,8 @@ cat <<EOF > "$BUILD_OUTPUT/app/secrets.json"
   },
   "Auth": {
     "BackendClientSecret": "${AUTH_BACKEND_SECRET}",
-    "WebhookPassword": "${AUTH_WEBHOOK_PASSWORD}"
+    "WebhookPassword": "${AUTH_WEBHOOK_PASSWORD}",
+    "HealthCheckApiKey": "${AUTH_HEALTH_CHECK_API_KEY}"
   },
   "Site": {
     "Origin": "https://${HOSTNAME};${ALTERNATE_DOMAIN}",

--- a/src/SIL.XForge.Scripture/Controllers/HealthController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/HealthController.cs
@@ -2,8 +2,12 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Serval.Client;
+using SIL.XForge.Configuration;
 using SIL.XForge.DataAccess;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
@@ -18,43 +22,38 @@ namespace SIL.XForge.Scripture.Controllers;
 /// </remarks>
 [Route("health-check")]
 [ApiController]
-public class HealthController : ControllerBase
+[AllowAnonymous]
+public class HealthController(
+    IOptions<AuthOptions> authOptions,
+    IExceptionHandler exceptionHandler,
+    IRealtimeService realtimeService,
+    ITranslationEnginesClient translationEnginesClient
+) : ControllerBase
 {
     public const int Status531MongoDown = 531;
     public const int Status532RealtimeServerDown = 532;
     public const int Status533ServalDown = 533;
 
-    private readonly IExceptionHandler _exceptionHandler;
-    private readonly IRealtimeService _realtimeService;
-    private readonly ITranslationEnginesClient _translationEnginesClient;
-
-    public HealthController(
-        IExceptionHandler exceptionHandler,
-        IRealtimeService realtimeService,
-        ITranslationEnginesClient translationEnginesClient
-    )
-    {
-        _exceptionHandler = exceptionHandler;
-        _realtimeService = realtimeService;
-        _translationEnginesClient = translationEnginesClient;
-    }
-
     /// <summary>
     /// Executes the health check.
     /// </summary>
+    /// <param name="apiKey">The API key to access this endpoint.</param>
     /// <returns>A JSON object containing values corresponding to the health of various systems.</returns>
     /// <response code="200">All systems are healthy.</response>
     /// <response code="403">You do not have permission to view the health check.</response>
     /// <response code="531">Mongo is down.</response>
     /// <response code="532">The Realtime Server is down.</response>
     /// <response code="533">Serval is down.</response>
-    [HttpGet]
-    public async Task<ActionResult<HealthCheckResponse>> HealthCheckAsync()
+    [HttpPost]
+    public async Task<ActionResult<HealthCheckResponse>> HealthCheckAsync(
+        [FromHeader(Name = "X-Api-Key")] string apiKey
+    )
     {
-        // Restrict this endpoint to local requests
-        if (!IsLocal())
+        // Restrict this endpoint to requests with the correct API key
+        if (authOptions.Value.HealthCheckApiKey != apiKey)
         {
-            return Forbid();
+            // Returning Forbid() results in a 400 error when executed in a POST action
+            return new StatusCodeResult(StatusCodes.Status403Forbidden);
         }
 
         // Create the object to return for the health check
@@ -66,7 +65,7 @@ public class HealthController : ControllerBase
         try
         {
             stopWatch = Stopwatch.StartNew();
-            project = await _realtimeService.QuerySnapshots<SFProject>().FirstOrDefaultAsync();
+            project = await realtimeService.QuerySnapshots<SFProject>().FirstOrDefaultAsync();
             stopWatch.Stop();
             response.Mongo.Up = project is not null;
             response.Mongo.Time = stopWatch.ElapsedMilliseconds;
@@ -75,7 +74,7 @@ public class HealthController : ControllerBase
         catch (Exception e)
         {
             response.Mongo.Status = e.Message;
-            _exceptionHandler.ReportException(e);
+            exceptionHandler.ReportException(e);
         }
 
         // Second, check the realtime server
@@ -84,7 +83,7 @@ public class HealthController : ControllerBase
             try
             {
                 stopWatch = Stopwatch.StartNew();
-                await using IConnection conn = await _realtimeService.ConnectAsync();
+                await using IConnection conn = await realtimeService.ConnectAsync();
                 IDocument<SFProject> projectDoc = await conn.FetchAsync<SFProject>(project.Id);
                 stopWatch.Stop();
                 response.RealtimeServer.Up = projectDoc.IsLoaded;
@@ -96,7 +95,7 @@ public class HealthController : ControllerBase
             catch (Exception e)
             {
                 response.RealtimeServer.Status = e.Message;
-                _exceptionHandler.ReportException(e);
+                exceptionHandler.ReportException(e);
             }
         }
         else
@@ -108,7 +107,7 @@ public class HealthController : ControllerBase
         try
         {
             stopWatch = Stopwatch.StartNew();
-            var translationEngines = await _translationEnginesClient.GetAllAsync();
+            var translationEngines = await translationEnginesClient.GetAllAsync();
             stopWatch.Stop();
             response.Serval.Up = translationEngines.Any();
             response.Serval.Time = stopWatch.ElapsedMilliseconds;
@@ -117,7 +116,7 @@ public class HealthController : ControllerBase
         catch (Exception e)
         {
             response.Serval.Status = e.Message;
-            _exceptionHandler.ReportException(e);
+            exceptionHandler.ReportException(e);
         }
 
         // Calculate the status code and return the results
@@ -140,26 +139,5 @@ public class HealthController : ControllerBase
         }
 
         return StatusCode(statusCode, response);
-    }
-
-    /// <summary>
-    /// Returns if a request is from localhost.
-    /// </summary>
-    /// <returns><c>true</c> if the request is local; otherwise, <c>false</c>.</returns>
-    /// <remarks>This check uses similar logic to Hangfire's dashboard.</remarks>
-    private bool IsLocal()
-    {
-        // Get the local and remote IP addresses
-        string remoteIp = HttpContext.Connection.RemoteIpAddress?.ToString();
-        string localIp = HttpContext.Connection.LocalIpAddress?.ToString();
-
-        // Assume not local if remote IP is unknown
-        if (string.IsNullOrEmpty(remoteIp))
-        {
-            return false;
-        }
-
-        // See if localhost
-        return remoteIp is "127.0.0.1" or "::1" || remoteIp == localIp;
     }
 }

--- a/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
+++ b/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
@@ -8,15 +8,15 @@ public class HealthCheckResponse
     /// <summary>
     /// Gets or sets the health check status for Mongo.
     /// </summary>
-    public HealthCheckComponent Mongo { get; set; } = new HealthCheckComponent();
+    public HealthCheckComponent Mongo { get; } = new HealthCheckComponent();
 
     /// <summary>
     /// Gets or sets the health check status for the Realtime Server.
     /// </summary>
-    public HealthCheckComponent RealtimeServer { get; set; } = new HealthCheckComponent();
+    public HealthCheckComponent RealtimeServer { get; } = new HealthCheckComponent();
 
     /// <summary>
     /// Gets or sets the health check status for Serval.
     /// </summary>
-    public HealthCheckComponent Serval { get; set; } = new HealthCheckComponent();
+    public HealthCheckComponent Serval { get; } = new HealthCheckComponent();
 }

--- a/src/SIL.XForge/Configuration/AuthOptions.cs
+++ b/src/SIL.XForge/Configuration/AuthOptions.cs
@@ -14,4 +14,5 @@ public class AuthOptions
     public string BackendClientSecret { get; set; }
     public string WebhookUsername { get; set; }
     public string WebhookPassword { get; set; }
+    public string HealthCheckApiKey { get; set; }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,14 +8,18 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Serval.Client;
+using SIL.XForge.Configuration;
 using SIL.XForge.Realtime;
 using SIL.XForge.Scripture.Models;
+using Options = Microsoft.Extensions.Options.Options;
 
 namespace SIL.XForge.Scripture.Controllers;
 
 [TestFixture]
 public class HealthCheckControllerTests
 {
+    private const string ApiKey = "this_is_a_secret";
+
     [Test]
     public async Task HealthCheck_FailureWithMongo()
     {
@@ -24,7 +27,7 @@ public class HealthCheckControllerTests
         env.RealtimeService.QuerySnapshots<SFProject>().Throws(new ArgumentException());
 
         // SUT
-        var actual = await env.Controller.HealthCheckAsync();
+        var actual = await env.Controller.HealthCheckAsync(ApiKey);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
         Assert.IsInstanceOf<ObjectResult>(actual.Result);
@@ -41,7 +44,7 @@ public class HealthCheckControllerTests
         env.RealtimeService.ConnectAsync().Throws(new ArgumentException());
 
         // SUT
-        var actual = await env.Controller.HealthCheckAsync();
+        var actual = await env.Controller.HealthCheckAsync(ApiKey);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
         Assert.IsInstanceOf<ObjectResult>(actual.Result);
@@ -58,7 +61,7 @@ public class HealthCheckControllerTests
         env.TranslationEnginesClient.GetAllAsync().Throws(new ArgumentException());
 
         // SUT
-        var actual = await env.Controller.HealthCheckAsync();
+        var actual = await env.Controller.HealthCheckAsync(ApiKey);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<ArgumentException>());
         Assert.IsInstanceOf<ObjectResult>(actual.Result);
@@ -69,29 +72,15 @@ public class HealthCheckControllerTests
     }
 
     [Test]
-    public async Task HealthCheck_NotLocal()
+    public async Task HealthCheck_InvalidKey()
     {
         var env = new TestEnvironment();
-        env.Controller.HttpContext.Connection.RemoteIpAddress = IPAddress.Parse("192.168.0.1");
 
         // SUT
-        var actual = await env.Controller.HealthCheckAsync();
+        var actual = await env.Controller.HealthCheckAsync("invalid_key");
 
-        Assert.IsInstanceOf<ForbidResult>(actual.Result);
-    }
-
-    [Test]
-    public async Task HealthCheck_SameIp()
-    {
-        var env = new TestEnvironment();
-        var ipAddress = IPAddress.Parse("192.168.0.1");
-        env.Controller.HttpContext.Connection.LocalIpAddress = ipAddress;
-        env.Controller.HttpContext.Connection.RemoteIpAddress = ipAddress;
-
-        // SUT
-        var actual = await env.Controller.HealthCheckAsync();
-
-        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
     }
 
     [Test]
@@ -100,7 +89,7 @@ public class HealthCheckControllerTests
         var env = new TestEnvironment();
 
         // SUT
-        var actual = await env.Controller.HealthCheckAsync();
+        var actual = await env.Controller.HealthCheckAsync(ApiKey);
 
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
     }
@@ -112,35 +101,28 @@ public class HealthCheckControllerTests
         public TestEnvironment()
         {
             // Set up the controller and services
+            var authOptions = Options.Create(new AuthOptions { HealthCheckApiKey = ApiKey });
             ExceptionHandler = Substitute.For<IExceptionHandler>();
             RealtimeService = Substitute.For<IRealtimeService>();
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
-            Controller = new HealthController(ExceptionHandler, RealtimeService, TranslationEnginesClient)
-            {
-                ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext(), },
-            };
-
-            // Most tests will run as if from localhost
-            Controller.HttpContext.Connection.RemoteIpAddress = IPAddress.Loopback;
+            Controller = new HealthController(authOptions, ExceptionHandler, RealtimeService, TranslationEnginesClient);
 
             // Set up a default project to return from Mongo
             RealtimeService
                 .QuerySnapshots<SFProject>()
                 .Returns(new List<SFProject> { new SFProject { Id = Project01 } }.AsQueryable());
 
-            // Setup a default connection and document to return from the realtime server
+            // Set up a default connection and document to return from the realtime server
             var connection = Substitute.For<IConnection>();
             var document = Substitute.For<IDocument<SFProject>>();
             document.IsLoaded.Returns(true);
             connection.Get<SFProject>(Project01).Returns(document);
             RealtimeService.ConnectAsync().Returns(Task.FromResult(connection));
 
-            // Setup a default translation engine to return from Serval
+            // Set up a default translation engine to return from Serval
             TranslationEnginesClient
                 .GetAllAsync()
-                .Returns(
-                    Task.FromResult<IList<TranslationEngine>>(new List<TranslationEngine> { new TranslationEngine() })
-                );
+                .Returns(Task.FromResult<IList<TranslationEngine>>([new TranslationEngine()]));
         }
 
         public HealthController Controller { get; }


### PR DESCRIPTION
This PR adds support for an API key to the health check endpoint.

Before running this locally, add a test key to your user secrets:
```sh
dotnet user-secrets set "Auth:HealthCheckApiKey" "test_key"
```

After starting Scripture Forge, you can test the endpoint via Swagger (http://localhost:5000/swagger/index.html) or curl:
```sh
curl -X 'POST' 'http://localhost:5000/health-check' -H 'X-Api-Key: test_key' -d ''
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2847)
<!-- Reviewable:end -->
