### PR TITLE
SF-3077 Add UI for mixed training sources

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -27,6 +27,14 @@ export interface BaseProject {
   shortName: string;
 }
 
+/**
+ * A per-project scripture range.
+ */
+export interface ProjectScriptureRange {
+  projectId: string;
+  scriptureRange: string;
+}
+
 export interface DraftConfig {
   additionalTrainingData: boolean;
   additionalTrainingSourceEnabled: boolean;
@@ -38,6 +46,7 @@ export interface DraftConfig {
   lastSelectedTrainingBooks: number[];
   lastSelectedTrainingDataFiles: string[];
   lastSelectedTrainingScriptureRange?: string;
+  lastSelectedTrainingScriptureRanges?: ProjectScriptureRange[];
   lastSelectedTranslationBooks: number[];
   lastSelectedTranslationScriptureRange?: string;
   servalConfig?: string;

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -573,7 +573,7 @@ describe('SFProjectMigrations', () => {
 
   describe('version 22', () => {
     it('copies selected training and translation books to scripture ranges', async () => {
-      const env = new TestEnvironment(20);
+      const env = new TestEnvironment(21);
       const conn = env.server.connect();
 
       await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.spec.ts
@@ -570,6 +570,28 @@ describe('SFProjectMigrations', () => {
       expect(projectDoc.data.translateConfig.shareEnabled).not.toBeDefined();
     });
   });
+
+  describe('version 22', () => {
+    it('copies selected training and translation books to scripture ranges', async () => {
+      const env = new TestEnvironment(20);
+      const conn = env.server.connect();
+
+      await createDoc(conn, SF_PROJECTS_COLLECTION, 'project01', {
+        translateConfig: { draftConfig: { lastSelectedTrainingBooks: [1, 2, 3], lastSelectedTranslationBooks: [4, 5] } }
+      });
+      let projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingBooks).toEqual([1, 2, 3]);
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTranslationBooks).toEqual([4, 5]);
+
+      await env.server.migrateIfNecessary();
+
+      projectDoc = await fetchDoc(conn, SF_PROJECTS_COLLECTION, 'project01');
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingBooks).toEqual([1, 2, 3]);
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTranslationBooks).toEqual([4, 5]);
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTrainingScriptureRange).toEqual('GEN;EXO;LEV');
+      expect(projectDoc.data.translateConfig.draftConfig.lastSelectedTranslationScriptureRange).toEqual('NUM;DEU');
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -1,3 +1,4 @@
+import { Canon } from '@sillsdev/scripture';
 import { Doc, Op } from 'sharedb/lib/client';
 import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 import { Operation } from '../../common/models/project-rights';
@@ -387,6 +388,38 @@ class SFProjectMigration21 extends DocMigration {
   }
 }
 
+class SFProjectMigration22 extends DocMigration {
+  static readonly VERSION = 22;
+
+  async migrateDoc(doc: Doc): Promise<void> {
+    const ops: Op[] = [];
+    if (doc.data.translateConfig.draftConfig.lastSelectedTrainingScriptureRange == null) {
+      const trainingRangeFromBooks: string[] = doc.data.translateConfig.draftConfig.lastSelectedTrainingBooks.map(
+        (b: number) => Canon.bookNumberToId(b)
+      );
+      if (trainingRangeFromBooks.length > 0) {
+        ops.push({
+          p: ['translateConfig', 'draftConfig', 'lastSelectedTrainingScriptureRange'],
+          oi: trainingRangeFromBooks.join(';')
+        });
+      }
+    }
+    if (doc.data.translateConfig.draftConfig.lastSelectedTranslationScriptureRange == null) {
+      const translationRangeFromBooks: string[] = doc.data.translateConfig.draftConfig.lastSelectedTranslationBooks.map(
+        (b: number) => Canon.bookNumberToId(b)
+      );
+      if (translationRangeFromBooks.length > 0) {
+        ops.push({
+          p: ['translateConfig', 'draftConfig', 'lastSelectedTranslationScriptureRange'],
+          oi: translationRangeFromBooks.join(';')
+        });
+      }
+    }
+
+    await submitMigrationOp(SFProjectMigration22.VERSION, doc, ops);
+  }
+}
+
 export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([
   SFProjectMigration1,
   SFProjectMigration2,
@@ -408,5 +441,6 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = monotonicallyIncrea
   SFProjectMigration18,
   SFProjectMigration19,
   SFProjectMigration20,
-  SFProjectMigration21
+  SFProjectMigration21,
+  SFProjectMigration22
 ]);

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -266,6 +266,21 @@ export class SFProjectService extends ProjectService<SFProject> {
               lastSelectedTrainingScriptureRange: {
                 bsonType: 'string'
               },
+              lastSelectedTrainingScriptureRanges: {
+                bsonType: 'array',
+                items: {
+                  bsonType: 'object',
+                  properties: {
+                    projectId: {
+                      bsonType: 'string'
+                    },
+                    scriptureRange: {
+                      bsonType: 'string'
+                    }
+                  },
+                  additionalProperties: false
+                }
+              },
               lastSelectedTranslationBooks: {
                 bsonType: 'array',
                 items: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -222,7 +222,9 @@ describe('ServalProjectComponent', () => {
                 shortName: 'P4'
               },
               lastSelectedTrainingBooks: preTranslate ? [1, 2] : [],
-              lastSelectedTranslationBooks: preTranslate ? [3, 4] : []
+              lastSelectedTranslationBooks: preTranslate ? [3, 4] : [],
+              lastSelectedTrainingScriptureRange: preTranslate ? 'GEN;EXO' : undefined,
+              lastSelectedTranslationScriptureRange: preTranslate ? 'LEV;NUM' : undefined
             },
             preTranslate,
             source: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -17,7 +17,7 @@ import { BuildDto } from '../machine-api/build-dto';
 import { MobileNotSupportedComponent } from '../shared/mobile-not-supported/mobile-not-supported.component';
 import { NoticeComponent } from '../shared/notice/notice.component';
 import { SharedModule } from '../shared/shared.module';
-import { projectLabel } from '../shared/utils';
+import { booksFromScriptureRange, projectLabel } from '../shared/utils';
 import { DraftZipProgress } from '../translate/draft-generation/draft-generation';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DraftInformationComponent } from '../translate/draft-generation/draft-information/draft-information.component';
@@ -150,13 +150,13 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           this.rows = rows;
 
           // Setup the books
-          this.trainingBooks = project.translateConfig.draftConfig.lastSelectedTrainingBooks.map(bookNum =>
-            Canon.bookNumberToEnglishName(bookNum)
-          );
+          this.trainingBooks = booksFromScriptureRange(
+            project.translateConfig.draftConfig.lastSelectedTrainingScriptureRange ?? ''
+          ).map(bookNum => Canon.bookNumberToEnglishName(bookNum));
           this.trainingFiles = project.translateConfig.draftConfig.lastSelectedTrainingDataFiles;
-          this.translationBooks = project.translateConfig.draftConfig.lastSelectedTranslationBooks.map(bookNum =>
-            Canon.bookNumberToEnglishName(bookNum)
-          );
+          this.translationBooks = booksFromScriptureRange(
+            project.translateConfig.draftConfig.lastSelectedTranslationScriptureRange ?? ''
+          ).map(bookNum => Canon.bookNumberToEnglishName(bookNum));
 
           this.draftConfig = project.translateConfig.draftConfig;
           this.draftJob$ = SFProjectService.hasDraft(project) ? this.getDraftJob(projectDoc.id) : of(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'book_select'">
-  @if (availableBooks.length > 0 && !readonly) {
+  @if (availableBooks.length > 0 && !readonly && !basicMode) {
     <div>
       <mat-checkbox
         class="ot-checkbox"
@@ -44,14 +44,20 @@
         [disabled]="readonly"
         (change)="onChipListChange(book)"
       >
-        <mat-chip-option
-          [value]="book"
-          [selected]="book.selected"
-          [matTooltip]="t('book_progress', { percent: getPercentage(book) | l10nPercent })"
-        >
-          {{ "canon.book_names." + book.bookId | transloco }}
-          <div class="border-fill" [style.width]="book.progressPercentage + '%'"></div>
-        </mat-chip-option>
+        @if (!basicMode) {
+          <mat-chip-option
+            [value]="book"
+            [selected]="book.selected"
+            [matTooltip]="t('book_progress', { percent: getPercentage(book) | l10nPercent })"
+          >
+            {{ "canon.book_names." + book.bookId | transloco }}
+            <div class="border-fill" [style.width]="book.progressPercentage + '%'"></div>
+          </mat-chip-option>
+        } @else {
+          <mat-chip-option [value]="book" [selected]="book.selected">
+            {{ "canon.book_names." + book.bookId | transloco }}
+          </mat-chip-option>
+        }
       </mat-chip-listbox>
     }
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.html
@@ -1,6 +1,9 @@
 <ng-container *transloco="let t; read: 'book_select'">
   @if (availableBooks.length > 0 && !readonly && !basicMode) {
-    <div>
+    <div class="scope-selection">
+      @if (projectName != null) {
+        <span class="project-name">{{ projectName }}</span>
+      }
       <mat-checkbox
         class="ot-checkbox"
         value="OT"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.scss
@@ -1,5 +1,15 @@
 @use 'src/variables';
 
+.scope-selection {
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
+
+  .project-name {
+    font-weight: 500;
+  }
+}
+
 .book-multi-select {
   .mat-mdc-standard-chip {
     position: relative;
@@ -21,29 +31,6 @@
     left: 0;
     height: 3px;
     background: black;
-  }
-}
-
-.bulk-select {
-  width: fit-content;
-  margin-top: 2px;
-  margin-block-end: 12px;
-  font-weight: 300;
-  div {
-    display: flex;
-    align-items: center;
-    column-gap: 12px;
-    button {
-      padding-inline: 12px;
-      font-weight: 300;
-      font-size: 16px;
-    }
-    mat-button-toggle {
-      width: 50px;
-    }
-    .mat-button-toggle-checked {
-      background-color: unset;
-    }
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.spec.ts
@@ -50,9 +50,16 @@ describe('BookMultiSelectComponent', () => {
     fixture.detectChanges();
   });
 
+  it('supports providing project name', async () => {
+    await component.ngOnChanges();
+    expect(fixture.nativeElement.querySelector('.project-name')).toBeNull();
+    component.projectName = 'Test Project';
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.project-name')).not.toBeNull();
+  });
+
   it('should initialize book options on ngOnChanges', async () => {
     await component.ngOnChanges();
-
     expect(component.bookOptions).toEqual([
       { bookNum: 1, bookId: 'GEN', selected: true, progressPercentage: 0 },
       { bookNum: 2, bookId: 'EXO', selected: false, progressPercentage: 15 },
@@ -136,5 +143,16 @@ describe('BookMultiSelectComponent', () => {
     expect(component.partialOT).toBe(false);
     expect(component.partialOT).toBe(false);
     expect(component.partialDC).toBe(true);
+  });
+
+  it('can hide checkboxes and progress in basic mode', async () => {
+    await component.ngOnChanges();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.book-multi-select .border-fill')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.scope-selection')).not.toBeNull();
+    component.basicMode = true;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.book-multi-select .border-fill')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.scope-selection')).toBeNull();
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -28,6 +28,7 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
   @Input() availableBooks: number[] = [];
   @Input() selectedBooks: number[] = [];
   @Input() readonly: boolean = false;
+  @Input() projectName?: string;
   @Input() basicMode: boolean = false;
   @Output() bookSelect = new EventEmitter<number[]>();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -28,6 +28,7 @@ export class BookMultiSelectComponent extends SubscriptionDisposable implements 
   @Input() availableBooks: number[] = [];
   @Input() selectedBooks: number[] = [];
   @Input() readonly: boolean = false;
+  @Input() basicMode: boolean = false;
   @Output() bookSelect = new EventEmitter<number[]>();
 
   protected loaded = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -266,6 +266,11 @@ export function getUnsupportedTags(deltaOp: DeltaOperation): string[] {
   return [...invalidTags];
 }
 
+export function booksFromScriptureRange(scriptureRange: string): number[] {
+  if (scriptureRange === '') return [];
+  return scriptureRange.split(';').map(book => Canon.bookIdToNumber(book));
+}
+
 export class XmlUtils {
   /** Encode text to be valid xml text node. Escape reserved xml characters such as & and < >. */
   static encodeForXml(text: string): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -9,6 +9,7 @@ import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
 import { SelectableProject } from '../core/paratext.service';
+import { DraftSource } from '../translate/draft-generation/draft-sources.service';
 
 // Regular expression for getting the verse from a segment ref
 // Some projects will have the right to left marker in the segment attribute which we need to account for
@@ -190,7 +191,7 @@ export function checkAppAccess(
   }
 }
 
-export function projectLabel(project: SelectableProject | undefined): string {
+export function projectLabel(project: SelectableProject | DraftSource | undefined): string {
   if (project == null || (!project.shortName && !project.name)) {
     return '';
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -75,11 +75,13 @@
           </button>
         </div>
       </mat-step>
-      <mat-step [completed]="isTrainingOptional || userSelectedTrainingBooks.length > 0">
+      <mat-step [completed]="isTrainingOptional || userSelectedSourceTrainingBooks.length > 0">
         <ng-template matStepLabel>
           {{ t("choose_books_for_training_label") }}
         </ng-template>
         <h1 class="mat-headline-4">{{ t("choose_books_for_training") }}</h1>
+        <h2>{{ t("translated_books") }}</h2>
+        <p>{{ targetProjectName }}</p>
         <app-book-multi-select
           [availableBooks]="availableTrainingBooks"
           [selectedBooks]="initialSelectedTrainingBooks"
@@ -115,10 +117,30 @@
             </div>
           </app-notice>
         }
-        @if (unusableTranslateTargetBooks.length) {
-          <app-notice>
-            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-          </app-notice>
+        <h2>{{ t("reference_books") }}</h2>
+        <p>{{ trainingSourceProjectName }}</p>
+        @if (selectableTrainingBooks.length === 0) {
+          <app-notice mode="basic" type="light">{{ t("training_books_will_appear") }}</app-notice>
+        } @else {
+          <app-book-multi-select
+            [availableBooks]="selectableTrainingBooks"
+            [selectedBooks]="userSelectedSourceTrainingBooks"
+            [basicMode]="true"
+            (bookSelect)="onSourceTrainingBookSelect($event)"
+          ></app-book-multi-select>
+        }
+        @if (trainingAdditionalSourceProjectName != null) {
+          <p>{{ trainingAdditionalSourceProjectName }}</p>
+          @if (selectableAdditionalTrainingBooks.length === 0) {
+            <app-notice mode="basic" type="light">{{ t("training_books_will_appear") }}</app-notice>
+          } @else {
+            <app-book-multi-select
+              [availableBooks]="selectableAdditionalTrainingBooks"
+              [selectedBooks]="userSelectedAdditionalSourceTrainingBooks"
+              [basicMode]="true"
+              (bookSelect)="onAdditionalSourceTrainingBookSelect($event)"
+            ></app-book-multi-select>
+          }
         }
         @if (showBookSelectionError) {
           <app-notice type="error">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -75,7 +75,7 @@
           </button>
         </div>
       </mat-step>
-      <mat-step [completed]="!isTrainingOptional || userSelectedSourceTrainingBooks.length > 0">
+      <mat-step [completed]="isTrainingOptional || trainingSourceBooksSelected">
         <ng-template matStepLabel>
           {{ t("choose_books_for_training_label") }}
         </ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -75,16 +75,16 @@
           </button>
         </div>
       </mat-step>
-      <mat-step [completed]="isTrainingOptional || userSelectedSourceTrainingBooks.length > 0">
+      <mat-step [completed]="!isTrainingOptional || userSelectedSourceTrainingBooks.length > 0">
         <ng-template matStepLabel>
           {{ t("choose_books_for_training_label") }}
         </ng-template>
         <h1 class="mat-headline-4">{{ t("choose_books_for_training") }}</h1>
         <h2>{{ t("translated_books") }}</h2>
-        <p>{{ targetProjectName }}</p>
         <app-book-multi-select
           [availableBooks]="availableTrainingBooks"
           [selectedBooks]="initialSelectedTrainingBooks"
+          [projectName]="targetProjectName"
           (bookSelect)="onTrainingBookSelect($event)"
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
@@ -118,24 +118,28 @@
           </app-notice>
         }
         <h2>{{ t("reference_books") }}</h2>
-        <p>{{ trainingSourceProjectName }}</p>
-        @if (selectableTrainingBooks.length === 0) {
-          <app-notice mode="basic" type="light">{{ t("training_books_will_appear") }}</app-notice>
+        <p class="reference-project-label">{{ trainingSourceProjectName }}</p>
+        @if (selectableSourceTrainingBooks.length === 0) {
+          <app-notice mode="basic" type="light" class="books-appear-notice">{{
+            t("training_books_will_appear")
+          }}</app-notice>
         } @else {
           <app-book-multi-select
-            [availableBooks]="selectableTrainingBooks"
+            [availableBooks]="selectableSourceTrainingBooks"
             [selectedBooks]="userSelectedSourceTrainingBooks"
             [basicMode]="true"
             (bookSelect)="onSourceTrainingBookSelect($event)"
           ></app-book-multi-select>
         }
-        @if (trainingAdditionalSourceProjectName != null) {
-          <p>{{ trainingAdditionalSourceProjectName }}</p>
-          @if (selectableAdditionalTrainingBooks.length === 0) {
-            <app-notice mode="basic" type="light">{{ t("training_books_will_appear") }}</app-notice>
+        @if (trainingAdditionalSourceProjectName?.length > 0) {
+          <p class="reference-project-label">{{ trainingAdditionalSourceProjectName }}</p>
+          @if (selectableAdditionalSourceTrainingBooks.length === 0) {
+            <app-notice mode="basic" type="light" class="books-appear-notice">{{
+              t("training_books_will_appear")
+            }}</app-notice>
           } @else {
             <app-book-multi-select
-              [availableBooks]="selectableAdditionalTrainingBooks"
+              [availableBooks]="selectableAdditionalSourceTrainingBooks"
               [selectedBooks]="userSelectedAdditionalSourceTrainingBooks"
               [basicMode]="true"
               (bookSelect)="onAdditionalSourceTrainingBookSelect($event)"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -18,6 +18,10 @@ h1 {
   margin: 12px 0;
 }
 
+h2 {
+  font-weight: 500;
+}
+
 // Prevent font increase when selecting a step
 .mat-stepper-horizontal {
   --mat-stepper-header-selected-state-label-text-size: var(--mat-stepper-header-label-text-size);
@@ -95,6 +99,10 @@ app-notice {
     font-weight: 500;
     padding: 8px;
   }
+}
+
+.reference-project-label {
+  font-weight: 500;
 }
 
 .loading {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -618,9 +618,9 @@ describe('DraftGenerationStepsComponent', () => {
         translateConfig: {
           source: { projectRef: 'test' },
           draftConfig: {
-            lastSelectedTrainingBooks: [2, 3, 4],
             lastSelectedTrainingDataFiles: [],
-            lastSelectedTranslationBooks: [2, 3, 4]
+            lastSelectedTranslationScriptureRange: 'GEN;EXO',
+            lastSelectedTrainingScriptureRange: 'LEV'
           }
         }
       })
@@ -639,9 +639,9 @@ describe('DraftGenerationStepsComponent', () => {
       tick();
     }));
 
-    it('should restore previously selected books', () => {
-      expect(component.initialSelectedTrainingBooks).toEqual([2, 3]);
-      expect(component.initialSelectedTranslateBooks).toEqual([2, 3]);
+    it('should restore previously selected ranges', () => {
+      expect(component.initialSelectedTrainingBooks).toEqual([3]);
+      expect(component.initialSelectedTranslateBooks).toEqual([1, 2]);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -159,7 +159,6 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockProjectService.getProfile('alternateTrainingProject')).thenResolve(
         mockAlternateTrainingSourceProjectDoc
       );
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
       when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
       when(mockTrainingDataQuery.docs).thenReturn([]);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -59,6 +59,7 @@ describe('DraftGenerationStepsComponent', () => {
 
   const mockSourceNonNllbProjectDoc = {
     data: createTestProjectProfile({
+      paratextId: 'sourcePt1',
       texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 100 }],
       writingSystem: { tag: 'xyz' }
     })
@@ -73,6 +74,7 @@ describe('DraftGenerationStepsComponent', () => {
 
   const mockAlternateTrainingSourceProjectDoc = {
     data: createTestProjectProfile({
+      paratextId: 'sourcePtAlt1',
       texts: [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 8 }, { bookNum: 100 }],
       writingSystem: { tag: 'xyz' }
     })
@@ -80,6 +82,7 @@ describe('DraftGenerationStepsComponent', () => {
 
   const mockAdditionalTrainingSourceProjectDoc = {
     data: createTestProjectProfile({
+      paratextId: 'sourcePt2',
       texts: [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 8 }, { bookNum: 100 }],
       writingSystem: { tag: 'xyz' }
     })
@@ -226,6 +229,7 @@ describe('DraftGenerationStepsComponent', () => {
         trainingAlternateSourceId: 'alternateTrainingProject'
       };
       component.onStepChange();
+      fixture.detectChanges();
       expect(component.availableTrainingBooks).toEqual(trainingBooks);
       expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
       expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
@@ -352,7 +356,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingDataFiles,
         trainingScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'LEV' }],
-        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
+        translationScriptureRange: 'GEN;EXO',
         fastTraining: false
       } as DraftGenerationStepsResult);
       expect(component.isStepsCompleted).toBe(true);
@@ -425,10 +429,14 @@ describe('DraftGenerationStepsComponent', () => {
         data: createTestProjectProfile({
           texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 6 }, { bookNum: 7 }],
           translateConfig: {
-            source: { projectRef: 'sourceProject' },
+            source: { projectRef: 'sourceProject', writingSystem: { tag: 'xyz' }, paratextId: 'sourcePT1' },
             draftConfig: {
               additionalTrainingSourceEnabled: true,
-              additionalTrainingSource: { projectRef: 'sourceProject2' }
+              additionalTrainingSource: {
+                projectRef: 'sourceProject2',
+                writingSystem: { tag: 'xyz' },
+                paratextId: 'sourcePT2'
+              }
             }
           }
         })
@@ -493,7 +501,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(fixture.nativeElement.querySelector('.books-appear-notice')).not.toBeNull();
     });
 
-    it('should correctly emit the selected books when done', () => {
+    it('should correctly emit the selected books when done', fakeAsync(() => {
       const trainingBooks = [3];
       const trainingDataFiles: string[] = [];
       const translationBooks = [1, 2];
@@ -510,8 +518,12 @@ describe('DraftGenerationStepsComponent', () => {
       };
 
       spyOn(component.done, 'emit');
+      fixture.detectChanges();
+      clickConfirmLanguages(fixture);
       expect(component.isStepsCompleted).toBe(false);
       // Advance to the next step when at last step should emit books result
+      fixture.detectChanges();
+      component.tryAdvanceStep();
       fixture.detectChanges();
       component.tryAdvanceStep();
       fixture.detectChanges();
@@ -524,11 +536,11 @@ describe('DraftGenerationStepsComponent', () => {
           { projectId: 'sourceProject', scriptureRange: 'LEV' },
           { projectId: 'sourceProject2', scriptureRange: 'LEV' }
         ],
-        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
+        translationScriptureRange: 'GEN;EXO',
         fastTraining: false
       } as DraftGenerationStepsResult);
       expect(component.isStepsCompleted).toBe(true);
-    });
+    }));
 
     it('does not allow selecting not selectable additional source training books', () => {
       const trainingBooks = [3];
@@ -604,7 +616,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingDataFiles,
         trainingScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
-        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'LEV;NUM' }],
+        translationScriptureRange: 'LEV;NUM',
         fastTraining: true
       } as DraftGenerationStepsResult);
       expect(generateDraftButton['disabled']).toBe(true);
@@ -620,7 +632,7 @@ describe('DraftGenerationStepsComponent', () => {
           draftConfig: {
             lastSelectedTrainingDataFiles: [],
             lastSelectedTranslationScriptureRange: 'GEN;EXO',
-            lastSelectedTrainingScriptureRange: 'LEV'
+            lastSelectedTrainingScriptureRanges: [{ projectId: 'test', scriptureRange: 'LEV' }]
           }
         }
       })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -78,9 +78,18 @@ describe('DraftGenerationStepsComponent', () => {
     })
   } as SFProjectProfileDoc;
 
+  const mockAdditionalTrainingSourceProjectDoc = {
+    data: createTestProjectProfile({
+      texts: [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 8 }, { bookNum: 100 }],
+      writingSystem: { tag: 'xyz' }
+    })
+  } as SFProjectProfileDoc;
+
   const mockUserDoc = {
     data: createTestUser({
-      sites: { [environment.siteId]: { projects: ['alternateTrainingProject', 'sourceProject', 'test'] } }
+      sites: {
+        [environment.siteId]: { projects: ['alternateTrainingProject', 'sourceProject', 'test', 'sourceProject2'] }
+      }
     })
   } as UserDoc;
 
@@ -147,6 +156,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockProjectService.getProfile('alternateTrainingProject')).thenResolve(
         mockAlternateTrainingSourceProjectDoc
       );
+      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
       when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
       when(mockTrainingDataQuery.docs).thenReturn([]);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
@@ -201,6 +211,55 @@ describe('DraftGenerationStepsComponent', () => {
       verify(mockNoticeService.show(anything())).once();
       expect(component.stepper.selectedIndex).toBe(2);
     }));
+
+    it('should allow selecting books from the alternate training source project', () => {
+      const trainingBooks = [3];
+      const trainingDataFiles: string[] = [];
+      const translationBooks = [2];
+
+      component.userSelectedTrainingBooks = trainingBooks;
+      component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
+      component['draftSourceProjectIds'] = {
+        draftingSourceId: 'sourceProject',
+        trainingSourceId: 'sourceProject',
+        trainingAlternateSourceId: 'alternateTrainingProject'
+      };
+      component.onStepChange();
+      expect(component.availableTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
+      expect(fixture.nativeElement.querySelector('.books-appear-notice')).toBeNull();
+
+      component.onSourceTrainingBookSelect([]);
+      fixture.detectChanges();
+      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedSourceTrainingBooks).toEqual([]);
+      expect(fixture.nativeElement.querySelector('.books-appear-notice')).toBeNull();
+    });
+
+    it('does not allow selecting not selectable source training books', () => {
+      const trainingBooks = [3];
+      const trainingDataFiles: string[] = [];
+      const translationBooks = [2];
+
+      component.userSelectedTrainingBooks = trainingBooks;
+      component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
+      component['draftSourceProjectIds'] = {
+        draftingSourceId: 'sourceProject',
+        trainingSourceId: 'sourceProject',
+        trainingAlternateSourceId: 'alternateTrainingProject'
+      };
+      component.onStepChange();
+      expect(component.availableTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
+
+      component.onSourceTrainingBookSelect([2, 3]);
+      fixture.detectChanges();
+      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
+    });
   });
 
   describe('NO alternate training source project', () => {
@@ -259,6 +318,8 @@ describe('DraftGenerationStepsComponent', () => {
     it('should select no books initially', () => {
       expect(component.initialSelectedTrainingBooks).toEqual([]);
       expect(component.userSelectedTrainingBooks).toEqual([]);
+      expect(component.userSelectedSourceTrainingBooks).toEqual([]);
+      expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual([]);
       expect(component.initialSelectedTranslateBooks).toEqual([]);
       expect(component.userSelectedTranslateBooks).toEqual([]);
     });
@@ -271,6 +332,8 @@ describe('DraftGenerationStepsComponent', () => {
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
       component.selectedTrainingDataIds = trainingDataFiles;
+      component.userSelectedSourceTrainingBooks = trainingBooks;
+      component['draftSourceProjectIds'] = { draftingSourceId: 'sourceProject', trainingSourceId: 'sourceProject' };
 
       spyOn(component.done, 'emit');
       expect(component.isStepsCompleted).toBe(false);
@@ -287,11 +350,9 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
 
       expect(component.done.emit).toHaveBeenCalledWith({
-        trainingBooks: trainingBooks.filter(book => !translationBooks.includes(book)),
         trainingDataFiles,
-        trainingScriptureRanges: [],
-        translationBooks,
-        translationScriptureRanges: [],
+        trainingScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'LEV' }],
+        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
         fastTraining: false
       } as DraftGenerationStepsResult);
       expect(component.isStepsCompleted).toBe(true);
@@ -358,6 +419,143 @@ describe('DraftGenerationStepsComponent', () => {
     }));
   });
 
+  describe('additional training source project', () => {
+    beforeEach(fakeAsync(() => {
+      const mockTargetProjectDoc = {
+        data: createTestProjectProfile({
+          texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 6 }, { bookNum: 7 }],
+          translateConfig: {
+            source: { projectRef: 'sourceProject' },
+            draftConfig: {
+              additionalTrainingSourceEnabled: true,
+              additionalTrainingSource: { projectRef: 'sourceProject2' }
+            }
+          }
+        })
+      } as SFProjectProfileDoc;
+      when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
+      const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
+      when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
+      when(mockUserService.getCurrentUser()).thenResolve(mockUserDoc);
+      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockProjectService.getProfile('sourceProject')).thenResolve(mockSourceNonNllbProjectDoc);
+      when(mockProjectService.getProfile('sourceProject2')).thenResolve(mockAdditionalTrainingSourceProjectDoc);
+      when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
+      when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
+      when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
+      when(mockTrainingDataQuery.docs).thenReturn([]);
+
+      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+      component = fixture.componentInstance;
+      tick();
+      fixture.detectChanges();
+    }));
+
+    it('should show and hide selectable training source books when training books selected', () => {
+      const trainingBooks = [3];
+      const trainingDataFiles: string[] = [];
+      const translationBooks = [1, 2];
+
+      component.userSelectedTrainingBooks = [];
+      component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
+      component.userSelectedSourceTrainingBooks = [];
+      component.userSelectedAdditionalSourceTrainingBooks = [];
+      component['availableAdditionalTrainingBooks'] = trainingBooks;
+      component['draftSourceProjectIds'] = {
+        draftingSourceId: 'sourceProject',
+        trainingSourceId: 'sourceProject',
+        trainingAdditionalSourceId: 'sourceProject2'
+      };
+      component.onStepChange();
+      fixture.detectChanges();
+      expect(component.availableTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableSourceTrainingBooks).toEqual([]);
+      expect(component.selectableAdditionalSourceTrainingBooks).toEqual([]);
+      expect(fixture.nativeElement.querySelector('.books-appear-notice')).not.toBeNull();
+
+      // select a training book
+      component.onTrainingBookSelect(trainingBooks);
+      fixture.detectChanges();
+      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableAdditionalSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual(trainingBooks);
+      expect(fixture.nativeElement.querySelector('.books-appear-notice')).toBeNull();
+
+      // deselect all training books
+      component.onTrainingBookSelect([]);
+      fixture.detectChanges();
+      expect(component.selectableSourceTrainingBooks).toEqual([]);
+      expect(component.selectableAdditionalSourceTrainingBooks).toEqual([]);
+      expect(component.userSelectedSourceTrainingBooks).toEqual([]);
+      expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual([]);
+      expect(fixture.nativeElement.querySelector('.books-appear-notice')).not.toBeNull();
+    });
+
+    it('should correctly emit the selected books when done', () => {
+      const trainingBooks = [3];
+      const trainingDataFiles: string[] = [];
+      const translationBooks = [1, 2];
+
+      component.userSelectedTrainingBooks = trainingBooks;
+      component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
+      component.userSelectedSourceTrainingBooks = trainingBooks;
+      component.userSelectedAdditionalSourceTrainingBooks = trainingBooks;
+      component['draftSourceProjectIds'] = {
+        draftingSourceId: 'sourceProject',
+        trainingSourceId: 'sourceProject',
+        trainingAdditionalSourceId: 'sourceProject2'
+      };
+
+      spyOn(component.done, 'emit');
+      expect(component.isStepsCompleted).toBe(false);
+      // Advance to the next step when at last step should emit books result
+      fixture.detectChanges();
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+
+      expect(component.done.emit).toHaveBeenCalledWith({
+        trainingDataFiles,
+        trainingScriptureRanges: [
+          { projectId: 'sourceProject', scriptureRange: 'LEV' },
+          { projectId: 'sourceProject2', scriptureRange: 'LEV' }
+        ],
+        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
+        fastTraining: false
+      } as DraftGenerationStepsResult);
+      expect(component.isStepsCompleted).toBe(true);
+    });
+
+    it('does not allow selecting not selectable additional source training books', () => {
+      const trainingBooks = [3];
+      const trainingDataFiles: string[] = [];
+      const translationBooks = [1, 2];
+
+      component.userSelectedTrainingBooks = trainingBooks;
+      component.userSelectedTranslateBooks = translationBooks;
+      component.selectedTrainingDataIds = trainingDataFiles;
+      component['draftSourceProjectIds'] = {
+        draftingSourceId: 'sourceProject',
+        trainingSourceId: 'sourceProject',
+        trainingAdditionalSourceId: 'sourceProject2'
+      };
+      component.onStepChange();
+      expect(component.availableTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.selectableAdditionalSourceTrainingBooks).toEqual(trainingBooks);
+      expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual(trainingBooks);
+
+      component.onAdditionalSourceTrainingBookSelect([2, 3]);
+      fixture.detectChanges();
+      expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual(trainingBooks);
+    });
+  });
+
   describe('allow fast training feature flag is enabled', () => {
     beforeEach(fakeAsync(() => {
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
@@ -381,6 +579,8 @@ describe('DraftGenerationStepsComponent', () => {
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
       component.selectedTrainingDataIds = trainingDataFiles;
+      component.userSelectedSourceTrainingBooks = trainingBooks;
+      component['draftSourceProjectIds'] = { draftingSourceId: 'sourceProject', trainingSourceId: 'sourceProject' };
 
       spyOn(component.done, 'emit');
 
@@ -402,11 +602,9 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
 
       expect(component.done.emit).toHaveBeenCalledWith({
-        trainingBooks,
         trainingDataFiles,
-        trainingScriptureRanges: [],
-        translationBooks,
-        translationScriptureRanges: [],
+        trainingScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'GEN;EXO' }],
+        translationScriptureRanges: [{ projectId: 'sourceProject', scriptureRange: 'LEV;NUM' }],
         fastTraining: true
       } as DraftGenerationStepsResult);
       expect(generateDraftButton['disabled']).toBe(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -407,11 +407,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
       this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingScriptureRanges?.find(
         r => r.projectId === trainingSourceId
       )?.scriptureRange ?? '';
-    const trainingScriptureRange =
+    const trainingScriptureRange: string | undefined =
       this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingScriptureRange;
     if (previousTrainingRange === '' && trainingScriptureRange != null) {
-      previousTrainingRange =
-        this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingScriptureRange ?? '';
+      previousTrainingRange = trainingScriptureRange;
     }
     const previousBooks: Set<number> = new Set<number>(booksFromScriptureRange(previousTrainingRange));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -28,11 +28,9 @@ import { TrainingDataUploadDialogComponent } from '../training-data/training-dat
 import { TrainingDataService } from '../training-data/training-data.service';
 
 export interface DraftGenerationStepsResult {
-  trainingBooks: number[];
   trainingDataFiles: string[];
   trainingScriptureRange?: string;
   trainingScriptureRanges: ProjectScriptureRange[];
-  translationBooks: number[];
   translationScriptureRange?: string;
   translationScriptureRanges: ProjectScriptureRange[];
   fastTraining: boolean;
@@ -61,8 +59,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   availableTranslateBooks?: number[] = undefined;
   availableTrainingBooks: number[] = [];
-  selectableTrainingBooks: number[] = [];
-  selectableAdditionalTrainingBooks: number[] = [];
+  selectableSourceTrainingBooks: number[] = [];
+  selectableAdditionalSourceTrainingBooks: number[] = [];
   availableTrainingData: Readonly<TrainingData>[] = [];
 
   // Unusable books do not exist in the target or corresponding drafting/training source project
@@ -253,14 +251,22 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   onTrainingBookSelect(selectedBooks: number[]): void {
     const newBookSelections: number[] = selectedBooks.filter(b => !this.userSelectedTrainingBooks.includes(b));
-    this.userSelectedTrainingBooks = selectedBooks;
-    this.selectableTrainingBooks = selectedBooks;
-    this.selectableAdditionalTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+    this.userSelectedTrainingBooks = [...selectedBooks];
+    this.selectableSourceTrainingBooks = [...selectedBooks];
+    this.selectableAdditionalSourceTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
       selectedBooks.includes(b)
     );
+
+    // remove selected books that are no longer selectable
+    this.userSelectedSourceTrainingBooks = this.userSelectedSourceTrainingBooks.filter(b => selectedBooks.includes(b));
+    this.userSelectedAdditionalSourceTrainingBooks = this.userSelectedAdditionalSourceTrainingBooks.filter(b =>
+      selectedBooks.includes(b)
+    );
+
+    // automatically select books that are newly selected as training books
     for (const bookNum of newBookSelections) {
       this.userSelectedSourceTrainingBooks.push(bookNum);
-      if (this.selectableAdditionalTrainingBooks.includes(bookNum)) {
+      if (this.selectableAdditionalSourceTrainingBooks.includes(bookNum)) {
         this.userSelectedAdditionalSourceTrainingBooks.push(bookNum);
       }
     }
@@ -274,12 +280,14 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   onSourceTrainingBookSelect(selectedBooks: number[]): void {
-    this.userSelectedSourceTrainingBooks = selectedBooks;
+    this.userSelectedSourceTrainingBooks = this.selectableSourceTrainingBooks.filter(b => selectedBooks.includes(b));
     this.clearErrorMessage();
   }
 
   onAdditionalSourceTrainingBookSelect(selectedBooks: number[]): void {
-    this.userSelectedAdditionalSourceTrainingBooks = selectedBooks;
+    this.userSelectedAdditionalSourceTrainingBooks = this.selectableAdditionalSourceTrainingBooks.filter(b =>
+      selectedBooks.includes(b)
+    );
     this.clearErrorMessage();
   }
 
@@ -327,11 +335,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         this.userSelectedTranslateBooks
       );
       this.done.emit({
-        // TODO: Can trainingBooks and translationBooks be removed?
-        trainingBooks: this.userSelectedTrainingBooks,
         trainingScriptureRanges,
         trainingDataFiles: this.selectedTrainingDataIds,
-        translationBooks: this.userSelectedTranslateBooks,
         translationScriptureRanges: [translationScriptureRange],
         fastTraining: this.fastTraining
       });
@@ -356,8 +361,12 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
     this.initialSelectedTrainingBooks = newSelectedTrainingBooks;
     this.userSelectedTrainingBooks = [...newSelectedTrainingBooks];
-    this.selectableTrainingBooks = [...newSelectedTrainingBooks];
-    this.selectableAdditionalTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+    this.selectableSourceTrainingBooks = [...newSelectedTrainingBooks];
+    this.userSelectedSourceTrainingBooks = [...newSelectedTrainingBooks];
+    this.selectableAdditionalSourceTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+      newSelectedTrainingBooks.includes(b)
+    );
+    this.userSelectedAdditionalSourceTrainingBooks = this.selectableAdditionalSourceTrainingBooks.filter(b =>
       newSelectedTrainingBooks.includes(b)
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -116,6 +116,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     super();
   }
 
+  get trainingSourceBooksSelected(): boolean {
+    return this.userSelectedSourceTrainingBooks.length > 0 || this.userSelectedAdditionalSourceTrainingBooks.length > 0;
+  }
+
   ngOnInit(): void {
     this.subscribe(
       this.draftSourcesService.getDraftProjectSources().pipe(
@@ -314,12 +318,18 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         return;
       }
       this.isStepsCompleted = true;
-      const trainingScriptureRange: ProjectScriptureRange = this.convertToScriptureRange(
-        this.draftSourceProjectIds!.trainingAlternateSourceId ?? this.draftSourceProjectIds!.trainingSourceId,
-        this.userSelectedSourceTrainingBooks
-      );
+      const trainingScriptureRange: ProjectScriptureRange | undefined =
+        this.userSelectedSourceTrainingBooks.length > 0
+          ? this.convertToScriptureRange(
+              this.draftSourceProjectIds!.trainingAlternateSourceId ?? this.draftSourceProjectIds!.trainingSourceId,
+              this.userSelectedSourceTrainingBooks
+            )
+          : undefined;
 
-      const trainingScriptureRanges: ProjectScriptureRange[] = [trainingScriptureRange];
+      const trainingScriptureRanges: ProjectScriptureRange[] = [];
+      if (trainingScriptureRange != null) {
+        trainingScriptureRanges.push(trainingScriptureRange);
+      }
       // Use the additional training range if selected
       const useAdditionalTranslateRange: boolean = this.userSelectedAdditionalSourceTrainingBooks.length > 0;
       if (useAdditionalTranslateRange) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -18,7 +18,7 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
 import { SharedModule } from '../../../shared/shared.module';
-import { projectLabel } from '../../../shared/utils';
+import { booksFromScriptureRange, projectLabel } from '../../../shared/utils';
 import { NllbLanguageService } from '../../nllb-language.service';
 import { ConfirmSourcesComponent } from '../confirm-sources/confirm-sources.component';
 import { ProjectScriptureRange } from '../draft-generation';
@@ -391,12 +391,12 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   private setInitialTranslateBooks(availableBooks: number[]): void {
     // Get the previously selected translation books from the target project
-    const previousBooks: Set<number> = new Set<number>(
-      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTranslationBooks ?? []
-    );
+    const previousTranslationRange: string =
+      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTranslationScriptureRange ?? '';
+    const previousBooks: Set<number> = new Set<number>(booksFromScriptureRange(previousTranslationRange));
 
     // The intersection is all of the available books in the source project that match the target's previous books
-    const intersection = availableBooks.filter(bookNum => previousBooks.has(bookNum));
+    const intersection: number[] = availableBooks.filter(bookNum => previousBooks.has(bookNum));
 
     // Set the selected books to the intersection, or if the intersection is empty, do not select any
     this.initialSelectedTranslateBooks = intersection.length > 0 ? intersection : [];
@@ -405,12 +405,12 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   private setInitialTrainingBooks(availableBooks: number[]): void {
     // Get the previously selected training books from the target project
-    const previousBooks: Set<number> = new Set<number>(
-      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingBooks ?? []
-    );
+    const previousTrainingRange: string =
+      this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingScriptureRange ?? '';
+    const previousBooks: Set<number> = new Set<number>(booksFromScriptureRange(previousTrainingRange));
 
     // The intersection is all of the available books in the source project that match the target's previous books
-    const intersection = availableBooks.filter(bookNum => previousBooks.has(bookNum));
+    const intersection: number[] = availableBooks.filter(bookNum => previousBooks.has(bookNum));
 
     // Set the selected books to the intersection, or if the intersection is empty, do not select any
     this.initialSelectedTrainingBooks = intersection.length > 0 ? intersection : [];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -18,10 +18,11 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
 import { SharedModule } from '../../../shared/shared.module';
+import { projectLabel } from '../../../shared/utils';
 import { NllbLanguageService } from '../../nllb-language.service';
 import { ConfirmSourcesComponent } from '../confirm-sources/confirm-sources.component';
 import { ProjectScriptureRange } from '../draft-generation';
-import { DraftSource, DraftSourcesService } from '../draft-sources.service';
+import { DraftSource, DraftSourceIds, DraftSourcesService } from '../draft-sources.service';
 import { TrainingDataMultiSelectComponent } from '../training-data/training-data-multi-select.component';
 import { TrainingDataUploadDialogComponent } from '../training-data/training-data-upload-dialog.component';
 import { TrainingDataService } from '../training-data/training-data.service';
@@ -60,6 +61,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   availableTranslateBooks?: number[] = undefined;
   availableTrainingBooks: number[] = [];
+  selectableTrainingBooks: number[] = [];
+  selectableAdditionalTrainingBooks: number[] = [];
   availableTrainingData: Readonly<TrainingData>[] = [];
 
   // Unusable books do not exist in the target or corresponding drafting/training source project
@@ -72,14 +75,14 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   initialSelectedTranslateBooks: number[] = [];
   userSelectedTrainingBooks: number[] = [];
   userSelectedTranslateBooks: number[] = [];
+  userSelectedSourceTrainingBooks: number[] = [];
+  userSelectedAdditionalSourceTrainingBooks: number[] = [];
 
   selectedTrainingDataIds: string[] = [];
 
-  // When translate books are selected, they will be filtered out from this list
-  initialAvailableTrainingBooks: number[] = [];
-
   draftingSourceProjectName?: string;
   trainingSourceProjectName?: string;
+  trainingAdditionalSourceProjectName?: string;
   targetProjectName?: string;
 
   showBookSelectionError = false;
@@ -95,6 +98,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   protected languagesVerified = false;
   protected nextClickedOnLanguageVerification = false;
 
+  // When translate books are selected, they will be filtered out from this list
+  private initialAvailableTrainingBooks: number[] = [];
+  private availableAdditionalTrainingBooks: number[] = [];
+  private draftSourceProjectIds?: DraftSourceIds;
   private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
   private trainingDataSub?: Subscription;
 
@@ -114,13 +121,25 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   ngOnInit(): void {
     this.subscribe(
       this.draftSourcesService.getDraftProjectSources().pipe(
-        filter(({ target, source, alternateSource, alternateTrainingSource }) => {
-          this.setProjectDisplayNames(target, alternateSource ?? source, alternateTrainingSource);
+        filter(({ target, source, alternateSource, alternateTrainingSource, additionalTrainingSource }) => {
+          this.setProjectDisplayNames(
+            target,
+            alternateSource ?? source,
+            alternateTrainingSource,
+            additionalTrainingSource
+          );
           return target != null && source != null;
         })
       ),
       // Build book lists
-      async ({ target, source, alternateSource, alternateTrainingSource }) => {
+      async ({
+        target,
+        source,
+        alternateSource,
+        alternateTrainingSource,
+        additionalTrainingSource,
+        draftSourceIds
+      }) => {
         // The null values will have been filtered above
         target = target!;
         // Use the alternate source if specified, otherwise use the source
@@ -132,21 +151,20 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
           (await this.nllbLanguageService.isNllbLanguageAsync(draftingSource.writingSystem.tag));
 
         const draftingSourceBooks = new Set<number>();
-        let trainingSourceBooks = new Set<number>();
-
         for (const text of draftingSource.texts) {
           draftingSourceBooks.add(text.bookNum);
         }
 
-        if (alternateTrainingSource != null) {
-          for (const text of alternateTrainingSource.texts) {
-            trainingSourceBooks.add(text.bookNum);
-          }
-        } else {
-          // If no training source project, use drafting source project books
-          trainingSourceBooks = draftingSourceBooks;
-        }
+        let trainingSourceBooks: Set<number> =
+          alternateTrainingSource != null
+            ? new Set<number>(alternateTrainingSource.texts.map(t => t.bookNum))
+            : draftingSourceBooks;
+        let additionalTrainingSourceBooks: Set<number> | undefined =
+          additionalTrainingSource != null
+            ? new Set<number>(additionalTrainingSource?.texts.map(t => t.bookNum))
+            : undefined;
 
+        this.draftSourceProjectIds = draftSourceIds;
         this.availableTranslateBooks = [];
 
         // If book exists in both target and source, add to available books.
@@ -175,6 +193,9 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
           } else {
             this.unusableTrainingSourceBooks.push(bookNum);
           }
+          if (additionalTrainingSourceBooks != null && additionalTrainingSourceBooks.has(bookNum)) {
+            this.availableAdditionalTrainingBooks.push(bookNum);
+          }
         }
 
         // Store initially available training books that will be filtered to remove user selected translate books
@@ -201,7 +222,6 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
           // Query for all training data files in the project
           this.trainingDataQuery?.dispose();
           this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id);
-
           let projectChanged: boolean = true;
 
           // Subscribe to this query, and show these
@@ -232,12 +252,34 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   onTrainingBookSelect(selectedBooks: number[]): void {
+    const newBookSelections: number[] = selectedBooks.filter(b => !this.userSelectedTrainingBooks.includes(b));
     this.userSelectedTrainingBooks = selectedBooks;
+    this.selectableTrainingBooks = selectedBooks;
+    this.selectableAdditionalTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+      selectedBooks.includes(b)
+    );
+    for (const bookNum of newBookSelections) {
+      this.userSelectedSourceTrainingBooks.push(bookNum);
+      if (this.selectableAdditionalTrainingBooks.includes(bookNum)) {
+        this.userSelectedAdditionalSourceTrainingBooks.push(bookNum);
+      }
+    }
+
     this.clearErrorMessage();
   }
 
   onTrainingDataSelect(selectedTrainingDataIds: string[]): void {
     this.selectedTrainingDataIds = selectedTrainingDataIds;
+    this.clearErrorMessage();
+  }
+
+  onSourceTrainingBookSelect(selectedBooks: number[]): void {
+    this.userSelectedSourceTrainingBooks = selectedBooks;
+    this.clearErrorMessage();
+  }
+
+  onAdditionalSourceTrainingBookSelect(selectedBooks: number[]): void {
+    this.userSelectedAdditionalSourceTrainingBooks = selectedBooks;
     this.clearErrorMessage();
   }
 
@@ -264,12 +306,33 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
         return;
       }
       this.isStepsCompleted = true;
+      const trainingScriptureRange: ProjectScriptureRange = this.convertToScriptureRange(
+        this.draftSourceProjectIds!.trainingAlternateSourceId ?? this.draftSourceProjectIds!.trainingSourceId,
+        this.userSelectedSourceTrainingBooks
+      );
+
+      const trainingScriptureRanges: ProjectScriptureRange[] = [trainingScriptureRange];
+      // Use the additional training range if selected
+      const useAdditionalTranslateRange: boolean = this.userSelectedAdditionalSourceTrainingBooks.length > 0;
+      if (useAdditionalTranslateRange) {
+        trainingScriptureRanges.push(
+          this.convertToScriptureRange(
+            this.draftSourceProjectIds!.trainingAdditionalSourceId,
+            this.userSelectedAdditionalSourceTrainingBooks
+          )
+        );
+      }
+      const translationScriptureRange: ProjectScriptureRange = this.convertToScriptureRange(
+        this.draftSourceProjectIds!.draftingSourceId,
+        this.userSelectedTranslateBooks
+      );
       this.done.emit({
+        // TODO: Can trainingBooks and translationBooks be removed?
         trainingBooks: this.userSelectedTrainingBooks,
-        trainingScriptureRanges: [],
+        trainingScriptureRanges,
         trainingDataFiles: this.selectedTrainingDataIds,
         translationBooks: this.userSelectedTranslateBooks,
-        translationScriptureRanges: [],
+        translationScriptureRanges: [translationScriptureRange],
         fastTraining: this.fastTraining
       });
     }
@@ -277,7 +340,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
   /**
    * Filter selected translate books from available/selected training books.
-   * Currently, training books cannot in the set of translate books,
+   * Currently, training books cannot be in the set of translate books,
    * but this requirement may be removed in the future.
    */
   updateTrainingBooks(): void {
@@ -292,11 +355,19 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     );
 
     this.initialSelectedTrainingBooks = newSelectedTrainingBooks;
-    this.userSelectedTrainingBooks = newSelectedTrainingBooks;
+    this.userSelectedTrainingBooks = [...newSelectedTrainingBooks];
+    this.selectableTrainingBooks = [...newSelectedTrainingBooks];
+    this.selectableAdditionalTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+      newSelectedTrainingBooks.includes(b)
+    );
   }
 
   bookNames(books: number[]): string {
     return this.i18n.enumerateList(books.map(bookNum => this.i18n.localizeBook(bookNum)));
+  }
+
+  private convertToScriptureRange(projectId: string, books: number[]): ProjectScriptureRange {
+    return { projectId: projectId, scriptureRange: books.map(b => Canon.bookNumberToId(b)).join(';') };
   }
 
   private validateCurrentStep(): boolean {
@@ -320,7 +391,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
     // Set the selected books to the intersection, or if the intersection is empty, do not select any
     this.initialSelectedTranslateBooks = intersection.length > 0 ? intersection : [];
-    this.userSelectedTranslateBooks = this.initialSelectedTranslateBooks;
+    this.userSelectedTranslateBooks = [...this.initialSelectedTranslateBooks];
   }
 
   private setInitialTrainingBooks(availableBooks: number[]): void {
@@ -334,7 +405,11 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
     // Set the selected books to the intersection, or if the intersection is empty, do not select any
     this.initialSelectedTrainingBooks = intersection.length > 0 ? intersection : [];
-    this.userSelectedTrainingBooks = this.initialSelectedTrainingBooks;
+    this.userSelectedTrainingBooks = [...this.initialSelectedTrainingBooks];
+    this.userSelectedSourceTrainingBooks = [...this.initialSelectedTrainingBooks];
+    this.userSelectedAdditionalSourceTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
+      this.initialSelectedTrainingBooks.includes(b)
+    );
   }
 
   private setInitialTrainingDataFiles(availableDataFiles: string[]): void {
@@ -355,12 +430,14 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   private setProjectDisplayNames(
     target: DraftSource | undefined,
     draftingSource: DraftSource | undefined,
-    trainingSource: DraftSource | undefined
+    trainingSource: DraftSource | undefined,
+    additionalTrainingSource: DraftSource | undefined
   ): void {
-    this.targetProjectName = target != null ? `${target.shortName} - ${target.name}` : '';
-    this.draftingSourceProjectName =
-      draftingSource != null ? `${draftingSource.shortName} - ${draftingSource.name}` : '';
+    this.targetProjectName = target != null ? projectLabel(target) : '';
+    this.draftingSourceProjectName = draftingSource != null ? projectLabel(draftingSource) : '';
     this.trainingSourceProjectName =
-      trainingSource != null ? `${trainingSource.shortName} - ${trainingSource.name}` : this.draftingSourceProjectName;
+      trainingSource != null ? projectLabel(trainingSource) : this.draftingSourceProjectName;
+    this.trainingAdditionalSourceProjectName =
+      additionalTrainingSource != null ? projectLabel(additionalTrainingSource) : '';
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -185,7 +185,9 @@ describe('DraftGenerationComponent', () => {
             },
             draftConfig: {
               lastSelectedTrainingBooks: preTranslate ? [1] : [],
-              lastSelectedTranslationBooks: preTranslate ? [2] : []
+              lastSelectedTranslationBooks: preTranslate ? [2] : [],
+              lastSelectedTrainingScriptureRange: preTranslate ? 'GEN' : undefined,
+              lastSelectedTranslationScriptureRange: preTranslate ? 'EXO' : undefined
             }
           },
           texts: [
@@ -2367,7 +2369,7 @@ describe('DraftGenerationComponent', () => {
 
       // Update the has draft flag for the project
       projectDoc.data!.texts[0].chapters[0].hasDraft = true;
-      projectDoc.data!.translateConfig.draftConfig.lastSelectedTranslationBooks = [1];
+      projectDoc.data!.translateConfig.draftConfig.lastSelectedTranslationScriptureRange = 'GEN';
       projectSubject.next(projectDoc);
       buildSubject.next({ ...buildDto, state: BuildStates.Completed });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1974,10 +1974,8 @@ describe('DraftGenerationComponent', () => {
 
       env.component.currentPage = 'steps';
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -1986,10 +1984,8 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.currentPage).toBe('steps');
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });
@@ -2005,10 +2001,8 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -2016,10 +2010,8 @@ describe('DraftGenerationComponent', () => {
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Queued });
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });
@@ -2034,10 +2026,8 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -2045,10 +2035,8 @@ describe('DraftGenerationComponent', () => {
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Pending });
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });
@@ -2063,10 +2051,8 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -2074,10 +2060,8 @@ describe('DraftGenerationComponent', () => {
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Active });
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });
@@ -2093,10 +2077,8 @@ describe('DraftGenerationComponent', () => {
       env.component.cancelDialogRef = instance(mockDialogRef);
 
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -2104,10 +2086,8 @@ describe('DraftGenerationComponent', () => {
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Canceled });
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });
@@ -2122,10 +2102,8 @@ describe('DraftGenerationComponent', () => {
       });
 
       env.component.startBuild({
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false,
         projectId: projectId
@@ -2134,10 +2112,8 @@ describe('DraftGenerationComponent', () => {
 
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).toHaveBeenCalledWith({
         projectId: projectId,
-        trainingBooks: [],
         trainingDataFiles: [],
         trainingScriptureRanges: [],
-        translationBooks: [],
         translationScriptureRanges: [],
         fastTraining: false
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -456,7 +456,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
       trainingScriptureRange: result.trainingScriptureRange,
       trainingScriptureRanges: result.trainingScriptureRanges,
       translationScriptureRange: result.translationScriptureRange,
-      translationScriptureRanges: result.trainingScriptureRanges,
+      translationScriptureRanges: result.translationScriptureRanges,
       fastTraining: result.fastTraining
     });
   }
@@ -578,7 +578,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   private hasStartedBuild(projectDoc: SFProjectProfileDoc): boolean {
     return (
       projectDoc.data?.translateConfig.preTranslate === true &&
-      projectDoc.data?.translateConfig.draftConfig.lastSelectedTranslationBooks.length > 0
+      projectDoc.data?.translateConfig.draftConfig.lastSelectedTranslationScriptureRange != null
     );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -452,11 +452,9 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   onPreGenerationStepsComplete(result: DraftGenerationStepsResult): void {
     this.startBuild({
       projectId: this.activatedProject.projectId!,
-      trainingBooks: result.trainingBooks,
       trainingDataFiles: result.trainingDataFiles,
       trainingScriptureRange: result.trainingScriptureRange,
       trainingScriptureRanges: result.trainingScriptureRanges,
-      translationBooks: result.translationBooks,
       translationScriptureRange: result.translationScriptureRange,
       translationScriptureRanges: result.trainingScriptureRanges,
       fastTraining: result.fastTraining

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -41,10 +41,8 @@ describe('DraftGenerationService', () => {
   const projectId = 'testProjectId';
   const buildConfig: BuildConfig = {
     projectId,
-    trainingBooks: [],
     trainingDataFiles: [],
     translationScriptureRanges: [],
-    translationBooks: [],
     trainingScriptureRanges: [],
     fastTraining: false
   };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { ProjectScriptureRange } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { BuildStates } from '../../machine-api/build-states';
 
 /**
@@ -12,14 +13,6 @@ export interface BuildConfig {
   translationScriptureRange?: string;
   translationScriptureRanges: ProjectScriptureRange[];
   fastTraining: boolean;
-}
-
-/**
- * A per-project scripture range.
- */
-export interface ProjectScriptureRange {
-  projectId: string;
-  scriptureRange: string;
 }
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -6,11 +6,9 @@ import { BuildStates } from '../../machine-api/build-states';
  */
 export interface BuildConfig {
   projectId: string;
-  trainingBooks: number[];
   trainingDataFiles: string[];
   trainingScriptureRange?: string;
   trainingScriptureRanges: ProjectScriptureRange[];
-  translationBooks: number[];
   translationScriptureRange?: string;
   translationScriptureRanges: ProjectScriptureRange[];
   fastTraining: boolean;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
@@ -11,7 +11,7 @@ import { UserService } from 'xforge-common/user.service';
 import { environment } from '../../../environments/environment';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
-import { DraftSources, DraftSourcesService } from './draft-sources.service';
+import { DraftSource, DraftSources, DraftSourcesService } from './draft-sources.service';
 
 describe('DraftSourcesService', () => {
   let service: DraftSourcesService;
@@ -45,7 +45,14 @@ describe('DraftSourcesService', () => {
           source: undefined,
           alternateSource: undefined,
           alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
+          additionalTrainingSource: undefined,
+          draftSourceIds: {
+            draftingSourceId: undefined,
+            draftingAlternateSourceId: undefined,
+            trainingSourceId: undefined,
+            trainingAlternateSourceId: undefined,
+            trainingAdditionalSourceId: undefined
+          }
         } as DraftSources);
         done();
       });
@@ -141,6 +148,13 @@ describe('DraftSourcesService', () => {
               tag: 'en_UK'
             },
             noAccess: true
+          },
+          draftSourceIds: {
+            draftingSourceId: 'source_project',
+            draftingAlternateSourceId: 'alternate_source_project',
+            trainingSourceId: 'source_project',
+            trainingAlternateSourceId: 'alternate_training_source_project',
+            trainingAdditionalSourceId: 'additional_training_source_project'
           }
         } as DraftSources);
         done();
@@ -242,7 +256,14 @@ describe('DraftSourcesService', () => {
           source: sourceProject,
           alternateSource: alternateSourceProject,
           alternateTrainingSource: alternateTrainingSourceProject,
-          additionalTrainingSource: additionalTrainingSourceProject
+          additionalTrainingSource: additionalTrainingSourceProject,
+          draftSourceIds: {
+            draftingSourceId: 'source_project',
+            draftingAlternateSourceId: 'alternate_source_project',
+            trainingSourceId: 'source_project',
+            trainingAlternateSourceId: 'alternate_training_source_project',
+            trainingAdditionalSourceId: 'additional_training_source_project'
+          }
         } as DraftSources);
         done();
       });
@@ -271,13 +292,7 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
@@ -286,7 +301,7 @@ describe('DraftSourcesService', () => {
       const targetProject = createTestProjectProfile({
         translateConfig: {
           draftConfig: {
-            alternateSourceEnabled: false
+            alternateSourceEnabled: true
           }
         }
       });
@@ -297,13 +312,7 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
@@ -331,13 +340,7 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
@@ -346,7 +349,7 @@ describe('DraftSourcesService', () => {
       const targetProject = createTestProjectProfile({
         translateConfig: {
           draftConfig: {
-            alternateTrainingSourceEnabled: false
+            alternateTrainingSourceEnabled: true
           }
         }
       });
@@ -357,13 +360,7 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
@@ -391,13 +388,7 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
@@ -406,7 +397,7 @@ describe('DraftSourcesService', () => {
       const targetProject = createTestProjectProfile({
         translateConfig: {
           draftConfig: {
-            additionalTrainingSourceEnabled: false
+            additionalTrainingSourceEnabled: true
           }
         }
       });
@@ -417,15 +408,26 @@ describe('DraftSourcesService', () => {
       );
 
       service.getDraftProjectSources().subscribe(result => {
-        expect(result).toEqual({
-          target: targetProject,
-          source: undefined,
-          alternateSource: undefined,
-          alternateTrainingSource: undefined,
-          additionalTrainingSource: undefined
-        } as DraftSources);
+        expectTargetOnly(targetProject, result);
         done();
       });
     });
   });
+
+  function expectTargetOnly(targetProject: DraftSource, result: DraftSources): void {
+    expect(result).toEqual({
+      target: targetProject,
+      source: undefined,
+      alternateSource: undefined,
+      alternateTrainingSource: undefined,
+      additionalTrainingSource: undefined,
+      draftSourceIds: {
+        draftingSourceId: undefined,
+        draftingAlternateSourceId: undefined,
+        trainingSourceId: undefined,
+        trainingAlternateSourceId: undefined,
+        trainingAdditionalSourceId: undefined
+      }
+    } as DraftSources);
+  }
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
@@ -25,10 +25,11 @@ interface DraftSourceDoc {
 }
 
 export interface DraftSourceIds {
-  trainingSourceId: string;
+  trainingSourceId?: string;
   trainingAlternateSourceId?: string;
   trainingAdditionalSourceId?: string;
-  draftingSourceId: string;
+  draftingSourceId?: string;
+  draftingAlternateSourceId?: string;
 }
 
 export interface DraftSources {
@@ -129,9 +130,10 @@ export class DraftSourcesService {
               additionalTrainingSource: additionalTrainingSourceProjectDoc?.data,
               draftSourceIds: {
                 trainingSourceId: sourceProjectId,
-                trainingAlternateSourceId: alternateSourceProjectId,
+                trainingAlternateSourceId: alternateTrainingSourceProjectId,
                 trainingAdditionalSourceId: additionalTrainingSourceProjectId,
-                draftingSourceId: alternateSourceProjectId ?? sourceProjectId
+                draftingSourceId: sourceProjectId,
+                draftingAlternateSourceId: alternateSourceProjectId
               }
             };
           })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
@@ -23,12 +23,21 @@ export interface DraftSource {
 interface DraftSourceDoc {
   data: DraftSource;
 }
+
+export interface DraftSourceIds {
+  trainingSourceId: string;
+  trainingAlternateSourceId?: string;
+  trainingAdditionalSourceId?: string;
+  draftingSourceId: string;
+}
+
 export interface DraftSources {
   target?: Readonly<DraftSource>;
   source?: Readonly<DraftSource>;
   alternateSource?: Readonly<DraftSource>;
   alternateTrainingSource?: Readonly<DraftSource>;
   additionalTrainingSource?: Readonly<DraftSource>;
+  draftSourceIds?: DraftSourceIds;
 }
 
 @Injectable({
@@ -117,7 +126,13 @@ export class DraftSourcesService {
               source: sourceDoc?.data,
               alternateSource: alternateSourceDoc?.data,
               alternateTrainingSource: alternateTrainingSourceDoc?.data,
-              additionalTrainingSource: additionalTrainingSourceProjectDoc?.data
+              additionalTrainingSource: additionalTrainingSourceProjectDoc?.data,
+              draftSourceIds: {
+                trainingSourceId: sourceProjectId,
+                trainingAlternateSourceId: alternateSourceProjectId,
+                trainingAdditionalSourceId: additionalTrainingSourceProjectId,
+                draftingSourceId: alternateSourceProjectId ?? sourceProjectId
+              }
             };
           })
         );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -266,7 +266,7 @@ class TestEnvironment {
       ],
       translateConfig: {
         preTranslate: true,
-        draftConfig: { lastSelectedTranslationBooks: [40], lastSelectedTrainingBooks: [41] }
+        draftConfig: { lastSelectedTranslationScriptureRange: 'MAT', lastSelectedTrainingScriptureRange: 'MRK' }
       },
       userRoles: TestEnvironment.rolesByUser,
       biblicalTermsConfig: { biblicalTermsEnabled: true }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -251,8 +251,11 @@
     "next": "Next",
     "no_available_books": "You have no books available for drafting.",
     "overview": "Overview",
+    "reference_books": "Reference books",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ trainingSourceProjectName }}).",
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
+    "training_books_will_appear": "Training books will appear as you select books under translated books",
+    "translated_books": "Translated books",
     "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project."
   },
   "draft_preview_books": {


### PR DESCRIPTION
This PR adds the ability to mix in training data from multiple sources. See the [balsamiq](https://balsamiq.cloud/sghq53/pejrlz8/r5325) for the original design.

No training books selected
![Mixed Training No Books Selected](https://github.com/user-attachments/assets/413fbceb-f9f3-4bff-ac04-e995403f62f9)

Training books selected
![Mixed training current books selected](https://github.com/user-attachments/assets/98f492cd-6c84-4cee-9e5a-ef028dd5ad12)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2875)
<!-- Reviewable:end -->
