### PR TITLE
Add logging for note sync failure

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2928,7 +2928,7 @@ public class ParatextService : DisposableBase, IParatextService
                         continue;
                     if (!string.IsNullOrEmpty(note.SyncUserRef))
                         throw new DataNotFoundException(
-                            "Could not find the matching comment for a note containing a sync user."
+                            $"Could not find the matching comment for note {note.DataId} in thread {note.ThreadId} containing sync user {note.SyncUserRef}."
                         );
 
                     // new comment added


### PR DESCRIPTION
(cherry picked from commit ed33d050129e6622fe601927d943a1fcfaaa2f39)

This was originally a hotfix on live, which is now being merged to master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2932)
<!-- Reviewable:end -->
