### PR TITLE
SF-2864 Fix icon run-off on smaller mobile devices

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -79,7 +79,6 @@
               </app-book-chapter-chooser>
               @if (chapterHasAudio) {
                 <button
-                  type="button"
                   mat-icon-button
                   [matTooltip]="t('play_chapter')"
                   [matTooltipDisabled]="isAudioPlaying()"
@@ -93,7 +92,6 @@
             <div class="action-icons">
               @if (canCreateScriptureAudio) {
                 <button
-                  type="button"
                   mat-icon-button
                   [matTooltip]="t('manage_audio')"
                   (click)="addAudioTimingData()"
@@ -187,24 +185,24 @@
       </div>
       @if (projectDoc && totalVisibleQuestions() > 0) {
         <div id="question-nav" [ngClass]="{ hide: textboxIsShownMobile || userOpenedChapterAudio }">
-          <div class="question-nav-left">
+          <div class="question-nav-start">
             @if (canCreateQuestions) {
               <button
                 mat-icon-button
-                type="button"
                 [matTooltip]="t('add_question')"
                 (click)="questionDialog()"
                 class="add-question-button"
               >
                 <mat-icon class="mirror-rtl">post_add</mat-icon>
               </button>
-              <button mat-button type="button" (click)="questionDialog()" class="add-question-button">
+              <button mat-button (click)="questionDialog()" class="add-question-button">
                 <mat-icon class="mirror-rtl">post_add</mat-icon>
                 <span>{{ t("add_question") }}</span>
               </button>
             }
             @if (!isQuestionListPermanent) {
-              <button mat-button type="button" (click)="setQuestionsOverlayVisibility(true)">
+              <button mat-button class="view-questions" (click)="setQuestionsOverlayVisibility(true)">
+                <mat-icon>keyboard_arrow_up</mat-icon>
                 {{ t("view_questions") }}
               </button>
             }
@@ -212,7 +210,6 @@
           <div class="question-nav-wrapper">
             <button
               mat-button
-              type="button"
               (click)="activateQuestion(prevQuestion!)"
               [disabled]="prevQuestion == null"
               class="prev-question"
@@ -222,7 +219,6 @@
             </button>
             <button
               mat-button
-              type="button"
               (click)="activateQuestion(nextQuestion!)"
               [disabled]="nextQuestion == null"
               class="next-question"
@@ -231,7 +227,6 @@
             </button>
             <button
               mat-icon-button
-              type="button"
               (click)="activateQuestion(prevQuestion!)"
               [disabled]="prevQuestion == null"
               class="prev-question"
@@ -240,7 +235,6 @@
             </button>
             <button
               mat-icon-button
-              type="button"
               (click)="activateQuestion(nextQuestion!)"
               [disabled]="nextQuestion == null"
               class="next-question"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -183,7 +183,7 @@
           </as-split>
         </div>
       </div>
-      @if (projectDoc && (totalVisibleQuestions() > 0 || canCreateQuestions)) {
+      @if (projectDoc) {
         <div id="question-nav" [ngClass]="{ hide: textboxIsShownMobile || userOpenedChapterAudio }">
           <div class="question-nav-start">
             @if (canCreateQuestions) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -64,35 +64,33 @@
       <div id="scripture-panel">
         <header>
           <div class="panel-nav">
-            <app-book-chapter-chooser
-              [books]="books"
-              [book]="book"
-              [chapters]="chapters"
-              [chapter]="chapter"
-              [bookSelectDisabled]="activeQuestionScope === 'all'"
-              [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
-              [prevNextHidden]="activeQuestionScope !== 'chapter' || isScreenSmall"
-              (bookChange)="onBookSelect($event)"
-              (chapterChange)="onChapterSelect($event)"
-            >
-            </app-book-chapter-chooser>
-
-            <div class="action-icons">
-              @if (canCreateQuestions) {
+            <div class="book-chapter">
+              <app-book-chapter-chooser
+                [books]="books"
+                [book]="book"
+                [chapters]="chapters"
+                [chapter]="chapter"
+                [bookSelectDisabled]="activeQuestionScope === 'all'"
+                [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
+                [prevNextHidden]="activeQuestionScope !== 'chapter' || isScreenSmall"
+                (bookChange)="onBookSelect($event)"
+                (chapterChange)="onChapterSelect($event)"
+              >
+              </app-book-chapter-chooser>
+              @if (chapterHasAudio) {
                 <button
-                  mat-icon-button
                   type="button"
-                  [matTooltip]="t('add_question')"
-                  (click)="questionDialog()"
-                  class="add-question-button hide-gt-xl"
+                  mat-icon-button
+                  [matTooltip]="t('play_chapter')"
+                  [matTooltipDisabled]="isAudioPlaying()"
+                  (click)="toggleAudio()"
                 >
-                  <mat-icon class="mirror-rtl">post_add</mat-icon>
-                </button>
-                <button mat-button type="button" (click)="questionDialog()" class="add-question-button hide-lt-xl">
-                  <mat-icon class="mirror-rtl">post_add</mat-icon>
-                  <span>{{ t("add_question") }}</span>
+                  <mat-icon>{{ isAudioPlaying() ? "stop" : "play_arrow" }}</mat-icon>
                 </button>
               }
+            </div>
+
+            <div class="action-icons">
               @if (canCreateScriptureAudio) {
                 <button
                   type="button"
@@ -102,17 +100,6 @@
                   class="add-audio-button"
                 >
                   <mat-icon class="material-icons-outlined">audio_file</mat-icon>
-                </button>
-              }
-              @if (chapterHasAudio) {
-                <button
-                  type="button"
-                  mat-icon-button
-                  [matTooltip]="t('play_chapter')"
-                  [matTooltipDisabled]="isAudioPlaying()"
-                  (click)="toggleAudio()"
-                >
-                  <mat-icon>{{ isAudioPlaying() ? "stop" : "play_circle_outline" }}</mat-icon>
                 </button>
               }
               <app-font-size [class.hidden]="hideChapterText" (apply)="applyFontChange($event)"></app-font-size>
@@ -200,11 +187,28 @@
       </div>
       @if (projectDoc && totalVisibleQuestions() > 0) {
         <div id="question-nav" [ngClass]="{ hide: textboxIsShownMobile || userOpenedChapterAudio }">
-          @if (!isQuestionListPermanent) {
-            <button mat-button type="button" (click)="setQuestionsOverlayVisibility(true)">
-              {{ t("view_questions") }}
-            </button>
-          }
+          <div class="question-nav-left">
+            @if (canCreateQuestions) {
+              <button
+                mat-icon-button
+                type="button"
+                [matTooltip]="t('add_question')"
+                (click)="questionDialog()"
+                class="add-question-button"
+              >
+                <mat-icon class="mirror-rtl">post_add</mat-icon>
+              </button>
+              <button mat-button type="button" (click)="questionDialog()" class="add-question-button">
+                <mat-icon class="mirror-rtl">post_add</mat-icon>
+                <span>{{ t("add_question") }}</span>
+              </button>
+            }
+            @if (!isQuestionListPermanent) {
+              <button mat-button type="button" (click)="setQuestionsOverlayVisibility(true)">
+                {{ t("view_questions") }}
+              </button>
+            }
+          </div>
           <div class="question-nav-wrapper">
             <button
               mat-button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -77,6 +77,9 @@
                 (chapterChange)="onChapterSelect($event)"
               >
               </app-book-chapter-chooser>
+            </div>
+
+            <div class="action-icons">
               @if (chapterHasAudio) {
                 <button
                   mat-icon-button
@@ -84,12 +87,9 @@
                   [matTooltipDisabled]="isAudioPlaying()"
                   (click)="toggleAudio()"
                 >
-                  <mat-icon>{{ isAudioPlaying() ? "stop" : "play_arrow" }}</mat-icon>
+                  <mat-icon>{{ isAudioPlaying() ? "stop" : "play_circle_outline" }}</mat-icon>
                 </button>
               }
-            </div>
-
-            <div class="action-icons">
               @if (canCreateScriptureAudio) {
                 <button
                   mat-icon-button
@@ -183,7 +183,7 @@
           </as-split>
         </div>
       </div>
-      @if (projectDoc && totalVisibleQuestions() > 0) {
+      @if (projectDoc && (totalVisibleQuestions() > 0 || canCreateQuestions)) {
         <div id="question-nav" [ngClass]="{ hide: textboxIsShownMobile || userOpenedChapterAudio }">
           <div class="question-nav-start">
             @if (canCreateQuestions) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -222,9 +222,7 @@ header {
     padding: 9px;
 
     .mat-icon {
-      font-size: 24px;
-      height: 24px;
-      width: 24px;
+      @include checkingVars.md-icon-size(24px);
     }
 
     .view-questions .mat-icon {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -217,8 +217,28 @@ header {
     background-color: lighten(vars.$sf_grey, 70%);
     display: flex;
     align-items: center;
-    justify-content: flex-end;
+    justify-content: space-between;
     padding: 9px;
+
+    .question-nav-left {
+      display: flex;
+      align-items: center;
+      column-gap: 4px;
+    }
+
+    .add-question-button.mat-mdc-icon-button {
+      display: none;
+    }
+
+    @include media-breakpoint('<=', sm) {
+      .add-question-button.mat-mdc-button {
+        display: none;
+      }
+
+      .add-question-button.mat-mdc-icon-button {
+        display: block;
+      }
+    }
 
     .question-nav-wrapper {
       display: flex;
@@ -247,7 +267,6 @@ header {
     @include media-breakpoint('<=', sm, $questionsPanelBreakpoint) {
       // Widen once the questions panel is hidden
       margin-inline-start: -20px;
-      justify-content: space-between;
     }
 
     .next-question {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -86,17 +86,18 @@ header {
   // Override 'sm' breakpoint for this element (also adjusts BreakPointObserver 'SM' for this element)
   @include media-breakpoint('<=', sm, $questionsPanelBreakpoint) {
     position: absolute;
-    top: 0;
-    left: -100%;
+    bottom: 0;
+    left: 0;
     width: 100%;
-    height: 100%;
+    height: 0;
     margin: 0;
     z-index: 7;
+    overflow: hidden;
     background: #fff;
-    transition: transform 0.4s cubic-bezier(0.68, -0.6, 0.265, 1.6); // Snap back effect
+    transition: height 0.4s cubic-bezier(0.68, -0.6, 0.265, 1.6); // Snap back effect
 
     &.overlay-visible {
-      transform: translateX(100%);
+      height: 100%;
 
       .questions-overlay-close {
         display: block;
@@ -220,7 +221,17 @@ header {
     justify-content: space-between;
     padding: 9px;
 
-    .question-nav-left {
+    .mat-icon {
+      font-size: 24px;
+      height: 24px;
+      width: 24px;
+    }
+
+    .view-questions .mat-icon {
+      margin-inline-end: 4px;
+    }
+
+    .question-nav-start {
       display: flex;
       align-items: center;
       column-gap: 4px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -10,6 +10,11 @@
 #chapter-select,
 #book-select {
   @include material-styles.dense_mat_select();
+
+  ::ng-deep .mat-mdc-text-field-wrapper {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
 }
 
 ::ng-deep .mat-mdc-select-panel {


### PR DESCRIPTION
This focuses on both checkers and admin's, with checkers being the primary target.

- Slightly narrowed the book-chapter chooser. I'm aware there's an existing refactor to this, so hopefully it will make this less necessary
- Moved chapter audio next to the book-chapter chooser. This makes a little more sense for checkers, since the chapter audio is near the chapter selection
- Removed circle outline from chapter audio icon
- Moved Add Question button to question nav panel. This is still a logical place for it to live, and it fixes a run-off issue for admin's

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2993)
<!-- Reviewable:end -->
