### PR TITLE
Rename lint job in workflow file

### DIFF
--- a/.github/workflows/ci-lint-prettier.yml
+++ b/.github/workflows/ci-lint-prettier.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    name: check on Ubuntu Node.js
+    name: Lint and Prettier
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
When looking at a list of jobs for branch protection rules, this job in particular has a confusingly meaningless name:
![](https://github.com/user-attachments/assets/0d3a3b9b-3df7-4195-a1a7-e90a6fe821a7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2961)
<!-- Reviewable:end -->
