### PR TITLE
SF-3070 Refresh the selected verse if the states are wrong

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -743,7 +743,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     for (const segment of this.viewModel.segments) {
       const range = segment[1];
       const formats = getAttributesAtPosition(this.editor, range.index);
-      if (formats['commenter-selection'] != null && formats['commenter-selection'] === true) {
+      if (formats['commenter-selection'] === true) {
         ret.push(range);
       }
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -18,7 +18,7 @@ import QuillCursors from 'quill-cursors';
 import { AuthType, getAuthType } from 'realtime-server/lib/esm/common/models/user';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
-import { Subject, Subscription, fromEvent, timer } from 'rxjs';
+import { fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { LocalPresence, Presence } from 'sharedb/lib/sharedb';
 import tinyColor from 'tinycolor2';
@@ -36,11 +36,11 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
 import { MultiCursorViewer } from '../../translate/editor/multi-viewer/multi-viewer.component';
 import {
-  VERSE_REGEX,
   attributeFromMouseEvent,
   getBaseVerse,
   getVerseRefFromSegmentRef,
-  getVerseStrFromSegmentRef
+  getVerseStrFromSegmentRef,
+  VERSE_REGEX
 } from '../utils';
 import { getAttributesAtPosition, registerScripture } from './quill-scripture';
 import { Segment } from './segment';
@@ -736,6 +736,19 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
     if (position != null && this.editor != null) {
       this.editor.formatText(position, 1, embedName, format, 'api');
     }
+  }
+
+  get commenterSelection(): RangeStatic[] {
+    const ret = [];
+    for (const segment of this.viewModel.segments) {
+      const range = segment[1];
+      const formats = getAttributesAtPosition(this.editor, range.index);
+      if (formats['commenter-selection'] != null && formats['commenter-selection'] === true) {
+        ret.push(range);
+      }
+    }
+
+    return ret;
   }
 
   toggleVerseSelection(verseRef: VerseRef): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -924,7 +924,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.syncScrollRequested$.next();
     }
 
-    if (this.target.commenterSelection.length === 0 && this.commenterSelectedVerseRef != null) {
+    if (this.commenterSelectedVerseRef != null && this.target.commenterSelection.length === 0) {
       // if we're here, the state hasn't been updated, and we need to re-toggle the selected verse
       const correctVerseRef = this.commenterSelectedVerseRef;
       this.commenterSelectedVerseRef = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -924,6 +924,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.syncScrollRequested$.next();
     }
 
+    if (this.target.commenterSelection.length === 0 && this.commenterSelectedVerseRef != null) {
+      // if we're here, the state hasn't been updated, and we need to re-toggle the selected verse
+      const correctVerseRef = this.commenterSelectedVerseRef;
+      this.commenterSelectedVerseRef = undefined;
+      this.toggleVerseRefElement(correctVerseRef);
+    }
+
     if (delta != null && this.shouldNoteThreadsRespondToEdits) {
       // wait 20 ms so that note thread docs have time to receive the updated note positions
       setTimeout(() => {


### PR DESCRIPTION
This fixes a bug where the selected verse would be doubly toggled in some cases, especially after a history restore. The selected verse is tracked via state in the editor with a simple field, and it can become wrong. With the design in place, it is tricky to keep this field in sync.

The core of this comes down to the difficulty in distinguishing between different types of local changes, some coming from the editor and some from elsewhere. Local changes from elsewhere, like a history restore, will overwrite the text doc completely, including clearing its selected verse. To fix the bug, we check if the selection has been cleared and the editor thinks it hasn't, then refresh the editor.

I'm not sure about a unit test here. This is a really niche use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2911)
<!-- Reviewable:end -->
