### PR TITLE
SF-3085 Fix back translation draft not showing progress

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -751,6 +751,8 @@ public class MachineApiService(
                 p => p.TranslateConfig.DraftConfig.LastSelectedTranslationScriptureRange,
                 buildConfig.TranslationScriptureRange
             );
+            if (!projectDoc.Data.TranslateConfig.PreTranslate)
+                op.Set(p => p.TranslateConfig.PreTranslate, true);
         });
 
         // Sync the source and target before running the build

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -202,12 +202,6 @@ public class MachineProjectService(
                 }
             );
 
-            // If the pre-translate flag is not set, set it now for the front-end UI
-            if (preTranslate && !projectDoc.Data.TranslateConfig.PreTranslate)
-            {
-                await projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.TranslateConfig.PreTranslate, true));
-            }
-
             // Create the Serval project, and get the translation engine id
             translationEngineId = await CreateServalProjectAsync(projectDoc.Data, preTranslate, cancellationToken);
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1823,13 +1823,12 @@ public class MachineApiServiceTests
         Assert.AreEqual(JobId, env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationJobId);
         Assert.IsNotNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationQueuedAt);
         Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationErrorMessage);
-        Assert.AreEqual(0, env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTrainingBooks.Count);
-        Assert.AreEqual(2, env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks.Count);
-        Assert.AreEqual(
-            1,
-            env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks.First()
-        );
-        Assert.AreEqual(2, env.Projects.Get(Project01).TranslateConfig.DraftConfig.LastSelectedTranslationBooks.Last());
+        SFProject project = env.Projects.Get(Project01);
+        Assert.IsTrue(project.TranslateConfig.PreTranslate);
+        Assert.AreEqual(0, project.TranslateConfig.DraftConfig.LastSelectedTrainingBooks.Count);
+        Assert.AreEqual(2, project.TranslateConfig.DraftConfig.LastSelectedTranslationBooks.Count);
+        Assert.AreEqual(1, project.TranslateConfig.DraftConfig.LastSelectedTranslationBooks.First());
+        Assert.AreEqual(2, project.TranslateConfig.DraftConfig.LastSelectedTranslationBooks.Last());
     }
 
     [Test]


### PR DESCRIPTION
When generating a draft for the first time for a Back translation project, it is possible that while the draft is queued the spinning gears animation will not show if a user navigates away and back to the page because the preTranslate flag has not been set on the project in `MachineProjectService.StartBuildAsync`. This change moves setting the preTranslate flag just before the project is synced in `MachineApiService.StartPreTranslationBuildAsync`.

I marked this as testing not required since a developer will be able to confirm these steps acceptance steps easily.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2859)
<!-- Reviewable:end -->
