### PR TITLE
SF-3173 Show error when matching training pairs not selected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -75,7 +75,9 @@
           </button>
         </div>
       </mat-step>
-      <mat-step [completed]="isTrainingOptional || trainingSourceBooksSelected">
+      <mat-step
+        [completed]="(isTrainingOptional || trainingSourceBooksSelected) && translatedBooksSelectedInTrainingSources"
+      >
         <ng-template matStepLabel>
           {{ t("choose_books_for_training_header") }}
         </ng-template>
@@ -133,14 +135,13 @@
             ></app-book-multi-select>
           }
         }
-        @if (showBookSelectionError) {
-          <app-notice type="error">
-            {{ t("choose_books_for_training_error") }}
-          </app-notice>
-        }
         @if (!translatedBooksSelectedInTrainingSources) {
-          <app-notice class="warn-translated-books-unselected" type="warning" icon="warning">
+          <app-notice class="error-translated-books-unselected" type="error">
             {{ t("translated_book_selected_no_training_pair") }}
+          </app-notice>
+        } @else if (showBookSelectionError) {
+          <app-notice class="error-choose-training-books" type="error">
+            {{ t("choose_books_for_training_error") }}
           </app-notice>
         }
         @if (translatedBooksWithNoSource.length > 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -484,10 +484,12 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.stepper.selectedIndex).toBe(2);
       component.onSourceTrainingBookSelect([2], config.trainingSources[0]);
       fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('.warn-translated-books-unselected')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('.error-translated-books-unselected')).not.toBeNull();
       component.tryAdvanceStep();
       fixture.detectChanges();
-      expect(component.stepper.selectedIndex).toBe(3);
+      // The user cannot advance if reference books are not provided for training
+      expect(component.stepper.selectedIndex).toBe(2);
+      expect(fixture.nativeElement.querySelector('.error-choose-training-books')).toBeNull();
     });
 
     it('clears selected reference books when translated book is unselected', () => {


### PR DESCRIPTION
When the books selected for training do not have selection in both the translated books and reference texts the user will be shown an error directing them to fix the mistake. This change forces the user to fix the mistake before generating the draft.

![Draft steps matching books error](https://github.com/user-attachments/assets/f4aed32b-b7d9-46ac-9b80-36fa02bc6317)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2980)
<!-- Reviewable:end -->
