### PR TITLE
Update definition of corrupted chapter to include insert.link bug

### DIFF
--- a/mongodb/Texts/CorruptedTexts.mongodb
+++ b/mongodb/Texts/CorruptedTexts.mongodb
@@ -8,6 +8,7 @@ const texts = db.texts.find({
   ops: {
     $elemMatch: {
       $or: [
+        { 'insert.link': true },
         { 'insert.verse': true },
         { 'attributes.segment': /(?:null|undefined)/ },
         // This will match delete and retain ops, which should not exist, but have been found in production

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -83,6 +83,10 @@ describe('shared utils', () => {
       expect(isBadDelta([chapterInsert])).toBeFalse();
       expect(isBadDelta([chapterInsert, chapterInsert])).toBeTrue();
     });
+
+    it('does not allow op.insert.link to be true', () => {
+      expect(isBadDelta([{ insert: { link: true } }])).toBeTrue();
+    });
   });
 
   it('compares projects for sorting', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -2,9 +2,10 @@ import { Router } from '@angular/router';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { DeltaOperation } from 'rich-text';
+import { isObj } from '../../type-utils';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
@@ -223,6 +224,8 @@ export function isBadDelta(ops: DeltaOperation[]): boolean {
       (typeof op.insert === 'object' &&
         'verse' in op.insert &&
         (op.insert.verse == null || typeof op.insert.verse !== 'object')) ||
+      // insert.link should not exist
+      (isObj(op.insert) && op.insert.link === true) ||
       // the segment identifier should not have null or undefined in it, like we've seen in the past
       (typeof op.attributes?.segment === 'string' && /(?:undefined|null)/.test(op.attributes.segment))
   );


### PR DESCRIPTION
This will ensure chapters corrupted in this way can not continue to be edited.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3022)
<!-- Reviewable:end -->
