### PR TITLE
Fix filtering of Transcelerator files

### DIFF
--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -52,7 +52,7 @@ public class TransceleratorService : ITransceleratorService
         });
     }
 
-    private IEnumerable<string> QuestionFiles(string paratextId)
+    public IEnumerable<string> QuestionFiles(string paratextId)
     {
         string pathToFiles = Path.Combine(
             _siteOptions.Value.SiteDir,
@@ -63,9 +63,9 @@ public class TransceleratorService : ITransceleratorService
             "Transcelerator",
             "Transcelerator"
         );
-        string fileRegex = "Translated Checking Questions for \\w+\\.xml$";
+        string fileRegex = "^Translated Checking Questions for \\w+\\.xml$";
         return _fileService.DirectoryExists(pathToFiles)
-            ? _fileService.EnumerateFiles(pathToFiles).Where(file => Regex.IsMatch(file, fileRegex))
+            ? _fileService.EnumerateFiles(pathToFiles).Where(file => Regex.IsMatch(Path.GetFileName(file), fileRegex))
             : System.Array.Empty<string>();
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TransceleratorServiceTests.cs
@@ -45,6 +45,28 @@ public class TransceleratorServiceTests
         Assert.DoesNotThrow(() => env.Service.Questions(Project01));
     }
 
+    [Test]
+    public void TransceleratorService_QuestionFiles_FiltersFiles()
+    {
+        var env = new TestEnvironment();
+        env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
+        env.FileSystemService.EnumerateFiles(Arg.Any<string>())
+            .Returns(
+                new string[]
+                {
+                    "._Translated Checking Questions for 1SA.xml",
+                    "Phrase substitutions.xml",
+                    "Question Customizations.xml",
+                    "Translated Checking Questions for 1SA.xml",
+                    "Translations of Checking Questions.xml",
+                }
+            );
+        Assert.AreEqual(
+            env.Service.QuestionFiles("project_id"),
+            new string[] { "Translated Checking Questions for 1SA.xml" }
+        );
+    }
+
     private class TestEnvironment
     {
         public TestEnvironment()


### PR DESCRIPTION
A project had a file named `._Translated Checking Questions for 1SA.xml` which appeared to have binary garbage in it. This improves the filtering to more carefully match only the correct Trascelerator files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3007)
<!-- Reviewable:end -->
