### PR TITLE
SF-3103 Warn user when project does not contain all draft chapters

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
@@ -16,6 +16,7 @@ export enum CustomValidatorState {
   InvalidProject,
   BookNotFound,
   NoWritePermissions,
+  MissingChapters,
   None
 }
 
@@ -87,6 +88,8 @@ export class SFValidators {
           return { bookNotFound: true };
         case CustomValidatorState.NoWritePermissions:
           return { noWritePermissions: true };
+        case CustomValidatorState.MissingChapters:
+          return { missingChapters: true };
         default:
           return null;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -21,7 +21,11 @@
         <div class="target-project-content">
           @if (targetChapters$ | async; as chapters) {
             <app-notice icon="warning" type="warning"
-              >{{ t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name }) }}
+              >{{
+                chapters > 1
+                  ? t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name })
+                  : t("project_has_text_in_one_chapter", { bookName, projectName: project.name })
+              }}
             </app-notice>
           } @else {
             <app-notice [icon]="'verified'">{{

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -22,7 +22,7 @@
           @if (targetChapters$ | async; as chapters) {
             <app-notice icon="warning" type="warning"
               >{{
-                chapters > 1
+                i18n.getPluralRule(chapters) !== "one"
                   ? t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name })
                   : t("project_has_text_in_one_chapter", { bookName, projectName: project.name })
               }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
@@ -147,7 +147,7 @@ describe('DraftApplyDialogComponent', () => {
     expect(env.component['getCustomErrorState']()).toBe(CustomValidatorState.InvalidProject);
   }));
 
-  it('notifies user if books has missing chapters', fakeAsync(() => {
+  it('notifies user if book has missing chapters', fakeAsync(() => {
     const projectDoc = {
       id: 'project03',
       data: createTestProjectProfile({
@@ -156,7 +156,30 @@ describe('DraftApplyDialogComponent', () => {
         texts: [
           {
             bookNum: 1,
-            chapters: [{ number: 1, permissions: { user01: TextInfoPermission.Write } }],
+            chapters: [{ number: 1, permissions: { user01: TextInfoPermission.Write }, lastVerse: 31 }],
+            permissions: { user01: TextInfoPermission.Write }
+          }
+        ]
+      })
+    } as SFProjectProfileDoc;
+    env = new TestEnvironment({ projectDoc });
+    env.selectParatextProject('paratextId3');
+    expect(env.component['targetProjectId']).toBe('project03');
+    tick();
+    env.fixture.detectChanges();
+    expect(env.component['getCustomErrorState']()).toBe(CustomValidatorState.MissingChapters);
+  }));
+
+  it('notifies user if book is empty', fakeAsync(() => {
+    const projectDoc = {
+      id: 'project03',
+      data: createTestProjectProfile({
+        paratextId: 'paratextId3',
+        userRoles: { user01: SFProjectRole.ParatextAdministrator },
+        texts: [
+          {
+            bookNum: 1,
+            chapters: [{ number: 1, permissions: { user01: TextInfoPermission.Write }, lastVerse: 0 }],
             permissions: { user01: TextInfoPermission.Write }
           }
         ]
@@ -272,8 +295,8 @@ class TestEnvironment {
               {
                 bookNum: 1,
                 chapters: [
-                  { number: 1, permissions: { user01: permission } },
-                  { number: 2, permissions: { user01: permission } }
+                  { number: 1, permissions: { user01: permission }, lastVerse: 31 },
+                  { number: 2, permissions: { user01: permission }, lastVerse: 25 }
                 ],
                 permissions: { user01: permission }
               }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -160,8 +160,12 @@ export class DraftApplyDialogComponent implements OnInit {
     this.canEditProject =
       this.textDocService.userHasGeneralEditRight(project) &&
       targetBook?.permissions[this.userService.currentUserId] === TextInfoPermission.Write;
+
+    // also check if this is an empty book
+    const bookIsEmpty: boolean = targetBook?.chapters.length === 1 && targetBook?.chapters[0].lastVerse < 1;
     const targetBookChapters: number[] = targetBook?.chapters.map(c => c.number) ?? [];
-    this.projectHasMissingChapters = this.data.chapters.filter(c => !targetBookChapters.includes(c)).length > 0;
+    this.projectHasMissingChapters =
+      bookIsEmpty || this.data.chapters.filter(c => !targetBookChapters.includes(c)).length > 0;
     // emit the project profile document
     if (this.canEditProject && !this.projectHasMissingChapters) {
       this.targetProject$.next(project);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -28,6 +28,11 @@ export interface DraftApplyDialogResult {
   projectId: string;
 }
 
+export interface DraftApplyDialogConfig {
+  bookNum: number;
+  chapters: number[];
+}
+
 @Component({
   selector: 'app-draft-apply-dialog',
   standalone: true,
@@ -48,6 +53,7 @@ export class DraftApplyDialogComponent implements OnInit {
   targetChapters$: BehaviorSubject<number> = new BehaviorSubject<number>(0);
   canEditProject: boolean = true;
   targetBookExists: boolean = true;
+  projectHasMissingChapters: boolean = false;
   addToProjectClicked: boolean = false;
   /** An observable that emits the target project profile if the user has permission to write to the book. */
   targetProject$: BehaviorSubject<SFProjectProfile | undefined> = new BehaviorSubject<SFProjectProfile | undefined>(
@@ -56,7 +62,8 @@ export class DraftApplyDialogComponent implements OnInit {
   invalidMessageMapper: { [key: string]: string } = {
     invalidProject: translate('draft_apply_dialog.please_select_valid_project'),
     bookNotFound: translate('draft_apply_dialog.book_does_not_exist', { bookName: this.bookName }),
-    noWritePermissions: translate('draft_apply_dialog.no_write_permissions')
+    noWritePermissions: translate('draft_apply_dialog.no_write_permissions'),
+    missingChapters: translate('draft_apply_dialog.project_has_chapters_missing', { bookName: this.bookName })
   };
 
   // the project id to add the draft to
@@ -64,7 +71,7 @@ export class DraftApplyDialogComponent implements OnInit {
   private paratextIdToProjectId: Map<string, string> = new Map<string, string>();
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) private data: { bookNum: number },
+    @Inject(MAT_DIALOG_DATA) private data: DraftApplyDialogConfig,
     @Inject(MatDialogRef) private dialogRef: MatDialogRef<DraftApplyDialogComponent, DraftApplyDialogResult>,
     private readonly userProjectsService: SFUserProjectsService,
     private readonly projectService: SFProjectService,
@@ -153,9 +160,10 @@ export class DraftApplyDialogComponent implements OnInit {
     this.canEditProject =
       this.textDocService.userHasGeneralEditRight(project) &&
       targetBook?.permissions[this.userService.currentUserId] === TextInfoPermission.Write;
-
+    const targetBookChapters: number[] = targetBook?.chapters.map(c => c.number) ?? [];
+    this.projectHasMissingChapters = this.data.chapters.filter(c => !targetBookChapters.includes(c)).length > 0;
     // emit the project profile document
-    if (this.canEditProject) {
+    if (this.canEditProject && !this.projectHasMissingChapters) {
       this.targetProject$.next(project);
     } else {
       this.targetProject$.next(undefined);
@@ -193,6 +201,9 @@ export class DraftApplyDialogComponent implements OnInit {
     }
     if (!this.canEditProject) {
       return CustomErrorState.NoWritePermissions;
+    }
+    if (this.projectHasMissingChapters) {
+      return CustomErrorState.MissingChapters;
     }
     return CustomErrorState.None;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -16,7 +16,11 @@ import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../../core/models/text-doc';
-import { DraftApplyDialogComponent, DraftApplyDialogResult } from '../draft-apply-dialog/draft-apply-dialog.component';
+import {
+  DraftApplyDialogComponent,
+  DraftApplyDialogConfig as DraftApplyDialogData,
+  DraftApplyDialogResult
+} from '../draft-apply-dialog/draft-apply-dialog.component';
 import {
   DraftApplyProgress,
   DraftApplyProgressDialogComponent
@@ -104,9 +108,13 @@ export class DraftPreviewBooksComponent {
   }
 
   async chooseAlternateProjectToAddDraft(bookWithDraft: BookWithDraft): Promise<void> {
+    const dialogData: DraftApplyDialogData = {
+      bookNum: bookWithDraft.bookNumber,
+      chapters: bookWithDraft.chaptersWithDrafts
+    };
     const dialogRef: MatDialogRef<DraftApplyDialogComponent, DraftApplyDialogResult> = this.dialogService.openMatDialog(
       DraftApplyDialogComponent,
-      { data: { bookNum: bookWithDraft.bookNumber }, width: '600px' }
+      { data: dialogData, width: '600px' }
     );
     const result: DraftApplyDialogResult | undefined = await firstValueFrom(dialogRef.afterClosed());
     if (result == null || result.projectId == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -162,6 +162,7 @@
     "looking_for_unlisted_project": "Looking for a project that is not listed? Connect it on {{ underlineStart }}the projects page{{ underlineEnd }} first.",
     "no_write_permissions": "You do not have permission to write to this book on this project. Contact the project's administrator to get permission.",
     "please_select_valid_project": "Please select a valid project",
+    "project_has_chapters_missing": "{{ bookName }} in this project has chapters missing. Please add the missing chapters in Paratext",
     "project_has_text_in_chapters": "{{ bookName }} in {{ projectName }} has text in {{ numChapters }} chapters",
     "select_alternate_project": "Select the project you want to add the draft to"
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -164,6 +164,7 @@
     "please_select_valid_project": "Please select a valid project",
     "project_has_chapters_missing": "{{ bookName }} in this project has chapters missing. Please add the missing chapters in Paratext",
     "project_has_text_in_chapters": "{{ bookName }} in {{ projectName }} has text in {{ numChapters }} chapters",
+    "project_has_text_in_one_chapter": "{{ bookName }} in {{ projectName }} has text in 1 chapter",
     "select_alternate_project": "Select the project you want to add the draft to"
   },
   "draft_apply_progress-dialog": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -206,6 +206,26 @@ describe('I18nService', () => {
       expect(service.getLanguageDisplayName('123')).toBe('123');
     });
   });
+
+  describe('getPluralRule', () => {
+    it('should return rule for zero, one and other', () => {
+      const service = getI18nService();
+      service.setLocale('en');
+      expect(service.getPluralRule(0)).toEqual('other');
+      expect(service.getPluralRule(1)).toEqual('one');
+      expect(service.getPluralRule(2)).toEqual('other');
+    });
+
+    it('supports arabic plural rules', () => {
+      const service = getI18nService();
+      service.setLocale('ar');
+      expect(service.getPluralRule(0)).toEqual('zero');
+      expect(service.getPluralRule(1)).toEqual('one');
+      expect(service.getPluralRule(2)).toEqual('two');
+      expect(service.getPluralRule(6)).toEqual('few');
+      expect(service.getPluralRule(18)).toEqual('many');
+    });
+  });
 });
 
 function getI18nService(): I18nService {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -418,6 +418,13 @@ export class I18nService {
       .find(e => e.type === 'timeZoneName').value;
   }
 
+  /** Takes a number and returns a rule representing the plural-related rule for the current locale.
+   * Possible values include 'zero', 'one', 'two', 'few', 'many', and 'other'.
+   */
+  getPluralRule(number: number): Intl.LDMLPluralRule {
+    return new Intl.PluralRules(this.locale.canonicalTag).select(number);
+  }
+
   private getTranslation(key: I18nKey): string {
     return (
       this.transloco.getTranslation(this.transloco.getActiveLang())[key] ??


### PR DESCRIPTION
When a book is essentially blank on the project selected to apply a draft to, our mongoDB only has the first chapter for text documents. One option is to create the additional text documents and then apply the drafts, but this appears to go against our normal approach to have users format and create books in Paratext.
This PR gives the user a warning if they are attempting to add a draft to a book where chapters from the draft are not all present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2903)
<!-- Reviewable:end -->
