### PR TITLE
SF-3081 Show draft queued immediately when job started

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -115,9 +115,18 @@
         }
         <div class="button-strip">
           <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-          <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+          <button
+            mat-flat-button
+            (click)="tryAdvanceStep()"
+            color="primary"
+            class="advance-button"
+            [disabled]="isStepsCompleted"
+          >
             {{ featureFlags.allowFastTraining.enabled || trainingDataFilesAvailable ? t("next") : t("generate_draft") }}
           </button>
+          @if (isStepsCompleted) {
+            <mat-spinner diameter="24"></mat-spinner>
+          }
         </div>
       </mat-step>
       @if (trainingDataFilesAvailable) {
@@ -134,9 +143,18 @@
           ></app-training-data-multi-select>
           <div class="button-strip">
             <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-            <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+            <button
+              mat-flat-button
+              (click)="tryAdvanceStep()"
+              color="primary"
+              class="advance-button"
+              [disabled]="isStepsCompleted"
+            >
               {{ featureFlags.allowFastTraining.enabled ? t("next") : t("generate_draft") }}
             </button>
+            @if (isStepsCompleted) {
+              <mat-spinner diameter="24"></mat-spinner>
+            }
           </div>
         </mat-step>
       }
@@ -154,9 +172,18 @@
           }
           <div class="button-strip">
             <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
-            <button mat-flat-button (click)="tryAdvanceStep()" color="primary">
+            <button
+              mat-flat-button
+              (click)="tryAdvanceStep()"
+              color="primary"
+              class="advance-button"
+              [disabled]="isStepsCompleted"
+            >
               {{ t("generate_draft") }}
             </button>
+            @if (isStepsCompleted) {
+              <mat-spinner diameter="24"></mat-spinner>
+            }
           </div>
         </mat-step>
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -37,6 +37,7 @@ h1 {
   margin-top: 20px;
   display: flex;
   justify-content: flex-start;
+  align-items: center;
   gap: 8px;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -227,12 +227,15 @@ describe('DraftGenerationStepsComponent', () => {
       component.selectedTrainingDataIds = trainingDataFiles;
 
       spyOn(component.done, 'emit');
-
+      expect(component.isStepsCompleted).toBe(false);
       // Advance to the next step when at last step should emit books result
       fixture.detectChanges();
       component.tryAdvanceStep();
       fixture.detectChanges();
+      const generateDraftButton: HTMLElement = fixture.nativeElement.querySelector('.advance-button');
+      expect(generateDraftButton['disabled']).toBe(false);
       component.tryAdvanceStep();
+      fixture.detectChanges();
 
       expect(component.done.emit).toHaveBeenCalledWith({
         translationBooks,
@@ -240,6 +243,8 @@ describe('DraftGenerationStepsComponent', () => {
         trainingBooks: trainingBooks.filter(book => !translationBooks.includes(book)),
         fastTraining: false
       } as DraftGenerationStepsResult);
+      expect(component.isStepsCompleted).toBe(true);
+      expect(generateDraftButton['disabled']).toBe(true);
     });
 
     it('should emit the correct selected books when bookSelect is called', fakeAsync(() => {
@@ -325,7 +330,10 @@ describe('DraftGenerationStepsComponent', () => {
 
       // Click next on the final step to generate the draft
       fixture.detectChanges();
+      const generateDraftButton: HTMLElement = fixture.nativeElement.querySelector('.advance-button');
+      expect(generateDraftButton['disabled']).toBe(false);
       component.tryAdvanceStep();
+      fixture.detectChanges();
 
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingBooks,
@@ -333,6 +341,7 @@ describe('DraftGenerationStepsComponent', () => {
         translationBooks,
         fastTraining: true
       } as DraftGenerationStepsResult);
+      expect(generateDraftButton['disabled']).toBe(true);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -83,6 +83,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   expandUnusableTranslateBooks = false;
   expandUnusableTrainingBooks = false;
+  isStepsCompleted = false;
 
   private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
   private trainingDataSub?: Subscription;
@@ -246,6 +247,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     if (this.stepper.selected !== this.stepper.steps.last) {
       this.stepper.next();
     } else {
+      this.isStepsCompleted = true;
       this.done.emit({
         trainingBooks: this.userSelectedTrainingBooks,
         trainingDataFiles: this.selectedTrainingDataIds,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -79,7 +79,7 @@ describe('DraftGenerationComponent', () => {
 
   class TestEnvironment {
     readonly testOnlineStatusService: TestOnlineStatusService;
-    readonly startedOrActiveBuild$: Subject<BuildDto> = new Subject<BuildDto>();
+    readonly startedOrActiveBuild$ = new Subject<BuildDto>();
     component!: DraftGenerationComponent;
     fixture!: ComponentFixture<DraftGenerationComponent>;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -439,7 +439,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   }
 
   onPreGenerationStepsComplete(result: DraftGenerationStepsResult): void {
-    this.currentPage = 'initial';
     this.startBuild({
       projectId: this.activatedProject.projectId!,
       trainingBooks: result.trainingBooks,
@@ -501,6 +500,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     this.jobSubscription = this.subscribe(
       this.draftGenerationService.startBuildOrGetActiveBuild(buildConfig).pipe(
         tap((job?: BuildDto) => {
+          this.currentPage = 'initial';
           // Handle automatic closing of dialog if job finishes while cancel dialog is open
           if (!this.canCancel(job)) {
             if (this.cancelDialogRef?.getState() === MatDialogState.OPEN) {


### PR DESCRIPTION
There is a small delay between when a draft is started and when we get the draft job from the draft generation service that indicates that the build was queued. The small delay after the build is started will look like nothing happened when the user initiates a draft build and can be confusing. This PR delays closing the draft generation stepper until a queued job is retrieved from serval. A spinner progress is displayed as the user waits for the queued job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2853)
<!-- Reviewable:end -->
