### PR TITLE
SF-3068 Update BT offline message

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -37,7 +37,7 @@
     "loading": "Loading...",
     "not_found": "No Biblical Terms match your criteria.",
     "notes": "Notes",
-    "offline": "Currently unavailable offline. Please connect to the internet, once loaded you can continue viewing them offline.",
+    "offline": "Currently unavailable offline. Please connect to the internet to access Biblical Terms.",
     "renderings": "Renderings",
     "settings": "Settings",
     "show": "Show",


### PR DESCRIPTION
This PR addresses the confusion of the offline message that is shown for BT that was found during regression testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2935)
<!-- Reviewable:end -->
