### PR TITLE
SF-3124 Add sync message before draft queued message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -260,13 +260,18 @@
             @if (draftJob != null) {
               @if (isDraftQueued(draftJob)) {
                 <section>
-                  <h3>{{ t("draft_queued_header") }}</h3>
-                  @if (!hasDraftQueueDepth(draftJob)) {
-                    <p>{{ t("draft_queued_detail") }}</p>
+                  @if (isSyncing()) {
+                    <h3>{{ t("draft_syncing") }}</h3>
+                    <p>{{ t("draft_syncing_detail") }}</p>
                   } @else {
-                    <p>
-                      {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
-                    </p>
+                    <h3>{{ t("draft_queued_header") }}</h3>
+                    @if (!hasDraftQueueDepth(draftJob)) {
+                      <p>{{ t("draft_queued_detail") }}</p>
+                    } @else {
+                      <p>
+                        {{ t("draft_queued_detail_multiple", { count: draftJob.queueDepth }) }}
+                      </p>
+                    }
                   }
                   <app-working-animated-indicator></app-working-animated-indicator>
                   <div class="button-strip">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -2032,6 +2032,49 @@ describe('DraftGenerationComponent', () => {
       verify(mockDialogRef.close()).once();
     });
 
+    it('should track whether the current project is not syncing', fakeAsync(() => {
+      let env = new TestEnvironment();
+      env.fixture.detectChanges();
+      tick();
+
+      expect(env.component.isSyncing()).toBe(false);
+    }));
+
+    it('should track whether the current project is syncing', fakeAsync(() => {
+      const projectDoc: SFProjectProfileDoc = {
+        data: createTestProjectProfile({
+          writingSystem: {
+            tag: 'xyz'
+          },
+          translateConfig: {
+            projectType: ProjectType.BackTranslation,
+            source: {
+              projectRef: 'testSourceProjectId',
+              writingSystem: {
+                tag: 'en'
+              }
+            }
+          },
+          sync: {
+            queuedCount: 1
+          }
+        })
+      } as SFProjectProfileDoc;
+      let env = new TestEnvironment(() => {
+        mockActivatedProjectService = jasmine.createSpyObj('ActivatedProjectService', [''], {
+          projectId: projectId,
+          projectId$: of(projectId),
+          projectDoc: projectDoc,
+          projectDoc$: of(projectDoc),
+          changes$: of(projectDoc)
+        });
+      });
+      env.fixture.detectChanges();
+      tick();
+
+      expect(env.component.isSyncing()).toBe(true);
+    }));
+
     it('should display the Paratext credentials update prompt when startBuild throws a forbidden error', fakeAsync(() => {
       let env = new TestEnvironment(() => {
         mockDraftGenerationService.startBuildOrGetActiveBuild.and.returnValue(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -460,6 +460,10 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return activeBuildStates.includes(job?.state as BuildStates);
   }
 
+  isSyncing(): boolean {
+    return this.activatedProject.projectDoc.data.sync.queuedCount > 0;
+  }
+
   isDraftQueued(job?: BuildDto): boolean {
     return [BuildStates.Queued, BuildStates.Pending].includes(job?.state as BuildStates);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -189,6 +189,8 @@
     "draft_active_detail": "Generating draft; this usually takes at least {{ count }} hours.",
     "draft_active_header": "Draft in progress",
     "draft_is_ready": "Your draft is ready",
+    "draft_syncing": "Draft initializing",
+    "draft_syncing_detail": "Your project is being synced before queuing the draft.",
     "draft_queued_detail_multiple": "The translation draft generation is number {{ count }} in the queue, and will begin once the server is finished with other projects. Please check back later.",
     "draft_queued_detail": "Generation of the translation draft has been queued, and will begin once the server is finished with another project. Please check back later.",
     "draft_queued_header": "Draft queued",


### PR DESCRIPTION
To do this, we check the queue count in the project doc and display that message if the build job state is queued. Once the sync count is zero, we display the regular queue message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2923)
<!-- Reviewable:end -->
