### PR TITLE
SF-3095 Fix sync progress display when loading a resource.

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.html
@@ -1,19 +1,24 @@
-<div *transloco="let t; read: 'sync'">
-  <div class="sync-header">
-    <h3>{{ activeSyncProjectName }}</h3>
-  </div>
-  <div class="sync-status">
-    @if (syncPhaseMessage.includes("_percent")) {
-      {{ t(syncPhaseMessage, { progressPercent: phasePercentage }) }}
-    } @else {
-      {{ t(syncPhaseMessage) }}
-    }
-  </div>
+<div class="sync-progress">
+  @if (showSyncStatus) {
+    <div *transloco="let t; read: 'sync'">
+      <div class="sync-header">
+        <h3>{{ activeSyncProjectName }}</h3>
+      </div>
+      <div class="sync-status">
+        @if (syncPhaseMessage.includes("_percent")) {
+          {{ t(syncPhaseMessage, { progressPercent: phasePercentage }) }}
+        } @else {
+          {{ t(syncPhaseMessage) }}
+        }
+      </div>
+    </div>
+  }
+
+  <mat-progress-bar
+    class="progress-bar"
+    [mode]="(syncProgressMode$ | async) ?? 'indeterminate'"
+    [value]="syncProgressPercent$ | async"
+    [bufferValue]="1"
+    color="accent"
+  ></mat-progress-bar>
 </div>
-<mat-progress-bar
-  class="progress-bar"
-  [mode]="(syncProgressMode$ | async) ?? 'indeterminate'"
-  [value]="syncProgressPercent$ | async"
-  [bufferValue]="1"
-  color="accent"
-></mat-progress-bar>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -39,6 +39,7 @@ enum SyncPhase {
   styleUrl: '../sync.component.scss'
 })
 export class SyncProgressComponent extends SubscriptionDisposable {
+  @Input() showSyncStatus: boolean = true;
   @Output() inProgress: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   syncPhase: SyncPhase;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -16,6 +16,12 @@
   min-width: 25rem;
 }
 
+.sync-progress {
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rem;
+}
+
 .sync-status,
 .sync-header {
   display: flex;
@@ -28,10 +34,6 @@
 
 app-sync-progress {
   width: 100%;
-}
-
-mat-progress-bar {
-  padding-top: 2rem;
 }
 
 #btn-log-in {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.html
@@ -1,7 +1,11 @@
 @if (isLoading && !isSyncActive) {
   <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
 } @else if (isSyncActive) {
-  <app-sync-progress [projectDoc]="selectedProjectDoc" (inProgress)="onSyncProgress($event)"></app-sync-progress>
+  <app-sync-progress
+    [projectDoc]="selectedProjectDoc"
+    [showSyncStatus]="false"
+    (inProgress)="onSyncProgress($event)"
+  ></app-sync-progress>
 }
 
 <ng-container *transloco="let t; read: 'editor_add_tab_resource_dialog'">


### PR DESCRIPTION
This PR fixes how the sync progress is displayed in the tab resource dialog to prevent overlapping of text. Rather than optionally hiding the new sync info, this moves the sync progress into the space where the "Loading..." message previously appeared during the sync progress. This allows users to have the same visual insight into the status of thy sync across the app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2873)
<!-- Reviewable:end -->
