### PR TITLE
SF-3131 Add support for retrieving drafts as USX

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -320,7 +320,7 @@ public class MachineApiController : ControllerBase
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="bookNum">The book number.</param>
-    /// <param name="chapterNum">The chapter number.</param>
+    /// <param name="chapterNum">The chapter number. This cannot be zero.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The pre-translations were successfully queried for.</response>
     /// <response code="403">You do not have permission to retrieve the pre-translations for this project.</response>
@@ -376,7 +376,7 @@ public class MachineApiController : ControllerBase
     /// <remarks>This method can be called by Serval Administrators for any project.</remarks>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="bookNum">The book number.</param>
-    /// <param name="chapterNum">The chapter number. If zero, the entire book is returned</param>
+    /// <param name="chapterNum">The chapter number. If zero, the entire book is returned.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The pre-translations were successfully queried for.</response>
     /// <response code="403">You do not have permission to retrieve the pre-translations for this project.</response>
@@ -404,6 +404,61 @@ public class MachineApiController : ControllerBase
                 cancellationToken
             );
             return Ok(usfm);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException)
+        {
+            return Conflict();
+        }
+        catch (NotSupportedException)
+        {
+            return new StatusCodeResult(StatusCodes.Status405MethodNotAllowed);
+        }
+    }
+
+    /// <summary>
+    /// Gets the pre-translations for the specified chapter as USX.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="chapterNum">The chapter number. If zero, the entire book is returned.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The pre-translations were successfully queried for.</response>
+    /// <response code="403">You do not have permission to retrieve the pre-translations for this project.</response>
+    /// <response code="404">The project does not exist or is not configured on the ML server.</response>
+    /// <response code="405">Retrieving the pre-translations in this format is not supported.</response>
+    /// <response code="409">The engine has not been built on the ML server.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
+    [HttpGet(MachineApi.GetPreTranslationUsx)]
+    public async Task<ActionResult<string>> GetPreTranslationUsxAsync(
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            string usx = await _machineApiService.GetPreTranslationUsxAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                bookNum,
+                chapterNum,
+                cancellationToken
+            );
+            return Ok(usx);
         }
         catch (BrokenCircuitException e)
         {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -27,6 +27,8 @@ public static class MachineApi
         "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}/delta";
     public const string GetPreTranslationUsfm =
         "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}/usfm";
+    public const string GetPreTranslationUsx =
+        "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}/usx";
     public const string GetLastCompletedPreTranslationBuild =
         "translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild";
 

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -63,6 +63,13 @@ public interface IMachineApiService
         bool isServalAdmin,
         CancellationToken cancellationToken
     );
+    Task<string> GetPreTranslationUsxAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        int chapterNum,
+        CancellationToken cancellationToken
+    );
     Task<WordGraph> GetWordGraphAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -42,7 +42,7 @@ public interface IParatextService
     bool ResourceDocsNeedUpdating(SFProject project, ParatextResource resource);
 
     IReadOnlyList<int> GetBookList(UserSecret userSecret, string paratextId);
-    string GetBookText(UserSecret userSecret, string paratextId, int bookNum);
+    string GetBookText(UserSecret userSecret, string paratextId, int bookNum, string? usfm = null);
     Task<int> PutBookText(
         UserSecret userSecret,
         string paratextId,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -989,13 +989,22 @@ public class ParatextService : DisposableBase, IParatextService
         return scrText.Settings.BooksPresentSet.SelectedBookNumbers.ToArray();
     }
 
-    /// <summary> Get PT book text in USX, or throw if can't. </summary>
-    public string GetBookText(UserSecret userSecret, string paratextId, int bookNum)
+    /// <summary>
+    /// Gets a book's text in USX, with the option of overriding the USFM.
+    /// </summary>
+    /// <param name="userSecret">The user secret.</param>
+    /// <param name="paratextId">The Paratext project identifier.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="usfm">Optional. Override the USFM.</param>
+    /// <returns>The book's contents as USX.</returns>
+    /// <exception cref="DataNotFoundException">The project cannot be accessed.</exception>
+    /// <remarks>Specify the USFM if you are parsing USFM from another source (i.e. Serval) for this book.</remarks>
+    public string GetBookText(UserSecret userSecret, string paratextId, int bookNum, string? usfm = null)
     {
         using ScrText scrText =
             ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId)
             ?? throw new DataNotFoundException("Can't get access to cloned project.");
-        string usfm = scrText.GetText(bookNum);
+        usfm ??= scrText.GetText(bookNum);
         return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1047,6 +1047,123 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetPreTranslationUsxAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetPreTranslationUsxAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetPreTranslationUsxAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetPreTranslationUsxAsync_NotBuilt()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new InvalidOperationException());
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ConflictResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetPreTranslationUsxAsync_NotSupported()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Throws(new NotSupportedException());
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<IStatusCodeActionResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status405MethodNotAllowed, (actual.Result as IStatusCodeActionResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetPreTranslationUsxAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPreTranslationUsxAsync(User01, Project01, 40, 1, CancellationToken.None)
+            .Returns(Task.FromResult(string.Empty));
+
+        // SUT
+        ActionResult<string> actual = await env.Controller.GetPreTranslationUsxAsync(
+            Project01,
+            40,
+            1,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
     public async Task GetWordGraphAsync_MachineApiDown()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -511,6 +511,30 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public void GetBookText_OverrideUSFM()
+    {
+        const string ruthBookUsfm =
+            "\\id RUT - ProjectNameHere\n \\c 1\n"
+            + "\\v 1 Updated Verse 1 here.\n"
+            + "\\v 2 Updated Verse 2 here.\n"
+            + "\\v 3 New Verse 3 here.";
+        const string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Updated Verse 1 here. <verse number=\"2\" style=\"v\" />Updated Verse 2 here. "
+            + "<verse number=\"3\" style=\"v\" />New Verse 3 here.</usx>";
+
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // SUT
+        string result = env.Service.GetBookText(null, ptProjectId, 8, ruthBookUsfm);
+        Assert.That(result, Is.EqualTo(ruthBookUsx));
+    }
+
+    [Test]
     public void GetBookText_Works()
     {
         string ruthBookUsx =


### PR DESCRIPTION
This PR adds support for a USX endpoint for downloading drafts, in the format: http://localhost:5000/machine-api/v3/translation/engines/project:6759d685b919b5bce800eb16/actions/preTranslate/40_0/usx

This endpoint can be tested via Swagger (http://localhost:5000/swagger/index.html).

As this has no user facing interface, I have marked this as testing not required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2936)
<!-- Reviewable:end -->
