### PR TITLE
SF-3188 Upgrade to ShareDB 5.1.1 on server side

### DIFF
--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -152,7 +152,8 @@ export class RealtimeServer extends ShareDB {
       milestoneDb,
       presence: true,
       disableDocAction: true,
-      disableSpaceDelimitedActions: true
+      disableSpaceDelimitedActions: true,
+      doNotForwardSendPresenceErrorsToClient: true
     });
     shareDBAccess(this);
 

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -49,7 +49,7 @@
         "jest-expect-message": "^1.1.3",
         "jest-teamcity-reporter": "^0.9.0",
         "prettier": "^3.3.3",
-        "sharedb-mingo-memory": "^1.2.0",
+        "sharedb-mingo-memory": "^4.0.1",
         "ts-jest": "^29.1.2",
         "ts-mockito": "^2.6.1",
         "typescript": "~5.2.2"
@@ -6879,6 +6879,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7047,9 +7053,9 @@
       }
     },
     "node_modules/mingo": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-4.4.1.tgz",
-      "integrity": "sha512-aig/3anjeJ8VcXLqDQmB/iO8Z8BVzln2BeWcyeI5NtOiLMAQ5xX00QHX9piy8OBAC9pSDYWErY8MHoh8nlCHig==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.1.tgz",
+      "integrity": "sha512-0gHnErBHs2borfxmTmVeu0fRKBgBl1Qewtd8pt2eva8qHa4rw43pEvzbOGHNdyPtsYkxIEbifV+xWIFjhFwWWw==",
       "dev": true
     },
     "node_modules/minimatch": {
@@ -8030,16 +8036,17 @@
       }
     },
     "node_modules/sharedb-mingo-memory": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sharedb-mingo-memory/-/sharedb-mingo-memory-1.2.0.tgz",
-      "integrity": "sha512-KXGiSQbhfu+s/q7slBBjQrRaNJ85D4qdK+fOj89TE989A3E3dG4RUEmDpYXQRQmLOeE0ZvfAjmkIH11z344WrQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sharedb-mingo-memory/-/sharedb-mingo-memory-4.0.1.tgz",
+      "integrity": "sha512-hJsW+i6guxWugkXTeORfkfpUKOkaaFfGXte06Po7xeRvFbHiDOiV2wrBOr2Ov6X9IaK1Z3MzaooX4x+21361Bg==",
       "dev": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
-        "mingo": "^4.1.5"
+        "lodash.isobject": "^3.0.2",
+        "mingo": "6.1.0 - 6.2.1"
       },
       "peerDependencies": {
-        "sharedb": "^1.0.0-beta || ^2.0.0"
+        "sharedb": "^1.0.0-beta || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/sharedb-mongo": {
@@ -14127,6 +14134,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14254,9 +14267,9 @@
       "dev": true
     },
     "mingo": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-4.4.1.tgz",
-      "integrity": "sha512-aig/3anjeJ8VcXLqDQmB/iO8Z8BVzln2BeWcyeI5NtOiLMAQ5xX00QHX9piy8OBAC9pSDYWErY8MHoh8nlCHig==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.1.tgz",
+      "integrity": "sha512-0gHnErBHs2borfxmTmVeu0fRKBgBl1Qewtd8pt2eva8qHa4rw43pEvzbOGHNdyPtsYkxIEbifV+xWIFjhFwWWw==",
       "dev": true
     },
     "minimatch": {
@@ -14951,13 +14964,14 @@
       }
     },
     "sharedb-mingo-memory": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sharedb-mingo-memory/-/sharedb-mingo-memory-1.2.0.tgz",
-      "integrity": "sha512-KXGiSQbhfu+s/q7slBBjQrRaNJ85D4qdK+fOj89TE989A3E3dG4RUEmDpYXQRQmLOeE0ZvfAjmkIH11z344WrQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sharedb-mingo-memory/-/sharedb-mingo-memory-4.0.1.tgz",
+      "integrity": "sha512-hJsW+i6guxWugkXTeORfkfpUKOkaaFfGXte06Po7xeRvFbHiDOiV2wrBOr2Ov6X9IaK1Z3MzaooX4x+21361Bg==",
       "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0",
-        "mingo": "^4.1.5"
+        "lodash.isobject": "^3.0.2",
+        "mingo": "6.1.0 - 6.2.1"
       }
     },
     "sharedb-mongo": {

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -23,10 +23,10 @@
         "mongodb": "^4.6.0",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
-        "sharedb": "^1.9.2",
+        "sharedb": "^5.1.1",
         "sharedb-access": "^5.0.0",
-        "sharedb-milestone-mongo": "^1.0.0",
-        "sharedb-mongo": "^1.0.0",
+        "sharedb-milestone-mongo": "^2.0.0",
+        "sharedb-mongo": "^5.0.0",
         "ts-object-path": "^0.1.2",
         "websocket-json-stream": "^0.0.3",
         "ws": "^8.18.0"
@@ -3494,12 +3494,9 @@
       "integrity": "sha512-t0OgO06uolEcMUvV8+yHc9Pc9pazh8wi/Dtyok/sQwvcr8iFV+P86IfAzK7upUDhI4oavhVREMY7iSWtm38LeA=="
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -8003,15 +8000,15 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-5.1.1.tgz",
+      "integrity": "sha512-qNiO2nJdvnQYRvKMiZzbPyyXuBN0uulP4VaFrybJRLVSif8XPEnNO7Up/aHO3nwA5UejizzncOL8KVba4Rj4KA==",
       "dependencies": {
-        "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
-        "fast-deep-equal": "^2.0.1",
+        "arraydiff": "^0.1.3",
+        "async": "^3.2.4",
+        "fast-deep-equal": "^3.1.3",
         "hat": "0.0.3",
-        "ot-json0": "^1.0.1"
+        "ot-json0": "^1.1.0"
       }
     },
     "node_modules/sharedb-access": {
@@ -8024,12 +8021,12 @@
       }
     },
     "node_modules/sharedb-milestone-mongo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-1.0.0.tgz",
-      "integrity": "sha512-5rkL61bEZR0YwXe7PUWKLQFe7wJb1GkLrMtRSW3tQiprJnAZHagDPbJhMOQNgXFFLgOWgfyzF4FtslX6+/DWoQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-2.0.0.tgz",
+      "integrity": "sha512-TOFuABUnlNWiTcThVF9oAZRUumfoBbC/p02IXerH9zCWB/vsdzKTahcu3C4rq0MAq/1AjlX0nPxa5U1+oS9btw==",
       "dependencies": {
-        "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
-        "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+        "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/sharedb-mingo-memory": {
@@ -8046,20 +8043,13 @@
       }
     },
     "node_modules/sharedb-mongo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sharedb-mongo/-/sharedb-mongo-1.0.0.tgz",
-      "integrity": "sha512-qzLsrrl+/KPUjNShrwUbprvr1lEl/l/KuzkwAez4Dw7okJPvktcdv30AuoihILEC2Xv66CHZUrDmxscbF+tbzg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-mongo/-/sharedb-mongo-5.0.0.tgz",
+      "integrity": "sha512-BhT4SsQZOEX/PtfE5E3mghfHRweJW+Z9A/jdLUHVIYEI8Yz7c/368XsfQXnN32tn3bwmijBR1Rzw8nPfG/9jdQ==",
       "dependencies": {
-        "async": "^2.6.3",
-        "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
-        "sharedb": "^1.9.1 || ^2.0.0"
+        "mongodb": "^3.1.13 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
-    },
-    "node_modules/sharedb/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -11680,12 +11670,9 @@
       "integrity": "sha512-t0OgO06uolEcMUvV8+yHc9Pc9pazh8wi/Dtyok/sQwvcr8iFV+P86IfAzK7upUDhI4oavhVREMY7iSWtm38LeA=="
     },
     "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -14934,22 +14921,15 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sharedb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-1.9.2.tgz",
-      "integrity": "sha512-YioIGNOjITm+loRrGYSCF1S6tbid15MUHloQN7035tAbDlJuveHmxnQ/6e/CguAFsGvFom2zfj3xUJLXGaTyYg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-5.1.1.tgz",
+      "integrity": "sha512-qNiO2nJdvnQYRvKMiZzbPyyXuBN0uulP4VaFrybJRLVSif8XPEnNO7Up/aHO3nwA5UejizzncOL8KVba4Rj4KA==",
       "requires": {
-        "arraydiff": "^0.1.1",
-        "async": "^2.6.3",
-        "fast-deep-equal": "^2.0.1",
+        "arraydiff": "^0.1.3",
+        "async": "^3.2.4",
+        "fast-deep-equal": "^3.1.3",
         "hat": "0.0.3",
-        "ot-json0": "^1.0.1"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
-        }
+        "ot-json0": "^1.1.0"
       }
     },
     "sharedb-access": {
@@ -14962,12 +14942,12 @@
       }
     },
     "sharedb-milestone-mongo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-1.0.0.tgz",
-      "integrity": "sha512-5rkL61bEZR0YwXe7PUWKLQFe7wJb1GkLrMtRSW3tQiprJnAZHagDPbJhMOQNgXFFLgOWgfyzF4FtslX6+/DWoQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-milestone-mongo/-/sharedb-milestone-mongo-2.0.0.tgz",
+      "integrity": "sha512-TOFuABUnlNWiTcThVF9oAZRUumfoBbC/p02IXerH9zCWB/vsdzKTahcu3C4rq0MAq/1AjlX0nPxa5U1+oS9btw==",
       "requires": {
-        "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
-        "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+        "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "sharedb-mingo-memory": {
@@ -14981,13 +14961,12 @@
       }
     },
     "sharedb-mongo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sharedb-mongo/-/sharedb-mongo-1.0.0.tgz",
-      "integrity": "sha512-qzLsrrl+/KPUjNShrwUbprvr1lEl/l/KuzkwAez4Dw7okJPvktcdv30AuoihILEC2Xv66CHZUrDmxscbF+tbzg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sharedb-mongo/-/sharedb-mongo-5.0.0.tgz",
+      "integrity": "sha512-BhT4SsQZOEX/PtfE5E3mghfHRweJW+Z9A/jdLUHVIYEI8Yz7c/368XsfQXnN32tn3bwmijBR1Rzw8nPfG/9jdQ==",
       "requires": {
-        "async": "^2.6.3",
-        "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
-        "sharedb": "^1.9.1 || ^2.0.0"
+        "mongodb": "^3.1.13 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "shebang-command": {

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -20,7 +20,7 @@
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^2.1.2",
         "lodash-es": "^4.17.21",
-        "mongodb": "^4.6.0",
+        "mongodb": "^4.17.2",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
         "sharedb": "^5.1.1",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -32,7 +32,7 @@
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.2",
     "lodash-es": "^4.17.21",
-    "mongodb": "^4.6.0",
+    "mongodb": "^4.17.2",
     "ot-json0": "^1.1.0",
     "rich-text": "^4.1.0",
     "sharedb": "^5.1.1",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -61,7 +61,7 @@
     "jest-expect-message": "^1.1.3",
     "jest-teamcity-reporter": "^0.9.0",
     "prettier": "^3.3.3",
-    "sharedb-mingo-memory": "^1.2.0",
+    "sharedb-mingo-memory": "^4.0.1",
     "ts-jest": "^29.1.2",
     "ts-mockito": "^2.6.1",
     "typescript": "~5.2.2"

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -35,10 +35,10 @@
     "mongodb": "^4.6.0",
     "ot-json0": "^1.1.0",
     "rich-text": "^4.1.0",
-    "sharedb": "^1.9.2",
+    "sharedb": "^5.1.1",
     "sharedb-access": "^5.0.0",
-    "sharedb-milestone-mongo": "^1.0.0",
-    "sharedb-mongo": "^1.0.0",
+    "sharedb-milestone-mongo": "^2.0.0",
+    "sharedb-mongo": "^5.0.0",
     "ts-object-path": "^0.1.2",
     "websocket-json-stream": "^0.0.3",
     "ws": "^8.18.0"

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sharedb 1.0
+// Type definitions for sharedb 5.1.1
 // Project: https://github.com/share/sharedb
 // Definitions by: Steve Oney <https://github.com/soney>
 //                 Eric Hwang <https://github.com/ericyhwang>
@@ -35,6 +35,7 @@ declare class ShareDB {
     presence?: boolean;
     disableDocAction?: boolean;
     disableSpaceDelimitedActions?: boolean;
+    doNotForwardSendPresenceErrorsToClient?: boolean;
   });
   connect(connection?: Connection, req?: any): Connection;
   /**


### PR DESCRIPTION
This PR upgrades sharedb to version 5.1.1 on the realtime server. This may be a safer way of upgrading because we can have confidence that having sharedb at version 5.1.1 is still compatible with clients on the previous sharedb 1.9.2. Then we can upgrade sharedb on the client app.

From running the realtime server tests, I found some deprecated messages that needed to be addressed

- updated realtime server constructor initializes ShareDB with `doNotForwardSendPresenceErrorsToClient`
- updated to mongodb 4.17.2 to satisfy the punycode deprecation warning (but it seems we should upgrade to further to 6.x)

Things I checked:

- the breaking changes from shareDB 1.x to 5.1.1 do not affect us (most breaking changes are dropping support for older versions of node).
- our sharedb extended classes overriding private methods (i.e. MigrationAgent._handleMessage()) do not affect how we override the method
- manual real-time testing for behaviour (online and offline)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3035)
<!-- Reviewable:end -->
