### PR TITLE
Update serval admin page with additional training source info

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -89,15 +89,17 @@
 <h2>Last Draft Settings</h2>
 <h3>Training books</h3>
 @for (book of trainingBooksByProject; track book.source) {
-  <p>{{ book.source }}</p>
-  <p>{{ book.scriptureRange }}</p>
+  <div class="training">
+    <p>{{ book.source }}</p>
+    <p class="training-source-range">{{ book.scriptureRange }}</p>
+  </div>
 } @empty {
-  <p>None</p>
+  <p class="training">None</p>
 }
 <h3>Training data files</h3>
 <p>{{ trainingFiles.join(", ") || "None" }}</p>
 <h3>Translation books</h3>
-<p>{{ translationBooks.join(", ") || "None" }}</p>
+<p class="translation-range">{{ translationBooks.join(", ") || "None" }}</p>
 
 @if (draftJob$ | async; as draftJob) {
   <h3>Diagnostic Information</h3>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -88,7 +88,12 @@
 
 <h2>Last Draft Settings</h2>
 <h3>Training books</h3>
-<p>{{ trainingBooks.join(", ") || "None" }}</p>
+@for (book of trainingBooksByProject; track book.source) {
+  <p>{{ book.source }}</p>
+  <p>{{ book.scriptureRange }}</p>
+} @empty {
+  <p>None</p>
+}
 <h3>Training data files</h3>
 <p>{{ trainingFiles.join(", ") || "None" }}</p>
 <h3>Translation books</h3>


### PR DESCRIPTION
The serval admin page needs to be updated to account for the additional training source. This adds the additional training source as an entry that can be downloaded and correctly shows the training sources and selected book configuration for a draft build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2950)
<!-- Reviewable:end -->
