### PR TITLE
Add heap snapshot generation to the realtime server

### DIFF
--- a/src/RealtimeServer/common/diagnostics.ts
+++ b/src/RealtimeServer/common/diagnostics.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import inspector from 'inspector';
+import { writeHeapSnapshot } from 'node:v8';
 import path from 'path';
 
 const secondsToProfile = 30;
@@ -7,7 +8,12 @@ const secondsToProfile = 30;
 // POSIX defines SIGUSR1 and SIGUSR2 as user-defined signals, but SIGUSR1 is reserved by Node.js to start the debugger.
 // Send the signal using e.g. kill -USR2 <node process id>
 process.on('SIGUSR2', () => {
-  console.log('Signal SIGUSR2 received; starting profiling');
+  console.log('Signal SIGUSR2 received; writing heap snapshot');
+  const heapPath = path.join(process.cwd(), 'scriptureforge.heapsnapshot');
+  // Warning: This is a synchronous operation and will block the event loop!
+  writeHeapSnapshot(heapPath);
+  console.log(`Heap snapshot written to ${heapPath}`);
+  console.log('Starting profiling');
   const session = new inspector.Session();
   session.connect();
 


### PR DESCRIPTION
This PR adds support for generating heap snapshots of the Realtime Server. This will be useful to diagnose why the Out of Memory errors are occurring every 1-3 days, which result in the Realtime Server restarting.

**To Use:**
1. Get the process id of node: `ps aux | grep node`
2. Send the USR2 signal to the node process: `kill -USR2 {process_id_here}`

If developing, the console output will tell you where it was written, for example:
```
Heap snapshot written to /home/peter/src/web-xforge/src/SIL.XForge.Scripture/bin/Debug/net8.0/scriptureforge.heapsnapshot
```
If on QA or Production, look in the journal to see where the file was written.

**Note:** As we are already using USR2, I was unable to use the Node command line argument [--heapsnapshot-signalsignal](https://nodejs.org/api/cli.html#--heapsnapshot-signalsignal).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2975)
<!-- Reviewable:end -->
