### PR TITLE
SF-3117 Add logo option to remove branding on auth0 page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -416,6 +416,22 @@ describe('AuthService', () => {
     }
   }));
 
+  it('should login with defined logo', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedLocationService.origin).thenReturn('https://scriptureforge.org');
+
+    env.service.logIn({ returnUrl: 'test-returnUrl' });
+
+    verify(mockedWebAuth.loginWithRedirect(anything())).once();
+    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
+      mockedWebAuth.loginWithRedirect
+    ).last()[0];
+    expect(authOptions).toBeDefined();
+    if (authOptions != null) {
+      expect(authOptions.authorizationParams!.logo).toBeDefined();
+    }
+  }));
+
   it('should link with Paratext', fakeAsync(() => {
     const env = new TestEnvironment({ isOnline: true, isLoggedIn: true });
     const returnUrl = 'test-returnUrl';

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -75,6 +75,7 @@ interface LoginParams {
 
 interface xForgeAuth0Parameters extends AuthorizationParams {
   mode?: string;
+  logo?: string;
   login_hint?: string;
   language?: string;
   enablePasswordless?: boolean;
@@ -247,7 +248,8 @@ export class AuthService {
       ui_locales: language,
       enablePasswordless: true,
       language,
-      login_hint: ui_locales
+      login_hint: ui_locales,
+      logo: 'https://auth0.languagetechnology.org/assets/sf.svg'
     };
 
     if (signUp || this.isJoining) {


### PR DESCRIPTION
This PR calls the Auth0 login API with the additional useBranding and logo parameters that will configure Auth0 to hide the SF name and SIL logo when using a site other than localhost or scriptureforge.org.
I marked this as testing not required since it won't be testable until the non-branded site is live. A developer can test this by setting useBranding to false.

![Auth0 Login White Label](https://github.com/user-attachments/assets/7841692c-fbfd-4566-ab2c-5815f3080f33)
![Auth0 Change Password White Label](https://github.com/user-attachments/assets/99710b15-870b-465f-90c7-587108af80dc)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2937)
<!-- Reviewable:end -->
