### PR TITLE
Change draft cancel icon to simple x icon

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -267,7 +267,7 @@
                   <div class="button-strip">
                     @if (canCancel(draftJob)) {
                       <button mat-flat-button color="primary" (click)="cancel()">
-                        <mat-icon>highlight_off</mat-icon>
+                        <mat-icon>close</mat-icon>
                         {{ t("cancel_generation_button") }}
                       </button>
                     }
@@ -283,7 +283,7 @@
                   <div class="button-strip">
                     @if (canCancel(draftJob)) {
                       <button mat-flat-button color="primary" (click)="cancel()">
-                        <mat-icon>highlight_off</mat-icon>
+                        <mat-icon>close</mat-icon>
                         {{ t("cancel_generation_button") }}
                       </button>
                     }


### PR DESCRIPTION
Before | After
-------|------
![](https://github.com/user-attachments/assets/ba496306-fa0e-4420-a351-4290425da784) | ![](https://github.com/user-attachments/assets/2689acc5-f5c6-49c7-8293-2d34f1f85b07)

This makes it more consistent with the rest of the application, where we use the simple x for cancel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2970)
<!-- Reviewable:end -->
