### PR TITLE
SF-3182 Fix warning message when training book no longer selectable

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -268,6 +268,58 @@ describe('DraftGenerationStepsComponent', () => {
       component.onTranslatedBookSelect([]);
       expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([]);
     });
+
+    it('clears selected translated and reference books in training when translate book selected', () => {
+      clickConfirmLanguages(fixture);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      component.onTranslateBookSelect([3]);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      component.onTranslatedBookSelect([1, 2]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([
+        { number: 1, selected: true },
+        { number: 2, selected: true }
+      ]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([
+        { number: 1, selected: true },
+        { number: 2, selected: true }
+      ]);
+      component.stepper.selectedIndex = 1;
+      fixture.detectChanges();
+      component.onTranslateBookSelect([2, 3]);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 1, selected: true }]);
+    });
+
+    it('shows unselected translate book on training page', () => {
+      clickConfirmLanguages(fixture);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      // select Exodus and Leviticus
+      component.onTranslateBookSelect([2, 3]);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      component.onTranslatedBookSelect([1]);
+      expect(component.selectableTrainingBooksByProj('project01')).toEqual([{ number: 1, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 1, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
+      component.stepper.selectedIndex = 1;
+      fixture.detectChanges();
+      // deselect Exodus and keep Leviticus
+      component.onTranslateBookSelect([3]);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      // Exodus becomes a selectable training book
+      expect(component.selectableTrainingBooksByProj('project01')).toEqual([
+        { number: 1, selected: true },
+        { number: 2, selected: false }
+      ]);
+      expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
+      expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 1, selected: true }]);
+    });
   });
 
   describe('additional training source', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -426,6 +426,7 @@ export class DraftGenerationStepsComponent implements OnInit {
     for (const book of this.availableTranslateBooks) {
       book.selected = selectedBooks.includes(book.number);
     }
+    this.updateSelectedTrainingBooks();
     this.clearErrorMessage();
   }
 
@@ -450,7 +451,7 @@ export class DraftGenerationStepsComponent implements OnInit {
 
       const trainingData: ProjectScriptureRange[] = [];
       for (const source of this.trainingSources) {
-        const booksForThisSource = this.availableTrainingBooks[source.projectRef].filter(b => b.selected);
+        const booksForThisSource: Book[] = this.selectedTrainingBooksByProj(source.projectRef);
         if (booksForThisSource.length > 0) {
           trainingData.push({
             projectId: source.projectRef,
@@ -476,6 +477,14 @@ export class DraftGenerationStepsComponent implements OnInit {
 
   protected projectLabel(source: TranslateSource): string {
     return projectLabel(source);
+  }
+
+  private updateSelectedTrainingBooks(): void {
+    const booksForTranslation: number[] = this.availableTranslateBooks.filter(b => b.selected).map(b => b.number);
+    for (const [, trainingBooks] of Object.entries(this.availableTrainingBooks)) {
+      // set the selected state of any training book to false if it is selected for translation
+      trainingBooks.forEach(b => (b.selected = booksForTranslation.includes(b.number) ? false : b.selected));
+    }
   }
 
   private validateCurrentStep(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -426,11 +426,11 @@ export class DraftGenerationStepsComponent implements OnInit {
     for (const book of this.availableTranslateBooks) {
       book.selected = selectedBooks.includes(book.number);
     }
-    this.updateSelectedTrainingBooks();
     this.clearErrorMessage();
   }
 
   onStepChange(): void {
+    this.updateSelectedTrainingBooks();
     this.clearErrorMessage();
   }
 


### PR DESCRIPTION
An issue appeared when a training book is selected, but then the user goes back and selects the book as a translation book. Even though the book is no longer a selectable training book, it still appears as a selected training book. This fixes the problem by ensuring that the list of selectable and selected training books are current when a user selects translation books.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2986)
<!-- Reviewable:end -->
