### PR TITLE
SF-3082 Remove persisted resource tabs from deleted projects

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -60,7 +60,7 @@ import { TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-dat
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import * as RichText from 'rich-text';
-import { BehaviorSubject, Observable, Subject, defer, of, take } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, defer, firstValueFrom, of, take } from 'rxjs';
 import { anything, capture, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
@@ -3867,6 +3867,21 @@ describe('EditorComponent', () => {
         env.wait();
         expect(spyCreateTab).toHaveBeenCalledWith('biblical-terms', jasmine.any(Object));
         discardPeriodicTasks();
+      }));
+
+      it('should exclude deleted resource tabs (tabs that have "projectDoc" but not "projectDoc.data")', fakeAsync(async () => {
+        const absentProjectId = 'absentProjectId';
+        when(mockedSFProjectService.getProfile(absentProjectId)).thenResolve({ data: null } as SFProjectProfileDoc);
+        const env = new TestEnvironment();
+        env.setProjectUserConfig({
+          editorTabsOpen: [{ tabType: 'project-resource', groupId: 'target', projectId: absentProjectId }]
+        });
+        env.routeWithParams({ projectId: 'project01', bookId: 'GEN', chapter: '1' });
+        env.wait();
+
+        const tabs = await firstValueFrom(env.component.tabState.tabs$);
+        expect(tabs.find(t => t.projectId === absentProjectId)).toBeUndefined();
+        env.dispose();
       }));
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1281,6 +1281,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             continue;
           }
 
+          // Exclude tabs that have projectDoc but not projectDoc data (project may have been deleted).
+          // These will be cleaned out the next time tab state is persisted.
+          if (tabData.projectDoc != null && tabData.projectDoc.data == null) {
+            continue;
+          }
+
           // Create the tab
           const tab: EditorTabInfo = await this.editorTabFactory.createTab(tabData.tabType, {
             projectId: tabData.projectId,


### PR DESCRIPTION
This PR fixes an issue where deleting a project that was referenced in a resource tab for a different project was throwing an exception when loading the tab.  Now, the deleted project tab is excluded when loading editor tabs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2898)
<!-- Reviewable:end -->
