### PR TITLE
SF-3123 Update ParatextData to 9.5.0.8

### DIFF
--- a/src/Migrations/BackoutCommits/BackoutCommits.csproj
+++ b/src/Migrations/BackoutCommits/BackoutCommits.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
     <ProjectReference Include="..\..\SIL.XForge\SIL.XForge.csproj" />
-    <PackageReference Include="ParatextData" Version="9.5.0.5" />
+    <PackageReference Include="ParatextData" Version="9.5.0.8" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.1.1" />
   </ItemGroup>
 

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="NPOI" Version="2.7.2" />
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
-    <PackageReference Include="ParatextData" Version="9.5.0.5" />
+    <PackageReference Include="ParatextData" Version="9.5.0.8" />
     <PackageReference Include="Serval.Client" Version="1.8.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -209,8 +209,11 @@ public static class NotesFormatter
             contents = sb.ToString();
         }
 
-        comment.AddTextToContent(string.Empty, false);
-        comment.Contents.InnerXml = contents;
+        // Since PTX-23738 we must create the contents node,
+        // as the setter for Contents reads and stores the OuterXml
+        XmlElement contentsElement = comment.GetOrCreateCommentNode();
+        contentsElement.InnerXml = contents;
+        comment.Contents = contentsElement;
     }
 
     private static void ParseParagraph(XElement paraElem, StringBuilder sb)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -348,7 +348,17 @@ public class ParatextService : DisposableBase, IParatextService
                 if (
                     !noErrors
                     || !success
-                    || (results != null && results.Any(r => r != null && r.Result == SendReceiveResultEnum.Failed))
+                    || (
+                        results != null
+                        && results.Any(r =>
+                            r
+                                is {
+                                    Result: SendReceiveResultEnum.Failed
+                                        or SendReceiveResultEnum.NotUpgraded
+                                        or SendReceiveResultEnum.ProjectVersionUpgraded,
+                                }
+                        )
+                    )
                 )
                 {
                     string resultsInfo = ExplainSRResults(results);
@@ -627,7 +637,7 @@ public class ParatextService : DisposableBase, IParatextService
         return canRead ? TextInfoPermission.Read : TextInfoPermission.None;
     }
 
-    private static string ExplainSRResults(IEnumerable<SendReceiveResult> srResults)
+    private static string ExplainSRResults(IEnumerable<SendReceiveResult>? srResults)
     {
         return string.Join(
             ";",

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MongoDB.Driver.Linq;
 using Newtonsoft.Json.Linq;
 using Paratext.Data;
 using Paratext.Data.Languages;
@@ -1050,7 +1049,8 @@ public class ParatextService : DisposableBase, IParatextService
                 scrText.ScrStylesheet(bookNum),
                 usx.CreateNavigator(),
                 XPathExpression.Compile("*[false()]"),
-                out string usfm
+                out string usfm,
+                scrText.Settings.AllowInvisibleChars
             );
             log.AppendLine($"Created usfm of {usfm}");
             // Among other things, normalizing the USFM will remove trailing spaces at the end of verses,
@@ -2911,9 +2911,11 @@ public class ParatextService : DisposableBase, IParatextService
                         {
                             try
                             {
-                                if (comment.Contents == null)
-                                    comment.AddTextToContent(string.Empty, false);
-                                comment.Contents!.InnerXml = xml;
+                                // Since PTX-23738 we must create the contents node,
+                                // as the setter for Contents reads and stores the OuterXml
+                                XmlElement contentsElement = comment.GetOrCreateCommentNode();
+                                contentsElement.InnerXml = xml;
+                                comment.Contents = contentsElement;
                                 comment.VersionNumber++;
                                 commentUpdated = true;
                             }
@@ -3181,7 +3183,14 @@ public class ParatextService : DisposableBase, IParatextService
         comment.Deleted = note.Deleted;
 
         if (!string.IsNullOrEmpty(note.Content))
-            comment.GetOrCreateCommentNode().InnerXml = GetCommentContentsFromNote(note, displayNames, ptProjectUsers);
+        {
+            // Since PTX-23738 we must create the contents node,
+            // as the setter for Contents reads and stores the OuterXml
+            XmlElement contentsElement = comment.GetOrCreateCommentNode();
+            contentsElement.InnerXml = GetCommentContentsFromNote(note, displayNames, ptProjectUsers) ?? string.Empty;
+            comment.Contents = contentsElement;
+        }
+
         if (!_userSecretRepository.Query().Any(u => u.Id == note.OwnerRef))
             comment.ExternalUser = note.OwnerRef;
         comment.TagsAdded =

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -347,17 +347,9 @@ public class ParatextService : DisposableBase, IParatextService
                 if (
                     !noErrors
                     || !success
-                    || (
-                        results != null
-                        && results.Any(r =>
-                            r
-                                is {
-                                    Result: SendReceiveResultEnum.Failed
-                                        or SendReceiveResultEnum.NotUpgraded
-                                        or SendReceiveResultEnum.ProjectVersionUpgraded,
-                                }
-                        )
-                    )
+                    || results is null
+                    || results.Any(r => r == null)
+                    || results.Any(r => r.Result != SendReceiveResultEnum.Succeeded)
                 )
                 {
                     string resultsInfo = ExplainSRResults(results);

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NUnit.Framework;
+using Paratext.Data;
 using SIL.XForge.Realtime.RichText;
 using SIL.XForge.Scripture.Models;
 
@@ -24,6 +25,7 @@ public class DeltaUsxMapperTests
     private IGuidService _testGuidService;
     private ILogger<DeltaUsxMapper> _logger;
     private IExceptionHandler _exceptionHandler;
+    private ScrText _scrText;
 
     [SetUp]
     public void Init()
@@ -32,6 +34,7 @@ public class DeltaUsxMapperTests
         _testGuidService = new TestGuidService();
         _logger = Substitute.For<ILogger<DeltaUsxMapper>>();
         _exceptionHandler = Substitute.For<IExceptionHandler>();
+        _scrText = new MockScrText(new SFParatextUser("ptUser01"), new ProjectName());
     }
 
     [Test]
@@ -2825,8 +2828,9 @@ public class DeltaUsxMapperTests
 \p E
 \v 2 F \nd ND\nd*
 """;
-        XmlDocument usfmToUsxLoading = Paratext.Data.UsfmToUsx.ConvertToXmlDocument(
-            new Paratext.Data.MockScrStylesheet("usfm.sty"),
+        XmlDocument usfmToUsxLoading = UsfmToUsx.ConvertToXmlDocument(
+            _scrText,
+            new MockScrStylesheet("usfm.sty"),
             bookUsfm
         );
         using XmlNodeReader nodeReader = new(usfmToUsxLoading);
@@ -3703,8 +3707,9 @@ public class DeltaUsxMapperTests
     {
         string bookCode = ExtractBookCode(bookUsfm);
 
-        XmlDocument bookUsxLoading = Paratext.Data.UsfmToUsx.ConvertToXmlDocument(
-            new Paratext.Data.MockScrStylesheet("usfm.sty"),
+        XmlDocument bookUsxLoading = UsfmToUsx.ConvertToXmlDocument(
+            _scrText,
+            new MockScrStylesheet("usfm.sty"),
             bookUsfm
         );
         using XmlNodeReader nodeReader = new(bookUsxLoading);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -3885,8 +3885,10 @@ public class ParatextServiceTests
         Assert.That(ex.Message, Does.Contain("PT projects with the following PT ids were requested"));
     }
 
-    [Test]
-    public void SendReceiveAsync_ShareChangesErrors_InResultsOnly()
+    [TestCase(SendReceiveResultEnum.Failed)]
+    [TestCase(SendReceiveResultEnum.NotUpgraded)]
+    [TestCase(SendReceiveResultEnum.ProjectVersionUpgraded)]
+    public void SendReceiveAsync_ShareChangesErrors_InResultsOnly(SendReceiveResultEnum sendReceiveResult)
     {
         var env = new TestEnvironment();
         var associatedPtUser = new SFParatextUser(env.Username01);
@@ -3907,7 +3909,7 @@ public class ParatextServiceTests
             {
                 x[2] = new List<SendReceiveResult>
                 {
-                    new SendReceiveResult(new SharedProject()) { Result = SendReceiveResultEnum.Failed },
+                    new SendReceiveResult(new SharedProject()) { Result = sendReceiveResult },
                 };
                 return true;
             });

--- a/tools/CommentGenerator/CommentGenerator.csproj
+++ b/tools/CommentGenerator/CommentGenerator.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NLipsum" Version="1.1.0" />
-    <PackageReference Include="ParatextData" Version="9.5.0.5" />
+    <PackageReference Include="ParatextData" Version="9.5.0.8" />
   </ItemGroup>
 
 </Project>

--- a/tools/RepoInfo/RepoInfo.csproj
+++ b/tools/RepoInfo/RepoInfo.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ParatextData" Version="9.5.0.5" />
+    <PackageReference Include="ParatextData" Version="9.5.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR:

 * Updates ParatextData to 9.5.0.8
 * Marks a sync as failed when ParatextData refuses to send/receive because the project requires a version of Paratext greater than the version Scripture Forge users.
 * Adds support for projects that utilize whitespace and invisible characters (a new feature in Paratext 9.5).
    * These whitespace characters can be added to a chapter in Paratext, and are viewable in Scripture Forge. They can be removed or replaced in the Scripture Forge Quill editor.

Known bugs:

 * You cannot paste the special whitespace characters into Quill. This is fixed in Quill 2.0.

Known behavior change:

 * After syncing a project after this update, the file ParatextVersionForUsers.xml will be created with this contents:
```xml
<?xml version="1.0" encoding="utf-8"?>
<ParatextVersionList>
  <ParatextVersionForUser>
    <UserName>[username goes here...]</UserName>
    <MachineName>[machine name goes here...]</MachineName>
    <VersionNbr>1</VersionNbr>
    <LatestProductionReleaseStr>9.5.0.8</LatestProductionReleaseStr>
  </ParatextVersionForUser>
</ParatextVersionList>
```

Due to the wide range of potential issues, a full regression run should be performed when this is deployed to QA. I have tested core Scripture Forge functionality (updating chapters, notes, and biblical terms), but there is always a risk of change in expected behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2917)
<!-- Reviewable:end -->
