### PR TITLE
SF-3222 Fix training data files not updated after file uploaded

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -1,3 +1,5 @@
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -6,14 +8,14 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { BehaviorSubject, of, Subject } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { AuthService } from 'xforge-common/auth.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
-import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
+import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { ProgressService, TextProgress } from '../../../shared/progress-service/progress.service';
 import { NllbLanguageService } from '../../nllb-language.service';
@@ -33,8 +35,6 @@ describe('DraftGenerationStepsComponent', () => {
   const mockOnlineStatusService = mock(OnlineStatusService);
   const mockNoticeService = mock(NoticeService);
   const mockDraftSourceService = mock(DraftSourcesService);
-  const mockAuthService = mock(AuthService);
-  const mockUserService = mock(UserService);
 
   const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
   const trainingDataQueryLocalChanges$: Subject<void> = new Subject<void>();
@@ -45,7 +45,7 @@ describe('DraftGenerationStepsComponent', () => {
   when(mockActivatedProjectService.projectId).thenReturn('project01');
 
   configureTestingModule(() => ({
-    imports: [TestTranslocoModule, NoopAnimationsModule],
+    imports: [TestTranslocoModule, TestRealtimeModule.forRoot(SF_TYPE_REGISTRY), NoopAnimationsModule],
     providers: [
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: DraftSourcesService, useMock: mockDraftSourceService },
@@ -55,8 +55,8 @@ describe('DraftGenerationStepsComponent', () => {
       { provide: ProgressService, useMock: mockProgressService },
       { provide: OnlineStatusService, useMock: mockOnlineStatusService },
       { provide: NoticeService, useMock: mockNoticeService },
-      { provide: AuthService, useMock: mockAuthService },
-      { provide: UserService, useMock: mockUserService }
+      provideHttpClient(withInterceptorsFromDi()),
+      provideHttpClientTesting()
     ]
   }));
 
@@ -891,7 +891,6 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.availableTrainingFiles.length).toEqual(1);
 
       // Delete a training data file
-      const mockTrainingDataDoc = mock(TrainingDataDoc);
       when(mockTrainingDataQuery.docs).thenReturn([]);
       trainingDataQueryLocalChanges$.next();
       fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -917,7 +917,6 @@ describe('DraftGenerationStepsComponent', () => {
 
       // Upload a training data file
       const mockTrainingDataDoc = mock(TrainingDataDoc);
-      when(mockTrainingDataDoc.id);
       when(mockTrainingDataQuery.docs).thenReturn([mockTrainingDataDoc]);
       trainingDataQueryLocalChanges$.next();
       fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -854,6 +854,7 @@ describe('DraftGenerationStepsComponent', () => {
       })
     } as SFProjectProfileDoc;
     const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
+    const mockTrainingDataDoc = mock(TrainingDataDoc);
 
     beforeEach(fakeAsync(() => {
       when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
@@ -863,7 +864,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
         instance(mockTrainingDataQuery)
       );
-      when(mockTrainingDataQuery.docs).thenReturn([]);
+      when(mockTrainingDataQuery.docs).thenReturn([mockTrainingDataDoc]);
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -873,6 +874,7 @@ describe('DraftGenerationStepsComponent', () => {
 
     it('should allow additional training data', () => {
       expect(component.trainingDataFilesAvailable).toBe(true);
+      expect(component.availableTrainingFiles.length).toBe(1);
     });
 
     it('updates available training data file after uploaded or deleted', () => {
@@ -886,20 +888,20 @@ describe('DraftGenerationStepsComponent', () => {
       component.onTranslatedBookSelect([2]);
       fixture.detectChanges();
       component.tryAdvanceStep();
-      expect(component.availableTrainingFiles.length).toEqual(0);
-
-      // Upload a training data file
-      const mockTrainingDataDoc = mock(TrainingDataDoc);
-      when(mockTrainingDataQuery.docs).thenReturn([mockTrainingDataDoc]);
-      trainingDataQueryLocalChanges$.next();
-      fixture.detectChanges();
       expect(component.availableTrainingFiles.length).toEqual(1);
 
       // Delete a training data file
+      const mockTrainingDataDoc = mock(TrainingDataDoc);
       when(mockTrainingDataQuery.docs).thenReturn([]);
       trainingDataQueryLocalChanges$.next();
       fixture.detectChanges();
       expect(component.availableTrainingFiles.length).toEqual(0);
+
+      // Upload a training data file
+      when(mockTrainingDataQuery.docs).thenReturn([mockTrainingDataDoc]);
+      trainingDataQueryLocalChanges$.next();
+      fixture.detectChanges();
+      expect(component.availableTrainingFiles.length).toEqual(1);
     });
 
     it('generates draft with training data file', () => {
@@ -913,17 +915,13 @@ describe('DraftGenerationStepsComponent', () => {
       component.onTranslatedBookSelect([2]);
       fixture.detectChanges();
       component.tryAdvanceStep();
-      expect(component.availableTrainingFiles.length).toEqual(0);
-
-      // Upload a training data file
-      const mockTrainingDataDoc = mock(TrainingDataDoc);
-      when(mockTrainingDataQuery.docs).thenReturn([mockTrainingDataDoc]);
-      trainingDataQueryLocalChanges$.next();
-      fixture.detectChanges();
       expect(component.availableTrainingFiles.length).toEqual(1);
+      expect(component.selectedTrainingFileIds).toEqual([]);
 
       const fileIds = ['file1'];
       component.onTrainingDataSelect(fileIds);
+      fixture.detectChanges();
+      expect(component.selectedTrainingFileIds).toEqual(fileIds);
       spyOn(component.done, 'emit');
       component.tryAdvanceStep();
       fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -6,8 +6,8 @@ import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { ProjectScriptureRange, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { combineLatest, merge } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { combineLatest, merge, Subject, Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -105,6 +105,8 @@ export class DraftGenerationStepsComponent implements OnInit {
   protected translatedBooksWithNoSource: number[] = [];
 
   private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
+  private trainingDataQuerySubject: Subject<void> = new Subject<void>();
+  private trainingDataQuerySubscription?: Subscription;
   private isTrainingDataInitialized: boolean = false;
 
   constructor(
@@ -221,39 +223,36 @@ export class DraftGenerationStepsComponent implements OnInit {
 
     // Get the training data files for the project
     this.activatedProject.projectDoc$
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        filterNullish(),
-        switchMap(async projectDoc => {
-          this.isTrainingDataInitialized = false;
-          // Query for all training data files in the project
-          this.trainingDataQuery?.dispose();
-          this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(
-            projectDoc.id,
-            this.destroyRef
-          );
+      .pipe(takeUntilDestroyed(this.destroyRef), filterNullish())
+      .subscribe(async projectDoc => {
+        this.isTrainingDataInitialized = false;
+        // Query for all training data files in the project
+        this.trainingDataQuery?.dispose();
+        this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id, this.destroyRef);
+        this.trainingDataQuerySubscription?.unsubscribe();
 
-          // switch to the observable from trainingDataQuery
-          return merge(
-            this.trainingDataQuery.localChanges$,
-            this.trainingDataQuery.ready$,
-            this.trainingDataQuery.remoteChanges$,
-            this.trainingDataQuery.remoteDocChanges$
-          );
-        })
-      )
-      .subscribe(() => {
-        this.availableTrainingFiles = [];
-        if (this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.additionalTrainingData) {
-          this.availableTrainingFiles =
-            this.trainingDataQuery?.docs.filter(d => d.data != null).map(d => d.data!) ?? [];
-        }
-        if (!this.isTrainingDataInitialized) {
-          // Set the selection based on previous builds
-          this.isTrainingDataInitialized = true;
-          this.setInitialTrainingDataFiles(this.availableTrainingFiles.map(d => d.dataId));
-        }
+        // Subscribe to the training data query changes
+        this.trainingDataQuerySubscription = merge(
+          this.trainingDataQuery.localChanges$,
+          this.trainingDataQuery.ready$,
+          this.trainingDataQuery.remoteChanges$,
+          this.trainingDataQuery.remoteDocChanges$
+        )
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe(() => this.trainingDataQuerySubject.next());
       });
+
+    this.trainingDataQuerySubject.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.availableTrainingFiles = [];
+      if (this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.additionalTrainingData) {
+        this.availableTrainingFiles = this.trainingDataQuery?.docs.filter(d => d.data != null).map(d => d.data!) ?? [];
+      }
+      if (!this.isTrainingDataInitialized) {
+        // Set the selection based on previous builds
+        this.isTrainingDataInitialized = true;
+        this.setInitialTrainingDataFiles(this.availableTrainingFiles.map(d => d.dataId));
+      }
+    });
   }
 
   get trainingSourceBooksSelected(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'training_data_multi_select'">
   <div class="flex-row">
-    @for (trainingData of trainingDataOptions; track trainingData) {
+    @for (trainingData of trainingDataOptions; track trainingData.value.dataId) {
       <mat-chip-listbox
         class="training-data-multi-select"
         hideSingleSelectionIndicator


### PR DESCRIPTION
This PR fixes a problem where the training data files available are not updated correctly when files are uploaded or deleted.

Additionally, the training data multi select had a warning tracking the files in the for loop. I updated the track parameter to track the training data file's dataId

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3030)
<!-- Reviewable:end -->
