### PR TITLE
SF-3199 CacheService disposes of older subscriptions

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -39,6 +39,7 @@ import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
 import { roleCanAccessTranslate } from './core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from './core/models/sf-project-user-config-doc';
 import { SFProjectService } from './core/sf-project.service';
+import { CacheService } from './shared/cache-service/cache.service';
 import { checkAppAccess } from './shared/utils';
 
 declare function gtag(...args: any): void;
@@ -77,6 +78,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
     private readonly activatedProjectService: ActivatedProjectService,
+    private readonly cacheService: CacheService,
     private readonly locationService: LocationService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly breakpointService: MediaBreakpointService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -78,7 +78,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly fileService: FileService,
     private readonly reportingService: ErrorReportingService,
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly cacheService: CacheService,
     private readonly locationService: LocationService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly breakpointService: MediaBreakpointService,
@@ -88,6 +87,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     readonly urls: ExternalUrlService,
     readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService,
+    _cacheService: CacheService, //don't remove, as this needs to be used to be constructed
     onlineStatusService: OnlineStatusService
   ) {
     super(noticeService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
@@ -2,30 +2,42 @@ import { NgZone } from '@angular/core';
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
+import { BehaviorSubject } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { MemoryRealtimeDocAdapter } from '../../../xforge-common/memory-realtime-remote-store';
+import { RealtimeDocAdapter } from '../../../xforge-common/realtime-remote-store';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
-import { TextDocId } from '../../core/models/text-doc';
+import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { CacheService } from './cache.service';
 
 const mockedProjectService = mock(SFProjectService);
-const mockedProjectDoc = mock(SFProjectProfileDoc);
 const mockedPermissionService = mock(PermissionsService);
+const mockedActivatedProject = mock(ActivatedProjectService);
+const projectId$ = new BehaviorSubject<string>('');
 
 describe('cache service', () => {
   configureTestingModule(() => ({
     providers: [
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: PermissionsService, useMock: mockedPermissionService }
+      { provide: PermissionsService, useMock: mockedPermissionService },
+      { provide: ActivatedProjectService, useMock: mockedActivatedProject }
     ]
   }));
+
   describe('load all texts', () => {
+    beforeEach(() => {
+      const text = { adapter: instance(mock<RealtimeDocAdapter>()) } as TextDoc;
+      when(mockedProjectService.getText(anything())).thenResolve(text);
+      when(mockedActivatedProject.projectId$).thenReturn(projectId$);
+    });
+
     it('does not get texts from project service if no permission', fakeAsync(async () => {
-      const env = new TestEnvironment();
       when(mockedPermissionService.canAccessText(anything())).thenResolve(false);
-      await env.service.cache(env.projectDoc);
+      const env = new TestEnvironment();
       env.wait();
 
       verify(mockedProjectService.getText(anything())).times(0);
@@ -36,38 +48,62 @@ describe('cache service', () => {
 
     it('gets all texts from project service', fakeAsync(async () => {
       const env = new TestEnvironment();
-      await env.service.cache(env.projectDoc);
       env.wait();
+      flush();
 
-      verify(mockedProjectService.getText(anything())).times(200 * 100 * 2);
+      verify(mockedProjectService.getText(anything())).times(20 * 10 * 2);
 
       flush();
       expect(true).toBeTruthy();
     }));
 
     it('stops the current operation if cache is called again', fakeAsync(async () => {
-      const env = new TestEnvironment();
+      // configure the first project to interrupt itself
+      let timesCalled = 0;
+      const text = { adapter: instance(mock(MemoryRealtimeDocAdapter)) as RealtimeDocAdapter } as TextDoc;
+      when(mockedProjectService.getText(anything())).thenCall(async () => {
+        ++timesCalled;
+        if (timesCalled > 1) {
+          await cacheNewProject();
+        }
 
-      const mockProject = mock(SFProjectProfileDoc);
-      when(mockProject.id).thenReturn('new project');
-      const data = createTestProjectProfile({
-        texts: env.createTexts()
+        return text;
       });
-      when(mockProject.data).thenReturn(data);
 
-      env.service.cache(env.projectDoc);
-      await env.service.cache(instance(mockProject));
+      // configure the new project
+      when(
+        mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
+      ).thenResolve(text);
+
+      const env = new TestEnvironment();
+      when(
+        mockedPermissionService.canAccessText(deepEqual(new TextDocId('sourceId', anything(), anything(), 'target')))
+      ).thenResolve(false); // remove source permissions for simpler test calculations
+
       env.wait();
+      flush();
 
       verify(
         mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
-      ).times(200 * 100);
+      ).times(20 * 10);
 
       //verify at least some books were not gotten
-      verify(mockedProjectService.getText(anything())).atMost(200 * 100 * 2 - 1);
+      verify(mockedProjectService.getText(anything())).atMost(20 * 10 * 2 - 1);
 
       flush();
       expect(true).toBeTruthy();
+
+      async function cacheNewProject(): Promise<void> {
+        const mockProject = mock(SFProjectProfileDoc);
+        when(mockProject.id).thenReturn('new project');
+        const data = createTestProjectProfile({
+          texts: env.createTexts()
+        });
+        when(mockProject.data).thenReturn(data);
+
+        await env.service['cache'](instance(mockProject));
+        env.wait();
+      }
     }));
 
     it('gets the source texts if they are present and the user can access', fakeAsync(async () => {
@@ -76,14 +112,60 @@ describe('cache service', () => {
         false
       ); //remove access for one source doc
 
-      await env.service.cache(env.projectDoc);
       env.wait();
+      flush();
 
       //verify all sources and targets were gotten except the inaccessible one
-      verify(mockedProjectService.getText(anything())).times(200 * 100 * 2 - 1);
+      verify(mockedProjectService.getText(anything())).times(20 * 10 * 2 - 1);
 
       flush();
       expect(true).toBeTruthy();
+    }));
+
+    it('destroys the old text subscriptions when switching to a new project', fakeAsync(async () => {
+      //save all adapters for original project
+      const adapterMocks: RealtimeDocAdapter[] = [];
+      for (let book = 0; book < 20; book++) {
+        for (let chapter = 0; chapter < 10; chapter++) {
+          when(mockedProjectService.getText(deepEqual(new TextDocId(anything(), book, chapter, 'target')))).thenCall(
+            _ => {
+              const adapterMock = mock<RealtimeDocAdapter>();
+              adapterMocks.push(adapterMock);
+              return { adapter: instance(adapterMock) } as TextDoc;
+            }
+          );
+        }
+      }
+
+      //ensure new project doesn't add its adapters to the above list
+      when(
+        mockedProjectService.getText(deepEqual(new TextDocId('new project', anything(), anything(), 'target')))
+      ).thenResolve({ adapter: instance(mock(MemoryRealtimeDocAdapter)) as RealtimeDocAdapter } as TextDoc);
+
+      const env = new TestEnvironment();
+      env.wait();
+      flush();
+
+      //trigger a project change
+      when(mockedProjectService.getProfile('new project')).thenResolve({
+        id: 'new project',
+        data: createTestProjectProfile({ texts: env.createTexts() })
+      } as SFProjectProfileDoc);
+      projectId$.next('new project');
+      env.wait();
+      flush();
+
+      //verify all adapters are destroyed
+      for (const adapterMock of adapterMocks) {
+        verify(adapterMock.destroy()).once();
+      }
+
+      //verify no original adapter is present
+      for (const text of env.service['subscribedTexts']) {
+        for (const adapterMock of adapterMocks) {
+          expect(text.adapter).not.toBe(instance(adapterMock));
+        }
+      }
     }));
   });
 });
@@ -91,11 +173,8 @@ describe('cache service', () => {
 class TestEnvironment {
   readonly ngZone: NgZone = TestBed.inject(NgZone);
   readonly service: CacheService;
-  readonly projectDoc: SFProjectProfileDoc = instance(mockedProjectDoc);
 
   constructor() {
-    this.service = TestBed.inject(CacheService);
-
     const data = createTestProjectProfile({
       texts: this.createTexts(),
       translateConfig: {
@@ -105,15 +184,17 @@ class TestEnvironment {
       }
     });
 
-    when(mockedProjectDoc.data).thenReturn(data);
     when(mockedPermissionService.canAccessText(anything())).thenResolve(true);
+    when(mockedProjectService.getProfile(anything())).thenResolve({ data } as SFProjectProfileDoc);
+
+    this.service = TestBed.inject(CacheService);
   }
 
   createTexts(): TextInfo[] {
     const texts: TextInfo[] = [];
-    for (let book = 0; book < 200; book++) {
+    for (let book = 0; book < 20; book++) {
       const chapters: Chapter[] = [];
-      for (let chapter = 0; chapter < 100; chapter++) {
+      for (let chapter = 0; chapter < 10; chapter++) {
         chapters.push({ isValid: true, lastVerse: 1, number: chapter, permissions: {}, hasAudio: false });
       }
       texts.push({ bookNum: book, chapters: chapters, hasSource: true, permissions: {} });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
@@ -5,9 +5,9 @@ import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models
 import { BehaviorSubject } from 'rxjs';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { MemoryRealtimeDocAdapter } from 'xforge-common/memory-realtime-remote-store';
+import { RealtimeDocAdapter } from 'xforge-common/realtime-remote-store';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { MemoryRealtimeDocAdapter } from '../../../xforge-common/memory-realtime-remote-store';
-import { RealtimeDocAdapter } from '../../../xforge-common/realtime-remote-store';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
@@ -94,6 +94,8 @@ describe('cache service', () => {
       expect(true).toBeTruthy();
 
       async function cacheNewProject(): Promise<void> {
+        projectId$.next('new project');
+        when(mockedActivatedProject.projectId).thenReturn('new project');
         const mockProject = mock(SFProjectProfileDoc);
         when(mockProject.id).thenReturn('new project');
         const data = createTestProjectProfile({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, EventEmitter, Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
@@ -8,13 +8,12 @@ import { SFProjectService } from '../../core/sf-project.service';
 
 @Injectable({ providedIn: 'root' })
 export class CacheService {
-  private readonly abortCurrent: EventEmitter<void> = new EventEmitter();
   private readonly subscribedTexts: TextDoc[] = [];
 
   constructor(
     private readonly projectService: SFProjectService,
     private readonly permissionsService: PermissionsService,
-    currentProject: ActivatedProjectService,
+    private readonly currentProject: ActivatedProjectService,
     destroyRef: DestroyRef
   ) {
     currentProject.projectId$.pipe(takeUntilDestroyed(destroyRef)).subscribe(async projectId => {
@@ -27,28 +26,24 @@ export class CacheService {
   }
 
   private uncache(): void {
-    this.subscribedTexts.forEach(t => t.adapter.destroy());
+    for (const t of this.subscribedTexts) {
+      t.adapter.destroy();
+    }
+
     this.subscribedTexts.length = 0;
   }
 
   private async cache(project: SFProjectProfileDoc): Promise<void> {
-    this.abortCurrent.emit();
     await this.loadAllChapters(project);
   }
 
   private async loadAllChapters(project: SFProjectProfileDoc): Promise<void> {
-    let abort = false;
-    const sub = this.abortCurrent.subscribe(() => (abort = true));
-
     if (project?.data != null) {
       const sourceId = project.data.translateConfig.source?.projectRef;
 
       for (const text of project.data.texts) {
         for (const chapter of text.chapters) {
-          if (abort) {
-            sub.unsubscribe();
-            return;
-          }
+          if (this.currentProject.projectId != null && this.currentProject.projectId !== project.id) return;
 
           const textDocId = new TextDocId(project.id, text.bookNum, chapter.number, 'target');
           if (await this.permissionsService.canAccessText(textDocId)) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
@@ -1,63 +1,45 @@
 import { DestroyRef, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TEXTS_COLLECTION } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { ActivatedProjectService } from '../../../xforge-common/activated-project.service';
-import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
-import { TextDoc, TextDocId } from '../../core/models/text-doc';
-import { PermissionsService } from '../../core/permissions.service';
+import { RealtimeQuery } from '../../../xforge-common/models/realtime-query';
+import { RealtimeService } from '../../../xforge-common/realtime.service';
+import { filterNullish } from '../../../xforge-common/util/rxjs-util';
+import { TextDoc } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 
 @Injectable({ providedIn: 'root' })
 export class CacheService {
-  private readonly subscribedTexts: TextDoc[] = [];
+  private query?: RealtimeQuery<TextDoc>;
+  private sourceQuery?: RealtimeQuery<TextDoc>;
 
   constructor(
     private readonly projectService: SFProjectService,
-    private readonly permissionsService: PermissionsService,
-    private readonly currentProject: ActivatedProjectService,
-    destroyRef: DestroyRef
+    private readonly realtimeService: RealtimeService,
+    private readonly destroyRef: DestroyRef,
+    currentProject: ActivatedProjectService
   ) {
-    currentProject.projectId$.pipe(takeUntilDestroyed(destroyRef)).subscribe(async projectId => {
-      if (projectId == null) return;
+    currentProject.projectId$.pipe(takeUntilDestroyed(destroyRef), filterNullish()).subscribe(async projectId => {
+      this.query?.dispose();
+      this.sourceQuery?.dispose();
 
-      this.uncache();
+      this.query = await this.cache(projectId);
+
       const project = await this.projectService.getProfile(projectId);
-      await this.cache(project);
+      const sourceId = project.data!.translateConfig.source?.projectRef;
+      if (sourceId != null) {
+        this.sourceQuery = await this.cache(sourceId);
+      }
     });
   }
 
-  private uncache(): void {
-    for (const t of this.subscribedTexts) {
-      t.adapter.destroy();
-    }
+  private async cache(projectId: string): Promise<RealtimeQuery<TextDoc>> {
+    const params = {
+      ['_id']: { $regex: `^${projectId}:.*` }
+    };
+    const query = await this.realtimeService.subscribeQuery<TextDoc>(TEXTS_COLLECTION, params, this.destroyRef);
+    query.subscribe();
 
-    this.subscribedTexts.length = 0;
-  }
-
-  private async cache(project: SFProjectProfileDoc): Promise<void> {
-    await this.loadAllChapters(project);
-  }
-
-  private async loadAllChapters(project: SFProjectProfileDoc): Promise<void> {
-    if (project?.data != null) {
-      const sourceId = project.data.translateConfig.source?.projectRef;
-
-      for (const text of project.data.texts) {
-        for (const chapter of text.chapters) {
-          if (this.currentProject.projectId != null && this.currentProject.projectId !== project.id) return;
-
-          const textDocId = new TextDocId(project.id, text.bookNum, chapter.number, 'target');
-          if (await this.permissionsService.canAccessText(textDocId)) {
-            this.subscribedTexts.push(await this.projectService.getText(textDocId));
-          }
-
-          if (text.hasSource && sourceId != null) {
-            const sourceTextDocId = new TextDocId(sourceId, text.bookNum, chapter.number, 'target');
-            if (await this.permissionsService.canAccessText(sourceTextDocId)) {
-              this.subscribedTexts.push(await this.projectService.getText(sourceTextDocId));
-            }
-          }
-        }
-      }
-    }
+    return query;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -5,9 +5,7 @@ import ObjectID from 'bson-objectid';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, map, startWith, switchMap } from 'rxjs/operators';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
-import { PermissionsService } from '../app/core/permissions.service';
 import { SFProjectService } from '../app/core/sf-project.service';
-import { CacheService } from '../app/shared/cache-service/cache.service';
 import { SubscriptionDisposable } from './subscription-disposable';
 
 interface IActiveProjectIdService {
@@ -55,7 +53,6 @@ export class ActivatedProjectService extends SubscriptionDisposable {
 
   constructor(
     private readonly projectService: SFProjectService,
-    private readonly cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
     super();
@@ -83,9 +80,6 @@ export class ActivatedProjectService extends SubscriptionDisposable {
   private set projectDoc(projectDoc: SFProjectProfileDoc | undefined) {
     if (this.projectDoc !== projectDoc) {
       this._projectDoc$.next(projectDoc);
-      if (this.projectDoc !== undefined) {
-        this.cacheService.cache(this.projectDoc);
-      }
     }
   }
 
@@ -125,19 +119,13 @@ export class TestActiveProjectIdService implements IActiveProjectIdService {
 export class TestActivatedProjectService extends ActivatedProjectService {
   constructor(
     projectService: SFProjectService,
-    cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
-    super(projectService, cacheService, activeProjectIdService);
+    super(projectService, activeProjectIdService);
   }
 
   static withProjectId(projectId: string): TestActivatedProjectService {
     const projectService = TestBed.inject(SFProjectService);
-    const permissionsService = TestBed.inject(PermissionsService);
-    return new TestActivatedProjectService(
-      projectService,
-      new CacheService(projectService, permissionsService),
-      new TestActiveProjectIdService(projectId)
-    );
+    return new TestActivatedProjectService(projectService, new TestActiveProjectIdService(projectId));
   }
 }


### PR DESCRIPTION
The CacheService was subscribing to all chapters for each project visited during the lifetime of the app. This was causing memory issues for the server, though this hasn't always been a problem. I'm not exactly sure what changed -- maybe the space for each chapter is growing, or we're getting more concurrent users. This changes the CacheService to uncache its subscriptions, when the project changes, before subscribing to the new chapters. I verified with the Node Dev Tools in Chrome that, while the number of ClientSessions still grows, the memory usage does not grow when switching projects.

I also took the opportunity to refactor away the service's dependence on some other class to tell it when to cache. It now listens to the activated project and cues its own operations. You simply need to reference it somewhere (currently in app.component).

I of course updated the tests and, as part of this, reduced the total number of chapters being used in the tests. I had to reduce this number, because the 20000 mock creations (or something) were crashing the test client. I'm sad to say it couldn't even handle 2000, but I believe the tests are just as effective at 200. I also reworked one of the more interesting tests to be more explicit/dependable.

![Screenshot 2025-02-12 150419](https://github.com/user-attachments/assets/f5513768-af56-482e-9f81-2633900247fe)

Above, you can see the memory usage as I navigate to different projects with the new code (green line) and the old code (orange line), with the first snapshot of each "section" being taken from the My Projects page (no project loaded). For the third "section" I navigated to six different projects before taking that second and final snapshot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3009)
<!-- Reviewable:end -->
