### PR TITLE
Add Mongo query to find latest sync results for group of projects

### DIFF
--- a/mongodb/Projects/LatestSyncInfo.mongodb
+++ b/mongodb/Projects/LatestSyncInfo.mongodb
@@ -1,0 +1,48 @@
+use('xforge');
+
+// Add the short names of the projects you want to check for the latest sync status
+const shortNames = ''.split(' ');
+
+const latestSyncMetricByProject = db.sf_projects.aggregate([
+  {
+    $match: {
+      shortName: { $in: shortNames }
+    }
+  },
+  {
+    $project: {
+      _id: 1,
+      shortName: 1
+    }
+  },
+  {
+    $lookup: {
+      from: 'sync_metrics',
+      let: { projectId: '$_id' },
+      pipeline: [
+        {
+          $match: {
+            $expr: {
+              $eq: ['$projectRef', '$$projectId']
+            }
+          }
+        },
+        {
+          $sort: { dateStarted: -1 },
+        },
+        { $limit: 1 }
+      ],
+      as: 'latestSync'
+    }
+  }, { $unwind: "$latestSync" }
+])
+
+while (latestSyncMetricByProject.hasNext()) {
+  const project = latestSyncMetricByProject.next();
+  const shortName = project.shortName;
+  const metric = project.latestSync;
+  console.log(`Project short name: ${shortName}`);
+  console.log(`Status: ${metric.status}`);
+  if (metric.errorDetails != null) console.log(metric.errorDetails);
+  console.log('\n');
+}

--- a/mongodb/Projects/SyncFailureCause.mongodb
+++ b/mongodb/Projects/SyncFailureCause.mongodb
@@ -1,6 +1,6 @@
 use("xforge");
 
-const shortName = "WOElai";
+const shortName = "";
 
 const project = db.sf_projects.findOne({
   shortName: shortName


### PR DESCRIPTION
This is useful for when you have several projects complaining of problems, you can add them to this query, run it, and see the error (or success) each one has.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3010)
<!-- Reviewable:end -->
