### PR TITLE
SF-3151 Fix Serval build failures when changing source languages

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -661,6 +661,25 @@ public class MachineProjectService(
         CancellationToken cancellationToken
     )
     {
+        // Check that the parallel corpus exists on Serval, and that we have access to it
+        if (!string.IsNullOrWhiteSpace(parallelCorpusId))
+        {
+            try
+            {
+                TranslationParallelCorpus parallelCorpus = await translationEnginesClient.GetParallelCorpusAsync(
+                    translationEngineId,
+                    parallelCorpusId,
+                    cancellationToken
+                );
+                parallelCorpusId = parallelCorpus.Id;
+            }
+            catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+            {
+                // The parallel corpus does not exist or is inaccessible
+                parallelCorpusId = null;
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(parallelCorpusId))
         {
             // Create a new parallel corpus
@@ -1457,11 +1476,22 @@ public class MachineProjectService(
             // Remove the parallel corpora
             if (!string.IsNullOrWhiteSpace(additionalTrainingData.ParallelCorpusId))
             {
-                await translationEnginesClient.DeleteParallelCorpusAsync(
-                    translationEngineId,
-                    additionalTrainingData.ParallelCorpusId,
-                    cancellationToken
-                );
+                try
+                {
+                    await translationEnginesClient.DeleteParallelCorpusAsync(
+                        translationEngineId,
+                        additionalTrainingData.ParallelCorpusId,
+                        cancellationToken
+                    );
+                }
+                catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+                {
+                    // If the parallel corpus was already deleted, just log a message
+                    string message =
+                        $"Parallel Corpus {additionalTrainingData.ParallelCorpusId.Sanitize()}"
+                        + $" in project {project.Id.Sanitize()} was missing or already deleted.";
+                    logger.LogInformation(e, message);
+                }
             }
 
             // Remove the corpora and files
@@ -1607,7 +1637,12 @@ public class MachineProjectService(
             ServalCorpusFile servalCorpusFile = projectSecret.ServalData.CorpusFiles.SingleOrDefault(f =>
                 f.ProjectId == projectId
             );
-            if (servalCorpusFile is null || servalCorpusFile.LanguageCode != languageCode)
+
+            // Ensure that the corpus exists - if it does not, corpusId will be null
+            string corpusId = servalCorpusFile is null
+                ? null
+                : await CorpusExistsAsync(servalCorpusFile.CorpusId, cancellationToken);
+            if (string.IsNullOrWhiteSpace(corpusId) || servalCorpusFile.LanguageCode != languageCode)
             {
                 // Create the corpus if it does not exist or the language code has changed
                 Corpus corpus = await corporaClient.CreateAsync(
@@ -1766,6 +1801,36 @@ public class MachineProjectService(
     }
 
     /// <summary>
+    /// Determines where the specified corpus exists on Serval, and we have access to it.
+    /// </summary>
+    /// <param name="corpusId">The corpus identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The corpus identifier if it exists; otherwise <c>null</c>.</returns>
+    protected internal virtual async Task<string?> CorpusExistsAsync(
+        string? corpusId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Null or blank identifiers do not exist
+        if (string.IsNullOrWhiteSpace(corpusId))
+        {
+            return null;
+        }
+
+        try
+        {
+            // Check that the corpus exists on Serval, and we have access to it
+            Corpus corpus = await corporaClient.GetAsync(corpusId, cancellationToken);
+            return corpus.Id;
+        }
+        catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+        {
+            // The corpus does not exist
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Determines whether a translation engine exists for the specified project.
     /// </summary>
     /// <param name="projectId">The Scripture Forge project identifier.</param>
@@ -1841,9 +1906,23 @@ public class MachineProjectService(
             && !string.IsNullOrWhiteSpace(corpusId)
         )
         {
-            await corporaClient.DeleteAsync(corpusId, cancellationToken);
+            try
+            {
+                await corporaClient.DeleteAsync(corpusId, cancellationToken);
+            }
+            catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
+            {
+                // If the corpus was already deleted, just log a message
+                string message =
+                    $"Corpus {corpusId.Sanitize()} in project {projectId.Sanitize()}"
+                    + " was missing or already deleted.";
+                logger.LogInformation(e, message);
+            }
             corpusId = null;
         }
+
+        // Ensure that the corpus exists - if it does not, corpusId will be null
+        corpusId = await CorpusExistsAsync(corpusId, cancellationToken);
 
         // If there is no corpus, create it
         if (string.IsNullOrWhiteSpace(corpusId))

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -531,42 +531,6 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task CorpusExistsAsync_Null()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-
-        // SUT
-        string actual = await env.Service.CorpusExistsAsync(corpusId: null, CancellationToken.None);
-        Assert.IsNull(actual);
-    }
-
-    [Test]
-    public async Task CorpusExistsAsync_Missing()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.CorporaClient.GetAsync(Corpus01, CancellationToken.None).ThrowsAsync(ServalApiExceptions.NotFound);
-
-        // SUT
-        string actual = await env.Service.CorpusExistsAsync(Corpus01, CancellationToken.None);
-        Assert.IsNull(actual);
-    }
-
-    [Test]
-    public async Task CorpusExistsAsync_Success()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.CorporaClient.GetAsync(Corpus01, CancellationToken.None)
-            .Returns(Task.FromResult(new Corpus { Id = Corpus01 }));
-
-        // SUT
-        string actual = await env.Service.CorpusExistsAsync(Corpus01, CancellationToken.None);
-        Assert.AreEqual(Corpus01, actual);
-    }
-
-    [Test]
     public async Task CreateOrUpdateParallelCorpusAsync_CreatesParallelCorpus()
     {
         // Set up test environment
@@ -1149,6 +1113,42 @@ public class MachineProjectServiceTests
                     CancellationToken.None
                 )
         );
+    }
+
+    [Test]
+    public async Task GetCorpusIdFromServalAsync_Null()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        string actual = await env.Service.GetCorpusIdFromServalAsync(corpusId: null, CancellationToken.None);
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public async Task GetCorpusIdFromServalAsync_Missing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.CorporaClient.GetAsync(Corpus01, CancellationToken.None).ThrowsAsync(ServalApiExceptions.NotFound);
+
+        // SUT
+        string actual = await env.Service.GetCorpusIdFromServalAsync(Corpus01, CancellationToken.None);
+        Assert.IsNull(actual);
+    }
+
+    [Test]
+    public async Task GetCorpusIdFromServalAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.CorporaClient.GetAsync(Corpus01, CancellationToken.None)
+            .Returns(Task.FromResult(new Corpus { Id = Corpus01 }));
+
+        // SUT
+        string actual = await env.Service.GetCorpusIdFromServalAsync(Corpus01, CancellationToken.None);
+        Assert.AreEqual(Corpus01, actual);
     }
 
     [Test]
@@ -2715,7 +2715,9 @@ public class MachineProjectServiceTests
                 HasTranslationEngineForSmt = !options.PreTranslate,
             }
         );
-        env.Service.Configure().CorpusExistsAsync(Corpus01, CancellationToken.None).Returns(Task.FromResult(Corpus01));
+        env.Service.Configure()
+            .GetCorpusIdFromServalAsync(Corpus01, CancellationToken.None)
+            .Returns(Task.FromResult(Corpus01));
         env.Service.Configure()
             .UploadParatextFileAsync(Arg.Any<ServalCorpusFile>(), Arg.Any<string>(), CancellationToken.None)
             .Returns(Task.CompletedTask);
@@ -3294,7 +3296,9 @@ public class MachineProjectServiceTests
         env.Service.Configure()
             .UploadTextFileAsync(servalCorpusFile, text, CancellationToken.None)
             .Returns(Task.FromResult(false));
-        env.Service.Configure().CorpusExistsAsync(Corpus01, CancellationToken.None).Returns(Task.FromResult(Corpus01));
+        env.Service.Configure()
+            .GetCorpusIdFromServalAsync(Corpus01, CancellationToken.None)
+            .Returns(Task.FromResult(Corpus01));
 
         string actual = await env.Service.UploadAdditionalTrainingDataAsync(
             Project01,
@@ -3415,7 +3419,9 @@ public class MachineProjectServiceTests
         env.Service.Configure()
             .UploadTextFileAsync(Arg.Any<ServalCorpusFile>(), text, CancellationToken.None)
             .Returns(Task.FromResult(true));
-        env.Service.Configure().CorpusExistsAsync(Corpus01, CancellationToken.None).Returns(Task.FromResult(Corpus01));
+        env.Service.Configure()
+            .GetCorpusIdFromServalAsync(Corpus01, CancellationToken.None)
+            .Returns(Task.FromResult(Corpus01));
 
         string actual = await env.Service.UploadAdditionalTrainingDataAsync(
             Project01,

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -2023,6 +2023,9 @@ public class MachineProjectServiceTests
             new ServalData
             {
                 PreTranslationEngineId = TranslationEngine01,
+                ParallelCorpusIdForPreTranslate = ParallelCorpus01,
+                ParallelCorpusIdForTrainOn = ParallelCorpus02,
+                PreTranslationsRetrieved = true,
                 CorpusFiles =
                 [
                     new ServalCorpusFile { CorpusId = Corpus01, FileId = File01 },
@@ -2054,6 +2057,15 @@ public class MachineProjectServiceTests
         await env.DataFilesClient.Received(1).DeleteAsync(File02);
         await env.DataFilesClient.Received(1).DeleteAsync(File03);
         await env.DataFilesClient.Received(1).DeleteAsync(File04);
+
+        // Verify that the project secret is correct
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.IsNull(projectSecret.ServalData!.AdditionalTrainingData);
+        Assert.IsNull(projectSecret.ServalData!.PreTranslationEngineId);
+        Assert.IsNull(projectSecret.ServalData!.PreTranslationsRetrieved);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForPreTranslate);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForTrainOn);
+        Assert.IsEmpty(projectSecret.ServalData!.CorpusFiles);
     }
 
     [Test]
@@ -2066,7 +2078,11 @@ public class MachineProjectServiceTests
             new ServalData
             {
                 PreTranslationEngineId = TranslationEngine01,
+                ParallelCorpusIdForPreTranslate = ParallelCorpus01,
+                ParallelCorpusIdForTrainOn = ParallelCorpus02,
+                PreTranslationsRetrieved = true,
                 TranslationEngineId = TranslationEngine02,
+                ParallelCorpusIdForSmt = ParallelCorpus03,
                 CorpusFiles =
                 [
                     new ServalCorpusFile { CorpusId = Corpus01, FileId = File01 },
@@ -2105,6 +2121,17 @@ public class MachineProjectServiceTests
         await env.CorporaClient.DidNotReceive().DeleteAsync(Corpus02);
         await env.DataFilesClient.DidNotReceive().DeleteAsync(File01);
         await env.DataFilesClient.DidNotReceive().DeleteAsync(File02);
+
+        // Verify that the project secret is correct
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.IsNull(projectSecret.ServalData!.AdditionalTrainingData);
+        Assert.IsNull(projectSecret.ServalData!.PreTranslationEngineId);
+        Assert.IsNull(projectSecret.ServalData!.PreTranslationsRetrieved);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForPreTranslate);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForTrainOn);
+        Assert.IsNotEmpty(projectSecret.ServalData!.CorpusFiles);
+        Assert.AreEqual(TranslationEngine02, projectSecret.ServalData!.TranslationEngineId);
+        Assert.AreEqual(ParallelCorpus03, projectSecret.ServalData!.ParallelCorpusIdForSmt);
     }
 
     [Test]
@@ -2117,6 +2144,7 @@ public class MachineProjectServiceTests
             new ServalData
             {
                 TranslationEngineId = TranslationEngine02,
+                ParallelCorpusIdForSmt = ParallelCorpus03,
                 CorpusFiles =
                 [
                     new ServalCorpusFile { CorpusId = Corpus01, FileId = File01 },
@@ -2134,6 +2162,12 @@ public class MachineProjectServiceTests
         await env.CorporaClient.Received(1).DeleteAsync(Corpus02);
         await env.DataFilesClient.Received(1).DeleteAsync(File01);
         await env.DataFilesClient.Received(1).DeleteAsync(File02);
+
+        // Verify that the project secret is correct
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.IsEmpty(projectSecret.ServalData!.CorpusFiles);
+        Assert.IsNull(projectSecret.ServalData!.TranslationEngineId);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForSmt);
     }
 
     [Test]
@@ -2146,7 +2180,11 @@ public class MachineProjectServiceTests
             new ServalData
             {
                 PreTranslationEngineId = TranslationEngine01,
+                ParallelCorpusIdForPreTranslate = ParallelCorpus01,
+                ParallelCorpusIdForTrainOn = ParallelCorpus02,
+                PreTranslationsRetrieved = true,
                 TranslationEngineId = TranslationEngine02,
+                ParallelCorpusIdForSmt = ParallelCorpus03,
                 CorpusFiles =
                 [
                     new ServalCorpusFile { CorpusId = Corpus01, FileId = File01 },
@@ -2185,6 +2223,17 @@ public class MachineProjectServiceTests
         await env.DataFilesClient.DidNotReceive().DeleteAsync(File04);
         await env.DataFilesClient.DidNotReceive().DeleteAsync(File05);
         await env.DataFilesClient.DidNotReceive().DeleteAsync(File06);
+
+        // Verify that the project secret is correct
+        SFProjectSecret projectSecret = env.ProjectSecrets.Get(Project01);
+        Assert.IsNotNull(projectSecret.ServalData!.AdditionalTrainingData);
+        Assert.AreEqual(TranslationEngine01, projectSecret.ServalData!.PreTranslationEngineId);
+        Assert.IsTrue(projectSecret.ServalData!.PreTranslationsRetrieved);
+        Assert.AreEqual(ParallelCorpus01, projectSecret.ServalData!.ParallelCorpusIdForPreTranslate);
+        Assert.AreEqual(ParallelCorpus02, projectSecret.ServalData!.ParallelCorpusIdForTrainOn);
+        Assert.IsNotEmpty(projectSecret.ServalData!.CorpusFiles);
+        Assert.IsNull(projectSecret.ServalData!.TranslationEngineId);
+        Assert.IsNull(projectSecret.ServalData!.ParallelCorpusIdForSmt);
     }
 
     [Test]


### PR DESCRIPTION
This PR fixes build failures that occur when changing to a source from a different language by:

* Clearing the ProjectSecret fields when a Serval project is removed
* Correctly handling missing corpora and parallel corpora by ignoring deletion "not found" failures, and creating corpora and parallel corpora when they are missing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2945)
<!-- Reviewable:end -->
