### PR TITLE
Update CSharpier to 0.30.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.28.2",
+      "version": "0.30.3",
       "commands": ["dotnet-csharpier"],
       "rollForward": false
     }

--- a/.editorconfig
+++ b/.editorconfig
@@ -175,7 +175,7 @@ dotnet_style_qualification_for_field = false:silent
 dotnet_style_qualification_for_property = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_event = false:silent
-dotnet_style_prefer_collection_expression = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_exactly_match:warning
 dotnet_sort_system_directives_first = true
 
 # Define the 'private_fields' symbol group:

--- a/.editorconfig
+++ b/.editorconfig
@@ -91,6 +91,7 @@ csharp_style_prefer_primary_constructors = true:suggestion
 csharp_style_prefer_readonly_struct_member = true:suggestion
 csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
 csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_prefer_system_threading_lock = true:suggestion
 
 [*.{cs,vb}]
 tab_width = 4
@@ -214,7 +215,6 @@ dotnet_diagnostic.CA1829.severity = warning # Use the Count or Length property i
 dotnet_diagnostic.CA1834.severity = warning # Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)'
 dotnet_diagnostic.CA2016.severity = warning # Forward the 'token' parameter to the async method
 
-# Downgrade the following code style diagnostic messages so dotnet format does not fix them automatically.]]
-# NOTE: Consider changing to warning when migrating from .NET 6.
-# The following diagnostic is automatically fixed in .NET SDK 7.0.304 or higher - older versions will cause variance.
-dotnet_diagnostic.IDE0270.severity = suggestion # Null check can be simplified
+# This rule conflicts with CSharpier
+# See https://csharpier.com/docs/IntegratingWithLinters
+dotnet_diagnostic.IDE0055.severity = none

--- a/src/Help/UpdateHelp/Program.cs
+++ b/src/Help/UpdateHelp/Program.cs
@@ -71,7 +71,7 @@ class Program
         {
             { "es", "9f727aa1dd179dd6d" },
             { "fr", "7da597faaebed6cc7" },
-            { "pt_BR", "40bf11d4080246d99" }
+            { "pt_BR", "40bf11d4080246d99" },
         };
 
         Console.WriteLine("Update Help files.\n");

--- a/src/Help/UpdateHelp/Program.cs
+++ b/src/Help/UpdateHelp/Program.cs
@@ -152,7 +152,7 @@ class Program
 
             string[] htmlFiles = Directory.GetFiles(targetPath, "*.htm", SearchOption.AllDirectories);
             // auxiliary html files with titles or headings that can be ignored
-            string[] ignoreFiles = { "index1.htm", "csh-redirect.htm" };
+            string[] ignoreFiles = ["index1.htm", "csh-redirect.htm"];
             IEnumerable<string> targetFiles = htmlFiles.Where(t => !ignoreFiles.Contains(Path.GetFileName(t)));
             foreach (string file in targetFiles)
             {

--- a/src/Migrations/BackoutCommits/Program.cs
+++ b/src/Migrations/BackoutCommits/Program.cs
@@ -230,7 +230,7 @@ public class Program
             Arguments = arguments,
             UseShellExecute = false,
             RedirectStandardOutput = true,
-            RedirectStandardError = true
+            RedirectStandardError = true,
         };
         process.Start();
         while (!process.HasExited)

--- a/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
+++ b/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
@@ -86,8 +86,8 @@ namespace PTDDCloneAll
                         ParatextTokens = new Tokens
                         {
                             AccessToken = "test_access_token1",
-                            RefreshToken = "test_refresh_token1"
-                        }
+                            RefreshToken = "test_refresh_token1",
+                        },
                     },
                     new UserSecret
                     {
@@ -95,9 +95,9 @@ namespace PTDDCloneAll
                         ParatextTokens = new Tokens
                         {
                             AccessToken = "test_access_token2",
-                            RefreshToken = "test_refresh_token2"
-                        }
-                    }
+                            RefreshToken = "test_refresh_token2",
+                        },
+                    },
                 }
             );
 
@@ -131,7 +131,7 @@ namespace PTDDCloneAll
                     {
                         new User { Id = "user01", ParatextId = "pt01" },
                         new User { Id = "user02", ParatextId = "pt02" },
-                        new User { Id = "user03", ParatextId = "pt03" }
+                        new User { Id = "user03", ParatextId = "pt03" },
                     }
                 )
             );
@@ -150,7 +150,7 @@ namespace PTDDCloneAll
                             {
                                 { "user01", SFProjectRole.Administrator },
                                 { "user02", SFProjectRole.Translator },
-                                { "user03", SFProjectRole.Administrator }
+                                { "user03", SFProjectRole.Administrator },
                             },
                             ParatextId = "target01",
                             TranslateConfig = new TranslateConfig
@@ -161,11 +161,11 @@ namespace PTDDCloneAll
                                     ParatextId = "source01",
                                     Name = "Source",
                                     ShortName = "SRC",
-                                    WritingSystem = new WritingSystem { Tag = "en" }
-                                }
+                                    WritingSystem = new WritingSystem { Tag = "en" },
+                                },
                             },
                             CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
-                            Sync = new Sync { QueuedCount = 1 }
+                            Sync = new Sync { QueuedCount = 1 },
                         },
                         new SFProject
                         {
@@ -176,7 +176,7 @@ namespace PTDDCloneAll
                             {
                                 { "user01", SFProjectRole.Administrator },
                                 { "user02", SFProjectRole.Translator },
-                                { "user03", SFProjectRole.Administrator }
+                                { "user03", SFProjectRole.Administrator },
                             },
                             ParatextId = "target02",
                             TranslateConfig = new TranslateConfig
@@ -187,12 +187,12 @@ namespace PTDDCloneAll
                                     ParatextId = "source02",
                                     Name = "Source",
                                     ShortName = "SR2",
-                                    WritingSystem = new WritingSystem { Tag = "en" }
-                                }
+                                    WritingSystem = new WritingSystem { Tag = "en" },
+                                },
                             },
                             CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
-                            Sync = new Sync { QueuedCount = 1 }
-                        }
+                            Sync = new Sync { QueuedCount = 1 },
+                        },
                     }
                 )
             );

--- a/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
+++ b/src/Migrations/PTDDCloneAll/PTDDSyncRunner.cs
@@ -524,7 +524,7 @@ namespace PTDDCloneAll
                             Number = kvp.Key,
                             LastVerse = kvp.Value.LastVerse,
                             IsValid = kvp.Value.IsValid,
-                            Permissions = { }
+                            Permissions = { },
                         }
                     );
                 }

--- a/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
+++ b/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
@@ -477,7 +477,7 @@ namespace PtdaSyncAll
                 .Add(
                     new TextData(Delta.New().InsertText("old text"))
                     {
-                        Id = TextData.GetTextDocId("project01", 42, 1, TextType.Target)
+                        Id = TextData.GetTextDocId("project01", 42, 1, TextType.Target),
                     }
                 );
             env.SetupPTData(new Book("MAT", 2), new Book("MRK", 2), new Book("LUK", 2));
@@ -529,7 +529,7 @@ namespace PtdaSyncAll
             Book matBook = new Book("MAT", 3, 3)
             {
                 MissingTargetChapters = { 1, 2, 3 },
-                MissingSourceChapters = { 1, 2, 3 }
+                MissingSourceChapters = { 1, 2, 3 },
             };
             env.SetupSFData(true, true, false, matBook);
             env.SetupPTData(new Book("MAT", 3, true));
@@ -762,7 +762,7 @@ namespace PtdaSyncAll
             var book = new Book("MAT", numberChapters, true)
             {
                 MissingTargetChapters = missingDbChapters,
-                MissingSourceChapters = missingDbChapters
+                MissingSourceChapters = missingDbChapters,
             };
             env.SetupSFData(true, true, false, book);
 
@@ -847,7 +847,7 @@ namespace PtdaSyncAll
                 var ptUserRoles = new Dictionary<string, string>
                 {
                     { "pt01", SFProjectRole.Administrator },
-                    { "pt02", SFProjectRole.Translator }
+                    { "pt02", SFProjectRole.Translator },
                 };
                 ParatextService
                     .GetProjectRolesAsync(Arg.Any<UserSecret>(), "target")
@@ -930,7 +930,7 @@ namespace PtdaSyncAll
                         new[]
                         {
                             new User { Id = "user01", ParatextId = "pt01" },
-                            new User { Id = "user02", ParatextId = "pt02" }
+                            new User { Id = "user02", ParatextId = "pt02" },
                         }
                     )
                 );
@@ -948,7 +948,7 @@ namespace PtdaSyncAll
                                 UserRoles = new Dictionary<string, string>
                                 {
                                     { "user01", SFProjectRole.Administrator },
-                                    { "user02", SFProjectRole.Translator }
+                                    { "user02", SFProjectRole.Translator },
                                 },
                                 ParatextId = "target",
                                 TranslateConfig = new TranslateConfig
@@ -959,13 +959,13 @@ namespace PtdaSyncAll
                                         ParatextId = "source",
                                         Name = "Source",
                                         ShortName = "SRC",
-                                        WritingSystem = new WritingSystem { Tag = "en" }
-                                    }
+                                        WritingSystem = new WritingSystem { Tag = "en" },
+                                    },
                                 },
                                 CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
                                 Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                                Sync = new Sync { QueuedCount = 1 }
-                            }
+                                Sync = new Sync { QueuedCount = 1 },
+                            },
                         }
                     )
                 );
@@ -1022,10 +1022,10 @@ namespace PtdaSyncAll
                         {
                             Number = c,
                             LastVerse = 10,
-                            IsValid = !book.InvalidChapters.Contains(c)
+                            IsValid = !book.InvalidChapters.Contains(c),
                         })
                         .ToList(),
-                    HasSource = book.HighestSourceChapter > 0
+                    HasSource = book.HighestSourceChapter > 0,
                 };
             }
 
@@ -1175,8 +1175,8 @@ namespace PtdaSyncAll
                                     Id = $"project01:question{bookId}{c}",
                                     DataId = $"question{bookId}{c}",
                                     ProjectRef = "project01",
-                                    VerseRef = new VerseRefData(bookNum, c, 1)
-                                }
+                                    VerseRef = new VerseRefData(bookNum, c, 1),
+                                },
                             }
                         );
                 }

--- a/src/Migrations/PtdaSyncAll.Tests/SyncAllServiceTests.cs
+++ b/src/Migrations/PtdaSyncAll.Tests/SyncAllServiceTests.cs
@@ -347,8 +347,8 @@ namespace PtdaSyncAll
                             ParatextTokens = new Tokens
                             {
                                 AccessToken = CreateAccessToken(DateTime.Now),
-                                RefreshToken = "test_refresh_token1"
-                            }
+                                RefreshToken = "test_refresh_token1",
+                            },
                         },
                         new UserSecret
                         {
@@ -356,9 +356,9 @@ namespace PtdaSyncAll
                             ParatextTokens = new Tokens
                             {
                                 AccessToken = CreateAccessToken(DateTime.Now),
-                                RefreshToken = "test_refresh_token2"
-                            }
-                        }
+                                RefreshToken = "test_refresh_token2",
+                            },
+                        },
                     }
                 );
 
@@ -426,7 +426,7 @@ namespace PtdaSyncAll
                         {
                             new User { Id = "user01", ParatextId = "pt01" },
                             new User { Id = "user02", ParatextId = "pt02" },
-                            new User { Id = "user03", ParatextId = "pt03" }
+                            new User { Id = "user03", ParatextId = "pt03" },
                         }
                     )
                 );
@@ -445,7 +445,7 @@ namespace PtdaSyncAll
                                 {
                                     { "user01", SFProjectRole.Administrator },
                                     { "user02", SFProjectRole.Translator },
-                                    { "user03", SFProjectRole.Administrator }
+                                    { "user03", SFProjectRole.Administrator },
                                 },
                                 ParatextId = "target",
                                 TranslateConfig = new TranslateConfig
@@ -456,11 +456,11 @@ namespace PtdaSyncAll
                                         ParatextId = "source",
                                         Name = "Source",
                                         ShortName = "SRC",
-                                        WritingSystem = new WritingSystem { Tag = "en" }
-                                    }
+                                        WritingSystem = new WritingSystem { Tag = "en" },
+                                    },
                                 },
                                 CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
-                                Sync = new Sync { QueuedCount = 1 }
+                                Sync = new Sync { QueuedCount = 1 },
                             },
                             new SFProject
                             {
@@ -471,7 +471,7 @@ namespace PtdaSyncAll
                                 {
                                     { "user01", SFProjectRole.Administrator },
                                     { "user02", SFProjectRole.Translator },
-                                    { "user03", SFProjectRole.Administrator }
+                                    { "user03", SFProjectRole.Administrator },
                                 },
                                 ParatextId = "target",
                                 TranslateConfig = new TranslateConfig
@@ -482,12 +482,12 @@ namespace PtdaSyncAll
                                         ParatextId = "source",
                                         Name = "Source",
                                         ShortName = "SR2",
-                                        WritingSystem = new WritingSystem { Tag = "en" }
-                                    }
+                                        WritingSystem = new WritingSystem { Tag = "en" },
+                                    },
                                 },
                                 CheckingConfig = new CheckingConfig { CheckingEnabled = checkingEnabled },
-                                Sync = new Sync { QueuedCount = 1 }
-                            }
+                                Sync = new Sync { QueuedCount = 1 },
+                            },
                         }
                     )
                 );
@@ -505,7 +505,7 @@ namespace PtdaSyncAll
                     new[]
                     {
                         new Claim(JwtClaimTypes.Subject, "paratext01"),
-                        new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
+                        new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString()),
                     },
                     expires: issuedAt + TimeSpan.FromMinutes(5)
                 );

--- a/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
+++ b/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
@@ -467,8 +467,8 @@ namespace PtdaSyncAll
                                 Arguments = $"-u {tempOldUsxFile} {tempNewUsxFile}",
                                 UseShellExecute = false,
                                 CreateNoWindow = true,
-                                RedirectStandardOutput = true
-                            }
+                                RedirectStandardOutput = true,
+                            },
                         }
                     )
                     {
@@ -545,7 +545,7 @@ namespace PtdaSyncAll
                     {
                         Number = incomingChapter.Key,
                         LastVerse = incomingChapter.Value.LastVerse,
-                        IsValid = incomingChapter.Value.IsValid
+                        IsValid = incomingChapter.Value.IsValid,
                     }
                 );
             }
@@ -669,7 +669,7 @@ namespace PtdaSyncAll
                     {
                         Number = kvp.Key,
                         LastVerse = kvp.Value.LastVerse,
-                        IsValid = kvp.Value.IsValid
+                        IsValid = kvp.Value.IsValid,
                     }
                 );
             }

--- a/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
+++ b/src/Migrations/SourceTargetSplitting/ObjectMigrator.cs
@@ -795,7 +795,7 @@ namespace SourceTargetSplitting
                     {
                         Number = kvp.Key,
                         LastVerse = kvp.Value.LastVerse,
-                        IsValid = kvp.Value.IsValid
+                        IsValid = kvp.Value.IsValid,
                     }
                 );
             }

--- a/src/Migrations/WhitespaceRestoreMigration/Migrator.cs
+++ b/src/Migrations/WhitespaceRestoreMigration/Migrator.cs
@@ -18,7 +18,7 @@ enum DirtyStatus
 {
     CLEAN,
     DIRTY,
-    MATCHES_NEW
+    MATCHES_NEW,
 }
 
 /// <summary>
@@ -413,8 +413,12 @@ public class Migrator : DisposableBase
     )
     {
         IDocument<TextData> chapterTextDocInSFDB = bookChapterTextDocsInSFDB[chapter.Number];
-        ChapterDelta chapterDeltaInSFDB =
-            new(chapter.Number, chapter.LastVerse, chapter.IsValid, chapterTextDocInSFDB.Data);
+        ChapterDelta chapterDeltaInSFDB = new(
+            chapter.Number,
+            chapter.LastVerse,
+            chapter.IsValid,
+            chapterTextDocInSFDB.Data
+        );
 
         // The chapter text in SF DB came from USX originally, and would have been parsed by the older parsing
         // method. Has it been untouched since that time?
@@ -546,7 +550,7 @@ public class Migrator : DisposableBase
             .GroupBy(row => new
             {
                 SFProjectId = row.Field<string>("SFProjectId"),
-                DirtyStatus = row.Field<DirtyStatus>("DirtyStatus")
+                DirtyStatus = row.Field<DirtyStatus>("DirtyStatus"),
             })
             .OrderBy(group => group.Key.SFProjectId);
 

--- a/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
@@ -69,7 +69,7 @@ public class AnonymousController(
     [HttpGet("featureFlags")]
     public async Task<ActionResult<Dictionary<string, bool>>> FeatureFlags()
     {
-        Dictionary<string, bool> features = new Dictionary<string, bool>();
+        Dictionary<string, bool> features = [];
         await foreach (string feature in featureManager.GetFeatureNamesAsync())
         {
             features.Add(feature, await featureManager.IsEnabledAsync(feature));

--- a/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/AnonymousController.cs
@@ -105,7 +105,7 @@ public class AnonymousController(
                 { "method", "GenerateAccount" },
                 { "shareKey", request.ShareKey },
                 { "displayName", request.DisplayName },
-                { "language", request.Language }
+                { "language", request.Language },
             }
         );
         try

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -60,7 +60,7 @@ public class SFProjectsRpcController(
                     { "method", "Create" },
                     { "ParatextId", settings?.ParatextId },
                     { "SourceParatextId", settings?.SourceParatextId },
-                    { "CheckingEnabled", settings?.CheckingEnabled.ToString() }
+                    { "CheckingEnabled", settings?.CheckingEnabled.ToString() },
                 }
             );
             throw;
@@ -89,7 +89,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "CreateResourceProject" }, { "ParatextId", paratextId }, }
+                new Dictionary<string, string> { { "method", "CreateResourceProject" }, { "ParatextId", paratextId } }
             );
             throw;
         }
@@ -117,7 +117,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "Delete" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -238,7 +238,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "GetProjectRole" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -324,7 +324,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "UninviteUser" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -347,7 +347,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "IsAlreadyInvited" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -370,7 +370,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "InvitedUsers" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -396,7 +396,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "shareKey", shareKey }, }
+                new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "shareKey", shareKey } }
             );
             throw;
         }
@@ -475,7 +475,7 @@ public class SFProjectsRpcController(
                 {
                     { "method", "ReserveLinkSharingKey" },
                     { "shareKey", shareKey },
-                    { "daysBeforeExpiration", daysBeforeExpiration.ToString() }
+                    { "daysBeforeExpiration", daysBeforeExpiration.ToString() },
                 }
             );
             throw;
@@ -529,7 +529,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "Sync" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -553,7 +553,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "CancelSync" }, { "projectId", projectId } }
             );
             throw;
         }
@@ -754,7 +754,7 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "TransceleratorQuestions" }, { "projectId", projectId }, }
+                new Dictionary<string, string> { { "method", "TransceleratorQuestions" }, { "projectId", projectId } }
             );
             throw;
         }

--- a/src/SIL.XForge.Scripture/Models/Answer.cs
+++ b/src/SIL.XForge.Scripture/Models/Answer.cs
@@ -6,7 +6,7 @@ public class Answer : Comment
 {
     public VerseRefData? VerseRef { get; set; }
     public string? ScriptureText { get; set; }
-    public List<Like> Likes { get; set; } = new List<Like>();
-    public List<Comment> Comments { get; set; } = new List<Comment>();
+    public List<Like> Likes { get; set; } = [];
+    public List<Comment> Comments { get; set; } = [];
     public string Status { get; set; } = AnswerStatus.None;
 }

--- a/src/SIL.XForge.Scripture/Models/BiblicalTerm.cs
+++ b/src/SIL.XForge.Scripture/Models/BiblicalTerm.cs
@@ -8,11 +8,10 @@ public class BiblicalTerm : ProjectData
     public string DataId { get; set; } = string.Empty;
     public string TermId { get; set; } = string.Empty;
     public string Transliteration { get; set; } = string.Empty;
-    public IList<string> Renderings { get; set; } = new List<string>();
+    public IList<string> Renderings { get; set; } = [];
     public string Description { get; set; } = string.Empty;
     public string Language { get; set; } = string.Empty;
-    public IList<string> Links { get; set; } = new List<string>();
-    public IList<int> References { get; set; } = new List<int>();
-    public IDictionary<string, BiblicalTermDefinition> Definitions { get; set; } =
-        new Dictionary<string, BiblicalTermDefinition>();
+    public IList<string> Links { get; set; } = [];
+    public IList<int> References { get; set; } = [];
+    public Dictionary<string, BiblicalTermDefinition> Definitions { get; set; } = [];
 }

--- a/src/SIL.XForge.Scripture/Models/BiblicalTermDefinition.cs
+++ b/src/SIL.XForge.Scripture/Models/BiblicalTermDefinition.cs
@@ -4,8 +4,8 @@ namespace SIL.XForge.Scripture.Models;
 
 public class BiblicalTermDefinition
 {
-    public IList<string> Categories { get; set; } = new List<string>();
-    public IList<string> Domains { get; set; } = new List<string>();
+    public IList<string> Categories { get; set; } = [];
+    public IList<string> Domains { get; set; } = [];
     public string Gloss { get; set; } = string.Empty;
     public string Notes { get; set; } = string.Empty;
 }

--- a/src/SIL.XForge.Scripture/Models/Chapter.cs
+++ b/src/SIL.XForge.Scripture/Models/Chapter.cs
@@ -13,7 +13,7 @@ public class Chapter
     /// it will not be editable in SF.
     /// </summary>
     public bool IsValid { get; set; }
-    public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
+    public Dictionary<string, string> Permissions { get; set; } = [];
     public bool? HasAudio { get; set; }
     public bool? HasDraft { get; set; }
     public bool? DraftApplied { get; set; }

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -10,7 +10,7 @@ public class NoteThread : ProjectData
     public string DataId { get; set; }
     public string ThreadId { get; set; }
     public VerseRefData VerseRef { get; set; }
-    public List<Note> Notes { get; set; } = new List<Note>();
+    public List<Note> Notes { get; set; } = [];
     public string OriginalSelectedText { get; set; }
     public string OriginalContextBefore { get; set; }
     public string OriginalContextAfter { get; set; }

--- a/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThreadChange.cs
@@ -28,12 +28,12 @@ public class NoteThreadChange
     public BiblicalTermNoteHeadingInfo? ExtraHeadingInfo { get; set; }
 
     public bool ThreadUpdated { get; set; }
-    public List<Note> NotesAdded { get; set; } = new List<Note>();
-    public List<Note> NotesUpdated { get; set; } = new List<Note>();
-    public List<Note> NotesDeleted { get; set; } = new List<Note>();
+    public List<Note> NotesAdded { get; set; } = [];
+    public List<Note> NotesUpdated { get; set; } = [];
+    public List<Note> NotesDeleted { get; set; } = [];
 
     /// <summary> IDs for notes that have been permanently removed. </summary>
-    public List<string> NoteIdsRemoved { get; set; } = new List<string>();
+    public List<string> NoteIdsRemoved { get; set; } = [];
 
     public bool HasChange
     {

--- a/src/SIL.XForge.Scripture/Models/ParatextResource.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextResource.cs
@@ -104,7 +104,7 @@ public class ParatextResource : ParatextProject
                 InstalledRevision.ToString(),
                 CreatedTimestamp.ToString(CultureInfo.CurrentCulture),
                 ManifestChecksum,
-                PermissionsChecksum
+                PermissionsChecksum,
             }
         )
         {

--- a/src/SIL.XForge.Scripture/Models/PreTranslationDto.cs
+++ b/src/SIL.XForge.Scripture/Models/PreTranslationDto.cs
@@ -1,8 +1,6 @@
-using System;
-
 namespace SIL.XForge.Scripture.Models;
 
 public class PreTranslationDto
 {
-    public PreTranslation[] PreTranslations { get; set; } = Array.Empty<PreTranslation>();
+    public PreTranslation[] PreTranslations { get; set; } = [];
 }

--- a/src/SIL.XForge.Scripture/Models/Question.cs
+++ b/src/SIL.XForge.Scripture/Models/Question.cs
@@ -10,7 +10,7 @@ public class Question : ProjectData
     public VerseRefData VerseRef { get; set; }
     public string Text { get; set; }
     public string AudioUrl { get; set; }
-    public List<Answer> Answers { get; set; } = new List<Answer>();
+    public List<Answer> Answers { get; set; } = [];
     public bool IsArchived { get; set; }
     public DateTime? DateArchived { get; set; }
     public DateTime DateModified { get; set; }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -13,17 +13,17 @@ public class SFProject : Project
     public TranslateConfig TranslateConfig { get; set; } = new TranslateConfig();
     public CheckingConfig CheckingConfig { get; set; } = new CheckingConfig();
     public ResourceConfig? ResourceConfig { get; set; }
-    public List<TextInfo> Texts { get; set; } = new List<TextInfo>();
+    public List<TextInfo> Texts { get; set; } = [];
     public Sync Sync { get; set; } = new Sync();
 
     /// <summary>
     /// Paratext users on this SF project that are associated with a project component (e.g. a note)
     /// </summary>
-    public List<ParatextUserProfile> ParatextUsers { get; set; } = new List<ParatextUserProfile>();
+    public List<ParatextUserProfile> ParatextUsers { get; set; } = [];
     public bool Editable { get; set; } = true;
     public int? DefaultFontSize { get; set; }
     public string? DefaultFont { get; set; }
-    public List<NoteTag> NoteTags { get; set; } = new List<NoteTag>();
+    public List<NoteTag> NoteTags { get; set; } = [];
     public BiblicalTermsConfig BiblicalTermsConfig { get; set; } = new BiblicalTermsConfig();
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectSecret.cs
@@ -14,7 +14,7 @@ public class SFProjectSecret : ProjectSecret
     /// <remarks>
     /// The <see cref="List{T}.Count">Count</see> should correspond to <see cref="Sync.QueuedCount" />.
     /// </remarks>
-    public List<string> JobIds { get; set; } = new List<string>();
+    public List<string> JobIds { get; set; } = [];
 
     /// <summary>
     /// The queued or active SyncMetrics Ids for the project.
@@ -26,7 +26,7 @@ public class SFProjectSecret : ProjectSecret
     /// This functions in a similar way to <see cref="JobIds"/>,
     /// so that we can mark the <see cref="SyncMetrics"/> as cancelled.
     /// </remarks>
-    public List<string> SyncMetricsIds { get; set; } = new List<string>();
+    public List<string> SyncMetricsIds { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the Serval data.

--- a/src/SIL.XForge.Scripture/Models/TextAudio.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAudio.cs
@@ -10,7 +10,7 @@ public class TextAudio : ProjectData
         $"{projectId}:{Canon.BookNumberToId(book)}:{chapter}:target";
 
     public string DataId { get; set; }
-    public List<AudioTiming> Timings { get; set; } = new List<AudioTiming>();
+    public List<AudioTiming> Timings { get; set; } = [];
     public string MimeType { get; set; }
     public string AudioUrl { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/TextInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/TextInfo.cs
@@ -6,6 +6,6 @@ public class TextInfo
 {
     public int BookNum { get; set; }
     public bool HasSource { get; set; }
-    public List<Chapter> Chapters { get; set; } = new List<Chapter>();
-    public Dictionary<string, string> Permissions { get; set; } = new Dictionary<string, string>();
+    public List<Chapter> Chapters { get; set; } = [];
+    public Dictionary<string, string> Permissions { get; set; } = [];
 }

--- a/src/SIL.XForge.Scripture/Services/AnonymousService.cs
+++ b/src/SIL.XForge.Scripture/Services/AnonymousService.cs
@@ -36,7 +36,7 @@ public class AnonymousService : IAnonymousService
         {
             ProjectName = validShareKey.Project.Name,
             Role = validShareKey.ShareKey.ProjectRole,
-            ShareKey = shareKey
+            ShareKey = shareKey,
         };
     }
 
@@ -55,7 +55,7 @@ public class AnonymousService : IAnonymousService
         var credentials = new TransparentAuthenticationCredentials
         {
             Username = _securityService.GenerateKey(),
-            Password = _securityService.GenerateKey(16)
+            Password = _securityService.GenerateKey(16),
         };
         _ = await _authService.GenerateAnonymousUser(displayName, credentials, language);
         await _projectService.IncreaseShareKeyUsersGenerated(shareKey);

--- a/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
@@ -64,7 +64,7 @@ public static class ApiDocumentationExtensions
                     {
                         new OpenApiSecurityScheme
                         {
-                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer", },
+                            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
                         },
                         Array.Empty<string>()
                     },

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -7,7 +7,7 @@ public static class DeltaUsxExtensions
 {
     public static Delta InsertPara(this Delta delta, JObject paraAttributes, JObject attributes = null)
     {
-        attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+        attributes = (JObject)attributes?.DeepClone() ?? [];
         attributes.Add(new JProperty("para", paraAttributes));
         return delta.Insert("\n", attributes);
     }
@@ -16,7 +16,7 @@ public static class DeltaUsxExtensions
     {
         if (segRef != null)
         {
-            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes = (JObject)attributes?.DeepClone() ?? [];
             attributes.Add(new JProperty("segment", segRef));
         }
         return delta.Insert(text, attributes);
@@ -30,7 +30,7 @@ public static class DeltaUsxExtensions
 
     public static Delta InsertEmpty(this Delta delta, string segRef, JObject attributes = null)
     {
-        attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+        attributes = (JObject)attributes?.DeepClone() ?? [];
         attributes.Add(new JProperty("segment", segRef));
         return delta.Insert(new { empty = true }, attributes);
     }
@@ -47,7 +47,7 @@ public static class DeltaUsxExtensions
 
         if (segRef != null)
         {
-            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes = (JObject)attributes?.DeepClone() ?? [];
             attributes.Add(new JProperty("segment", segRef));
         }
 

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -26,8 +26,8 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     /// Paragraph, Poetry, and List styles. This indicates paragraph styles that can contain verse text. For example, s
     /// is not included in the set, because it cannot contain verse text. See also text-view-model.ts PARA_STYLES.
     ///</summary>
-    private static readonly HashSet<string> ParagraphPoetryListStyles = new HashSet<string>
-    {
+    private static readonly HashSet<string> ParagraphPoetryListStyles =
+    [
         // Paragraphs
         "p",
         "nb",
@@ -56,7 +56,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         "li",
         "lf",
         "lim",
-    };
+    ];
 
     private IGuidService GuidService;
     private ILogger<DeltaUsxMapper> Logger;
@@ -287,14 +287,14 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                         break;
 
                     case "ref":
-                        var newRefAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
+                        var newRefAttributes = (JObject)attributes?.DeepClone() ?? [];
                         newRefAttributes.Add(new JProperty(elem.Name.LocalName, GetAttributes(elem)));
                         newRefAttributes = AddInvalidInlineAttribute(invalidNodes, elem, newRefAttributes);
                         newDelta.InsertText(elem.Value, state.CurRef, newRefAttributes);
                         break;
 
                     case "char":
-                        var newChildAttributes = (JObject)attributes?.DeepClone() ?? new JObject();
+                        var newChildAttributes = (JObject)attributes?.DeepClone() ?? [];
                         JToken existingCharAttrs = newChildAttributes["char"];
                         JObject newCharAttrs = GetAttributes(elem);
                         if (!newCharAttrs.ContainsKey("cid"))
@@ -476,7 +476,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     {
         if (invalidNodes.Contains(node))
         {
-            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes = (JObject)attributes?.DeepClone() ?? [];
             attributes["invalid-inline"] = true;
         }
         return attributes;
@@ -486,7 +486,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     {
         if (invalidNodes.Contains(node))
         {
-            attributes = (JObject)attributes?.DeepClone() ?? new JObject();
+            attributes = (JObject)attributes?.DeepClone() ?? [];
             attributes["invalid-block"] = true;
         }
         return attributes;
@@ -595,7 +595,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         // In-progress nested text and formatting, with the top of the stack representing the inner part of the nesting.
         // Each element contains a first-to-last set of XML nodes.
         var childNodes = new Stack<List<XNode>>();
-        childNodes.Push(new List<XNode>());
+        childNodes.Push([]);
         JObject curTableAttrs = null;
         JObject curRowAttrs = null;
         foreach (JToken op in delta.Ops)
@@ -625,7 +625,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                 // If the current op is inserting text with formatting that is not already being tracked for the
                 // existing text, prepare places to isolate the new text that the new formatting will apply to.
                 for (int i = curCharAttrs.Count; i < charAttrs.Count; i++)
-                    childNodes.Push(new List<XNode>());
+                    childNodes.Push([]);
                 curCharAttrs = charAttrs;
             }
 
@@ -667,9 +667,9 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     }
 
                     while (childNodes.Count < 2)
-                        childNodes.Push(new List<XNode>());
+                        childNodes.Push([]);
                     childNodes.Peek().Add(cellElem);
-                    childNodes.Push(new List<XNode>());
+                    childNodes.Push([]);
 
                     curTableAttrs = tableAttrs;
                     curRowAttrs = rowAttrs;
@@ -793,8 +793,8 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         return charAttrs switch
         {
             JArray array => new List<JObject>(array.Children<JObject>()),
-            JObject obj => new List<JObject> { obj },
-            _ => new List<JObject>(),
+            JObject obj => [obj],
+            _ => [],
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -55,7 +55,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         "lh",
         "li",
         "lf",
-        "lim"
+        "lim",
     };
 
     private IGuidService GuidService;

--- a/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
+++ b/src/SIL.XForge.Scripture/Services/DictionaryComparer.cs
@@ -7,9 +7,7 @@ namespace SIL.XForge.Scripture.Services;
 public class DictionaryComparer<TKey, TValue> : IEqualityComparer<Dictionary<TKey, TValue>>
 {
     public bool Equals(Dictionary<TKey, TValue>? x, Dictionary<TKey, TValue>? y) =>
-        (x ?? new Dictionary<TKey, TValue>())
-            .OrderBy(p => p.Key)
-            .SequenceEqual((y ?? new Dictionary<TKey, TValue>()).OrderBy(p => p.Key));
+        (x ?? []).OrderBy(p => p.Key).SequenceEqual((y ?? []).OrderBy(p => p.Key));
 
     public int GetHashCode(Dictionary<TKey, TValue>? obj)
     {

--- a/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
+++ b/src/SIL.XForge.Scripture/Services/DotNetCoreAlert.cs
@@ -9,7 +9,7 @@ namespace SIL.XForge.Scripture.Services;
 /// <summary> Simple alert implementation for Paratext Data to use when running in dotnet core. </summary>
 class DotNetCoreAlert : PtxUtils.Alert
 {
-    private readonly List<Action<string>> _listeners = new List<Action<String>>();
+    private readonly List<Action<string>> _listeners = [];
     private readonly ILogger _logger;
 
     public DotNetCoreAlert(ILogger logger) => _logger = logger;

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -47,7 +47,7 @@ public class HgWrapper : IHgWrapper
     public string GetLastPublicRevision(string repository)
     {
         string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
-        string revision = ids.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
+        string revision = ids.Split(["\n"], StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
         return revision;
     }
 

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -76,7 +76,7 @@ public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource,
             "projid",
             pullRepo.SendReceiveId.Id,
             "type",
-            "zstd-v2"
+            "zstd-v2",
         };
         if (baseRev != null)
         {

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -67,8 +67,8 @@ public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource,
 
         // Get bundle
         string guid = Guid.NewGuid().ToString();
-        List<string> query = new List<string>
-        {
+        List<string> query =
+        [
             "guid",
             guid,
             "proj",
@@ -77,18 +77,18 @@ public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource,
             pullRepo.SendReceiveId.Id,
             "type",
             "zstd-v2",
-        };
+        ];
         if (baseRev != null)
         {
             query.Add("base1");
             query.Add(baseRev);
         }
 
-        byte[] bundle = client.GetStreaming("pullbundle", query.ToArray());
+        byte[] bundle = client.GetStreaming("pullbundle", [.. query]);
         // Finish bundle
         client.Get("pullbundlefinish", "guid", guid);
         if (bundle.Length == 0)
-            return Array.Empty<string>();
+            return [];
 
         // Use bundle
         string[] changeSets = HgWrapper.Pull(repository, bundle);
@@ -205,7 +205,7 @@ public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource,
         JArray licenses = GetJson<JArray>("my/licenses");
         if (licenses == null)
             return null;
-        List<ProjectLicense> result = new List<ProjectLicense>();
+        List<ProjectLicense> result = [];
         foreach (JObject license in licenses.Cast<JObject>())
         {
             var projLicense = new ProjectLicense(license);

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -76,7 +76,7 @@ public class JwtTokenHelper(IExceptionHandler exceptionHandler, ILogger<JwtToken
         Tokens tokens = new Tokens
         {
             AccessToken = (string)responseObj["access_token"],
-            RefreshToken = (string)responseObj["refresh_token"]
+            RefreshToken = (string)responseObj["refresh_token"],
         };
 
         // Track the clock drift between the Scripture Forge and the Paratext Registry servers

--- a/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
+++ b/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
@@ -123,7 +123,7 @@ public class MutexAttribute(string? resource = null) : JobFilterAttribute, IElec
     public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction) { }
 
     private static DeletedState CreateDeletedState(string blockedBy) =>
-        new DeletedState { Reason = $"Execution was blocked by background job {blockedBy}, all attempts exhausted", };
+        new DeletedState { Reason = $"Execution was blocked by background job {blockedBy}, all attempts exhausted" };
 
     private ScheduledState CreateScheduledState(string blockedBy, int currentAttempt)
     {

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -154,7 +154,7 @@ public static class NotesFormatter
     #region Private helper methods for parsing
     private static List<Comment> ParseThread(XElement threadElem, ParatextUser ptUser)
     {
-        List<Comment> result = new List<Comment>();
+        List<Comment> result = [];
         Comment comment = null;
         foreach (var commentElem in threadElem.Elements("comment"))
         {
@@ -225,7 +225,7 @@ public static class NotesFormatter
                 XElement elem = (XElement)node;
                 if (elem.Name == "span")
                 {
-                    string[] styles = { "bold", "italic" };
+                    string[] styles = ["bold", "italic"];
                     var style = styles.SingleOrDefault(s => s == elem.Attribute("style")?.Value) ?? "span";
                     p.Add(new XElement(style, elem.GetInnerText()));
                 }

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -66,10 +66,10 @@ public class ParatextNotesMapper(
     )
     {
         // Usernames of SF community checker users. Paratext users are mapped to null.
-        Dictionary<string, string> checkerUsernames = new Dictionary<string, string>();
+        Dictionary<string, string> checkerUsernames = [];
         var version = (string)oldNotesElem.Attribute("version") ?? "1.1";
         Dictionary<string, XElement> oldCommentElems = GetOldCommentElements(oldNotesElem, ptProjectUsers);
-        List<XElement> commentsToDelete = new List<XElement>();
+        List<XElement> commentsToDelete = [];
 
         var notesElem = new XElement("notes", new XAttribute("version", version));
         if (answerExportMethod != CheckingAnswerExport.None)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -741,7 +741,7 @@ public class ParatextService : DisposableBase, IParatextService
             foreach (
                 ParatextProjectUser user in project.UserRoles.Keys.Select(userId => new ParatextProjectUser
                 {
-                    Id = userId
+                    Id = userId,
                 })
             )
             {
@@ -949,7 +949,7 @@ public class ParatextService : DisposableBase, IParatextService
                 TagId = t.Id,
                 Icon = t.Icon,
                 Name = t.Name,
-                CreatorResolve = t.CreatorResolve
+                CreatorResolve = t.CreatorResolve,
             });
 
         // If the copyright banner is blank or empty, make it null so it will not be displayed
@@ -1350,7 +1350,7 @@ public class ParatextService : DisposableBase, IParatextService
             {
                 Position = GetThreadTextAnchor(thread, chapterDeltas),
                 Status = thread.Status.InternalValue,
-                Assignment = GetAssignedUserRef(thread.AssignedUser, ptProjectUsers)
+                Assignment = GetAssignedUserRef(thread.AssignedUser, ptProjectUsers),
             };
             foreach (var comm in thread.Comments)
             {
@@ -1460,7 +1460,7 @@ public class ParatextService : DisposableBase, IParatextService
                     return new BiblicalTermsChanges
                     {
                         ErrorCode = BiblicalTermErrorCode.NotSynced,
-                        ErrorMessage = message
+                        ErrorMessage = message,
                     };
                 }
 
@@ -1480,7 +1480,7 @@ public class ParatextService : DisposableBase, IParatextService
                     return new BiblicalTermsChanges
                     {
                         ErrorCode = BiblicalTermErrorCode.NoPermission,
-                        ErrorMessage = message
+                        ErrorMessage = message,
                     };
                 }
 
@@ -1941,7 +1941,7 @@ public class ParatextService : DisposableBase, IParatextService
                 Id = id,
                 Version = 0,
                 Data = new TextData(chapterDelta.Delta),
-                IsValid = chapterDelta.IsValid
+                IsValid = chapterDelta.IsValid,
             };
         }
         else
@@ -1954,7 +1954,7 @@ public class ParatextService : DisposableBase, IParatextService
                 Id = snapshot.Id,
                 Version = snapshot.Version,
                 Data = snapshot.Data,
-                IsValid = chapterDelta.IsValid
+                IsValid = chapterDelta.IsValid,
             };
         }
 
@@ -2571,7 +2571,7 @@ public class ParatextService : DisposableBase, IParatextService
             Repository = sharedRepository,
             SendReceiveId = HexId.FromStr(paratextId),
             ScrText = scrText,
-            Permissions = scrText.Permissions
+            Permissions = scrText.Permissions,
         };
     }
 
@@ -2960,13 +2960,12 @@ public class ParatextService : DisposableBase, IParatextService
                         ExtraHeadingInfo = threadDoc.Data.ExtraHeadingInfo switch
                         {
                             null => null,
-                            _
-                                => new TermNoteHeadingInfo(
-                                    threadDoc.Data.ExtraHeadingInfo.Lemma,
-                                    threadDoc.Data.ExtraHeadingInfo.Language,
-                                    threadDoc.Data.ExtraHeadingInfo.Transliteration,
-                                    threadDoc.Data.ExtraHeadingInfo.Gloss
-                                ),
+                            _ => new TermNoteHeadingInfo(
+                                threadDoc.Data.ExtraHeadingInfo.Lemma,
+                                threadDoc.Data.ExtraHeadingInfo.Language,
+                                threadDoc.Data.ExtraHeadingInfo.Transliteration,
+                                threadDoc.Data.ExtraHeadingInfo.Gloss
+                            ),
                         },
                     };
 
@@ -3370,7 +3369,7 @@ public class ParatextService : DisposableBase, IParatextService
             ptProjectUser = new ParatextUserProfile
             {
                 OpaqueUserId = _guidService.NewObjectId(),
-                Username = paratextUsername
+                Username = paratextUsername,
             };
             ptProjectUsers.Add(paratextUsername, ptProjectUser);
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -280,12 +280,11 @@ public class ParatextService : DisposableBase, IParatextService
                 StartProgressReporting(progress);
 
                 string username = GetParatextUsername(userSecret);
-                using ScrText scrText = ScrTextCollection.FindById(username, paratextId);
-                if (scrText == null)
-                    throw new Exception(
+                using ScrText scrText =
+                    ScrTextCollection.FindById(username, paratextId)
+                    ?? throw new Exception(
                         $"Failed to fetch ScrText for PT project id {paratextId} using PT username {username}"
                     );
-
                 SharedProject sharedProj = CreateSharedProject(
                     paratextId,
                     ptProject.ShortName,
@@ -638,7 +637,7 @@ public class ParatextService : DisposableBase, IParatextService
                     + $"Revisions sent: {string.Join(",", r.RevisionsSent ?? Enumerable.Empty<string>())}, "
                     + $"Revisions received: {string.Join(",", r.RevisionsReceived ?? Enumerable.Empty<string>())}, "
                     + $"Failure message: {r.FailureMessage}."
-            ) ?? Enumerable.Empty<string>()
+            ) ?? []
         );
     }
 
@@ -726,16 +725,9 @@ public class ParatextService : DisposableBase, IParatextService
 
             IEnumerable<SharedRepository> remotePtProjects = GetRepositories(ptRepoSource, contextInformation);
 
-            SharedRepository remotePtProject = remotePtProjects.SingleOrDefault(p =>
-                p.SendReceiveId.Id == project.ParatextId
-            );
-
-            // if the paratext id could not be found then the user does not have access.
-            // Throw the ForbiddenException and fail the sync.
-            if (remotePtProject is null)
-            {
-                throw new ForbiddenException();
-            }
+            SharedRepository remotePtProject =
+                remotePtProjects.SingleOrDefault(p => p.SendReceiveId.Id == project.ParatextId)
+                ?? throw new ForbiddenException();
 
             // Build a dictionary of user IDs mapped to usernames using the user secrets
             foreach (
@@ -999,9 +991,9 @@ public class ParatextService : DisposableBase, IParatextService
     /// <summary> Get PT book text in USX, or throw if can't. </summary>
     public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
     {
-        using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-        if (scrText == null)
-            throw new DataNotFoundException("Can't get access to cloned project.");
+        using ScrText scrText =
+            ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId)
+            ?? throw new DataNotFoundException("Can't get access to cloned project.");
         string usfm = scrText.GetText(bookNum);
         return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
     }
@@ -1029,7 +1021,7 @@ public class ParatextService : DisposableBase, IParatextService
         StringBuilder log = new StringBuilder(
             $"ParatextService.PutBookText(userSecret, paratextId {paratextId}, bookNum {bookNum}, usx {usx.Root}, chapterAuthors: {(chapNumToAuthorSFUserIdMap == null ? "null" : ($"count {chapNumToAuthorSFUserIdMap.Count}"))})"
         );
-        Dictionary<string, ScrText> scrTexts = new Dictionary<string, ScrText>();
+        Dictionary<string, ScrText> scrTexts = [];
         try
         {
             log.AppendLine(
@@ -1224,15 +1216,15 @@ public class ParatextService : DisposableBase, IParatextService
     {
         CommentManager commentManager = GetCommentManager(userSecret, paratextId);
         CommentTags commentTags = GetCommentTags(userSecret, paratextId);
-        List<string> matchedThreadIds = new List<string>();
-        List<NoteThreadChange> changes = new List<NoteThreadChange>();
+        List<string> matchedThreadIds = [];
+        List<NoteThreadChange> changes = [];
         IEnumerable<IDocument<NoteThread>> activeNoteThreadDocs = noteThreadDocs.Where(nt =>
             nt.Data.Notes.Any(n => !n.Deleted)
         );
 
         foreach (var threadDoc in activeNoteThreadDocs)
         {
-            List<string> matchedCommentIds = new List<string>();
+            List<string> matchedCommentIds = [];
             NoteThreadChange threadChange = new NoteThreadChange(
                 threadDoc.Data.DataId,
                 threadDoc.Data.ThreadId,
@@ -1525,8 +1517,7 @@ public class ParatextService : DisposableBase, IParatextService
             )
             {
                 TermRendering termRendering = termRenderings.GetRendering(term.Id);
-                Dictionary<string, BiblicalTermDefinition> definitions =
-                    new Dictionary<string, BiblicalTermDefinition>();
+                Dictionary<string, BiblicalTermDefinition> definitions = [];
                 foreach ((string language, TermLocalizations termLocalizations) in allTermLocalizations)
                 {
                     TermLocalization termLocalization = termLocalizations.GetTermLocalization(term.Id);
@@ -2150,18 +2141,14 @@ public class ParatextService : DisposableBase, IParatextService
 
     private ScrText GetScrText(UserSecret userSecret, string paratextId)
     {
-        string? ptUsername = GetParatextUsername(userSecret);
-        if (ptUsername == null)
-        {
-            throw new DataNotFoundException($"Failed to get username for UserSecret id {userSecret.Id}.");
-        }
-        ScrText? scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId);
-        if (scrText == null)
-        {
-            throw new DataNotFoundException(
+        _ =
+            GetParatextUsername(userSecret)
+            ?? throw new DataNotFoundException($"Failed to get username for UserSecret id {userSecret.Id}.");
+        ScrText? scrText =
+            ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId)
+            ?? throw new DataNotFoundException(
                 $"Could not find project for UserSecret id {userSecret.Id}, PT project id {paratextId}"
             );
-        }
         return scrText;
     }
 
@@ -2257,7 +2244,7 @@ public class ParatextService : DisposableBase, IParatextService
         if (userSecret == null)
             throw new ArgumentNullException();
 
-        List<ParatextProject> paratextProjects = new List<ParatextProject>();
+        List<ParatextProject> paratextProjects = [];
         IQueryable<SFProject> existingSfProjects = _realtimeService.QuerySnapshots<SFProject>();
 
         foreach (SharedRepository remotePtProject in remotePtProjects)
@@ -2643,7 +2630,7 @@ public class ParatextService : DisposableBase, IParatextService
         }
 
         string username = GetParatextUsername(userSecret);
-        List<string> users = new List<string>();
+        List<string> users = [];
         ScrText scrText =
             ScrTextCollection.FindById(username, paratextId)
             ?? throw new DataNotFoundException("Can't get access to cloned project.");
@@ -2873,14 +2860,13 @@ public class ParatextService : DisposableBase, IParatextService
         Dictionary<string, ParatextUserProfile> ptProjectUsers
     )
     {
-        List<List<Paratext.Data.ProjectComments.Comment>> changes =
-            new List<List<Paratext.Data.ProjectComments.Comment>>();
+        List<List<Paratext.Data.ProjectComments.Comment>> changes = [];
         IEnumerable<IDocument<NoteThread>> activeThreadDocs = noteThreadDocs.Where(t => t.Data != null);
         foreach (IDocument<NoteThread> threadDoc in activeThreadDocs)
         {
-            List<Paratext.Data.ProjectComments.Comment> thread = new List<Paratext.Data.ProjectComments.Comment>();
+            List<Paratext.Data.ProjectComments.Comment> thread = [];
             CommentThread? existingThread = commentManager.FindThread(threadDoc.Data.ThreadId);
-            List<(int, string)> threadNoteParatextUserRefs = new List<(int, string)>();
+            List<(int, string)> threadNoteParatextUserRefs = [];
             for (int i = 0; i < threadDoc.Data.Notes.Count; i++)
             {
                 Note note = threadDoc.Data.Notes[i];
@@ -3191,9 +3177,9 @@ public class ParatextService : DisposableBase, IParatextService
         comment.TagsAdded =
             note.TagId == null
                 ? isFirstComment
-                    ? new[] { sfNoteTagId.ToString() }
+                    ? [sfNoteTagId.ToString()]
                     : null
-                : new[] { note.TagId.ToString() };
+                : [note.TagId.ToString()];
         comment.VersionNumber = note.VersionNumber ?? 1;
 
         if (note.Status == NoteStatus.Todo.InternalValue)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1561,7 +1561,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             {
                 TagId = NoteTag.notSetId,
                 Icon = NoteTag.sfNoteTagIcon,
-                Name = NoteTag.sfNoteTagName
+                Name = NoteTag.sfNoteTagName,
             };
             // Note: If we introduce a new note tag and the remote PT repo also introduces a note tag,
             // the tag introduced here will get overwritten
@@ -1579,7 +1579,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         {
             TagId = NoteTag.notSetId,
             Icon = NoteTag.checkingTagIcon,
-            Name = NoteTag.checkingTagName
+            Name = NoteTag.checkingTagName,
         };
         noteTagId = _paratextService.UpdateCommentTag(_userSecret, targetParatextId, newNoteTag);
         await _projectDoc.SubmitJson0OpAsync(op => op.Set(p => p.CheckingConfig.NoteTagId, noteTagId));
@@ -2133,7 +2133,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                         1.0 / _numberOfPhases * (double)syncPhase
                         + (progress > 1.0 ? progress / 100.0 : progress) * 1.0 / _numberOfPhases,
                     SyncPhase = syncPhase,
-                    SyncProgress = progress
+                    SyncProgress = progress,
                 }
             );
         }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -659,7 +659,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         LogMetric("Updating Paratext biblical terms");
         await NotifySyncProgress(syncPhase, 50);
         double i = 0.0;
-        List<BiblicalTerm> biblicalTermsToUpdate = new List<BiblicalTerm>();
+        List<BiblicalTerm> biblicalTermsToUpdate = [];
         foreach (IDocument<BiblicalTerm> biblicalTermDoc in biblicalTermDocs)
         {
             i++;
@@ -695,11 +695,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
     )
     {
         LogMetric("Updating Biblical Terms thread docs");
-        await UpdateNoteThreadDocsAsync(
-            null,
-            biblicalTermNoteThreadDocs.ToDictionary(nt => nt.Data.DataId),
-            new Dictionary<int, ChapterDelta>()
-        );
+        await UpdateNoteThreadDocsAsync(null, biblicalTermNoteThreadDocs.ToDictionary(nt => nt.Data.DataId), []);
 
         LogMetric("Getting Paratext biblical terms");
         await NotifySyncProgress(syncPhase, 0);
@@ -918,7 +914,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 !targetTextDocsByBook.TryGetValue(text.BookNum, out SortedList<int, IDocument<TextData>> targetTextDocs)
             )
             {
-                targetTextDocs = new SortedList<int, IDocument<TextData>>();
+                targetTextDocs = [];
             }
 
             LogMetric("Updating text docs - get deltas");
@@ -1028,7 +1024,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
         }
         _userIdsToDisplayNames = await _userService.DisplayNamesFromUserIds(
             userId,
-            _projectDoc.Data.UserRoles.Keys.ToArray()
+            [.. _projectDoc.Data.UserRoles.Keys]
         );
 
         if (!(await _userSecrets.TryGetAsync(userId)).TryResult(out _userSecret))

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -169,11 +169,9 @@ public class SFInstallableDblResource : InstallableResource
                 if (_fileSystemService.FileExists(projectPath))
                 {
                     var name = new ProjectName(projectPath);
-                    string userName = _jwtTokenHelper.GetParatextUsername(_userSecret);
-                    if (userName == null)
-                    {
-                        throw new Exception($"Failed to get a PT username for SF user id {_userSecret.Id}.");
-                    }
+                    string userName =
+                        _jwtTokenHelper.GetParatextUsername(_userSecret)
+                        ?? throw new Exception($"Failed to get a PT username for SF user id {_userSecret.Id}.");
                     var passwordProvider = new ParatextZippedResourcePasswordProvider(_paratextOptions);
                     var resourceScrText = _scrTextCollection.CreateResourceScrText(userName, name, passwordProvider);
                     if (resourceScrText.Settings.DBLId == DBLEntryUid)
@@ -345,7 +343,7 @@ public class SFInstallableDblResource : InstallableResource
             var report = new Exception(errorExplanation);
             // Report to bugsnag, but don't throw.
             exceptionHandler.ReportException(report);
-            return Enumerable.Empty<SFInstallableDblResource>();
+            return [];
         }
         IEnumerable<SFInstallableDblResource> resources = ConvertJsonResponseToInstallableDblResources(
             baseUrl,
@@ -480,7 +478,7 @@ public class SFInstallableDblResource : InstallableResource
     internal static IReadOnlyDictionary<string, int> GetInstalledResourceRevisions()
     {
         // Initialize variables
-        Dictionary<string, int> resourceRevisions = new Dictionary<string, int>();
+        Dictionary<string, int> resourceRevisions = [];
         string resourcesDirectory;
         string resourcesByIdDirectory;
 
@@ -501,8 +499,7 @@ public class SFInstallableDblResource : InstallableResource
         if (!string.IsNullOrWhiteSpace(resourcesDirectory) && Directory.Exists(resourcesDirectory))
         {
             const string resourceFilesPattern = $"*{ProjectFileManager.resourceFileExtension}";
-            List<string> resourceFiles = new List<string>();
-            resourceFiles.AddRange(Directory.EnumerateFiles(resourcesDirectory, resourceFilesPattern));
+            List<string> resourceFiles = [.. Directory.EnumerateFiles(resourcesDirectory, resourceFilesPattern)];
             if (Directory.Exists(resourcesByIdDirectory))
             {
                 resourceFiles.AddRange(Directory.EnumerateFiles(resourcesByIdDirectory, resourceFilesPattern));
@@ -671,7 +668,7 @@ public class SFInstallableDblResource : InstallableResource
                 // This is probably caused by partial result from poor connection to DBL
                 yield break;
             }
-            foreach (JToken jsonResource in jsonResources["resources"] as JArray ?? new JArray())
+            foreach (JToken jsonResource in jsonResources["resources"] as JArray ?? [])
             {
                 var name = (string)jsonResource["name"];
                 var nameCommon = (string)jsonResource["nameCommon"];

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -941,7 +941,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         {
             Project = project,
             ProjectSecret = projectSecret,
-            ShareKey = projectSecretShareKey
+            ShareKey = projectSecretShareKey,
         };
     }
 
@@ -1578,11 +1578,10 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 {
                     TextInfoPermission.None => Attempt.Failure(ProjectRole.None),
                     TextInfoPermission.Read => Attempt.Success(SFProjectRole.PTObserver),
-                    _
-                        => throw new ArgumentException(
-                            $"Unknown resource permission: '{permission}'",
-                            nameof(permission)
-                        ),
+                    _ => throw new ArgumentException(
+                        $"Unknown resource permission: '{permission}'",
+                        nameof(permission)
+                    ),
                 };
             }
             else

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -274,7 +274,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             if (FileSystemService.DirectoryExists(trainingDataDir))
                 FileSystemService.DeleteDirectory(trainingDataDir);
 
-            string[] projectUserIds = projectDoc.Data.UserRoles.Keys.ToArray();
+            string[] projectUserIds = [.. projectDoc.Data.UserRoles.Keys];
             await projectDoc.DeleteAsync();
             async Task removeUser(string projectUserId)
             {
@@ -1789,12 +1789,14 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     private string[] GetProjectWithReferenceToSource(string projectId)
     {
         if (string.IsNullOrEmpty(projectId))
-            return Array.Empty<string>();
+            return [];
         IQueryable<SFProject> projectQuery = RealtimeService.QuerySnapshots<SFProject>();
-        return projectQuery
-            .Where(p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId)
-            .Select(p => p.Id)
-            .ToArray();
+        return
+        [
+            .. projectQuery
+                .Where(p => p.TranslateConfig.Source != null && p.TranslateConfig.Source.ProjectRef == projectId)
+                .Select(p => p.Id),
+        ];
     }
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -14,7 +14,7 @@ namespace SIL.XForge.Scripture.Services;
 public class SFScrTextCollection : ScrTextCollection
 {
     // Keep track of languages that weren't found in SLDR so we don't call over and over for the same bad code.
-    private static readonly List<string> _sldrLookupFailed = new List<string>();
+    private static readonly List<string> _sldrLookupFailed = [];
 
     /// <summary>
     /// The location where resources reside if there is more than one resource with the same short name.

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hangfire;
@@ -370,8 +369,8 @@ public class SyncService(
                 projectSecret.Id,
                 u =>
                 {
-                    u.Set(p => p.JobIds, new List<string>());
-                    u.Set(p => p.SyncMetricsIds, new List<string>());
+                    u.Set(p => p.JobIds, []);
+                    u.Set(p => p.SyncMetricsIds, []);
                 }
             );
 

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -48,7 +48,7 @@ public class TransceleratorService : ITransceleratorService
                     EndChapter = AttributeText(q, "endChapter"),
                     EndVerse = AttributeText(q, "endVerse"),
                     Text = NodeTextOfLanguage(q.SelectNodes("Q/StringAlt").Cast<XmlNode>(), lang),
-                    Id = AttributeText(q, "id")
+                    Id = AttributeText(q, "id"),
                 });
         });
     }

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -27,8 +27,7 @@ public class TransceleratorService : ITransceleratorService
         // Check that the schema version declared in the file is at least 1.1 (coresponding to Transcelerator version 1.5.2)
         if (
             docs.Any(doc =>
-                doc.Attributes["version"] == null
-                || !VersionSatisfies(doc.Attributes["version"].Value, new int[] { 1, 1 })
+                doc.Attributes["version"] == null || !VersionSatisfies(doc.Attributes["version"].Value, [1, 1])
             )
         )
         {

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -28,7 +28,7 @@ public enum SpaDevServerStartup
 {
     None,
     Start,
-    Listen
+    Listen,
 }
 
 public class Startup
@@ -49,7 +49,7 @@ public class Startup
         "main.js.map",
         "manifest.json",
         "sockjs-node",
-        "3rdpartylicenses.txt"
+        "3rdpartylicenses.txt",
     };
 
     // examples of filenames are "main-es5.4e5295b95e4b6c37b696.js", "styles.a2f070be0b37085d72ba.css"
@@ -61,7 +61,7 @@ public class Startup
         "runtime-es5",
         "main-es2015",
         "main-es5",
-        "styles"
+        "styles",
     };
     private static readonly HashSet<string> SpaGetRoutes = new HashSet<string>
     {
@@ -73,7 +73,7 @@ public class Startup
         "serval-administration",
         "system-administration",
         "favicon.ico",
-        "assets"
+        "assets",
     };
 
     private static readonly HashSet<string> DevelopmentSpaPostRoutes = new HashSet<string> { "sockjs-node" };
@@ -230,7 +230,7 @@ public class Startup
             new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SiteDir, "audio")),
-                RequestPath = "/assets/audio"
+                RequestPath = "/assets/audio",
             }
         );
         app.UseStaticFiles(

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -33,8 +33,8 @@ public enum SpaDevServerStartup
 
 public class Startup
 {
-    private static readonly HashSet<string> DevelopmentSpaGetRoutes = new HashSet<string>
-    {
+    private static readonly HashSet<string> DevelopmentSpaGetRoutes =
+    [
         "runtime.js",
         "runtime.js.map",
         "polyfills.js",
@@ -50,11 +50,11 @@ public class Startup
         "manifest.json",
         "sockjs-node",
         "3rdpartylicenses.txt",
-    };
+    ];
 
     // examples of filenames are "main-es5.4e5295b95e4b6c37b696.js", "styles.a2f070be0b37085d72ba.css"
-    private static readonly HashSet<string> ProductionSpaGetRoutes = new HashSet<string>
-    {
+    private static readonly HashSet<string> ProductionSpaGetRoutes =
+    [
         "polyfills-es2015",
         "polyfills-es5",
         "runtime-es2015",
@@ -62,9 +62,9 @@ public class Startup
         "main-es2015",
         "main-es5",
         "styles",
-    };
-    private static readonly HashSet<string> SpaGetRoutes = new HashSet<string>
-    {
+    ];
+    private static readonly HashSet<string> SpaGetRoutes =
+    [
         "callback",
         "connect-project",
         "login",
@@ -74,11 +74,11 @@ public class Startup
         "system-administration",
         "favicon.ico",
         "assets",
-    };
+    ];
 
-    private static readonly HashSet<string> DevelopmentSpaPostRoutes = new HashSet<string> { "sockjs-node" };
-    private static readonly HashSet<string> ProductionSpaPostRoutes = new HashSet<string>();
-    private static readonly HashSet<string> SpaPostRoutes = new HashSet<string>();
+    private static readonly HashSet<string> DevelopmentSpaPostRoutes = ["sockjs-node"];
+    private static readonly HashSet<string> ProductionSpaPostRoutes = [];
+    private static readonly HashSet<string> SpaPostRoutes = [];
 
     public Startup(IConfiguration configuration, IWebHostEnvironment env, ILoggerFactory loggerFactory)
     {

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -22,11 +22,11 @@ public class RealtimeOptions
     /// Additional document types (importantly, collection names) that have project related data. Defining this
     /// helps identify and delete project data when removing a project.
     /// </summary>
-    public List<DocConfig> ProjectDataDocs { get; set; } = new List<DocConfig>();
+    public List<DocConfig> ProjectDataDocs { get; set; } = [];
 
     /// <summary>
     /// Document types (importantly, collection names) that have user information, from which to delete records
     /// when removing a user from the database.
     /// </summary>
-    public List<DocConfig> UserDataDocs { get; set; } = new List<DocConfig>();
+    public List<DocConfig> UserDataDocs { get; set; } = [];
 }

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -66,7 +66,7 @@ public class UsersRpcController : RpcControllerBase
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId }, }
+                new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId } }
             );
             throw;
         }
@@ -119,7 +119,7 @@ public class UsersRpcController : RpcControllerBase
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "UpdateAvatarFromDisplayName" }, }
+                new Dictionary<string, string> { { "method", "UpdateAvatarFromDisplayName" } }
             );
             throw;
         }
@@ -135,7 +135,7 @@ public class UsersRpcController : RpcControllerBase
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "UpdateInterfaceLanguage" }, { "language", language }, }
+                new Dictionary<string, string> { { "method", "UpdateInterfaceLanguage" }, { "language", language } }
             );
             throw;
         }
@@ -155,7 +155,7 @@ public class UsersRpcController : RpcControllerBase
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId }, }
+                new Dictionary<string, string> { { "method", "Delete" }, { "userId", userId } }
             );
 
             throw;

--- a/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
@@ -170,7 +170,7 @@ public static class DataAccessExtensions
         if (queryable is IMongoQueryable<T> mongoQueryable)
             return await IAsyncCursorSourceExtensions.ToListAsync(mongoQueryable);
         else
-            return queryable.ToList();
+            return [.. queryable];
     }
 
     public static async Task<List<TResult>> ToListAsync<TSource, TResult>(

--- a/src/SIL.XForge/DataAccess/MemoryRepository.cs
+++ b/src/SIL.XForge/DataAccess/MemoryRepository.cs
@@ -17,7 +17,7 @@ public class MemoryRepository<T> : IRepository<T>
     private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
     {
         TypeNameHandling = TypeNameHandling.Auto,
-        ContractResolver = new WritableContractResolver()
+        ContractResolver = new WritableContractResolver(),
     };
 
     private readonly ConcurrentDictionary<string, string> _entities;

--- a/src/SIL.XForge/DataAccess/MemoryRepository.cs
+++ b/src/SIL.XForge/DataAccess/MemoryRepository.cs
@@ -29,10 +29,10 @@ public class MemoryRepository<T> : IRepository<T>
 
     public MemoryRepository(IEnumerable<Func<T, object>> uniqueKeySelectors = null, IEnumerable<T> entities = null)
     {
-        _uniqueKeySelectors = uniqueKeySelectors?.ToArray() ?? Array.Empty<Func<T, object>>();
+        _uniqueKeySelectors = uniqueKeySelectors?.ToArray() ?? [];
         _uniqueKeys = new HashSet<object>[_uniqueKeySelectors.Length];
         for (int i = 0; i < _uniqueKeys.Length; i++)
-            _uniqueKeys[i] = new HashSet<object>();
+            _uniqueKeys[i] = [];
 
         _entities = new ConcurrentDictionary<string, string>();
         if (entities != null)
@@ -168,7 +168,7 @@ public class MemoryRepository<T> : IRepository<T>
 
     public Task<int> DeleteAllAsync(Expression<Func<T, bool>> filter)
     {
-        T[] entities = Query().Where(filter).ToArray();
+        T[] entities = [.. Query().Where(filter)];
         foreach (T entity in entities)
             Remove(entity);
         return Task.FromResult(entities.Length);

--- a/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
@@ -26,7 +26,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
     public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
     {
         (IEnumerable<object> owners, PropertyInfo propInfo, object index) = GetFieldOwners(field);
-        object[] indices = index == null ? null : new[] { index };
+        object[] indices = index == null ? null : [index];
         foreach (object owner in owners)
             propInfo.SetValue(owner, value, indices);
         return this;
@@ -47,9 +47,9 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
             // remove value from a dictionary
             Type dictionaryType = prop.DeclaringType;
             Type keyType = dictionaryType.GetGenericArguments()[0];
-            MethodInfo removeMethod = dictionaryType.GetMethod("Remove", new[] { keyType });
+            MethodInfo removeMethod = dictionaryType.GetMethod("Remove", [keyType]);
             foreach (object owner in owners)
-                removeMethod.Invoke(owner, new[] { index });
+                removeMethod.Invoke(owner, [index]);
         }
         else
         {
@@ -66,7 +66,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
     public IUpdateBuilder<T> Inc(Expression<Func<T, int>> field, int value)
     {
         (IEnumerable<object> owners, PropertyInfo prop, object index) = GetFieldOwners(field);
-        object[] indices = index == null ? null : new[] { index };
+        object[] indices = index == null ? null : [index];
         foreach (object owner in owners)
         {
             var curValue = (int)prop.GetValue(owner, indices);
@@ -86,7 +86,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
         TItem[] toRemove = collection.Where(predicate.Compile()).ToArray();
         MethodInfo removeMethod = collection.GetType().GetMethod("Remove");
         foreach (TItem item in toRemove)
-            removeMethod.Invoke(collection, new object[] { item });
+            removeMethod.Invoke(collection, [item]);
         return this;
     }
 
@@ -95,7 +95,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
         Func<T, IEnumerable<TItem>> getCollection = field.Compile();
         IEnumerable<TItem> collection = getCollection(_entity);
         MethodInfo addMethod = collection.GetType().GetMethod("Remove");
-        addMethod.Invoke(collection, new object[] { value });
+        addMethod.Invoke(collection, [value]);
         return this;
     }
 
@@ -104,7 +104,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
         Func<T, IEnumerable<TItem>> getCollection = field.Compile();
         IEnumerable<TItem> collection = getCollection(_entity);
         MethodInfo addMethod = collection.GetType().GetMethod("Add");
-        addMethod.Invoke(collection, new object[] { value });
+        addMethod.Invoke(collection, [value]);
         return this;
     }
 
@@ -150,10 +150,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
                                         var predicate = (LambdaExpression)callExpr.Arguments[1];
                                         Type itemType = predicate.Parameters[0].Type;
                                         MethodInfo firstOrDefault = GetFirstOrDefaultMethod(itemType);
-                                        newOwner = firstOrDefault.Invoke(
-                                            null,
-                                            new object[] { owner, predicate.Compile() }
-                                        );
+                                        newOwner = firstOrDefault.Invoke(null, [owner, predicate.Compile()]);
                                         if (newOwner != null)
                                             newOwners.Add(newOwner);
                                     }
@@ -178,7 +175,7 @@ public class MemoryUpdateBuilder<T> : IUpdateBuilder<T>
                                     }
                                     else
                                     {
-                                        newOwner = method.Invoke(owner, new object[] { index });
+                                        newOwner = method.Invoke(owner, [index]);
                                         if (newOwner != null)
                                             newOwners.Add(newOwner);
                                     }

--- a/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MongoUpdateBuilder.cs
@@ -16,7 +16,7 @@ public class MongoUpdateBuilder<T> : IUpdateBuilder<T>
     public MongoUpdateBuilder()
     {
         _builder = Builders<T>.Update;
-        _defs = new List<UpdateDefinition<T>>();
+        _defs = [];
     }
 
     public IUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
@@ -18,15 +18,14 @@ public class ExceptionHandler : IExceptionHandler
         string responseContent = string.Join("\n", (await response.Content.ReadAsStringAsync()).Split('\n').Take(10));
         return string.Join(
                 "\n",
-                new string[]
-                {
+                [
                     "HTTP Request error:",
                     $"{response.RequestMessage.Method} {response.RequestMessage.RequestUri}",
                     "Response:",
                     response.ToString(),
                     "Response content begins with:",
                     responseContent,
-                }
+                ]
             )
             .Replace("\n", "\n    ");
     }

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
@@ -25,7 +25,7 @@ public class ExceptionHandler : IExceptionHandler
                     "Response:",
                     response.ToString(),
                     "Response content begins with:",
-                    responseContent
+                    responseContent,
                 }
             )
             .Replace("\n", "\n    ");
@@ -69,7 +69,7 @@ public class ExceptionHandler : IExceptionHandler
     {
         if (!string.IsNullOrWhiteSpace(userId))
         {
-            _bugsnag.BeforeNotify(report => report.Event.User = new Bugsnag.Payload.User { Id = userId, });
+            _bugsnag.BeforeNotify(report => report.Event.User = new Bugsnag.Payload.User { Id = userId });
         }
     }
 }

--- a/src/SIL.XForge/Models/ProjectSecret.cs
+++ b/src/SIL.XForge/Models/ProjectSecret.cs
@@ -9,5 +9,5 @@ public abstract class ProjectSecret : IIdentifiable
     /// <summary>
     /// Outstanding project access shares to specific people, represented by an email address and code pair.
     /// </summary>
-    public List<ShareKey> ShareKeys { get; set; } = new List<ShareKey>();
+    public List<ShareKey> ShareKeys { get; set; } = [];
 }

--- a/src/SIL.XForge/Models/Site.cs
+++ b/src/SIL.XForge/Models/Site.cs
@@ -7,5 +7,5 @@ namespace SIL.XForge.Models;
 public class Site
 {
     public string CurrentProjectId { get; set; }
-    public List<string> Projects { get; set; } = new List<string>();
+    public List<string> Projects { get; set; } = [];
 }

--- a/src/SIL.XForge/Models/User.cs
+++ b/src/SIL.XForge/Models/User.cs
@@ -6,7 +6,7 @@ public class User : Json0Snapshot
 {
     public string Name { get; set; }
     public string Email { get; set; }
-    public List<string> Roles { get; set; } = new List<string>();
+    public List<string> Roles { get; set; } = [];
     public string AvatarUrl { get; set; }
 
     /// <summary>PT user id, as determined from auth0 profile, from authenticating with Paratext.</summary>
@@ -22,5 +22,5 @@ public class User : Json0Snapshot
     /// is authenticating with Paratext.
     /// </summary>
     public string AuthId { get; set; }
-    public Dictionary<string, Site> Sites { get; set; } = new Dictionary<string, Site>();
+    public Dictionary<string, Site> Sites { get; set; } = [];
 }

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -191,7 +191,7 @@ public class Connection : DisposableBase, IConnection
             );
 
             // Return a snapshot
-            return new Snapshot<T> { Data = data, Version = 1, };
+            return new Snapshot<T> { Data = data, Version = 1 };
         }
         else
         {

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -28,7 +28,7 @@ public class Connection : DisposableBase, IConnection
     /// <remarks>
     /// These are in the form "Type.Property.Property", in lower case.
     /// </remarks>
-    private readonly List<string> _excludedProperties = new List<string>();
+    private readonly List<string> _excludedProperties = [];
 
     /// <summary>
     /// The connection handle.

--- a/src/SIL.XForge/Realtime/DeleteOnSuccessAttribute.cs
+++ b/src/SIL.XForge/Realtime/DeleteOnSuccessAttribute.cs
@@ -12,7 +12,7 @@ public class DeleteOnSuccess : JobFilterAttribute, IElectStateFilter
     {
         if (context.CandidateState.Name == SucceededState.StateName)
         {
-            context.CandidateState = new DeletedState { Reason = "Deleted automatically when succeeded.", };
+            context.CandidateState = new DeletedState { Reason = "Deleted automatically when succeeded." };
         }
     }
 }

--- a/src/SIL.XForge/Realtime/Json0/Json0Op.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0Op.cs
@@ -10,7 +10,7 @@ namespace SIL.XForge.Realtime.Json0;
 public class Json0Op
 {
     [JsonProperty("p")]
-    public List<object> Path { get; set; } = new List<object>();
+    public List<object> Path { get; set; } = [];
 
     [JsonProperty("li")]
     public object InsertItem { get; set; }

--- a/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
@@ -16,12 +16,12 @@ public class Json0OpBuilder<T>
 
     public Json0OpBuilder(T data) => _data = data;
 
-    public List<Json0Op> Op { get; } = new List<Json0Op>();
+    public List<Json0Op> Op { get; } = [];
 
     public Json0OpBuilder<T> Insert<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
     {
         var objectPath = new ObjectPath(field);
-        List<object> path = objectPath.Items.ToList();
+        List<object> path = [.. objectPath.Items];
         path.Add(index);
         Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
         return this;
@@ -32,7 +32,7 @@ public class Json0OpBuilder<T>
         var objectPath = new ObjectPath(field);
         if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
             throw new InvalidOperationException("The specified list does not exist.");
-        List<object> path = objectPath.Items.ToList();
+        List<object> path = [.. objectPath.Items];
         path.Add(list.Count);
         Op.Add(new Json0Op { Path = CreateJson0Path(path), InsertItem = item });
         return this;
@@ -43,7 +43,7 @@ public class Json0OpBuilder<T>
         var objectPath = new ObjectPath(field);
         if (!objectPath.TryGetValue(_data, out List<TItem> list) || list == null)
             throw new InvalidOperationException("The specified list does not exist.");
-        List<object> path = objectPath.Items.ToList();
+        List<object> path = [.. objectPath.Items];
         path.Add(index);
         Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = list[index] });
         return this;
@@ -52,7 +52,7 @@ public class Json0OpBuilder<T>
     public Json0OpBuilder<T> Remove<TItem>(Expression<Func<T, List<TItem>>> field, int index, TItem item)
     {
         var objectPath = new ObjectPath(field);
-        List<object> path = objectPath.Items.ToList();
+        List<object> path = [.. objectPath.Items];
         path.Add(index);
         Op.Add(new Json0Op { Path = CreateJson0Path(path), DeleteItem = item });
         return this;
@@ -74,7 +74,7 @@ public class Json0OpBuilder<T>
         TItem oldItem = list[index];
         if (!equalityComparer.Equals(oldItem, newItem))
         {
-            List<object> path = objectPath.Items.ToList();
+            List<object> path = [.. objectPath.Items];
             path.Add(index);
             Op.Add(
                 new Json0Op
@@ -106,7 +106,7 @@ public class Json0OpBuilder<T>
         if (!equalityComparer.Equals(oldItem, newItem))
         {
             var objectPath = new ObjectPath(field);
-            List<object> path = objectPath.Items.ToList();
+            List<object> path = [.. objectPath.Items];
             path.Add(index);
             Op.Add(
                 new Json0Op

--- a/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
@@ -81,7 +81,7 @@ public class Json0OpBuilder<T>
                 {
                     Path = CreateJson0Path(path),
                     DeleteItem = oldItem,
-                    InsertItem = newItem
+                    InsertItem = newItem,
                 }
             );
         }
@@ -113,7 +113,7 @@ public class Json0OpBuilder<T>
                 {
                     Path = CreateJson0Path(path),
                     DeleteItem = oldItem,
-                    InsertItem = newItem
+                    InsertItem = newItem,
                 }
             );
         }
@@ -138,7 +138,7 @@ public class Json0OpBuilder<T>
                 {
                     Path = CreateJson0Path(objectPath.Items),
                     DeleteProp = hasOldValue ? (object)oldValue : null,
-                    InsertProp = value
+                    InsertProp = value,
                 }
             );
         }
@@ -163,7 +163,7 @@ public class Json0OpBuilder<T>
                 {
                     Path = CreateJson0Path(objectPath.Items),
                     DeleteProp = oldValue,
-                    InsertProp = newValue
+                    InsertProp = newValue,
                 }
             );
         }

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -17,7 +17,7 @@ public class MemoryConnection : IConnection
     internal MemoryConnection(MemoryRealtimeService realtimeService)
     {
         _realtimeService = realtimeService;
-        _documents = new Dictionary<(string, string), object>();
+        _documents = [];
     }
 
     /// <summary>
@@ -153,7 +153,7 @@ public class MemoryConnection : IConnection
     public async Task<IReadOnlyCollection<IDocument<T>>> GetAndFetchDocsAsync<T>(IReadOnlyCollection<string> ids)
         where T : IIdentifiable
     {
-        List<IDocument<T>> docs = new List<IDocument<T>>();
+        List<IDocument<T>> docs = [];
         foreach (IDocument<T> doc in ids.Select(Get<T>))
         {
             await doc.FetchAsync();

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -35,8 +35,8 @@ public class MemoryRealtimeService : IRealtimeService
 
     public MemoryRealtimeService()
     {
-        _repos = new Dictionary<Type, object>();
-        _docConfigs = new Dictionary<Type, DocConfig>();
+        _repos = [];
+        _docConfigs = [];
     }
 
     /// <summary>

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -54,7 +54,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
         _configuration = configuration;
 
         RealtimeOptions options = _realtimeOptions.Value;
-        _docConfigs = new Dictionary<Type, DocConfig>();
+        _docConfigs = [];
         AddDocConfig(options.UserDoc);
         AddDocConfig(options.ProjectDoc);
         foreach (DocConfig projectDataDoc in options.ProjectDataDocs)

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -510,14 +510,11 @@ public class Delta
     }
 
     /// <summary>Provides methods to process ops for text that may have attribute changes</summary>
-    private class DeltaOpsAttributeHelper
+    private class DeltaOpsAttributeHelper(bool retainCharIdsOnAttributes)
     {
-        private List<int> opLengths = [];
-        private List<JObject> originalDeltaOps = [];
-        private List<JObject> newDeltaOps = [];
-        private bool retainCharIdsOnAttributes;
-
-        public DeltaOpsAttributeHelper(bool retainCharIds) => retainCharIdsOnAttributes = retainCharIds;
+        private readonly List<int> opLengths = [];
+        private readonly List<JObject> originalDeltaOps = [];
+        private readonly List<JObject> newDeltaOps = [];
 
         public void Add(int length, JToken originalOp, JToken newOp)
         {

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -28,7 +28,7 @@ public class Delta
     /// For a document, represents a sequence of content. Paragraph and table information describes the content that
     /// came before, not after, in the sequence.
     /// </summary>
-    public Delta() => Ops = new List<JToken>();
+    public Delta() => Ops = [];
 
     public Delta(IEnumerable<JToken> ops) => Ops = ops.ToList();
 
@@ -229,7 +229,7 @@ public class Delta
     /// <param name="includeParaWithStyle">Function to determine if the paragraph break should be included.</param>
     public bool TryConcatenateInserts(out string opStr, string verseRef, Func<string, bool> includeParaWithStyle)
     {
-        List<JToken> verseOps = new List<JToken>();
+        List<JToken> verseOps = [];
         bool isTargetVerse = verseRef == "0";
         foreach (JToken op in this.Ops)
         {
@@ -320,8 +320,8 @@ public class Delta
 
     private static JToken ComposeAttributes(JToken a, JToken b, bool keepNull)
     {
-        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
-        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
+        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : [];
+        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : [];
         JObject attributes = (JObject)bObj.DeepClone();
         if (!keepNull)
             attributes = new JObject(attributes.Properties().Where(p => p.Value.Type != JTokenType.Null));
@@ -375,8 +375,8 @@ public class Delta
 
     static JToken DiffAttributes(JToken a, JToken b, bool ignoreCharIdDifferences)
     {
-        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : new JObject();
-        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : new JObject();
+        JObject aObj = a?.Type == JTokenType.Object ? (JObject)a : [];
+        JObject bObj = b?.Type == JTokenType.Object ? (JObject)b : [];
         // Clone the objects so that if there is a real difference in the attributes we can update the cid
         // to be the cid for the new object
         JObject aClone = (JObject)aObj.DeepClone();
@@ -512,9 +512,9 @@ public class Delta
     /// <summary>Provides methods to process ops for text that may have attribute changes</summary>
     private class DeltaOpsAttributeHelper
     {
-        private List<int> opLengths = new List<int>();
-        private List<JObject> originalDeltaOps = new List<JObject>();
-        private List<JObject> newDeltaOps = new List<JObject>();
+        private List<int> opLengths = [];
+        private List<JObject> originalDeltaOps = [];
+        private List<JObject> newDeltaOps = [];
         private bool retainCharIdsOnAttributes;
 
         public DeltaOpsAttributeHelper(bool retainCharIds) => retainCharIdsOnAttributes = retainCharIds;
@@ -522,8 +522,8 @@ public class Delta
         public void Add(int length, JToken originalOp, JToken newOp)
         {
             opLengths.Add(length);
-            JObject originalOpObject = originalOp?.Type == JTokenType.Object ? (JObject)originalOp : new JObject();
-            JObject newOpObject = newOp?.Type == JTokenType.Object ? (JObject)newOp : new JObject();
+            JObject originalOpObject = originalOp?.Type == JTokenType.Object ? (JObject)originalOp : [];
+            JObject newOpObject = newOp?.Type == JTokenType.Object ? (JObject)newOp : [];
             originalDeltaOps.Add(originalOpObject);
             newDeltaOps.Add(newOpObject);
         }
@@ -557,8 +557,8 @@ public class Delta
 
         private bool HaveOpsChanged()
         {
-            JObject[] originalOpsArray = originalDeltaOps.ToArray();
-            JObject[] newOpsArray = newDeltaOps.ToArray();
+            JObject[] originalOpsArray = [.. originalDeltaOps];
+            JObject[] newOpsArray = [.. newDeltaOps];
             for (int i = 0; i < originalOpsArray.Length; i++)
             {
                 JObject originalOp = originalOpsArray[i];

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ public static class AuthServiceCollectionExtensions
                         if (!scopes.Contains(authOptions.Scope))
                             context.Fail("A required scope has not been granted.");
                         return Task.CompletedTask;
-                    }
+                    },
                 };
             })
             .AddBasic(options =>
@@ -75,14 +75,14 @@ public static class AuthServiceCollectionExtensions
                                     context.Username,
                                     ClaimValueTypes.String,
                                     context.Options.ClaimsIssuer
-                                )
+                                ),
                             };
 
                             context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
                             context.Success();
                         }
                         return Task.CompletedTask;
-                    }
+                    },
                 };
             });
         return services;

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -62,8 +62,8 @@ public static class AuthServiceCollectionExtensions
                         var authService = context.HttpContext.RequestServices.GetService<IAuthService>();
                         if (authService.ValidateWebhookCredentials(context.Username, context.Password))
                         {
-                            Claim[] claims = new[]
-                            {
+                            Claim[] claims =
+                            [
                                 new Claim(
                                     ClaimTypes.NameIdentifier,
                                     context.Username,
@@ -76,7 +76,7 @@ public static class AuthServiceCollectionExtensions
                                     ClaimValueTypes.String,
                                     context.Options.ClaimsIssuer
                                 ),
-                            };
+                            ];
 
                             context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
                             context.Success();

--- a/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class JsonRpcServiceCollectionExtensions
             config.JsonSerializerSettings = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             };
 
             config.OnInvokeException = context =>

--- a/src/SIL.XForge/Services/PingApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Services/PingApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class PingApplicationBuilderExtensions
                     {
                         NoCache = true,
                         NoStore = true,
-                        MustRevalidate = true
+                        MustRevalidate = true,
                     };
                     headers.Set(HeaderNames.Pragma, "no-cache");
                     headers.Set(HeaderNames.Expires, "0");

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -91,7 +91,7 @@ public class UserService : IUserService
                 op.Set(u => u.Name, name);
                 op.Set(u => u.Email, (string)userProfile["email"]);
                 op.Set(u => u.AvatarUrl, avatarUrl);
-                List<string> roles = new List<string>();
+                List<string> roles = [];
                 if (userProfile["app_metadata"]?["xf_role"] is JArray)
                 {
                     roles.AddRange(userProfile["app_metadata"]["xf_role"].Select(r => r.ToString()));
@@ -207,7 +207,7 @@ public class UserService : IUserService
         await using IConnection conn = await _realtimeService.ConnectAsync(curUserId);
         IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
         // Only overwrite the avatar for allowed domains so as not to overwrite an avatar provided by a social connection
-        string[] allowedDomains = { "cdn.auth0.com", "gravatar.com" };
+        string[] allowedDomains = ["cdn.auth0.com", "gravatar.com"];
         if (!allowedDomains.Any(userDoc.Data.AvatarUrl.Contains))
         {
             return;
@@ -215,7 +215,7 @@ public class UserService : IUserService
 
         string initials = string.Concat(
             userDoc
-                .Data.DisplayName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Data.DisplayName.Split([' '], StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => x.Length > 1 && char.IsLetter(x[0]))
                 .Select(x => char.ToLower(x[0]))
         );

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -127,7 +127,7 @@ public class UserService : IUserService
             var newPTTokens = new Tokens
             {
                 AccessToken = (string)ptIdentity["access_token"],
-                RefreshToken = (string)ptIdentity["refresh_token"]
+                RefreshToken = (string)ptIdentity["refresh_token"],
             };
             UserSecret userSecret = await _userSecrets.UpdateAsync(
                 curUserId,
@@ -180,7 +180,7 @@ public class UserService : IUserService
         var ptTokens = new Tokens
         {
             AccessToken = (string)ptIdentity["access_token"],
-            RefreshToken = (string)ptIdentity["refresh_token"]
+            RefreshToken = (string)ptIdentity["refresh_token"],
         };
         await _userSecrets.UpdateAsync(primaryUserId, update => update.Set(us => us.ParatextTokens, ptTokens), true);
 

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -215,7 +215,7 @@ public class UserService : IUserService
 
         string initials = string.Concat(
             userDoc
-                .Data.DisplayName.Split([' '], StringSplitOptions.RemoveEmptyEntries)
+                .Data.DisplayName.Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Where(x => x.Length > 1 && char.IsLetter(x[0]))
                 .Select(x => char.ToLower(x[0]))
         );

--- a/src/SIL.XForge/Utils/FieldExpressionFlattener.cs
+++ b/src/SIL.XForge/Utils/FieldExpressionFlattener.cs
@@ -7,7 +7,7 @@ namespace SIL.XForge.Utils;
 internal class FieldExpressionFlattener : ExpressionVisitor
 {
     private readonly Stack<Expression> _nodes = new Stack<Expression>();
-    private readonly HashSet<Expression> _argExprs = new HashSet<Expression>();
+    private readonly HashSet<Expression> _argExprs = [];
 
     public IEnumerable<Expression> Nodes => _nodes;
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
@@ -53,7 +53,7 @@ public class AnonymousControllerTests
         var expectedCookie = new Cookie
         {
             Name = CookieConstants.TransparentAuthentication,
-            Value = Uri.EscapeDataString(Newtonsoft.Json.JsonConvert.SerializeObject(credentials))
+            Value = Uri.EscapeDataString(Newtonsoft.Json.JsonConvert.SerializeObject(credentials)),
         };
         env.AnonymousService.GenerateAccount(request.ShareKey, request.DisplayName, request.Language)
             .Returns(Task.FromResult(credentials));
@@ -207,7 +207,7 @@ public class AnonymousControllerTests
             // Add the body to a new request message
             var request = new HttpRequestMessage
             {
-                Content = new StringContent(body, Encoding.UTF8, "application/json")
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
             };
 
             // Set up the HTTP context with this data

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -389,7 +389,7 @@ public class ParatextControllerTests
             Data = new TextData(),
             Id = "textId",
             Version = 1,
-            IsValid = true
+            IsValid = true,
         };
 
         public readonly byte[] ZipHeader = [80, 75, 05, 06];

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -28,7 +28,7 @@ public class SFProjectsRpcControllerTests
     private static readonly string[] Permissions =
     [
         SFProjectRights.JoinRight(SFProjectDomain.Questions, Operation.Create),
-        SFProjectRights.JoinRight(SFProjectDomain.Questions, Operation.Edit)
+        SFProjectRights.JoinRight(SFProjectDomain.Questions, Operation.Edit),
     ];
     private static readonly string[] Roles = [SystemRole.User];
 

--- a/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;
@@ -185,8 +184,8 @@ public class AnonymousServiceTests
                     new SFProjectSecret
                     {
                         Id = Project01,
-                        ShareKeys = new List<ShareKey>
-                        {
+                        ShareKeys =
+                        [
                             new ShareKey
                             {
                                 Key = "key01",
@@ -208,7 +207,7 @@ public class AnonymousServiceTests
                                 ShareLinkType = ShareLinkType.Recipient,
                                 UsersGenerated = MaxUsers,
                             },
-                        },
+                        ],
                     },
                 }
             );

--- a/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
@@ -34,7 +34,7 @@ public class AnonymousServiceTests
                     {
                         Project = project,
                         ProjectSecret = projectSecret,
-                        ShareKey = projectSecretShareKey
+                        ShareKey = projectSecretShareKey,
                     }
                 )
             );
@@ -73,7 +73,7 @@ public class AnonymousServiceTests
                     {
                         Project = project,
                         ProjectSecret = projectSecret,
-                        ShareKey = projectSecretShareKey
+                        ShareKey = projectSecretShareKey,
                     }
                 )
             );
@@ -147,7 +147,7 @@ public class AnonymousServiceTests
                     {
                         Project = project,
                         ProjectSecret = projectSecret,
-                        ShareKey = projectSecretShareKey
+                        ShareKey = projectSecretShareKey,
                     }
                 )
             );
@@ -175,7 +175,7 @@ public class AnonymousServiceTests
             Projects = new MemoryRepository<SFProject>(
                 new[]
                 {
-                    new SFProject { Id = Project01, Name = "Test Project 1" }
+                    new SFProject { Id = Project01, Name = "Test Project 1" },
                 }
             );
 
@@ -191,14 +191,14 @@ public class AnonymousServiceTests
                             {
                                 Key = "key01",
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
                                 Key = "key02",
                                 RecipientUserId = "user01",
                                 ProjectRole = SFProjectRole.CommunityChecker,
-                                ShareLinkType = ShareLinkType.Recipient
+                                ShareLinkType = ShareLinkType.Recipient,
                             },
                             new ShareKey
                             {
@@ -206,10 +206,10 @@ public class AnonymousServiceTests
                                 RecipientUserId = "user01",
                                 ProjectRole = SFProjectRole.CommunityChecker,
                                 ShareLinkType = ShareLinkType.Recipient,
-                                UsersGenerated = MaxUsers
-                            }
-                        }
-                    }
+                                UsersGenerated = MaxUsers,
+                            },
+                        },
+                    },
                 }
             );
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -370,7 +370,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup1CharID }
+                        new CharAttr { Style = "sup", CharID = sup1CharID },
                     },
                     "verse_1_1"
                 )
@@ -380,7 +380,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup2CharID }
+                        new CharAttr { Style = "sup", CharID = sup2CharID },
                     },
                     "verse_1_1"
                 )
@@ -390,7 +390,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup3CharID }
+                        new CharAttr { Style = "sup", CharID = sup3CharID },
                     },
                     "verse_1_1"
                 )
@@ -435,7 +435,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup1CharID }
+                        new CharAttr { Style = "sup", CharID = sup1CharID },
                     },
                     "verse_1_1"
                 )
@@ -444,7 +444,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup2CharID }
+                        new CharAttr { Style = "sup", CharID = sup2CharID },
                     },
                     "verse_1_1"
                 )
@@ -453,7 +453,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup3CharID }
+                        new CharAttr { Style = "sup", CharID = sup3CharID },
                     },
                     "verse_1_1"
                 )
@@ -500,7 +500,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup1CharID }
+                        new CharAttr { Style = "sup", CharID = sup1CharID },
                     },
                     "verse_1_1"
                 )
@@ -510,7 +510,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "no", CharID = noCharID }
+                        new CharAttr { Style = "no", CharID = noCharID },
                     },
                     "verse_1_1"
                 )
@@ -520,7 +520,7 @@ public class DeltaUsxMapperTests
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
                         new CharAttr { Style = "no", CharID = noCharID },
-                        new CharAttr { Style = "sup", CharID = sup2CharID }
+                        new CharAttr { Style = "sup", CharID = sup2CharID },
                     },
                     "verse_1_1"
                 )
@@ -530,7 +530,7 @@ public class DeltaUsxMapperTests
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
                         new CharAttr { Style = "no", CharID = noCharID },
-                        new CharAttr { Style = "sup", CharID = sup3CharID }
+                        new CharAttr { Style = "sup", CharID = sup3CharID },
                     },
                     "verse_1_1"
                 )
@@ -540,7 +540,7 @@ public class DeltaUsxMapperTests
                     new List<CharAttr>
                     {
                         new CharAttr { Style = "bd", CharID = bdCharID },
-                        new CharAttr { Style = "sup", CharID = sup4CharID }
+                        new CharAttr { Style = "sup", CharID = sup4CharID },
                     },
                     "verse_1_1"
                 )
@@ -1050,7 +1050,7 @@ public class DeltaUsxMapperTests
                     .InsertVerse("2")
                     .InsertBlank("verse_2_2")
                     .Insert("\n")
-            )
+            ),
         };
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
@@ -1202,7 +1202,7 @@ public class DeltaUsxMapperTests
                     .InsertVerse("2")
                     .InsertBlank("verse_2_2")
                     .Insert("\n")
-            )
+            ),
         };
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
@@ -1366,7 +1366,7 @@ public class DeltaUsxMapperTests
                     .InsertVerse("1")
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("p")
-            )
+            ),
         };
 
         var oldUsxDoc = Usx(
@@ -1438,7 +1438,7 @@ public class DeltaUsxMapperTests
                     .InsertVerse("1")
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("p")
-            )
+            ),
         };
 
         var oldUsxDoc = Usx(
@@ -1510,7 +1510,7 @@ public class DeltaUsxMapperTests
                     .InsertVerse("1")
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("bad", true)
-            )
+            ),
         };
 
         var oldUsxDoc = Usx(
@@ -1744,7 +1744,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "tei", CharID = _testGuidService.Generate() },
-                    new CharAttr { Style = "ver", CharID = _testGuidService.Generate() }
+                    new CharAttr { Style = "ver", CharID = _testGuidService.Generate() },
                 },
                 "verse_1_1",
                 invalid: true
@@ -2170,7 +2170,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                    new CharAttr { Style = "sup", CharID = sup1CharID },
                 },
                 "verse_1_1"
             )
@@ -2180,7 +2180,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                    new CharAttr { Style = "sup", CharID = sup2CharID },
                 },
                 "verse_1_1"
             )
@@ -2190,7 +2190,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                    new CharAttr { Style = "sup", CharID = sup3CharID },
                 },
                 "verse_1_1"
             )
@@ -2234,7 +2234,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                    new CharAttr { Style = "sup", CharID = sup1CharID },
                 },
                 "verse_1_1"
             )
@@ -2243,7 +2243,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                    new CharAttr { Style = "sup", CharID = sup2CharID },
                 },
                 "verse_1_1"
             )
@@ -2252,7 +2252,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                    new CharAttr { Style = "sup", CharID = sup3CharID },
                 },
                 "verse_1_1"
             )
@@ -2305,7 +2305,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                    new CharAttr { Style = "sup", CharID = sup1CharID },
                 },
                 "verse_1_1"
             )
@@ -2315,7 +2315,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "no", CharID = noCharID }
+                    new CharAttr { Style = "no", CharID = noCharID },
                 },
                 "verse_1_1"
             )
@@ -2325,7 +2325,7 @@ public class DeltaUsxMapperTests
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
                     new CharAttr { Style = "no", CharID = noCharID },
-                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                    new CharAttr { Style = "sup", CharID = sup2CharID },
                 },
                 "verse_1_1"
             )
@@ -2335,7 +2335,7 @@ public class DeltaUsxMapperTests
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
                     new CharAttr { Style = "no", CharID = noCharID },
-                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                    new CharAttr { Style = "sup", CharID = sup3CharID },
                 },
                 "verse_1_1"
             )
@@ -2345,7 +2345,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bd", CharID = bdCharID },
-                    new CharAttr { Style = "sup", CharID = sup4CharID }
+                    new CharAttr { Style = "sup", CharID = sup4CharID },
                 },
                 "verse_1_1"
             )
@@ -2389,7 +2389,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bad", CharID = badCharID },
-                    new CharAttr { Style = "sup", CharID = sup1CharID }
+                    new CharAttr { Style = "sup", CharID = sup1CharID },
                 },
                 "verse_1_1",
                 true
@@ -2400,7 +2400,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bad", CharID = badCharID },
-                    new CharAttr { Style = "sup", CharID = sup2CharID }
+                    new CharAttr { Style = "sup", CharID = sup2CharID },
                 },
                 "verse_1_1",
                 true
@@ -2411,7 +2411,7 @@ public class DeltaUsxMapperTests
                 new List<CharAttr>
                 {
                     new CharAttr { Style = "bad", CharID = badCharID },
-                    new CharAttr { Style = "sup", CharID = sup3CharID }
+                    new CharAttr { Style = "sup", CharID = sup3CharID },
                 },
                 "verse_1_1",
                 true

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3665,7 +3665,7 @@ public class DeltaUsxMapperTests
         using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
         Assert.That(archive.Entries.Any(), "setup. unexpected input size.");
         bool allBooksRoundtrip = true;
-        List<string> errorMessages = new();
+        List<string> errorMessages = [];
         foreach (ZipArchiveEntry entry in archive.Entries)
         {
             string bookCode = Regex

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
@@ -160,7 +160,7 @@ public static class DeltaUsxTestExtensions
     }
 
     public static Delta InsertOptBreak(this Delta delta, string segRef = null) =>
-        delta.InsertEmbed("optbreak", new JObject(), segRef);
+        delta.InsertEmbed("optbreak", [], segRef);
 
     public static Delta InsertMilestone(this Delta delta, string style, string segRef = null, bool invalid = false)
     {

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -35,8 +35,8 @@ public class InternetSharedRepositorySourceProviderTests
             ParatextTokens = new Tokens
             {
                 AccessToken = TokenHelper.CreateNewAccessToken(),
-                RefreshToken = "refresh_token01"
-            }
+                RefreshToken = "refresh_token01",
+            },
         };
         IInternetSharedRepositorySource source = env.Provider.GetSource(userSecret, "srServer", "regServer");
         Assert.That(source, Is.Not.Null);
@@ -52,8 +52,8 @@ public class InternetSharedRepositorySourceProviderTests
             ParatextTokens = new Tokens
             {
                 AccessToken = TokenHelper.CreateNewAccessToken(),
-                RefreshToken = "refresh_token01"
-            }
+                RefreshToken = "refresh_token01",
+            },
         };
         env.MockJwtTokenHelper.GetParatextUsername(Arg.Any<UserSecret>()).Returns(default(string?));
         Assert.Throws<Exception>(() => env.Provider.GetSource(userSecret, "srServer", "regServer"));
@@ -72,7 +72,7 @@ public class InternetSharedRepositorySourceProviderTests
             RegistryU.Implementation = new DotNetCoreRegistry();
             InternetAccess.RawStatus = InternetUse.Enabled;
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            siteOptions.Value.Returns(new SiteOptions { Name = "xForge", });
+            siteOptions.Value.Returns(new SiteOptions { Name = "xForge" });
             Provider = new InternetSharedRepositorySourceProvider(
                 MockJwtTokenHelper,
                 siteOptions,

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -3780,8 +3780,11 @@ public class MachineProjectServiceTests
             int expected = options switch
             {
                 { PreTranslate: false } => 1,
-                { PreTranslate: true, AlternateTrainingSource: true, AlternateTrainingSourceAndSourceAreTheSame: true }
-                    => 2,
+                {
+                    PreTranslate: true,
+                    AlternateTrainingSource: true,
+                    AlternateTrainingSourceAndSourceAreTheSame: true
+                } => 2,
                 { PreTranslate: true, AlternateTrainingSource: true, AlternateSource: true } => 0,
                 { PreTranslate: true, AlternateTrainingSource: true } => 1,
                 { PreTranslate: true, AlternateSource: true } => 1,

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -33,7 +33,7 @@ public class MockScrText : ScrText
         }
     }
 
-    public Dictionary<string, string> Data { get; } = new Dictionary<string, string>();
+    public Dictionary<string, string> Data { get; } = [];
 
     /// <summary>
     /// Return text of specified chapter or book.

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -38,15 +38,15 @@ public class NotesFormatterTests
             Thread = "Answer_dataId0123",
             VerseRefStr = "RUT 1:1",
         };
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment> { comment },
+                Comments = [comment],
             },
-        };
+        ];
 
         // We use StringBuilder so we can have the environment specific new line
         StringBuilder sb = new StringBuilder();
@@ -90,15 +90,15 @@ public class NotesFormatterTests
             Type = NoteType.Conflict,
             VerseRefStr = "RUT 1:1",
         };
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment> { comment },
+                Comments = [comment],
             },
-        };
+        ];
 
         // We use StringBuilder so we can have the environment specific new line
         StringBuilder sb = new StringBuilder();
@@ -132,14 +132,14 @@ public class NotesFormatterTests
 
         // Setup the test data
         const string expected = "<notes version=\"1.1\" />";
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment>
-                {
+                Comments =
+                [
                     new Comment(associatedPtUser)
                     {
                         DateTime = DateTimeOffset.Now,
@@ -147,9 +147,9 @@ public class NotesFormatterTests
                         Thread = "Answer_dataId0123",
                         VerseRefStr = "RUT 1:1",
                     },
-                },
+                ],
             },
-        };
+        ];
 
         // SUT
         string actual = NotesFormatter.FormatNotes(commentThreads);
@@ -176,15 +176,15 @@ public class NotesFormatterTests
             Thread = "Answer_dataId0123",
             VerseRefStr = "RUT 1:1",
         };
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment> { comment },
+                Comments = [comment],
             },
-        };
+        ];
 
         // We use StringBuilder so we can have the environment specific new line
         StringBuilder sb = new StringBuilder();
@@ -248,15 +248,15 @@ public class NotesFormatterTests
             VerseRefStr = verseRefStr,
             Contents = doc.DocumentElement,
         };
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment> { comment },
+                Comments = [comment],
             },
-        };
+        ];
 
         // SUT
         string actual = NotesFormatter.FormatNotes(commentThreads);
@@ -289,23 +289,23 @@ public class NotesFormatterTests
         sb.AppendLine("  </thread>");
         sb.Append("</notes>");
         string expected = sb.ToString();
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment>
-                {
+                Comments =
+                [
                     new Comment(associatedPtUser)
                     {
                         DateTime = commentDate,
                         Thread = thread,
                         VerseRefStr = verseRefStr,
                     },
-                },
+                ],
             },
-        };
+        ];
 
         // SUT
         string actual = NotesFormatter.FormatNotes(commentThreads);
@@ -348,14 +348,14 @@ public class NotesFormatterTests
         sb.AppendLine("  </thread>");
         sb.Append("</notes>");
         string expected = sb.ToString();
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment>
-                {
+                Comments =
+                [
                     new Comment(firstPtUser)
                     {
                         DateTime = firstCommentDate,
@@ -369,9 +369,9 @@ public class NotesFormatterTests
                         VerseRefStr = verseRefStr,
                         Contents = doc.DocumentElement,
                     },
-                },
+                ],
             },
-        };
+        ];
 
         // SUT
         string actual = NotesFormatter.FormatNotes(commentThreads);
@@ -388,10 +388,10 @@ public class NotesFormatterTests
 
         // Setup the test data
         const string expected = "<notes version=\"1.1\" />";
-        List<CommentThread> commentThreads = new List<CommentThread>
-        {
+        List<CommentThread> commentThreads =
+        [
             new CommentThread { ContextScrTextName = env.ProjectScrText?.Name, ScrText = env.ProjectScrText },
-        };
+        ];
 
         // SUT
         string actual = NotesFormatter.FormatNotes(commentThreads);

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -246,7 +246,7 @@ public class NotesFormatterTests
             DateTime = commentDate,
             Thread = thread,
             VerseRefStr = verseRefStr,
-            Contents = doc.DocumentElement
+            Contents = doc.DocumentElement,
         };
         List<CommentThread> commentThreads = new List<CommentThread>
         {
@@ -254,8 +254,8 @@ public class NotesFormatterTests
             {
                 ContextScrTextName = env.ProjectScrText?.Name,
                 ScrText = env.ProjectScrText,
-                Comments = new List<Comment> { comment }
-            }
+                Comments = new List<Comment> { comment },
+            },
         };
 
         // SUT

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -974,7 +974,7 @@ public class ParatextNotesMapperTests
             var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
             var localizer = new StringLocalizer<SharedResource>(factory);
             var siteOptions = Substitute.For<IOptions<SiteOptions>>();
-            siteOptions.Value.Returns(new SiteOptions { Name = "xForge", });
+            siteOptions.Value.Returns(new SiteOptions { Name = "xForge" });
             Mapper = new ParatextNotesMapper(
                 UserSecrets,
                 ParatextService,
@@ -1087,9 +1087,9 @@ public class ParatextNotesMapperTests
                                             OwnerRef = "user03",
                                             SyncUserRef = commentSyncUserId1,
                                             DateCreated = new DateTime(2019, 1, 3, 9, 0, 0, DateTimeKind.Utc),
-                                            Text = "Test comment 4."
-                                        }
-                                    }
+                                            Text = "Test comment 4.",
+                                        },
+                                    },
                                 },
                                 new Answer
                                 {
@@ -1162,7 +1162,7 @@ public class ParatextNotesMapperTests
                     {
                         Id = "user03",
                         ParatextId = "ptuser03",
-                        Role = SFProjectRole.Translator
+                        Role = SFProjectRole.Translator,
                     }
                 );
             return ptUsers;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -151,7 +151,7 @@ public class ParatextServiceTests
         project.UserRoles = new Dictionary<string, string>
         {
             { env.User01, SFProjectRole.Administrator },
-            { env.User02, SFProjectRole.CommunityChecker }
+            { env.User02, SFProjectRole.CommunityChecker },
         };
         env.AddProjectRepository(project);
         // Check resulting IsConnectable and IsConnected values across various scenarios of SF project existing,
@@ -173,7 +173,7 @@ public class ParatextServiceTests
                 isConnected = true,
                 reason1 = "sf project exists and sf user is member of the sf project",
                 isConnectable = false,
-                reason2 = "can not re-connect to project"
+                reason2 = "can not re-connect to project",
             },
             new
             {
@@ -187,7 +187,7 @@ public class ParatextServiceTests
                 isConnected = false,
                 reason1 = "sf project exists and but sf user is not member of the sf project",
                 isConnectable = true,
-                reason2 = "can connect to existing SF project"
+                reason2 = "can connect to existing SF project",
             },
             new
             {
@@ -201,7 +201,7 @@ public class ParatextServiceTests
                 isConnected = false,
                 reason1 = "sf project does not exist",
                 isConnectable = true,
-                reason2 = "pt admin can start connection to not-yet-existing sf project"
+                reason2 = "pt admin can start connection to not-yet-existing sf project",
             },
             new
             {
@@ -215,7 +215,7 @@ public class ParatextServiceTests
                 isConnected = false,
                 reason1 = "sf project does not exist",
                 isConnectable = false,
-                reason2 = "pt non-admin can not start connection to not-yet-existing sf project"
+                reason2 = "pt non-admin can not start connection to not-yet-existing sf project",
             },
         };
 
@@ -358,12 +358,12 @@ public class ParatextServiceTests
         project.UserRoles = new Dictionary<string, string>
         {
             { env.User01, SFProjectRole.Administrator },
-            { env.User02, SFProjectRole.CommunityChecker }
+            { env.User02, SFProjectRole.CommunityChecker },
         };
         var ptUsernameMapping = new Dictionary<string, string>()
         {
             { env.User01, env.Username01 },
-            { env.User02, env.Username02 }
+            { env.User02, env.Username02 },
         };
 
         var permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping);
@@ -635,7 +635,7 @@ public class ParatextServiceTests
             "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
             + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
             + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User01 }, };
+        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User01 } };
 
         // SUT
         int booksUpdated = await env.Service.PutBookText(
@@ -675,7 +675,7 @@ public class ParatextServiceTests
             "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
             + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
             + "Verse 1 here. <verse number=\"2\" style=\"v\" />Verse 2 here.</usx>";
-        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User02 }, };
+        var chapterAuthors = new Dictionary<int, string> { { 1, env.User01 }, { 2, env.User02 } };
 
         // SUT
         int booksUpdated = await env.Service.PutBookText(
@@ -714,7 +714,7 @@ public class ParatextServiceTests
             new Paratext.Data.ProjectComments.Comment(associatedPtUser)
             {
                 Thread = "Answer_dataId0123",
-                VerseRefStr = "RUT 1:1"
+                VerseRefStr = "RUT 1:1",
             }
         );
         string notes = env.Service.GetNotes(userSecret, ptProjectId, ruthBookNum);
@@ -780,7 +780,7 @@ public class ParatextServiceTests
         env.AddNoteThreadData(
             new[]
             {
-                new ThreadComponents { threadNum = 1, noteCount = 1 }
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
             }
         );
         env.AddParatextComments(
@@ -790,15 +790,15 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    username = env.Username01
+                    username = env.Username01,
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
                     username = env.Username01,
-                    appliesToVerse = true
-                }
+                    appliesToVerse = true,
+                },
             }
         );
 
@@ -812,7 +812,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
 
         string contextBefore = "Context before changed ";
@@ -858,7 +858,7 @@ public class ParatextServiceTests
         env.AddNoteThreadData(
             new[]
             {
-                new ThreadComponents { threadNum = 1, noteCount = 1 }
+                new ThreadComponents { threadNum = 1, noteCount = 1 },
             }
         );
         env.AddParatextComments(
@@ -868,8 +868,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    username = env.Username01
-                }
+                    username = env.Username01,
+                },
             }
         );
 
@@ -883,7 +883,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
             1,
@@ -923,7 +923,7 @@ public class ParatextServiceTests
         {
             ownerRef = env.User01,
             content = "Admin comment no xml tags.",
-            assignedPTUser = CommentThread.unassignedUser
+            assignedPTUser = CommentThread.unassignedUser,
         };
         env.AddNoteThreadData(
             new[]
@@ -932,46 +932,46 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 3,
                     notes = new[] { user1Note, user1NoteNoTag, user1NoteNoTag },
-                    deletedNotes = new[] { false, true, false }
+                    deletedNotes = new[] { false, true, false },
                 },
                 new ThreadComponents
                 {
                     threadNum = 5,
                     noteCount = 2,
                     notes = new[] { user1Note, user1NoteNoTag },
-                    deletedNotes = new[] { true, false }
+                    deletedNotes = new[] { true, false },
                 },
                 new ThreadComponents
                 {
                     threadNum = 7,
                     noteCount = 1,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
-                    notes = new[] { thread8Note }
+                    notes = new[] { thread8Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 9,
                     noteCount = 3,
-                    notes = new[] { user1Note, user1Note, user1Note }
-                }
+                    notes = new[] { user1Note, user1Note, user1Note },
+                },
             }
         );
         env.AddParatextComments(
@@ -983,7 +983,7 @@ public class ParatextServiceTests
                     noteCount = 1,
                     username = env.Username01,
                     notes = new[] { user1Note },
-                    isEdited = true
+                    isEdited = true,
                 },
                 new ThreadComponents
                 {
@@ -991,50 +991,50 @@ public class ParatextServiceTests
                     noteCount = 1,
                     username = env.Username01,
                     notes = new[] { user1Note },
-                    deletedNotes = new[] { true }
+                    deletedNotes = new[] { true },
                 },
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 1,
                     username = env.Username02,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 6,
                     noteCount = 1,
                     isConflict = true,
-                    notes = new[] { user1Note }
+                    notes = new[] { user1Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 7,
                     noteCount = 2,
                     username = env.Username01,
-                    notes = new[] { user1Note, user1NoteNoTag }
+                    notes = new[] { user1Note, user1NoteNoTag },
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { thread8Note }
+                    notes = new[] { thread8Note },
                 },
                 new ThreadComponents
                 {
                     threadNum = 9,
                     noteCount = 3,
                     username = env.Username01,
-                    notes = new[] { user1Note, user1NoteNoTag, user1NoteNoTag }
-                }
+                    notes = new[] { user1Note, user1NoteNoTag, user1NoteNoTag },
+                },
             }
         );
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
@@ -1044,7 +1044,7 @@ public class ParatextServiceTests
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected");
 
@@ -1157,8 +1157,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 3,
-                    notes = new[] { note1a, note2a, note3a }
-                }
+                    notes = new[] { note1a, note2a, note3a },
+                },
             }
         );
 
@@ -1166,7 +1166,7 @@ public class ParatextServiceTests
         {
             content = content1b,
             ownerRef = env.User01,
-            tagsAdded = new[] { "1" }
+            tagsAdded = new[] { "1" },
         };
         var note2b = new ThreadNoteComponents { content = content2b, ownerRef = env.User01 };
         var note3b = new ThreadNoteComponents { content = content3, ownerRef = env.User01 };
@@ -1178,8 +1178,8 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 3,
                     username = env.Username01,
-                    notes = new[] { note1b, note2b, note3b }
-                }
+                    notes = new[] { note1b, note2b, note3b },
+                },
             }
         );
 
@@ -1191,9 +1191,9 @@ public class ParatextServiceTests
                 {
                     Username = env.Username01,
                     OpaqueUserId = "syncuser01",
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
-            }
+            },
         };
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
@@ -1312,16 +1312,16 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User05,
                 tagsAdded = new[] { "2" },
-                content = "original content"
+                content = "original content",
             },
-            new ThreadNoteComponents { ownerRef = env.User05 }
+            new ThreadNoteComponents { ownerRef = env.User05 },
         };
         var threadDocs = new ThreadComponents
         {
             threadNum = 1,
             noteCount = 2,
             username = env.Username01,
-            notes = notes
+            notes = notes,
         };
         env.AddNoteThreadData(new[] { threadDocs });
         string originalContent = $"<p>[User 05 - xForge]</p><p>original content</p>";
@@ -1332,16 +1332,16 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User05,
                 tagsAdded = new[] { "2" },
-                content = originalContent
+                content = originalContent,
             },
-            new ThreadNoteComponents { ownerRef = env.User05, content = editedContent }
+            new ThreadNoteComponents { ownerRef = env.User05, content = editedContent },
         };
         var commentThreads = new ThreadComponents
         {
             threadNum = 1,
             noteCount = 2,
             username = env.Username01,
-            notes = comments
+            notes = comments,
         };
         env.AddParatextComments(new[] { commentThreads });
 
@@ -1352,7 +1352,7 @@ public class ParatextServiceTests
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected");
 
@@ -1409,7 +1409,7 @@ public class ParatextServiceTests
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected");
 
@@ -1493,7 +1493,7 @@ public class ParatextServiceTests
             chapterDeltas.Add(1, chapterDelta);
             Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
             {
-                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
             }.ToDictionary(u => u.Username);
             IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
                 userSecret,
@@ -1574,8 +1574,8 @@ public class ParatextServiceTests
                 tagsAdded = new[] { "1" },
                 assignedPTUser = CommentThread.unassignedUser,
                 // tests that if duplicate project notes exist, the sync succeeds
-                duplicate = true
-            }
+                duplicate = true,
+            },
         };
         env.AddNoteThreadData(
             new[]
@@ -1584,8 +1584,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    notes = noteComponents
-                }
+                    notes = noteComponents,
+                },
             }
         );
 
@@ -1597,8 +1597,8 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 1,
                     notes = noteComponents,
-                    username = env.Username01
-                }
+                    username = env.Username01,
+                },
             }
         );
 
@@ -1614,7 +1614,7 @@ public class ParatextServiceTests
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
             userSecret,
@@ -1796,7 +1796,7 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "2" }
+                tagsAdded = new[] { "2" },
             },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
@@ -1805,7 +1805,7 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "3" }
+                tagsAdded = new[] { "3" },
             },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Done },
@@ -1814,8 +1814,8 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "4" }
-            }
+                tagsAdded = new[] { "4" },
+            },
         };
         env.AddParatextComments(
             new[]
@@ -1825,7 +1825,7 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = threadNotes.Length,
                     notes = threadNotes,
-                    username = env.Username01
+                    username = env.Username01,
                 },
             }
         );
@@ -1837,7 +1837,7 @@ public class ParatextServiceTests
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected");
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
@@ -1849,7 +1849,7 @@ public class ParatextServiceTests
             ptProjectUsers
         );
 
-        List<int?> expectedIcons = new List<int?>() { 2, null, null, 2, 3, null, 3, 3, 4, };
+        List<int?> expectedIcons = new List<int?>() { 2, null, null, 2, 3, null, 3, 3, 4 };
         NoteThreadChange changedThread = changes.Where(c => c.ThreadId == "thread1").Single();
         for (int i = 0; i < expectedIcons.Count; i++)
         {
@@ -1872,7 +1872,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
 
         ThreadNoteComponents[] getThreadNoteComponents(int noteCount, string[] assignedUsers, bool iconChange = false)
@@ -1898,7 +1898,7 @@ public class ParatextServiceTests
                     status = NoteStatus.Todo,
                     tagsAdded = i == 0 ? commentTagsAdded : null,
                     assignedPTUser = assignedUser,
-                    ownerRef = env.User01
+                    ownerRef = env.User01,
                 };
                 components.Add(noteComponents);
             }
@@ -1918,14 +1918,14 @@ public class ParatextServiceTests
                 {
                     threadNum = 7,
                     noteCount = 1,
-                    notes = threadDocNotes7
+                    notes = threadDocNotes7,
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
-                    notes = threadDocNotes8
-                }
+                    notes = threadDocNotes8,
+                },
             }
         );
 
@@ -1946,57 +1946,57 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 2,
                     username = env.Username01,
-                    notes = threadNotes1
+                    notes = threadNotes1,
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes2
+                    notes = threadNotes2,
                 },
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes3
+                    notes = threadNotes3,
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes4
+                    notes = threadNotes4,
                 },
                 new ThreadComponents
                 {
                     threadNum = 5,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes5
+                    notes = threadNotes5,
                 },
                 new ThreadComponents
                 {
                     threadNum = 6,
                     noteCount = 1,
-                    username = env.Username01
+                    username = env.Username01,
                 },
                 new ThreadComponents
                 {
                     threadNum = 7,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes7
+                    notes = threadNotes7,
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = threadNotes8
+                    notes = threadNotes8,
                 },
-                new ThreadComponents { threadNum = 9, noteCount = 1 }
+                new ThreadComponents { threadNum = 9, noteCount = 1 },
             }
         );
 
@@ -2088,29 +2088,29 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    alternateText = SelectionType.RelatedVerse
+                    alternateText = SelectionType.RelatedVerse,
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
                     username = env.Username01,
-                    alternateText = SelectionType.Section
+                    alternateText = SelectionType.Section,
                 },
                 new ThreadComponents
                 {
                     threadNum = 9,
                     noteCount = 1,
                     username = env.Username01,
-                    alternateText = SelectionType.SectionEnd
+                    alternateText = SelectionType.SectionEnd,
                 },
                 new ThreadComponents
                 {
                     threadNum = 10,
                     noteCount = 1,
                     username = env.Username01,
-                    alternateText = SelectionType.RelatedVerse
-                }
+                    alternateText = SelectionType.RelatedVerse,
+                },
             }
         );
 
@@ -2122,7 +2122,7 @@ public class ParatextServiceTests
                 {
                     env.Username01,
                     new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-                }
+                },
             };
             IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
                 userSecret,
@@ -2185,15 +2185,15 @@ public class ParatextServiceTests
                 {
                     threadNum = 3,
                     noteCount = 1,
-                    reattachedVerseStr = verseStr
+                    reattachedVerseStr = verseStr,
                 },
                 new ThreadComponents { threadNum = 4, noteCount = 1 },
                 new ThreadComponents
                 {
                     threadNum = 5,
                     noteCount = 1,
-                    reattachedVerseStr = verseStr
-                }
+                    reattachedVerseStr = verseStr,
+                },
             }
         );
         env.AddParatextComments(
@@ -2204,35 +2204,35 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    reattachedVerseStr = verseStr
+                    reattachedVerseStr = verseStr,
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
                     username = env.Username01,
-                    reattachedVerseStr = verseStr
+                    reattachedVerseStr = verseStr,
                 },
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 1,
                     username = env.Username01,
-                    reattachedVerseStr = verseStr
+                    reattachedVerseStr = verseStr,
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 2,
                     username = env.Username01,
-                    reattachedVerseStr = verseStr
+                    reattachedVerseStr = verseStr,
                 },
                 new ThreadComponents
                 {
                     threadNum = 5,
                     noteCount = 1,
-                    username = env.Username01
-                }
+                    username = env.Username01,
+                },
             }
         );
 
@@ -2247,7 +2247,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
             userSecret,
@@ -2268,7 +2268,7 @@ public class ParatextServiceTests
         TextAnchor expectedAnchor = new TextAnchor
         {
             Start = rti.contextBefore.Length,
-            Length = rti.selectedText.Length
+            Length = rti.selectedText.Length,
         };
         Assert.That(change1.Position, Is.EqualTo(expectedAnchor));
 
@@ -2294,7 +2294,7 @@ public class ParatextServiceTests
         TextAnchor originalAnchor = new TextAnchor
         {
             Start = change5.ContextBefore.Length,
-            Length = change5.SelectedText.Length
+            Length = change5.SelectedText.Length,
         };
         Assert.That(change5.Position, Is.EqualTo(originalAnchor));
     }
@@ -2439,8 +2439,8 @@ public class ParatextServiceTests
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    deletedNotes = new[] { true }
-                }
+                    deletedNotes = new[] { true },
+                },
             }
         );
 
@@ -2450,7 +2450,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
         IEnumerable<IDocument<NoteThread>> emptyDocs = Array.Empty<IDocument<NoteThread>>();
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
@@ -2481,8 +2481,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    deletedNotes = new[] { true }
-                }
+                    deletedNotes = new[] { true },
+                },
             }
         );
 
@@ -2493,8 +2493,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    username = env.Username01
-                }
+                    username = env.Username01,
+                },
             }
         );
         string newDataId = "newdataid1";
@@ -2513,9 +2513,9 @@ public class ParatextServiceTests
                 {
                     Username = env.Username01,
                     OpaqueUserId = "syncuser01",
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
-            }
+            },
         };
         var changes = env.Service.GetNoteThreadChanges(
             userSecret,
@@ -2570,14 +2570,14 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content4 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content5a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6a },
-            new ThreadNoteComponents { ownerRef = env.User01, content = content7a }
+            new ThreadNoteComponents { ownerRef = env.User01, content = content7a },
         };
         ThreadComponents threadCompSF = new ThreadComponents
         {
             threadNum = 1,
             noteCount = notesSF.Length,
             username = env.Username01,
-            notes = notesSF
+            notes = notesSF,
         };
         env.AddNoteThreadData(new[] { threadCompSF });
         ThreadNoteComponents[] notesPT =
@@ -2588,14 +2588,14 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content4 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content5b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6b },
-            new ThreadNoteComponents { ownerRef = env.User01, content = content7b }
+            new ThreadNoteComponents { ownerRef = env.User01, content = content7b },
         };
         ThreadComponents threadCompPT = new ThreadComponents
         {
             threadNum = 1,
             noteCount = notesPT.Length,
             username = env.Username01,
-            notes = notesPT
+            notes = notesPT,
         };
         env.AddParatextComments(new[] { threadCompPT });
 
@@ -2609,9 +2609,9 @@ public class ParatextServiceTests
                 {
                     OpaqueUserId = "syncuser01",
                     Username = env.Username01,
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
-            }
+            },
         };
 
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
@@ -2855,7 +2855,7 @@ public class ParatextServiceTests
                     isNew = true,
                     notes = new[] { new ThreadNoteComponents { } },
                     editable = true,
-                }
+                },
             }
         );
         await using IConnection conn = await env.RealtimeService.ConnectAsync(env.User01);
@@ -2894,9 +2894,9 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 tagsAdded = new[] { "2" },
-                versionNumber = 1
+                versionNumber = 1,
             },
-            new ThreadNoteComponents { ownerRef = env.User05, versionNumber = 1 }
+            new ThreadNoteComponents { ownerRef = env.User05, versionNumber = 1 },
         };
         env.AddNoteThreadData(
             new[]
@@ -2909,7 +2909,7 @@ public class ParatextServiceTests
                     notes = threadNoteComponents,
                     isEdited = true,
                     editable = true,
-                }
+                },
             }
         );
         env.AddParatextComments(
@@ -2921,7 +2921,7 @@ public class ParatextServiceTests
                     noteCount = 2,
                     username = env.Username01,
                     notes = threadNoteComponents,
-                }
+                },
             }
         );
 
@@ -2933,8 +2933,8 @@ public class ParatextServiceTests
             {
                 OpaqueUserId = "syncuser01",
                 Username = env.Username01,
-                SFUserId = env.User01
-            }
+                SFUserId = env.User01,
+            },
         }.ToDictionary(u => u.Username);
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -2991,13 +2991,13 @@ public class ParatextServiceTests
         {
             content = "thread1 note 1",
             syncUserRef = "syncuser01",
-            ownerRef = env.User01
+            ownerRef = env.User01,
         };
         ThreadNoteComponents note2 = new ThreadNoteComponents
         {
             content = "thread1 note 2",
             syncUserRef = string.Empty,
-            ownerRef = env.User01
+            ownerRef = env.User01,
         };
         ThreadComponents sfThread1 = new ThreadComponents
         {
@@ -3013,7 +3013,7 @@ public class ParatextServiceTests
             noteCount = 1,
             username = env.Username01,
             editable = true,
-            isNew = true
+            isNew = true,
         };
         env.AddNoteThreadData([sfThread1, sfThread2]);
         ThreadComponents ptThread = new ThreadComponents
@@ -3036,7 +3036,7 @@ public class ParatextServiceTests
                 {
                     OpaqueUserId = "syncuser01",
                     Username = env.Username01,
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
             },
             {
@@ -3045,13 +3045,13 @@ public class ParatextServiceTests
                 {
                     OpaqueUserId = "syncuser02",
                     Username = env.Username02,
-                    SFUserId = env.User02
+                    SFUserId = env.User02,
                 }
             },
             {
                 newUsername,
-                new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = newUsername, }
-            }
+                new ParatextUserProfile { OpaqueUserId = "syncuser03", Username = newUsername }
+            },
         };
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -3088,7 +3088,7 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 tagsAdded = new[] { "2" },
-                versionNumber = 1
+                versionNumber = 1,
             },
             new ThreadNoteComponents { ownerRef = env.User05, versionNumber = 1 },
         };
@@ -3272,7 +3272,7 @@ public class ParatextServiceTests
             threadNum = 1,
             noteCount = 1,
             versionNumber = 1,
-            editable = true
+            editable = true,
         };
         env.AddNoteThreadData(new[] { threadComp });
 
@@ -3282,7 +3282,7 @@ public class ParatextServiceTests
             noteCount = 1,
             username = env.Username01,
             versionNumber = 2,
-            isEdited = true
+            isEdited = true,
         };
         env.AddParatextComments(new[] { threadCompPt });
 
@@ -3297,9 +3297,9 @@ public class ParatextServiceTests
                 {
                     OpaqueUserId = "syncuser01",
                     Username = env.Username01,
-                    SFUserId = env.User01
+                    SFUserId = env.User01,
                 }
-            }
+            },
         };
 
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
@@ -3364,7 +3364,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content4 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content5a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6a },
-            new ThreadNoteComponents { ownerRef = env.User01, content = content7a }
+            new ThreadNoteComponents { ownerRef = env.User01, content = content7a },
         };
         ThreadComponents threadCompSF = new ThreadComponents
         {
@@ -3372,7 +3372,7 @@ public class ParatextServiceTests
             noteCount = 7,
             username = env.Username01,
             notes = notesSF,
-            versionNumber = 1
+            versionNumber = 1,
         };
         env.AddNoteThreadData(new[] { threadCompSF });
         ThreadNoteComponents[] notesPT = new[]
@@ -3383,7 +3383,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content4 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content5b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6b },
-            new ThreadNoteComponents { ownerRef = env.User01, content = content7b }
+            new ThreadNoteComponents { ownerRef = env.User01, content = content7b },
         };
         ThreadComponents threadCompPT = new ThreadComponents
         {
@@ -3391,7 +3391,7 @@ public class ParatextServiceTests
             noteCount = 7,
             username = env.Username01,
             notes = notesPT,
-            versionNumber = 1
+            versionNumber = 1,
         };
         env.AddParatextComments(new[] { threadCompPT });
 
@@ -3403,8 +3403,8 @@ public class ParatextServiceTests
             {
                 OpaqueUserId = "syncuser01",
                 Username = env.Username01,
-                SFUserId = env.User01
-            }
+                SFUserId = env.User01,
+            },
         }.ToDictionary(u => u.Username);
         SyncMetricInfo syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -3499,7 +3499,7 @@ public class ParatextServiceTests
         // One comment is marked deleted, the other is permanently deleted
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -3534,7 +3534,7 @@ public class ParatextServiceTests
                     username = env.Username01,
                     deletedNotes = new[] { true },
                     versionNumber = 1,
-                }
+                },
             }
         );
         env.AddParatextComments(
@@ -3546,8 +3546,8 @@ public class ParatextServiceTests
                     noteCount = 2,
                     username = env.Username01,
                     deletedNotes = new[] { true, false },
-                    versionNumber = 1
-                }
+                    versionNumber = 1,
+                },
             }
         );
 
@@ -3557,7 +3557,7 @@ public class ParatextServiceTests
         // One comment is marked deleted, the other is permanently deleted
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -3618,8 +3618,8 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User05,
                 forceNullContent = true,
-                status = NoteStatus.Resolved
-            }
+                status = NoteStatus.Resolved,
+            },
         };
         ThreadComponents components = new ThreadComponents
         {
@@ -3627,7 +3627,7 @@ public class ParatextServiceTests
             noteCount = 2,
             username = env.Username01,
             notes = threadNotes,
-            editable = true
+            editable = true,
         };
         env.AddNoteThreadData(new[] { components });
         env.AddParatextComments(new[] { components });
@@ -3639,7 +3639,7 @@ public class ParatextServiceTests
 
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
-            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+            new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
         }.ToDictionary(u => u.Username);
         var syncMetricInfo = await env.Service.UpdateParatextCommentsAsync(
             userSecret,
@@ -3713,8 +3713,8 @@ public class ParatextServiceTests
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    username = env.Username01
-                }
+                    username = env.Username01,
+                },
             }
         );
         CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
@@ -3725,7 +3725,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
 
         IEnumerable<IDocument<NoteThread>> emptyDocs = Array.Empty<IDocument<NoteThread>>();
@@ -3769,7 +3769,7 @@ public class ParatextServiceTests
             {
                 env.Username01,
                 new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
-            }
+            },
         };
         // The comment thread must exist if the Note Thread is not new
         Assert.ThrowsAsync<DataNotFoundException>(
@@ -3797,7 +3797,7 @@ public class ParatextServiceTests
             TagId = 5,
             Icon = "sf05",
             Name = "SF Note Tag",
-            CreatorResolve = true
+            CreatorResolve = true,
         };
         env.SetupCommentTags(env.ProjectScrText, noteTag);
         ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
@@ -3818,7 +3818,7 @@ public class ParatextServiceTests
             TagId = CommentTag.notSetId,
             Icon = "sf05",
             Name = "SF Note Tag",
-            CreatorResolve = false
+            CreatorResolve = false,
         };
         ParatextSettings? settings = env.Service.GetParatextSettings(userSecret, paratextId);
         Assert.That(settings?.NoteTags.FirstOrDefault(t => t.Icon == noteTag.Icon), Is.Null);
@@ -3836,7 +3836,7 @@ public class ParatextServiceTests
         {
             TagId = CommentTag.notSetId,
             Icon = icon,
-            Name = "SF Note Tag"
+            Name = "SF Note Tag",
         };
         env.Service.UpdateCommentTag(userSecret, paratextId, noteTag);
         // the new tag is created with a tag id one greater than the last used id
@@ -3857,7 +3857,7 @@ public class ParatextServiceTests
         {
             TagId = existingId,
             Icon = "existingIcon",
-            Name = "SF Note Tag"
+            Name = "SF Note Tag",
         };
         env.SetupCommentTags(env.ProjectScrText, noteTag);
         Assert.Throws<ArgumentException>(() => env.Service.UpdateCommentTag(userSecret, paratextId, noteTag));
@@ -3957,7 +3957,7 @@ public class ParatextServiceTests
             {
                 x[2] = new List<SendReceiveResult>
                 {
-                    new SendReceiveResult(new SharedProject()) { Result = SendReceiveResultEnum.Failed, },
+                    new SendReceiveResult(new SharedProject()) { Result = SendReceiveResultEnum.Failed },
                 };
                 return true;
             });
@@ -4998,7 +4998,7 @@ public class ParatextServiceTests
     {
         // Setup test environment
         var env = new TestEnvironment();
-        var project = new SFProject { ParatextId = env.PTProjectIds[env.Project01].Id, };
+        var project = new SFProject { ParatextId = env.PTProjectIds[env.Project01].Id };
         var resource = new ParatextResource();
 
         // SUT
@@ -5012,7 +5012,7 @@ public class ParatextServiceTests
     {
         // Setup test environment
         var env = new TestEnvironment();
-        var project = new SFProject { ParatextId = env.Resource1Id, };
+        var project = new SFProject { ParatextId = env.Resource1Id };
         var resource = new ParatextResource();
 
         // SUT
@@ -6071,7 +6071,7 @@ public class ParatextServiceTests
                 ScrTextCollection = MockScrTextCollection,
                 SharingLogicWrapper = MockSharingLogicWrapper,
                 SyncDir = SyncDir,
-                _registryClient = MockRegistryHttpClient
+                _registryClient = MockRegistryHttpClient,
             };
 
             PTProjectIds.Add(Project01, HexId.CreateNew());
@@ -6153,7 +6153,7 @@ public class ParatextServiceTests
             UserSecret userSecret = new UserSecret
             {
                 Id = userSecretId,
-                ParatextTokens = new Tokens { AccessToken = accessToken, RefreshToken = "refresh_token_1234" }
+                ParatextTokens = new Tokens { AccessToken = accessToken, RefreshToken = "refresh_token_1234" },
             };
             return userSecret;
         }
@@ -6470,7 +6470,7 @@ public class ParatextServiceTests
             Delta chapterDelta = Delta.New().Insert("In the beginning");
             var textDoc = new TextData(chapterDelta)
             {
-                Id = TextData.GetTextDocId("sf_id_" + Project01, bookNum, chapterNum)
+                Id = TextData.GetTextDocId("sf_id_" + Project01, bookNum, chapterNum),
             };
             var texts = new TextData[] { textDoc };
             RealtimeService.AddRepository("texts", OTType.RichText, new MemoryRepository<TextData>(texts));
@@ -6511,7 +6511,7 @@ public class ParatextServiceTests
                     {
                         status = NoteStatus.Todo,
                         tagsAdded = new[] { CommentTag.toDoTagId.ToString() },
-                        assignedPTUser = CommentThread.unassignedUser
+                        assignedPTUser = CommentThread.unassignedUser,
                     };
                     if (comp.notes != null)
                         noteComponent = comp.notes[i - 1];
@@ -6807,7 +6807,7 @@ public class ParatextServiceTests
                 new MockZippedResourcePasswordProvider()
             )
             {
-                CachedGuid = HexId.FromStr(projectId)
+                CachedGuid = HexId.FromStr(projectId),
             };
             scrText.Settings.LanguageID = LanguageId.English;
             scrText.ZipFile.AddFile(
@@ -6842,7 +6842,7 @@ public class ParatextServiceTests
                         tags.Add(
                             new CommentTag(noteTag.Name, noteTag.Icon, tagId)
                             {
-                                CreatorResolve = noteTag.CreatorResolve
+                                CreatorResolve = noteTag.CreatorResolve,
                             }
                         );
                     }
@@ -6963,8 +6963,8 @@ public class ParatextServiceTests
                         Assignment = CommentThread.unassignedUser,
                         Content = "<p>Note content.</p>",
                         AcceptedChangeXml = null,
-                    }
-                }
+                    },
+                },
             };
             modifyNoteThread?.Invoke(thread01);
 
@@ -6999,7 +6999,7 @@ public class ParatextServiceTests
             IEnumerable<IDocument<NoteThread>> noteThreadDocs = await GetNoteThreadDocsAsync(conn, ["dataId01"]);
             Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
             {
-                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 }
+                new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
             }.ToDictionary(u => u.Username);
             Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(
                 1,

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -777,15 +777,9 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         env.AddTextDocs(40, 1, 6, "Context before ", "Text selected");
 
-        env.AddNoteThreadData(
-            new[]
-            {
-                new ThreadComponents { threadNum = 1, noteCount = 1 },
-            }
-        );
+        env.AddNoteThreadData([new ThreadComponents { threadNum = 1, noteCount = 1 }]);
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -799,13 +793,13 @@ public class ParatextServiceTests
                     username = env.Username01,
                     appliesToVerse = true,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
@@ -855,28 +849,22 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         env.AddTextDocs(40, 1, 6, "Context before ", "Text selection", false);
 
-        env.AddNoteThreadData(
-            new[]
-            {
-                new ThreadComponents { threadNum = 1, noteCount = 1 },
-            }
-        );
+        env.AddNoteThreadData([new ThreadComponents { threadNum = 1, noteCount = 1 }]);
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
         {
@@ -917,7 +905,7 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
 
-        ThreadNoteComponents user1Note = new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = new[] { "1" } };
+        ThreadNoteComponents user1Note = new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = ["1"] };
         ThreadNoteComponents user1NoteNoTag = new ThreadNoteComponents { ownerRef = env.User01 };
         ThreadNoteComponents thread8Note = new ThreadNoteComponents
         {
@@ -926,63 +914,61 @@ public class ParatextServiceTests
             assignedPTUser = CommentThread.unassignedUser,
         };
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 2,
                     noteCount = 1,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 3,
-                    notes = new[] { user1Note, user1NoteNoTag, user1NoteNoTag },
-                    deletedNotes = new[] { false, true, false },
+                    notes = [user1Note, user1NoteNoTag, user1NoteNoTag],
+                    deletedNotes = [false, true, false],
                 },
                 new ThreadComponents
                 {
                     threadNum = 5,
                     noteCount = 2,
-                    notes = new[] { user1Note, user1NoteNoTag },
-                    deletedNotes = new[] { true, false },
+                    notes = [user1Note, user1NoteNoTag],
+                    deletedNotes = [true, false],
                 },
                 new ThreadComponents
                 {
                     threadNum = 7,
                     noteCount = 1,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
-                    notes = new[] { thread8Note },
+                    notes = [thread8Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 9,
                     noteCount = 3,
-                    notes = new[] { user1Note, user1Note, user1Note },
+                    notes = [user1Note, user1Note, user1Note],
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                     isEdited = true,
                 },
                 new ThreadComponents
@@ -990,57 +976,57 @@ public class ParatextServiceTests
                     threadNum = 2,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { user1Note },
-                    deletedNotes = new[] { true },
+                    notes = [user1Note],
+                    deletedNotes = [true],
                 },
                 new ThreadComponents
                 {
                     threadNum = 3,
                     noteCount = 1,
                     username = env.Username02,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 4,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 6,
                     noteCount = 1,
                     isConflict = true,
-                    notes = new[] { user1Note },
+                    notes = [user1Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 7,
                     noteCount = 2,
                     username = env.Username01,
-                    notes = new[] { user1Note, user1NoteNoTag },
+                    notes = [user1Note, user1NoteNoTag],
                 },
                 new ThreadComponents
                 {
                     threadNum = 8,
                     noteCount = 1,
                     username = env.Username01,
-                    notes = new[] { thread8Note },
+                    notes = [thread8Note],
                 },
                 new ThreadComponents
                 {
                     threadNum = 9,
                     noteCount = 3,
                     username = env.Username01,
-                    notes = new[] { user1Note, user1NoteNoTag, user1NoteNoTag },
+                    notes = [user1Note, user1NoteNoTag, user1NoteNoTag],
                 },
-            }
+            ]
         );
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1", "dataId2", "dataId4", "dataId5", "dataId7", "dataId8", "dataId9" }
+            ["dataId1", "dataId2", "dataId4", "dataId5", "dataId7", "dataId8", "dataId9"]
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
@@ -1147,40 +1133,38 @@ public class ParatextServiceTests
         string content2b = "";
         string content3 = "";
 
-        var note1a = new ThreadNoteComponents { content = content1a, tagsAdded = new[] { "1" } };
+        var note1a = new ThreadNoteComponents { content = content1a, tagsAdded = ["1"] };
         var note2a = new ThreadNoteComponents { content = content2a };
         var note3a = new ThreadNoteComponents { content = content3 };
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 3,
-                    notes = new[] { note1a, note2a, note3a },
+                    notes = [note1a, note2a, note3a],
                 },
-            }
+            ]
         );
 
         var note1b = new ThreadNoteComponents
         {
             content = content1b,
             ownerRef = env.User01,
-            tagsAdded = new[] { "1" },
+            tagsAdded = ["1"],
         };
         var note2b = new ThreadNoteComponents { content = content2b, ownerRef = env.User01 };
         var note3b = new ThreadNoteComponents { content = content3, ownerRef = env.User01 };
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 3,
                     username = env.Username01,
-                    notes = new[] { note1b, note2b, note3b },
+                    notes = [note1b, note2b, note3b],
                 },
-            }
+            ]
         );
 
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new Dictionary<string, ParatextUserProfile>
@@ -1198,7 +1182,7 @@ public class ParatextServiceTests
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
 
@@ -1311,7 +1295,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents
             {
                 ownerRef = env.User05,
-                tagsAdded = new[] { "2" },
+                tagsAdded = ["2"],
                 content = "original content",
             },
             new ThreadNoteComponents { ownerRef = env.User05 },
@@ -1323,7 +1307,7 @@ public class ParatextServiceTests
             username = env.Username01,
             notes = notes,
         };
-        env.AddNoteThreadData(new[] { threadDocs });
+        env.AddNoteThreadData([threadDocs]);
         string originalContent = $"<p>[User 05 - xForge]</p><p>original content</p>";
         string editedContent = $"<p>[User 05 - xForge]</p><p>content that will be discarded</p>";
         var comments = new[]
@@ -1331,7 +1315,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents
             {
                 ownerRef = env.User05,
-                tagsAdded = new[] { "2" },
+                tagsAdded = ["2"],
                 content = originalContent,
             },
             new ThreadNoteComponents { ownerRef = env.User05, content = editedContent },
@@ -1343,12 +1327,12 @@ public class ParatextServiceTests
             username = env.Username01,
             notes = comments,
         };
-        env.AddParatextComments(new[] { commentThreads });
+        env.AddParatextComments([commentThreads]);
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
@@ -1403,10 +1387,7 @@ public class ParatextServiceTests
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         // But we have no SF notes.
-        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
-            conn,
-            Array.Empty<string>()
-        );
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(conn, []);
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
             new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
@@ -1473,7 +1454,7 @@ public class ParatextServiceTests
         await using (await env.RealtimeService.ConnectAsync())
         {
             IEnumerable<IDocument<NoteThread>> noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
-            Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
+            Dictionary<int, ChapterDelta> chapterDeltas = [];
             string chapterText =
                 "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, "
                 + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } },"
@@ -1566,32 +1547,30 @@ public class ParatextServiceTests
         string projectId = env.SetupProject(env.Project01, associatedPTUser);
         var userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
-        ThreadNoteComponents[] noteComponents = new[]
-        {
+        ThreadNoteComponents[] noteComponents =
+        [
             new ThreadNoteComponents
             {
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "1" },
+                tagsAdded = ["1"],
                 assignedPTUser = CommentThread.unassignedUser,
                 // tests that if duplicate project notes exist, the sync succeeds
                 duplicate = true,
             },
-        };
+        ];
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     notes = noteComponents,
                 },
-            }
+            ]
         );
 
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -1599,7 +1578,7 @@ public class ParatextServiceTests
                     notes = noteComponents,
                     username = env.Username01,
                 },
-            }
+            ]
         );
 
         var commentThread = env.ProjectCommentManager.FindThread("thread1");
@@ -1609,7 +1588,7 @@ public class ParatextServiceTests
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
@@ -1784,19 +1763,14 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         env.AddTextDocs(40, 1, 10, "Context before ", "Text selected");
 
-        env.AddNoteThreadData(
-            new[]
-            {
-                new ThreadComponents { threadNum = 1, noteCount = 9 },
-            }
-        );
-        ThreadNoteComponents[] threadNotes = new[]
-        {
+        env.AddNoteThreadData([new ThreadComponents { threadNum = 1, noteCount = 9 }]);
+        ThreadNoteComponents[] threadNotes =
+        [
             new ThreadNoteComponents
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "2" },
+                tagsAdded = ["2"],
             },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
@@ -1805,7 +1779,7 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "3" },
+                tagsAdded = ["3"],
             },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Unspecified },
             new ThreadNoteComponents { ownerRef = env.User01, status = NoteStatus.Done },
@@ -1814,12 +1788,11 @@ public class ParatextServiceTests
             {
                 ownerRef = env.User01,
                 status = NoteStatus.Todo,
-                tagsAdded = new[] { "4" },
+                tagsAdded = ["4"],
             },
-        };
+        ];
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -1827,13 +1800,13 @@ public class ParatextServiceTests
                     notes = threadNotes,
                     username = env.Username01,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1" }
+            ["dataId1"]
         );
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
@@ -1849,7 +1822,7 @@ public class ParatextServiceTests
             ptProjectUsers
         );
 
-        List<int?> expectedIcons = new List<int?>() { 2, null, null, 2, 3, null, 3, 3, 4 };
+        List<int?> expectedIcons = [2, null, null, 2, 3, null, 3, 3, 4];
         NoteThreadChange changedThread = changes.Where(c => c.ThreadId == "thread1").Single();
         for (int i = 0; i < expectedIcons.Count; i++)
         {
@@ -1878,11 +1851,11 @@ public class ParatextServiceTests
         ThreadNoteComponents[] getThreadNoteComponents(int noteCount, string[] assignedUsers, bool iconChange = false)
         {
             var components = new List<ThreadNoteComponents>();
-            string[] commentTagsAdded = new[] { CommentTag.toDoTagId.ToString() };
+            string[] commentTagsAdded = [CommentTag.toDoTagId.ToString()];
             if (iconChange)
             {
                 string newIconId = "2";
-                commentTagsAdded = new[] { newIconId };
+                commentTagsAdded = [newIconId];
             }
             for (int i = 0; i < noteCount; i++)
             {
@@ -1902,13 +1875,12 @@ public class ParatextServiceTests
                 };
                 components.Add(noteComponents);
             }
-            return components.ToArray();
+            return [.. components];
         }
-        ThreadNoteComponents[] threadDocNotes7 = getThreadNoteComponents(1, new[] { env.Username02 });
-        ThreadNoteComponents[] threadDocNotes8 = getThreadNoteComponents(1, new[] { env.Username02 });
+        ThreadNoteComponents[] threadDocNotes7 = getThreadNoteComponents(1, [env.Username02]);
+        ThreadNoteComponents[] threadDocNotes8 = getThreadNoteComponents(1, [env.Username02]);
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents { threadNum = 1, noteCount = 1 },
                 new ThreadComponents { threadNum = 3, noteCount = 1 },
                 new ThreadComponents { threadNum = 4, noteCount = 1 },
@@ -1926,21 +1898,20 @@ public class ParatextServiceTests
                     noteCount = 1,
                     notes = threadDocNotes8,
                 },
-            }
+            ]
         );
 
         string unassignedUserString = CommentThread.unassignedUser;
         string teamUserString = CommentThread.teamUser;
-        ThreadNoteComponents[] threadNotes1 = getThreadNoteComponents(2, new[] { teamUserString, env.Username02 });
-        ThreadNoteComponents[] threadNotes2 = getThreadNoteComponents(1, new[] { env.Username02 });
-        ThreadNoteComponents[] threadNotes3 = getThreadNoteComponents(1, new[] { env.Username02 });
-        ThreadNoteComponents[] threadNotes4 = getThreadNoteComponents(1, new[] { teamUserString });
-        ThreadNoteComponents[] threadNotes5 = getThreadNoteComponents(1, new[] { unassignedUserString }, true);
+        ThreadNoteComponents[] threadNotes1 = getThreadNoteComponents(2, [teamUserString, env.Username02]);
+        ThreadNoteComponents[] threadNotes2 = getThreadNoteComponents(1, [env.Username02]);
+        ThreadNoteComponents[] threadNotes3 = getThreadNoteComponents(1, [env.Username02]);
+        ThreadNoteComponents[] threadNotes4 = getThreadNoteComponents(1, [teamUserString]);
+        ThreadNoteComponents[] threadNotes5 = getThreadNoteComponents(1, [unassignedUserString], true);
         ThreadNoteComponents[] threadNotes7 = getThreadNoteComponents(1, null);
-        ThreadNoteComponents[] threadNotes8 = getThreadNoteComponents(1, new[] { unassignedUserString });
+        ThreadNoteComponents[] threadNotes8 = getThreadNoteComponents(1, [unassignedUserString]);
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -1997,14 +1968,14 @@ public class ParatextServiceTests
                     notes = threadNotes8,
                 },
                 new ThreadComponents { threadNum = 9, noteCount = 1 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         // SUT
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1", "dataId3", "dataId4", "dataId5", "dataId6", "dataId7", "dataId8" }
+            ["dataId1", "dataId3", "dataId4", "dataId5", "dataId6", "dataId7", "dataId8"]
         );
         var deltas = env.GetChapterDeltasByBook(1, "Context before ", "Text selected", true);
         IEnumerable<NoteThreadChange> changes = env.Service.GetNoteThreadChanges(
@@ -2081,8 +2052,7 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -2111,7 +2081,7 @@ public class ParatextServiceTests
                     username = env.Username01,
                     alternateText = SelectionType.RelatedVerse,
                 },
-            }
+            ]
         );
 
         await using (await env.RealtimeService.ConnectAsync())
@@ -2178,8 +2148,7 @@ public class ParatextServiceTests
         ReattachedThreadInfo rti = env.GetReattachedThreadInfo(verseStr);
 
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents { threadNum = 1, noteCount = 1 },
                 new ThreadComponents
                 {
@@ -2194,11 +2163,10 @@ public class ParatextServiceTests
                     noteCount = 1,
                     reattachedVerseStr = verseStr,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -2233,13 +2201,13 @@ public class ParatextServiceTests
                     noteCount = 1,
                     username = env.Username01,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1", "dataId3", "dataId4", "dataId5" }
+            ["dataId1", "dataId3", "dataId4", "dataId5"]
         );
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         Dictionary<string, ParatextUserProfile> syncUsers = new Dictionary<string, ParatextUserProfile>
@@ -2311,8 +2279,7 @@ public class ParatextServiceTests
         string verseStr = "MAT 1:7 This is not a valid verse   It was badly reattached";
 
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents { threadNum = 1, noteCount = 1 },
                 new ThreadComponents
                 {
@@ -2329,11 +2296,10 @@ public class ParatextServiceTests
                     reattachedVerseStr = verseStr,
                     doNotParseReattachedVerseStr = true,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -2372,13 +2338,13 @@ public class ParatextServiceTests
                     noteCount = 1,
                     username = env.Username01,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { "dataId1", "dataId3", "dataId4", "dataId5" }
+            ["dataId1", "dataId3", "dataId4", "dataId5"]
         );
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         Dictionary<string, ParatextUserProfile> syncUsers = new Dictionary<string, ParatextUserProfile>
@@ -2432,16 +2398,15 @@ public class ParatextServiceTests
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
 
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    deletedNotes = new[] { true },
+                    deletedNotes = [true],
                 },
-            }
+            ]
         );
 
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
@@ -2475,34 +2440,32 @@ public class ParatextServiceTests
         string threadId = "thread1";
         string originalDataId = "dataId1";
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
-                    deletedNotes = new[] { true },
+                    deletedNotes = [true],
                 },
-            }
+            ]
         );
 
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
                 },
-            }
+            ]
         );
         string newDataId = "newdataid1";
         env.MockGuidService.NewObjectId().Returns(newDataId);
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
             conn,
-            new[] { originalDataId }
+            [originalDataId]
         );
         Dictionary<int, ChapterDelta> chapterDeltas = env.GetChapterDeltasByBook(1, env.ContextBefore, "Text selected");
         var ptProjectUsers = new Dictionary<string, ParatextUserProfile>
@@ -2563,7 +2526,7 @@ public class ParatextServiceTests
         // string content8b = "<p>\n      First paragraph content.\n</p><p>Second paragraph content.</p>";
 
         ThreadNoteComponents[] notesSF =
-        {
+        [
             new ThreadNoteComponents { ownerRef = env.User05, content = content1a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content2 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content3 },
@@ -2571,7 +2534,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content5a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content7a },
-        };
+        ];
         ThreadComponents threadCompSF = new ThreadComponents
         {
             threadNum = 1,
@@ -2579,9 +2542,9 @@ public class ParatextServiceTests
             username = env.Username01,
             notes = notesSF,
         };
-        env.AddNoteThreadData(new[] { threadCompSF });
+        env.AddNoteThreadData([threadCompSF]);
         ThreadNoteComponents[] notesPT =
-        {
+        [
             new ThreadNoteComponents { ownerRef = env.User05, content = content1b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content2 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content3 },
@@ -2589,7 +2552,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content5b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content7b },
-        };
+        ];
         ThreadComponents threadCompPT = new ThreadComponents
         {
             threadNum = 1,
@@ -2597,7 +2560,7 @@ public class ParatextServiceTests
             username = env.Username01,
             notes = notesPT,
         };
-        env.AddParatextComments(new[] { threadCompPT });
+        env.AddParatextComments([threadCompPT]);
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
@@ -2662,10 +2625,7 @@ public class ParatextServiceTests
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         // But we have no SF notes.
-        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(
-            conn,
-            Array.Empty<string>()
-        );
+        IEnumerable<IDocument<NoteThread>> noteThreadDocs = await TestEnvironment.GetNoteThreadDocsAsync(conn, []);
         Dictionary<string, ParatextUserProfile> ptProjectUsers = new[]
         {
             new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = env.Username01 },
@@ -2846,17 +2806,16 @@ public class ParatextServiceTests
         string threadId = "thread1";
         string dataId = "dataId1";
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     isNew = true,
-                    notes = new[] { new ThreadNoteComponents { } },
+                    notes = [new ThreadNoteComponents { }],
                     editable = true,
                 },
-            }
+            ]
         );
         await using IConnection conn = await env.RealtimeService.ConnectAsync(env.User01);
         CommentThread commentThread = env.ProjectCommentManager.FindThread(threadId);
@@ -2893,14 +2852,13 @@ public class ParatextServiceTests
             new ThreadNoteComponents
             {
                 ownerRef = env.User01,
-                tagsAdded = new[] { "2" },
+                tagsAdded = ["2"],
                 versionNumber = 1,
             },
             new ThreadNoteComponents { ownerRef = env.User05, versionNumber = 1 },
         };
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -2910,11 +2868,10 @@ public class ParatextServiceTests
                     isEdited = true,
                     editable = true,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -2922,7 +2879,7 @@ public class ParatextServiceTests
                     username = env.Username01,
                     notes = threadNoteComponents,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
@@ -3087,14 +3044,13 @@ public class ParatextServiceTests
             new ThreadNoteComponents
             {
                 ownerRef = env.User01,
-                tagsAdded = new[] { "2" },
+                tagsAdded = ["2"],
                 versionNumber = 1,
             },
             new ThreadNoteComponents { ownerRef = env.User05, versionNumber = 1 },
         };
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -3104,11 +3060,10 @@ public class ParatextServiceTests
                     isEdited = true,
                     editable = false,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -3116,7 +3071,7 @@ public class ParatextServiceTests
                     username = env.Username01,
                     notes = threadNoteComponents,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
@@ -3189,11 +3144,10 @@ public class ParatextServiceTests
         const string dataId = "dataId1";
         var threadNoteComponents = new[]
         {
-            new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = new[] { "2" } },
+            new ThreadNoteComponents { ownerRef = env.User01, tagsAdded = ["2"] },
         };
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -3204,11 +3158,10 @@ public class ParatextServiceTests
                     editable = true,
                     versionNumber = 1,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
@@ -3217,7 +3170,7 @@ public class ParatextServiceTests
                     notes = threadNoteComponents,
                     versionNumber = 2,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
@@ -3274,7 +3227,7 @@ public class ParatextServiceTests
             versionNumber = 1,
             editable = true,
         };
-        env.AddNoteThreadData(new[] { threadComp });
+        env.AddNoteThreadData([threadComp]);
 
         ThreadComponents threadCompPt = new ThreadComponents
         {
@@ -3284,7 +3237,7 @@ public class ParatextServiceTests
             versionNumber = 2,
             isEdited = true,
         };
-        env.AddParatextComments(new[] { threadCompPt });
+        env.AddParatextComments([threadCompPt]);
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         string dataId = "dataId1";
@@ -3356,8 +3309,8 @@ public class ParatextServiceTests
         string content7a = "<p>\n  <bold>First paragraph content.</bold>\n  </p><p>Second paragraph content.</p>";
         string content7b = "<p><bold>First paragraph content.</bold></p><p>Second paragraph content.</p>";
 
-        ThreadNoteComponents[] notesSF = new[]
-        {
+        ThreadNoteComponents[] notesSF =
+        [
             new ThreadNoteComponents { ownerRef = env.User05, content = content1a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content2 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content3 },
@@ -3365,7 +3318,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content5a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6a },
             new ThreadNoteComponents { ownerRef = env.User01, content = content7a },
-        };
+        ];
         ThreadComponents threadCompSF = new ThreadComponents
         {
             threadNum = 1,
@@ -3374,9 +3327,9 @@ public class ParatextServiceTests
             notes = notesSF,
             versionNumber = 1,
         };
-        env.AddNoteThreadData(new[] { threadCompSF });
-        ThreadNoteComponents[] notesPT = new[]
-        {
+        env.AddNoteThreadData([threadCompSF]);
+        ThreadNoteComponents[] notesPT =
+        [
             new ThreadNoteComponents { ownerRef = env.User05, content = content1b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content2 },
             new ThreadNoteComponents { ownerRef = env.User01, content = content3 },
@@ -3384,7 +3337,7 @@ public class ParatextServiceTests
             new ThreadNoteComponents { ownerRef = env.User01, content = content5b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content6b },
             new ThreadNoteComponents { ownerRef = env.User01, content = content7b },
-        };
+        ];
         ThreadComponents threadCompPT = new ThreadComponents
         {
             threadNum = 1,
@@ -3393,7 +3346,7 @@ public class ParatextServiceTests
             notes = notesPT,
             versionNumber = 1,
         };
-        env.AddParatextComments(new[] { threadCompPT });
+        env.AddParatextComments([threadCompPT]);
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
@@ -3487,9 +3440,9 @@ public class ParatextServiceTests
             username = env.Username01,
             editable = true,
         };
-        env.AddParatextComments(new[] { components });
-        components.deletedNotes = new[] { true };
-        env.AddNoteThreadData(new[] { components });
+        env.AddParatextComments([components]);
+        components.deletedNotes = [true];
+        env.AddNoteThreadData([components]);
         CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
         Assert.That(thread, Is.Not.Null);
 
@@ -3525,30 +3478,28 @@ public class ParatextServiceTests
         string threadId = "thread1";
         string dataId = "dataId1";
         env.AddNoteThreadData(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
-                    deletedNotes = new[] { true },
+                    deletedNotes = [true],
                     versionNumber = 1,
                 },
-            }
+            ]
         );
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 2,
                     username = env.Username01,
-                    deletedNotes = new[] { true, false },
+                    deletedNotes = [true, false],
                     versionNumber = 1,
                 },
-            }
+            ]
         );
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
@@ -3612,7 +3563,7 @@ public class ParatextServiceTests
         string threadId = "thread1";
         string dataId = "dataId1";
         ThreadNoteComponents[] threadNotes =
-        {
+        [
             new ThreadNoteComponents { ownerRef = env.User05 },
             new ThreadNoteComponents
             {
@@ -3620,7 +3571,7 @@ public class ParatextServiceTests
                 forceNullContent = true,
                 status = NoteStatus.Resolved,
             },
-        };
+        ];
         ThreadComponents components = new ThreadComponents
         {
             threadNum = 1,
@@ -3629,8 +3580,8 @@ public class ParatextServiceTests
             notes = threadNotes,
             editable = true,
         };
-        env.AddNoteThreadData(new[] { components });
-        env.AddParatextComments(new[] { components });
+        env.AddNoteThreadData([components]);
+        env.AddParatextComments([components]);
         CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
         Assert.That(thread, Is.Not.Null);
 
@@ -3671,9 +3622,9 @@ public class ParatextServiceTests
             username = env.Username01,
             editable = false,
         };
-        env.AddParatextComments(new[] { components });
-        components.deletedNotes = new[] { true };
-        env.AddNoteThreadData(new[] { components });
+        env.AddParatextComments([components]);
+        components.deletedNotes = [true];
+        env.AddNoteThreadData([components]);
         CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
         Assert.NotNull(thread);
 
@@ -3707,15 +3658,14 @@ public class ParatextServiceTests
 
         string threadId = "thread1";
         env.AddParatextComments(
-            new[]
-            {
+            [
                 new ThreadComponents
                 {
                     threadNum = 1,
                     noteCount = 1,
                     username = env.Username01,
                 },
-            }
+            ]
         );
         CommentThread thread = env.ProjectCommentManager.FindThread(threadId);
         Assert.That(thread, Is.Not.Null);
@@ -3759,7 +3709,7 @@ public class ParatextServiceTests
             editable = true,
             versionNumber = 1,
         };
-        env.AddNoteThreadData(new[] { thread });
+        env.AddNoteThreadData([thread]);
 
         await using IConnection conn = await env.RealtimeService.ConnectAsync();
         IDocument<NoteThread> noteThreadDoc = await TestEnvironment.GetNoteThreadDocAsync(conn, dataId);
@@ -5361,7 +5311,7 @@ public class ParatextServiceTests
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         SFProject project = env.NewSFProject();
-        project.UserRoles = new Dictionary<string, string>();
+        project.UserRoles = [];
         env.AddProjectRepository(project);
 
         // SUT
@@ -5482,7 +5432,7 @@ public class ParatextServiceTests
         var env = new TestEnvironment();
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         SFProject project = env.NewSFProject();
-        project.UserRoles = new Dictionary<string, string>();
+        project.UserRoles = [];
         env.AddProjectRepository(project);
 
         // SUT
@@ -5915,7 +5865,7 @@ public class ParatextServiceTests
         public readonly string Resource1Id = "e01f11e9b4b8e338";
         public readonly string Resource2Id = "5e51f89e89947acb";
         public readonly string Resource3Id = "9bb76cd3e5a7f9b4";
-        public readonly Dictionary<string, HexId> PTProjectIds = new Dictionary<string, HexId>();
+        public readonly Dictionary<string, HexId> PTProjectIds = [];
         public readonly string User01 = "user01";
         public readonly string User02 = "user02";
         public readonly string User03 = "user03";
@@ -6510,7 +6460,7 @@ public class ParatextServiceTests
                     ThreadNoteComponents noteComponent = new ThreadNoteComponents
                     {
                         status = NoteStatus.Todo,
-                        tagsAdded = new[] { CommentTag.toDoTagId.ToString() },
+                        tagsAdded = [CommentTag.toDoTagId.ToString()],
                         assignedPTUser = CommentThread.unassignedUser,
                     };
                     if (comp.notes != null)
@@ -6602,7 +6552,7 @@ public class ParatextServiceTests
             bool includeRelatedVerse = false
         )
         {
-            Dictionary<int, ChapterDelta> chapterDeltas = new Dictionary<int, ChapterDelta>();
+            Dictionary<int, ChapterDelta> chapterDeltas = [];
             const int numVersesInChapter = 10;
             for (int i = 1; i <= chapters; i++)
             {
@@ -6659,7 +6609,7 @@ public class ParatextServiceTests
             string[] dataIds
         )
         {
-            List<IDocument<NoteThread>> noteThreadDocs = new List<IDocument<NoteThread>>();
+            List<IDocument<NoteThread>> noteThreadDocs = [];
             foreach (string dataId in dataIds)
                 noteThreadDocs.Add(await GetNoteThreadDocAsync(connection, dataId));
             return noteThreadDocs;
@@ -6739,7 +6689,7 @@ public class ParatextServiceTests
                     ThreadNoteComponents note = new ThreadNoteComponents
                     {
                         status = NoteStatus.Todo,
-                        tagsAdded = new[] { CommentTag.toDoTagId.ToString() },
+                        tagsAdded = [CommentTag.toDoTagId.ToString()],
                         assignedPTUser = CommentThread.unassignedUser,
                     };
                     if (comp.notes != null)
@@ -6855,7 +6805,7 @@ public class ParatextServiceTests
 
             CommentTags.CommentTagList list = new CommentTags.CommentTagList
             {
-                SerializedData = tags.ToArray(),
+                SerializedData = [.. tags],
                 SerializedLastUsedId = TagCount,
             };
             scrText.FileManager.GetXml<CommentTags.CommentTagList>(Arg.Any<string>()).Returns(list);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -111,7 +111,7 @@ public class ParatextSyncRunnerTests
             )
             .Throws(new ForbiddenException());
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
-            .Returns(new ParatextSettings { ProjectType = ProjectType.BackTranslation.ToString(), });
+            .Returns(new ParatextSettings { ProjectType = ProjectType.BackTranslation.ToString() });
         await env.Runner.RunAsync("project01", "user02", "project01", false, CancellationToken.None);
 
         SFProject project = env.VerifyProjectSync(false, projectSFId: "project01");
@@ -803,20 +803,20 @@ public class ParatextSyncRunnerTests
             {
                 TagId = 1,
                 Name = "To do",
-                Icon = NoteTag.defaultTagIcon
+                Icon = NoteTag.defaultTagIcon,
             },
             new NoteTag
             {
                 TagId = 2,
                 Name = "Original tag",
-                Icon = "originalIcon"
+                Icon = "originalIcon",
             },
             new NoteTag
             {
                 TagId = 3,
                 Name = "Tag to delete",
-                Icon = "delete"
-            }
+                Icon = "delete",
+            },
         };
         await env.SetupProjectNoteTags("project01", noteTags);
         env.SetupPTData(books);
@@ -826,14 +826,14 @@ public class ParatextSyncRunnerTests
             {
                 TagId = 1,
                 Name = "To do",
-                Icon = NoteTag.defaultTagIcon
+                Icon = NoteTag.defaultTagIcon,
             },
             new NoteTag
             {
                 TagId = 2,
                 Name = "Edited tag",
-                Icon = "editedIcon"
-            }
+                Icon = "editedIcon",
+            },
         };
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(new ParatextSettings { NoteTags = newNoteTags });
@@ -1863,7 +1863,7 @@ public class ParatextSyncRunnerTests
             ParatextId = TestEnvironment.ParatextProjectUser01.ParatextId,
             Username = "New User 1",
             Id = TestEnvironment.ParatextProjectUser01.Id,
-            Role = TestEnvironment.ParatextProjectUser01.Role
+            Role = TestEnvironment.ParatextProjectUser01.Role,
         };
         env.ParatextService.GetParatextUsersAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), CancellationToken.None)
             .Returns([newUser, TestEnvironment.ParatextProjectUser02]);
@@ -1892,7 +1892,7 @@ public class ParatextSyncRunnerTests
             ParatextId = TestEnvironment.ParatextProjectUser01.ParatextId,
             Username = "User 2",
             Id = TestEnvironment.ParatextProjectUser01.Id,
-            Role = TestEnvironment.ParatextProjectUser01.Role
+            Role = TestEnvironment.ParatextProjectUser01.Role,
         };
         env.ParatextService.GetParatextUsersAsync(Arg.Any<UserSecret>(), Arg.Any<SFProject>(), CancellationToken.None)
             .Returns([user2]);
@@ -1982,7 +1982,7 @@ public class ParatextSyncRunnerTests
             "reattach selected text",
             "16",
             "Reattach before ",
-            " reattach after."
+            " reattach after.",
         };
         string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachedParts);
         string expected = "Context before Scripture text in project context after-" + $"Start:16-Length:22-MAT 1:1";
@@ -2102,7 +2102,7 @@ public class ParatextSyncRunnerTests
                 ThreadId = threadId,
                 SyncUserRef = "syncuser02",
                 Content = "Paratext note 3.",
-                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
             }
         );
         await env.SetThreadNotesAsync(sfProjectId, dataId, beginningNoteSet);
@@ -2169,7 +2169,7 @@ public class ParatextSyncRunnerTests
                 ThreadId = threadId,
                 SyncUserRef = "syncuser02",
                 Content = "Paratext note 3.",
-                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc)
+                DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
             }
         );
         await env.SetThreadNotesAsync(sfProjectId, dataId, beginningNoteSet);
@@ -3181,7 +3181,7 @@ public class ParatextSyncRunnerTests
                 Id = "project01",
                 Name = "project01",
                 ShortName = "P01",
-                UserRoles = new Dictionary<string, string> { { "user01", SFProjectRole.Administrator }, },
+                UserRoles = new Dictionary<string, string> { { "user01", SFProjectRole.Administrator } },
                 ParatextId = "pt01",
                 IsRightToLeft = false,
                 DefaultFontSize = 10,
@@ -3196,15 +3196,15 @@ public class ParatextSyncRunnerTests
                         Name = "Source",
                         ShortName = "SRC",
                         WritingSystem = new WritingSystem { Tag = "en" },
-                        IsRightToLeft = false
+                        IsRightToLeft = false,
                     },
-                    DefaultNoteTagId = 1234
+                    DefaultNoteTagId = 1234,
                 },
                 CheckingConfig = new CheckingConfig
                 {
                     CheckingEnabled = true,
                     AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
-                    NoteTagId = 1234
+                    NoteTagId = 1234,
                 },
                 Texts = books.Select(b => textInfo).ToList(),
                 Sync = new Sync
@@ -3213,14 +3213,14 @@ public class ParatextSyncRunnerTests
                     // it to 1 to simulate it being incremented.
                     QueuedCount = 1,
                     SyncedToRepositoryVersion = "beforeSR",
-                    DataInSync = true
+                    DataInSync = true,
                 },
                 ParatextUsers =
                 [
                     new ParatextUserProfile { OpaqueUserId = "syncuser01", Username = "User 1" },
-                    new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" }
+                    new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" },
                 ],
-                NoteTags = []
+                NoteTags = [],
             },
         ];
         env.RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
@@ -3277,7 +3277,7 @@ public class ParatextSyncRunnerTests
                         Number = chapterDelta.Number,
                         IsValid = chapterDelta.IsValid,
                         LastVerse = chapterDelta.LastVerse,
-                        Permissions = new Dictionary<string, string>()
+                        Permissions = new Dictionary<string, string>(),
                     }
             )
             .ToList();
@@ -3289,7 +3289,7 @@ public class ParatextSyncRunnerTests
                 new[]
                 {
                     new User { Id = "user01", ParatextId = "pt01" },
-                    new User { Id = "user02", ParatextId = "pt02" }
+                    new User { Id = "user02", ParatextId = "pt02" },
                 }
             )
         );
@@ -3397,7 +3397,7 @@ public class ParatextSyncRunnerTests
             _projectSecrets = new MemoryRepository<SFProjectSecret>(
                 new[]
                 {
-                    new SFProjectSecret { Id = "project01", JobIds = ["test_jobid"], },
+                    new SFProjectSecret { Id = "project01", JobIds = ["test_jobid"] },
                     new SFProjectSecret { Id = "project02" },
                     new SFProjectSecret { Id = "project03" },
                     new SFProjectSecret { Id = "project04" },
@@ -3454,7 +3454,7 @@ public class ParatextSyncRunnerTests
                 {
                     FullName = (string)x[1],
                     IsRightToLeft = false,
-                    Editable = true
+                    Editable = true,
                 });
             ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "target").Returns("beforeSR");
             ParatextService.GetLatestSharedVersion(Arg.Any<UserSecret>(), "source").Returns("beforeSR", "afterSR");
@@ -3611,18 +3611,18 @@ public class ParatextSyncRunnerTests
                 BookNum = bookNum,
                 Chapters = new List<Chapter>
                 {
-                    new Chapter { Number = chapterNum, Permissions = chapterPermissions, },
+                    new Chapter { Number = chapterNum, Permissions = chapterPermissions },
                 },
             };
             RealtimeService.AddRepository(
                 "users",
                 OTType.Json0,
-                new MemoryRepository<User>(new[] { new User { Id = "user01" }, })
+                new MemoryRepository<User>(new[] { new User { Id = "user01" } })
             );
             RealtimeService.AddRepository(
                 "texts",
                 OTType.RichText,
-                new MemoryRepository<TextData>(new[] { new TextData(Delta.New()) { Id = id }, })
+                new MemoryRepository<TextData>(new[] { new TextData(Delta.New()) { Id = id } })
             );
             SFProject[] sfProjects = new[]
             {
@@ -3678,7 +3678,7 @@ public class ParatextSyncRunnerTests
                     new[]
                     {
                         new User { Id = "user01", ParatextId = "pt01" },
-                        new User { Id = "user02", ParatextId = "pt02" }
+                        new User { Id = "user02", ParatextId = "pt02" },
                     }
                 )
             );
@@ -3689,8 +3689,8 @@ public class ParatextSyncRunnerTests
                 new MemoryRepository<SFProjectUserConfig>(
                     new[]
                     {
-                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user01"), },
-                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user02"), }
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user01") },
+                        new SFProjectUserConfig { Id = SFProjectUserConfig.GetDocId("project01", "user02") },
                     }
                 )
             );
@@ -3705,7 +3705,7 @@ public class ParatextSyncRunnerTests
                     {
                         { "user01", SFProjectRole.Administrator },
                         { "user02", SFProjectRole.Translator },
-                        { "user03", SFProjectRole.Commenter }
+                        { "user03", SFProjectRole.Commenter },
                     },
                     ParatextId = "target",
                     IsRightToLeft = false,
@@ -3721,15 +3721,15 @@ public class ParatextSyncRunnerTests
                             Name = "Source",
                             ShortName = "SRC",
                             WritingSystem = new WritingSystem { Tag = "en" },
-                            IsRightToLeft = false
+                            IsRightToLeft = false,
                         },
-                        DefaultNoteTagId = translateNoteTagId
+                        DefaultNoteTagId = translateNoteTagId,
                     },
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
                         AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
-                        NoteTagId = checkingNoteTagId
+                        NoteTagId = checkingNoteTagId,
                     },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                     Sync = new Sync
@@ -3738,7 +3738,7 @@ public class ParatextSyncRunnerTests
                         // it to 1 to simulate it being incremented.
                         QueuedCount = 1,
                         SyncedToRepositoryVersion = "beforeSR",
-                        DataInSync = true
+                        DataInSync = true,
                     },
                     ParatextUsers = new List<ParatextUserProfile>
                     {
@@ -3746,11 +3746,11 @@ public class ParatextSyncRunnerTests
                         {
                             OpaqueUserId = "syncuser01",
                             Username = "User 1",
-                            SFUserId = "user01"
+                            SFUserId = "user01",
                         },
-                        new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" }
+                        new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" },
                     },
-                    NoteTags = new List<NoteTag>()
+                    NoteTags = new List<NoteTag>(),
                 },
                 new SFProject
                 {
@@ -3769,7 +3769,7 @@ public class ParatextSyncRunnerTests
                     },
                     WritingSystem = new WritingSystem { Tag = "en" },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
-                    Sync = new Sync { QueuedCount = 0, SyncedToRepositoryVersion = "beforeSR" }
+                    Sync = new Sync { QueuedCount = 0, SyncedToRepositoryVersion = "beforeSR" },
                 },
                 new SFProject
                 {
@@ -3781,7 +3781,7 @@ public class ParatextSyncRunnerTests
                     UserRoles = new Dictionary<string, string>
                     {
                         { "user01", SFProjectRole.Administrator },
-                        { "user02", SFProjectRole.Translator }
+                        { "user02", SFProjectRole.Translator },
                     },
                     ParatextId = "paratext-project03",
                     IsRightToLeft = false,
@@ -3795,13 +3795,13 @@ public class ParatextSyncRunnerTests
                             Name = "project04",
                             ShortName = "P04",
                             WritingSystem = new WritingSystem { Tag = "en" },
-                            IsRightToLeft = false
-                        }
+                            IsRightToLeft = false,
+                        },
                     },
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
-                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
                     },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                     Sync = new Sync
@@ -3823,7 +3823,7 @@ public class ParatextSyncRunnerTests
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
-                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
                     },
                     WritingSystem = new WritingSystem { Tag = "en" },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
@@ -3832,7 +3832,7 @@ public class ParatextSyncRunnerTests
                         QueuedCount = 0,
                         // No SyncedToRepositoryVersion
                         // No DataInSync
-                    }
+                    },
                 },
                 new SFProject
                 {
@@ -3845,7 +3845,7 @@ public class ParatextSyncRunnerTests
                     UserRoles = new Dictionary<string, string>
                     {
                         { "user01", SFProjectRole.Administrator },
-                        { "user02", SFProjectRole.Translator }
+                        { "user02", SFProjectRole.Translator },
                     },
                     ParatextId = "paratext-project05",
                     IsRightToLeft = false,
@@ -3859,23 +3859,23 @@ public class ParatextSyncRunnerTests
                             Name = "project04",
                             ShortName = "P04",
                             WritingSystem = new WritingSystem { Tag = "en" },
-                            IsRightToLeft = false
-                        }
+                            IsRightToLeft = false,
+                        },
                     },
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
-                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport
+                        AnswerExportMethod = CheckingAnswerExport.MarkedForExport,
                     },
                     Texts = books.Select(b => TextInfoFromBook(b)).ToList(),
                     Sync = new Sync
                     {
                         QueuedCount = 1,
-                        DataInSync = false
+                        DataInSync = false,
                         // No SyncedToRepositoryVersion
                     },
-                    NoteTags = new List<NoteTag>()
-                }
+                    NoteTags = new List<NoteTag>(),
+                },
             };
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
@@ -3943,10 +3943,10 @@ public class ParatextSyncRunnerTests
                         Number = c,
                         LastVerse = 10,
                         IsValid = !book.InvalidChapters.Contains(c),
-                        Permissions = { }
+                        Permissions = { },
                     })
                     .ToList(),
-                HasSource = book.HighestSourceChapter > 0
+                HasSource = book.HighestSourceChapter > 0,
             };
         }
 
@@ -4014,7 +4014,7 @@ public class ParatextSyncRunnerTests
                 {
                     ThreadUpdated = true,
                     Position = new TextAnchor { Start = 0, Length = 0 },
-                    Assignment = CommentThread.teamUser
+                    Assignment = CommentThread.teamUser,
                 };
                 noteThreadChange.AddChange(
                     CreateNote(threadId, "n01", "syncuser01", $"{threadId} updated.", ChangeType.Updated, null, 2),
@@ -4058,7 +4058,7 @@ public class ParatextSyncRunnerTests
                 ""
             )
             {
-                ThreadUpdated = true
+                ThreadUpdated = true,
             };
             SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
         }
@@ -4077,7 +4077,7 @@ public class ParatextSyncRunnerTests
             )
             {
                 Position = new TextAnchor { Start = 0, Length = 0 },
-                Assignment = CommentThread.teamUser
+                Assignment = CommentThread.teamUser,
             };
             noteThreadChange.AddChange(
                 CreateNote(threadId, "n01", syncUserId, $"New {threadId} added.", ChangeType.Added),
@@ -4099,7 +4099,7 @@ public class ParatextSyncRunnerTests
                 ""
             )
             {
-                Position = new TextAnchor { Start = 0, Length = 0 }
+                Position = new TextAnchor { Start = 0, Length = 0 },
             };
             noteThreadChange.AddChange(
                 CreateNote(threadId, "conflict1", "", "Conflict on note.", ChangeType.Added, CommentTag.conflictTagId),
@@ -4126,7 +4126,7 @@ public class ParatextSyncRunnerTests
                 ""
             )
             {
-                NoteIdsRemoved = new List<string>(noteIds)
+                NoteIdsRemoved = new List<string>(noteIds),
             };
             SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
         }
@@ -4568,8 +4568,8 @@ public class ParatextSyncRunnerTests
                                 Id = $"{projectId}:question{bookId}{c}",
                                 DataId = $"question{bookId}{c}",
                                 ProjectRef = projectId,
-                                VerseRef = new VerseRefData(bookNum, c, 1)
-                            }
+                                VerseRef = new VerseRefData(bookNum, c, 1),
+                            },
                         }
                     );
             }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -340,7 +340,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_DataNotChanged()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, false, false, books);
         env.SetupPTData(books);
 
@@ -390,7 +390,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_DataChangedTranslateAndCheckingEnabled()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
 
@@ -433,7 +433,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_DataChangedTranslateEnabledCheckingDisabled()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, false, true, false, books);
         env.SetupPTData(books);
 
@@ -486,7 +486,7 @@ public class ParatextSyncRunnerTests
         var env = new TestEnvironment();
         env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
         env.SetupPTData(new Book("MAT", 3), new Book("MRK", 1));
-        Book[] books = new[] { new Book("MRK", 2) };
+        Book[] books = [new Book("MRK", 2)];
         env.AddParatextNoteThreadData(books);
         Assert.That(env.ContainsNote(1), Is.True);
 
@@ -548,7 +548,7 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, false, false, new Book("MAT", 2), new Book("MRK", 2));
         env.SetupPTData(new Book("MAT", 2), new Book("LUK", 2));
         // Need to make sure we have notes BEFORE the sync
-        Book[] books = new[] { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.AddParatextNoteThreadData(books);
 
         // Expectations of setup
@@ -719,7 +719,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_CreatesNoteTagIcon()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(true, true, false, true, books);
         await env.SetupUndefinedNoteTag("project01", false);
         SFProject project = env.GetProject();
@@ -749,7 +749,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_CreatesCheckingNoteTag()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(false, true, false, false, books);
         env.SetupPTData(books);
 
@@ -795,7 +795,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_UpdatesExistingNoteTags()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 1) };
+        Book[] books = [new Book("MAT", 1)];
         env.SetupSFData(true, true, false, true, books);
         var noteTags = new List<NoteTag>
         {
@@ -1019,7 +1019,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_LanguageIsRightToLeft_ProjectPropertySet()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, false, false, false, books);
         env.SetupPTData(books);
 
@@ -1038,7 +1038,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_FullName_ProjectPropertyNotSetIfNull()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, false, false, false, books);
         env.SetupPTData(books);
 
@@ -1056,7 +1056,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_FullName_ProjectPropertySet()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, false, false, false, books);
         env.SetupPTData(books);
 
@@ -1807,7 +1807,7 @@ public class ParatextSyncRunnerTests
         var book = new Book("MAT", 1, true);
         env.SetupSFData(true, false, false, true, book);
         env.SetupPTData(book);
-        Book[] books = new[] { book };
+        Book[] books = [book];
         env.AddParatextNoteThreadData(books, true, true);
         SyncMetricInfo info = new SyncMetricInfo(1, 0, 0);
         env.ParatextService.UpdateParatextCommentsAsync(
@@ -1976,14 +1976,7 @@ public class ParatextSyncRunnerTests
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
         NoteThread thread01 = env.GetNoteThread("project01", "dataId01");
-        string[] reattachedParts = new[]
-        {
-            "MAT 1:5",
-            "reattach selected text",
-            "16",
-            "Reattach before ",
-            " reattach after.",
-        };
+        string[] reattachedParts = ["MAT 1:5", "reattach selected text", "16", "Reattach before ", " reattach after."];
         string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachedParts);
         string expected = "Context before Scripture text in project context after-" + $"Start:16-Length:22-MAT 1:1";
         Assert.That(thread01.NoteThreadToString(), Is.EqualTo(expected));
@@ -2107,7 +2100,7 @@ public class ParatextSyncRunnerTests
         );
         await env.SetThreadNotesAsync(sfProjectId, dataId, beginningNoteSet);
         env.SetupPTData(book);
-        env.SetupNoteRemovedChange(dataId, threadId, new[] { "n02" });
+        env.SetupNoteRemovedChange(dataId, threadId, ["n02"]);
         NoteThread thread01 = env.GetNoteThread(sfProjectId, dataId);
         Assert.That(
             thread01.Notes.Select(n => n.DataId),
@@ -2133,7 +2126,7 @@ public class ParatextSyncRunnerTests
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
 
         // Remove note 3
-        env.SetupNoteRemovedChange(dataId, threadId, new[] { "n03" });
+        env.SetupNoteRemovedChange(dataId, threadId, ["n03"]);
 
         // SUT 2
         await env.Runner.RunAsync(sfProjectId, "user01", "project01_alt1", false, CancellationToken.None);
@@ -2182,7 +2175,7 @@ public class ParatextSyncRunnerTests
         );
 
         // Remove note 2 and 3
-        env.SetupNoteRemovedChange(dataId, threadId, new[] { "n02", "n03" });
+        env.SetupNoteRemovedChange(dataId, threadId, ["n02", "n03"]);
         // SUT
         await env.Runner.RunAsync(sfProjectId, "user01", sfProjectId, false, CancellationToken.None);
         Assert.That(env.ContainsNoteThread(sfProjectId, dataId), Is.True);
@@ -2203,7 +2196,7 @@ public class ParatextSyncRunnerTests
         var book = new Book("MAT", 1);
         env.SetupSFData(true, false, false, true, book);
         env.SetupPTData(book);
-        env.SetupNoteRemovedChange("dataId01", "thread01", new[] { "n01", "n02" });
+        env.SetupNoteRemovedChange("dataId01", "thread01", ["n01", "n02"]);
 
         await env.Runner.RunAsync("project01", "user01", "project01", false, CancellationToken.None);
 
@@ -2487,7 +2480,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_SyncMetricsRecordsParatextNotes()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
         var syncMetricInfo = new SyncMetricInfo(1, 2, 3);
@@ -2508,7 +2501,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_SyncMetricsRecordsParatextBooks()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
         env.ParatextService.PutBookText(
@@ -2590,7 +2583,7 @@ public class ParatextSyncRunnerTests
     public async Task SyncAsync_BiblicalTermsAreUpdated()
     {
         var env = new TestEnvironment();
-        Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+        Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
 
@@ -2753,7 +2746,7 @@ public class ParatextSyncRunnerTests
         var book = new Book("MAT", 1, true);
         env.SetupSFData(true, false, false, true, book);
         env.SetupPTData(book);
-        Book[] books = { book };
+        Book[] books = [book];
         env.AddParatextNoteThreadData(books, true, true, true);
         SyncMetricInfo info = new SyncMetricInfo(1, 0, 0);
         env.ParatextService.UpdateParatextCommentsAsync(
@@ -3277,7 +3270,7 @@ public class ParatextSyncRunnerTests
                         Number = chapterDelta.Number,
                         IsValid = chapterDelta.IsValid,
                         LastVerse = chapterDelta.LastVerse,
-                        Permissions = new Dictionary<string, string>(),
+                        Permissions = [],
                     }
             )
             .ToList();
@@ -3342,9 +3335,9 @@ public class ParatextSyncRunnerTests
         public int HighestTargetChapter { get; }
         public int HighestSourceChapter { get; }
 
-        public HashSet<int> InvalidChapters { get; } = new HashSet<int>();
-        public HashSet<int> MissingTargetChapters { get; set; } = new HashSet<int>();
-        public HashSet<int> MissingSourceChapters { get; set; } = new HashSet<int>();
+        public HashSet<int> InvalidChapters { get; } = [];
+        public HashSet<int> MissingTargetChapters { get; set; } = [];
+        public HashSet<int> MissingSourceChapters { get; set; } = [];
     }
 
     private class TestEnvironment
@@ -3600,7 +3593,7 @@ public class ParatextSyncRunnerTests
             int bookNum = 70;
             int chapterNum = 1;
             string id = TextData.GetTextDocId(projectId, bookNum, chapterNum);
-            Dictionary<string, string> chapterPermissions = new Dictionary<string, string>();
+            Dictionary<string, string> chapterPermissions = [];
             if (setChapterPermissions)
             {
                 chapterPermissions.Add("user01", TextInfoPermission.Write);
@@ -3609,10 +3602,7 @@ public class ParatextSyncRunnerTests
             var textInfo = new TextInfo
             {
                 BookNum = bookNum,
-                Chapters = new List<Chapter>
-                {
-                    new Chapter { Number = chapterNum, Permissions = chapterPermissions },
-                },
+                Chapters = [new Chapter { Number = chapterNum, Permissions = chapterPermissions }],
             };
             RealtimeService.AddRepository(
                 "users",
@@ -3624,8 +3614,8 @@ public class ParatextSyncRunnerTests
                 OTType.RichText,
                 new MemoryRepository<TextData>(new[] { new TextData(Delta.New()) { Id = id } })
             );
-            SFProject[] sfProjects = new[]
-            {
+            SFProject[] sfProjects =
+            [
                 new SFProject
                 {
                     Id = projectId,
@@ -3635,7 +3625,7 @@ public class ParatextSyncRunnerTests
                         { "user04", SFProjectRole.Translator },
                     },
                 },
-            };
+            ];
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
 
@@ -3694,8 +3684,8 @@ public class ParatextSyncRunnerTests
                     }
                 )
             );
-            SFProject[] sfProjects = new[]
-            {
+            SFProject[] sfProjects =
+            [
                 new SFProject
                 {
                     Id = "project01",
@@ -3740,8 +3730,8 @@ public class ParatextSyncRunnerTests
                         SyncedToRepositoryVersion = "beforeSR",
                         DataInSync = true,
                     },
-                    ParatextUsers = new List<ParatextUserProfile>
-                    {
+                    ParatextUsers =
+                    [
                         new ParatextUserProfile
                         {
                             OpaqueUserId = "syncuser01",
@@ -3749,19 +3739,19 @@ public class ParatextSyncRunnerTests
                             SFUserId = "user01",
                         },
                         new ParatextUserProfile { OpaqueUserId = "syncuser02", Username = "User 2" },
-                    },
-                    NoteTags = new List<NoteTag>(),
+                    ],
+                    NoteTags = [],
                 },
                 new SFProject
                 {
                     Id = "project02",
                     Name = "Source",
                     ShortName = "SRC",
-                    UserRoles = new Dictionary<string, string>(),
+                    UserRoles = [],
                     ParatextId = "source",
                     IsRightToLeft = false,
                     TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
-                    NoteTags = new List<NoteTag>(),
+                    NoteTags = [],
                     CheckingConfig = new CheckingConfig
                     {
                         CheckingEnabled = checkingEnabled,
@@ -3816,7 +3806,7 @@ public class ParatextSyncRunnerTests
                     Id = "project04",
                     Name = "project04",
                     ShortName = "P04",
-                    UserRoles = new Dictionary<string, string>(),
+                    UserRoles = [],
                     ParatextId = "paratext-project04",
                     IsRightToLeft = false,
                     TranslateConfig = new TranslateConfig { TranslationSuggestionsEnabled = false },
@@ -3874,9 +3864,9 @@ public class ParatextSyncRunnerTests
                         DataInSync = false,
                         // No SyncedToRepositoryVersion
                     },
-                    NoteTags = new List<NoteTag>(),
+                    NoteTags = [],
                 },
-            };
+            ];
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(sfProjects));
             MockProjectDirsExist(sfProjects.Select((SFProject proj) => proj.ParatextId));
 
@@ -3885,7 +3875,7 @@ public class ParatextSyncRunnerTests
             RealtimeService.AddRepository("biblical_terms", OTType.Json0, new MemoryRepository<BiblicalTerm>());
             if (noteOnFirstBook && books.Length > 0)
             {
-                Book[] book = new[] { books[0] };
+                Book[] book = [books[0]];
                 AddParatextNoteThreadData(book);
             }
             else
@@ -4060,7 +4050,7 @@ public class ParatextSyncRunnerTests
             {
                 ThreadUpdated = true,
             };
-            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+            SetupNoteThreadChanges([noteThreadChange], "target", 40);
         }
 
         public void SetupNewNoteThreadChange(string threadId, string syncUserId, string verseRef = "MAT 1:1")
@@ -4083,7 +4073,7 @@ public class ParatextSyncRunnerTests
                 CreateNote(threadId, "n01", syncUserId, $"New {threadId} added.", ChangeType.Added),
                 ChangeType.Added
             );
-            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+            SetupNoteThreadChanges([noteThreadChange], "target", 40);
         }
 
         public void SetupNewConflictNoteThreadChange(string threadId, string verseRef = "MAT 1:1")
@@ -4105,7 +4095,7 @@ public class ParatextSyncRunnerTests
                 CreateNote(threadId, "conflict1", "", "Conflict on note.", ChangeType.Added, CommentTag.conflictTagId),
                 ChangeType.Added
             );
-            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+            SetupNoteThreadChanges([noteThreadChange], "target", 40);
         }
 
         public void SetupNoteRemovedChange(
@@ -4128,7 +4118,7 @@ public class ParatextSyncRunnerTests
             {
                 NoteIdsRemoved = new List<string>(noteIds),
             };
-            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+            SetupNoteThreadChanges([noteThreadChange], "target", 40);
         }
 
         public void SetupNoteReattachedChange(string dataId, string threadId, string verseRef)
@@ -4148,7 +4138,7 @@ public class ParatextSyncRunnerTests
             int start = before.Length;
             int length = reattachSelectedText.Length;
             noteThreadChange.Position = new TextAnchor { Start = start, Length = length };
-            string[] reattachParts = { verseRef, reattachSelectedText, start.ToString(), before, " reattach after." };
+            string[] reattachParts = [verseRef, reattachSelectedText, start.ToString(), before, " reattach after."];
             string reattached = string.Join(PtxUtils.StringUtils.orcCharacter, reattachParts);
             Note reattachedNote = CreateNote(threadId, "reattached01", "syncuser01", null, ChangeType.Added);
             reattachedNote.Reattached = reattached;
@@ -4187,7 +4177,7 @@ public class ParatextSyncRunnerTests
             }
 
             // Cause the created NoteThreadChange to be what is given when changes are asked for.
-            SetupNoteThreadChanges(new[] { noteThreadChange }, "target", 40);
+            SetupNoteThreadChanges([noteThreadChange], "target", 40);
         }
 
         /// <summary> Set the project's default comment tag to the a blank comment tag. </summary>
@@ -4283,8 +4273,8 @@ public class ParatextSyncRunnerTests
                     OriginalContextAfter = " context after",
                     OriginalSelectedText = "Scripture text in project",
                     PublishedToSF = publishedToSF,
-                    Notes = new List<Note>
-                    {
+                    Notes =
+                    [
                         new Note
                         {
                             DataId = "n01",
@@ -4307,7 +4297,7 @@ public class ParatextSyncRunnerTests
                             TagId = tagId,
                             DateCreated = new DateTime(2019, 1, 1, 8, 0, 0, DateTimeKind.Utc),
                         },
-                    },
+                    ],
                 };
                 if (biblicalTermNote)
                 {
@@ -4340,7 +4330,7 @@ public class ParatextSyncRunnerTests
             string? startingDBSyncedToRepositoryVersion
         )
         {
-            Book[] books = { new Book("MAT", 2), new Book("MRK", 2) };
+            Book[] books = [new Book("MAT", 2), new Book("MRK", 2)];
             bool translationSuggestionsEnabled = false;
             bool checkingEnabled = true;
             bool changed = true;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2623,7 +2623,7 @@ public class SFProjectServiceTests
             new SFProjectSettings
             {
                 SourceParatextId = SFProjectService.ProjectSettingValueUnset,
-                TranslationSuggestionsEnabled = false
+                TranslationSuggestionsEnabled = false,
             }
         );
 
@@ -4223,7 +4223,6 @@ public class SFProjectServiceTests
                             {
                                 {
                                     User03,
-
                                     [
                                         SFProjectRights.JoinRight(SFProjectDomain.TextAudio, Operation.Create),
                                         SFProjectRights.JoinRight(SFProjectDomain.TextAudio, Operation.Delete),

--- a/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
+++ b/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
@@ -14,7 +14,7 @@ namespace SIL.XForge.Controllers;
 [TestFixture]
 public class UsersRpcControllerTests
 {
-    private static readonly string[] Roles = { SystemRole.User };
+    private static readonly string[] Roles = [SystemRole.User];
     private const string User01 = "user01";
     private const string User02 = "user02";
 

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -128,9 +128,9 @@ public class MemoryUpdateBuilderTests
             TestEntity = new TestEntity
             {
                 Id = "test_id_1",
-                TestChildCollection = new List<TestEntity> { new TestEntity { Id = "test_id_2" }, },
+                TestChildCollection = new List<TestEntity> { new TestEntity { Id = "test_id_2" } },
                 TestNumber = 1,
-                TestStringCollection = new List<string> { "test_value_1", "test_value_2", },
+                TestStringCollection = new List<string> { "test_value_1", "test_value_2" },
                 TestStringField = "test_value",
             };
 

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -115,8 +115,8 @@ public class MemoryUpdateBuilderTests
     {
         public string Id { get; set; }
         public int TestNumber { get; set; }
-        public List<TestEntity> TestChildCollection { get; set; } = new List<TestEntity>();
-        public List<string> TestStringCollection { get; set; } = new List<string>();
+        public List<TestEntity> TestChildCollection { get; set; } = [];
+        public List<string> TestStringCollection { get; set; } = [];
         public string TestStringField { get; set; }
     }
 
@@ -128,9 +128,9 @@ public class MemoryUpdateBuilderTests
             TestEntity = new TestEntity
             {
                 Id = "test_id_1",
-                TestChildCollection = new List<TestEntity> { new TestEntity { Id = "test_id_2" } },
+                TestChildCollection = [new TestEntity { Id = "test_id_2" }],
                 TestNumber = 1,
-                TestStringCollection = new List<string> { "test_value_1", "test_value_2" },
+                TestStringCollection = ["test_value_1", "test_value_2"],
                 TestStringField = "test_value",
             };
 

--- a/test/SIL.XForge.Tests/Models/TokensTests.cs
+++ b/test/SIL.XForge.Tests/Models/TokensTests.cs
@@ -41,7 +41,7 @@ public class TokensTests
         var tokens = new Tokens()
         {
             AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
-            RefreshToken = null
+            RefreshToken = null,
         };
 
         // SUT
@@ -56,7 +56,7 @@ public class TokensTests
         var tokens = new Tokens()
         {
             AccessToken = TokenHelper.CreateAccessToken(issuedAt, expiration, "paratext01"),
-            RefreshToken = null
+            RefreshToken = null,
         };
 
         // SUT

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -331,11 +331,10 @@ public class ConnectionTests
         // Setup
         var env = new TestEnvironment();
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
-        string[] ids = { "id1", "id2" };
+        string[] ids = ["id1", "id2"];
         env.RealtimeService.Server.FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
             .Returns(
-                new Snapshot<Project>[]
-                {
+                [
                     new Snapshot<Project>
                     {
                         Data = null,
@@ -348,7 +347,7 @@ public class ConnectionTests
                         Id = "id2",
                         Version = 2,
                     },
-                }
+                ]
             );
 
         // SUT
@@ -367,18 +366,17 @@ public class ConnectionTests
         // Setup
         var env = new TestEnvironment(documentCacheDisabled: true);
         string collection = env.RealtimeService.GetDocConfig<Project>().CollectionName;
-        string[] ids = { "id1" };
+        string[] ids = ["id1"];
         env.RealtimeService.Server.FetchDocsAsync<Project>(Arg.Any<int>(), collection, ids)
             .Returns(
-                new Snapshot<Project>[]
-                {
+                [
                     new Snapshot<Project>
                     {
                         Data = new TestProject(),
                         Id = "id1",
                         Version = 1,
                     },
-                }
+                ]
             );
 
         // SUT
@@ -626,8 +624,8 @@ public class ConnectionTests
                 new RealtimeOptions()
                 {
                     ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                    ProjectDataDocs = new List<DocConfig>(),
-                    UserDataDocs = new List<DocConfig>(),
+                    ProjectDataDocs = [],
+                    UserDataDocs = [],
                 }
             );
             var authOptions = Options.Create(Substitute.For<AuthOptions>());

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -67,13 +67,13 @@ public class ConnectionTests
         string otTypeName = OTType.Json0;
         var snapshot = new Snapshot<TestProject>
         {
-            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Data = new TestProject() { Id = id, SyncDisabled = false },
             Version = 1,
         };
         var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
         builder.Set(p => p.SyncDisabled, true);
         List<Json0Op> op = builder.Op;
-        var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
+        var updatedData = new TestProject() { Id = id, SyncDisabled = true };
 
         env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
             .Returns(Task.FromResult(snapshot));
@@ -118,7 +118,7 @@ public class ConnectionTests
         var env = new TestEnvironment();
         string collection = "test_project";
         string id = "id1";
-        var data = new TestProject { Id = id, Name = "Test Project 1", };
+        var data = new TestProject { Id = id, Name = "Test Project 1" };
         string otTypeName = OTType.Json0;
 
         // SUT
@@ -151,7 +151,7 @@ public class ConnectionTests
         var env = new TestEnvironment();
         string collection = "test_project";
         string id = "id1";
-        var data = new TestProject { Id = id, Name = "Test Project 1", };
+        var data = new TestProject { Id = id, Name = "Test Project 1" };
         string otTypeName = OTType.Json0;
 
         // SUT
@@ -444,7 +444,7 @@ public class ConnectionTests
             Data = new TestProject { Id = id, SyncDisabled = true },
             Version = 2,
         };
-        var expected = new Snapshot<TestProject> { Data = snapshot.Data, Version = 3, };
+        var expected = new Snapshot<TestProject> { Data = snapshot.Data, Version = 3 };
         var builder = new Json0OpBuilder<TestProject>(data);
         builder.Set(p => p.SyncDisabled, true);
         List<Json0Op> op = builder.Op;
@@ -484,13 +484,13 @@ public class ConnectionTests
         string otTypeName = OTType.Json0;
         var snapshot = new Snapshot<TestProject>
         {
-            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Data = new TestProject() { Id = id, SyncDisabled = false },
             Version = 1,
         };
         var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
         builder.Set(p => p.SyncDisabled, true);
         List<Json0Op> op = builder.Op;
-        var updatedData = new TestProject() { Id = id, SyncDisabled = true, };
+        var updatedData = new TestProject() { Id = id, SyncDisabled = true };
 
         env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
             .Returns(Task.FromResult(snapshot));
@@ -540,7 +540,7 @@ public class ConnectionTests
         string id = "id1";
         var snapshot = new Snapshot<TestProject>
         {
-            Data = new TestProject() { Id = id, SyncDisabled = false, },
+            Data = new TestProject() { Id = id, SyncDisabled = false },
             Version = 1,
         };
         var builder = new Json0OpBuilder<TestProject>(snapshot.Data);

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -318,7 +318,7 @@ public class RealtimeServiceTests
                 {
                     Audience = "https://scriptureforge.org/",
                     Domain = "login.scriptureforge.org",
-                    Scope = "sf_data"
+                    Scope = "sf_data",
                 }
             );
 

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -35,7 +35,7 @@ public class RealtimeServiceTests
         // is defined in TestEnvironment.
         var collectionsToBePruned = new Dictionary<string, IMongoCollection<BsonDocument>>();
         string[] collectionNames =
-        {
+        [
             "some_projects",
             "favorite_numbers",
             "favorite_things",
@@ -48,7 +48,7 @@ public class RealtimeServiceTests
             "m_favorite_numbers",
             "m_favorite_things",
             "m_favorite_verses",
-        };
+        ];
         foreach (string collectionName in collectionNames)
         {
             IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
@@ -85,14 +85,14 @@ public class RealtimeServiceTests
         // is defined in TestEnvironment.
         var collectionsToBePruned = new Dictionary<string, IMongoCollection<BsonDocument>>();
         string[] collectionNames =
-        {
+        [
             "users",
             "o_users",
             "m_users",
             "favorite_animals",
             "o_favorite_animals",
             "m_favorite_animals",
-        };
+        ];
         foreach (string collectionName in collectionNames)
         {
             IMongoCollection<BsonDocument> collection = Substitute.For<IMongoCollection<BsonDocument>>();
@@ -304,13 +304,13 @@ public class RealtimeServiceTests
                 new RealtimeOptions
                 {
                     ProjectDoc = new DocConfig("some_projects", typeof(Project)),
-                    ProjectDataDocs = new List<DocConfig>
-                    {
+                    ProjectDataDocs =
+                    [
                         new DocConfig("favorite_numbers", typeof(int)),
                         new DocConfig("favorite_things", typeof(object)),
                         new DocConfig("favorite_verses", typeof(string)),
-                    },
-                    UserDataDocs = new List<DocConfig> { new DocConfig("favorite_animals", typeof(object)) },
+                    ],
+                    UserDataDocs = [new DocConfig("favorite_animals", typeof(object))],
                 }
             );
             IOptions<AuthOptions> authOptions = Microsoft.Extensions.Options.Options.Create(

--- a/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/AudioServiceTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -16,7 +15,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(Array.Empty<byte>());
+        await using var stream = new MemoryStream([]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -29,7 +28,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0x44, 0x2E, 0x56, 0x2E });
+        await using var stream = new MemoryStream([0x44, 0x2E, 0x56, 0x2E]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -42,7 +41,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xFF });
+        await using var stream = new MemoryStream([0xFF, 0xFF]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -55,7 +54,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0x0 });
+        await using var stream = new MemoryStream([0x0, 0x0, 0x0, 0x0]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -68,7 +67,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0x49, 0x44, 0x33, 0x03 });
+        await using var stream = new MemoryStream([0x49, 0x44, 0x33, 0x03]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -81,7 +80,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xEB, 0x10, 0x0 });
+        await using var stream = new MemoryStream([0xFF, 0xEB, 0x10, 0x0]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -94,7 +93,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0xFF, 0xF3, 0x28, 0xC4 });
+        await using var stream = new MemoryStream([0xFF, 0xF3, 0x28, 0xC4]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT
@@ -107,7 +106,7 @@ internal class AudioServiceTests
     {
         var env = new TestEnvironment();
         const string path = "file.mp3";
-        await using var stream = new MemoryStream(new byte[] { 0x0, 0x0, 0x0, 0xFF, 0xF3, 0x28, 0xC4 });
+        await using var stream = new MemoryStream([0x0, 0x0, 0x0, 0xFF, 0xF3, 0x28, 0xC4]);
         env.FileSystemService.OpenFile(path, FileMode.Open).Returns(stream);
 
         // SUT

--- a/test/SIL.XForge.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Tests/Services/MockLogger.cs
@@ -59,7 +59,7 @@ public class MockLogger<T> : ILogger<T>
                 LogLevel = logLevel,
                 EventId = eventId,
                 State = state,
-                Exception = exception
+                Exception = exception,
             }
         );
     }

--- a/test/SIL.XForge.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Tests/Services/MockLogger.cs
@@ -37,7 +37,7 @@ public class MockLogger<T> : ILogger<T>
     /// <summary>
     /// Stores logged events.
     /// </summary>
-    public readonly List<LogEvent> LogEvents = new List<LogEvent>();
+    public readonly List<LogEvent> LogEvents = [];
 
     public MockLogger() { }
 

--- a/test/SIL.XForge.Tests/Services/TokenHelper.cs
+++ b/test/SIL.XForge.Tests/Services/TokenHelper.cs
@@ -19,7 +19,7 @@ public class TokenHelper
             new[]
             {
                 new Claim(JwtClaimTypes.Subject, paratextUserId),
-                new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString())
+                new Claim(JwtClaimTypes.IssuedAt, EpochTime.GetIntDate(issuedAt).ToString()),
             },
             expires: expiration
         );

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -318,12 +318,8 @@ public class UserServiceTests
     public void DeleteAsync_BadArguments()
     {
         var env = new TestEnvironment();
-        Assert.ThrowsAsync<ArgumentNullException>(
-            () => env.Service.DeleteAsync(null, new string[] { "systemRole" }, "userId")
-        );
-        Assert.ThrowsAsync<ArgumentNullException>(
-            () => env.Service.DeleteAsync("curUserId", new string[] { "systemRole" }, null)
-        );
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync(null, ["systemRole"], "userId"));
+        Assert.ThrowsAsync<ArgumentNullException>(() => env.Service.DeleteAsync("curUserId", ["systemRole"], null));
     }
 
     [Test]
@@ -332,7 +328,7 @@ public class UserServiceTests
         var env = new TestEnvironment();
         string curUserId = "user01";
         // Role is not a system admin
-        string[] curUserSystemRoles = { SystemRole.User };
+        string[] curUserSystemRoles = [SystemRole.User];
         string userIdToDelete = "user02";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
@@ -348,7 +344,7 @@ public class UserServiceTests
         var env = new TestEnvironment();
         string curUserId = "user01";
         // Role is not a system admin
-        string[] curUserSystemRoles = { SystemRole.User };
+        string[] curUserSystemRoles = [SystemRole.User];
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
@@ -361,7 +357,7 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string[] curUserSystemRoles = { SystemRole.SystemAdmin };
+        string[] curUserSystemRoles = [SystemRole.SystemAdmin];
         string userIdToDelete = "user02";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
@@ -374,7 +370,7 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string[] curUserSystemRoles = { SystemRole.SystemAdmin };
+        string[] curUserSystemRoles = [SystemRole.SystemAdmin];
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT
@@ -387,7 +383,7 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string[] curUserSystemRoles = { SystemRole.User };
+        string[] curUserSystemRoles = [SystemRole.User];
         string userIdToDelete = "user01";
         // SUT
         await env.Service.DeleteAsync(curUserId, curUserSystemRoles, userIdToDelete);
@@ -399,7 +395,7 @@ public class UserServiceTests
     {
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string[] curUserSystemRoles = { SystemRole.User };
+        string[] curUserSystemRoles = [SystemRole.User];
         string userIdToDelete = "user01";
         Assert.That(env.UserSecrets.Contains(userIdToDelete), Is.True);
         // SUT
@@ -415,7 +411,7 @@ public class UserServiceTests
         // page.
         var env = new TestEnvironment();
         string curUserId = "user01";
-        string[] curUserSystemRoles = { SystemRole.User };
+        string[] curUserSystemRoles = [SystemRole.User];
         string userIdToDelete = "user01";
         Assert.That(env.ContainsUser(userIdToDelete), Is.True);
         // SUT

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -259,7 +259,7 @@ public class UserServiceTests
             { "U Name", "N" },
             { "1 Number", "N" },
             { "11 Number", "N" },
-            { "U", "example" } // Should not change from what is already set
+            { "U", "example" }, // Should not change from what is already set
         };
         var expectedAvatarUrl = "";
         User user;
@@ -444,9 +444,9 @@ public class UserServiceTests
                         ParatextTokens = new Tokens
                         {
                             AccessToken = TokenHelper.CreateAccessToken(IssuedAt),
-                            RefreshToken = "refresh_token"
-                        }
-                    }
+                            RefreshToken = "refresh_token",
+                        },
+                    },
                 }
             );
 
@@ -462,26 +462,26 @@ public class UserServiceTests
                             Id = "user01",
                             AvatarUrl = "http://example.com/avatar.png",
                             AuthId = "auth01",
-                            ParatextId = "paratext01"
+                            ParatextId = "paratext01",
                         },
                         new User
                         {
                             Id = "user02",
                             AvatarUrl = "http://example.com/avatar2.png",
-                            AuthId = "auth02"
+                            AuthId = "auth02",
                         },
                         new User
                         {
                             Id = "user04",
                             AvatarUrl = "https://cdn.auth0.com/avatars/example.png",
-                            AuthId = "auth04"
-                        }
+                            AuthId = "auth04",
+                        },
                     }
                 )
             );
 
             var options = Substitute.For<IOptions<SiteOptions>>();
-            options.Value.Returns(new SiteOptions { Id = "xf", });
+            options.Value.Returns(new SiteOptions { Id = "xf" });
 
             Service = new UserService(RealtimeService, options, UserSecrets, AuthService, ProjectService, Logger);
         }
@@ -543,13 +543,14 @@ public class UserServiceTests
         roleType switch
         {
             RoleType.None => new JObject(new JProperty("xf_user_id", userId)),
-            RoleType.String
-                => new JObject(new JProperty("xf_user_id", userId), new JProperty("xf_role", SystemRole.User)),
-            RoleType.Array
-                => new JObject(
-                    new JProperty("xf_user_id", userId),
-                    new JProperty("xf_role", new JArray(new List<string> { SystemRole.User }))
-                ),
+            RoleType.String => new JObject(
+                new JProperty("xf_user_id", userId),
+                new JProperty("xf_role", SystemRole.User)
+            ),
+            RoleType.Array => new JObject(
+                new JProperty("xf_user_id", userId),
+                new JProperty("xf_role", new JArray(new List<string> { SystemRole.User }))
+            ),
             _ => throw new ArgumentOutOfRangeException(nameof(roleType)),
         };
 

--- a/tools/RepoInfo/Program.cs
+++ b/tools/RepoInfo/Program.cs
@@ -200,8 +200,7 @@ foreach (var revision in revisions)
                 or ProjectFileType.StatusCheckBoxes
                 or ProjectFileType.StudyBibleAdditions
                 or ProjectFileType.StudyBibleAdditionBooks
-                or ProjectFileType.Unspecified
-                    => "NA",
+                or ProjectFileType.Unspecified => "NA",
                 ProjectFileType.RolesPermissions => "PE",
                 ProjectFileType.Notes or ProjectFileType.NoteLanguages or ProjectFileType.NoteTags => "NT",
                 ProjectFileType.BookNames
@@ -211,8 +210,7 @@ foreach (var revision in revisions)
                 or ProjectFileType.ProjectUpdate
                 or ProjectFileType.Stylesheet
                 or ProjectFileType.Versification
-                or ProjectFileType.XmlResourceProject
-                    => "PR",
+                or ProjectFileType.XmlResourceProject => "PR",
                 _ => string.Empty,
             };
 


### PR DESCRIPTION
This PR:

 * Updates CSharpier to 0.30.3, which performs these changes:
    * Enforce trailing commas for multi-line object and collection initializer
    * Remove training commas for for singleline object and collection initializer
    * Fix blank line being added with lambda returning collection expression
    * Fix inconsistent Formatting for new() Operator Compared to Explicit Object Constructor
 * Updates .editorconfig to match CSharpier's suggested configuration
 * Enable collection expressions by default via `dotnet format`

If have broken these changes into separate commits in case you think collection expressions are a bad idea and I need to revert it (I personally prefer the syntax and use it when updating code or writing new code).

I figure now is the best time for a change like this, as a major update to the C# code base (SF-2900) has been merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2912)
<!-- Reviewable:end -->
