### PR TITLE
Make projectToDraftSources from ConfirmSourcesComponent a util function

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -7,6 +7,7 @@ import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/t
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeComponent } from '../../../shared/notice/notice.component';
+import { DraftSourcesAsArrays, projectToDraftSources } from '../draft-utils';
 
 @Component({
   selector: 'app-confirm-sources',
@@ -26,36 +27,11 @@ export class ConfirmSourcesComponent {
     private readonly i18nService: I18nService,
     activatedProjectService: ActivatedProjectService
   ) {
-    const project = activatedProjectService.projectDoc!.data!;
-    this.trainingTargets.push(project);
+    const sources: DraftSourcesAsArrays = projectToDraftSources(activatedProjectService.projectDoc.data);
 
-    const draftConfig = project.translateConfig.draftConfig;
-
-    let trainingSource: TranslateSource | undefined;
-    if (draftConfig.alternateTrainingSourceEnabled && draftConfig.alternateTrainingSource != null) {
-      trainingSource = draftConfig.alternateTrainingSource;
-    } else {
-      trainingSource = project.translateConfig.source;
-    }
-
-    if (trainingSource != null) {
-      this.trainingSources.push(trainingSource);
-    }
-
-    if (draftConfig.additionalTrainingSourceEnabled && draftConfig.additionalTrainingSource != null) {
-      this.trainingSources.push(draftConfig.additionalTrainingSource!);
-    }
-
-    let draftingSource: TranslateSource | undefined;
-    if (draftConfig.alternateSourceEnabled && draftConfig.alternateSource != null) {
-      draftingSource = draftConfig.alternateSource;
-    } else {
-      draftingSource = project.translateConfig.source;
-    }
-
-    if (draftingSource != null) {
-      this.draftingSources.push(draftingSource);
-    }
+    this.trainingSources = sources.trainingSources;
+    this.trainingTargets = sources.trainingTargets;
+    this.draftingSources = sources.draftingSources;
   }
 
   confirmationChanged(change: MatCheckboxChange): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-utils.ts
@@ -1,0 +1,63 @@
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
+
+export interface DraftSourcesAsArrays {
+  trainingSources: [TranslateSource?, TranslateSource?];
+  trainingTargets: [SFProjectProfile];
+  draftingSources: [TranslateSource?];
+}
+
+/**
+ * Takes a SFProjectProfile and returns the training and drafting sources for the project as three arrays.
+ *
+ * This considers properties such as alternateTrainingSourceEnabled and alternateTrainingSource and makes sure to only
+ * include a source if it's enabled and not null. It also considers whether the project source is implicitly the
+ * training and/or drafting source.
+ *
+ * This method is also intended to be act as an abstraction layer to allow changing the data model in the future without
+ * needing to change all the places that use this method.
+ *
+ * Currently this method provides guarantees via the type system that there will be at most 2 training sources, exactly
+ * 1 training target, and at most 1 drafting source. Consumers of this method that cannot accept an arbitrary length for
+ * each of these arrays are encouraged to write there code in such a way that it will noticeably break (preferably at
+ * build time) if these guarantees are changed, to make it easier to find code that relies on the current limit on the
+ * number of sources in each category.
+ * @param project The project to get the sources for
+ * @returns An object with three arrays: trainingSources, trainingTargets, and draftingSources
+ */
+export function projectToDraftSources(project: SFProjectProfile): DraftSourcesAsArrays {
+  const trainingSources: [TranslateSource?, TranslateSource?] = [];
+  const draftingSources: [TranslateSource?] = [];
+
+  const trainingTargets: [SFProjectProfile] = [project];
+
+  const draftConfig = project.translateConfig.draftConfig;
+
+  let trainingSource: TranslateSource | undefined;
+  if (draftConfig.alternateTrainingSourceEnabled && draftConfig.alternateTrainingSource != null) {
+    trainingSource = draftConfig.alternateTrainingSource;
+  } else {
+    trainingSource = project.translateConfig.source;
+  }
+
+  if (trainingSource != null) {
+    trainingSources.push(trainingSource);
+  }
+
+  if (draftConfig.additionalTrainingSourceEnabled && draftConfig.additionalTrainingSource != null) {
+    trainingSources.push(draftConfig.additionalTrainingSource);
+  }
+
+  let draftingSource: TranslateSource | undefined;
+  if (draftConfig.alternateSourceEnabled && draftConfig.alternateSource != null) {
+    draftingSource = draftConfig.alternateSource;
+  } else {
+    draftingSource = project.translateConfig.source;
+  }
+
+  if (draftingSource != null) {
+    draftingSources.push(draftingSource);
+  }
+
+  return { trainingSources, trainingTargets, draftingSources };
+}


### PR DESCRIPTION
There are a lot of ways to misinterpret the configured draft sources, and the model may change in the future. Read the doc comment for rationale.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2906)
<!-- Reviewable:end -->
