### PR TITLE
Remove unused private members from TypeScript files

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -8,7 +8,6 @@ import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question
 import { toStartAndEndVerseRefs } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { NoticeService } from 'xforge-common/notice.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
@@ -63,7 +62,6 @@ export class QuestionDialogComponent extends SubscriptionDisposable implements O
   constructor(
     private readonly dialogRef: MatDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>,
     @Inject(MAT_DIALOG_DATA) private data: QuestionDialogData,
-    private noticeService: NoticeService,
     readonly i18n: I18nService,
     readonly dialogService: DialogService
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -2,7 +2,6 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
-  DestroyRef,
   ElementRef,
   EventEmitter,
   Input,
@@ -246,7 +245,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   private _placeholder?: string;
   private currentUserDoc?: UserDoc;
   private readonly cursorColorStorageKey = 'cursor_color';
-  private displayMessage: string = '';
   private isDestroyed: boolean = false;
   private localPresenceChannel?: LocalPresence<PresenceData>;
   private localPresenceDoc?: LocalPresence<RangeStatic | null>;
@@ -266,7 +264,6 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     private readonly transloco: TranslocoService,
     private readonly userService: UserService,
     private readonly viewModel: TextViewModel,
-    private readonly destroyRef: DestroyRef,
     private readonly textDocService: TextDocService
   ) {
     super();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -27,7 +27,6 @@ import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { isString } from '../../../../type-utils';
 import { Delta, TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
-import { TextDocService } from '../../../core/text-doc.service';
 import { TextComponent } from '../../../shared/text/text.component';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { DraftHandlingService } from '../../draft-generation/draft-handling.service';
@@ -68,8 +67,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     readonly fontService: FontService,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
-    readonly onlineStatusService: OnlineStatusService,
-    private readonly textDocService: TextDocService
+    readonly onlineStatusService: OnlineStatusService
   ) {}
 
   ngOnChanges(): void {


### PR DESCRIPTION
These were found by temporarily adding `"noUnusedLocals": true` to `src/SIL.XForge.Scripture/ClientApp/tsconfig.json`.

I did not persist the config change because the FeatureFlagService has private properties that are accessed via `Object.values(this)`, but appear to not be used when only statically analyzed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2890)
<!-- Reviewable:end -->
