### PR TITLE
Update vscode settings for C# extension changes v2.63.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,7 @@
     "zizmor"
   ],
   "dotnet.defaultSolution": "xForge.sln",
+  "dotnet.formatting.organizeImportsOnFormat": true,
   "dotnet-test-explorer.testProjectPath": "test/**/*.Tests.csproj",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
@@ -104,7 +105,6 @@
   "liveSassCompile.settings.generateMap": false,
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
-  "omnisharp.organizeImportsOnFormat": true,
   "python.formatting.provider": "black",
   "typescript.tsdk": "./src/SIL.XForge.Scripture/ClientApp/node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,


### PR DESCRIPTION
The C# extension (v2.63.x) updated to Roslyn v4.14.0-1.25074.7, this change renamed the vscode setting for [organizing imports on format](https://github.com/dotnet/roslyn/pull/76806). This PR updates our settings.json to keep our preferred defaults with the latest version of the extension.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2997)
<!-- Reviewable:end -->
