### PR TITLE
Add robust error dialog for when digest cycle is broken

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { browserLinks, getLinkHTML, issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
@@ -14,9 +14,11 @@ export interface ErrorAlertData {
   templateUrl: './error-dialog.component.html',
   styleUrls: ['./error-dialog.component.scss']
 })
-export class ErrorDialogComponent {
+export class ErrorDialogComponent implements OnInit {
+  initComplete = false;
   showDetails = false;
   browserUnsupported = !supportedBrowser();
+  outsideAngularErrorDialog?: OutsideAngularErrorDialog;
 
   issueEmailLink = getLinkHTML(environment.issueEmail, issuesEmailTemplate(this.data.eventId));
 
@@ -24,9 +26,78 @@ export class ErrorDialogComponent {
     public dialogRef: MatDialogRef<ErrorDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: ErrorAlertData,
     readonly i18n: I18nService
-  ) {}
+  ) {
+    // If the dialog doesn't init in the expected time, open the outsideAngularErrorDialog
+    setTimeout(() => {
+      if (!this.initComplete) this.openOutsideAngularErrorDialog();
+    }, 100);
+  }
 
   get browserLinks(): { chromeLink: string; firefoxLink: string; safariLink: string } {
     return browserLinks();
+  }
+
+  ngOnInit(): void {
+    this.initComplete = true;
+    // In the unlikely event that this dialog didn't init in the expected time, but eventually did init, and the
+    // outsideAngularErrorDialog was wrongly created, close it.
+    if (this.outsideAngularErrorDialog != null) {
+      this.outsideAngularErrorDialog.close();
+    }
+  }
+
+  openOutsideAngularErrorDialog(): void {
+    this.outsideAngularErrorDialog = new OutsideAngularErrorDialog(
+      this.data.message,
+      issuesEmailTemplate(this.data.eventId)
+    );
+  }
+}
+
+/**
+ * This is a last-ditch error dialog for when an error prevents Angular from rendering the error dialog, such as when
+ * there's an error happening in every Angular digest cycle.
+ * It is not internationalized, and is not intended to look like the normal error dialog.
+ */
+class OutsideAngularErrorDialog {
+  private dialogElement: HTMLDialogElement;
+
+  constructor(message: string, linkUrl: string) {
+    // Elements
+    this.dialogElement = document.createElement('dialog');
+    const titleElement = document.createElement('h1');
+    const messageElement = document.createElement('p');
+    const issueLinkWrapper = document.createElement('p');
+    const issueLinkElement = document.createElement('a');
+    const closeElement = document.createElement('button');
+
+    // Text content
+    titleElement.textContent = 'An error has occurred';
+    messageElement.textContent = `Error: ${message}`;
+    issueLinkElement.textContent = `Report error to ${environment.issueEmail}`;
+    closeElement.textContent = 'Close';
+
+    // Report issue link
+    issueLinkElement.href = linkUrl;
+    issueLinkElement.target = '_blank';
+    issueLinkWrapper.appendChild(issueLinkElement);
+
+    // Close button
+    closeElement.onclick = () => this.close();
+
+    // Assemble element tree
+    this.dialogElement.appendChild(titleElement);
+    this.dialogElement.appendChild(messageElement);
+    this.dialogElement.appendChild(issueLinkWrapper);
+    this.dialogElement.appendChild(closeElement);
+
+    // Create and open dialog
+    document.body.appendChild(this.dialogElement);
+    this.dialogElement.showModal();
+  }
+
+  close(): void {
+    this.dialogElement.close();
+    this.dialogElement.remove();
   }
 }


### PR DESCRIPTION
When there's an error in every single digest cycle, the page is completely broken, and not even the error dialog can display. This change adds an extra robust error dialog that is only shown when the normal error dialog is not capable of opening. 

The simplest way to cause this to happen is to add an error to a template that will occur every single time. This can be done by adding this to the template:
``` html
{{ throwError() }}
```
And adding this to the associated component:
``` ts
  throwError(): never {
    throw new Error('This is a test');
  }
```

The result is that the page fails to update, and is covered with a dialog backdrop, but no actual error dialog. Depending on where the error occurs, the page may be completely rendered and just not able to update, or barely rendered at all:

![](https://github.com/user-attachments/assets/f96096ea-e76f-43c6-84ed-2c5cf2ff1fa4)

This change detects this type of situation by listening for the `onInit` event of the error dialog, and if it hasn't fired within 100ms, assumes the page is broken, and opens a backup error dialog, which is significantly more limited, but more reliable and not dependent on Angular to work. This detection method can have false positives (e.g. performance issues may cause the error dialog to take more than 100ms to open), so if the `onInit` event fires after the backup dialog has been opened, it is closed to prevent duplicate dialogs.

![](https://github.com/user-attachments/assets/0491b8e1-121c-4f21-8670-309e6768a5b4)

To test this change, make the described changes to a component, and observe the behavior on this branch and on master.