### PR TITLE
SF-3187 Store the correct language code when migrating resources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2536,6 +2536,9 @@ public class ParatextService : DisposableBase, IParatextService
         if (overrideLanguage is not null)
         {
             scrText.Settings.LanguageID = overrideLanguage;
+
+            // This will create Settings.xml with the correct LanguageIsoCode value
+            scrText.Settings.Save();
         }
 
         // Perform a simple migration of the Paratext 7 LDML file to the new Paratext 8+ location.

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4285,6 +4285,15 @@ public class ParatextServiceTests
         env.MockScrTextCollection.FindById(Arg.Any<string>(), resourceId).Returns(scrText);
         ScrTextCollection.Initialize("/srv/scriptureforge/projects");
 
+        // The FileManager will be disposed via the using statement in ParatextService.MigrateResourceIfRequired(),
+        // so capture the saving of the settings here
+        bool settingsSaved = false;
+        scrText
+            .FileManager.When(fm =>
+                fm.WriteFileCreatingBackup("Settings.xml", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+            )
+            .Do(_ => settingsSaved = true);
+
         // Set up the mock file system calls used by the migration
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith("ldml.xml"))).Returns(true);
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith(".ldml"))).Returns(false);
@@ -4305,6 +4314,7 @@ public class ParatextServiceTests
         env.MockFileSystemService.Received(1)
             .MoveFile(Arg.Is<string>(p => p.EndsWith("ldml.xml")), Arg.Is<string>(p => p.EndsWith(".ldml")));
         Assert.AreEqual(scrText.Settings.LanguageID.Code, zipLanguageCode);
+        Assert.IsTrue(settingsSaved);
     }
 
     [Test]
@@ -4338,6 +4348,15 @@ public class ParatextServiceTests
         env.MockScrTextCollection.FindById(Arg.Any<string>(), resourceId).Returns(scrText);
         ScrTextCollection.Initialize("/srv/scriptureforge/projects");
 
+        // The FileManager will be disposed via the using statement in ParatextService.MigrateResourceIfRequired(),
+        // so capture the saving of the settings here
+        bool settingsSaved = false;
+        scrText
+            .FileManager.When(fm =>
+                fm.WriteFileCreatingBackup("Settings.xml", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+            )
+            .Do(_ => settingsSaved = true);
+
         // Set up the mock file system calls used by the migration
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith("ldml.xml"))).Returns(true);
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith(".ldml"))).Returns(false);
@@ -4355,6 +4374,7 @@ public class ParatextServiceTests
         env.MockFileSystemService.Received(1)
             .MoveFile(Arg.Is<string>(p => p.EndsWith("ldml.xml")), Arg.Is<string>(p => p.EndsWith(".ldml")));
         Assert.AreEqual(resourceScrText.Settings.LanguageID?.Code, "en");
+        Assert.IsTrue(settingsSaved);
     }
 
     [Test]


### PR DESCRIPTION
This PR fixes a bug where some older resources which have invalid language codes, like "English-KJV", were not having their correct language code written to the project settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2990)
<!-- Reviewable:end -->
