### PR TITLE
SF-3144 Show logo and project abbreviation on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -16,20 +16,22 @@
             <mat-icon>menu</mat-icon>
           </button>
         }
-        @if (isLoggedIn | async) {
-          <a id="sf-logo-button" mat-icon-button class="hide-lt-sm" [routerLink]="appIconLink">
-            <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
-          </a>
-        } @else {
-          <a id="sf-logo-button" mat-icon-button class="hide-lt-sm" href="/">
-            <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
-          </a>
-        }
-        @if (isProjectSelected) {
-          <span class="project-name-wrapper hide-lt-sm">
-            <span class="project-name">{{ selectedProjectDoc?.data?.name }}</span>
-            <span class="project-short-name">{{ selectedProjectDoc?.data?.shortName }}</span>
-          </span>
+        @if (!isScreenTiny || (isExpanded && !closeDrawerRequested)) {
+          @if (isLoggedIn | async) {
+            <a id="sf-logo-button" mat-icon-button [routerLink]="appIconLink">
+              <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
+            </a>
+          } @else {
+            <a id="sf-logo-button" mat-icon-button href="/">
+              <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
+            </a>
+          }
+          @if (!isScreenTiny && isProjectSelected) {
+            <span class="project-name-wrapper">
+              <span class="project-name">{{ selectedProjectDoc?.data?.name }}</span>
+              <span class="project-short-name">{{ selectedProjectDoc?.data?.shortName }}</span>
+            </span>
+          }
         }
         <span class="toolbar-spacer"></span>
         @if (isAppOnline) {
@@ -189,6 +191,7 @@
         [mode]="isDrawerPermanent ? 'side' : 'over'"
         [opened]="isExpanded || isDrawerPermanent"
         (closed)="drawerCollapsed()"
+        (closedStart)="closeDrawerRequested = true"
         autoFocus="false"
       >
         <app-navigation></app-navigation>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -16,22 +16,24 @@
             <mat-icon>menu</mat-icon>
           </button>
         }
-        @if (!isScreenTiny || (isExpanded && !closeDrawerRequested)) {
-          @if (isLoggedIn | async) {
-            <a id="sf-logo-button" mat-icon-button [routerLink]="appIconLink">
-              <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
-            </a>
-          } @else {
-            <a id="sf-logo-button" mat-icon-button href="/">
-              <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
-            </a>
-          }
-          @if (!isScreenTiny && isProjectSelected) {
-            <span class="project-name-wrapper">
+        @if (isLoggedIn | async) {
+          <a id="sf-logo-button" mat-icon-button [routerLink]="appIconLink">
+            <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
+          </a>
+        } @else {
+          <a id="sf-logo-button" mat-icon-button href="/">
+            <mat-icon><img src="/assets/images/sf.svg" height="38" /></mat-icon>
+          </a>
+        }
+        @if (isProjectSelected) {
+          <span class="project-name-wrapper" [routerLink]="appIconLink">
+            @if (isScreenTiny) {
+              <span class="project-name">{{ selectedProjectDoc?.data?.shortName }}</span>
+            } @else {
               <span class="project-name">{{ selectedProjectDoc?.data?.name }}</span>
               <span class="project-short-name">{{ selectedProjectDoc?.data?.shortName }}</span>
-            </span>
-          }
+            }
+          </span>
         }
         <span class="toolbar-spacer"></span>
         @if (isAppOnline) {
@@ -191,7 +193,6 @@
         [mode]="isDrawerPermanent ? 'side' : 'over'"
         [opened]="isExpanded || isDrawerPermanent"
         (closed)="drawerCollapsed()"
-        (closedStart)="closeDrawerRequested = true"
         autoFocus="false"
       >
         <app-navigation></app-navigation>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -240,10 +240,22 @@ header {
   z-index: 10;
 }
 
+@keyframes expandIcon {
+  from {
+    width: 0;
+  }
+  to {
+    width: var(--mdc-icon-button-state-layer-size);
+  }
+}
+
 #sf-logo-button {
   display: flex;
   align-items: center;
   justify-content: center;
+
+  transform-origin: left;
+  animation: expandIcon 0.3s ease forwards;
 }
 
 .project-name-wrapper {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.scss
@@ -240,22 +240,10 @@ header {
   z-index: 10;
 }
 
-@keyframes expandIcon {
-  from {
-    width: 0;
-  }
-  to {
-    width: var(--mdc-icon-button-state-layer-size);
-  }
-}
-
 #sf-logo-button {
   display: flex;
   align-items: center;
   justify-content: center;
-
-  transform-origin: left;
-  animation: expandIcon 0.3s ease forwards;
 }
 
 .project-name-wrapper {
@@ -265,6 +253,7 @@ header {
   max-width: 20em;
   min-width: 0;
   margin-inline-start: 4px;
+  cursor: pointer;
 
   .project-name {
     font-size: 0.8em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -199,18 +199,18 @@ describe('AppComponent', () => {
     // The user opens the drawer again.
     env.click(env.hamburgerMenuButton);
     expect(env.isDrawerVisible).toBe(true);
-    expect(env.component.isExpanded).toBe(true);
+    expect(env.component['isExpanded']).toBe(true);
     // The user clicks to navigate to the translate overview page.
     env.click(env.menuListItems[1]);
     // The drawer disappears, but is still in the dom.
     expect(env.isDrawerVisible).toBe(false);
     expect(env.menuDrawer).not.toBeNull();
-    expect(env.component.isExpanded).toBe(false);
+    expect(env.component['isExpanded']).toBe(false);
 
     // The user opens the drawer.
     env.click(env.hamburgerMenuButton);
     expect(env.isDrawerVisible).toBe(true);
-    expect(env.component.isExpanded).toBe(true);
+    expect(env.component['isExpanded']).toBe(true);
     // The user navigates to the My projects page by clicking the SF logo in the
     // toolbar (or from the My projects item in the avatar menu).
     env.click(env.sfLogoButton);
@@ -218,12 +218,12 @@ describe('AppComponent', () => {
     expect(env.isDrawerVisible).toBe(false);
     expect(env.menuDrawer).toBeNull();
     expect(env.hamburgerMenuButton).toBeNull();
-    expect(env.component.isExpanded).toBe(false);
+    expect(env.component['isExpanded']).toBe(false);
     // The user clicks in the My projects component to open another project.
     env.navigateFully(['projects', 'project02']);
     // The drawer should not be showing, but is in the dom.
     expect(env.isDrawerVisible).toBe(false);
-    expect(env.component.isExpanded).toBe(false);
+    expect(env.component['isExpanded']).toBe(false);
     expect(env.menuDrawer).not.toBeNull();
     expect(env.hamburgerMenuButton).not.toBeNull();
   }));
@@ -427,12 +427,12 @@ describe('AppComponent', () => {
     const env = new TestEnvironment('offline');
     env.init();
 
-    expect(env.component.isAppOnline).toBe(false);
+    expect(env.component['isAppOnline']).toBe(false);
     verify(mockedAuthService.checkOnlineAuth()).never();
 
     env.setBrowserOnlineStatus(true);
     tick();
-    expect(env.component.isAppOnline).toBe(false);
+    expect(env.component['isAppOnline']).toBe(false);
     verify(mockedAuthService.checkOnlineAuth()).once();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -59,7 +59,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   protected isAppOnline: boolean = false;
   protected isExpanded: boolean = false;
   protected isScreenTiny = false;
-  protected closeDrawerRequested = false;
 
   private currentUserDoc?: UserDoc;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
@@ -399,22 +398,18 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   collapseDrawer(): void {
     this.isExpanded = false;
-    this.closeDrawerRequested = true;
   }
 
   openDrawer(): void {
     this.isExpanded = true;
-    this.closeDrawerRequested = false;
   }
 
   toggleDrawer(): void {
     this.isExpanded = !this.isExpanded;
-    this.closeDrawerRequested = !this.isExpanded;
   }
 
   drawerCollapsed(): void {
     this.isExpanded = false;
-    this.closeDrawerRequested = false;
   }
 
   reloadWithUpdates(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -52,11 +52,14 @@ declare function gtag(...args: any): void;
 export class AppComponent extends DataLoadingComponent implements OnInit, OnDestroy {
   version: string = versionData.version;
   issueEmail: string = environment.issueEmail;
-  isAppOnline: boolean = false;
-  isExpanded: boolean = false;
   versionNumberClickCount = 0;
 
   hasUpdate: boolean = false;
+
+  protected isAppOnline: boolean = false;
+  protected isExpanded: boolean = false;
+  protected isScreenTiny = false;
+  protected closeDrawerRequested = false;
 
   private currentUserDoc?: UserDoc;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
@@ -91,6 +94,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     this.subscribe(
       this.breakpointObserver.observe(this.breakpointService.width('>', Breakpoint.LG)),
       (value: BreakpointState) => (this.isDrawerPermanent = value.matches)
+    );
+
+    this.subscribe(
+      this.breakpointObserver.observe(this.breakpointService.width('<', Breakpoint.SM)),
+      (state: BreakpointState) => (this.isScreenTiny = state.matches)
     );
 
     // Check full online status changes
@@ -391,18 +399,22 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   collapseDrawer(): void {
     this.isExpanded = false;
+    this.closeDrawerRequested = true;
   }
 
   openDrawer(): void {
     this.isExpanded = true;
+    this.closeDrawerRequested = false;
   }
 
   toggleDrawer(): void {
     this.isExpanded = !this.isExpanded;
+    this.closeDrawerRequested = !this.isExpanded;
   }
 
   drawerCollapsed(): void {
     this.isExpanded = false;
+    this.closeDrawerRequested = false;
   }
 
   reloadWithUpdates(): void {


### PR DESCRIPTION
This allows navigation to My Projects when clicking the menu drawer on phones. It's a little confusing that the logo is present on desktop but not mobile. Users with both will be wondering where to go. This solution maintains the original intent of minimizing onscreen clutter for mobile.

(We don't have enough space to show the project name, but this is okay.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2915)
<!-- Reviewable:end -->
