### PR TITLE
SF-3201 Fix broken editor jump links

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-scripture.ts
@@ -10,6 +10,7 @@ import QuillTextBlot from 'quill/blots/text';
 import QuillClipboard from 'quill/modules/clipboard';
 import QuillHistory, { StackItem } from 'quill/modules/history';
 import { DeltaOperation, StringMap } from 'rich-text';
+import { isString } from '../../../type-utils';
 import { DragAndDrop } from './drag-and-drop';
 import { TextComponent } from './text.component';
 
@@ -224,6 +225,28 @@ export function registerScripture(): string[] {
     contentNode!: HTMLElement;
   }
   formats.push(EmptyEmbed);
+
+  class JumpLinkEmbed extends QuillEmbedBlot {
+    static blotName = 'link';
+    static tagName = 'span'; // TODO: Support jump links in the future
+
+    static create(value: any): Node {
+      const node = super.create(value) as HTMLElement;
+
+      // If link is a jump link to a project/book/chapter/verse, extract the link contents and display as non-link text
+      if (value['link-href'] != null && isString(value.contents?.ops?.[0]?.insert)) {
+        node.innerText = value.contents.ops[0].insert;
+      }
+
+      setUsxValue(node, value);
+      return node;
+    }
+
+    static value(node: HTMLElement): any {
+      return getUsxValue(node);
+    }
+  }
+  formats.push(JumpLinkEmbed);
 
   /** Span of characters or elements, that can have formatting. */
   class CharInline extends QuillInlineBlot {


### PR DESCRIPTION
This PR fixes an error in some resources since upgrading to Quill v2: `[Parchment] Unable to create link blot`.

Quill v1 didn't render the links at all.  These "jump links" seem to be intending to link to a project/book/chapter/verse.  The quick fix is to render the link contents in a span.  In the future, we may try to support these links.

Here is an example value being sent to a 'link' blot:
```json
{
  "style": "jmp",
  "link-href": "prj:TNN.XXB.1.0",
  "contents": {
    "ops": [
      {
        "insert": "Guidelines for Using the Translator's Notes Series"
      }
    ]
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/2999)
<!-- Reviewable:end -->
