### PR TITLE
SF-3170 Show a summary message when no training books are selected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -211,31 +211,35 @@
 
         <h2>{{ t("summary_training_title") }}</h2>
         <mat-card class="confirm-section mat-elevation-z2">
-          <span class="explanation">{{ t("summary_training") }}</span>
-          <table mat-table class="confirm-training" [dataSource]="selectedTrainingBooksCollapsed()">
-            <ng-container matColumnDef="book">
-              <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell *matCellDef="let element">
-                <div class="confirm-books cell-padding-block">
-                  {{ i18n.enumerateList(element.ranges) }}
-                </div>
-              </td>
-            </ng-container>
-            <ng-container matColumnDef="source">
-              <th mat-header-cell *matHeaderCellDef>
-                {{ i18n.getLanguageDisplayName(trainingSources[0].writingSystem.tag) }}
-              </th>
-              <td mat-cell *matCellDef="let element">{{ element.sourceName }}</td>
-            </ng-container>
-            <ng-container matColumnDef="target">
-              <th mat-header-cell *matHeaderCellDef>
-                {{ i18n.getLanguageDisplayName(trainingTargets[0].writingSystem.tag) }}
-              </th>
-              <td mat-cell *matCellDef="let element">{{ trainingTargets[0].shortName }}</td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="['book', 'source', 'target']"></tr>
-            <tr mat-row *matRowDef="let row; columns: ['book', 'source', 'target']"></tr>
-          </table>
+          @if (selectedTrainingBooksCollapsed().length === 0) {
+            <span>No training books selected</span>
+          } @else {
+            <span class="explanation">{{ t("summary_training") }}</span>
+            <table mat-table class="confirm-training" [dataSource]="selectedTrainingBooksCollapsed()">
+              <ng-container matColumnDef="book">
+                <th mat-header-cell *matHeaderCellDef></th>
+                <td mat-cell *matCellDef="let element">
+                  <div class="confirm-books cell-padding-block">
+                    {{ i18n.enumerateList(element.ranges) }}
+                  </div>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="source">
+                <th mat-header-cell *matHeaderCellDef>
+                  {{ i18n.getLanguageDisplayName(trainingSources[0].writingSystem.tag) }}
+                </th>
+                <td mat-cell *matCellDef="let element">{{ element.sourceName }}</td>
+              </ng-container>
+              <ng-container matColumnDef="target">
+                <th mat-header-cell *matHeaderCellDef>
+                  {{ i18n.getLanguageDisplayName(trainingTargets[0].writingSystem.tag) }}
+                </th>
+                <td mat-cell *matCellDef="let element">{{ trainingTargets[0].shortName }}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="['book', 'source', 'target']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['book', 'source', 'target']"></tr>
+            </table>
+          }
         </mat-card>
 
         <h2>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -212,7 +212,7 @@
         <h2>{{ t("summary_training_title") }}</h2>
         <mat-card class="confirm-section mat-elevation-z2">
           @if (selectedTrainingBooksCollapsed().length === 0) {
-            <span>No training books selected</span>
+            <span>{{ t("no_training_books") }}</span>
           } @else {
             <span class="explanation">{{ t("summary_training") }}</span>
             <table mat-table class="confirm-training" [dataSource]="selectedTrainingBooksCollapsed()">

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -260,6 +260,7 @@
     "loading": "Loading...",
     "next": "Next",
     "no_available_books": "You have no books available for drafting.",
+    "no_training_books": "No training books selected",
     "overview": "Overview",
     "reference_books": "Reference books",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ firstTrainingSource }}).",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b353a91e-d23d-4d08-bdf3-2a363188ae34)

I opted for a minimalistic solution here, because this seems to be a rare use case, based on a conversation with Nathaniel. We need to support it, but most target languages won't be in the NLLB. We can certainly do more with the UI -- on the Summary and Training pages -- but apparently it's not necessary to guide them down this path too forcefully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2971)
<!-- Reviewable:end -->
