### PR TITLE
SF-3080 Remove enable translation suggestions from connect settings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.html
@@ -5,15 +5,6 @@
   }
   <div class="content">
     @switch (state) {
-      @case ("login") {
-        <div class="paratext-login-container">
-          <div>{{ t("you_must_be_logged_in_to_paratext") }}</div>
-          <button mat-flat-button id="paratext-login-button" type="button" (click)="logInWithParatext()">
-            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-            {{ t("log_in_with_paratext") }}
-          </button>
-        </div>
-      }
       @case ("connecting") {
         <mat-card class="progress-container card-outline">
           <mat-card-content>
@@ -34,7 +25,6 @@
               <mat-card-subtitle>{{ t("you_can_change_later") }}</mat-card-subtitle>
               <mat-card-content class="card-content">
                 <p>{{ t("select_project_or_resource") }}</p>
-                <p>{{ t("translation_suggestions_require_source_text") }}</p>
                 <app-project-select
                   formControlName="sourceParatextId"
                   [placeholder]="t('source_text_placeholder')"
@@ -45,17 +35,6 @@
                 ></app-project-select>
                 @if (showResourcesLoadingFailedMessage) {
                   <mat-error>{{ t("error_fetching_resources") }}</mat-error>
-                }
-                @if (isBasedOnProjectSet) {
-                  <div>
-                    <mat-checkbox formControlName="translationSuggestions" id="translation-suggestions-checkbox">
-                      {{ t("enable_translation_suggestions") }}
-                    </mat-checkbox>
-                    <p
-                      class="helper-text"
-                      [innerHTML]="i18n.translateAndInsertTags('settings.translations_will_be_suggested')"
-                    ></p>
-                  </div>
                 }
               </mat-card-content>
               <mat-divider></mat-divider>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.scss
@@ -32,23 +32,6 @@
   max-width: 512px;
   width: 100%;
 
-  .paratext-login-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    > button {
-      margin-top: 19px;
-      background-color: $pt-button-green;
-      color: white;
-      height: 40px;
-
-      .paratext-logo {
-        width: 100%;
-      }
-    }
-  }
-
   .progress-container {
     padding: 32px;
     mat-card-content {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.spec.ts
@@ -69,16 +69,11 @@ describe('ConnectProjectComponent', () => {
     ]
   }));
 
-  it('should display login button when PT projects is null', fakeAsync(() => {
+  it('should show no projects if cannot access projects', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setupProjectsResources(undefined, undefined);
     env.waitForProjectsResponse();
-
-    expect(env.component.state).toEqual('login');
-    expect(env.loginButton).not.toBeNull();
-    expect(env.loginButton.nativeElement.disabled).toBe(false);
-    env.onlineStatus = false;
-    expect(env.loginButton).toBeNull();
+    expect(env.component.projects).toEqual([]);
   }));
 
   it('should display form when PT projects is empty', fakeAsync(() => {
@@ -99,7 +94,6 @@ describe('ConnectProjectComponent', () => {
 
     env.clickElement(env.inputElement(env.checkingCheckbox));
 
-    expect(env.translationSuggestionsCheckbox).toBeNull();
     env.openSourceProjectAutocomplete();
     // NOTE: The source projects list excludes pt01 (as it is our selected project above)
     expect(env.selectableSourceProjectsAndResources.projects.length).toEqual(3);
@@ -170,10 +164,6 @@ describe('ConnectProjectComponent', () => {
 
     env.selectSourceProject('pt04');
     expect(env.component.connectProjectForm.valid).toBe(true);
-    expect(env.translationSuggestionsCheckbox).not.toBeNull();
-
-    env.clickElement(env.inputElement(env.translationSuggestionsCheckbox));
-    expect(env.inputElement(env.translationSuggestionsCheckbox).checked).toBe(true);
 
     env.clickElement(env.submitButton);
     expect(env.projectTitle).toBeUndefined();
@@ -186,7 +176,6 @@ describe('ConnectProjectComponent', () => {
     const settings: SFProjectCreateSettings = {
       paratextId: 'pt01',
       checkingEnabled: false,
-      translationSuggestionsEnabled: true,
       sourceParatextId: 'pt04'
     };
     verify(mockedSFProjectService.onlineCreate(deepEqual(settings))).once();
@@ -198,7 +187,6 @@ describe('ConnectProjectComponent', () => {
     env.setupDefaultProjectData();
     env.waitForProjectsResponse();
     expect(env.component.state).toEqual('input');
-    expect(env.translationSuggestionsCheckbox).toBeNull();
     expect(env.inputElement(env.checkingCheckbox).checked).toBe(true);
 
     env.clickElement(env.submitButton);
@@ -212,7 +200,6 @@ describe('ConnectProjectComponent', () => {
     const project: SFProjectCreateSettings = {
       paratextId: 'pt01',
       checkingEnabled: true,
-      translationSuggestionsEnabled: false,
       sourceParatextId: null
     };
     verify(mockedSFProjectService.onlineCreate(deepEqual(project))).once();
@@ -229,7 +216,6 @@ describe('ConnectProjectComponent', () => {
     env.setupDefaultProjectData();
     env.waitForProjectsResponse();
     expect(env.component.state).toEqual('input');
-    expect(env.translationSuggestionsCheckbox).toBeNull();
     expect(env.inputElement(env.checkingCheckbox).checked).toBe(true);
     // Simulate someone else connecting the PT project to SF while we are working on the Connect Project form.
     when(mockedSFProjectService.onlineCreate(anything())).thenThrow(
@@ -261,13 +247,11 @@ describe('ConnectProjectComponent', () => {
     env.waitForProjectsResponse();
 
     expect(env.component.state).toEqual('input');
-    expect(env.translationSuggestionsCheckbox).toBeNull();
 
     expect(env.resourceLoadingErrorMessage.nativeElement.textContent).toContain('error fetching');
 
     env.selectSourceProject('pt04');
     expect(env.component.connectProjectForm.valid).toBe(true);
-    expect(env.translationSuggestionsCheckbox).not.toBeNull();
     env.clickElement(env.submitButton);
 
     expect(env.component.state).toEqual('connecting');
@@ -277,7 +261,6 @@ describe('ConnectProjectComponent', () => {
     const settings: SFProjectCreateSettings = {
       paratextId: 'pt01',
       checkingEnabled: true,
-      translationSuggestionsEnabled: false,
       sourceParatextId: 'pt04'
     };
     verify(mockedSFProjectService.onlineCreate(deepEqual(settings))).once();
@@ -364,7 +347,7 @@ class TestEnvironment {
       const newProject: SFProject = createTestProject({
         paratextId: settings.paratextId,
         translateConfig: {
-          translationSuggestionsEnabled: settings.translationSuggestionsEnabled,
+          translationSuggestionsEnabled: false,
           source:
             settings.sourceParatextId == null
               ? undefined
@@ -410,10 +393,6 @@ class TestEnvironment {
     this.component = this.fixture.componentInstance;
   }
 
-  get loginButton(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#paratext-login-button'));
-  }
-
   get submitButton(): DebugElement {
     return this.fixture.debugElement.query(By.css('#connect-submit-button'));
   }
@@ -432,10 +411,6 @@ class TestEnvironment {
 
   get checkingCheckbox(): DebugElement {
     return this.fixture.debugElement.query(By.css('#checking-checkbox'));
-  }
-
-  get translationSuggestionsCheckbox(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#translation-suggestions-checkbox'));
   }
 
   get sourceProjectSelect(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-create-settings.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/sf-project-create-settings.ts
@@ -1,6 +1,5 @@
 export interface SFProjectCreateSettings {
   paratextId: string;
-  translationSuggestionsEnabled: boolean;
   sourceParatextId: string | null;
   checkingEnabled: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -110,19 +110,15 @@
     "connect": "Connect",
     "connecting_to_project": "Connecting to {{ projectName }}...",
     "enable_community_checking": "Enable Community Checking",
-    "enable_translation_suggestions": "Enable translation suggestions",
     "engage_the_wider_community_to_check_scripture": "Engage the wider community to ensure that the translation is clear, accurate, and natural. Select verses, ask targeted questions, allow discussion of answers.",
     "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
-    "log_in_with_paratext": "Log in with Paratext",
     "paratext_account_linked_to_another_user": "You have logged into a Paratext account that is already linked to a user with the email {{ email }}. You will be logged out of your current account and proceed as the Paratext user.",
     "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
     "proceed": "Proceed",
     "project_settings": "Project Settings",
     "select_project_or_resource": "Select the Paratext project or Digital Bible Library resource that your project is based on. If your project is based on a Paratext project, it's best to set it up as a daughter project in Paratext.",
     "source_text_placeholder": "Source text (optional)",
-    "translation_suggestions_require_source_text": "Note: Translation suggestions are only available if a source text is selected.",
-    "you_can_change_later": "You can change these later.",
-    "you_must_be_logged_in_to_paratext": "You must login with your Paratext account to connect to a project."
+    "you_can_change_later": "You can change these later."
   },
   "delete_project_dialog": {
     "are_you_sure_you_want_to_delete": "Are you sure you want to delete this project?",

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -60,8 +60,7 @@ public class SFProjectsRpcController(
                     { "method", "Create" },
                     { "ParatextId", settings?.ParatextId },
                     { "SourceParatextId", settings?.SourceParatextId },
-                    { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
-                    { "TranslationSuggestionsEnabled", settings?.TranslationSuggestionsEnabled.ToString() },
+                    { "CheckingEnabled", settings?.CheckingEnabled.ToString() }
                 }
             );
             throw;

--- a/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
@@ -3,7 +3,6 @@ namespace SIL.XForge.Scripture.Models;
 public class SFProjectCreateSettings
 {
     public string ParatextId { get; set; }
-    public bool TranslationSuggestionsEnabled { get; set; }
     public string? SourceParatextId { get; set; }
     public bool CheckingEnabled { get; set; }
     public string AnswerExportMethod { get; set; } = CheckingAnswerExport.MarkedForExport;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2773,12 +2773,7 @@ public class SFProjectServiceTests
         // SUT
         string sfProjectId = await env.Service.CreateProjectAsync(
             User01,
-            new SFProjectCreateSettings()
-            {
-                ParatextId = "ptProject123",
-                SourceParatextId = "resource_project",
-                TranslationSuggestionsEnabled = true,
-            }
+            new SFProjectCreateSettings() { ParatextId = "ptProject123", SourceParatextId = "resource_project" }
         );
         Assert.That(env.ContainsProject(sfProjectId), Is.True);
         Assert.That(
@@ -2955,12 +2950,7 @@ public class SFProjectServiceTests
         // SUT
         string sfProjectId = await env.Service.CreateProjectAsync(
             User03,
-            new SFProjectCreateSettings()
-            {
-                ParatextId = targetProjectPTId,
-                SourceParatextId = sourceProjectPTId,
-                TranslationSuggestionsEnabled = true,
-            }
+            new SFProjectCreateSettings() { ParatextId = targetProjectPTId, SourceParatextId = sourceProjectPTId }
         );
 
         SFProject project = env.GetProject(sfProjectId);
@@ -2977,7 +2967,7 @@ public class SFProjectServiceTests
         // permissions on them.
         await env
             .SyncService.Received()
-            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == sfProjectId && s.TrainEngine && s.UserId == User03));
+            .SyncAsync(Arg.Is<SyncConfig>(s => s.ProjectId == sfProjectId && !s.TrainEngine && s.UserId == User03));
 
         // Don't check that permissions were added to the target project, because we mock the Sync functionality.
         // But we can show that source resource permissions were set:


### PR DESCRIPTION
This change removes the translation suggestions option from the connect project page. This also includes changes to remove the "login" state from the connect project page which is no longer relevant. A user not logged into Paratext is not able to access this page. If it was typed into the browser manually, the user would be redirected to the my projects page.

Before
![Connect project no suggestions before](https://github.com/user-attachments/assets/fb3be9e1-2208-4247-87cf-4d6ecb4220a8)

After
![Connect project no suggestions after](https://github.com/user-attachments/assets/2c77d9d8-6512-4437-b1bd-26d30d406b3e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2854)
<!-- Reviewable:end -->
