### PR TITLE
SF-3156 Warn user when mismatch in translated and training books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -138,6 +138,16 @@
             {{ t("choose_books_for_training_error") }}
           </app-notice>
         }
+        @if (!translatedBooksSelectedInTrainingSources) {
+          <app-notice class="warn-translated-books-unselected" type="warning" icon="warning">
+            {{ t("translated_book_selected_no_training_pair") }}
+          </app-notice>
+        }
+        @if (translatedBooksWithNoSource.length > 0) {
+          <app-notice class="warn-source-books-missing" type="warning" icon="warning">
+            {{ t("source_books_missing") }}
+          </app-notice>
+        }
         <div class="button-strip">
           <button mat-stroked-button matStepperPrevious>{{ t("back") }}</button>
           <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -32,6 +32,7 @@ import { TrainingDataDoc } from '../../core/models/training-data-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
+import { ProgressService } from '../../shared/progress-service/progress.service';
 import { NllbLanguageService } from '../nllb-language.service';
 import { DraftGenerationComponent } from './draft-generation.component';
 import { DraftGenerationService } from './draft-generation.service';
@@ -53,6 +54,7 @@ describe('DraftGenerationComponent', () => {
   let mockPreTranslationSignupUrlService: jasmine.SpyObj<PreTranslationSignupUrlService>;
   let mockNllbLanguageService: jasmine.SpyObj<NllbLanguageService>;
   let mockTrainingDataService: jasmine.SpyObj<TrainingDataService>;
+  let mockProgressService: jasmine.SpyObj<ProgressService>;
 
   const buildDto: BuildDto = {
     id: 'testId',
@@ -115,7 +117,8 @@ describe('DraftGenerationComponent', () => {
           { provide: PreTranslationSignupUrlService, useValue: mockPreTranslationSignupUrlService },
           { provide: NllbLanguageService, useValue: mockNllbLanguageService },
           { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-          { provide: TrainingDataService, useValue: mockTrainingDataService }
+          { provide: TrainingDataService, useValue: mockTrainingDataService },
+          { provide: ProgressService, useValue: mockProgressService }
         ]
       });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -264,12 +264,12 @@
     "no_training_books": "No training books selected",
     "overview": "Overview",
     "reference_books": "Reference books",
-    "source_books_missing": "The source for this project does not contain all the translated books. Are you sure you are using the correct source?",
+    "source_books_missing": "The reference text is missing one or more of the translated books in your project. Consider choosing a reference text that contains a match for all the translated books",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ firstTrainingSource }}).",
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
     "training_books_will_appear": "Training books will appear as you select books under translated books",
     "translated_books": "Translated books",
-    "translated_book_selected_no_training_pair": "You selected translated books but did not select matching reference books for training. Please choose matching reference books",
+    "translated_book_selected_no_training_pair": "Some of the training books you selected have no matching reference books selected. Please select matching reference books.",
     "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project."
   },
   "draft_preview_books": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -264,10 +264,12 @@
     "no_training_books": "No training books selected",
     "overview": "Overview",
     "reference_books": "Reference books",
+    "source_books_missing": "The source for this project does not contain all the translated books. Are you sure you are using the correct source?",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ firstTrainingSource }}).",
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
     "training_books_will_appear": "Training books will appear as you select books under translated books",
     "translated_books": "Translated books",
+    "translated_book_selected_no_training_pair": "You selected translated books but did not select matching reference books for training. Please choose matching reference books",
     "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project."
   },
   "draft_preview_books": {


### PR DESCRIPTION
The user should see warnings on the training step for two scenarios:

- The user's training source does not contain all of the translated books (books with more than 10 translated segments). This can indicate the user is using a source other than the one they are actually translating from.
- The user selected translated books to use for training, but did not select matching books an any of the reference projects.

Warnings will appear for the user, but they can still proceed to generate a draft.

![Draft generation training warning source](https://github.com/user-attachments/assets/9db5d87b-ea81-4a31-af55-e7c132f26241)
![Draft generation training warning books](https://github.com/user-attachments/assets/118121ed-9176-4304-87f9-651cb140585c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2956)
<!-- Reviewable:end -->
