### PR TITLE
Fix common audio test failure

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.spec.ts
@@ -9,7 +9,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
-import { TestTranslocoModule, getAudioBlob } from 'xforge-common/test-utils';
+import { getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { AudioStatus } from '../../../shared/audio/audio-player';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
@@ -60,7 +60,7 @@ describe('CheckingAudioPlayerComponent', () => {
     const env = new TestEnvironment(template);
     await env.waitForPlayer(playerLoadTimeMs);
     env.clickButton(env.playButton(1));
-    await env.waitForPlayer(1100);
+    await env.waitForPlayer(1200);
     env.fixture.detectChanges();
     env.clickButton(env.pauseButton(1));
     await env.waitForPlayer(1100);


### PR DESCRIPTION
I put this test in a loop and ran it 100 times. With an 1100ms delay, it failed 56 times. With a 1200ms delay, it didn't fail once. I don't think in practice this means this test will completely stop failing, but it should be a lot less frequent.

Note that if the delay is set to 1500ms, it starts failing with another error. This is a very short audio file, and we're trying to pause it after 1s and before it finishes playing, so we can see a paused state. If I log the duration, it's `1.296`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3019)
<!-- Reviewable:end -->
