### PR TITLE
Dependency Security Updates

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="NPOI" Version="2.7.1" />
+    <PackageReference Include="NPOI" Version="2.7.2" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.5" />
@@ -41,6 +41,12 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+  </ItemGroup>
+  <!-- Override vulnerable versions of ParatextData dependencies -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.6" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.IO.Packaging" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -15,9 +15,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.7" />
     <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
-    <PackageReference Include="MailKit" Version="4.7.0" />
+    <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="idunno.Authentication.Basic" Version="2.3.1" />
     <PackageReference Include="AbrarJahin.DiffMatchPatch" Version="0.1.0" />
     <PackageReference Include="SIL.Core" Version="13.0.1" />
+  </ItemGroup>
+  <!-- Override vulnerable versions of dependencies -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -19,10 +19,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />

--- a/test/SIL.XForge.Scripture.Tests/Services/FileSystemServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/FileSystemServiceTests.cs
@@ -4,8 +4,9 @@ using System.Text;
 using NUnit.Framework;
 using Paratext.Data.ProjectComments;
 using Paratext.Data.Users;
+using SIL.XForge.Services;
 
-namespace SIL.XForge.Services;
+namespace SIL.XForge.Scripture.Services;
 
 [TestFixture]
 public class FileSystemServiceTests
@@ -15,7 +16,7 @@ public class FileSystemServiceTests
     {
         var env = new TestEnvironment();
         using MemoryStream stream = new MemoryStream();
-        CommentList data = new CommentList();
+        CommentList data = [];
 
         // SUT
         env.Service.WriteXmlFile(stream, data);
@@ -37,13 +38,13 @@ public class FileSystemServiceTests
     {
         var env = new TestEnvironment();
         using MemoryStream stream = new MemoryStream();
-        CommentList data = new CommentList();
+        CommentList data = [];
         string xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n";
         xml += "<CommentList />";
 
         // Get the XML as a byte array with BOM
         Encoding encoding = new UTF8Encoding(true);
-        byte[] expected = encoding.GetPreamble().Concat(encoding.GetBytes(xml)).ToArray();
+        byte[] expected = [.. encoding.GetPreamble().Concat(encoding.GetBytes(xml))];
 
         // SUT
         env.Service.WriteXmlFile(stream, data);
@@ -72,9 +73,9 @@ public class FileSystemServiceTests
         const bool hideInTextWindow = false;
         const string contents = "Plain Text";
 
-        // Setup the Comment List
-        CommentList data = new CommentList
-        {
+        // Set up the Comment List
+        CommentList data =
+        [
             new Comment(new DummyParatextUser(user))
             {
                 Thread = thread,
@@ -89,7 +90,7 @@ public class FileSystemServiceTests
                 ReplyToUser = string.Empty,
                 HideInTextWindow = false,
             },
-        };
+        ];
         data.First().AddTextToContent(contents, false);
 
         // Setup the XML data for comparison
@@ -115,7 +116,7 @@ public class FileSystemServiceTests
 
         // Get the XML as a byte array with BOM
         Encoding encoding = new UTF8Encoding(true);
-        byte[] expected = encoding.GetPreamble().Concat(encoding.GetBytes(xml)).ToArray();
+        byte[] expected = [.. encoding.GetPreamble().Concat(encoding.GetBytes(xml))];
 
         // SUT
         env.Service.WriteXmlFile(stream, data);
@@ -125,8 +126,6 @@ public class FileSystemServiceTests
 
     private class TestEnvironment
     {
-        public TestEnvironment() => Service = new FileSystemService();
-
-        public IFileSystemService Service { get; }
+        public IFileSystemService Service { get; } = new FileSystemService();
     }
 }

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="ParatextData" Version="9.5.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIL.XForge\SIL.XForge.csproj" />

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -20,10 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SIL.XForge\SIL.XForge.csproj" />


### PR DESCRIPTION
This PR updates some package dependencies that contain known vulnerabilities:

_I have updated these to the minimum fix versions to reduce incompatibilities._

 - NPOI 2.7.1 to 2.7.2
 - MailKit 4.7.0 to 4.8.0
 - Update dependencies of dependencies that dotnet reports as vulnerable:
    - Microsoft.Windows.Compatibility from 6.0.0 to 6.0.6
    - System.Data.SqlClient from 4.8.3 to 4.8.6
    - System.IO.Packaging 6.0.0 to 6.0.1
    - System.Text.Json 7.0.3 to 8.0.5
    - System.Text.RegularExpressions 4.3.0 to 4.3.1
 - Move FileSystemServiceTests to SIL.XForge.Scripture .Tests so that ParatextData is no longer a dependency of SIL.XForge.Tests.

Not Fixed:

 - BugSnag. BugSnag plan to update this in Q1 2025 (see https://github.com/bugsnag/bugsnag-dotnet/issues/170).
    - The only other alternative would have been to re-implement this ourselves, as Serval has done (see https://github.com/sillsdev/serval/issues/544)
  - DotNetZip. There is no planned update for this vulnerability. ParatextData uses this library, so we have little choice but to continue with it until ParatextData is updated to use another library like SharpZipLib or sharpcompress.

I also updated test dependencies as these are low risk.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2878)
<!-- Reviewable:end -->
