### PR TITLE
SF-3196 Remove Manual link from Help Menu

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.html
@@ -59,7 +59,6 @@
         </button>
         <mat-menu #helpMenu="matMenu" class="help-menu">
           <a mat-menu-item target="_blank" [href]="urls.helps"><mat-icon>help</mat-icon> {{ t("help") }}</a>
-          <a mat-menu-item target="_blank" [href]="urls.manual"><mat-icon>book</mat-icon> {{ t("manual") }}</a>
           <a mat-menu-item target="_blank" [href]="urls.announcementPage">
             <mat-icon>campaign</mat-icon> {{ t("announcements") }}
           </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -20,7 +20,6 @@
     "language": "Language",
     "log_out": "Log out",
     "logged_in_as": "Logged in as",
-    "manual": "Manual",
     "my_progress": "My progress",
     "offline": "Offline",
     "online": "Online",


### PR DESCRIPTION
As we want users to have up-to-date documentation to assist with FAQ's and newer app features we should remove the RoboHelp Manaul from the Help Menu dropdown as it is not currently maintained/updated as frequently as the Help site.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2995)
<!-- Reviewable:end -->
