### PR TITLE
Verify migrations have monotonically increasing version numbers

### DIFF
--- a/src/RealtimeServer/common/migration.ts
+++ b/src/RealtimeServer/common/migration.ts
@@ -33,3 +33,21 @@ export abstract class DocMigration implements Migration {
     // do nothing
   }
 }
+
+/**
+ * Verifies that the specified migrations are have version numbers monotonically increasing by 1 and that the class
+ * names include the version number. Throws an error if any of the migrations violate this rule. Otherwise, returns the
+ * migrations.
+ */
+export function monotonicallyIncreasingMigrationList(migrations: MigrationConstructor[]): MigrationConstructor[] {
+  for (const [index, migration] of migrations.entries()) {
+    const expectedVersion = index + 1;
+    if (migration.VERSION !== expectedVersion) {
+      throw new Error(`Migration version mismatch: expected ${expectedVersion}, got ${migration.VERSION}`);
+    }
+    if (!migration.name.includes(migration.VERSION.toString())) {
+      throw new Error(`Migration class name must include the version number: ${migration.name}`);
+    }
+  }
+  return migrations;
+}

--- a/src/RealtimeServer/common/services/user-migrations.ts
+++ b/src/RealtimeServer/common/services/user-migrations.ts
@@ -1,6 +1,6 @@
 import { Doc, Op } from 'sharedb/lib/client';
 import { submitMigrationOp } from '../../common/realtime-server';
-import { DocMigration, MigrationConstructor } from '../migration';
+import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../migration';
 
 class UserMigration1 extends DocMigration {
   static readonly VERSION = 1;
@@ -21,4 +21,4 @@ class UserMigration1 extends DocMigration {
   }
 }
 
-export const USER_MIGRATIONS: MigrationConstructor[] = [UserMigration1];
+export const USER_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([UserMigration1]);

--- a/src/RealtimeServer/scriptureforge/services/biblical-term-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/biblical-term-migrations.ts
@@ -1,3 +1,3 @@
-import { MigrationConstructor } from '../../common/migration';
+import { MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 
-export const BIBLICAL_TERM_MIGRATIONS: MigrationConstructor[] = [];
+export const BIBLICAL_TERM_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([]);

--- a/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-migrations.ts
@@ -1,5 +1,5 @@
 import { Doc, Op } from 'sharedb/lib/client';
-import { DocMigration, MigrationConstructor } from '../../common/migration';
+import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 import { submitMigrationOp } from '../../common/realtime-server';
 
 class NoteThreadMigration1 extends DocMigration {
@@ -69,9 +69,9 @@ class NoteThreadMigration4 extends DocMigration {
   }
 }
 
-export const NOTE_THREAD_MIGRATIONS: MigrationConstructor[] = [
+export const NOTE_THREAD_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([
   NoteThreadMigration1,
   NoteThreadMigration2,
   NoteThreadMigration3,
   NoteThreadMigration4
-];
+]);

--- a/src/RealtimeServer/scriptureforge/services/question-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-migrations.ts
@@ -1,5 +1,5 @@
 import { Doc, Op } from 'sharedb/lib/client';
-import { DocMigration, MigrationConstructor } from '../../common/migration';
+import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 import { submitMigrationOp } from '../../common/realtime-server';
 
 class QuestionMigration1 extends DocMigration {
@@ -24,4 +24,4 @@ class QuestionMigration1 extends DocMigration {
   }
 }
 
-export const QUESTION_MIGRATIONS: MigrationConstructor[] = [QuestionMigration1];
+export const QUESTION_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([QuestionMigration1]);

--- a/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-migrations.ts
@@ -1,5 +1,5 @@
 import { Doc, Op } from 'sharedb/lib/client';
-import { DocMigration, MigrationConstructor } from '../../common/migration';
+import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 import { Operation } from '../../common/models/project-rights';
 import { submitMigrationOp } from '../../common/realtime-server';
 import { NoteTag } from '../models/note-tag';
@@ -387,7 +387,7 @@ class SFProjectMigration21 extends DocMigration {
   }
 }
 
-export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
+export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([
   SFProjectMigration1,
   SFProjectMigration2,
   SFProjectMigration3,
@@ -409,4 +409,4 @@ export const SF_PROJECT_MIGRATIONS: MigrationConstructor[] = [
   SFProjectMigration19,
   SFProjectMigration20,
   SFProjectMigration21
-];
+]);

--- a/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-user-config-migrations.ts
@@ -1,5 +1,5 @@
 import { Doc, ObjectDeleteOp, ObjectInsertOp } from 'sharedb/lib/client';
-import { DocMigration, MigrationConstructor } from '../../common/migration';
+import { DocMigration, MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 import { submitMigrationOp } from '../../common/realtime-server';
 
 class SFProjectUserConfigMigration1 extends DocMigration {
@@ -85,7 +85,7 @@ class SFProjectUserConfigMigration7 extends DocMigration {
   }
 }
 
-export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = [
+export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([
   SFProjectUserConfigMigration1,
   SFProjectUserConfigMigration2,
   SFProjectUserConfigMigration3,
@@ -93,4 +93,4 @@ export const SF_PROJECT_USER_CONFIG_MIGRATIONS: MigrationConstructor[] = [
   SFProjectUserConfigMigration5,
   SFProjectUserConfigMigration6,
   SFProjectUserConfigMigration7
-];
+]);

--- a/src/RealtimeServer/scriptureforge/services/text-audio-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-audio-migrations.ts
@@ -1,3 +1,3 @@
-import { MigrationConstructor } from '../../common/migration';
+import { MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 
-export const TEXT_AUDIO_MIGRATIONS: MigrationConstructor[] = [];
+export const TEXT_AUDIO_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([]);

--- a/src/RealtimeServer/scriptureforge/services/text-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/text-migrations.ts
@@ -1,3 +1,3 @@
-import { MigrationConstructor } from '../../common/migration';
+import { MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 
-export const TEXT_MIGRATIONS: MigrationConstructor[] = [];
+export const TEXT_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([]);

--- a/src/RealtimeServer/scriptureforge/services/training-data-migrations.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-migrations.ts
@@ -1,3 +1,3 @@
-import { MigrationConstructor } from '../../common/migration';
+import { MigrationConstructor, monotonicallyIncreasingMigrationList } from '../../common/migration';
 
-export const TRAINING_DATA_MIGRATIONS: MigrationConstructor[] = [];
+export const TRAINING_DATA_MIGRATIONS: MigrationConstructor[] = monotonicallyIncreasingMigrationList([]);


### PR DESCRIPTION
I'm fairly certain there's a way to do this at compile time with the type system, but doing a runtime check is much easier to implement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2916)
<!-- Reviewable:end -->
