### PR TITLE
Prevent front-end tests from passing when warnings are printed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,8 +84,14 @@ jobs:
             -p:CollectCoverage=true \
             -e:CoverletOutputFormat=opencover \
             -e:Exclude=\"[NUnit3.TestAdapter]*,[SIL.XForge.*.Views]*,[SIL.XForge.Tests]*\"
+
+      # Run the tests while making sure none of the common/known warnings are printed
       - name: "Test: Frontend"
-        run: cd src/SIL.XForge.Scripture/ClientApp && npm run test:gha
+        run: |
+          set -e
+          cd src/SIL.XForge.Scripture/ClientApp
+          npm run test:gha | tee output.log
+          ! grep NG0303 output.log # Can't bind to 'some_property since it isn't a known property of 'some_element'
 
       - name: "Coverage: Backend"
         run: |

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/attach-audio/attach-audio.component.spec.ts
@@ -3,6 +3,7 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
+import { ngfModule } from 'angular-file';
 import { InvalidFileItem } from 'angular-file/file-upload/fileTools';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
@@ -23,7 +24,14 @@ describe('AttachAudioComponent', () => {
   let env: TestEnvironment;
 
   configureTestingModule(() => ({
-    imports: [CommonModule, UICommonModule, SharedModule, TestTranslocoModule, TestOnlineStatusModule.forRoot()],
+    imports: [
+      CommonModule,
+      UICommonModule,
+      ngfModule,
+      SharedModule,
+      TestTranslocoModule,
+      TestOnlineStatusModule.forRoot()
+    ],
     declarations: [AttachAudioComponent],
     providers: [
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },


### PR DESCRIPTION
We frequently end up merging tests that pass but cause warnings to be printed. This updates the workflow to try to stop this. Initially, this branch will fail *on purpose* to prove the change works. Then it will be updated to fix the warnings.

Actually, not sure if that strategy will work, because maybe it will run the workflow as it already exists on master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3008)
<!-- Reviewable:end -->
