### PR TITLE
SF-3206 Display Cancel Draft dialog regardless of build state

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1270,8 +1270,45 @@ describe('DraftGenerationComponent', () => {
       expect(mockDraftGenerationService.cancelBuild).not.toHaveBeenCalled();
     });
 
-    it('should cancel the draft build without dialog if the build state is not active', async () => {
+    it('should cancel pending draft build if user confirms "cancel" dialog', async () => {
       const env = new TestEnvironment(() => {
+        mockDialogService.openGenericDialog.and.returnValue({
+          dialogRef: {} as MatDialogRef<any>,
+          result: Promise.resolve(true)
+        });
+        mockDraftGenerationService.cancelBuild.and.returnValue(EMPTY);
+      });
+
+      env.component.draftJob = { ...buildDto, state: BuildStates.Pending };
+      await env.component.cancel();
+      env.component.draftJob = { ...buildDto, state: BuildStates.Canceled };
+      env.fixture.detectChanges();
+      expect(mockDialogService.openGenericDialog).toHaveBeenCalledTimes(1);
+      expect(mockDraftGenerationService.cancelBuild).toHaveBeenCalledWith('testProjectId');
+      expect(mockDraftGenerationService.getBuildProgress).toHaveBeenCalledWith(mockActivatedProjectService.projectId!);
+    });
+
+    it('should not cancel pending draft build if user exits "cancel" dialog', async () => {
+      const env = new TestEnvironment(() => {
+        mockDialogService.openGenericDialog.and.returnValue({
+          dialogRef: {} as MatDialogRef<any>,
+          result: Promise.resolve(false)
+        });
+        mockDraftGenerationService.cancelBuild.and.returnValue(EMPTY);
+      });
+
+      env.component.draftJob = { ...buildDto, state: BuildStates.Pending };
+      await env.component.cancel();
+      expect(mockDialogService.openGenericDialog).toHaveBeenCalledTimes(1);
+      expect(mockDraftGenerationService.cancelBuild).not.toHaveBeenCalled();
+    });
+
+    it('should cancel queued draft build if user confirms "cancel" dialog', async () => {
+      const env = new TestEnvironment(() => {
+        mockDialogService.openGenericDialog.and.returnValue({
+          dialogRef: {} as MatDialogRef<any>,
+          result: Promise.resolve(true)
+        });
         mockDraftGenerationService.cancelBuild.and.returnValue(EMPTY);
       });
 
@@ -1279,9 +1316,24 @@ describe('DraftGenerationComponent', () => {
       await env.component.cancel();
       env.component.draftJob = { ...buildDto, state: BuildStates.Canceled };
       env.fixture.detectChanges();
-      expect(mockDialogService.openGenericDialog).not.toHaveBeenCalled();
+      expect(mockDialogService.openGenericDialog).toHaveBeenCalledTimes(1);
       expect(mockDraftGenerationService.cancelBuild).toHaveBeenCalledWith('testProjectId');
       expect(mockDraftGenerationService.getBuildProgress).toHaveBeenCalledWith(mockActivatedProjectService.projectId!);
+    });
+
+    it('should not cancel queued draft build if user exits "cancel" dialog', async () => {
+      const env = new TestEnvironment(() => {
+        mockDialogService.openGenericDialog.and.returnValue({
+          dialogRef: {} as MatDialogRef<any>,
+          result: Promise.resolve(false)
+        });
+        mockDraftGenerationService.cancelBuild.and.returnValue(EMPTY);
+      });
+
+      env.component.draftJob = { ...buildDto, state: BuildStates.Queued };
+      await env.component.cancel();
+      expect(mockDialogService.openGenericDialog).toHaveBeenCalledTimes(1);
+      expect(mockDraftGenerationService.cancelBuild).not.toHaveBeenCalled();
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -357,26 +357,24 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   }
 
   async cancel(): Promise<void> {
-    if (this.draftJob?.state === BuildStates.Active) {
-      const { dialogRef, result } = this.dialogService.openGenericDialog({
-        title: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_title'),
-        message: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_message'),
-        options: [
-          { value: false, label: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_no') },
-          {
-            value: true,
-            label: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_yes'),
-            highlight: true
-          }
-        ]
-      });
+    const { dialogRef, result } = this.dialogService.openGenericDialog({
+      title: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_title'),
+      message: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_message'),
+      options: [
+        { value: false, label: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_no') },
+        {
+          value: true,
+          label: this.i18n.translate('draft_generation.dialog_confirm_draft_cancellation_yes'),
+          highlight: true
+        }
+      ]
+    });
 
-      this.cancelDialogRef = dialogRef;
-      const isConfirmed: boolean | undefined = await result;
+    this.cancelDialogRef = dialogRef;
+    const isConfirmed: boolean | undefined = await result;
 
-      if (!isConfirmed) {
-        return;
-      }
+    if (!isConfirmed) {
+      return;
     }
 
     this.cancelBuild();


### PR DESCRIPTION
This PR updates the existing Cancel Draft dialog to always display when a user selects to cancel a draft. This is intended to reduce incidental cancelation of drafts because of different draft build states allowing cancellation without displaying the prompt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3021)
<!-- Reviewable:end -->
