### PR TITLE
Add global notices component with upcoming downtime message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -197,6 +197,7 @@
     <!-- The cdkScrollable attribute is needed so the CDK can listen to scroll events within this container -->
     <div #appContent cdkScrollable class="app-content" [dir]="i18n.direction">
       <div>
+        <app-global-notices></app-global-notices>
         <router-outlet></router-outlet>
         @if (showCheckingDisabled) {
           <p class="checking-unavailable">{{ t("scripture_checking_not_available") }}</p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { ProjectComponent } from './project/project.component';
 import { ScriptureChooserDialogComponent } from './scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { DeleteProjectDialogComponent } from './settings/delete-project-dialog/delete-project-dialog.component';
 import { SettingsComponent } from './settings/settings.component';
+import { GlobalNoticesComponent } from './shared/global-notices/global-notices.component';
 import { SharedModule } from './shared/shared.module';
 import { TextNoteDialogComponent } from './shared/text/text-note-dialog/text-note-dialog.component';
 import { SyncComponent } from './sync/sync.component';
@@ -75,7 +76,8 @@ import { UsersModule } from './users/users.module';
     AppRoutingModule,
     SharedModule,
     AvatarComponent,
-    MatRipple
+    MatRipple,
+    GlobalNoticesComponent
   ],
   providers: [
     CookieService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
@@ -1,0 +1,20 @@
+<ng-container *transloco="let t; read: 'global_notices'">
+  @if (showDowntimeNotice) {
+    <app-notice class="downtime-notice" type="warning" mode="fill-dark" icon="construction">
+      <div class="downtime-notice-content-wrapper">
+        <div>
+          {{
+            t("upcoming_maintenance", {
+              duration,
+              startTime: i18n.formatDate(upcomingDowntime.start, { showTimeZone: true })
+            })
+          }}
+          <a [href]="upcomingDowntime.detailsUrl" target="_blank">{{ t("learn_more") }}</a>
+        </div>
+        <button mat-icon-button (click)="showDowntimeNotice = false" [matTooltip]="t('close')">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    </app-notice>
+  }
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.scss
@@ -1,0 +1,12 @@
+.downtime-notice {
+  margin: 0 auto 12px;
+  padding-block: 6px;
+  width: 65em;
+  max-width: 100%;
+}
+
+.downtime-notice-content-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslocoModule } from '@ngneat/transloco';
+import { I18nService } from 'xforge-common/i18n.service';
+import { NoticeComponent } from '../notice/notice.component';
+
+@Component({
+  selector: 'app-global-notices',
+  standalone: true,
+  imports: [CommonModule, NoticeComponent, MatIconModule, MatButtonModule, MatTooltipModule, TranslocoModule],
+  templateUrl: './global-notices.component.html',
+  styleUrl: './global-notices.component.scss'
+})
+export class GlobalNoticesComponent {
+  // This is only an input so that the Storybook can turn this on even when it's off in the app
+  @Input() showDowntimeNotice = false;
+
+  upcomingDowntime = {
+    start: new Date('2024-12-04 16:30 UTC'),
+    durationMin: 2,
+    durationMax: 6,
+    durationUnit: 'hour',
+    detailsUrl: 'https://software.sil.org/scriptureforge/scripture-forge-will-be-unavailable-for-scheduled-maintenance/'
+  } as const;
+
+  constructor(readonly i18n: I18nService) {}
+
+  get duration(): string {
+    return this.i18n.translateStatic(`global_notices.${this.upcomingDowntime.durationUnit}_range`, {
+      min: this.upcomingDowntime.durationMin,
+      max: this.upcomingDowntime.durationMax
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.stories.ts
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { GlobalNoticesComponent } from './global-notices.component';
+
+const meta: Meta<GlobalNoticesComponent> = {
+  title: 'Shared/Global Notices',
+  component: GlobalNoticesComponent
+};
+
+export default meta;
+type Story = StoryObj<GlobalNoticesComponent>;
+
+export const Default: Story = {
+  args: { showDowntimeNotice: true }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -343,6 +343,13 @@
   "font_size": {
     "text_size": "Text size"
   },
+  "global_notices": {
+    "close": "Close",
+    "hour_range": "{{ min }} to {{ max }} hours",
+    "learn_more": "Learn more",
+    "minute_range": "{{ min }} to {{ max }} minutes",
+    "upcoming_maintenance": "Scripture Forge will be down for maintenance for about {{ duration }} starting at {{ startTime }}."
+  },
   "issue_email": {
     "heading": "Please explain the problem.",
     "technical_details": "Technical details",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -239,6 +239,13 @@ export class I18nService {
     return this.transloco.selectTranslate<string>(key, params);
   }
 
+  /** Returns a translation for the given I18nKey. A string is returned, so this cannot be used to keep a localization
+   * updated without re-calling this whenever the locale changes. Avoid using this when observing a localization is
+   * possible. */
+  translateStatic(key: I18nKey, params: object = {}): string {
+    return this.transloco.translate(key, params);
+  }
+
   translateAndInsertTags(key: I18nKey, params: object = {}): string {
     return this.transloco.translate(key, {
       ...params,


### PR DESCRIPTION
This is based off the recent downtime notice that was pushed as a hotfix to live.

This branch:
- Adds a component that shows up globally and can list notices
- Adds a single notice about upcoming downtime (but keeps it hidden)

![](https://github.com/user-attachments/assets/cb5c741a-b084-4647-88d7-a5de8714a9eb)

This is mainly about creating a slot in the UI for showing notices. There are a lot of options for how we might be able to load these notices in the future.

One important aspect of this change is that it adds localization strings for an "upcoming maintenance" notice. By getting this into the project, we can hopefully have it localized before downtime is going to occur, and reuse it as many times as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2888)
<!-- Reviewable:end -->
