### PR TITLE
SF-3202 Add IsDraftingEnabled flag to Projects API

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -66,6 +66,11 @@ public class ParatextProject
     public bool IsDraftingEnabled { get; init; }
 
     /// <summary>
+    /// If the specified project has a draft generated.
+    /// </summary>
+    public bool HasDraft { get; init; }
+
+    /// <summary>
     /// A descriptive string of object's properties, for debugging.
     /// </summary>
     /// <returns>
@@ -87,6 +92,7 @@ public class ParatextProject
                 IsConnectable.ToString(),
                 IsConnected.ToString(),
                 IsDraftingEnabled.ToString(),
+                HasDraft.ToString(),
                 IsRightToLeft?.ToString(),
             }
         )

--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -57,6 +57,15 @@ public class ParatextProject
     public bool IsConnected { get; init; }
 
     /// <summary>
+    /// If the specified project has drafting enabled.
+    /// </summary>
+    /// <remarks>
+    /// A <c>true</c> value does not infer that the user has access to drafting,
+    /// but that drafting has been configured or can be configured for the project.
+    /// </remarks>
+    public bool IsDraftingEnabled { get; init; }
+
+    /// <summary>
     /// A descriptive string of object's properties, for debugging.
     /// </summary>
     /// <returns>
@@ -77,6 +86,7 @@ public class ParatextProject
                 ProjectId,
                 IsConnectable.ToString(),
                 IsConnected.ToString(),
+                IsDraftingEnabled.ToString(),
                 IsRightToLeft?.ToString(),
             }
         )

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2252,8 +2252,7 @@ public class ParatextService : DisposableBase, IParatextService
         IEnumerable<ProjectMetadata> projectsMetadata
     )
     {
-        if (userSecret == null)
-            throw new ArgumentNullException();
+        ArgumentNullException.ThrowIfNull(userSecret, nameof(userSecret));
 
         List<ParatextProject> paratextProjects = [];
         IQueryable<SFProject> existingSfProjects = _realtimeService.QuerySnapshots<SFProject>();
@@ -2281,6 +2280,11 @@ public class ParatextService : DisposableBase, IParatextService
                 correspondingSfProject?.WritingSystem.Tag ?? projectMD?.LanguageId.Code
             );
 
+            // Determine if drafting is enabled
+            bool isBackTranslation =
+                correspondingSfProject?.TranslateConfig.ProjectType == ProjectType.BackTranslation.ToString();
+            bool preTranslationEnabled = correspondingSfProject?.TranslateConfig.PreTranslate == true;
+
             paratextProjects.Add(
                 new ParatextProject
                 {
@@ -2293,6 +2297,7 @@ public class ParatextService : DisposableBase, IParatextService
                     ProjectId = correspondingSfProject?.Id,
                     IsConnectable = ptProjectIsConnectable,
                     IsConnected = sfProjectExists && sfUserIsOnSfProject,
+                    IsDraftingEnabled = isBackTranslation || preTranslationEnabled,
                 }
             );
         }
@@ -2817,6 +2822,7 @@ public class ParatextService : DisposableBase, IParatextService
                         : 0,
                     IsConnectable = false,
                     IsConnected = false,
+                    IsDraftingEnabled = false,
                     IsInstalled = resourceRevisions.ContainsKey(r.DBLEntryUid.Id),
                     LanguageRegion = writingSystem.Region,
                     LanguageScript = writingSystem.Script,


### PR DESCRIPTION
This PR adds an additional property to the /paratext-api/projects endpoint to express whether a project has drafting enabled or not.

This will make it easier for the Paratext Extension to determine what projects can be connected to that already have pre-translation drafting enabled.

This PR is marked as testing not required, as it is an API endpoint change, and so can be tested by a developer as it does not change user experience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3002)
<!-- Reviewable:end -->
