### PR TITLE
Fix NG0955 warnings in unit tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -238,12 +238,14 @@ describe('DraftGenerationStepsComponent', () => {
       trainingSources: [
         {
           projectRef: 'source1',
+          paratextId: 'PT_SP1',
           shortName: 'sP1',
           writingSystem: { tag: 'eng' },
           texts: availableBooks.concat({ bookNum: 1 })
         },
         {
           projectRef: 'source2',
+          paratextId: 'PT_SP2',
           shortName: 'sP2',
           writingSystem: { tag: 'eng' },
           texts: availableBooks.concat({ bookNum: 6 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -18,6 +18,7 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Locale } from 'xforge-common/models/i18n-locale';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -26,7 +27,6 @@ import { TestOnlineStatusService } from 'xforge-common/test-online-status.servic
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { RealtimeQuery } from '../../../xforge-common/models/realtime-query';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TrainingDataDoc } from '../../core/models/training-data-doc';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -2256,7 +2256,7 @@ describe('DraftGenerationComponent', () => {
       expect(env.downloadButton).not.toBeNull();
     });
 
-    it('button should not display if there is no completed build while a build is faulter', () => {
+    it('button should not display if there is no completed build while a build is faulted', () => {
       const env = new TestEnvironment();
       env.component.draftJob = { ...buildDto, state: BuildStates.Faulted };
       env.component.lastCompletedBuild = undefined;


### PR DESCRIPTION
When you run the Angular frontend unit tests, the following warning will be logged in the console multiple times:

```
WARN: 'NG0955: The provided track expression resulted in duplicated keys for a given collection. Adjust the tracking expression such that it uniquely identifies all the items in the collection. Duplicated keys were:
key "" at index "0" and "1". Find more at https://angular.dev/errors/NG0955', [[[...]]]
```

This PR fixes this warning, and fixes a couple of minor typos in a related `.spec.ts` files I noticed.

As this PR only affects unit tests, testing is not required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2968)
<!-- Reviewable:end -->
