### PR TITLE
SF-3083 Resolve icon should change when editing resolved note

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1366,6 +1366,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const tagId: number | undefined =
       params.threadDataId == null ? this.projectDoc?.data?.translateConfig.defaultNoteTagId : undefined;
     const noteContent: string | undefined = params.content == null ? undefined : XmlUtils.encodeForXml(params.content);
+    const noteStatus: NoteStatus = params.status ?? NoteStatus.Todo;
     // Configure the note
     const note: Note = {
       dateCreated: currentDate,
@@ -1377,7 +1378,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       content: noteContent,
       conflictType: NoteConflictType.DefaultValue,
       type: NoteType.Normal,
-      status: params.status ?? NoteStatus.Todo,
+      status: noteStatus,
       deleted: false,
       editable: true,
       versionNumber: 1
@@ -1411,9 +1412,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           await threadDoc!.submitJson0Op(op => {
             op.set(t => t.notes[noteIndex].content, noteContent);
             op.set(t => t.notes[noteIndex].dateModified, currentDate);
+            op.set(t => t.notes[noteIndex].status, noteStatus);
+            // also set the status of the thread to be the status of the note
+            op.set(t => t.status, noteStatus);
           });
         } else {
-          this.dialogService.message(this.i18n.translate('editor.cannot_edit_note_paratext'));
+          this.dialogService.message('editor.cannot_edit_note_paratext');
         }
       } else {
         note.threadId = threadDoc.data!.threadId;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -400,6 +400,27 @@ describe('NoteDialogComponent', () => {
     expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05' });
   }));
 
+  it('allows user to resolve the last note in the thread', fakeAsync(() => {
+    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread(undefined, undefined, true) });
+    // note03 is marked as deleted
+    expect(env.notes.length).toEqual(4);
+    const noteThread: NoteThreadDoc = env.getNoteThreadDoc('dataid01');
+    expect(noteThread.data!.notes[4].content).toEqual('note05');
+    const noteNumbers = [1, 2, 3];
+    noteNumbers.forEach(n => expect(env.noteHasEditActions(n)).toBe(false));
+    expect(env.noteHasEditActions(4)).toBe(true);
+    env.clickEditNote();
+    expect(env.noteInputElement).toBeTruthy();
+    expect(env.notes.length).toEqual(3);
+    noteNumbers.forEach(n => expect(env.noteHasEditActions(n)).toBe(false));
+    expect(env.component.currentNoteContent).toEqual('note05');
+    const content = 'note 05 edited content';
+    env.enterNoteContent(content);
+    env.selectResolveOption();
+    env.submit();
+    expect(env.dialogResult).toEqual({ noteContent: content, noteDataId: 'note05', status: NoteStatus.Resolved });
+  }));
+
   it('does not allow user to edit the last note in the thread if it is not editable', fakeAsync(() => {
     env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
     // note03 is marked as deleted
@@ -494,7 +515,7 @@ describe('NoteDialogComponent', () => {
     env.enterNoteContent(content);
     env.selectResolveOption();
     env.submit();
-    expect(env.dialogResult).toEqual({ status: NoteStatus.Resolved, noteContent: content });
+    expect(env.dialogResult).toEqual({ status: NoteStatus.Resolved, noteContent: content, noteDataId: undefined });
   }));
 
   it('allows changing save option', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -359,6 +359,7 @@ export class NoteDialogComponent implements OnInit {
     const content: NoteDialogResult = { status: NoteStatus.Resolved };
     if (this.currentNoteContent.trim().length > 0) {
       content.noteContent = this.currentNoteContent;
+      content.noteDataId = this.noteIdBeingEdited;
     }
     this.dialogRef.close(content);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -28,6 +28,7 @@
     "all": "All",
     "biblical_terms_renderings": "Biblical Terms Renderings",
     "blank": "(Blank)",
+    "cannot_edit_note_paratext": "You cannot edit this note as it has been edited in Paratext.",
     "category": "Category",
     "current_book": "Current Book",
     "current_chapter": "Current Chapter",


### PR DESCRIPTION
This PR makes it so that editing a resolved note will un-resolve that note thread.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2964)
<!-- Reviewable:end -->
