### PR TITLE
SF-3185 Add replaceDoc support to realtime server

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -338,6 +338,7 @@ export = {
     // Build the ops from a diff
     // NOTE: We do not use diff-patch-match, as that may result in
     // op conflicts when ops are submitted from multiple sources.
+    // diff-patch-match mutates the string, but we want to replace it.
     const ops = json0OtDiff(doc.data, data);
 
     // Submit the ops

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -15,6 +15,7 @@
         "ajv": "^8.12.0",
         "ajv-bsontype": "^1.0.7",
         "express": "^4.18.1",
+        "json0-ot-diff": "^1.1.2",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
         "lodash-es": "^4.17.21",
@@ -3776,15 +3777,44 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4039,6 +4069,26 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4071,11 +4121,12 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
       "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -4143,6 +4194,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -4253,12 +4318,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4277,6 +4340,18 @@
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -5167,7 +5242,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5191,15 +5265,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5215,6 +5295,19 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -5313,11 +5406,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5376,21 +5470,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5399,12 +5483,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5599,6 +5683,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5661,7 +5761,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -5760,7 +5859,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6613,6 +6711,15 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/json0-ot-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json0-ot-diff/-/json0-ot-diff-1.1.2.tgz",
+      "integrity": "sha512-je6cDbmPc+BkbfyvKo7y1jgQLTrX81L8fkKEIPXRUGFSxK4HTSF6u44ELR35i12tEIWh5+8KfIJH2aJgzKrFww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6809,6 +6916,15 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
@@ -7022,11 +7138,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7564,14 +7695,17 @@
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7816,6 +7950,21 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       },
       "engines": {
@@ -11708,15 +11857,32 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
     "call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       }
     },
     "callsites": {
@@ -11885,6 +12051,19 @@
       "dev": true,
       "requires": {}
     },
+    "deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "requires": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -11908,11 +12087,11 @@
       }
     },
     "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "requires": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
@@ -11955,6 +12134,16 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -12050,12 +12239,9 @@
       }
     },
     "es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "requires": {
-        "get-intrinsic": "^1.2.4"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
     "es-errors": {
       "version": "1.3.0",
@@ -12067,6 +12253,14 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
       "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -12731,8 +12925,7 @@
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -12747,15 +12940,20 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-package-type": {
@@ -12763,6 +12961,15 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -12827,12 +13034,9 @@
       }
     },
     "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "graceful-fs": {
       "version": "4.2.10",
@@ -12875,23 +13079,17 @@
         "es-define-property": "^1.0.0"
       }
     },
-    "has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
-    },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "requires": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       }
     },
     "hasown": {
@@ -13023,6 +13221,15 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -13067,7 +13274,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -13130,7 +13336,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -13777,6 +13982,14 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json0-ot-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json0-ot-diff/-/json0-ot-diff-1.1.2.tgz",
+      "integrity": "sha512-je6cDbmPc+BkbfyvKo7y1jgQLTrX81L8fkKEIPXRUGFSxK4HTSF6u44ELR35i12tEIWh5+8KfIJH2aJgzKrFww==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -13942,6 +14155,11 @@
         "tmpl": "1.0.5"
       }
     },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -14099,11 +14317,19 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g=="
     },
+    "object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
@@ -14476,14 +14702,16 @@
       "dev": true
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       }
     },
     "require-directory": {
@@ -14647,6 +14875,17 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
+    "set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
       }
     },

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -27,6 +27,7 @@
     "ajv": "^8.12.0",
     "ajv-bsontype": "^1.0.7",
     "express": "^4.18.1",
+    "json0-ot-diff": "^1.1.2",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.2",
     "lodash-es": "^4.17.21",

--- a/src/RealtimeServer/typings/json0-ot-diff.d.ts
+++ b/src/RealtimeServer/typings/json0-ot-diff.d.ts
@@ -1,0 +1,4 @@
+declare module 'json0-ot-diff' {
+  const json0OtDiff: any;
+  export default json0OtDiff;
+}

--- a/src/SIL.XForge/Models/QueuedAction.cs
+++ b/src/SIL.XForge/Models/QueuedAction.cs
@@ -16,4 +16,9 @@ internal enum QueuedAction
     /// The <c>submitOp</c> action.
     /// </summary>
     Submit = 2,
+
+    /// <summary>
+    /// The <c>replaceDoc</c> action.
+    /// </summary>
+    Replace = 3,
 }

--- a/src/SIL.XForge/Realtime/Document.cs
+++ b/src/SIL.XForge/Realtime/Document.cs
@@ -111,6 +111,20 @@ public class Document<T> : IDocument<T>
         }
     }
 
+    public async Task ReplaceAsync(T data, OpSource? source)
+    {
+        await _lock.WaitAsync();
+        try
+        {
+            Snapshot<T> snapshot = await _connection.ReplaceDocAsync(Collection, Id, data, Version, source);
+            UpdateFromSnapshot(snapshot);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
     private void UpdateFromSnapshot(Snapshot<T> snapshot)
     {
         Version = snapshot.Version;

--- a/src/SIL.XForge/Realtime/IConnection.cs
+++ b/src/SIL.XForge/Realtime/IConnection.cs
@@ -32,4 +32,5 @@ public interface IConnection : IDisposable, IAsyncDisposable
         int currentVersion,
         OpSource? source
     );
+    Task<Snapshot<T>> ReplaceDocAsync<T>(string collection, string id, T data, int currentVersion, OpSource? source);
 }

--- a/src/SIL.XForge/Realtime/IDocument.cs
+++ b/src/SIL.XForge/Realtime/IDocument.cs
@@ -23,4 +23,6 @@ public interface IDocument<T>
     Task SubmitOpAsync(object op, OpSource? source);
 
     Task DeleteAsync();
+
+    Task ReplaceAsync(T data, OpSource? source);
 }

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -21,4 +21,5 @@ public interface IRealtimeServer
     bool IsServerRunning();
     bool Restart(object options);
     Task<Snapshot<T>> SubmitOpAsync<T>(int handle, string collection, string id, object op, OpSource? source);
+    Task<Snapshot<T>> ReplaceDocAsync<T>(int handle, string collection, string id, T data, OpSource? source);
 }

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -158,4 +158,18 @@ public class MemoryConnection : IConnection
         int currentVersion,
         OpSource? source
     ) => throw new NotImplementedException();
+
+    /// <summary>
+    /// Replaces a document asynchronously.
+    /// </summary>
+    /// <exception cref="NotImplementedException">
+    /// This is not supported by a <see cref="MemoryConnection" />.
+    /// </exception>
+    public Task<Snapshot<T>> ReplaceDocAsync<T>(
+        string collection,
+        string id,
+        T data,
+        int currentVersion,
+        OpSource? source
+    ) => throw new NotImplementedException();
 }

--- a/src/SIL.XForge/Realtime/MemoryDocument.cs
+++ b/src/SIL.XForge/Realtime/MemoryDocument.cs
@@ -74,9 +74,18 @@ public class MemoryDocument<T> : IDocument<T>
 
     public async Task SubmitOpAsync(object op, OpSource? source)
     {
-        Data = await MemoryRealtimeService.Server.ApplyOpAsync(OTTypeName, Data, op);
-        Data.Id = Id;
+        T data = await MemoryRealtimeService.Server.ApplyOpAsync(OTTypeName, Data, op);
+        data.Id = Id;
+        await _repo.ReplaceAsync(data);
+        Data = data;
         Version++;
-        await _repo.ReplaceAsync(Data);
+    }
+
+    public async Task ReplaceAsync(T data, OpSource? source)
+    {
+        data.Id = Id;
+        await _repo.ReplaceAsync(data);
+        Data = data;
+        Version++;
     }
 }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -99,6 +99,9 @@ public class RealtimeServer : IRealtimeServer
     public Task<T> ApplyOpAsync<T>(string otTypeName, T data, object op) =>
         InvokeExportAsync<T>("applyOp", otTypeName, data, op);
 
+    public Task<Snapshot<T>> ReplaceDocAsync<T>(int handle, string collection, string id, T data, OpSource? source) =>
+        InvokeExportAsync<Snapshot<T>>("replaceDoc", handle, collection, id, data, source);
+
     private Task<T> InvokeExportAsync<T>(string exportedFunctionName, params object?[] args) =>
         _nodeJSService.InvokeFromFileAsync<T>(_modulePath, exportedFunctionName, args);
 

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -168,7 +168,7 @@ public class ConnectionTests
         // Verify queue is empty
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
-        // Verify that the call was not passed to the underlying realtime server
+        // Verify that the call was passed to the underlying realtime server
         await env
             .RealtimeService.Server.Received(1)
             .CreateDocAsync(
@@ -219,7 +219,7 @@ public class ConnectionTests
         // Verify queue is empty
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
-        // Verify that the call was not passed to the underlying realtime server
+        // Verify that the call was passed to the underlying realtime server
         await env
             .RealtimeService.Server.Received(1)
             .DeleteDocAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>());
@@ -468,7 +468,7 @@ public class ConnectionTests
         // Verify queue is empty
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
-        // Verify that the call was not passed to the underlying realtime server
+        // Verify that the call was passed to the underlying realtime server
         await env.RealtimeService.Server.Received(1).ReplaceDocAsync(Arg.Any<int>(), collection, id, data, source);
     }
 
@@ -634,7 +634,7 @@ public class ConnectionTests
         // Verify queue
         Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
 
-        // Verify that the call was not passed to the underlying realtime server
+        // Verify that the call was passed to the underlying realtime server
         await env
             .RealtimeService.Server.Received(1)
             .SubmitOpAsync<TestProject>(

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -62,18 +62,15 @@ public class ConnectionTests
     {
         // Setup
         var env = new TestEnvironment();
-        string collection = "test_project";
-        string id = "id1";
-        string otTypeName = OTType.Json0;
-        var snapshot = new Snapshot<TestProject>
-        {
-            Data = new TestProject() { Id = id, SyncDisabled = false },
-            Version = 1,
-        };
+        const string collection = "test_project";
+        const string id = "id1";
+        const string otTypeName = OTType.Json0;
+        var data = new TestProject { Id = id, SyncDisabled = false };
+        var snapshot = new Snapshot<TestProject> { Data = data, Version = 1 };
         var builder = new Json0OpBuilder<TestProject>(snapshot.Data);
         builder.Set(p => p.SyncDisabled, true);
         List<Json0Op> op = builder.Op;
-        var updatedData = new TestProject() { Id = id, SyncDisabled = true };
+        var updatedData = new TestProject { Id = id, SyncDisabled = true };
 
         env.RealtimeService.Server.FetchDocAsync<TestProject>(Arg.Any<int>(), collection, id)
             .Returns(Task.FromResult(snapshot));
@@ -82,13 +79,15 @@ public class ConnectionTests
         // Setup Queue
         env.Service.BeginTransaction();
         await env.Service.CreateDocAsync(collection, id, snapshot.Data, otTypeName);
-        await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version, null);
+        await env.Service.SubmitOpAsync(collection, id, op, snapshot.Data, snapshot.Version, source: null);
+        await env.Service.ReplaceDocAsync(collection, id, data, snapshot.Version, source: null);
         await env.Service.DeleteDocAsync(collection, id);
 
         // Verify Queue
-        Assert.AreEqual(env.Service.QueuedOperations.First().Action, QueuedAction.Create);
-        Assert.AreEqual(env.Service.QueuedOperations.Skip(1).First().Action, QueuedAction.Submit);
-        Assert.AreEqual(env.Service.QueuedOperations.Last().Action, QueuedAction.Delete);
+        Assert.AreEqual(QueuedAction.Create, env.Service.QueuedOperations.First().Action);
+        Assert.AreEqual(QueuedAction.Submit, env.Service.QueuedOperations.Skip(1).First().Action);
+        Assert.AreEqual(QueuedAction.Replace, env.Service.QueuedOperations.Skip(2).First().Action);
+        Assert.AreEqual(QueuedAction.Delete, env.Service.QueuedOperations.Last().Action);
 
         // SUT
         await env.Service.CommitTransactionAsync();
@@ -103,6 +102,15 @@ public class ConnectionTests
         await env
             .RealtimeService.Server.Received(1)
             .SubmitOpAsync<object>(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<OpSource?>()
+            );
+        await env
+            .RealtimeService.Server.Received(1)
+            .ReplaceDocAsync(
                 Arg.Any<int>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
@@ -326,6 +334,20 @@ public class ConnectionTests
     }
 
     [Test]
+    public async Task GetAndFetchDocsAsync_NoIds()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        string[] ids = [];
+
+        // SUT
+        IReadOnlyCollection<IDocument<Project>> actual = await env.Service.GetAndFetchDocsAsync<Project>(ids);
+
+        // Verify
+        Assert.IsEmpty(actual);
+    }
+
+    [Test]
     public async Task GetAndFetchDocsAsync_RetrievesDocsWithData()
     {
         // Setup
@@ -387,6 +409,67 @@ public class ConnectionTests
         Assert.AreEqual("id1", result.First().Id);
         Assert.AreEqual(1, result.First().Version);
         Assert.IsNotNull(result.First().Data);
+    }
+
+    [Test]
+    public async Task ReplaceDocAsync_QueuesAction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        const string collection = "test_project";
+        const string id = "id1";
+        var data = new TestProject { Id = id, Name = "Test Project 1" };
+        const int currentVersion = 1;
+        OpSource? source = OpSource.Draft;
+
+        // SUT
+        env.Service.BeginTransaction();
+        Snapshot<TestProject> actual = await env.Service.ReplaceDocAsync(collection, id, data, currentVersion, source);
+
+        // Verify result
+        Assert.AreEqual(currentVersion + 1, actual.Version);
+        Assert.AreEqual(data, actual.Data);
+
+        // Verify queue
+        Assert.AreEqual(1, env.Service.QueuedOperations.Count);
+        QueuedOperation queuedOperation = env.Service.QueuedOperations.First();
+        Assert.AreEqual(QueuedAction.Replace, queuedOperation.Action);
+        Assert.AreEqual(collection, queuedOperation.Collection);
+        Assert.AreEqual(data, queuedOperation.Data);
+        Assert.AreEqual(id, queuedOperation.Id);
+        Assert.AreEqual(source, queuedOperation.Source);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env
+            .RealtimeService.Server.Received(0)
+            .ReplaceDocAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<OpSource?>()
+            );
+    }
+
+    [Test]
+    public async Task ReplaceDocAsync_UsesUnderlyingRealtimeServerOutsideOfATransaction()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        const string collection = "test_project";
+        const string id = "id1";
+        var data = new TestProject { Id = id, Name = "Test Project 1" };
+        const int currentVersion = 1;
+        OpSource? source = OpSource.Draft;
+
+        // SUT
+        await env.Service.ReplaceDocAsync(collection, id, data, currentVersion, source);
+
+        // Verify queue is empty
+        Assert.AreEqual(env.Service.QueuedOperations.Count, 0);
+
+        // Verify that the call was not passed to the underlying realtime server
+        await env.RealtimeService.Server.Received(1).ReplaceDocAsync(Arg.Any<int>(), collection, id, data, source);
     }
 
     [Test]

--- a/test/SIL.XForge.Tests/Realtime/DocumentTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/DocumentTests.cs
@@ -77,7 +77,6 @@ public class DocumentTests
     public async Task FetchAsyncOrCreate_Fetches()
     {
         var env = new TestEnvironment();
-        env.Connection.CreateDocAsync(Collection, Id, _data, OtTypeName).Returns(Task.FromResult(_snapshot));
         env.Connection.FetchDocAsync<Json0Snapshot>(Collection, Id).Returns(Task.FromResult(_snapshot));
 
         // SUT

--- a/test/SIL.XForge.Tests/Realtime/DocumentTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/DocumentTests.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Realtime;
+
+[TestFixture]
+public class DocumentTests
+{
+    // Values used for tests
+    private const string Collection = "collection_name";
+    private const string Id = "id1";
+    private const string OtTypeName = OTType.Json0;
+    private const OpSource Source = OpSource.Draft;
+    private const int Version = 1;
+    private static readonly Json0Snapshot _data = new Json0Snapshot { Id = Id };
+    private static readonly Op _op = new Op();
+    private static readonly Snapshot<Json0Snapshot> _snapshot = new Snapshot<Json0Snapshot>
+    {
+        Data = _data,
+        Id = Id,
+        Version = Version,
+    };
+
+    [Test]
+    public async Task CreateAsync_Success()
+    {
+        var env = new TestEnvironment();
+        env.Connection.CreateDocAsync(Collection, Id, _data, OtTypeName).Returns(Task.FromResult(_snapshot));
+
+        // SUT
+        await env.Document.CreateAsync(_data);
+
+        await env.Connection.Received(1).CreateDocAsync(Collection, Id, _data, OtTypeName);
+    }
+
+    [Test]
+    public async Task DeleteAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Document.DeleteAsync();
+
+        await env.Connection.Received(1).DeleteDocAsync(Collection, Id);
+    }
+
+    [Test]
+    public async Task FetchAsync_Success()
+    {
+        var env = new TestEnvironment();
+        env.Connection.FetchDocAsync<Json0Snapshot>(Collection, Id).Returns(Task.FromResult(_snapshot));
+
+        // SUT
+        await env.Document.FetchAsync();
+
+        await env.Connection.Received(1).FetchDocAsync<Json0Snapshot>(Collection, Id);
+    }
+
+    [Test]
+    public async Task FetchAsyncOrCreate_Creates()
+    {
+        var env = new TestEnvironment();
+        env.Connection.CreateDocAsync(Collection, Id, _data, OtTypeName).Returns(Task.FromResult(_snapshot));
+        env.Connection.FetchDocAsync<Json0Snapshot>(Collection, Id)
+            .Returns(Task.FromResult(new Snapshot<Json0Snapshot>()));
+
+        // SUT
+        await env.Document.FetchOrCreateAsync(() => _data);
+
+        await env.Connection.Received(1).FetchDocAsync<Json0Snapshot>(Collection, Id);
+        await env.Connection.Received(1).CreateDocAsync(Collection, Id, _data, OtTypeName);
+    }
+
+    [Test]
+    public async Task FetchAsyncOrCreate_Fetches()
+    {
+        var env = new TestEnvironment();
+        env.Connection.CreateDocAsync(Collection, Id, _data, OtTypeName).Returns(Task.FromResult(_snapshot));
+        env.Connection.FetchDocAsync<Json0Snapshot>(Collection, Id).Returns(Task.FromResult(_snapshot));
+
+        // SUT
+        await env.Document.FetchOrCreateAsync(() => _data);
+
+        await env.Connection.Received(1).FetchDocAsync<Json0Snapshot>(Collection, Id);
+        await env.Connection.Received(0).CreateDocAsync(Collection, Id, _data, OtTypeName);
+    }
+
+    [Test]
+    public async Task ReplaceAsync_Success()
+    {
+        var env = new TestEnvironment();
+        env.Connection.ReplaceDocAsync(Collection, Id, _data, Version, Source).Returns(Task.FromResult(_snapshot));
+
+        // SUT
+        await env.Document.ReplaceAsync(_data, Source);
+
+        await env.Connection.Received(1).ReplaceDocAsync(Collection, Id, _data, Version, Source);
+    }
+
+    [Test]
+    public async Task SubmitOpAsync_Success()
+    {
+        var env = new TestEnvironment();
+        env.Connection.SubmitOpAsync(Collection, Id, _op, _data, Version, Source).Returns(Task.FromResult(_snapshot));
+
+        // SUT
+        await env.Document.SubmitOpAsync(_op, Source);
+
+        await env.Connection.Received(1).SubmitOpAsync(Collection, Id, _op, _data, Version, Source);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment() =>
+            Document = new Document<Json0Snapshot>(Connection, OtTypeName, Collection, Id, _snapshot);
+
+        public IConnection Connection { get; } = Substitute.For<IConnection>();
+        public Document<Json0Snapshot> Document { get; }
+    }
+}

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServerTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServerTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Threading.Tasks;
+using Jering.Javascript.NodeJS;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace SIL.XForge.Realtime;
+
+[TestFixture]
+public class RealtimeServerTests
+{
+    [Test]
+    public async Task ApplyOpAsync_Success()
+    {
+        var env = new TestEnvironment();
+        object data = new { };
+        object op = new { };
+
+        // SUT
+        await env.Service.ApplyOpAsync(OTType.Json0, data, op);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<object>(Arg.Any<string>(), "applyOp", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task CreateDocAsync_Success()
+    {
+        var env = new TestEnvironment();
+        object data = new { };
+
+        // SUT
+        await env.Service.CreateDocAsync(0, string.Empty, string.Empty, data, OTType.Json0);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>>(Arg.Any<string>(), "createDoc", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task ConnectAsync_NoUser()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.ConnectAsync();
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync<int>(Arg.Any<string>(), "connect", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task ConnectAsync_Success()
+    {
+        var env = new TestEnvironment();
+        const string userId = "user01";
+
+        // SUT
+        await env.Service.ConnectAsync(userId);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync<int>(Arg.Any<string>(), "connect", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task DeleteDocAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.DeleteDocAsync(0, string.Empty, string.Empty);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "deleteDoc", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Disconnect_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        env.Service.Disconnect(0);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "disconnect", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task DisconnectAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.DisconnectAsync(0);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "disconnect", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task FetchDocAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.FetchDocAsync<object>(0, string.Empty, string.Empty);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>>(Arg.Any<string>(), "fetchDoc", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task FetchDocsAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.FetchDocsAsync<object>(0, string.Empty, []);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>[]>(Arg.Any<string>(), "fetchDocs", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task FetchSnapshotAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.FetchSnapshotAsync<object>(0, string.Empty, string.Empty, DateTime.MinValue);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>>(Arg.Any<string>(), "fetchSnapshotByTimestamp", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task GetOpsAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.GetOpsAsync(string.Empty, string.Empty);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync<Op[]>(Arg.Any<string>(), "getOps", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task IsServerRunning_Success()
+    {
+        var env = new TestEnvironment();
+        env.Service.Start(options: new { });
+        env.NodeJsProcess.InvokeFromFileAsync<bool>(Arg.Any<string>(), "isServerRunning", Arg.Any<object[]>())
+            .Returns(true);
+
+        // SUT
+        bool actual = env.Service.IsServerRunning();
+        Assert.IsTrue(actual);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<bool>(Arg.Any<string>(), "isServerRunning", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task IsServerRunning_WillReturnFalseIfNotStarted()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        bool actual = env.Service.IsServerRunning();
+        Assert.IsFalse(actual);
+
+        await env
+            .NodeJsProcess.Received(0)
+            .InvokeFromFileAsync<bool>(Arg.Any<string>(), "isServerRunning", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task ReplaceDocAsync_Success()
+    {
+        var env = new TestEnvironment();
+        object data = new { };
+
+        // SUT
+        await env.Service.ReplaceDocAsync(0, string.Empty, string.Empty, data, null);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>>(Arg.Any<string>(), "replaceDoc", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Restart_Success()
+    {
+        var env = new TestEnvironment();
+        env.NodeJsProcess.InvokeFromFileAsync<bool>(Arg.Any<string>(), "isServerRunning", Arg.Any<object[]>())
+            .Returns(true);
+
+        // SUT
+        bool actual = env.Service.Restart(options: new { });
+        Assert.IsTrue(actual);
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "start", Arg.Any<object[]>());
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<bool>(Arg.Any<string>(), "isServerRunning", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Start_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        env.Service.Start(options: new { });
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "start", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Start_WillNotStartTwice()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        env.Service.Start(options: new { });
+        env.Service.Start(options: new { });
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "start", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Stop_Success()
+    {
+        var env = new TestEnvironment();
+        env.Service.Start(options: new { });
+
+        // SUT
+        env.Service.Stop();
+
+        await env.NodeJsProcess.Received(1).InvokeFromFileAsync(Arg.Any<string>(), "stop", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task Stop_WillNotStopIfNotStarted()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        env.Service.Stop();
+
+        await env.NodeJsProcess.Received(0).InvokeFromFileAsync(Arg.Any<string>(), "stop", Arg.Any<object[]>());
+    }
+
+    [Test]
+    public async Task SubmitOpAsync_Success()
+    {
+        var env = new TestEnvironment();
+        object op = new { };
+
+        // SUT
+        await env.Service.SubmitOpAsync<object>(0, string.Empty, string.Empty, op, null);
+
+        await env
+            .NodeJsProcess.Received(1)
+            .InvokeFromFileAsync<Snapshot<object>>(Arg.Any<string>(), "submitOp", Arg.Any<object[]>());
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment() => Service = new RealtimeServer(NodeJsProcess);
+
+        public INodeJSService NodeJsProcess { get; } = Substitute.For<INodeJSService>();
+        public RealtimeServer Service { get; }
+    }
+}


### PR DESCRIPTION
This PR adds support for replacing a document in the real time server, and having the real time server calculate the ops for you to replace the document.

This will be useful for updating JSON0 documents, which are complex and deeply nested.

This PR has been split off [feature/SF-3133](https://github.com/sillsdev/web-xforge/compare/feature/SF-3133) as it is a discrete piece of work, in the hope it will make code review easier, instead of one very large PR for [SF-3133](https://jira.sil.org/browse/SF-3133).

I also took the opportunity to add missing unit tests for classes I modified for this PR to help improve test coverage.

This PR doesn't have any acceptance criteria as the function is not yet in use (it is foundational work for [SF-3133](https://jira.sil.org/browse/SF-3133)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2991)
<!-- Reviewable:end -->
