### PR TITLE
Fix shadow on question count card

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -244,7 +244,7 @@
 
   <div class="reviewer-panels stat-panels">
     @if (canCreateQuestion) {
-      <mat-card class="card card-content-question mat-elevation-z2">
+      <mat-card class="card card-content-question">
         <mat-card-content>
           <span class="flex">
             <div class="stat-total">{{ allQuestionsCount | l10nNumber }}</div>


### PR DESCRIPTION
This may be the most insignificant bug I've ever fixed, but it's a bug nonetheless.

Before

![](https://github.com/user-attachments/assets/71b2b49d-b4b1-4883-b871-88cb80c2398b)

After

![](https://github.com/user-attachments/assets/79082af3-470a-4d3a-9e08-8ef1d6196b0b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2926)
<!-- Reviewable:end -->
