### PR TITLE
Add projectRef index to sync_metrics collection

### DIFF
--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -36,7 +36,14 @@ public static class SFDataAccessServiceCollectionExtensions
                     ]
                 )
         );
-        services.AddMongoRepository<SyncMetrics>("sync_metrics", cm => cm.MapIdProperty(sm => sm.Id));
+        services.AddMongoRepository<SyncMetrics>(
+            "sync_metrics",
+            cm => cm.MapIdProperty(sm => sm.Id),
+            im =>
+                im.CreateOne(
+                    new CreateIndexModel<SyncMetrics>(Builders<SyncMetrics>.IndexKeys.Ascending(sm => sm.ProjectRef))
+                )
+        );
 
         return services;
     }


### PR DESCRIPTION
This PR adds an index to `projectRef` in the `sync_metrics` collection, as follows:

![image](https://github.com/user-attachments/assets/7195002f-d34f-435d-bcba-e12f9839d49d)

This should speed up querying of sync_metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2934)
<!-- Reviewable:end -->
