### PR TITLE
SF-3126 Combine Add Draft dialogs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -94,14 +94,13 @@ export class ProjectSelectComponent extends SubscriptionDisposable implements Co
   }
 
   @Input() set value(id: string) {
-    if (this.paratextIdControl?.value.paratextId !== id) {
-      const project =
-        this.projects?.find(p => p.paratextId === id) ||
-        this.resources?.find(r => r.paratextId === id) ||
-        this.nonSelectableProjects?.find(p => p.paratextId === id);
-      if (project != null) {
-        this.paratextIdControl.setValue(project);
-      }
+    if (this.paratextIdControl?.value.paratextId === id) return;
+    const project =
+      this.projects?.find(p => p.paratextId === id) ||
+      this.resources?.find(r => r.paratextId === id) ||
+      this.nonSelectableProjects?.find(p => p.paratextId === id);
+    if (project != null) {
+      this.paratextIdControl.setValue(project);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -94,12 +94,14 @@ export class ProjectSelectComponent extends SubscriptionDisposable implements Co
   }
 
   @Input() set value(id: string) {
-    const project =
-      this.projects?.find(p => p.paratextId === id) ||
-      this.resources?.find(r => r.paratextId === id) ||
-      this.nonSelectableProjects?.find(p => p.paratextId === id);
-    if (project != null) {
-      this.paratextIdControl.setValue(project);
+    if (this.paratextIdControl?.value.paratextId !== id) {
+      const project =
+        this.projects?.find(p => p.paratextId === id) ||
+        this.resources?.find(r => r.paratextId === id) ||
+        this.nonSelectableProjects?.find(p => p.paratextId === id);
+      if (project != null) {
+        this.paratextIdControl.setValue(project);
+      }
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -6,35 +6,35 @@
   <h2 mat-dialog-title>{{ t("select_alternate_project") }}</h2>
   <div mat-dialog-content>
     <form [formGroup]="addToProjectForm">
-      <app-project-select
-        [projects]="projects"
-        [placeholder]="t('choose_project')"
-        [isDisabled]="projects.length === 0"
-        [invalidMessageMapper]="invalidMessageMapper"
-        (projectSelect)="projectSelected($event.paratextId)"
-        formControlName="targetParatextId"
-      ></app-project-select>
+      @if (!isLoading) {
+        <app-project-select
+          [projects]="projects"
+          [placeholder]="t('choose_project')"
+          [isDisabled]="projects.length === 0"
+          [invalidMessageMapper]="invalidMessageMapper"
+          (projectSelect)="projectSelected($event.paratextId)"
+          formControlName="targetParatextId"
+        ></app-project-select>
+      }
       @if (!isAppOnline) {
         <mat-error class="offline-message">{{ t("connect_to_the_internet") }}</mat-error>
       }
-      @if (targetProject$ | async; as project) {
+      @if (projectSelectValid && canEditProject) {
         <div class="target-project-content">
           @if (targetChapters$ | async; as chapters) {
             <app-notice icon="warning" type="warning"
               >{{
                 i18n.getPluralRule(chapters) !== "one"
-                  ? t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName: project.name })
-                  : t("project_has_text_in_one_chapter", { bookName, projectName: project.name })
+                  ? t("project_has_text_in_chapters", { bookName, numChapters: chapters, projectName })
+                  : t("project_has_text_in_one_chapter", { bookName, projectName })
               }}
             </app-notice>
           } @else {
-            <app-notice [icon]="'verified'">{{
-              t("book_is_empty", { bookName, projectName: project.name })
-            }}</app-notice>
+            <app-notice [icon]="'verified'">{{ t("book_is_empty", { bookName, projectName }) }}</app-notice>
           }
         </div>
         <mat-checkbox class="overwrite-content" formControlName="overwrite">{{
-          t("i_understand_overwrite_book", { projectName: project.name, bookName })
+          t("i_understand_overwrite_book", { projectName, bookName })
         }}</mat-checkbox>
         <mat-error class="form-error" [ngClass]="{ visible: addToProjectClicked && !overwriteConfirmed }">{{
           t("confirm_overwrite")

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.html
@@ -19,7 +19,7 @@
       @if (!isAppOnline) {
         <mat-error class="offline-message">{{ t("connect_to_the_internet") }}</mat-error>
       }
-      @if (projectSelectValid && canEditProject) {
+      @if (isValid) {
         <div class="target-project-content">
           @if (targetChapters$ | async; as chapters) {
             <app-notice icon="warning" type="warning"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -188,6 +188,7 @@ export class DraftApplyDialogComponent implements OnInit {
   }
 
   private validateProject(): void {
+    // setTimeout prevents a "changed after checked" exception
     setTimeout(() => this.projectSelect?.customValidate(SFValidators.customValidator(this.getCustomErrorState())));
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -70,6 +70,7 @@ export class DraftApplyDialogComponent implements OnInit {
   // the project id to add the draft to
   private targetProjectId?: string;
   private paratextIdToProjectId: Map<string, string> = new Map<string, string>();
+  isValid: boolean = false;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: DraftApplyDialogConfig,
@@ -188,8 +189,11 @@ export class DraftApplyDialogComponent implements OnInit {
   }
 
   private validateProject(): void {
-    // setTimeout prevents a "changed after checked" exception
-    setTimeout(() => this.projectSelect?.customValidate(SFValidators.customValidator(this.getCustomErrorState())));
+    // setTimeout prevents a "changed after checked" exception (may be removable after SF-3014)
+    setTimeout(() => {
+      this.isValid = this.getCustomErrorState() === CustomErrorState.None;
+      this.projectSelect?.customValidate(SFValidators.customValidator(this.getCustomErrorState()));
+    });
   }
 
   private async chaptersWithTextAsync(project: SFProjectProfile): Promise<number> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -29,7 +29,7 @@ export interface DraftApplyDialogResult {
 }
 
 export interface DraftApplyDialogConfig {
-  initialParatextId: string;
+  initialParatextId?: string;
   bookNum: number;
   chapters: number[];
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslocoModule, translate } from '@ngneat/transloco';
+import { translate, TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
@@ -29,6 +29,7 @@ export interface DraftApplyDialogResult {
 }
 
 export interface DraftApplyDialogConfig {
+  initialParatextId: string;
   bookNum: number;
   chapters: number[];
 }
@@ -41,12 +42,12 @@ export interface DraftApplyDialogConfig {
   styleUrl: './draft-apply-dialog.component.scss'
 })
 export class DraftApplyDialogComponent implements OnInit {
-  @ViewChild(ProjectSelectComponent) projectSelect!: ProjectSelectComponent;
+  @ViewChild(ProjectSelectComponent) projectSelect?: ProjectSelectComponent;
 
   _projects?: SFProjectProfile[];
-  isLoading: boolean = false;
+  protected isLoading: boolean = true;
   addToProjectForm = new FormGroup({
-    targetParatextId: new FormControl<string | undefined>('', Validators.required),
+    targetParatextId: new FormControl<string | undefined>(this.data.initialParatextId, Validators.required),
     overwrite: new FormControl(false, Validators.requiredTrue)
   });
   /** An observable that emits the number of chapters in the target project that have some text. */
@@ -106,6 +107,10 @@ export class DraftApplyDialogComponent implements OnInit {
     return this.addToProjectForm.controls.targetParatextId.valid;
   }
 
+  get projectName(): string {
+    return this.targetProject$.value?.name ?? '';
+  }
+
   get isAppOnline(): boolean {
     return this.onlineStatusService.isOnline;
   }
@@ -128,12 +133,15 @@ export class DraftApplyDialogComponent implements OnInit {
           return projects.sort(compareProjectsForSorting);
         })
       )
-      .subscribe(projects => (this._projects = projects));
+      .subscribe(projects => {
+        this._projects = projects;
+        this.isLoading = false;
+      });
   }
 
   addToProject(): void {
     this.addToProjectClicked = true;
-    this.projectSelect.customValidate(SFValidators.customValidator(this.getCustomErrorState()));
+    this.validateProject();
     if (!this.isAppOnline || !this.isFormValid || this.targetProjectId == null || !this.canEditProject) {
       return;
     }
@@ -150,7 +158,7 @@ export class DraftApplyDialogComponent implements OnInit {
       this.canEditProject = false;
       this.targetBookExists = false;
       this.targetProject$.next(undefined);
-      this.projectSelect.customValidate(SFValidators.customValidator(this.getCustomErrorState()));
+      this.validateProject();
       return;
     }
 
@@ -172,11 +180,15 @@ export class DraftApplyDialogComponent implements OnInit {
     } else {
       this.targetProject$.next(undefined);
     }
-    this.projectSelect.customValidate(SFValidators.customValidator(this.getCustomErrorState(paratextId)));
+    this.validateProject();
   }
 
   close(): void {
     this.dialogRef.close();
+  }
+
+  private validateProject(): void {
+    setTimeout(() => this.projectSelect?.customValidate(SFValidators.customValidator(this.getCustomErrorState())));
   }
 
   private async chaptersWithTextAsync(project: SFProjectProfile): Promise<number> {
@@ -196,8 +208,8 @@ export class DraftApplyDialogComponent implements OnInit {
     return textDoc.getNonEmptyVerses().length > 0;
   }
 
-  private getCustomErrorState(paratextId?: string): CustomErrorState {
-    if (!this.projectSelectValid && paratextId == null) {
+  private getCustomErrorState(): CustomErrorState {
+    if (!this.projectSelectValid) {
       return CustomErrorState.InvalidProject;
     }
     if (!this.targetBookExists) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -9,11 +9,11 @@
       </mat-button-toggle>
     </mat-button-toggle-group>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="confirmAndAddToProjectAsync(book)">
+      <button mat-menu-item (click)="chooseProjectToAddDraft(book, projectParatextId)">
         <mat-icon>input</mat-icon>{{ book.draftApplied ? t("readd_to_project") : t("add_to_project") }}
       </button>
       @if ((isProjectAdmin$ | async) === true) {
-        <button mat-menu-item (click)="chooseAlternateProjectToAddDraft(book)">
+        <button mat-menu-item (click)="chooseProjectToAddDraft(book)">
           <mat-icon>output</mat-icon>{{ t("add_to_different_project") }}
         </button>
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -89,73 +89,77 @@ describe('DraftPreviewBooks', () => {
   it('does not apply draft if user cancels', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(false);
+    setupDialog();
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).never();
   }));
 
   it('notifies user if applying a draft failed due to an error', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(true);
+    setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything()))
       .thenReject(new Error('Draft error'))
       .thenResolve(true)
       .thenResolve(false);
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
     expect(env.draftApplyProgress!.chaptersApplied).toEqual([2]);
     expect(env.draftApplyProgress!.completed).toBe(true);
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
     verify(mockedErrorReportingService.silentError(anything(), anything())).once();
-  }));
-
-  it('notifies user if they do not have permission to edit a book when applying a draft', fakeAsync(() => {
-    env = new TestEnvironment();
-    const bookWithDraft: BookWithDraft = env.booksWithDrafts[2];
-    when(mockedDialogService.message(anything())).thenResolve();
-    expect(env.getBookButtonAtIndex(2).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
-    tick();
-    env.fixture.detectChanges();
-    verify(mockedDialogService.confirmWithOptions(anything())).never();
-    verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).never();
-    verify(mockedErrorReportingService.silentError(anything(), anything())).never();
   }));
 
   it('can apply all chapters of a draft to a book', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(true);
+    setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).thenResolve(true);
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
     expect(env.draftApplyProgress!.chaptersApplied).toEqual([1, 2, 3]);
     expect(env.draftApplyProgress!.completed).toBe(true);
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
   }));
 
   it('can apply chapters with drafts and skips chapters without drafts', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[1];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(true);
+    setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).thenResolve(true);
     expect(env.getBookButtonAtIndex(1).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(1);
+  }));
+
+  it('can open dialog with the current project', fakeAsync(() => {
+    env = new TestEnvironment();
+    expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
+    const mockedDialogRef: MatDialogRef<DraftApplyDialogComponent> = mock(MatDialogRef<DraftApplyDialogComponent>);
+    when(mockedDialogRef.afterClosed()).thenReturn(of({ projectId: 'project01' }));
+    when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
+      instance(mockedDialogRef)
+    );
+    env.component.chooseProjectToAddDraft(env.booksWithDrafts[0], 'project01');
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
+    verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(
+      env.booksWithDrafts[0].chaptersWithDrafts.length
+    );
   }));
 
   it('can open dialog to apply draft to a different project', fakeAsync(() => {
@@ -166,7 +170,7 @@ describe('DraftPreviewBooks', () => {
     when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
       instance(mockedDialogRef)
     );
-    env.component.chooseAlternateProjectToAddDraft(env.booksWithDrafts[0]);
+    env.component.chooseProjectToAddDraft(env.booksWithDrafts[0]);
     tick();
     env.fixture.detectChanges();
     verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
@@ -192,12 +196,8 @@ describe('DraftPreviewBooks', () => {
 
   it('does not apply draft if user cancels applying to a different project', fakeAsync(() => {
     env = new TestEnvironment();
-    const mockedDialogRef: MatDialogRef<DraftApplyDialogComponent> = mock(MatDialogRef<DraftApplyDialogComponent>);
-    when(mockedDialogRef.afterClosed()).thenReturn(of(undefined));
-    when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
-      instance(mockedDialogRef)
-    );
-    env.component.chooseAlternateProjectToAddDraft(env.booksWithDrafts[0]);
+    setupDialog();
+    env.component.chooseProjectToAddDraft(env.booksWithDrafts[0]);
     tick();
     env.fixture.detectChanges();
     verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
@@ -208,20 +208,20 @@ describe('DraftPreviewBooks', () => {
   it('shows message to generate a new draft if legacy USFM draft', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(true);
+    setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).thenResolve(false);
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
   }));
 
   it('can track progress of chapters applied', fakeAsync(() => {
     env = new TestEnvironment();
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
-    when(mockedDialogService.confirmWithOptions(anything())).thenResolve(true);
+    setupDialog('project01');
     const resolveSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
     const promise: Promise<boolean> = new Promise<boolean>(resolve => {
       resolveSubject$.pipe(filter(value => value)).subscribe(() => resolve(true));
@@ -230,10 +230,10 @@ describe('DraftPreviewBooks', () => {
       .thenReturn(Promise.resolve(true))
       .thenReturn(promise);
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
-    env.component.confirmAndAddToProjectAsync(bookWithDraft);
+    env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
     env.fixture.detectChanges();
-    verify(mockedDialogService.confirmWithOptions(anything())).once();
+    verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(3);
     expect(env.component.numChaptersApplied).toEqual(1);
     resolveSubject$.next(true);
@@ -242,6 +242,14 @@ describe('DraftPreviewBooks', () => {
     env.fixture.detectChanges();
     expect(env.component.numChaptersApplied).toEqual(3);
   }));
+
+  function setupDialog(projectId?: string): void {
+    const mockedDialogRef: MatDialogRef<DraftApplyDialogComponent> = mock(MatDialogRef<DraftApplyDialogComponent>);
+    when(mockedDialogRef.afterClosed()).thenReturn(of(projectId ? { projectId } : undefined));
+    when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
+      instance(mockedDialogRef)
+    );
+  }
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -64,7 +64,7 @@ export class DraftPreviewBooksComponent {
     DraftApplyProgress | undefined
   >(undefined);
 
-  protected projectParatextId: string;
+  protected projectParatextId?: string;
 
   private applyChapters: number[] = [];
   private draftApplyBookNum: number = 0;
@@ -83,7 +83,7 @@ export class DraftPreviewBooksComponent {
   get isProjectAdmin$(): Observable<boolean> {
     return this.activatedProjectService.changes$.pipe(
       filterNullish(),
-      tap(p => (this.projectParatextId = p.data.paratextId)),
+      tap(p => (this.projectParatextId = p.data?.paratextId)),
       map(p => p.data?.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextAdministrator)
     );
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -144,11 +144,8 @@
     "project_name": "Project Name"
   },
   "draft_add_dialog": {
-    "add_book_to_project": "Add {{ bookName }} to project",
     "add_to_project": "Add to project",
-    "book_contents_will_be_overwritten": "Warning, this will overwrite any data in your project for the book of {{ bookName }}.",
     "cancel": "Cancel",
-    "readd_book_to_project": "Re-add {{ bookName }} to project",
     "readd_to_project": "Re-add to project"
   },
   "draft_apply_dialog": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -143,11 +143,6 @@
     "please_type_project_name": "Please type in the name of the project to confirm.",
     "project_name": "Project Name"
   },
-  "draft_add_dialog": {
-    "add_to_project": "Add to project",
-    "cancel": "Cancel",
-    "readd_to_project": "Re-add to project"
-  },
   "draft_apply_dialog": {
     "add_to_project": "Add to project",
     "book_does_not_exist": "{{ bookName }} on the selected project does not exist",


### PR DESCRIPTION
This includes:

- Delaying the creation of the project-select component until the projects list has loaded. This follows the basic pattern outlined by other usages of this component, and of course enables us to set the project on dialog creation. Setting the value programmatically after creation proved to be quite tricky, which explains why pages like Settings avoided it.

- Replaced dependence on targetProject$ in the template with the form control. Since the former was being changed in the event handler in the apply dialog, starting with a value (e.g. the current project) was causing the handler to be called immediately on dialog startup, which in turn triggered "changed after checked" exceptions. Apparently, depending on a different but equivalent property fixes this, as it likely isn't updated in quite the same cycle. I didn't solve this til much later, with it clearing up many issues, so it's possible some of my other changes aren't fully necessary.

- Using isLoading on the apply dialog. This wasn't being used at all beforehand. We consider the component to be loaded as soon as the projects are populated. This triggers the project-select to display.

- Removed a parameter from the project-select custom validation. It didn't appear to be used, though I could have been missing something.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2954)
<!-- Reviewable:end -->
