### PR TITLE
SF-3176 Add Upload Audio to Questions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'attach_audio'">
   <div [ngClass]="{ 'add-audio': isUploadEnabled }">
     @if (audioUrl == null && textAndAudio?.audioAttachment?.status !== "recording") {
-      <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
+      <button mat-icon-button class="record-audio" (click)="startRecording()" [matTooltip]="t('tooltip_record')">
         <mat-icon>mic</mat-icon>
       </button>
       @if (isUploadEnabled) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.html
@@ -1,9 +1,23 @@
 <ng-container *transloco="let t; read: 'attach_audio'">
-  <div class="add-audio">
+  <div [ngClass]="{ 'add-audio': isUploadEnabled }">
     @if (audioUrl == null && textAndAudio?.audioAttachment?.status !== "recording") {
       <button mat-icon-button (click)="startRecording()" [matTooltip]="t('tooltip_record')">
         <mat-icon>mic</mat-icon>
       </button>
+      @if (isUploadEnabled) {
+        <button
+          mat-icon-button
+          ngfSelect
+          [(file)]="uploadAudioFile"
+          (fileChange)="processAudioFileUpload()"
+          accept="audio/*"
+          class="upload-audio-file"
+          [(lastInvalids)]="lastInvalids"
+          [matTooltip]="t('tooltip_upload')"
+        >
+          <mat-icon>cloud_upload</mat-icon>
+        </button>
+      }
     }
   </div>
   @if (audioUrl != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.scss
@@ -16,3 +16,9 @@
 .clear {
   color: variables.$greenDark;
 }
+
+.add-audio {
+  background-color: rgba(0, 0, 0, 0.05);
+  padding-inline: 4px;
+  margin-block-start: 2px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
@@ -39,8 +39,8 @@ describe('AttachAudioComponent', () => {
     when(env.mockTextAndAudio.input).thenReturn({});
     when(env.mockTextAndAudio.audioAttachment).thenReturn({ status: 'reset' });
     env.fixture.detectChanges();
-    expect(env.firstIcon.nativeElement.textContent).toBe('mic');
-    env.firstIcon.nativeElement.click();
+    expect(env.recordIcon.nativeElement.textContent).toBe('mic');
+    env.recordIcon.nativeElement.click();
     tick();
     env.fixture.detectChanges();
     verify(mockDialogService.openMatDialog(AudioRecorderDialogComponent, anything())).once();
@@ -51,12 +51,12 @@ describe('AttachAudioComponent', () => {
     when(env.mockTextAndAudio.input).thenReturn({});
     when(env.mockRecorderDialogRef.afterClosed()).thenReturn(of(undefined));
     env.fixture.detectChanges();
-    env.firstIcon.nativeElement.click();
+    env.recordIcon.nativeElement.click();
     tick();
     env.fixture.detectChanges();
     verify(mockDialogService.openMatDialog(AudioRecorderDialogComponent, anything())).once();
     verify(env.mockTextAndAudio.setAudioAttachment(anything())).never();
-    expect(env.firstIcon.nativeElement.textContent).toBe('mic');
+    expect(env.recordIcon.nativeElement.textContent).toBe('mic');
   }));
 
   it('should show clear when audio is attached', () => {
@@ -64,8 +64,8 @@ describe('AttachAudioComponent', () => {
     when(env.mockTextAndAudio.input).thenReturn({ audioUrl: 'blob://audio' });
     env.fixture.detectChanges();
     expect(env.component.audioPlayer).not.toBeNull();
-    expect(env.firstIcon.nativeElement.textContent).toBe('clear');
-    env.firstIcon.nativeElement.click();
+    expect(env.clearIcon.nativeElement.textContent).toBe('clear');
+    env.clearIcon.nativeElement.click();
     env.fixture.detectChanges();
     verify(env.mockTextAndAudio.resetAudio()).once();
   });
@@ -117,8 +117,12 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
-  get firstIcon(): DebugElement {
-    return this.fixture.debugElement.query(By.css('button .mat-icon'));
+  get recordIcon(): DebugElement {
+    return this.fixture.debugElement.query(By.css('button.record-audio .mat-icon'));
+  }
+
+  get clearIcon(): DebugElement {
+    return this.fixture.debugElement.query(By.css('button.clear .mat-icon'));
   }
 
   get uploadAudioButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
+import { InvalidFileItem } from 'angular-file/file-upload/fileTools';
 import { firstValueFrom } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
 import {
@@ -7,6 +8,7 @@ import {
   AudioRecorderDialogData,
   AudioRecorderDialogResult
 } from '../../shared/audio-recorder-dialog/audio-recorder-dialog.component';
+import { AudioAttachment } from '../checking/checking-audio-player/checking-audio-player.component';
 import { SingleButtonAudioPlayerComponent } from '../checking/single-button-audio-player/single-button-audio-player.component';
 import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.component';
 
@@ -18,6 +20,9 @@ import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.componen
 export class AttachAudioComponent {
   @ViewChild(SingleButtonAudioPlayerComponent) audioPlayer?: SingleButtonAudioPlayerComponent;
   @Input() textAndAudio?: TextAndAudioComponent;
+  @Input() isUploadEnabled: boolean = false;
+
+  protected uploadAudioFile: File = {} as File;
 
   constructor(private readonly dialogService: DialogService) {}
 
@@ -46,5 +51,30 @@ export class AttachAudioComponent {
 
   toggleAudio(): void {
     this.audioPlayer?.playing ? this.audioPlayer?.stop() : this.audioPlayer?.play();
+  }
+
+  protected set lastInvalids(value: InvalidFileItem[]) {
+    if (value == null) {
+      return;
+    }
+    // Firefox does not recognize the valid .ogg file type because it reads it as a video, so handle it here
+    if (value.length > 0 && value[0].file.type === 'video/ogg') {
+      this.uploadAudioFile = value[0].file;
+      this.processAudioFileUpload();
+    }
+  }
+
+  protected processAudioFileUpload(): void {
+    if (this.uploadAudioFile.name != null) {
+      const audio: AudioAttachment = {};
+      audio.url = URL.createObjectURL(this.uploadAudioFile);
+      audio.blob = this.uploadAudioFile;
+      audio.fileName = this.uploadAudioFile.name;
+      audio.status = 'uploaded';
+
+      if (this.textAndAudio != null) {
+        this.textAndAudio.setAudioAttachment(audio);
+      }
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.html
@@ -48,7 +48,7 @@
       <div>
         <app-text-and-audio #input [input]="question" [textLabel]="t('question')"></app-text-and-audio>
         <div class="attachments">
-          <app-attach-audio [textAndAudio]="input"></app-attach-audio>
+          <app-attach-audio [textAndAudio]="input" [isUploadEnabled]="true"></app-attach-audio>
         </div>
       </div>
     </mat-dialog-content>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/text-and-audio/text-and-audio.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/text-and-audio/text-and-audio.component.ts
@@ -50,7 +50,11 @@ export class TextAndAudioComponent implements AfterViewInit, OnInit, OnDestroy {
   }
 
   updateFormValidity(): void {
-    if (this.hasTextOrAudio() || this._audioAttachment?.status === 'processed') {
+    if (
+      this.hasTextOrAudio() ||
+      this._audioAttachment?.status === 'processed' ||
+      this._audioAttachment?.status === 'uploaded'
+    ) {
       this.text.setErrors(null);
       this.input!.audioUrl = this._audioAttachment?.url;
     } else if (this._audioAttachment?.status === 'reset') {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -40,7 +40,8 @@
   },
   "attach_audio": {
     "tooltip_record": "Record audio",
-    "tooltip_stop": "Stop recording"
+    "tooltip_stop": "Stop recording",
+    "tooltip_upload": "Upload audio"
   },
   "canon": {
     "book_names": {


### PR DESCRIPTION
A good portion of this was restored from its last working state (last year), before we removed it, and updated. The file processing comes solely from the existence of the uploadAudioFile property. I also restored the old Firefox .ogg file workaround, though I didn't test that it's still required (yet).

The upload button must be enabled to be visible. This is controlled by a boolean Input on the control, and it's false for its usage within the answers.

Also accounting for the 'uploaded' state in text-and-audio, since beforehand it was only looking for the recorded 'processed' state.

![image](https://github.com/user-attachments/assets/5ed1e922-33ed-478f-8f3e-cd396b68904f)

The aesthetics come from [what was selected in Balsamiq](https://balsamiq.cloud/sghq53/pejrlz8/rADE4), but we can certainly adjust it, based on what the result actually looks like.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2984)
<!-- Reviewable:end -->
