### PR TITLE
Add support for showing timezone in date format

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -121,6 +121,20 @@ describe('I18nService', () => {
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
   });
 
+  it('should support including the timezone in the date', () => {
+    const date = new Date('November 25, 1991 17:28');
+    const service = getI18nService();
+
+    // look for ending with something like " UTC+5" or " EST"
+    const trailingTimezoneRegex = / (UTC[\-+−]\d+|[A-Z]+)$/;
+
+    service.setLocale('fr');
+    expect(service.formatDate(date, { showTimeZone: true })).toMatch(trailingTimezoneRegex);
+
+    service.setLocale('az');
+    expect(service.formatDate(date, { showTimeZone: true })).toMatch(trailingTimezoneRegex);
+  });
+
   it('should interpolate translations around and within numbered template tags', done => {
     when(mockedTranslocoService.selectTranslate<string>('app.settings', anything())).thenReturn(
       of('A quick brown { 1 }fox{ 2 } jumps over the lazy { 3 }dog{ 4 }.')


### PR DESCRIPTION
This is the code that was just temporarily on live for including the timezone in a date.

The tests however are new.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2887)
<!-- Reviewable:end -->
