### PR TITLE
SF-3166 Fix crash while retrieving history during sync

### DIFF
--- a/src/SIL.XForge.Scripture/Models/TextData.cs
+++ b/src/SIL.XForge.Scripture/Models/TextData.cs
@@ -11,6 +11,9 @@ public class TextData : Delta, IIdentifiable
     public static string GetTextDocId(string projectId, int book, int chapter) =>
         $"{projectId}:{Canon.BookNumberToId(book)}:{chapter}:target";
 
+    public static string GetTextDocId(string projectId, string book, int chapter) =>
+        $"{projectId}:{book}:{chapter}:target";
+
     public TextData() { }
 
     public TextData(Delta delta)

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1911,7 +1911,7 @@ public class ParatextService : DisposableBase, IParatextService
         VerseRef verseRef = new VerseRef($"{book} {chapter}:0");
 
         TextSnapshot ret;
-        string id = $"{sfProjectId}:{book}:{chapter}:target";
+        string id = TextData.GetTextDocId(sfProjectId, book, chapter);
         Snapshot<TextData> snapshot = await connection.FetchSnapshotAsync<TextData>(id, timestamp);
 
         if (snapshot.Data is null)
@@ -1988,7 +1988,7 @@ public class ParatextService : DisposableBase, IParatextService
             throw new ForbiddenException();
         }
 
-        string id = $"{sfProjectId}:{book}:{chapter}:target";
+        string id = TextData.GetTextDocId(sfProjectId, book, chapter);
         Op[] ops = await connection.GetOpsAsync<TextData>(id);
 
         // Iterate over the ops in reverse order, returning a milestone at least every 15 minutes

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -21,6 +21,13 @@ public class SFScrTextCollection : ScrTextCollection
     /// </summary>
     public static string ResourcesByIdDirectory => Path.Combine(SettingsDirectory, "_resourcesById");
 
+    /// <summary>
+    /// Adds a ScrText to the internal index. This should only be used for testing purposes!
+    /// </summary>
+    /// <param name="scrText">The scripture text to add to the index.</param>
+    public void AddToInternalIndex(ScrText scrText) =>
+        AddInternal(scrText, skipChangeNotify: false, checkAlreadyExists: false);
+
     protected override string DictionariesDirectoryInternal => null;
 
     protected override void InitializeInternal(string settingsDir, bool allowMigration)

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -11,18 +11,6 @@ namespace SIL.XForge.Realtime;
 
 public class MemoryConnection : IConnection
 {
-    /// <summary>
-    /// Gets a value of the last hour, for use with op generation.
-    /// </summary>
-    private readonly DateTime _thePreviousHour = new DateTime(
-        DateTime.UtcNow.Year,
-        DateTime.UtcNow.Month,
-        DateTime.UtcNow.Day,
-        DateTime.UtcNow.Hour,
-        0,
-        0,
-        DateTimeKind.Utc
-    );
     private readonly MemoryRealtimeService _realtimeService;
     private readonly Dictionary<(string, string), object> _documents;
 
@@ -115,40 +103,9 @@ public class MemoryConnection : IConnection
     /// <summary>
     /// Gets the ops for a document.
     /// </summary>
-    /// <returns>A default Op array for test purposes.</returns>
+    /// <returns>An Op array.</returns>
     public Task<Op[]> GetOpsAsync<T>(string id)
-        where T : IIdentifiable =>
-        Task.FromResult(
-            new Op[]
-            {
-                new Op
-                {
-                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-30) },
-                    Version = 1,
-                },
-                new Op
-                {
-                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-10) },
-                    Version = 2,
-                },
-                new Op
-                {
-                    // This op should be combined with the next
-                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-1) },
-                    Version = 3,
-                },
-                new Op
-                {
-                    Metadata = new OpMetadata
-                    {
-                        Timestamp = _thePreviousHour,
-                        UserId = "user01",
-                        Source = OpSource.Draft,
-                    },
-                    Version = 4,
-                },
-            }
-        );
+        where T : IIdentifiable => Task.FromResult(_realtimeService.GetRepository<T>().GetOps(id));
 
     public IDocument<T> Get<T>(string id)
         where T : IIdentifiable

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -11,6 +11,18 @@ namespace SIL.XForge.Realtime;
 
 public class MemoryConnection : IConnection
 {
+    /// <summary>
+    /// Gets a value of the last hour, for use with op generation.
+    /// </summary>
+    private readonly DateTime _thePreviousHour = new DateTime(
+        DateTime.UtcNow.Year,
+        DateTime.UtcNow.Month,
+        DateTime.UtcNow.Day,
+        DateTime.UtcNow.Hour,
+        0,
+        0,
+        DateTimeKind.Utc
+    );
     private readonly MemoryRealtimeService _realtimeService;
     private readonly Dictionary<(string, string), object> _documents;
 
@@ -111,24 +123,25 @@ public class MemoryConnection : IConnection
             {
                 new Op
                 {
-                    Metadata = new OpMetadata { Timestamp = DateTime.UtcNow.AddMinutes(-30) },
+                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-30) },
                     Version = 1,
                 },
                 new Op
                 {
-                    Metadata = new OpMetadata { Timestamp = DateTime.UtcNow.AddMinutes(-10) },
+                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-10) },
                     Version = 2,
                 },
                 new Op
                 {
-                    Metadata = new OpMetadata { Timestamp = DateTime.UtcNow.AddMinutes(-1) },
+                    // This op should be combined with the next
+                    Metadata = new OpMetadata { Timestamp = _thePreviousHour.AddMinutes(-1) },
                     Version = 3,
                 },
                 new Op
                 {
                     Metadata = new OpMetadata
                     {
-                        Timestamp = DateTime.UtcNow,
+                        Timestamp = _thePreviousHour,
                         UserId = "user01",
                         Source = OpSource.Draft,
                     },

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -30,14 +30,8 @@ public class MemoryRealtimeService : IRealtimeService
         return sp.GetRequiredService<INodeJSService>();
     }
 
-    private readonly Dictionary<Type, object> _repos;
-    private readonly Dictionary<Type, DocConfig> _docConfigs;
-
-    public MemoryRealtimeService()
-    {
-        _repos = [];
-        _docConfigs = [];
-    }
+    private readonly Dictionary<Type, object> _repos = [];
+    private readonly Dictionary<Type, DocConfig> _docConfigs = [];
 
     /// <summary>
     /// Gets or sets the last modified user identifier.

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1204,7 +1204,7 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
         Assert.AreEqual(expected.Ops[0], actual.Data.Ops[0]);
-        Assert.AreEqual($"{Project01}:MAT:1:target", actual.Id);
+        Assert.AreEqual(TextData.GetTextDocId(Project01, "MAT", 1), actual.Id);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/MockHg.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockHg.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Paratext.Data.Repository;
+
+namespace SIL.XForge.Scripture.Services;
+
+internal class MockHg : Hg
+{
+    /// <summary>
+    /// A log containing a revision from Paratext
+    /// </summary>
+    public readonly List<HgRevision> Log =
+    [
+        new HgRevision
+        {
+            Id = "2",
+            CommitTimeStampString = "2024-11-13T11:43:01+13:00",
+            Filenames = "08RUT.SFM",
+            ParentsString = "1",
+            UserEscaped = "pt_username",
+        },
+    ];
+
+    public override bool IsRepository(string repository) => true;
+
+    public override List<HgRevision> GetLog(string repository, string startRev, string endRev) => Log;
+
+    public override List<HgRevision> GetLogWithLimit(string repository, int limit) => Log;
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/MockHgRunner.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockHgRunner.cs
@@ -1,0 +1,59 @@
+using Paratext.Data;
+
+namespace SIL.XForge.Scripture.Services;
+
+internal class MockHgRunner() : HgExeRunner(null, null, null)
+{
+    private bool _appendCallCount;
+    private int _callCount;
+    private string _standardOutput = string.Empty;
+
+    /// <summary>
+    /// Mocks running a Mercurial command by incrementing a call count.
+    /// </summary>
+    /// <param name="args"></param>
+    public override void RunHg(string args) => _callCount++;
+
+    /// <summary>
+    /// Gets a success exit code.
+    /// </summary>
+    public override int ExitCode => 0;
+
+    /// <summary>
+    /// Gets the standard error, which is always empty.
+    /// </summary>
+    public override string StandardError => string.Empty;
+
+    /// <summary>
+    /// Gets the standard output.
+    /// </summary>
+    public override string StandardOutput =>
+        _standardOutput + (_appendCallCount ? _callCount.ToString() : string.Empty);
+
+    /// <summary>
+    /// Gets the standard output.
+    /// </summary>
+    public override string StandardOutputNoTrim => StandardOutput;
+
+    /// <summary>
+    /// Initialize the HgRunner (i.e. do nothing)
+    /// </summary>
+    public override void Initialize()
+    {
+        // Do nothing
+    }
+
+    /// <summary>
+    /// Sets the standard output
+    /// </summary>
+    /// <param name="standardOutput">The standard output.</param>
+    /// <param name="appendCallCountToOutput">
+    /// Adds the call count to the end of the output.
+    /// This is useful to simulate the last verse changing in hg cat output.
+    /// </param>
+    public void SetStandardOutput(string standardOutput, bool appendCallCountToOutput)
+    {
+        _standardOutput = standardOutput;
+        _appendCallCount = appendCallCountToOutput;
+    }
+}


### PR DESCRIPTION
When a user is retrieving the history for a chapter, and the project is being updated on disk by Paratext sync in another thread, the  get history request can fail with the following error:

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
```

This PR fixes that issue, which was recreated via a unit test. I also took the opportunity to unit test the get snapshot and get revisions code that interacts with the Paratext project on disk via Mercurial.

I have marked this as not requiring testing, as this crash is really difficult to recreate, and since the unit test recreates the environment of the crash, all that is necessary is Developer testing to ensure that history revisions can be viewed and the snapshot retrieved via the frontend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2965)
<!-- Reviewable:end -->
