### PR TITLE
Add workflow to scan workflows with zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: Run zizmor analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run zizmor
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,8 @@
     "webm",
     "xforge",
     "xfvalidators",
-    "xlink"
+    "xlink",
+    "zizmor"
   ],
   "dotnet.defaultSolution": "xForge.sln",
   "dotnet-test-explorer.testProjectPath": "test/**/*.Tests.csproj",


### PR DESCRIPTION
zizmor does static analysis of GitHub actions. To see what it produces for SF, run `pip install zizmor` and then `zizmor .` in the repo dir. To see only higher severity findings, run `zizmor --min-severity high .`

My review of the results leads me to believe that none of the findings are exploitable, but we have opportunities to reduce the attack surface.

This is copied almost verbatm from the recommended workflow at https://woodruffw.github.io/zizmor/usage/#use-in-github-actions

You can see the results generated by this action run here: https://github.com/sillsdev/web-xforge/security/code-scanning?query=pr%3A2907+tool%3Azizmor+is%3Aopen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2907)
<!-- Reviewable:end -->
