### PR TITLE
SF-3228 Replace multiple newlines and tabs with space on editor paste

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.spec.ts
@@ -1,5 +1,5 @@
 import Quill, { Delta, Range } from 'quill';
-import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { anything, deepEqual, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import { TextComponent } from '../text.component';
 import { DisableHtmlClipboard } from './quill-clipboard';
 
@@ -51,19 +51,72 @@ describe('DisableHtmlClipboard', () => {
       expect(true).toBe(true); // Prevent SPEC HAS NO EXPECTATIONS warning
     });
 
-    it('should clean and paste text with attributes', () => {
-      const inputText = 'test\ntext\\with\\backslashes';
-      const expectedText = 'test text with backslashes';
+    it('should replace multiple newlines with single space (testing regex)', () => {
+      const testCases = [
+        {
+          input: 'first\n\nsecond',
+          expected: 'first second'
+        },
+        {
+          input: 'first\r\n\r\nsecond',
+          expected: 'first second'
+        },
+        {
+          input: 'first\r\n\nsecond\n\r\nthird',
+          expected: 'first second third'
+        },
+        {
+          input: '\n\nstart\nmiddle\n\nend\n\n',
+          expected: ' start middle end '
+        }
+      ];
+
+      for (const testCase of testCases) {
+        // Override convert to capture the cleaned text passed for conversion
+        let capturedText = '';
+        clipboard.convert = (arg: { text: string }) => {
+          capturedText = arg.text;
+          return new Delta().insert(arg.text);
+        };
+
+        const event = createPasteEvent(testCase.input);
+        clipboard.onCapturePaste(event);
+
+        expect(capturedText).toBe(testCase.expected);
+
+        // Also verify that updateContents was called correctly
+        verify(
+          quillMock.updateContents(
+            deepEqual(
+              new Delta().retain(mockRange.index).insert(testCase.expected, mockFormat).delete(mockRange.length)
+            ),
+            'user'
+          )
+        ).once();
+
+        resetCalls(quillMock);
+      }
+    });
+
+    it('should handle mixed newlines and backslashes', () => {
+      const inputText = 'line1\\\r\n\\line2\n\\\nline3\\';
+      const expected = 'line1 line2 line3';
+
+      // Override convert to capture the cleaned text passed for conversion
+      let capturedText = '';
+      clipboard.convert = (arg: { text: string }) => {
+        capturedText = arg.text;
+        return new Delta().insert(arg.text);
+      };
 
       const event = createPasteEvent(inputText);
-      const pasteDelta = new Delta().insert(expectedText);
-      clipboard.convert = () => pasteDelta;
-
       clipboard.onCapturePaste(event);
+
+      expect(capturedText).toBe(expected);
 
       verify(
         quillMock.updateContents(
-          deepEqual(new Delta().retain(mockRange.index).insert(expectedText, mockFormat).delete(mockRange.length)),
+          deepEqual(new Delta().retain(mockRange.index).insert(expected, mockFormat).delete(mockRange.length)),
           'user'
         )
       ).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.spec.ts
@@ -51,7 +51,7 @@ describe('DisableHtmlClipboard', () => {
       expect(true).toBe(true); // Prevent SPEC HAS NO EXPECTATIONS warning
     });
 
-    it('should replace multiple newlines with single space (testing regex)', () => {
+    it('should replace multiple newlines and tabs with single space', () => {
       const testCases = [
         {
           input: 'first\n\nsecond',
@@ -68,6 +68,18 @@ describe('DisableHtmlClipboard', () => {
         {
           input: '\n\nstart\nmiddle\n\nend\n\n',
           expected: ' start middle end '
+        },
+        {
+          input: 'first\tsecond\t\tthird',
+          expected: 'first second third'
+        },
+        {
+          input: '\t\tstart\tmiddle\t\tend\t\t',
+          expected: ' start middle end '
+        },
+        {
+          input: 'first\n\t\nsecond\t\n\tthird',
+          expected: 'first second third'
         }
       ];
 
@@ -98,8 +110,8 @@ describe('DisableHtmlClipboard', () => {
       }
     });
 
-    it('should handle mixed newlines and backslashes', () => {
-      const inputText = 'line1\\\r\n\\line2\n\\\nline3\\';
+    it('should handle mixed newlines, tabs, and backslashes', () => {
+      const inputText = 'line1\\\t\r\n\\line2\n\t\\\nline3\\';
       const expected = 'line1 line2 line3';
 
       // Override convert to capture the cleaned text passed for conversion

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.ts
@@ -35,7 +35,7 @@ export class DisableHtmlClipboard extends QuillClipboard {
     const text = e.clipboardData.getData('text/plain');
     const cleanedText = text
       .replace(/\\/g, '') // Remove all backslashes first
-      .replace(/(?:\r?\n)+/g, ' '); // Replace all new lines with spaces
+      .replace(/(?:\r?\n|\t)+/g, ' '); // Replace all new lines and tabs with space
 
     const pasteDelta = this.convert({ text: cleanedText });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-clipboard.ts
@@ -34,8 +34,8 @@ export class DisableHtmlClipboard extends QuillClipboard {
 
     const text = e.clipboardData.getData('text/plain');
     const cleanedText = text
-      .replace(/(?:\r?\n)+/, ' ') // Replace new lines with spaces
-      .replace(/\\/g, ''); // Remove backslashes
+      .replace(/\\/g, '') // Remove all backslashes first
+      .replace(/(?:\r?\n)+/g, ' '); // Replace all new lines with spaces
 
     const pasteDelta = this.convert({ text: cleanedText });
 


### PR DESCRIPTION
This PR fixes an issue where, when pasting text into the editor with multiple newlines that aren't consecutive, only the first newline gets replaced with a space.  Also added replacement of tabs with space.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3039)
<!-- Reviewable:end -->
