### PR TITLE
Remove Serval status and add status summary to Health Check

### DIFF
--- a/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
+++ b/src/SIL.XForge.Scripture/Models/HealthCheckResponse.cs
@@ -6,6 +6,16 @@ namespace SIL.XForge.Scripture.Models;
 public class HealthCheckResponse
 {
     /// <summary>
+    /// The <see cref="StatusSummary"/> when all systems are healthy.
+    /// </summary>
+    public const string Healthy = "All systems are healthy.";
+
+    /// <summary>
+    /// The <see cref="StatusSummary"/> when one or more systems are down.
+    /// </summary>
+    public const string Down = "Some systems are down.";
+
+    /// <summary>
     /// Gets or sets the health check status for Mongo.
     /// </summary>
     public HealthCheckComponent Mongo { get; } = new HealthCheckComponent();
@@ -16,7 +26,7 @@ public class HealthCheckResponse
     public HealthCheckComponent RealtimeServer { get; } = new HealthCheckComponent();
 
     /// <summary>
-    /// Gets or sets the health check status for Serval.
+    /// Gets the status summary.
     /// </summary>
-    public HealthCheckComponent Serval { get; } = new HealthCheckComponent();
+    public string StatusSummary => Mongo.Up && RealtimeServer.Up ? Healthy : Down;
 }


### PR DESCRIPTION
This PR removes the Serval check from the health check API, and adds a status summary that will be one of two strings:

 * All systems are healthy.
 * Some systems are down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2951)
<!-- Reviewable:end -->
