### PR TITLE
SF-2502 Add Help Videos to Scripture Forge

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app-routing.module.ts
@@ -14,10 +14,12 @@ import { SettingsComponent } from './settings/settings.component';
 import { PageNotFoundComponent } from './shared/page-not-found/page-not-found.component';
 import { SettingsAuthGuard, SyncAuthGuard } from './shared/project-router.guard';
 import { SyncComponent } from './sync/sync.component';
+import { HelpVideosComponent } from './shared/help-videos/help-videos.component';
 
 const routes: Routes = [
   { path: 'callback/auth0', component: MyProjectsComponent, canActivate: [AuthGuard] },
   { path: 'connect-project', component: ConnectProjectComponent, canActivate: [AuthGuard] },
+  { path: 'help-videos', component: HelpVideosComponent },
   { path: 'login', redirectTo: 'projects', pathMatch: 'full' },
   { path: 'join/:shareKey', component: JoinComponent },
   { path: 'join/:shareKey/:locale', component: JoinComponent },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -55,6 +55,7 @@
         </button>
         <mat-menu #helpMenu="matMenu" class="help-menu">
           <a mat-menu-item target="_blank" [href]="urls.helps"><mat-icon>help</mat-icon> {{ t("help") }}</a>
+          <a mat-menu-item appRouterLink="help-videos"><mat-icon>smart_display</mat-icon> Tutorials</a>
           <a mat-menu-item target="_blank" [href]="urls.manual"><mat-icon>book</mat-icon> {{ t("manual") }}</a>
           <a mat-menu-item target="_blank" [href]="urls.announcementPage">
             <mat-icon>campaign</mat-icon> {{ t("announcements") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/help-video.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/help-video.ts
@@ -1,0 +1,8 @@
+export interface HelpVideo {
+  id: string;
+  name: string;
+  url: string;
+  description: string;
+  keywords: string[];
+  feature: string;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.html
@@ -1,0 +1,27 @@
+<h1>Tutorial Videos</h1>
+@if (!isOnline) {
+  <span class="offline-text"> Connect to internet to view videos </span>
+} @else {
+  <mat-form-field>
+    <mat-label>Search for video</mat-label>
+    <input matInput type="text" placeholder="Search for video" />
+  </mat-form-field>
+  <button mat-button mat-icon-button aria-label="Search">
+    <mat-icon>search</mat-icon>
+  </button>
+  <div class="help-videos">
+    @for (value of ["1", "2", "3", "4", "5"]; track value) {
+      <mat-card class="help-video">
+        <mat-card-header>
+          <mat-card-title>Video Name {{ value }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <iframe width="320" height="240" src="https://www.youtube.com/embed/qgTusgXJOoM"> </iframe>
+        </mat-card-content>
+        <mat-card-footer>
+          <mat-card-subtitle> Description of the video {{ value }} </mat-card-subtitle>
+        </mat-card-footer>
+      </mat-card>
+    }
+  </div>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.scss
@@ -1,0 +1,12 @@
+.help-videos,
+mat-card-header,
+mat-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+}
+
+mat-form-field {
+  width: 85%;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HelpVideosComponent } from './help-videos.component';
+
+describe('HelpVideosComponent', () => {
+  let component: HelpVideosComponent;
+  let fixture: ComponentFixture<HelpVideosComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HelpVideosComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HelpVideosComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/help-videos/help-videos.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { OnlineStatusService } from '../../../xforge-common/online-status.service';
+
+@Component({
+  selector: 'app-help-videos',
+  standalone: true,
+  imports: [MatCardModule, MatIconModule, MatInputModule, MatFormFieldModule],
+  templateUrl: './help-videos.component.html',
+  styleUrl: './help-videos.component.scss'
+})
+export class HelpVideosComponent {
+  isOnlineStatus: boolean;
+  constructor(private readonly onlineStatusService: OnlineStatusService) {
+    this.onlineStatusService.onlineStatus$.subscribe(isOnline => {
+      this.isOnlineStatus = isOnline;
+    });
+  }
+  get isOnline(): boolean {
+    return this.isOnlineStatus;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.html
@@ -1,0 +1,23 @@
+<h2 mat-dialog-title>{{ data.isEdit ? "Edit Help Video" : "Add Help Video" }}</h2>
+<mat-dialog-content>
+  <form [formGroup]="helpVideoForm">
+    <mat-form-field>
+      <mat-label>Title</mat-label>
+      <input matInput formControlName="title" required />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>URL</mat-label>
+      <input matInput formControlName="url" required />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Description</mat-label>
+      <textarea matInput formControlName="description"></textarea>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button [mat-dialog-close]="helpVideoForm.value" [disabled]="!helpVideoForm.valid">
+    {{ data.isEdit ? "Save" : "Add" }}
+  </button>
+</mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SaHelpVideosDialogComponent } from './sa-help-videos-dialog.component';
+
+describe('SaHelpVideosDialogComponent', () => {
+  let component: SaHelpVideosDialogComponent;
+  let fixture: ComponentFixture<SaHelpVideosDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SaHelpVideosDialogComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SaHelpVideosDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos-dialog/sa-help-videos-dialog.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sa-help-videos-dialog',
+  standalone: true,
+  imports: [],
+  templateUrl: './sa-help-videos-dialog.component.html',
+  styleUrl: './sa-help-videos-dialog.component.scss'
+})
+export class SaHelpVideosDialogComponent {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.html
@@ -1,0 +1,54 @@
+<button mat-raised-button (click)="addEditVideoData()">Add Video</button>
+<mat-table [dataSource]="dataSource">
+  <ng-container matColumnDef="videoName">
+    <mat-header-cell *matHeaderCellDef> Video Name </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.videoName }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="videoDescription">
+    <mat-header-cell *matHeaderCellDef> Video Description </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.videoDescription }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="url">
+    <mat-header-cell *matHeaderCellDef> URL </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.url }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="component">
+    <mat-header-cell *matHeaderCellDef> Component </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.component }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="keywords">
+    <mat-header-cell *matHeaderCellDef> Keywords </mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      {{ element.keywords }}
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="edit">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      <button mat-raised-button (click)="addEditVideoData()">Edit</button>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="delete">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let element">
+      <button mat-raised-button (click)="addEditVideoData()">Delete</button>
+    </mat-cell>
+  </ng-container>
+
+  <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+</mat-table>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.scss
@@ -1,0 +1,47 @@
+@use 'src/variables';
+@use 'src/breakpoints';
+
+.help-controls {
+  margin: 32px 0;
+}
+
+mat-form-field {
+  margin-top: 10px;
+}
+
+mat-table {
+  width: 100%;
+}
+
+.mat-column-tasks {
+  @include breakpoints.media-breakpoint-down(md) {
+    display: none;
+  }
+}
+
+.no-projects-label {
+  padding-top: 14px;
+}
+
+.connect-cell {
+  text-align: right;
+  text-overflow: initial;
+}
+
+.task-label {
+  font-size: small;
+  color: variables.$greyLight;
+}
+
+.small-form-field {
+  width: 130px;
+}
+
+td > mat-checkbox {
+  margin: 0 1em;
+}
+
+ng-container {
+  display: flex;
+  align-items: center;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SaHelpVideosComponent } from './sa-help-videos.component';
+
+describe('HelpVideosComponent', () => {
+  let component: SaHelpVideosComponent;
+  let fixture: ComponentFixture<SaHelpVideosComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SaHelpVideosComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SaHelpVideosComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-help-video-tab/sa-help-videos.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-sa-help-videos',
+  templateUrl: './sa-help-videos.component.html',
+  styleUrl: './sa-help-videos.component.scss'
+})
+export class SaHelpVideosComponent {
+  constructor() {}
+  displayedColumns: string[] = ['videoName', 'videoDescription', 'url', 'component', 'keywords', 'edit', 'delete'];
+  dataSource = [
+    {
+      videoName: 'Video 1',
+      videoDescription: 'Description for Video 1',
+      url: 'https://youtube.com',
+      component: ['Component1']
+    }
+  ];
+
+  componentOptions: string[] = ['Component1', 'Component2', 'Component3'];
+
+  addEditVideoData() {
+    this.dataSource.push({ videoName: '', videoDescription: '', url: '', component: [] });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/system-administration.component.html
@@ -8,5 +8,8 @@
     <mat-tab label="Projects">
       <app-sa-projects></app-sa-projects>
     </mat-tab>
+    <mat-tab label="Help Videos">
+      <app-sa-help-videos></app-sa-help-videos>
+    </mat-tab>
   </mat-tab-group>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/xforge-common.module.ts
@@ -23,6 +23,7 @@ import { SaUsersComponent } from './system-administration/sa-users.component';
 import { SystemAdministrationComponent } from './system-administration/system-administration.component';
 import { UICommonModule } from './ui-common.module';
 import { WriteStatusComponent } from './write-status/write-status.component';
+import { SaHelpVideosComponent } from './system-administration/sa-help-video-tab/sa-help-videos.component';
 
 const componentExports = [
   GenericDialogComponent,
@@ -34,7 +35,8 @@ const componentExports = [
   WriteStatusComponent,
   OwnerComponent,
   ProjectSelectComponent,
-  SyncProgressComponent
+  SyncProgressComponent,
+  SaHelpVideosComponent
 ];
 
 @NgModule({

--- a/src/SIL.XForge.Scripture/Controllers/SystemAdministrationController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SystemAdministrationController.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SIL.XForge.Models;
+using SIL.XForge.Scripture.Services;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Controllers;
+
+/// <summary>
+/// Provides methods for uploading files.
+/// </summary>
+[Authorize]
+[Route(UrlConstants.CommandApiNamespace + "/" + UrlConstants.SystemAdministration)]
+public class SystemAdministrationController : ControllerBase
+{
+    private readonly ISystemAdministrationService _systemAdministrationService;
+    private readonly IExceptionHandler _exceptionHandler;
+
+    public SystemAdministrationController(
+        ISystemAdministrationService systemAdministrationService,
+        IExceptionHandler exceptionHandler
+    )
+    {
+        _systemAdministrationService = systemAdministrationService;
+        _exceptionHandler = exceptionHandler;
+    }
+
+    [HttpGet("getHelpVideos")]
+    public IActionResult GetHelpVideos(string[] systemRoles)
+    {
+        try
+        {
+            return Ok(_systemAdministrationService.GetHelpVideos(systemRoles));
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "GetHelpVideos" } }
+            );
+            throw;
+        }
+    }
+
+    [HttpPost("saveHelpVideo")]
+    public async Task<IActionResult> SaveHelpVideo(HelpVideo helpVideo, string[] systemRoles)
+    {
+        try
+        {
+            return Ok(await _systemAdministrationService.SaveHelpVideoAsync(systemRoles, helpVideo));
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "SaveHelpVideo" } }
+            );
+            throw;
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/ISystemAdministrationService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISystemAdministrationService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+public interface ISystemAdministrationService
+{
+    IEnumerable<HelpVideo> GetHelpVideos(string[] systemRoles);
+    Task<IEnumerable<HelpVideo>> SaveHelpVideoAsync(string[] systemRoles, HelpVideo helpVideo);
+}

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class SFServiceCollectionExtensions
         services.AddSingleton<ISFRestClientFactory, SFDblRestClientFactory>();
         services.AddSingleton<IHgWrapper, HgWrapper>();
         services.AddSingleton<ISFProjectRights, SFProjectRights>();
+        services.AddSingleton<ISystemAdministrationService, SystemAdministrationService>();
         return services;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SystemAdministrationService.cs
+++ b/src/SIL.XForge.Scripture/Services/SystemAdministrationService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using PtxUtils;
+using SIL.XForge.DataAccess;
+using SIL.XForge.Models;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+public class SystemAdministrationService : ISystemAdministrationService
+{
+    private readonly IRepository<HelpVideo> _helpVideos;
+
+    public SystemAdministrationService(IRepository<HelpVideo> helpVideos) => _helpVideos = helpVideos;
+
+    public IEnumerable<HelpVideo> GetHelpVideos(string[] systemRoles)
+    {
+        if (!systemRoles.Contains(SystemRole.SystemAdmin))
+            throw new ForbiddenException();
+
+        return _helpVideos.Query().AsEnumerable();
+    }
+
+    public async Task<IEnumerable<HelpVideo>> SaveHelpVideoAsync(string[] systemRoles, HelpVideo helpVideo)
+    {
+        if (!systemRoles.Contains(SystemRole.SystemAdmin))
+            throw new ForbiddenException();
+
+        helpVideo.Id = new ObjectId().ToString();
+        await _helpVideos.InsertAsync(helpVideo);
+        return GetHelpVideos(systemRoles);
+    }
+}

--- a/src/SIL.XForge/Controllers/UrlConstants.cs
+++ b/src/SIL.XForge/Controllers/UrlConstants.cs
@@ -7,4 +7,5 @@ public static class UrlConstants
     public const string Users = "users";
     public const string Projects = "projects";
     public const string ProjectNotifications = "project-notifications";
+    public const string SystemAdministration = "system-administration";
 }

--- a/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
@@ -6,7 +6,11 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class DataAccessApplicationBuilderExtensions
 {
-    public static void UseDataAccess(this IApplicationBuilder app) => app.InitRepository<UserSecret>();
+    public static void UseDataAccess(this IApplicationBuilder app)
+    {
+        app.InitRepository<HelpVideo>();
+        app.InitRepository<UserSecret>();
+    }
 
     public static void InitRepository<T>(this IApplicationBuilder app)
         where T : IIdentifiable => app.ApplicationServices.GetService<IRepository<T>>().Init();

--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -45,10 +45,14 @@ public static class DataAccessServiceCollectionExtensions
         DataAccessClassMap.RegisterClass<Json0Snapshot>(cm => cm.MapIdProperty(e => e.Id));
         DataAccessClassMap.RegisterClass<ProjectSecret>(cm => cm.MapIdProperty(e => e.Id));
 
+        // DataAccessClassMap.RegisterClass<HelpVideo>(cm => cm.MapIdProperty(hv => hv.Id));
+
         services.AddSingleton<IMongoClient>(sp => new MongoClient(options.ConnectionString));
         services.AddSingleton(sp => sp.GetService<IMongoClient>().GetDatabase(options.MongoDatabaseName));
 
         services.AddMongoRepository<UserSecret>("user_secrets", cm => cm.MapIdProperty(us => us.Id));
+
+        services.AddMongoRepository<HelpVideo>("help_videos", cm => cm.MapIdProperty(hv => hv.Id));
 
         return services;
     }

--- a/src/SIL.XForge/Models/HelpVideo.cs
+++ b/src/SIL.XForge/Models/HelpVideo.cs
@@ -1,0 +1,11 @@
+namespace SIL.XForge.Models;
+
+public class HelpVideo : IIdentifiable
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+    public string Description { get; set; }
+    public string Feature { get; set; }
+    public string[] Keywords { get; set; }
+    public string Url { get; set; }
+}


### PR DESCRIPTION
This PR is a basic proof of concept for adding a Scripture Forge Help Video page for users.

It adds a Menu Item (Tutorials) that links to the help-video page which would be where the videos are viewable.
It adds a Help Video tab to the System Administrator page. The current behavior is just showing one video with a link to the help-video page. The idea behind this would be where we would add/update the videos we are displaying.

Further discussion is needed on hosting/general process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2897)
<!-- Reviewable:end -->
