### PR TITLE
SF-3026 Force consistent date format for Nepali across platforms

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -119,6 +119,9 @@ describe('I18nService', () => {
 
     service.setLocale('az');
     expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
+
+    service.setLocale('npi');
+    expect(service.formatDate(date)).toEqual('१९९१-११-२५, १७:२८');
   });
 
   it('should support including the timezone in the date', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -91,9 +91,9 @@ export class I18nService {
         hour12: false,
         numberingSystem: 'deva',
         ...options
-      };
+      } as const;
 
-      const parts = new Intl.DateTimeFormat('npi', o as any).formatToParts(d);
+      const parts = new Intl.DateTimeFormat('npi', o).formatToParts(d);
 
       // Build custom YYYY-MM-DD, HH:MM format
       const year = parts.find(p => p.type === 'year')?.value;


### PR DESCRIPTION
By default, Chrome on Windows defaults to standard English formatting for Nepali dates, whereas Chrome on Android uses Nepali script and formatting (to an extent). This change supplies a custom date format that all platforms will use. It gets as close to the appropriate date/time format as possible with what's built into the standard API.

The one difference/shortcoming of which I'm aware is that Nepal uses the Vikram Samvat calendar, which is not supported with the 'calendar' option. We could use the 'indian' calendar, but given that Android defaults to Nepali script and Gregorian calendar, it should be acceptable to do so here, as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2901)
<!-- Reviewable:end -->
