### PR TITLE
SF-3154 Fix splitter area shifting when manage audio dialog is closed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -451,10 +451,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       this.getCSSFloatPropertyOf(this.answersPanelContainerElement, 'padding-top') +
       this.getCSSFloatPropertyOf(this.answersPanelContainerElement, 'padding-bottom');
 
+    const addAnswerButton = document.querySelector('#add-answer') as Element;
+    const addAnswerButtonHeight = addAnswerButton == null ? 0 : addAnswerButton.getBoundingClientRect().height;
+
     return (
       Math.max(distanceFromTopToTotalAnswersMessageBottom, distanceFromTopToAddAnswerButtonBottom) +
       answersPanelVerticalPadding +
-      showUnreadsBannerHeight
+      showUnreadsBannerHeight +
+      addAnswerButtonHeight
     );
   }
 


### PR DESCRIPTION
This PR checks if the "Add Answer" button is present and accounts for its height when resizing the Question and Answers splitter area.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2943)
<!-- Reviewable:end -->
