### PR TITLE
SF-3167 Fix training books not correctly listed on summary page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -225,6 +225,10 @@ describe('DraftGenerationStepsComponent', () => {
       ]);
     });
 
+    it('does not select deselected reference book when selecting translated book', () => {
+      // TODO
+    });
+
     it('does not allow selecting not selectable source training books', () => {
       component.onSourceTrainingBookSelect([6, 7], config.trainingSources[0]);
       fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -231,6 +231,21 @@ describe('DraftGenerationStepsComponent', () => {
 
       expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([]);
     });
+
+    it('clears selected reference books when translated book is unselected', () => {
+      component.onTranslatedBookSelect([2, 3]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([
+        { number: 2, selected: true },
+        { number: 3, selected: true }
+      ]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([
+        { number: 2, selected: true },
+        { number: 3, selected: true }
+      ]);
+      component.onTranslatedBookSelect([2]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 2, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 2, selected: true }]);
+    });
   });
 
   describe('additional training source', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -226,7 +226,23 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('does not select deselected reference book when selecting translated book', () => {
-      // TODO
+      component.onTranslatedBookSelect([1, 2]);
+      fixture.detectChanges();
+      component.onSourceTrainingBookSelect([1], config.trainingSources[0]);
+      fixture.detectChanges();
+
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([
+        { number: 1, selected: true },
+        { number: 2, selected: true }
+      ]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
+
+      // deselect translated book 1
+      component.onTranslatedBookSelect([2]);
+      fixture.detectChanges();
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 2, selected: true }]);
+      // ensure that book 2 in the reference text is not re-selected
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([]);
     });
 
     it('does not allow selecting not selectable source training books', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -243,8 +243,10 @@ describe('DraftGenerationStepsComponent', () => {
         { number: 3, selected: true }
       ]);
       component.onTranslatedBookSelect([2]);
-      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 2, selected: true }]);
       expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 2, selected: true }]);
+
+      component.onTranslatedBookSelect([]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([]);
     });
   });
 
@@ -466,6 +468,30 @@ describe('DraftGenerationStepsComponent', () => {
       component.tryAdvanceStep();
       fixture.detectChanges();
       expect(component.stepper.selectedIndex).toBe(3);
+    });
+
+    it('clears selected reference books when translated book is unselected', () => {
+      component.onTranslatedBookSelect([2, 3]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([
+        { number: 2, selected: true },
+        { number: 3, selected: true }
+      ]);
+      expect(component.selectedTrainingBooksByProj('source1')).toEqual([
+        { number: 2, selected: true },
+        { number: 3, selected: true }
+      ]);
+      expect(component.selectedTrainingBooksByProj('source2')).toEqual([
+        { number: 2, selected: true },
+        { number: 3, selected: true }
+      ]);
+
+      component.onTranslatedBookSelect([2]);
+      expect(component.selectedTrainingBooksByProj('source1')).toEqual([{ number: 2, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('source2')).toEqual([{ number: 2, selected: true }]);
+
+      component.onTranslatedBookSelect([]);
+      expect(component.selectedTrainingBooksByProj('source1')).toEqual([]);
+      expect(component.selectedTrainingBooksByProj('source2')).toEqual([]);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -404,6 +404,13 @@ export class DraftGenerationStepsComponent implements OnInit {
       }
     }
 
+    // if no books are selected, deselect all books in reference projects
+    if (selectedBooks.length < 1) {
+      for (const [_, trainingBooks] of Object.entries(this.availableTrainingBooks)) {
+        trainingBooks.forEach(b => (b.selected = false));
+      }
+    }
+
     this.clearErrorMessage();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -397,6 +397,10 @@ export class DraftGenerationStepsComponent implements OnInit {
         if (sourceBook !== undefined) {
           sourceBook.selected = true;
         }
+        // ensure any books source training books not selected in translated books is unselected
+        trainingBooks.forEach(b => {
+          b.selected = selectedBooks.includes(b.number) ? b.selected : false;
+        });
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -384,31 +384,27 @@ export class DraftGenerationStepsComponent implements OnInit {
 
   onTranslatedBookSelect(selectedBooks: number[]): void {
     if (this.activatedProject.projectId == null) return;
+    const newlySelectedBooks: number[] = this.availableTrainingBooks[this.activatedProject.projectId]
+      .filter(b => !b.selected && selectedBooks.includes(b.number))
+      .map(b => b.number);
     //update selections in translated books
     for (const book of this.availableTrainingBooks[this.activatedProject.projectId]) {
       book.selected = selectedBooks.includes(book.number);
     }
 
     //for each selected book, select the matching book in the sources
-    for (const selectedBook of selectedBooks) {
-      for (const [projectRef, trainingBooks] of Object.entries(this.availableTrainingBooks)) {
-        if (projectRef === this.activatedProject.projectId) continue;
-        const sourceBook = trainingBooks.find(b => b.number === selectedBook);
-        if (sourceBook !== undefined) {
-          sourceBook.selected = true;
+    for (const [projectRef, trainingBooks] of Object.entries(this.availableTrainingBooks)) {
+      if (projectRef === this.activatedProject.projectId) continue;
+
+      trainingBooks.forEach(b => {
+        if (newlySelectedBooks.includes(b.number)) {
+          b.selected = true;
         }
         // ensure any books source training books not selected in translated books is unselected
-        trainingBooks.forEach(b => {
-          b.selected = selectedBooks.includes(b.number) ? b.selected : false;
-        });
-      }
-    }
-
-    // if no books are selected, deselect all books in reference projects
-    if (selectedBooks.length < 1) {
-      for (const [_, trainingBooks] of Object.entries(this.availableTrainingBooks)) {
-        trainingBooks.forEach(b => (b.selected = false));
-      }
+        if (!selectedBooks.includes(b.number)) {
+          b.selected = false;
+        }
+      });
     }
 
     this.clearErrorMessage();


### PR DESCRIPTION
When translated books are selected on the training page, they are automatically selected in the reference texts. Books should also be automatically deselected when the translated book is removed from training.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2969)
<!-- Reviewable:end -->
