### PR TITLE
SF-2799 Notify user when previous version is restored

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -151,6 +151,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       this.selectedRevision == null ||
       this.selectedSnapshot?.data.ops == null ||
       this.projectId == null ||
+      this.projectDoc?.data == null ||
       this.bookNum == null ||
       this.chapter == null ||
       !this.canRestoreSnapshot
@@ -163,12 +164,17 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       // Revert to the snapshot
       const delta: Delta = new Delta(this.selectedSnapshot.data.ops);
       const textDocId = new TextDocId(this.projectId, this.bookNum, this.chapter, 'target');
-      await this.projectService.onlineSetIsValid(
-        textDocId.projectId,
-        textDocId.bookNum,
-        textDocId.chapterNum,
-        this.selectedSnapshot.isValid
-      );
+      if (
+        this.projectDoc.data?.texts.find(t => t.bookNum === this.bookNum)?.chapters.find(c => c.number === this.chapter)
+          ?.isValid !== this.selectedSnapshot.isValid
+      ) {
+        await this.projectService.onlineSetIsValid(
+          textDocId.projectId,
+          textDocId.bookNum,
+          textDocId.chapterNum,
+          this.selectedSnapshot.isValid
+        );
+      }
       await this.textDocService.overwrite(textDocId, delta, 'History');
 
       this.noticeService.show(translate('history_chooser.revert_successful'));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -15,7 +15,9 @@ import {
   startWith,
   tap
 } from 'rxjs';
+import { CommandError } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
+import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { TextSnapshot } from 'xforge-common/models/textsnapshot';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -67,7 +69,8 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
     private readonly noticeService: NoticeService,
     private readonly paratextService: ParatextService,
     private readonly projectService: SFProjectService,
-    private readonly textDocService: TextDocService
+    private readonly textDocService: TextDocService,
+    private readonly errorReportingService: ErrorReportingService
   ) {}
 
   get canRestoreSnapshot(): boolean {
@@ -156,19 +159,29 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       return;
     }
 
-    // Revert to the snapshot
-    const delta: Delta = new Delta(this.selectedSnapshot.data.ops);
-    const textDocId = new TextDocId(this.projectId, this.bookNum, this.chapter, 'target');
-    await this.textDocService.overwrite(textDocId, delta, 'History');
-    await this.projectService.onlineSetIsValid(
-      textDocId.projectId,
-      textDocId.bookNum,
-      textDocId.chapterNum,
-      this.selectedSnapshot.isValid
-    );
+    try {
+      // Revert to the snapshot
+      const delta: Delta = new Delta(this.selectedSnapshot.data.ops);
+      const textDocId = new TextDocId(this.projectId, this.bookNum, this.chapter, 'target');
+      await this.projectService.onlineSetIsValid(
+        textDocId.projectId,
+        textDocId.bookNum,
+        textDocId.chapterNum,
+        this.selectedSnapshot.isValid
+      );
+      await this.textDocService.overwrite(textDocId, delta, 'History');
 
-    // Force the history editor to reload
-    this.revisionSelect.emit({ revision: this.selectedRevision, snapshot: this.selectedSnapshot });
+      this.noticeService.show(translate('history_chooser.revert_successful'));
+      // Force the history editor to reload
+      this.revisionSelect.emit({ revision: this.selectedRevision, snapshot: this.selectedSnapshot });
+    } catch (err) {
+      this.noticeService.showError(translate('history_chooser.revert_error'));
+      if (err instanceof CommandError && err.message.includes('504 Gateway Timeout')) return;
+      this.errorReportingService.silentError(
+        'Error occurred restoring a snapshot',
+        ErrorReportingService.normalizeError(err)
+      );
+    }
   }
 
   toggleDiff(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -347,6 +347,8 @@
     "please_connect": "Please connect to the internet to restore this version.",
     "revert": "Restore this version",
     "revert_details": "Restore this previous version of the chapter",
+    "revert_error": "Error occurred trying to restore the previous text version. Please try again later.",
+    "revert_successful": "Successfully restored previous version",
     "show_changes": "Show changes",
     "show_diff": "Show differences from the latest version"
   },


### PR DESCRIPTION
This PR adds a message when the previous version of a text was successfully restored and warns the user if the restoring a previous version failed.

![Restore version](https://github.com/user-attachments/assets/db21ac6b-eb57-4271-9790-aa6862a1669a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3033)
<!-- Reviewable:end -->
