### PR TITLE
SF-2829 Allow paratext roles that have changed to be updated

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
@@ -7,4 +7,5 @@ export interface ParatextProject {
   projectId?: string;
   isConnectable: boolean;
   isConnected: boolean;
+  hasUserRoleChanged?: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -6,6 +6,38 @@
         {{ t("no_projects") }} {{ t("access_another_project") }}
       </app-notice>
     }
+    @if (userUpdateParatextProjects.length > 0) {
+      <h2 id="header-update-projects">
+        {{ t("updates") }}
+      </h2>
+      @if ((isOnline | async) === false) {
+        <app-notice id="message-offline" icon="cloud_off" [type]="userHasProjects ? 'info' : 'error'">
+          {{ t("offline_update") }}
+        </app-notice>
+      }
+    }
+    @for (ptProject of userUpdateParatextProjects; track ptProject) {
+      <mat-card
+        id="user-update-project-card-{{ ptProject.projectId }}"
+        [attr.data-pt-project-id]="ptProject.projectId"
+        class="user-update-project mat-elevation-z4"
+      >
+        <span class="project-name">
+          <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
+        </span>
+        <span class="project-description">
+          {{ t("update_paratext_role") }}
+        </span>
+        <button
+          class="user-update-project-btn"
+          mat-flat-button
+          [disabled]="(isOnline | async) === false"
+          (click)="syncUserRole(ptProject.projectId!)"
+        >
+          {{ t("update") }}
+        </button>
+      </mat-card>
+    }
     @if (userConnectedProjects.length > 0 || initialLoadingSFProjects) {
       <h2 id="header-connected-projects">
         {{ t("connected") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.html
@@ -20,7 +20,7 @@
       <mat-card
         id="user-update-project-card-{{ ptProject.projectId }}"
         [attr.data-pt-project-id]="ptProject.projectId"
-        class="user-update-project mat-elevation-z4"
+        class="user-update-project"
       >
         <span class="project-name">
           <b>{{ ptProject.shortName }}</b> - {{ ptProject.name }}
@@ -31,6 +31,7 @@
         <button
           class="user-update-project-btn"
           mat-flat-button
+          color="primary"
           [disabled]="(isOnline | async) === false"
           (click)="syncUserRole(ptProject.projectId!)"
         >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
@@ -96,6 +96,22 @@ mat-card:active {
   flex-direction: column;
 }
 
+.user-update-project {
+  display: grid;
+  grid-template-areas:
+    'project-name project-name'
+    'description empty';
+  background-color: #e8fafd;
+}
+
+.user-update-project-btn {
+  background-color: #51d6f0 !important;
+}
+
+.user-update-project-btn:hover {
+  background-color: white !important;
+}
+
 .loading-card {
   display: grid;
   grid-template-areas:

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
@@ -54,10 +54,16 @@ mat-card {
   grid-template-columns: 1fr auto;
   cursor: pointer;
   transition: all 0.1s;
+  &.user-update-project {
+    cursor: unset;
+  }
 }
 
 mat-card:hover {
   filter: brightness(90%);
+  &.user-update-project {
+    filter: none;
+  }
 }
 
 mat-card:active {
@@ -101,15 +107,11 @@ mat-card:active {
   grid-template-areas:
     'project-name project-name'
     'description empty';
-  background-color: #e8fafd;
+  background-color: lighten(variables.$info-color, 40%);
 }
 
-.user-update-project-btn {
-  background-color: #51d6f0 !important;
-}
-
-.user-update-project-btn:hover {
-  background-color: white !important;
+.user-update-project-btn:not(:hover):not(:disabled) {
+  background-color: variables.$info-color !important;
 }
 
 .loading-card {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -28,7 +28,7 @@ import { SFProjectService } from '../core/sf-project.service';
   styleUrls: ['./my-projects.component.scss']
 })
 export class MyProjectsComponent extends SubscriptionDisposable implements OnInit {
-  /** PT projects that the user can access that they are not connected to on SF. */
+  /** PT projects that the user can access. */
   private userParatextProjects: ParatextProject[] = [];
 
   /** SF projects that the current user is on at SF. */
@@ -119,13 +119,6 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     return `${drafting}${checking}`;
   }
 
-  userRoleNeedsUpdated(projectId: string): boolean {
-    return (
-      this.userIsPTUser &&
-      (this.userParatextProjects?.find(project => project.projectId === projectId)?.hasUserRoleChanged ?? false)
-    );
-  }
-
   async joinProject(projectId: string): Promise<void> {
     try {
       this.noticeService.loadingStarted(this.constructor.name);
@@ -163,12 +156,12 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     this.loadingPTProjects = true;
     this.problemGettingPTProjects = false;
     try {
-      const getPtProjects = await this.paratextService.getProjects();
-      if (getPtProjects == null) {
+      const userPtProjects = await this.paratextService.getProjects();
+      if (userPtProjects == null) {
         this.problemGettingPTProjects = true;
         return;
       }
-      this.userParatextProjects = getPtProjects;
+      this.userParatextProjects = userPtProjects;
     } catch (err) {
       if (err instanceof HttpErrorResponse && err.status === HttpStatusCode.ServiceUnavailable) {
         this.errorMessage = 'failed_to_connect_to_pt_server';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -28,13 +28,14 @@ import { SFProjectService } from '../core/sf-project.service';
   styleUrls: ['./my-projects.component.scss']
 })
 export class MyProjectsComponent extends SubscriptionDisposable implements OnInit {
+  /** PT projects that the user can access that they are not connected to on SF. */
+  private userParatextProjects: ParatextProject[] = [];
+
   /** SF projects that the current user is on at SF. */
   userConnectedProjects: SFProjectProfileDoc[] = [];
   /** Resources on SF that the current user is on at SF. */
   userConnectedResources: SFProjectProfileDoc[] = [];
   sfProjects: SFProjectDoc[] = [];
-  /** PT projects that the user can access that they are not connected to on SF. */
-  userUnconnectedParatextProjects: ParatextProject[] = [];
 
   user?: UserDoc;
   problemGettingPTProjects: boolean = false;
@@ -62,8 +63,17 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     return (
       this.userConnectedProjects.length > 0 ||
       this.userConnectedResources.length > 0 ||
-      this.userUnconnectedParatextProjects.length > 0
+      this.userUnconnectedParatextProjects.length > 0 ||
+      this.userUpdateParatextProjects.length > 0
     );
+  }
+
+  get userUnconnectedParatextProjects(): ParatextProject[] {
+    return this.userParatextProjects.filter(project => !project.isConnected);
+  }
+
+  get userUpdateParatextProjects(): ParatextProject[] {
+    return this.userParatextProjects.filter(project => project.hasUserRoleChanged && project.projectId != null);
   }
 
   get isOnline(): Observable<boolean> {
@@ -83,6 +93,10 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
 
     await this.onlineStatusService.online;
     if (this.userIsPTUser) await this.loadParatextProjects();
+  }
+
+  currentUserRole(projectId: string): string | undefined {
+    return this.userConnectedProjects.find(project => project.id === projectId)?.data?.userRoles[this.user!.id];
   }
 
   isLastSelectedProject(project: SFProjectProfileDoc): boolean {
@@ -105,6 +119,13 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     return `${drafting}${checking}`;
   }
 
+  userRoleNeedsUpdated(projectId: string): boolean {
+    return (
+      this.userIsPTUser &&
+      (this.userParatextProjects?.find(project => project.projectId === projectId)?.hasUserRoleChanged ?? false)
+    );
+  }
+
   async joinProject(projectId: string): Promise<void> {
     try {
       this.noticeService.loadingStarted(this.constructor.name);
@@ -119,6 +140,20 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     }
   }
 
+  async syncUserRole(projectId: string): Promise<void> {
+    try {
+      this.noticeService.loadingStarted(this.constructor.name);
+      await this.projectService.onlineSyncUserRole(projectId);
+      this.noticeService.show(translate('my_projects.user_role_updated'));
+      const project = this.userParatextProjects.find(project => project.projectId === projectId);
+      if (project != null) project.hasUserRoleChanged = false;
+    } catch {
+      this.noticeService.showError(translate('my_projects.failed_to_update_user_role'));
+    } finally {
+      this.noticeService.loadingFinished(this.constructor.name);
+    }
+  }
+
   private async loadUser(): Promise<void> {
     this.user = await this.userService.getCurrentUser();
     this.userIsPTUser = this.user.data != null ? isPTUser(this.user.data) : false;
@@ -128,12 +163,12 @@ export class MyProjectsComponent extends SubscriptionDisposable implements OnIni
     this.loadingPTProjects = true;
     this.problemGettingPTProjects = false;
     try {
-      const userPTProjects = await this.paratextService.getProjects();
-      if (userPTProjects == null) {
+      const getPtProjects = await this.paratextService.getProjects();
+      if (getPtProjects == null) {
         this.problemGettingPTProjects = true;
         return;
       }
-      this.userUnconnectedParatextProjects = userPTProjects.filter(project => !project.isConnected);
+      this.userParatextProjects = getPtProjects;
     } catch (err) {
       if (err instanceof HttpErrorResponse && err.status === HttpStatusCode.ServiceUnavailable) {
         this.errorMessage = 'failed_to_connect_to_pt_server';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.stories.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, RouterModule } from '@angular/router';
-import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { DBL_RESOURCE_ID_LENGTH, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -45,6 +45,8 @@ interface ProjectScenario {
   projIsOnSF: boolean;
   userOnSFProject: boolean;
   isResource: boolean;
+  ptUserRoleNeedsUpdated?: boolean;
+  newPtUserRole?: string;
 }
 
 const projectScenarios: readonly ProjectScenario[] = [
@@ -77,6 +79,18 @@ const projectScenarios: readonly ProjectScenario[] = [
     projIsOnSF: true,
     userOnSFProject: true,
     isResource: false
+  },
+  {
+    code: 'userSFProjectPTRoleNeedsUpdated',
+    shortNameBase: 'PTRoleUpdateSF',
+    nameBase: 'PT role updated',
+    description: 'User PT role updated in Paratext but not SF.',
+    userPTRole: 'pt_translator',
+    projIsOnSF: true,
+    userOnSFProject: true,
+    isResource: false,
+    ptUserRoleNeedsUpdated: true,
+    newPtUserRole: 'pt_administrator'
   },
   {
     code: 'userSFResource',
@@ -162,7 +176,8 @@ const defaultArgs: StoryAppState = {
   userPTAdministratorNotSFConnectedAtAllCount: 0,
   userPTTranslatorNotSFConnectedAtAllCount: 0,
   userPTAdministratorNotConnectedToSFProjectCount: 0,
-  userPTTranslatorNotConnectedToSFProjectCount: 0
+  userPTTranslatorNotConnectedToSFProjectCount: 0,
+  userSFProjectPTRoleNeedsUpdatedCount: 0
 };
 
 const meta: Meta = {
@@ -288,7 +303,8 @@ const meta: Meta = {
                 name: projectName,
                 paratextId: ptProjectId,
                 isConnectable: ptProjectIsConnectable,
-                isConnected: sfUserIsOnSFProject
+                isConnected: sfUserIsOnSFProject,
+                hasUserRoleChanged: scenario.ptUserRoleNeedsUpdated
               } as ParatextProject);
             }
           };
@@ -419,6 +435,14 @@ export const PTTranslator: Story = {
     userSFResourceCount: 2,
     userPTTranslatorNotSFConnectedAtAllCount: 1,
     userPTTranslatorNotConnectedToSFProjectCount: 1
+  }
+};
+
+export const PTUserRoleUpdated: Story = {
+  args: {
+    isKnownPTUser: true,
+    userSFProjectPTTranslatorCount: 1,
+    userSFProjectPTRoleNeedsUpdatedCount: 1
   }
 };
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -377,11 +377,13 @@
     "access_another_project": "If you don't see a project you are expecting, you may need to receive an invitation to the project. Or, if you use Paratext, you can log out and log back in using 'Log in with Paratext', and connect to your Paratext projects.",
     "connect_a_project_to_get_started": "Connect a project to get started",
     "connected": "Connected",
+    "contact_admin_update_role": "Please contact your project administrator to sync this project.",
     "dbl_resource": "Digital Bible Library resource",
     "dbl_resources": "Digital Bible Library resources",
     "drafting": "Drafting",
     "failed_to_connect_to_pt_server": "There was a problem connecting to Paratext to get your projects. Please try again later. If the problem persists after several hours, please report the issue for help.",
     "failed_to_join_project": "Failed to join the project. Please check your internet connection and try again later.",
+    "failed_to_update_user_role": "Failed to update paratext role. Please contact your project administrator.",
     "join": "Join",
     "loading_more_pt_projects": "Loading additional Paratext projects ...",
     "looking_for_another_project": "Looking for another project?",
@@ -390,9 +392,14 @@
     "not_admin_cannot_connect_project": "To join this project in Scripture Forge, ask the administrator of the Paratext project to connect the project in Scripture Forge.",
     "not_connected": "Not connected",
     "offline": "You will need to connect to the internet to get started with a project.",
+    "offline_update": "You will need to connect to the internet to update your project.",
     "offline-accessible": "Offline Access",
     "open": "Open",
-    "problem_getting_pt_list": "There was a problem getting the list of available Paratext projects to connect to. If this continues to happen, and logging out and back in does not fix the problem, please report the issue for help."
+    "problem_getting_pt_list": "There was a problem getting the list of available Paratext projects to connect to. If this continues to happen, and logging out and back in does not fix the problem, please report the issue for help.",
+    "update": "Update",
+    "updates": "Updates",
+    "update_paratext_role": "Your role on this project has changed in Paratext.",
+    "user_role_updated": "Your role on this project has been updated successfully."
   },
   "roles": {
     "sf_community_checker": "Community Checker"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/project.service.ts
@@ -84,6 +84,10 @@ export abstract class ProjectService<
     return this.onlineInvoke('updateRole', { projectId, userId, projectRole });
   }
 
+  onlineSyncUserRole(projectId: string): Promise<void> {
+    return this.onlineInvoke('syncUserRole', { projectId });
+  }
+
   onlineDelete(id: string): Promise<void> {
     return this.onlineInvoke('delete', { projectId: id });
   }

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -274,6 +274,30 @@ public class SFProjectsRpcController(
         }
     }
 
+    public async Task<IRpcMethodResult> SyncUserRole(string projectId)
+    {
+        try
+        {
+            await projectService.SyncUserRoleAsync(UserId, projectId);
+            return Ok();
+        }
+        catch (ForbiddenException)
+        {
+            return ForbiddenError();
+        }
+        catch (DataNotFoundException dnfe)
+        {
+            return NotFoundError(dnfe.Message);
+        }
+        catch (Exception)
+        {
+            _exceptionHandler.RecordEndpointInfoForException(
+                new Dictionary<string, string> { { "method", "UpdateUser" }, { "projectId", projectId } }
+            );
+            throw;
+        }
+    }
+
     public async Task<IRpcMethodResult> Invite(string projectId, string email, string locale, string role)
     {
         try

--- a/src/SIL.XForge.Scripture/Models/ParatextProject.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextProject.cs
@@ -71,6 +71,11 @@ public class ParatextProject
     public bool HasDraft { get; init; }
 
     /// <summary>
+    /// If the user's role in the project needs to be updated.
+    /// </summary>
+    public bool HasUserRoleChanged { get; init; }
+
+    /// <summary>
     /// A descriptive string of object's properties, for debugging.
     /// </summary>
     /// <returns>
@@ -94,6 +99,7 @@ public class ParatextProject
                 IsDraftingEnabled.ToString(),
                 HasDraft.ToString(),
                 IsRightToLeft?.ToString(),
+                HasUserRoleChanged.ToString(),
             }
         )
         {

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -54,6 +54,7 @@ public interface ISFProjectService : IProjectService
     Task<IReadOnlyList<InviteeStatus>> InvitedUsersAsync(string curUserId, string projectId);
     bool IsSourceProject(string projectId);
     Task<IEnumerable<TransceleratorQuestion>> TransceleratorQuestionsAsync(string curUserId, string projectId);
+    Task SyncUserRoleAsync(string curUserId, string projectId);
     Task UpdatePermissionsAsync(
         string curUserId,
         IDocument<SFProject> projectDoc,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2264,10 +2264,14 @@ public class ParatextService : DisposableBase, IParatextService
 
             bool sfProjectExists = correspondingSfProject != null;
             bool sfUserIsOnSfProject = correspondingSfProject?.UserRoles.ContainsKey(userSecret.Id) ?? false;
-            bool adminOnPtProject =
-                remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret)) == UserRoles.Administrator;
+            UserRoles ptUserRole = remotePtProject.SourceUsers.GetRole(GetParatextUsername(userSecret));
+            bool adminOnPtProject = ptUserRole == UserRoles.Administrator;
             bool ptProjectIsConnectable =
                 (sfProjectExists && !sfUserIsOnSfProject) || (!sfProjectExists && adminOnPtProject);
+            bool hasUserRoleChanged =
+                sfProjectExists
+                && sfUserIsOnSfProject
+                && ConvertFromUserRole(ptUserRole) != correspondingSfProject.UserRoles[userSecret.Id];
 
             // On SF Live server, many users have projects without corresponding project metadata.
             // If this happens, default to using the project's short name
@@ -2304,6 +2308,7 @@ public class ParatextService : DisposableBase, IParatextService
                     IsConnected = sfProjectExists && sfUserIsOnSfProject,
                     IsDraftingEnabled = isDraftingEnabled,
                     HasDraft = hasDraft,
+                    HasUserRoleChanged = hasUserRoleChanged,
                 }
             );
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -4297,6 +4297,34 @@ public class SFProjectServiceTests
         );
     }
 
+    [Test]
+    public async Task SyncUserRoleAsync_Success()
+    {
+        var env = new TestEnvironment();
+        var user = env.GetProject(Project01).UserRoles[User01];
+        Assert.AreEqual(SFProjectRole.Administrator, user);
+
+        // SUT
+        env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Translator)));
+        await env.Service.SyncUserRoleAsync(User01, Project01);
+        user = env.GetProject(Project01).UserRoles[User01];
+        Assert.AreEqual(SFProjectRole.Translator, user);
+    }
+
+    [Test]
+    public void SyncUserRoleAsync_ForbiddenError()
+    {
+        var env = new TestEnvironment();
+        var user = env.GetProject(Project01).UserRoles[User01];
+        Assert.AreEqual(SFProjectRole.Administrator, user);
+
+        // SUT
+        env.ParatextService.TryGetProjectRoleAsync(Arg.Any<UserSecret>(), Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(Attempt.Failure(SFProjectRole.Translator)));
+        Assert.ThrowsAsync<ForbiddenException>(async () => await env.Service.SyncUserRoleAsync(User01, Project01));
+    }
+
     private class TestEnvironment
     {
         public static readonly Uri WebsiteUrl = new Uri("http://localhost/", UriKind.Absolute);


### PR DESCRIPTION
This PR addresses the issue where users roles have been updated in Paratext but not reflected in Scripture Forge. Primarily when a user is changed to an Paratext Administrator they do not have administrator access in SF until another admin runs a sync.

My Projects page UI change:
![](https://github.com/user-attachments/assets/27cdc3e6-1297-4ea6-bde2-45089ebf857e)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3012)
<!-- Reviewable:end -->
