### PR TITLE
SF-3108 Do not allow generating drafts in draft wizard when offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -149,7 +149,7 @@ describe('DraftGenerationStepsComponent', () => {
       );
       when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
       when(mockTrainingDataQuery.docs).thenReturn([]);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(true));
+      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -177,13 +177,29 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should not advance steps if user is offline', fakeAsync(() => {
-      expect(component.stepper.selectedIndex).toBe(0);
       when(mockOnlineStatusService.isOnline).thenReturn(false);
+      expect(component.stepper.selectedIndex).toBe(0);
+      component['languagesVerified'] = true;
+      fixture.detectChanges();
+      // Go to translation books
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      component.userSelectedTranslateBooks = [1];
+      fixture.detectChanges();
+      // Go to training books
       component.tryAdvanceStep();
       tick();
       fixture.detectChanges();
+      verify(mockNoticeService.show(anything())).never();
+      expect(component.stepper.selectedIndex).toBe(2);
+      component.userSelectedTrainingBooks = [2, 3];
+      tick();
+      fixture.detectChanges();
+      // Attempt to generate draft
+      component.tryAdvanceStep();
+      fixture.detectChanges();
       verify(mockNoticeService.show(anything())).once();
-      expect(component.stepper.selectedIndex).toBe(0);
+      expect(component.stepper.selectedIndex).toBe(2);
     }));
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -6,11 +6,14 @@ import { ActivatedRoute } from '@angular/router';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { BehaviorSubject, of } from 'rxjs';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
@@ -35,6 +38,9 @@ describe('DraftGenerationStepsComponent', () => {
   const mockTrainingDataService = mock(TrainingDataService);
   const mockUserService = mock(UserService);
   const mockProgressService = mock(ProgressService);
+  const mockOnlineStatusService = mock(OnlineStatusService);
+  const mockNoticeService = mock(NoticeService);
+  const mockI18nService = mock(I18nService);
 
   const mockTargetProjectDoc = {
     data: createTestProjectProfile({
@@ -67,7 +73,8 @@ describe('DraftGenerationStepsComponent', () => {
 
   const mockAlternateTrainingSourceProjectDoc = {
     data: createTestProjectProfile({
-      texts: [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 8 }, { bookNum: 100 }]
+      texts: [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 4 }, { bookNum: 5 }, { bookNum: 8 }, { bookNum: 100 }],
+      writingSystem: { tag: 'xyz' }
     })
   } as SFProjectProfileDoc;
 
@@ -95,7 +102,10 @@ describe('DraftGenerationStepsComponent', () => {
       { provide: TrainingDataService, useMock: mockTrainingDataService },
       { provide: UserService, useMock: mockUserService },
       { provide: ProgressService, useMock: mockProgressService },
-      { provide: ActivatedRoute, useMock: mockActivatedRoute }
+      { provide: ActivatedRoute, useMock: mockActivatedRoute },
+      { provide: OnlineStatusService, useMock: mockOnlineStatusService },
+      { provide: NoticeService, useMock: mockNoticeService },
+      { provide: I18nService, useMock: mockI18nService }
     ]
   }));
 
@@ -110,20 +120,23 @@ describe('DraftGenerationStepsComponent', () => {
       { text: { bookNum: 6 } } as TextProgress,
       { text: { bookNum: 7 } } as TextProgress
     ]);
+    when(mockOnlineStatusService.isOnline).thenReturn(true);
+    when(mockI18nService.localeCode).thenReturn('en');
   }));
 
-  describe('alternate training source project', () => {
+  describe('alternate training source project', async () => {
     beforeEach(fakeAsync(() => {
       const mockTargetProjectDoc = {
         data: createTestProjectProfile({
           texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 6 }, { bookNum: 7 }],
           translateConfig: {
-            source: { projectRef: 'sourceProject' },
+            source: { projectRef: 'sourceProject', writingSystem: { tag: 'xyz' } },
             draftConfig: {
               alternateTrainingSourceEnabled: true,
-              alternateTrainingSource: { projectRef: 'alternateTrainingProject' }
+              alternateTrainingSource: { projectRef: 'alternateTrainingProject', writingSystem: { tag: 'xyz' } }
             }
-          }
+          },
+          writingSystem: { tag: 'eng' }
         })
       } as SFProjectProfileDoc;
       const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
@@ -136,11 +149,13 @@ describe('DraftGenerationStepsComponent', () => {
       );
       when(mockTrainingDataService.queryTrainingDataAsync(anything())).thenResolve(instance(mockTrainingDataQuery));
       when(mockTrainingDataQuery.docs).thenReturn([]);
+      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(true));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
       tick();
+      fixture.detectChanges();
     }));
 
     it('should set "availableTranslateBooks" correctly', fakeAsync(() => {
@@ -159,6 +174,16 @@ describe('DraftGenerationStepsComponent', () => {
     it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
       expect(component.unusableTranslateTargetBooks).toEqual([4, 5]);
       expect(component.unusableTrainingTargetBooks).toEqual([4, 5, 8]);
+    }));
+
+    it('should not advance steps if user is offline', fakeAsync(() => {
+      expect(component.stepper.selectedIndex).toBe(0);
+      when(mockOnlineStatusService.isOnline).thenReturn(false);
+      component.tryAdvanceStep();
+      tick();
+      fixture.detectChanges();
+      verify(mockNoticeService.show(anything())).once();
+      expect(component.stepper.selectedIndex).toBe(0);
     }));
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -249,10 +249,6 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   tryAdvanceStep(): void {
-    if (!this.onlineStatusService.isOnline) {
-      this.noticeService.show(translate('draft_generation.offline_message'));
-      return;
-    }
     if (!this.validateCurrentStep()) {
       return;
     }
@@ -260,6 +256,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     if (this.stepper.selected !== this.stepper.steps.last) {
       this.stepper.next();
     } else {
+      if (!this.onlineStatusService.isOnline) {
+        this.noticeService.show(translate('draft_generation.offline_message'));
+        return;
+      }
       this.isStepsCompleted = true;
       this.done.emit({
         trainingBooks: this.userSelectedTrainingBooks,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,15 +1,17 @@
 import { Component, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
-import { TranslocoModule } from '@ngneat/transloco';
+import { translate, TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
-import { Subscription, merge } from 'rxjs';
+import { merge, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
@@ -99,7 +101,9 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     readonly featureFlags: FeatureFlagService,
     private readonly nllbLanguageService: NllbLanguageService,
     private readonly trainingDataService: TrainingDataService,
-    readonly i18n: I18nService
+    readonly i18n: I18nService,
+    private readonly onlineStatusService: OnlineStatusService,
+    private readonly noticeService: NoticeService
   ) {
     super();
   }
@@ -245,6 +249,10 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   tryAdvanceStep(): void {
+    if (!this.onlineStatusService.isOnline) {
+      this.noticeService.show(translate('draft_generation.offline_message'));
+      return;
+    }
     if (!this.validateCurrentStep()) {
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -382,6 +382,11 @@
       </section>
     }
   } @else if (currentPage === "steps") {
+    @if (!isOnline) {
+      <section>
+        <p class="offline-text">{{ t("offline_message") }}</p>
+      </section>
+    }
     <app-draft-generation-steps
       (done)="onPreGenerationStepsComplete($event)"
       (cancel)="currentPage = 'initial'"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -382,14 +382,12 @@
       </section>
     }
   } @else if (currentPage === "steps") {
-    @if (!isOnline) {
-      <section>
-        <p class="offline-text">{{ t("offline_message") }}</p>
-      </section>
-    }
     <app-draft-generation-steps
       (done)="onPreGenerationStepsComplete($event)"
       (cancel)="currentPage = 'initial'"
     ></app-draft-generation-steps>
+    @if (!isOnline) {
+      <p class="offline-text">{{ t("offline_message") }}</p>
+    }
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -670,13 +670,21 @@ describe('DraftGenerationComponent', () => {
     it('should display offline message when offline', () => {
       let env = new TestEnvironment();
       env.testOnlineStatusService.setIsOnline(false);
+      env.fixture.detectChanges();
+      expect(env.offlineTextElement).not.toBeNull();
 
-      expect(env.offlineTextElement).toBeDefined();
+      env.component.currentPage = 'steps';
+      env.fixture.detectChanges();
+      expect(env.offlineTextElement).not.toBeNull();
     });
 
     it('should not display offline message when online', () => {
       let env = new TestEnvironment();
+      env.fixture.detectChanges();
+      expect(env.offlineTextElement).toBeNull();
 
+      env.component.currentPage = 'steps';
+      env.fixture.detectChanges();
       expect(env.offlineTextElement).toBeNull();
     });
   });


### PR DESCRIPTION
The draft wizard cannot be opened offline, but if the user goes offline while the draft wizard is open, then the user can proceed and generate a draft that will fail. This PR prevents the user from advancing steps if the internet connection drops and shows a message to the user.

![image](https://github.com/user-attachments/assets/221ba54d-00e2-4d60-8a08-5e89f46e508b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2893)
<!-- Reviewable:end -->
