### PR TITLE
Move localization button into the user menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -32,23 +32,6 @@
           </span>
         }
         <span class="toolbar-spacer"></span>
-        @if (isAppOnline) {
-          <button mat-icon-button [title]="t('language')" [matMenuTriggerFor]="localeMenu">
-            <mat-icon>translate</mat-icon>
-          </button>
-        }
-        <mat-menu #localeMenu="matMenu" class="locale-menu">
-          @for (locale of i18n.locales; track locale.canonicalTag) {
-            <button
-              mat-menu-item
-              [class.active-locale]="locale.canonicalTag === i18n.localeCode"
-              (click)="setLocale(locale.canonicalTag)"
-            >
-              <mat-icon>check</mat-icon>
-              <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
-            </button>
-          }
-        </mat-menu>
 
         <button mat-icon-button [title]="t('help')" [matMenuTriggerFor]="helpMenu">
           <mat-icon class="mirror-rtl">help</mat-icon>
@@ -157,6 +140,11 @@
               <div class="install-button"><mat-icon>install_mobile</mat-icon> {{ t("install_on_device") }}</div>
             </button>
           }
+          @if (isAppOnline) {
+            <button mat-menu-item [matMenuTriggerFor]="localeMenu">
+              <mat-icon>translate</mat-icon> {{ i18n.locale.localName }}
+            </button>
+          }
           <button mat-menu-item (click)="logOut()" id="log-out-link">
             <mat-icon>logout</mat-icon> {{ t("log_out") }}
           </button>
@@ -170,6 +158,19 @@
               {{ t("offline") }}
             }
           </div>
+        </mat-menu>
+
+        <mat-menu #localeMenu="matMenu" class="locale-menu">
+          @for (locale of i18n.locales; track locale.canonicalTag) {
+            <button
+              mat-menu-item
+              [class.active-locale]="locale.canonicalTag === i18n.localeCode"
+              (click)="setLocale(locale.canonicalTag)"
+            >
+              <mat-icon>check</mat-icon>
+              <span [class.locale-disabled]="!locale.production">{{ locale.localName }}</span>
+            </button>
+          }
         </mat-menu>
       </mat-toolbar-row>
       @if (hasUpdate) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -699,6 +699,7 @@ class TestEnvironment {
     when(mockedNmtDraftAuthGuard.allowTransition(anything())).thenReturn(this.canSeeGenerateDraft$);
     when(mockedUsersAuthGuard.allowTransition(anything())).thenReturn(this.canSeeUsers$);
     when(mockedI18nService.localeCode).thenReturn('en');
+    when(mockedI18nService.locale).thenReturn({} as any);
     when(mockedUrlService.helps).thenReturn('helps');
     when(mockedUrlService.announcementPage).thenReturn('community-announcements');
     when(mockedUrlService.communitySupport).thenReturn('community-support');


### PR DESCRIPTION
This helps clean up the top bar. The localization button won't really be used after setting it once, possibly on the home page, before even seeing this button.

![image](https://github.com/user-attachments/assets/2bfa2b06-a9b4-444b-8f32-a553e3159342)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2922)
<!-- Reviewable:end -->
