### PR TITLE
SF-3100 Move to next question when previous question is archived

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -447,7 +447,7 @@ describe('CheckingComponent', () => {
         projectChapterRoute: 1,
         questionScope: 'chapter'
       });
-      env.selectQuestion(1);
+      env.selectQuestion(2);
       const question = env.component.answersPanel!.questionDoc!.data!;
       expect(question.isArchived).toBe(false);
       expect(env.component.questionDocs.length).toEqual(14);
@@ -459,6 +459,7 @@ describe('CheckingComponent', () => {
       expect(question.isArchived).toBe(true);
       expect(env.component.questionDocs.length).toEqual(13);
       expect(env.component.questionVerseRefs.length).toEqual(13);
+      expect(env.component.questionsList.activeQuestionDoc.id).toBe('project01:q3Id');
     }));
 
     it('opens a dialog when edit question is clicked', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -777,6 +777,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         break;
       case 'archive':
         this._scriptureAudioPlayer?.pause();
+        this.activateQuestion(this.nextQuestion);
         break;
       case 'like':
         if (answerAction.answer != null) {


### PR DESCRIPTION
This PR updates the behaviour so that when a question is archived from the Community Checking page by an admin, the current question is moved to the next question instead of moving back a question.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2877)
<!-- Reviewable:end -->
