### PR TITLE
SF-3084 Fix checking overview page not showing questions correctly

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -111,6 +111,16 @@ describe('CheckingOverviewComponent', () => {
       expect(env.noQuestionsLabel).not.toBeNull();
     }));
 
+    it('should not display loading if user is offline', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.testOnlineStatusService.setIsOnline(false);
+      tick();
+      env.fixture.detectChanges();
+      expect(env.loadingQuestionsLabel).toBeNull();
+      expect(env.noQuestionsLabel).not.toBeNull();
+      env.waitForQuestions();
+    }));
+
     it('should not display "Add question" button for community checker', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setCurrentUser(env.checkerUser);
@@ -418,6 +428,25 @@ describe('CheckingOverviewComponent', () => {
       expect(env.noArchivedQuestionsLabel).not.toBeNull();
 
       discardPeriodicTasks();
+    }));
+
+    it('should not display loading if user is offline', fakeAsync(async () => {
+      const env = new TestEnvironment();
+      const questionDoc: QuestionDoc = env.realtimeService.get(
+        QuestionDoc.COLLECTION,
+        getQuestionDocId('project01', 'q7Id')
+      );
+      await questionDoc.submitJson0Op(op => {
+        op.set(d => d.isArchived, false);
+      });
+      env.testOnlineStatusService.setIsOnline(false);
+      env.fixture.detectChanges();
+      tick();
+      env.fixture.detectChanges();
+      expect(env.loadingArchivedQuestionsLabel).toBeNull();
+      expect(env.noArchivedQuestionsLabel).not.toBeNull();
+
+      env.waitForQuestions();
     }));
 
     it('archives and republishes a question', fakeAsync(() => {
@@ -1067,6 +1096,7 @@ class TestEnvironment {
       }
     );
     this.setCurrentUser(this.adminUser);
+    this.testOnlineStatusService.setIsOnline(true);
 
     this.fixture = TestBed.createComponent(CheckingOverviewComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -75,24 +75,20 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   get showQuestionsLoadingMessage(): boolean {
-    return this.questionsQuery?.ready !== true && this.allQuestionsCount === 0;
+    return !this.questionsLoaded && this.allQuestionsCount === 0;
   }
 
   get showArchivedQuestionsLoadingMessage(): boolean {
-    return (
-      this.questionsQuery?.ready !== true &&
-      (this.questionsQuery?.docs || []).filter(qd => qd.data?.isArchived).length === 0
-    );
+    return !this.questionsLoaded && (this.questionsQuery?.docs ?? []).filter(qd => qd.data?.isArchived).length === 0;
   }
 
   get showNoQuestionsMessage(): boolean {
-    return this.questionsQuery?.ready === true && this.allQuestionsCount === 0;
+    return this.questionsLoaded && this.allQuestionsCount === 0;
   }
 
   get showNoArchivedQuestionsMessage(): boolean {
     return (
-      this.questionsQuery?.ready === true &&
-      this.questionsQuery?.docs.filter(qd => qd.data != null && qd.data.isArchived).length === 0
+      this.questionsLoaded && this.questionsQuery?.docs.filter(qd => qd.data != null && qd.data.isArchived).length === 0
     );
   }
 
@@ -192,6 +188,11 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       return [];
     }
     return this.questionsQuery.docs.filter(qd => qd.data != null && !qd.data.isArchived);
+  }
+
+  private get questionsLoaded(): boolean {
+    // if the user is offline, 'ready' will never be true, but the query will still return the offline docs
+    return !this.onlineStatusService.isOnline || this.questionsQuery?.ready === true;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
On the overview page, the user was wrongly being shown that questions were loading when they were offline. This is because the questionQuery.ready property never returns true if offline. However, the query results will still load the offline docs. This change adds checking for the online status and only shows the loading message if the user is online.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2959)
<!-- Reviewable:end -->
