### PR TITLE
Remove learning rate adjustment and notice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -7,21 +7,6 @@
         {{ t("generate_forward_translation_drafts_header") }}
       </h1>
     }
-    @if (showAdjustedLearningRateNotice) {
-      <app-notice type="primary" mode="fill-dark" icon="bolt" data-test-id="drafting-rate-notice">
-        @for (i of learningRateNotice | async; track i) {
-          <!-- prettier-ignore -->
-          @if (i.id == null) {{{ i.text }}}
-          <!-- prettier-ignore -->
-          @else if (i.id === 1) {{{ adjustedLearningRateDraftDurationHours | l10nNumber }}}
-          <!-- prettier-ignore -->
-          @else if (i.id === 3) {{{ legacyDraftDurationHours | l10nNumber }}}
-          @else if (i.id === 5) {
-            <a href="mailto:{{ issueEmail }}" target="_blank">{{ i.text }}</a>
-          }
-        }
-      </app-notice>
-    }
 
     <section>
       @if (isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
@@ -10,12 +10,12 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { BehaviorSubject, EMPTY, Subject, of, throwError } from 'rxjs';
+import { BehaviorSubject, EMPTY, of, Subject, throwError } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService, createTestFeatureFlag } from 'xforge-common/feature-flags/feature-flag.service';
+import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Locale } from 'xforge-common/models/i18n-locale';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -129,8 +129,7 @@ describe('DraftGenerationComponent', () => {
         'FeatureFlagService',
         {},
         {
-          allowForwardTranslationNmtDrafting: createTestFeatureFlag(false),
-          updatedLearningRateForServal: createTestFeatureFlag(true)
+          allowForwardTranslationNmtDrafting: createTestFeatureFlag(false)
         }
       );
       mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog']);
@@ -226,10 +225,6 @@ describe('DraftGenerationComponent', () => {
 
     get downloadSpinner(): HTMLElement | null {
       return this.getElementByTestId('download-spinner');
-    }
-
-    get draftingRateNotice(): HTMLElement | null {
-      return this.getElementByTestId('drafting-rate-notice');
     }
 
     get offlineTextElement(): HTMLElement | null {
@@ -342,55 +337,6 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isSourceAndTrainingSourceLanguageIdentical).toBe(true);
       expect(env.component.isPreTranslationApproved).toBe(true);
       expect(env.warningSourceTargetSame).not.toBeNull();
-    }));
-
-    it('should show draft speed notice if back translation or pre-translate approved', fakeAsync(() => {
-      let env = new TestEnvironment(() => {
-        mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
-          'FeatureFlagService',
-          {},
-          {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
-          }
-        );
-      });
-      env.component.isBackTranslation = true;
-      env.component.isPreTranslationApproved = false;
-      env.fixture.detectChanges();
-      tick();
-
-      expect(env.component.isBackTranslation).toBe(true);
-      expect(env.component.isPreTranslationApproved).toBe(false);
-      expect(env.draftingRateNotice).not.toBeNull();
-
-      env.component.isBackTranslation = false;
-      env.component.isPreTranslationApproved = true;
-      env.fixture.detectChanges();
-      tick();
-
-      expect(env.component.isBackTranslation).toBe(false);
-      expect(env.component.isPreTranslationApproved).toBe(true);
-      expect(env.draftingRateNotice).not.toBeNull();
-    }));
-
-    it('should not show drafting speed notice if not back translation nor pre-translate approved.', fakeAsync(() => {
-      let env = new TestEnvironment(() => {
-        mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
-          'FeatureFlagService',
-          {},
-          {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
-          }
-        );
-      });
-      env.component.isBackTranslation = false;
-      env.component.isPreTranslationApproved = false;
-      env.fixture.detectChanges();
-      tick();
-
-      expect(env.draftingRateNotice).toBeNull();
     }));
 
     it('should detect alternate training source language when different to alternate source language', fakeAsync(() => {
@@ -698,8 +644,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
       });
@@ -1013,8 +958,7 @@ describe('DraftGenerationComponent', () => {
             'FeatureFlagService',
             {},
             {
-              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-              updatedLearningRateForServal: createTestFeatureFlag(true)
+              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
             }
           );
         });
@@ -1171,8 +1115,7 @@ describe('DraftGenerationComponent', () => {
             'FeatureFlagService',
             {},
             {
-              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-              updatedLearningRateForServal: createTestFeatureFlag(true)
+              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
             }
           );
         });
@@ -1349,8 +1292,7 @@ describe('DraftGenerationComponent', () => {
             'FeatureFlagService',
             {},
             {
-              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-              updatedLearningRateForServal: createTestFeatureFlag(true)
+              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
             }
           );
         });
@@ -1549,8 +1491,7 @@ describe('DraftGenerationComponent', () => {
             'FeatureFlagService',
             {},
             {
-              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-              updatedLearningRateForServal: createTestFeatureFlag(true)
+              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
             }
           );
         });
@@ -1804,8 +1745,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
       });
@@ -1825,8 +1765,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
       });
@@ -1846,8 +1785,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
       });
@@ -1885,8 +1823,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
 
@@ -1924,8 +1861,7 @@ describe('DraftGenerationComponent', () => {
           'FeatureFlagService',
           {},
           {
-            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true),
-            updatedLearningRateForServal: createTestFeatureFlag(true)
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
           }
         );
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -10,7 +10,7 @@ import { RouterLink } from 'ngx-transloco-markup-router-link';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { Subscription, combineLatest, of } from 'rxjs';
+import { combineLatest, of, Subscription } from 'rxjs';
 import { catchError, filter, switchMap, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
@@ -33,7 +33,7 @@ import { ServalProjectComponent } from '../../serval-administration/serval-proje
 import { SharedModule } from '../../shared/shared.module';
 import { WorkingAnimatedIndicatorComponent } from '../../shared/working-animated-indicator/working-animated-indicator.component';
 import { NllbLanguageService } from '../nllb-language.service';
-import { BuildConfig, DraftZipProgress, activeBuildStates } from './draft-generation';
+import { activeBuildStates, BuildConfig, DraftZipProgress } from './draft-generation';
 import {
   DraftGenerationStepsComponent,
   DraftGenerationStepsResult
@@ -133,13 +133,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
 
   cancelDialogRef?: MatDialogRef<any>;
 
-  readonly legacyDraftDurationHours = 8;
-  readonly adjustedLearningRateDraftDurationHours = 2.5;
-  get draftDurationHours(): number {
-    return this.featureFlags.updatedLearningRateForServal.enabled
-      ? this.adjustedLearningRateDraftDurationHours
-      : this.legacyDraftDurationHours;
-  }
+  readonly draftDurationHours = 2.5;
 
   get draftEnabled(): boolean {
     return this.isBackTranslationMode || this.isPreTranslationApproved;
@@ -149,8 +143,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return environment.issueEmail;
   }
 
-  readonly learningRateNotice = this.i18n.interpolate('draft_generation.improved_learning_rate_notice');
-
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
@@ -159,7 +151,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly authService: AuthService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly draftSourcesService: DraftSourcesService,
-    readonly featureFlags: FeatureFlagService,
+    private readonly featureFlags: FeatureFlagService,
     private readonly nllbService: NllbLanguageService,
     protected readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
@@ -168,16 +160,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     protected readonly urlService: ExternalUrlService
   ) {
     super(noticeService);
-  }
-
-  // Stop showing learning rate notice 60 days after it went live
-  // TODO Remove the notice entirely after it's expired
-  readonly learningRateNoticeExpired = new Date() > new Date('2025-01-06');
-
-  get showAdjustedLearningRateNotice(): boolean {
-    return (
-      this.draftEnabled && this.featureFlags.updatedLearningRateForServal.enabled && !this.learningRateNoticeExpired
-    );
   }
 
   get downloadProgress(): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -196,7 +196,6 @@
     "generate_draft_button": "Generate draft",
     "generate_forward_translation_drafts_header": "Generate translation drafts",
     "generate_new_draft": "New draft",
-    "improved_learning_rate_notice": "Drafting is now much faster! Most drafts will now take about {1}{2} hours to complete instead of {3}{4}. Draft quality should be about the same as before, but please {5}contact us{6} if you notice any issues.",
     "info_alert_different_additional_training_and_source_language": "The language for your additional training text ({{ additionalTrainingSourceLanguageDisplayName }}) must be the same as the training source language ({{ alternateTrainingSourceLanguageDisplayName }}). Select a different additional training text on the [link:projectSettingsUrl]settings page[/link].",
     "info_alert_different_training_and_source_language": "The language for your alternate training text ({{ alternateTrainingSourceLanguageDisplayName }}) must be the same as the source language ({{ sourceLanguageDisplayName }}). Select a different alternate training text on the [link:projectSettingsUrl]settings page[/link].",
     "info_alert_last_sync_failed": "Your project failed to synchronize. It will be synchronized when you next generate a draft.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -306,7 +306,7 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  readonly updatedLearningRateForServal: FeatureFlag = new ServerOnlyFeatureFlag(
+  private readonly updatedLearningRateForServal: FeatureFlag = new ServerOnlyFeatureFlag(
     'UpdatedLearningRateForServal',
     'Updated Learning Rate For Serval',
     14,

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -5,6 +5,5 @@ namespace SIL.XForge.Scripture.Models;
 /// </summary>
 public static class FeatureFlags
 {
-    public const string UpdatedLearningRateForServal = "UpdatedLearningRateForServal";
     public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
 }

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -571,21 +571,6 @@ public class MachineProjectService(
             // Load the Serval Config from the Draft Config
             servalConfig = projectDoc.Data.TranslateConfig.DraftConfig.ServalConfig;
         }
-        else if (await featureManager.IsEnabledAsync(FeatureFlags.UpdatedLearningRateForServal))
-        {
-            // Specify the updated learning rate
-            servalConfig = """
-                {
-                    "train_params":
-                    {
-                        "warmup_steps": 1000,
-                        "learning_rate": 0.0002,
-                        "lr_scheduler_type": "cosine",
-                        "max_steps": 5000
-                    }
-                }
-                """;
-        }
 
         // Get the appropriate translation engine
         TranslationBuildConfig translationBuildConfig;

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -63,7 +63,6 @@
     "Serval": true,
     "MachineInProcess": false,
     "UploadParatextZipForPreTranslation": false,
-    "UseEchoForPreTranslation": false,
-    "UpdatedLearningRateForServal": true
+    "UseEchoForPreTranslation": false
   }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -528,29 +528,6 @@ public class MachineProjectServiceTests
                 Arg.Is<TranslationBuildConfig>(b => ((int)((JObject)b.Options)["max_steps"]) == 35),
                 CancellationToken.None
             );
-        await env.FeatureManager.DidNotReceive().IsEnabledAsync(FeatureFlags.UpdatedLearningRateForServal);
-    }
-
-    [Test]
-    public async Task BuildProjectAsync_UsesTheUpdatedLearningRateForServal()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.FeatureManager.IsEnabledAsync(FeatureFlags.UpdatedLearningRateForServal).Returns(Task.FromResult(true));
-        // SUT
-        await env.Service.BuildProjectAsync(
-            User01,
-            new BuildConfig { ProjectId = Project01, FastTraining = true },
-            preTranslate: true,
-            CancellationToken.None
-        );
-        await env
-            .TranslationEnginesClient.Received()
-            .StartBuildAsync(
-                TranslationEngine01,
-                Arg.Is<TranslationBuildConfig>(b => ((int)((JObject)b.Options)["train_params"]["max_steps"]) == 5000),
-                CancellationToken.None
-            );
     }
 
     [Test]


### PR DESCRIPTION
As the 60 days have passed and Serval automatically sets this rate for us, this PR reverts the following PRs:

 * #2829
 * #2832
 * #2902

The feature flag is retained so an version numbers with the feature flag will be parsed correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2933)
<!-- Reviewable:end -->
