### PR TITLE
SF-3203 Add an API endpoint to join an existing project

### DIFF
--- a/src/SIL.XForge/Services/IProjectService.cs
+++ b/src/SIL.XForge/Services/IProjectService.cs
@@ -5,7 +5,7 @@ namespace SIL.XForge.Services;
 
 public interface IProjectService
 {
-    Task AddUserAsync(string curUserId, string projectId, string projectRole = null);
+    Task AddUserAsync(string curUserId, string projectId, string? projectRole = null);
     Task RemoveUserAsync(string curUserId, string projectId, string projectUserId);
     Task RemoveUserWithoutPermissionsCheckAsync(string curUserId, string projectId, string projectUserId);
     Task<string> GetProjectRoleAsync(string curUserId, string projectId);

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -57,7 +57,11 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
                 throw new ForbiddenException();
         }
 
-        await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole!);
+        // Add the user, if they are not already on the project
+        if (!projectDoc.Data.UserRoles.ContainsKey(curUserId))
+        {
+            await AddUserToProjectAsync(conn, projectDoc, userDoc, projectRole!);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR exposes the AddUser JSON-RPC API endpoint to the Paratext API so that the Paratext Extension can join users to projects that have already connected to Scripture Forge.

I also took the opportunity to remove some unnecessary unit tests which check whether Administrators or Translations can sync resources or cancel resource syncs. (Resources can only have PT Observers).

I have marked this PR as testing not required, as it is an API endpoint and should be tested by a developer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3003)
<!-- Reviewable:end -->
