### PR TITLE
Fix wording around uploading training data to not imply CSV only

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -16,9 +16,9 @@
         </mat-chip-option>
       </mat-chip-listbox>
     }
-    <button mat-flat-button (click)="openUploadDialog()" color="accent">
+    <button mat-flat-button (click)="openUploadDialog()" color="primary">
       <mat-icon matChipAvatar>file_upload</mat-icon>
-      {{ t("upload_csv") }}
+      {{ t("upload_spreadsheet") }}
     </button>
     <app-info [text]="t('file_information', { sourceLanguage, targetLanguage })"></app-info>
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -599,7 +599,7 @@
     "confirm_delete": "Are you sure you want to permanently delete this training data?",
     "delete": "Delete",
     "file_information": "The file should be a spreadsheet that has two columns of text: the first column in {{ sourceLanguage }}, the second in {{ targetLanguage }}.",
-    "upload_csv": "Upload CSV"
+    "upload_spreadsheet": "Upload spreadsheet"
   },
   "training_data_upload_dialog": {
     "browse_files": "Browse Files",


### PR DESCRIPTION
### Before
![](https://github.com/user-attachments/assets/7ba26ceb-69f8-41cc-8d9f-9b24dc8e4638)

### After
![](https://github.com/user-attachments/assets/6742bd48-ccb2-42b3-9080-51bde8af3c5d)

Changes:
- No longer state CSV, since supported file formats are `.csv,.tsv,.txt,.xls,.xlsx`
- Make the button appear like our other buttons

It would be preferable to add text explaining what formats are acceptable, but for this PR I'm only focused on removing anything that's actively misleading. Our help site [currently says](https://help.scriptureforge.org/generating-a-draft) "These need to be in .csv format" (which is false), but was a completely reasonable conclusion based on the current UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2949)
<!-- Reviewable:end -->
