### PR TITLE
SF-3174 Fix 400 errors on Forbid() or with .NET 500 errors

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/HealthController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/HealthController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using SIL.XForge.Configuration;
@@ -47,8 +46,7 @@ public class HealthController(
         // Restrict this endpoint to requests with the correct API key
         if (authOptions.Value.HealthCheckApiKey != apiKey)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
 
         // Create the object to return for the health check

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -80,8 +80,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
     }
 
@@ -522,8 +521,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
         catch (InvalidOperationException)
         {
@@ -592,8 +590,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
         catch (UnauthorizedAccessException)
         {
@@ -641,8 +638,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
         catch (UnauthorizedAccessException)
         {
@@ -688,8 +684,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
     }
 
@@ -776,8 +771,7 @@ public class MachineApiController : ControllerBase
         }
         catch (ForbiddenException)
         {
-            // Returning Forbid() results in a 400 error when executed in a POST action
-            return new StatusCodeResult(StatusCodes.Status403Forbidden);
+            return Forbid();
         }
     }
 }

--- a/src/SIL.XForge.Scripture/Pages/Status/Error.cshtml.cs
+++ b/src/SIL.XForge.Scripture/Pages/Status/Error.cshtml.cs
@@ -1,9 +1,19 @@
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Localization;
 
 namespace SIL.XForge.Scripture.Pages.Status;
 
+/// <summary>
+/// Provides a page for displaying error messages.
+/// </summary>
+/// <param name="localizerFactory">The localizer factory.</param>
+/// <remarks>
+/// To prevent 400 errors when APIs return errors during a POST, this page does not require an anti-forgery token.
+/// This is because this page is called via UseStatusCodePagesWithReExecute() from Startup.cs.
+/// </remarks>
+[IgnoreAntiforgeryToken]
 public class ErrorModel(IStringLocalizerFactory localizerFactory) : PageModel
 {
     public IStringLocalizer Localizer { get; } =

--- a/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/HealthCheckControllerTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -63,8 +62,7 @@ public class HealthCheckControllerTests
         // SUT
         var actual = await env.Controller.HealthCheckAsync("invalid_key");
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -52,8 +52,7 @@ public class MachineApiControllerTests
         // SUT
         ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual);
     }
 
     [Test]
@@ -1198,8 +1197,7 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
 
     [Test]
@@ -1302,11 +1300,11 @@ public class MachineApiControllerTests
             .Throws(new BrokenCircuitException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+        ActionResult actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        Assert.IsInstanceOf<ObjectResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+        Assert.IsInstanceOf<ObjectResult>(actual);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual as ObjectResult)?.StatusCode);
     }
 
     [Test]
@@ -1318,10 +1316,9 @@ public class MachineApiControllerTests
             .Throws(new ForbiddenException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+        ActionResult actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual);
     }
 
     [Test]
@@ -1333,9 +1330,9 @@ public class MachineApiControllerTests
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+        ActionResult actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        Assert.IsInstanceOf<NotFoundResult>(actual);
     }
 
     [Test]
@@ -1347,9 +1344,9 @@ public class MachineApiControllerTests
             .Returns(Task.FromResult(new ServalBuildDto()));
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+        ActionResult actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        Assert.IsInstanceOf<OkObjectResult>(actual);
         await env.MachineApiService.Received(1).StartBuildAsync(User01, Project01, CancellationToken.None);
     }
 
@@ -1362,9 +1359,9 @@ public class MachineApiControllerTests
             .Throws(new UnauthorizedAccessException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
+        ActionResult actual = await env.Controller.StartBuildAsync(Project01, CancellationToken.None);
 
-        Assert.IsInstanceOf<UnauthorizedResult>(actual.Result);
+        Assert.IsInstanceOf<UnauthorizedResult>(actual);
     }
 
     [Test]
@@ -1380,14 +1377,14 @@ public class MachineApiControllerTests
             .Throws(new BrokenCircuitException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+        ActionResult actual = await env.Controller.StartPreTranslationBuildAsync(
             new BuildConfig { ProjectId = Project01 },
             CancellationToken.None
         );
 
         env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
-        Assert.IsInstanceOf<ObjectResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+        Assert.IsInstanceOf<ObjectResult>(actual);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual as ObjectResult)?.StatusCode);
     }
 
     [Test]
@@ -1403,13 +1400,12 @@ public class MachineApiControllerTests
             .Throws(new ForbiddenException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+        ActionResult actual = await env.Controller.StartPreTranslationBuildAsync(
             new BuildConfig { ProjectId = Project01 },
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual);
     }
 
     [Test]
@@ -1425,12 +1421,12 @@ public class MachineApiControllerTests
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+        ActionResult actual = await env.Controller.StartPreTranslationBuildAsync(
             new BuildConfig { ProjectId = Project01 },
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+        Assert.IsInstanceOf<NotFoundResult>(actual);
     }
 
     [Test]
@@ -1467,12 +1463,12 @@ public class MachineApiControllerTests
             .Throws(new UnauthorizedAccessException());
 
         // SUT
-        ActionResult<ServalBuildDto> actual = await env.Controller.StartPreTranslationBuildAsync(
+        ActionResult actual = await env.Controller.StartPreTranslationBuildAsync(
             new BuildConfig { ProjectId = Project01 },
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<UnauthorizedResult>(actual.Result);
+        Assert.IsInstanceOf<UnauthorizedResult>(actual);
     }
 
     [Test]
@@ -1504,8 +1500,7 @@ public class MachineApiControllerTests
         // SUT
         ActionResult actual = await env.Controller.TrainSegmentAsync(Project01, segmentPair, CancellationToken.None);
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual);
     }
 
     [Test]
@@ -1652,8 +1647,7 @@ public class MachineApiControllerTests
             CancellationToken.None
         );
 
-        Assert.IsInstanceOf<StatusCodeResult>(actual.Result);
-        Assert.AreEqual(StatusCodes.Status403Forbidden, (actual.Result as StatusCodeResult)?.StatusCode);
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
     }
 
     [Test]


### PR DESCRIPTION
This PR fixes our error page so that when errors that occur on a POST call this page, a 400 error is no longer thrown instead of the actual error code.

This not only allows us to use `Forbid()` in `[HttpPost]` actions, but it also means that if .NET throws a 500 error during a POST, it won't be rethrown as a 400 error.

I also took the opportunity to clean up some of the related tests to better reflect the type returned by their respective Controller action.

As this only affects API endpoints on error, this only requires developer testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2979)
<!-- Reviewable:end -->
