### PR TITLE
SF-3155 Fix incorrect draft source language codes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -446,30 +446,30 @@ public class MachineProjectService(
         // If there is an alternate training source, ensure that name, writing system and RTL is correct
         if (projectDoc.Data.TranslateConfig.DraftConfig.AlternateTrainingSource is not null)
         {
-            ParatextSettings? alternateSourceSettings = paratextService.GetParatextSettings(
+            ParatextSettings? alternateTrainingSourceSettings = paratextService.GetParatextSettings(
                 userSecret,
                 projectDoc.Data.TranslateConfig.DraftConfig.AlternateTrainingSource.ParatextId
             );
-            if (alternateSourceSettings is not null)
+            if (alternateTrainingSourceSettings is not null)
             {
                 await projectDoc.SubmitJson0OpAsync(op =>
                 {
                     op.Set(
                         pd => pd.TranslateConfig.DraftConfig.AlternateTrainingSource.IsRightToLeft,
-                        alternateSourceSettings.IsRightToLeft
+                        alternateTrainingSourceSettings.IsRightToLeft
                     );
-                    if (alternateSourceSettings.LanguageTag is not null)
+                    if (alternateTrainingSourceSettings.LanguageTag is not null)
                     {
                         op.Set(
                             pd => pd.TranslateConfig.DraftConfig.AlternateTrainingSource.WritingSystem.Tag,
-                            alternateSourceSettings.LanguageTag
+                            alternateTrainingSourceSettings.LanguageTag
                         );
                     }
-                    if (alternateSourceSettings.FullName is not null)
+                    if (alternateTrainingSourceSettings.FullName is not null)
                     {
                         op.Set(
                             pd => pd.TranslateConfig.DraftConfig.AlternateTrainingSource.Name,
-                            alternateSourceSettings.FullName
+                            alternateTrainingSourceSettings.FullName
                         );
                     }
                 });

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -960,7 +960,7 @@ public class ParatextService : DisposableBase, IParatextService
         }
 
         // Get the writing system details
-        WritingSystem writingSystem = GetWritingSystem(scrText.Language.Id);
+        WritingSystem writingSystem = GetWritingSystem(scrText.Settings.LanguageID.Id);
         return new ParatextSettings
         {
             FullName = scrText.FullName,
@@ -1848,7 +1848,7 @@ public class ParatextService : DisposableBase, IParatextService
     public WritingSystem GetWritingSystem(UserSecret userSecret, string ptProjectId)
     {
         using ScrText scrText = GetScrText(userSecret, ptProjectId);
-        return GetWritingSystem(scrText.Language.Id);
+        return GetWritingSystem(scrText.Settings.LanguageID.Id);
     }
 
     public void ClearParatextDataCaches(UserSecret userSecret, string paratextId)

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1831,6 +1831,10 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 if (sourceSettings != null)
                 {
                     op.Set(pd => pd.TranslateConfig.Source.IsRightToLeft, sourceSettings.IsRightToLeft);
+                    if (sourceSettings.LanguageRegion != null)
+                        op.Set(pd => pd.WritingSystem.Region, sourceSettings.LanguageRegion);
+                    if (sourceSettings.LanguageScript != null)
+                        op.Set(pd => pd.WritingSystem.Script, sourceSettings.LanguageScript);
                     if (sourceSettings.LanguageTag != null)
                         op.Set(pd => pd.TranslateConfig.Source.WritingSystem.Tag, sourceSettings.LanguageTag);
                 }


### PR DESCRIPTION
This PR fixes the incorrect language codes for resources created in Paratext 8 by retrieving the language code from the Settings XML (in this case an SSF file) instead of from the LDML file which will usually default to English in these cases.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2963)
<!-- Reviewable:end -->
