### PR TITLE
SF-3093 Allow adding draft to a book when project plans are used

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -882,15 +882,8 @@ public class ParatextService : DisposableBase, IParatextService
                             PermissionSet.Merged,
                             userName
                         );
-                        if (editable == null || !editable.Any())
-                        {
-                            // If there are no editable book permissions, check if they can edit all books
-                            if (scrText.Permissions.CanEditAllBooks(userName))
-                            {
-                                textInfoPermission = TextInfoPermission.Write;
-                            }
-                        }
-                        else if (editable.Contains(book))
+                        // Check if they can edit all books or the specified book
+                        if (scrText.Permissions.CanEditAllBooks(userName) || editable.Contains(book))
                         {
                             textInfoPermission = TextInfoPermission.Write;
                         }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -385,11 +385,11 @@ public class ParatextServiceTests
         var ptUsernameMapping = new Dictionary<string, string>() { { env.User01, env.Username01 } };
         ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
         scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, true);
-        // Give automatic permission to Mark but not Matthew
+        // Give User01 automatic permission to Mark but not Matthew
         scrText.Permissions.SetPermission(env.Username01, 41, PermissionSet.Automatic, true);
         env.MockScrTextCollection.FindById(env.Username01, project.ParatextId).Returns(scrText);
 
-        // Matthew has permission granted explicitly
+        // User01 has permission to Matthew granted explicitly
         Dictionary<string, string> permissions = await env.Service.GetPermissionsAsync(
             user01Secret,
             project,
@@ -398,7 +398,39 @@ public class ParatextServiceTests
         );
         string[] expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
-        // Mark has permission explicitly and automatically
+        // User01 permission to Mark explicitly and automatically
+        permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping, 41);
+        Assert.That(permissions.Values, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public async Task GetPermissionsAsync_AutomaticBooks_HasBookLevelPermission()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Set up mock project
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+
+        var ptUsernameMapping = new Dictionary<string, string>() { { env.User01, env.Username01 } };
+        ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
+        scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, false);
+        // Give automatic permission to User01 to Mark but not Matthew
+        scrText.Permissions.SetPermission(env.Username01, 41, PermissionSet.Automatic, true);
+        env.MockScrTextCollection.FindById(env.Username01, project.ParatextId).Returns(scrText);
+
+        // User01 does not have permission to Matthew
+        Dictionary<string, string> permissions = await env.Service.GetPermissionsAsync(
+            user01Secret,
+            project,
+            ptUsernameMapping,
+            40
+        );
+        string[] expected = [TextInfoPermission.Read, TextInfoPermission.None, TextInfoPermission.None];
+        Assert.That(permissions.Values, Is.EquivalentTo(expected));
+        // User01 has permission to Mark automatically
         permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping, 41);
         expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -353,7 +353,7 @@ public class ParatextServiceTests
 
         // Set up mock project
         var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
-        var project = projects.First();
+        SFProject project = projects.First();
         project.ParatextId = env.Resource2Id;
         project.UserRoles = new Dictionary<string, string>
         {
@@ -367,7 +367,39 @@ public class ParatextServiceTests
         };
 
         var permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping);
-        string[] expected = new[] { TextInfoPermission.Read, TextInfoPermission.None };
+        string[] expected = [TextInfoPermission.Read, TextInfoPermission.None];
+        Assert.That(permissions.Values, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public async Task GetPermissionsAsync_AllBooksAndAutomaticBooks_HasBookLevelPermission()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Set up mock project
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+
+        var ptUsernameMapping = new Dictionary<string, string>()
+        {
+            { env.User01, env.Username01 },
+            { env.User02, env.Username02 }
+        };
+        ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
+        scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, true);
+        // Give automatic permission to Mark but not Matthew
+        scrText.Permissions.SetPermission(env.Username01, 41, PermissionSet.Automatic, true);
+        env.MockScrTextCollection.FindById(env.Username01, project.ParatextId).Returns(scrText);
+
+        Dictionary<string, string> permissions = await env.Service.GetPermissionsAsync(
+            user01Secret,
+            project,
+            ptUsernameMapping,
+            40
+        );
+        string[] expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -382,17 +382,14 @@ public class ParatextServiceTests
         var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
         SFProject project = projects.First();
 
-        var ptUsernameMapping = new Dictionary<string, string>()
-        {
-            { env.User01, env.Username01 },
-            { env.User02, env.Username02 }
-        };
+        var ptUsernameMapping = new Dictionary<string, string>() { { env.User01, env.Username01 } };
         ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
         scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, true);
         // Give automatic permission to Mark but not Matthew
         scrText.Permissions.SetPermission(env.Username01, 41, PermissionSet.Automatic, true);
         env.MockScrTextCollection.FindById(env.Username01, project.ParatextId).Returns(scrText);
 
+        // Matthew has permission granted explicitly
         Dictionary<string, string> permissions = await env.Service.GetPermissionsAsync(
             user01Secret,
             project,
@@ -400,6 +397,10 @@ public class ParatextServiceTests
             40
         );
         string[] expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
+        Assert.That(permissions.Values, Is.EquivalentTo(expected));
+        // Mark has permission explicitly and automatically
+        permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping, 41);
+        expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
     }
 


### PR DESCRIPTION
When using a project plan, it is possible that a user can have permission on all books and automatic permissions on some books. When that happens, SF incorrectly calculates book level permissions. This change updates our permissions calculations to correctly give permission when automatic book permissions are set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2865)
<!-- Reviewable:end -->
