### PR TITLE
SF-3141 Fix selected reference books persisting between steps

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -198,6 +198,7 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
       component.userSelectedTranslateBooks = [1];
       component.userSelectedTrainingBooks = [2, 3];
+      component.userSelectedSourceTrainingBooks = [2, 3];
       fixture.detectChanges();
       // Go to training books
       component.tryAdvanceStep();
@@ -219,6 +220,7 @@ describe('DraftGenerationStepsComponent', () => {
       const trainingDataFiles: string[] = [];
       const translationBooks = [2];
 
+      component.userSelectedSourceTrainingBooks = trainingBooks;
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
       component.selectedTrainingDataIds = trainingDataFiles;
@@ -249,6 +251,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.userSelectedTrainingBooks = trainingBooks;
       component.userSelectedTranslateBooks = translationBooks;
       component.selectedTrainingDataIds = trainingDataFiles;
+      component.userSelectedSourceTrainingBooks = trainingBooks;
       component['draftSourceProjectIds'] = {
         draftingSourceId: 'sourceProject',
         trainingSourceId: 'sourceProject',
@@ -568,20 +571,15 @@ describe('DraftGenerationStepsComponent', () => {
     it('does not allow selecting not selectable additional source training books', () => {
       const trainingBooks = [3];
       const trainingDataFiles: string[] = [];
-      const translationBooks = [1, 2];
 
-      component.userSelectedTrainingBooks = trainingBooks;
-      component.userSelectedTranslateBooks = translationBooks;
+      component.selectableAdditionalSourceTrainingBooks = trainingBooks;
+      component.userSelectedAdditionalSourceTrainingBooks = trainingBooks;
       component.selectedTrainingDataIds = trainingDataFiles;
       component['draftSourceProjectIds'] = {
         draftingSourceId: 'sourceProject',
         trainingSourceId: 'sourceProject',
         trainingAdditionalSourceId: 'sourceProject2'
       };
-      component.onStepChange();
-      expect(component.availableTrainingBooks).toEqual(trainingBooks);
-      expect(component.selectableSourceTrainingBooks).toEqual(trainingBooks);
-      expect(component.userSelectedSourceTrainingBooks).toEqual(trainingBooks);
       expect(component.selectableAdditionalSourceTrainingBooks).toEqual(trainingBooks);
       expect(component.userSelectedAdditionalSourceTrainingBooks).toEqual(trainingBooks);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -367,13 +367,15 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
 
     this.initialSelectedTrainingBooks = newSelectedTrainingBooks;
     this.userSelectedTrainingBooks = [...newSelectedTrainingBooks];
-    this.selectableSourceTrainingBooks = [...newSelectedTrainingBooks];
-    this.userSelectedSourceTrainingBooks = [...newSelectedTrainingBooks];
+    this.selectableSourceTrainingBooks = this.availableTrainingBooks.filter(b => newSelectedTrainingBooks.includes(b));
     this.selectableAdditionalSourceTrainingBooks = this.availableAdditionalTrainingBooks.filter(b =>
       newSelectedTrainingBooks.includes(b)
     );
+    this.userSelectedSourceTrainingBooks = this.selectableSourceTrainingBooks.filter(b =>
+      this.userSelectedSourceTrainingBooks.includes(b)
+    );
     this.userSelectedAdditionalSourceTrainingBooks = this.selectableAdditionalSourceTrainingBooks.filter(b =>
-      newSelectedTrainingBooks.includes(b)
+      this.userSelectedAdditionalSourceTrainingBooks.includes(b)
     );
   }
 


### PR DESCRIPTION
This PR fixes the resource books selected for training not persisting between steps. It adds a variable to store the books that will be used for training.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2927)
<!-- Reviewable:end -->
