### PR TITLE
Add error message to error report email

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/error-dialog/error-dialog.component.ts
@@ -20,7 +20,13 @@ export class ErrorDialogComponent implements OnInit {
   browserUnsupported = !supportedBrowser();
   outsideAngularErrorDialog?: OutsideAngularErrorDialog;
 
-  issueEmailLink = getLinkHTML(environment.issueEmail, issuesEmailTemplate(this.data.eventId));
+  issueEmailLink = getLinkHTML(
+    environment.issueEmail,
+    issuesEmailTemplate({
+      errorId: this.data.eventId,
+      errorMessage: this.data.message
+    })
+  );
 
   constructor(
     public dialogRef: MatDialogRef<ErrorDialogComponent>,
@@ -49,7 +55,10 @@ export class ErrorDialogComponent implements OnInit {
   openOutsideAngularErrorDialog(): void {
     this.outsideAngularErrorDialog = new OutsideAngularErrorDialog(
       this.data.message,
-      issuesEmailTemplate(this.data.eventId)
+      issuesEmailTemplate({
+        errorId: this.data.eventId,
+        errorMessage: this.data.message
+      })
     );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -90,7 +90,7 @@ export function audioRecordingMimeType(): string {
   }
 }
 
-export function issuesEmailTemplate(errorId?: string): string {
+export function issuesEmailTemplate(errorInfo?: { errorMessage: string; errorId: string }): string {
   const bowser = Bowser.getParser(window.navigator.userAgent);
 
   const technicalDetails = Object.entries({
@@ -99,7 +99,8 @@ export function issuesEmailTemplate(errorId?: string): string {
     ...(isBrave() ? { Brave: 'Yes' } : {}),
     [bowser.getOSName()]: bowser.getOSVersion() ?? translate('issue_email.unknown'),
     URL: location.href,
-    ...(errorId ? { 'Error ID': errorId } : {})
+    ...(errorInfo?.errorId ? { 'Error ID': errorInfo?.errorId } : {}),
+    ...(errorInfo?.errorMessage ? { 'Error Message': errorInfo?.errorMessage } : {})
   })
     .map(([key, value]) => `${key}: ${value}`)
     .join('\n');


### PR DESCRIPTION
We've had some recent problems with error reports that don't describe the actual problem. Having an error ID is useful when it's found in Bugsnag, but not all errors get reported there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3029)
<!-- Reviewable:end -->
