### PR TITLE
Fix broken unit tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -46,6 +46,7 @@ import { SF_TYPE_REGISTRY } from './core/models/sf-type-registry';
 import { PermissionsService } from './core/permissions.service';
 import { SFProjectService } from './core/sf-project.service';
 import { NavigationComponent } from './navigation/navigation.component';
+import { GlobalNoticesComponent } from './shared/global-notices/global-notices.component';
 import { NmtDraftAuthGuard, SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from './shared/project-router.guard';
 import { paratextUsersFromRoles } from './shared/test-utils';
 
@@ -99,7 +100,8 @@ describe('AppComponent', () => {
       TestTranslocoModule,
       TestOnlineStatusModule.forRoot(),
       TestRealtimeModule.forRoot(SF_TYPE_REGISTRY),
-      AvatarComponent
+      AvatarComponent,
+      GlobalNoticesComponent
     ],
     providers: [
       { provide: AuthService, useMock: mockedAuthService },

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -125,8 +125,8 @@ describe('I18nService', () => {
     const date = new Date('November 25, 1991 17:28');
     const service = getI18nService();
 
-    // look for ending with something like " UTC+5" or " EST"
-    const trailingTimezoneRegex = / (UTC[\-+−]\d+|[A-Z]+)$/;
+    // look for ending with something like " GMT+13", " UTC+5", " UTC+13:45" or " EST"
+    const trailingTimezoneRegex = / ((GMT|UTC)[\-+−]\d{1,2}(:\d{2})?|[A-Z]+)$/;
 
     service.setLocale('fr');
     expect(service.formatDate(date, { showTimeZone: true })).toMatch(trailingTimezoneRegex);


### PR DESCRIPTION
This PR fixes front end unit tests that are not behaving correctly:

 * Time zone in date unit test fails in New Zealand and time zones that are not whole hours (i.e. India)
 * Error in `AppComponent`:
```
ERROR: 'NG0304: 'app-global-notices' is not a known element (used in the 'AppComponent' component template):
1. If 'app-global-notices' is an Angular component, then verify that it is a part of an @NgModule where this component is declared.
2. If 'app-global-notices' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.', [[[...]]]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2891)
<!-- Reviewable:end -->
