### PR TITLE
SF-3157 Enable strict null checking in typescript

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -155,7 +155,7 @@
                         <mat-selection-list [multiple]="false">
                           @for (
                             questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number));
-                            track questionDoc.data.dataId
+                            track questionDoc.data!.dataId
                           ) {
                             <mat-list-item disableRipple>
                               <div class="flex">
@@ -349,7 +349,7 @@
                       <mat-selection-list [multiple]="false">
                         @for (
                           questionDoc of getQuestionDocs(getTextDocIdType(text.bookNum, chapter.number), true);
-                          track questionDoc.data.dataId
+                          track questionDoc.data!.dataId
                         ) {
                           <mat-list-item disableRipple>
                             <div class="flex">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -460,7 +460,7 @@ describe('CheckingComponent', () => {
       expect(question.isArchived).toBe(true);
       expect(env.component.questionDocs.length).toEqual(13);
       expect(env.component.questionVerseRefs.length).toEqual(13);
-      expect(env.component.questionsList.activeQuestionDoc.id).toBe('project01:q3Id');
+      expect(env.component.questionsList!.activeQuestionDoc!.id).toBe('project01:q3Id');
     }));
 
     it('opens a dialog when edit question is clicked', fakeAsync(() => {
@@ -1209,7 +1209,7 @@ describe('CheckingComponent', () => {
       env.selectQuestion(6);
       env.clickButton(env.getAnswerEditButton(0));
       env.waitForSliderUpdate();
-      env.component.answersPanel.submit({ text: 'Answer 6 on question', audio: { status: 'reset' } });
+      env.component.answersPanel!.submit({ text: 'Answer 6 on question', audio: { status: 'reset' } });
       env.waitForSliderUpdate();
       verify(
         mockedFileService.deleteFile(FileType.Audio, 'project01', QuestionDoc.COLLECTION, 'a6Id', CHECKER_USER.id)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -301,7 +301,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
   get canShare(): boolean {
     return (
-      this.projectDoc != null &&
+      this.projectDoc?.data != null &&
       SF_PROJECT_RIGHTS.hasRight(
         this.projectDoc.data,
         this.userService.currentUserId,
@@ -600,7 +600,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             routeProjectId !== prevProjectId ||
             routeScope !== prevScope ||
             (routeScope !== 'all' && routeBookNum !== prevBookNum) ||
-            (routeScope === 'chapter' && parseInt(routeChapter) !== prevChapterNum)
+            (routeScope === 'chapter' && (routeChapter == null ? undefined : parseInt(routeChapter)) !== prevChapterNum)
           ) {
             this.cleanup();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -477,9 +477,10 @@ export class ImportQuestionsDialogComponent extends SubscriptionDisposable imple
       ImportQuestionsConfirmationDialogComponent,
       data
     ) as MatDialogRef<ImportQuestionsConfirmationDialogComponent, ImportQuestionsConfirmationDialogResult>;
-    (await lastValueFrom(dialogRef.afterClosed())).forEach(
-      (checked, index) => (changesToConfirm[index].checked = checked)
-    );
+    const result: ImportQuestionsConfirmationDialogResult | undefined = await lastValueFrom(dialogRef.afterClosed());
+    if (result != null) {
+      result.forEach((checked, index) => (changesToConfirm[index].checked = checked));
+    }
     this.updateSelectAllCheckbox();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -19,7 +19,7 @@ import { compareProjectsForSorting, projectLabel } from '../shared/utils';
 interface ConnectProjectFormValues {
   settings: {
     checking: boolean;
-    sourceParatextId: string;
+    sourceParatextId: string | null;
   };
 }
 
@@ -133,7 +133,12 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
     if (!this.connectProjectForm.valid || this.projectsFromParatext == null) {
       return;
     }
-    const values = this.connectProjectForm.value as ConnectProjectFormValues;
+    const values: ConnectProjectFormValues = {
+      settings: {
+        checking: !!this.connectProjectForm.value.settings?.checking,
+        sourceParatextId: this.connectProjectForm.value.settings?.sourceParatextId ?? null
+      }
+    };
     this.state = 'connecting';
     const settings: SFProjectCreateSettings = {
       paratextId: this.ptProjectId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -316,7 +316,11 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     });
   }
 
-  async onlineEventMetrics(projectId: string, pageIndex: number, pageSize: number): Promise<QueryResults<EventMetric>> {
+  async onlineEventMetrics(
+    projectId: string,
+    pageIndex: number,
+    pageSize: number
+  ): Promise<QueryResults<EventMetric> | undefined> {
     return await this.onlineInvoke<QueryResults<EventMetric>>('eventMetrics', { projectId, pageIndex, pageSize });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.spec.ts
@@ -94,7 +94,7 @@ describe('EventMetricsLogComponent', () => {
   it('should not display table if invalid results', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedProjectService.onlineEventMetrics(anything(), anything(), anything())).thenReturn(
-      Promise.resolve({ results: null, unpagedCount: 0 } as QueryResults<EventMetric>)
+      Promise.resolve({ results: null as unknown, unpagedCount: 0 } as QueryResults<EventMetric>)
     );
     env.wait();
     env.wait();
@@ -206,7 +206,7 @@ class TestEnvironment {
     when(mockedUserService.currentUserId).thenReturn('user01');
     when(mockedAuthService.currentUserRoles).thenReturn([]);
     when(mockDialogService.openMatDialog(EventMetricDialogComponent, anything())).thenReturn(instance(this.dialogRef));
-    when(mockedProjectService.onlineEventMetrics(anything(), anything(), anything())).thenReturn(null);
+    when(mockedProjectService.onlineEventMetrics(anything(), anything(), anything())).thenResolve(undefined);
 
     this.fixture = TestBed.createComponent(EventMetricsLogComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
@@ -22,7 +22,7 @@ interface Row {
   eventType: string;
   scope: string;
   timeStamp: string;
-  userId: string;
+  userId?: string;
   successful: boolean;
 }
 
@@ -98,9 +98,9 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
         switchMap(async ([projectId, pageIndex, pageSize, isOnline]) => {
           this.loadingStarted();
           if (isOnline) {
-            var queryResults = await this.projectService.onlineEventMetrics(projectId, pageIndex, pageSize);
-            this.length = queryResults.unpagedCount;
-            if (Array.isArray(queryResults.results)) {
+            const queryResults = await this.projectService.onlineEventMetrics(projectId, pageIndex, pageSize);
+            this.length = queryResults?.unpagedCount ?? 0;
+            if (Array.isArray(queryResults?.results)) {
               this.eventMetrics = queryResults.results as EventMetric[];
             } else {
               this.eventMetrics = [];
@@ -131,6 +131,10 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
 
   private generateRows(): void {
     const rows: Row[] = [];
+    if (this.eventMetrics == null) {
+      this.rows = rows;
+      return;
+    }
     for (const eventMetric of this.eventMetrics) {
       rows.push({
         dialogData: eventMetric,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -372,7 +372,7 @@ describe('ServalProjectComponent', () => {
     }
 
     getTrainingSourceBookNames(node: HTMLElement): string {
-      return node.querySelector('.training-source-range').textContent;
+      return node.querySelector('.training-source-range')?.textContent ?? '';
     }
   }
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -63,7 +63,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   columnsToDisplay = ['category', 'type', 'name', 'id'];
   rows: Row[] = [];
 
-  trainingBooksByProject: ProjectAndRange[];
+  trainingBooksByProject: ProjectAndRange[] = [];
   trainingFiles: string[] = [];
   translationBooks: string[] = [];
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -87,7 +87,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   }
 
   get eventLogLink(): string[] {
-    return ['/projects', this.activatedProjectService.projectId, 'event-log'];
+    return ['/projects', this.activatedProjectService.projectId!, 'event-log'];
   }
 
   get isOnline(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -1008,12 +1008,15 @@ describe('SettingsComponent', () => {
 
       it('should show Translation Suggestions when Based On is set', fakeAsync(() => {
         const env = new TestEnvironment();
-        env.setupProject({
-          translateConfig: {
-            translationSuggestionsEnabled: false,
-            source: null
-          }
-        });
+        env.setupProject(
+          {
+            translateConfig: {
+              translationSuggestionsEnabled: false,
+              source: undefined
+            }
+          },
+          true
+        );
         env.wait();
         expect(env.translationSuggestionsCheckbox).toBeNull();
         expect(env.basedOnSelectValue).toEqual('');
@@ -1102,12 +1105,14 @@ describe('SettingsComponent', () => {
 
       it('Translation Suggestions should remain unchanged when Based On is changed', fakeAsync(() => {
         const env = new TestEnvironment();
-        env.setupProject({
-          translateConfig: {
-            translationSuggestionsEnabled: false,
-            source: null
-          }
-        });
+        env.setupProject(
+          {
+            translateConfig: {
+              translationSuggestionsEnabled: false
+            }
+          },
+          true
+        );
         env.wait();
         expect(env.translationSuggestionsCheckbox).toBeNull();
         expect(env.basedOnSelectValue).toEqual('');
@@ -1949,10 +1954,13 @@ class TestEnvironment {
     }
   });
 
-  setupProject(data: RecursivePartial<SFProject> = {}): void {
+  setupProject(data: RecursivePartial<SFProject> = {}, noSource = false): void {
     const projectData = cloneDeep(this.testProject);
     if (data.translateConfig != null) {
       projectData.translateConfig = merge(projectData.translateConfig, data.translateConfig);
+      if (noSource) {
+        projectData.translateConfig.source = undefined;
+      }
     }
     if (data.checkingConfig != null) {
       projectData.checkingConfig = merge(projectData.checkingConfig, data.checkingConfig);
@@ -1964,7 +1972,11 @@ class TestEnvironment {
       projectData.sync = merge(projectData.sync, data.sync);
     }
     if (data.rolePermissions != null) {
-      projectData.rolePermissions = data.rolePermissions;
+      const rolePermissions: { [key: string]: string[] } = {};
+      for (const [role, permissions] of Object.entries(data.rolePermissions)) {
+        rolePermissions[role] = permissions?.filter(p => p != null) ?? [];
+      }
+      projectData.rolePermissions = rolePermissions;
     }
     this.realtimeService.addSnapshot<SFProject>(SFProjectDoc.COLLECTION, {
       id: 'project01',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -478,7 +478,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   ): void {
     if (this.settingChanged(newValue, setting)) {
       const right = SF_PROJECT_RIGHTS.joinRight(SFProjectDomain.UserInvites, Operation.Create);
-      const permissions = new Set(this.projectDoc.data.rolePermissions[role] ?? []);
+      const permissions = new Set(this.projectDoc!.data!.rolePermissions[role] ?? []);
       if (newValue[setting] === true) {
         permissions.add(right);
       } else {
@@ -487,7 +487,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
       this.checkUpdateStatus(
         setting,
-        this.projectService.onlineSetRoleProjectPermissions(this.projectDoc.id, role, Array.from(permissions))
+        this.projectService.onlineSetRoleProjectPermissions(this.projectDoc!.id, role, Array.from(permissions))
       );
       this.previousFormValues = this.form.value;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
@@ -2,7 +2,7 @@ import { NgZone } from '@angular/core';
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
+import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -126,7 +126,7 @@ class TestEnvironment {
   createTexts(): TextInfo[] {
     const texts: TextInfo[] = [];
     for (let book = 0; book < 200; book++) {
-      const chapters = [];
+      const chapters: Chapter[] = [];
       for (let chapter = 0; chapter < 100; chapter++) {
         chapters.push({ isValid: true, lastVerse: 1, number: chapter, permissions: {}, hasAudio: false });
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
@@ -2,7 +2,7 @@ import { NgZone } from '@angular/core';
 import { discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
-import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
+import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { BehaviorSubject, of } from 'rxjs';
 import { anything, deepEqual, instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
@@ -232,7 +232,7 @@ class TestEnvironment {
   createTexts(): TextInfo[] {
     const texts: TextInfo[] = [];
     for (let book = 0; book < this.numBooks; book++) {
-      const chapters = [];
+      const chapters: Chapter[] = [];
       for (let chapter = 0; chapter < this.numChapters; chapter++) {
         chapters.push({ isValid: true, lastVerse: 1, number: chapter, permissions: {}, hasAudio: false });
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-base.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-base.component.ts
@@ -62,6 +62,7 @@ export abstract class ShareBaseComponent extends SubscriptionDisposable {
       .filter(
         info =>
           info.permission &&
+          this.projectDoc?.data != null &&
           SF_PROJECT_RIGHTS.hasRight(
             this.projectDoc.data,
             this.userService.currentUserId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -97,12 +97,14 @@ export class ShareControlComponent extends ShareBaseComponent {
     }
 
     return (
+      this.projectDoc?.data != null &&
       SF_PROJECT_RIGHTS.hasRight(
         this.projectDoc.data,
         this.userService.currentUserId,
         SFProjectDomain.UserInvites,
         Operation.Create
-      ) && this.userShareableRoles.includes(this.shareRole)
+      ) &&
+      this.userShareableRoles.includes(this.shareRole)
     );
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -122,12 +122,14 @@ export class ShareDialogComponent extends ShareBaseComponent {
 
   get shareLinkUsageOptions(): ShareLinkType[] {
     const options: ShareLinkType[] = [];
-    const canShare = SF_PROJECT_RIGHTS.hasRight(
-      this.projectDoc.data,
-      this.userService.currentUserId,
-      SFProjectDomain.UserInvites,
-      Operation.Create
-    );
+    const canShare =
+      this.projectDoc?.data != null &&
+      SF_PROJECT_RIGHTS.hasRight(
+        this.projectDoc.data,
+        this.userService.currentUserId,
+        SFProjectDomain.UserInvites,
+        Operation.Create
+      );
     if (this.isProjectAdmin) {
       options.push(ShareLinkType.Anyone);
       options.push(ShareLinkType.Recipient);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -738,7 +738,7 @@ export function registerScripture(): string[] {
       if (this.stack[source].length === 0) {
         return;
       }
-      const stackItem: StackItem = this.stack[source].pop();
+      const stackItem: StackItem = this.stack[source].pop()!;
       if (stackItem == null) {
         return;
       }
@@ -761,7 +761,7 @@ export function registerScripture(): string[] {
   /**
    * Transforms a range based on a delta. This function was copied from the Quill history module.
    */
-  function transformRange(range: Range | null, delta: Delta): Range {
+  function transformRange(range: Range | null, delta: Delta): Range | null {
     if (!range) {
       return range;
     }
@@ -851,7 +851,7 @@ export function registerScripture(): string[] {
           curIndex++;
         }
       } else if (op.retain != null) {
-        const retainCount: number = getRetainCount(op);
+        const retainCount: number = getRetainCount(op)!;
         curIndex += retainCount;
         changeIndex = curIndex;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { TranslocoService } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import Quill, { Delta, EmitterSource, Range as QuillRange } from 'quill';
@@ -24,7 +24,7 @@ import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module'
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
-import { TestTranslocoModule, configureTestingModule } from 'xforge-common/test-utils';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
 import { isGecko } from 'xforge-common/utils';
@@ -291,7 +291,7 @@ describe('TextComponent', () => {
     tick();
     env.fixture.detectChanges();
     expect(env.isSegmentHighlighted(1, '2-3')).toBe(true);
-    expect(env.getSegment('s_2').classList.contains('highlight-segment')).toBe(false);
+    expect(env.getSegment('s_2')!.classList.contains('highlight-segment')).toBe(false);
 
     // segments overlaps on verse 3
     env.component.setSegment('verse_1_3');
@@ -301,13 +301,13 @@ describe('TextComponent', () => {
     tick();
     env.fixture.detectChanges();
     expect(env.isSegmentHighlighted(1, '2-3')).toBe(true);
-    expect(env.getSegment('s_2').classList.contains('highlight-segment')).toBe(false);
+    expect(env.getSegment('s_2')!.classList.contains('highlight-segment')).toBe(false);
 
     env.component.setSegment('s_2');
     tick();
     env.fixture.detectChanges();
     expect(env.component.segment!.ref).toEqual('s_2');
-    expect(env.getSegment('s_2').classList.contains('highlight-segment')).toBe(true);
+    expect(env.getSegment('s_2')!.classList.contains('highlight-segment')).toBe(true);
     expect(env.isSegmentHighlighted(1, '2-3')).toBe(false);
 
     TestEnvironment.waitForPresenceTimer();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -741,7 +741,8 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
   }
 
   get commenterSelection(): Range[] {
-    const ret = [];
+    const ret: Range[] = [];
+    if (this.editor == null) return ret;
     for (const segment of this.viewModel.segments) {
       const range = segment[1];
       const formats = getAttributesAtPosition(this.editor, range.index);
@@ -1657,7 +1658,7 @@ export class TextComponent extends SubscriptionDisposable implements AfterViewIn
       return;
     }
     const range = this._segment.range;
-    const bounds = this._editor.getBounds(range.index, range.length);
+    const bounds = this._editor.getBounds(range.index, range.length)!;
     this._selectionBoundsTop = bounds.top + this._editor.root.scrollTop;
     this.highlightMarkerHeight = bounds.height;
     this.highlightMarker.style.top = this._selectionBoundsTop + 'px';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -46,7 +46,7 @@ describe('shared utils', () => {
   describe('isBadDelta function', () => {
     it('requires op.insert to be a string or object', () => {
       expect(isBadDelta([{}])).toBeTrue();
-      expect(isBadDelta([{ insert: null }])).toBeTrue();
+      expect(isBadDelta([{ insert: undefined }])).toBeTrue();
       expect(isBadDelta([{ insert: 1 as any }])).toBeTrue();
       // this isn't actually a good op, but isBadDelta won't see a problem with it
       // it's looking for known issues, not proving validity

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ProgressBarMode } from '@angular/material/progress-bar';
 import { OtJson0Op } from 'ot-json0';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { BehaviorSubject, Observable, map, merge } from 'rxjs';
+import { BehaviorSubject, map, merge, Observable } from 'rxjs';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -42,7 +42,7 @@ export class SyncProgressComponent extends SubscriptionDisposable {
   @Input() showSyncStatus: boolean = true;
   @Output() inProgress: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  syncPhase: SyncPhase;
+  syncPhase?: SyncPhase;
   phasePercentage: number = 0;
   syncProgress: number = 0;
   activeSyncProjectName: string = '';
@@ -147,12 +147,12 @@ export class SyncProgressComponent extends SubscriptionDisposable {
     this.phasePercentage =
       progressState.syncProgress != null ? Math.round((progressState.syncProgress - this.syncProgress) * 100) : 0;
     if (projectId === this._projectDoc?.id) {
-      this.activeSyncProjectName = this._projectDoc.data.name;
+      this.activeSyncProjectName = this._projectDoc?.data?.name ?? '';
       this.progressPercent$.next(
         hasSourceProject ? 0.5 + progressState.progressValue * 0.5 : progressState.progressValue
       );
     } else if (hasSourceProject && projectId === this.sourceProjectDoc?.id) {
-      this.activeSyncProjectName = this.sourceProjectDoc.data.name;
+      this.activeSyncProjectName = this.sourceProjectDoc?.data?.name ?? '';
       this.progressPercent$.next(progressState.progressValue * 0.5);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.spec.ts
@@ -382,9 +382,9 @@ class TestEnvironment {
   };
 
   static segmentLen(verseNumber: number): number {
-    return TestEnvironment.delta.filter(
+    return TestEnvironment.delta!.filter(
       op => op.attributes != null && op.attributes.segment === 'verse_1_' + verseNumber
-    )[0].insert.length as number;
+    )[0].insert!.length as number;
   }
 
   readonly fixture: ComponentFixture<ChildViewContainerComponent>;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -10,11 +10,11 @@
       <h3>{{ t("targets_heading", { targetLanguage }) }}</h3>
     </div>
     <div class="sources">
-      @for (project of trainingSources; track project.paratextId) {
+      @for (project of trainingSources; track project!.paratextId) {
         <div class="project">
-          <span class="project-name">{{ project.name }}</span>
+          <span class="project-name">{{ project!.name }}</span>
           <span class="language-code">
-            {{ t("language_code") }} <strong>{{ project.writingSystem.tag }}</strong>
+            {{ t("language_code") }} <strong>{{ project!.writingSystem.tag }}</strong>
           </span>
         </div>
       }
@@ -34,11 +34,11 @@
 
   <h2>{{ t("drafting_from_heading", { draftingSourceShortNames, draftingSourceLanguage }) }}</h2>
   <div class="translation-data">
-    @for (project of draftingSources; track project.paratextId) {
+    @for (project of draftingSources; track project!.paratextId) {
       <div class="project">
-        <span class="project-name">{{ project.name }}</span>
+        <span class="project-name">{{ project!.name }}</span>
         <span class="language-code">
-          {{ t("language_code") }} <strong>{{ project.writingSystem.tag }}</strong>
+          {{ t("language_code") }} <strong>{{ project!.writingSystem.tag }}</strong>
         </span>
       </div>
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -44,8 +44,8 @@ export class ConfirmSourcesComponent implements OnInit {
     this.languageCodesVerified.emit(change.checked);
   }
 
-  displayNameForProjectsLanguages(projects: (TranslateSource | SFProjectProfile)[]): string {
-    const uniqueTags = Array.from(new Set(projects.map(p => p.writingSystem.tag)));
+  displayNameForProjectsLanguages(projects: (TranslateSource | SFProjectProfile | undefined)[]): string {
+    const uniqueTags = Array.from(new Set(projects.filter(p => p != null).map(p => p.writingSystem.tag)));
     const displayNames = uniqueTags.map(tag => this.i18nService.getLanguageDisplayName(tag) ?? tag);
     return this.i18nService.enumerateList(displayNames);
   }
@@ -63,6 +63,6 @@ export class ConfirmSourcesComponent implements OnInit {
   }
 
   get draftingSourceShortNames(): string {
-    return this.i18nService.enumerateList(this.draftingSources.map(p => p.shortName));
+    return this.i18nService.enumerateList(this.draftingSources.filter(p => p != null).map(p => p.shortName));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
@@ -48,7 +48,7 @@ export class DraftApplyProgressDialogComponent {
   get failedToApplyChapters(): string | undefined {
     if (this.draftApplyProgress == null || !this.draftApplyProgress.completed) return undefined;
     const chapters: string[] = this.draftApplyProgress.chapters
-      .filter(c => !this.draftApplyProgress.chaptersApplied.includes(c))
+      .filter(c => !this.draftApplyProgress?.chaptersApplied.includes(c))
       .map(c => c.toString());
     return chapters.length > 0 ? this.i18n.enumerateList(chapters) : undefined;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -62,6 +62,7 @@ describe('DraftGenerationStepsComponent', () => {
 
   beforeEach(fakeAsync(() => {
     when(mockActivatedProjectService.projectId).thenReturn('project01');
+    when(mockActivatedProjectService.projectId$).thenReturn(of('project01'));
     when(mockActivatedRoute.params).thenReturn(of({ projectId: 'project01' }));
     when(mockProgressService.isLoaded$).thenReturn(of(true));
     when(mockProgressService.texts).thenReturn([
@@ -81,12 +82,14 @@ describe('DraftGenerationStepsComponent', () => {
       trainingSources: [
         {
           projectRef: 'sourceProject',
+          paratextId: 'PT_SP',
+          name: 'Source Project',
           shortName: 'sP',
           writingSystem: { tag: 'eng' },
           texts: allBooks.filter(b => b.bookNum !== 6)
         },
         undefined
-      ] as [DraftSource, DraftSource],
+      ] as [DraftSource, DraftSource?],
       trainingTargets: [
         {
           projectRef: mockActivatedProjectService.projectId,
@@ -107,6 +110,7 @@ describe('DraftGenerationStepsComponent', () => {
     beforeEach(fakeAsync(() => {
       when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
       const mockTargetProjectDoc = {
+        id: 'project01',
         data: createTestProjectProfile({
           texts: allBooks,
           translateConfig: {
@@ -427,12 +431,14 @@ describe('DraftGenerationStepsComponent', () => {
       trainingSources: [
         {
           projectRef: 'source1',
+          paratextId: 'PT_SP1',
+          name: 'Source Project 1',
           shortName: 'sP1',
           writingSystem: { tag: 'eng' },
           texts: availableBooks.concat({ bookNum: 1 })
         },
         undefined
-      ] as [DraftSource, DraftSource],
+      ] as [DraftSource, DraftSource?],
       trainingTargets: [
         {
           projectRef: mockActivatedProjectService.projectId,
@@ -538,6 +544,7 @@ describe('DraftGenerationStepsComponent', () => {
     };
 
     const mockTargetProjectDoc = {
+      id: 'project01',
       data: createTestProjectProfile({
         texts: [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }],
         translateConfig: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -185,11 +185,7 @@ export class DraftGenerationStepsComponent implements OnInit {
             } else {
               this.unusableTrainingSourceBooks.push(bookNum);
             }
-            if (
-              trainingSources[1] != null &&
-              additionalTrainingSourceBooks != null &&
-              additionalTrainingSourceBooks.has(bookNum)
-            ) {
+            if (trainingSources[1] != null && additionalTrainingSourceBooks.has(bookNum)) {
               this.availableTrainingBooks[trainingSources[1].projectRef].push({ number: bookNum, selected: false });
               isPresentInASource = true;
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,11 +1,12 @@
 import { Component, DestroyRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatStepper } from '@angular/material/stepper';
 import { translate, TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { ProjectScriptureRange, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { merge, Subscription } from 'rxjs';
+import { combineLatest, merge, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
@@ -13,7 +14,6 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
@@ -65,7 +65,7 @@ interface TrainingPair {
     ConfirmSourcesComponent
   ]
 })
-export class DraftGenerationStepsComponent extends SubscriptionDisposable implements OnInit {
+export class DraftGenerationStepsComponent implements OnInit {
   @Output() readonly done = new EventEmitter<DraftGenerationStepsResult>();
   @Output() readonly cancel = new EventEmitter();
   @ViewChild(MatStepper) stepper!: MatStepper;
@@ -115,135 +115,137 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     protected readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly noticeService: NoticeService
-  ) {
-    super();
-  }
+  ) {}
 
   ngOnInit(): void {
-    this.subscribe(
-      this.draftSourcesService.getDraftProjectSources().pipe(
-        filter(({ trainingTargets, draftingSources }) => {
+    combineLatest([this.draftSourcesService.getDraftProjectSources(), this.activatedProject.projectId$])
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        filter(([{ trainingTargets, draftingSources }], projectId) => {
           this.setProjectDisplayNames(trainingTargets[0], draftingSources[0]);
-          return trainingTargets[0] != null && draftingSources[0] != null;
-        })
-      ),
-      // Build book lists
-      async ({ trainingTargets, trainingSources, draftingSources }) => {
-        // The null values will have been filtered above
-        const target = trainingTargets[0]!;
-        const draftingSource = draftingSources[0]!;
-        // If both source and target project languages are in the NLLB,
-        // training book selection is optional (and discouraged).
-        this.isTrainingOptional =
-          (await this.nllbLanguageService.isNllbLanguageAsync(target.writingSystem.tag)) &&
-          (await this.nllbLanguageService.isNllbLanguageAsync(draftingSource.writingSystem.tag));
-
-        this.trainingSources = trainingSources.filter(s => s !== undefined) ?? [];
-        this.trainingTargets = trainingTargets.filter(t => t !== undefined) ?? [];
-
-        const draftingSourceBooks = new Set<number>();
-        for (const text of draftingSource.texts) {
-          draftingSourceBooks.add(text.bookNum);
-        }
-
-        let trainingSourceBooks: Set<number> = new Set<number>(trainingSources[0]?.texts.map(t => t.bookNum));
-        let additionalTrainingSourceBooks: Set<number> = new Set<number>(trainingSources[1]?.texts.map(t => t.bookNum));
-
-        this.availableTranslateBooks = [];
-        this.availableTrainingBooks[this.activatedProject.projectId] = [];
-        for (const source of this.trainingSources) {
-          this.availableTrainingBooks[source?.projectRef] = [];
-        }
-
-        // If book exists in both target and source, add to available books.
-        // Otherwise, add to unusable books.
-        // Ensure books are displayed in ascending canonical order.
-        const targetBooks = new Set<number>();
-        for (const text of target.texts.slice().sort((a, b) => a.bookNum - b.bookNum)) {
-          const bookNum = text.bookNum;
-          targetBooks.add(bookNum);
-
-          // Exclude non-canonical books
-          if (Canon.isExtraMaterial(bookNum)) {
-            continue;
-          }
-
-          // Translate books
-          if (draftingSourceBooks.has(bookNum)) {
-            this.availableTranslateBooks.push({ number: bookNum, selected: false });
-          } else {
-            this.unusableTranslateSourceBooks.push(bookNum);
-          }
-
-          // Training books
-          let isPresentInASource = false;
-          if (trainingSourceBooks.has(bookNum)) {
-            this.availableTrainingBooks[trainingSources[0].projectRef].push({ number: bookNum, selected: false });
-            isPresentInASource = true;
-          } else {
-            this.unusableTrainingSourceBooks.push(bookNum);
-          }
-          if (additionalTrainingSourceBooks != null && additionalTrainingSourceBooks.has(bookNum)) {
-            this.availableTrainingBooks[trainingSources[1].projectRef].push({ number: bookNum, selected: false });
-            isPresentInASource = true;
-          }
-          if (isPresentInASource) {
-            this.availableTrainingBooks[this.activatedProject.projectId].push({ number: bookNum, selected: false });
-          }
-        }
-
-        this.setInitialTrainingBooks();
-        this.setInitialTranslateBooks();
-
-        // Store the books that are not in the target
-        this.unusableTrainingTargetBooks = [...trainingSourceBooks].filter(
-          bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
-        );
-        this.unusableTranslateTargetBooks = [...draftingSourceBooks].filter(
-          bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
-        );
-
-        this.hasLoaded = true;
-      }
-    );
-
-    // Get the training data files for the project
-    this.subscribe(
-      this.activatedProject.projectDoc$.pipe(
-        filterNullish(),
-        tap(async projectDoc => {
-          // Query for all training data files in the project
-          this.trainingDataQuery?.dispose();
-          this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(
-            projectDoc.id,
-            this.destroyRef
-          );
-          let projectChanged: boolean = true;
-
-          // Subscribe to this query, and show these
-          this.trainingDataSub?.unsubscribe();
-          this.trainingDataSub = this.subscribe(
-            merge(
-              this.trainingDataQuery.localChanges$,
-              this.trainingDataQuery.ready$,
-              this.trainingDataQuery.remoteChanges$,
-              this.trainingDataQuery.remoteDocChanges$
-            ),
-            () => {
-              this.availableTrainingFiles = [];
-              if (projectDoc.data?.translateConfig.draftConfig.additionalTrainingData) {
-                this.availableTrainingFiles =
-                  this.trainingDataQuery?.docs.filter(d => d.data != null).map(d => d.data!) ?? [];
-              }
-              if (projectChanged) {
-                // Set the selection based on previous builds
-                projectChanged = false;
-                this.setInitialTrainingDataFiles(this.availableTrainingFiles.map(d => d.dataId));
-              }
-            }
-          );
+          return trainingTargets[0] != null && draftingSources[0] != null && projectId != null;
         })
       )
+      .subscribe(
+        // Build book lists
+        async ([{ trainingTargets, trainingSources, draftingSources }, projectId]) => {
+          // The null values will have been filtered above
+          const target = trainingTargets[0]!;
+          const draftingSource = draftingSources[0]!;
+          // If both source and target project languages are in the NLLB,
+          // training book selection is optional (and discouraged).
+          this.isTrainingOptional =
+            (await this.nllbLanguageService.isNllbLanguageAsync(target.writingSystem.tag)) &&
+            (await this.nllbLanguageService.isNllbLanguageAsync(draftingSource.writingSystem.tag));
+
+          this.trainingSources = trainingSources.filter(s => s !== undefined) ?? [];
+          this.trainingTargets = trainingTargets.filter(t => t !== undefined) ?? [];
+
+          const draftingSourceBooks = new Set<number>();
+          for (const text of draftingSource.texts) {
+            draftingSourceBooks.add(text.bookNum);
+          }
+
+          let trainingSourceBooks: Set<number> = new Set<number>(trainingSources[0]?.texts.map(t => t.bookNum));
+          let additionalTrainingSourceBooks: Set<number> = new Set<number>(
+            trainingSources[1]?.texts.map(t => t.bookNum)
+          );
+
+          this.availableTranslateBooks = [];
+          this.availableTrainingBooks[projectId!] = [];
+          for (const source of this.trainingSources) {
+            this.availableTrainingBooks[source?.projectRef] = [];
+          }
+
+          // If book exists in both target and source, add to available books.
+          // Otherwise, add to unusable books.
+          // Ensure books are displayed in ascending canonical order.
+          const targetBooks = new Set<number>();
+          for (const text of target.texts.slice().sort((a, b) => a.bookNum - b.bookNum)) {
+            const bookNum = text.bookNum;
+            targetBooks.add(bookNum);
+
+            // Exclude non-canonical books
+            if (Canon.isExtraMaterial(bookNum)) {
+              continue;
+            }
+
+            // Translate books
+            if (draftingSourceBooks.has(bookNum)) {
+              this.availableTranslateBooks.push({ number: bookNum, selected: false });
+            } else {
+              this.unusableTranslateSourceBooks.push(bookNum);
+            }
+
+            // Training books
+            let isPresentInASource = false;
+            if (trainingSourceBooks.has(bookNum)) {
+              this.availableTrainingBooks[trainingSources[0]!.projectRef].push({ number: bookNum, selected: false });
+              isPresentInASource = true;
+            } else {
+              this.unusableTrainingSourceBooks.push(bookNum);
+            }
+            if (
+              trainingSources[1] != null &&
+              additionalTrainingSourceBooks != null &&
+              additionalTrainingSourceBooks.has(bookNum)
+            ) {
+              this.availableTrainingBooks[trainingSources[1].projectRef].push({ number: bookNum, selected: false });
+              isPresentInASource = true;
+            }
+            if (isPresentInASource) {
+              this.availableTrainingBooks[projectId!].push({ number: bookNum, selected: false });
+            }
+          }
+
+          this.setInitialTrainingBooks(projectId!);
+          this.setInitialTranslateBooks();
+
+          // Store the books that are not in the target
+          this.unusableTrainingTargetBooks = [...trainingSourceBooks].filter(
+            bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
+          );
+          this.unusableTranslateTargetBooks = [...draftingSourceBooks].filter(
+            bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
+          );
+
+          this.hasLoaded = true;
+        }
+      );
+
+    // Get the training data files for the project
+
+    this.activatedProject.projectDoc$.pipe(
+      takeUntilDestroyed(this.destroyRef),
+      filterNullish(),
+      tap(async projectDoc => {
+        // Query for all training data files in the project
+        this.trainingDataQuery?.dispose();
+        this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id, this.destroyRef);
+        let projectChanged: boolean = true;
+
+        // Subscribe to this query, and show these
+        this.trainingDataSub?.unsubscribe();
+        this.trainingDataSub = merge(
+          this.trainingDataQuery.localChanges$,
+          this.trainingDataQuery.ready$,
+          this.trainingDataQuery.remoteChanges$,
+          this.trainingDataQuery.remoteDocChanges$
+        )
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe(() => {
+            this.availableTrainingFiles = [];
+            if (projectDoc.data?.translateConfig.draftConfig.additionalTrainingData) {
+              this.availableTrainingFiles =
+                this.trainingDataQuery?.docs.filter(d => d.data != null).map(d => d.data!) ?? [];
+            }
+            if (projectChanged) {
+              // Set the selection based on previous builds
+              projectChanged = false;
+              this.setInitialTrainingDataFiles(this.availableTrainingFiles.map(d => d.dataId));
+            }
+          });
+      })
     );
   }
 
@@ -260,7 +262,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     return this.trainingSources[0]?.shortName ?? '';
   }
 
-  private _booksToTranslate: Book[];
+  private _booksToTranslate?: Book[];
   booksToTranslate(): Book[] {
     const value = this.availableTranslateBooks?.filter(b => b.selected) ?? [];
     if (this._booksToTranslate?.toString() !== value?.toString()) {
@@ -277,7 +279,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     const contiguousGroups: TrainingGroup[] = [];
     for (const projectRef in this.availableTrainingBooks) {
       if (projectRef === this.activatedProject.projectId) continue; //target would be a duplicate here
-      const sourceShortName = this.trainingSources.find(s => s.projectRef === projectRef).shortName;
+      const sourceShortName = this.trainingSources.find(s => s.projectRef === projectRef)!.shortName;
 
       let currentGroup: Book[] = [];
       for (const book of this.availableTrainingBooks[projectRef].filter(b => b.selected)) {
@@ -326,7 +328,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   private _selectableTrainingBooks: { [projectRef: string]: Book[] } = {};
-  selectableTrainingBooksByProj(projectRef: string): Book[] {
+  selectableTrainingBooksByProj(projectRef?: string): Book[] {
+    if (this.activatedProject.projectId == null || projectRef == null) return [];
     //start with the books in source and target
     const booksInTargetAndSource = this.availableTrainingBooks[projectRef] ?? [];
     //filter out selected books to draft
@@ -343,7 +346,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
       value = booksNotBeingTranslated.filter(b => translatedBooks.find(x => x.number === b.number));
     }
 
-    if (this._selectableTrainingBooks[projectRef]?.toString() !== value?.toString()) {
+    if (this._selectableTrainingBooks[projectRef]?.toString() !== value.toString()) {
       this._selectableTrainingBooks[projectRef] = value;
     }
 
@@ -351,7 +354,8 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   private _selectedTrainingBooks: { [projectRef: string]: Book[] } = {};
-  selectedTrainingBooksByProj(projectRef: string): Book[] {
+  selectedTrainingBooksByProj(projectRef?: string): Book[] {
+    if (projectRef == null) return [];
     const value = this.availableTrainingBooks[projectRef]?.filter(b => b.selected) ?? [];
     if (this._selectedTrainingBooks[projectRef]?.toString() !== value?.toString()) {
       this._selectedTrainingBooks[projectRef] = value;
@@ -361,6 +365,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
   }
 
   onTranslatedBookSelect(selectedBooks: number[]): void {
+    if (this.activatedProject.projectId == null) return;
     //update selections in translated books
     for (const book of this.availableTrainingBooks[this.activatedProject.projectId]) {
       book.selected = selectedBooks.includes(book.number);
@@ -472,7 +477,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
     }
   }
 
-  private setInitialTrainingBooks(): void {
+  private setInitialTrainingBooks(targetProjectId: string): void {
     // Get the previously selected training books from the target project
     const previousTraining =
       this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.lastSelectedTrainingScriptureRanges ?? [];
@@ -494,9 +499,7 @@ export class DraftGenerationStepsComponent extends SubscriptionDisposable implem
             sourceBook.selected = true;
           }
           //select in the target
-          const targetBook = this.availableTrainingBooks[this.activatedProject.projectId].find(
-            b => b.number === bookNum
-          );
+          const targetBook = this.availableTrainingBooks[targetProjectId].find(b => b.number === bookNum);
           if (targetBook !== undefined) {
             targetBook.selected = true;
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -939,6 +939,8 @@ describe('DraftGenerationComponent', () => {
                 {
                   name: 'source',
                   shortName: 'SRC',
+                  projectRef: 'source',
+                  paratextId: 'PT_SRC',
                   texts: [],
                   writingSystem: {
                     tag: 'es'
@@ -967,6 +969,8 @@ describe('DraftGenerationComponent', () => {
                 {
                   name: 'source',
                   shortName: 'SRC',
+                  projectRef: 'source',
+                  paratextId: 'PT_SRC',
                   texts: [],
                   writingSystem: {
                     tag: 'es'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -432,7 +432,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
       trainingScriptureRange: result.trainingScriptureRange,
       trainingScriptureRanges: result.trainingScriptureRanges,
       translationScriptureRange: result.translationScriptureRange,
-      translationScriptureRanges: result.translationScriptureRanges,
+      translationScriptureRanges: result.translationScriptureRanges || [],
       fastTraining: result.fastTraining
     });
   }
@@ -455,7 +455,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   }
 
   isSyncing(): boolean {
-    return this.activatedProject.projectDoc.data.sync.queuedCount > 0;
+    return this.activatedProject.projectDoc?.data != null && this.activatedProject.projectDoc.data.sync.queuedCount > 0;
   }
 
   isDraftQueued(job?: BuildDto): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -110,8 +110,8 @@ describe('DraftPreviewBooks', () => {
     env.component.confirmAndAddToProjectAsync(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    expect(env.draftApplyProgress.chaptersApplied).toEqual([2]);
-    expect(env.draftApplyProgress.completed).toBe(true);
+    expect(env.draftApplyProgress!.chaptersApplied).toEqual([2]);
+    expect(env.draftApplyProgress!.completed).toBe(true);
     verify(mockedDialogService.confirmWithOptions(anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
     verify(mockedErrorReportingService.silentError(anything(), anything())).once();
@@ -139,8 +139,8 @@ describe('DraftPreviewBooks', () => {
     env.component.confirmAndAddToProjectAsync(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    expect(env.draftApplyProgress.chaptersApplied).toEqual([1, 2, 3]);
-    expect(env.draftApplyProgress.completed).toBe(true);
+    expect(env.draftApplyProgress!.chaptersApplied).toEqual([1, 2, 3]);
+    expect(env.draftApplyProgress!.completed).toBe(true);
     verify(mockedDialogService.confirmWithOptions(anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
   }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.spec.ts
@@ -59,6 +59,7 @@ describe('DraftSourcesService', () => {
         translateConfig: {
           source: {
             projectRef: 'source_project',
+            paratextId: 'PT_SP',
             name: 'Source Project',
             shortName: 'SP',
             writingSystem: {
@@ -68,6 +69,7 @@ describe('DraftSourcesService', () => {
           draftConfig: {
             alternateSource: {
               projectRef: 'alternate_source_project',
+              paratextId: 'PT_ASP',
               name: 'Alternate Source Project',
               shortName: 'ASP',
               writingSystem: {
@@ -76,6 +78,7 @@ describe('DraftSourcesService', () => {
             },
             alternateTrainingSource: {
               projectRef: 'alternate_training_source_project',
+              paratextId: 'PT_ATSP',
               name: 'Alternate Training Source Project',
               shortName: 'ATSP',
               writingSystem: {
@@ -86,6 +89,7 @@ describe('DraftSourcesService', () => {
             alternateTrainingSourceEnabled: true,
             additionalTrainingSource: {
               projectRef: 'additional_training_source_project',
+              paratextId: 'PT_ADSP',
               name: 'Additional Training Source Project',
               shortName: 'ADSP',
               writingSystem: {
@@ -98,6 +102,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -110,7 +115,7 @@ describe('DraftSourcesService', () => {
               name: 'Alternate Source Project',
               projectRef: 'alternate_source_project',
               shortName: 'ASP',
-              paratextId: undefined,
+              paratextId: 'PT_ASP',
               texts: [],
               writingSystem: {
                 tag: 'en_NZ'
@@ -123,7 +128,7 @@ describe('DraftSourcesService', () => {
               name: 'Alternate Training Source Project',
               projectRef: 'alternate_training_source_project',
               shortName: 'ATSP',
-              paratextId: undefined,
+              paratextId: 'PT_ATSP',
               texts: [],
               writingSystem: {
                 tag: 'en_AU'
@@ -134,7 +139,7 @@ describe('DraftSourcesService', () => {
               name: 'Additional Training Source Project',
               projectRef: 'additional_training_source_project',
               shortName: 'ADSP',
-              paratextId: undefined,
+              paratextId: 'PT_ADSP',
               texts: [],
               writingSystem: {
                 tag: 'en_UK'
@@ -203,6 +208,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -267,6 +273,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -287,6 +294,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -315,6 +323,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -335,6 +344,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -363,6 +373,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );
@@ -383,6 +394,7 @@ describe('DraftSourcesService', () => {
       });
       when(mockActivatedProjectService.projectDoc$).thenReturn(
         new BehaviorSubject<SFProjectProfileDoc>({
+          id: 'project01',
           data: targetProject
         } as SFProjectProfileDoc)
       );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources.service.ts
@@ -22,7 +22,7 @@ interface DraftSourceDoc {
 
 export interface DraftSourcesAsArrays {
   trainingSources: [DraftSource?, DraftSource?];
-  trainingTargets: [DraftSource];
+  trainingTargets: [DraftSource?];
   draftingSources: [DraftSource?];
 }
 
@@ -76,19 +76,19 @@ export class DraftSourcesService {
         let alternateSourceProject = this.getDraftSource(
           alternateSourceProjectId,
           currentUser,
-          targetDoc?.data?.translateConfig?.draftConfig?.alternateSource
+          translateConfig?.draftConfig?.alternateSource
         );
 
         // If the user cannot access the alternate training source project,
         // populate using the target's alternate training source information, if enabled
         let alternateTrainingSourceProjectId: string | undefined = translateConfig?.draftConfig
           .alternateTrainingSourceEnabled
-          ? translateConfig.draftConfig.alternateTrainingSource?.projectRef
+          ? translateConfig?.draftConfig.alternateTrainingSource?.projectRef
           : undefined;
         let alternateTrainingSourceProject = this.getDraftSource(
           alternateTrainingSourceProjectId,
           currentUser,
-          targetDoc?.data?.translateConfig?.draftConfig?.alternateTrainingSource
+          translateConfig?.draftConfig?.alternateTrainingSource
         );
 
         // If the user cannot access the additional training source project,
@@ -100,7 +100,7 @@ export class DraftSourcesService {
         let additionalTrainingSourceProject = this.getDraftSource(
           additionalTrainingSourceProjectId,
           currentUser,
-          targetDoc?.data?.translateConfig?.draftConfig?.additionalTrainingSource
+          translateConfig?.draftConfig?.additionalTrainingSource
         );
 
         // Include the source projects, if they exist
@@ -121,24 +121,27 @@ export class DraftSourcesService {
           ])
         ).pipe(
           map(([sourceDoc, alternateSourceDoc, alternateTrainingSourceDoc, additionalTrainingSourceProjectDoc]) => {
-            let draftingSource: DraftSource = alternateSourceDoc
-              ? { ...alternateSourceDoc?.data, projectRef: alternateSourceProjectId }
-              : { ...sourceDoc?.data, projectRef: sourceProjectId };
-            let trainingSource: DraftSource = alternateTrainingSourceDoc
-              ? { ...alternateTrainingSourceDoc?.data, projectRef: alternateTrainingSourceProjectId }
-              : { ...sourceDoc?.data, projectRef: sourceProjectId };
-            let additionalTrainingSource: DraftSource = additionalTrainingSourceProjectDoc
-              ? { ...additionalTrainingSourceProjectDoc?.data, projectRef: additionalTrainingSourceProjectId }
-              : undefined;
-            let target = { ...targetDoc?.data, projectRef: this.activatedProject.projectId };
-
-            if (!draftingSource?.projectRef) draftingSource = undefined;
-            if (!trainingSource?.projectRef) trainingSource = undefined;
-            if (!additionalTrainingSource?.projectRef) additionalTrainingSource = undefined;
-            if (!target?.projectRef) target = undefined;
+            let draftingSource: DraftSource | undefined =
+              alternateSourceDoc?.data != null
+                ? { ...alternateSourceDoc.data, projectRef: alternateSourceProjectId! }
+                : sourceDoc?.data != null
+                  ? { ...sourceDoc.data, projectRef: sourceProjectId! }
+                  : undefined;
+            let trainingSource: DraftSource | undefined =
+              alternateTrainingSourceDoc?.data != null
+                ? { ...alternateTrainingSourceDoc.data, projectRef: alternateTrainingSourceProjectId! }
+                : sourceDoc?.data != null
+                  ? { ...sourceDoc.data, projectRef: sourceProjectId! }
+                  : undefined;
+            let additionalTrainingSource: DraftSource | undefined =
+              additionalTrainingSourceProjectDoc?.data != null
+                ? { ...additionalTrainingSourceProjectDoc.data, projectRef: additionalTrainingSourceProjectId! }
+                : undefined;
+            let target: DraftSource | undefined =
+              targetDoc?.data != null ? { ...targetDoc.data, projectRef: targetDoc.id } : undefined;
 
             return {
-              trainingSources: [trainingSource, additionalTrainingSource] as [DraftSource?, DraftSource?],
+              trainingSources: [trainingSource, additionalTrainingSource] as [DraftSource, DraftSource],
               trainingTargets: [target] as [DraftSource],
               draftingSources: [draftingSource] as [DraftSource]
             };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1588,10 +1588,10 @@ describe('EditorComponent', () => {
       });
       const textDoc: TextDoc = env.getTextDoc(new TextDocId('project01', 40, 1));
       const textOps = textDoc.data!.ops!;
-      expect(textOps[2].insert['verse']['number']).toBe('1');
+      expect(textOps[2].insert!['verse']['number']).toBe('1');
       expect(textOps[3].insert).toBe('target: chapter 1, verse 1.');
       expect(textOps[5].insert).toBe('t');
-      expect(contents.ops![verse1EmbedIndex]!.insert['verse']['number']).toBe('1');
+      expect(contents.ops![verse1EmbedIndex]!.insert!['verse']['number']).toBe('1');
       expect(contents.ops![verse1SegmentIndex].insert).toBe('target: ');
       expect(contents.ops![verse1NoteIndex]!.attributes!['iconsrc']).toBe(
         '--icon-file: url(/assets/icons/TagIcons/01flag1.png);'
@@ -2459,15 +2459,15 @@ describe('EditorComponent', () => {
       let contents: Delta = env.targetEditor.getContents(range.index, 3);
       expect(contents.length()).toEqual(3);
       expect(contents.ops![0].insert).toEqual('t');
-      expect(contents.ops![1].insert['verse']).toBeDefined();
-      expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+      expect(contents.ops![1].insert!['verse']).toBeDefined();
+      expect(contents.ops![2].insert!['note-thread-embed']).toBeDefined();
 
       env.backspace();
       contents = env.targetEditor.getContents(range.index, 3);
       expect(contents.length()).toEqual(3);
       expect((contents.ops![0].insert as any).blank).toBeDefined();
-      expect(contents.ops![1].insert['verse']).toBeDefined();
-      expect(contents.ops![2].insert['note-thread-embed']).toBeDefined();
+      expect(contents.ops![1].insert!['verse']).toBeDefined();
+      expect(contents.ops![2].insert!['note-thread-embed']).toBeDefined();
       env.dispose();
     }));
 
@@ -3878,7 +3878,9 @@ describe('EditorComponent', () => {
 
       it('should exclude deleted resource tabs (tabs that have "projectDoc" but not "projectDoc.data")', fakeAsync(async () => {
         const absentProjectId = 'absentProjectId';
-        when(mockedSFProjectService.getProfile(absentProjectId)).thenResolve({ data: null } as SFProjectProfileDoc);
+        when(mockedSFProjectService.getProfile(absentProjectId)).thenResolve({
+          data: undefined
+        } as SFProjectProfileDoc);
         const env = new TestEnvironment();
         env.setProjectUserConfig({
           editorTabsOpen: [{ tabType: 'project-resource', groupId: 'target', projectId: absentProjectId }]
@@ -4944,10 +4946,10 @@ class TestEnvironment {
   }
 
   backspace(): void {
-    const selection: Range = this.targetEditor.getSelection();
+    const selection: Range = this.targetEditor.getSelection()!;
     const testUserEvent: UserEvent = userEvent.setup();
     const [leaf] = this.targetEditor.getLeaf(selection.index);
-    testUserEvent.type(leaf.parent.domNode, '{Backspace}'); // This will trigger the 'isBackspaceAllowed' check
+    testUserEvent.type(leaf!.parent.domNode, '{Backspace}'); // This will trigger the 'isBackspaceAllowed' check
     this.wait();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -467,7 +467,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get canShare(): boolean {
     return (
-      this.projectDoc != null &&
+      this.projectDoc?.data != null &&
       SF_PROJECT_RIGHTS.hasRight(
         this.projectDoc.data,
         this.userService.currentUserId,
@@ -893,7 +893,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       }
 
       if (delta?.ops != null) {
-        const retainCount: number = getRetainCount(delta.ops[0]);
+        const retainCount: number | undefined = getRetainCount(delta.ops[0]);
         const insertText: string | undefined = isString(delta.ops[1]?.insert) ? delta.ops[1].insert : undefined;
         // insert a space if the user just inserted a suggestion and started typing
         if (
@@ -2363,7 +2363,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         return curIndex;
       }
 
-      const retainCount: number | undefined = getRetainCount(op) ?? 0;
+      const retainCount: number = getRetainCount(op) ?? 0;
       curIndex += retainCount;
     }
     return undefined;
@@ -2475,13 +2475,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     const targetRange: Range = this.target.segment.range;
-    const targetSelectionBounds: DOMRect | Bounds = this.target.editor.selection.getBounds(targetRange.index);
+    const targetSelectionBounds: DOMRect | Bounds = this.target.editor.selection.getBounds(targetRange.index)!;
 
     const sourceRange: Range = this.source.segment.range;
     const sourceSelectionBounds: DOMRect | Bounds = this.source.editor.selection.getBounds(
       sourceRange.index,
       sourceRange.length
-    );
+    )!;
 
     let newScrollTop: number =
       this.sourceScrollContainer.scrollTop + sourceSelectionBounds.top - targetSelectionBounds.top;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -224,12 +224,12 @@ export class SuggestionsComponent extends SubscriptionDisposable implements OnDe
     }
     const reference = this.editor.getBounds(selection.index, selection.length);
     // root.scrollTop should be 0 if scrollContainer !== root
-    this.top = reference.bottom + this.editor.root.scrollTop + 5;
+    this.top = reference!.bottom + this.editor.root.scrollTop + 5;
     const suggestionBounds = this.root.getBoundingClientRect();
     const editorBounds = this.editor.root.getBoundingClientRect();
 
-    let newLeft: number | undefined = reference.left + 1;
-    let newRight: number | undefined = editorBounds.width - reference.left - 1;
+    let newLeft: number | undefined = reference!.left + 1;
+    let newRight: number | undefined = editorBounds.width - reference!.left - 1;
     const leftExceedsBounds = newLeft + suggestionBounds.width > editorBounds.width;
     const rightExceedsBounds = newRight + suggestionBounds.width > editorBounds.width;
     if ((this.text?.isRtl && !rightExceedsBounds) || (leftExceedsBounds && newRight < newLeft)) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-persistence.service.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { cloneDeep } from 'lodash-es';
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
-import { Subject, of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { UserService } from 'xforge-common/user.service';
@@ -50,7 +50,7 @@ describe('EditorTabPersistenceService', () => {
   it('should not return invalid persisted tabs', fakeAsync(() => {
     const tabs = [{ tabType: 'invalid' }, { tabType: 'biblical-terms' }] as unknown as EditorTabPersistData[];
     const env = new TestEnvironment(tabs);
-    let persistedTabs = [];
+    let persistedTabs: EditorTabPersistData[] = [];
     env.service.persistedTabs$.subscribe(tabs => {
       persistedTabs = tabs;
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.ts
@@ -322,7 +322,7 @@ export class TranslateMetricsSession extends SubscriptionDisposable {
 
   private incrementMetric(metric: Extract<keyof TranslateMetrics, string>, amount: number = 1): void {
     if (this.metrics[metric] == null) {
-      (this.metrics[metric] as number) = 0;
+      (this.metrics[metric] as unknown as number) = 0;
     }
     (this.metrics[metric] as number) += amount;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/font.service.ts
@@ -78,7 +78,6 @@ export class FontService {
       project = project.data;
     }
 
-    // @ts-expect-error the update to TS ~5.5.4 throws TS2339:
     // Property 'defaultFont' does not exist on type 'SFProjectProfileDoc'
     // SFProjectProfileDoc ultimately extends SFProjectProfile, which has the defaultFont property
     return this.getCSSFontName(project?.defaultFont);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -415,7 +415,7 @@ export class I18nService {
   static getHumanReadableTimeZoneOffset(localeCode: string, date: Date): string {
     return new Intl.DateTimeFormat(localeCode, { timeZoneName: 'short' })
       .formatToParts(date)
-      .find(e => e.type === 'timeZoneName').value;
+      .find(e => e.type === 'timeZoneName')!.value;
   }
 
   /** Takes a number and returns a rule representing the plural-related rule for the current locale.

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/sharedb-realtime-remote-store.ts
@@ -291,7 +291,7 @@ export class SharedbRealtimeDocAdapter implements RealtimeDocAdapter {
    * pending ops to IndexedDB so they can be sent to the server when the connection is restored.
    */
   get pendingOps(): any[] {
-    let pendingOps = [];
+    let pendingOps: any[] = [];
     if (this.doc.hasWritePending()) {
       pendingOps = this.doc.pendingOps.slice();
 

--- a/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
+++ b/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Enabling strict null checking will help strongly type objects and values and will produce compile time errors if a type does not match the declared type.
I am marking this as testing not required. This will be tested on the full regression run when it goes to QA. We likely want to hold merging this one until PR #2787 is merged to QA and tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2952)
<!-- Reviewable:end -->
