### PR TITLE
SF-3138 Update projects list dynamically in Add Resource dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -4,13 +4,16 @@ import { provideAnimations } from '@angular/platform-browser/animations';
 
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { BehaviorSubject } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { SFUserProjectsService } from '../../../../../xforge-common/user-projects.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
+import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
 import { PermissionsService } from '../../../../core/permissions.service';
 import { SFProjectService } from '../../../../core/sf-project.service';
@@ -20,6 +23,7 @@ const mockSFProjectService = mock(SFProjectService);
 const mockParatextService = mock(ParatextService);
 const mockMatDialogRef = mock(MatDialogRef);
 const mockPermissionsService = mock(PermissionsService);
+const mockProjectsService = mock(SFUserProjectsService);
 
 describe('EditorTabAddResourceDialogComponent', () => {
   configureTestingModule(() => ({
@@ -30,10 +34,15 @@ describe('EditorTabAddResourceDialogComponent', () => {
       { provide: ParatextService, useMock: mockParatextService },
       { provide: PermissionsService, useMock: mockPermissionsService },
       { provide: MatDialogRef, useMock: mockMatDialogRef },
+      { provide: SFUserProjectsService, useMock: mockProjectsService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: MAT_DIALOG_DATA, useValue: {} }
     ]
   }));
+
+  beforeEach(() => {
+    when(mockProjectsService.projectDocs$).thenReturn(new BehaviorSubject<SFProjectProfileDoc[]>([]));
+  });
 
   afterEach(() => {
     expect(true).toBe(true); // Suppress 'no expectations' warning
@@ -50,9 +59,12 @@ describe('EditorTabAddResourceDialogComponent', () => {
   describe('getProjectsAndResources', () => {
     it('should set projects and resources and clear error flags', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.component['getProjectsAndResources']();
+      tick();
       env.component.projectLoadingFailed = true;
+      tick();
       env.component.resourceLoadingFailed = true;
+      tick();
+      env.component['getProjectsAndResources']();
       tick();
       verify(mockParatextService.getProjects()).once();
       verify(mockParatextService.getResources()).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.spec.ts
@@ -10,7 +10,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
-import { SFUserProjectsService } from '../../../../../xforge-common/user-projects.service';
+import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { mock, resetCalls, verify, when } from 'ts-mockito';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { SFUserProjectsService } from '../../../../../xforge-common/user-projects.service';
+import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.spec.ts
@@ -1,13 +1,17 @@
 import { TestBed } from '@angular/core/testing';
-import { mock, verify, when } from 'ts-mockito';
+import { BehaviorSubject } from 'rxjs';
+import { mock, resetCalls, verify, when } from 'ts-mockito';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { SFUserProjectsService } from '../../../../../xforge-common/user-projects.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
+import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
 import { EditorTabAddResourceDialogService } from './editor-tab-add-resource-dialog.service';
 
 describe('EditorTabAddResourceDialogService', () => {
   let service: EditorTabAddResourceDialogService;
   const mockParatextService = mock(ParatextService);
+  const mockProjectsService = mock(SFUserProjectsService);
   const mockProjects: ParatextProject[] = [
     { id: '1', name: 'Project 1' },
     { id: '2', name: 'Project 2' }
@@ -18,34 +22,59 @@ describe('EditorTabAddResourceDialogService', () => {
   ] as any;
 
   configureTestingModule(() => ({
-    providers: [{ provide: ParatextService, useMock: mockParatextService }]
+    providers: [
+      { provide: ParatextService, useMock: mockParatextService },
+      { provide: SFUserProjectsService, useMock: mockProjectsService }
+    ]
   }));
 
+  const projectDocs = new BehaviorSubject<SFProjectProfileDoc[]>([]);
+
   beforeEach(() => {
+    when(mockProjectsService.projectDocs$).thenReturn(projectDocs);
     service = TestBed.inject(EditorTabAddResourceDialogService);
   });
 
   it('should return cached projects if available', async () => {
-    service.projects = mockProjects;
+    when(mockParatextService.getProjects()).thenResolve(mockProjects);
     expect(await service.getProjects()).toEqual(mockProjects);
   });
 
-  it('should call getProjects if projects are not cached', async () => {
+  it('should return updated projects if they change', async () => {
     when(mockParatextService.getProjects()).thenResolve(mockProjects);
     expect(await service.getProjects()).toEqual(mockProjects);
-    expect(service.projects).toEqual(mockProjects);
+
+    const newProjects = [mockProjects[0]];
+    when(mockParatextService.getProjects()).thenResolve(newProjects);
+    expect(await service.getProjects()).not.toEqual(newProjects);
+
+    projectDocs.next([{} as SFProjectProfileDoc]);
+    await new Promise(resolve => setTimeout(resolve, 0)); // Wait for async subscription to execute
+    expect(await service.getProjects()).toEqual(newProjects);
+  });
+
+  it('should call getProjects if projects are not cached', async () => {
+    resetCalls(mockParatextService);
+
+    when(mockParatextService.getProjects()).thenResolve(mockProjects);
+    expect(await service.getProjects()).toEqual(mockProjects);
+    expect(await service.getProjects()).toEqual(mockProjects);
+
     verify(mockParatextService.getProjects()).once();
   });
 
   it('should return cached resources if available', async () => {
-    service.resources = mockResources;
+    when(mockParatextService.getResources()).thenResolve(mockResources);
     expect(await service.getResources()).toEqual(mockResources);
   });
 
   it('should call getResources if resources are not cached', async () => {
+    resetCalls(mockParatextService);
+
     when(mockParatextService.getResources()).thenResolve(mockResources);
     expect(await service.getResources()).toEqual(mockResources);
-    expect(service.resources).toEqual(mockResources);
+    expect(await service.getResources()).toEqual(mockResources);
+
     verify(mockParatextService.getResources()).once();
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
@@ -1,6 +1,6 @@
 import { DestroyRef, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { SFUserProjectsService } from '../../../../../xforge-common/user-projects.service';
+import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
@@ -24,14 +24,16 @@ export class EditorTabAddResourceDialogService {
   }
 
   async getProjects(): Promise<ParatextProject[] | undefined> {
-    return this.projects != null
-      ? await Promise.resolve(this.projects)
-      : await this.paratextService.getProjects().then(projects => (this.projects = projects));
+    if (!this.projects) {
+      this.projects = await this.paratextService.getProjects();
+    }
+    return this.projects;
   }
 
   async getResources(): Promise<SelectableProject[] | undefined> {
-    return this.resources != null
-      ? await Promise.resolve(this.resources)
-      : await this.paratextService.getResources().then(resources => (this.resources = resources));
+    if (!this.resources) {
+      this.resources = await this.paratextService.getResources();
+    }
+    return this.resources;
   }
 }


### PR DESCRIPTION
This fixes a bug where the cached projects state variable was wrong. The projects list can change, but it was never updated. Now we listen to the projectDocs$ observable and refresh the paratext projects list if the former changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2998)
<!-- Reviewable:end -->
