### PR TITLE
SF-3230 Get draft configuration for language code confirmation from parent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -46,6 +46,7 @@
 
   <app-language-codes-confirmation
     class="confirm-codes"
+    [draftSources]="draftSources"
     (languageCodesVerified)="confirmationChanged($event)"
   ></app-language-codes-confirmation>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -6,7 +6,7 @@ import { TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { I18nService } from 'xforge-common/i18n.service';
-import { DraftSourcesService } from '../draft-sources.service';
+import { DraftSourcesAsArrays, DraftSourcesService } from '../draft-sources.service';
 import { LanguageCodesConfirmationComponent } from '../language-codes-confirmation/language-codes-confirmation.component';
 
 @Component({
@@ -22,6 +22,7 @@ export class ConfirmSourcesComponent implements OnInit {
   trainingSources: TranslateSource[] = [];
   trainingTargets: TranslateSource[] = [];
   draftingSources: TranslateSource[] = [];
+  draftSources?: DraftSourcesAsArrays;
 
   constructor(
     private readonly destroyRef: DestroyRef,
@@ -50,6 +51,7 @@ export class ConfirmSourcesComponent implements OnInit {
       .getDraftProjectSources()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(async ({ trainingTargets, trainingSources, draftingSources }) => {
+        this.draftSources = { trainingTargets, trainingSources, draftingSources };
         this.trainingSources = trainingSources.filter(s => s !== undefined);
         this.trainingTargets = trainingTargets.filter(t => t !== undefined);
         this.draftingSources = draftingSources.filter(s => s !== undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -13,7 +13,7 @@ import { NoticeComponent } from '../../../shared/notice/notice.component';
 import { DraftSourcesAsArrays } from '../draft-sources.service';
 import { LanguageCodesConfirmationComponent } from './language-codes-confirmation.component';
 
-fdescribe('LanguageCodesConfirmationComponent', () => {
+describe('LanguageCodesConfirmationComponent', () => {
   let component: LanguageCodesConfirmationComponent;
   let fixture: ComponentFixture<LanguageCodesConfirmationComponent>;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -2,7 +2,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslocoMarkupComponent } from 'ngx-transloco-markup';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { of } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
@@ -11,22 +10,23 @@ import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { NoticeComponent } from '../../../shared/notice/notice.component';
-import { DraftSourcesAsArrays, DraftSourcesService } from '../draft-sources.service';
+import { DraftSourcesAsArrays } from '../draft-sources.service';
 import { LanguageCodesConfirmationComponent } from './language-codes-confirmation.component';
 
-const mockI18nService = mock(I18nService);
-const mockActivatedProject: ActivatedProjectService = mock(ActivatedProjectService);
-const mockAuthService = mock(AuthService);
-const mockDraftSourcesService = mock(DraftSourcesService);
+fdescribe('LanguageCodesConfirmationComponent', () => {
+  let component: LanguageCodesConfirmationComponent;
+  let fixture: ComponentFixture<LanguageCodesConfirmationComponent>;
 
-describe('LanguageCodesConfirmationComponent', () => {
+  const mockI18nService = mock(I18nService);
+  const mockActivatedProject: ActivatedProjectService = mock(ActivatedProjectService);
+  const mockAuthService = mock(AuthService);
+
   configureTestingModule(() => ({
     imports: [TestTranslocoModule, UICommonModule, NoticeComponent, TranslocoMarkupComponent],
     providers: [
       { provide: I18nService, useMock: mockI18nService },
       { provide: ActivatedProjectService, useMock: mockActivatedProject },
-      { provide: AuthService, useMock: mockAuthService },
-      { provide: DraftSourcesService, useMock: mockDraftSourcesService }
+      { provide: AuthService, useMock: mockAuthService }
     ]
   }));
 
@@ -39,12 +39,17 @@ describe('LanguageCodesConfirmationComponent', () => {
       id: 'target',
       data: createTestProjectProfile({ userRoles: { user1: SFProjectRole.ParatextAdministrator } })
     } as SFProjectProfileDoc);
+
+    fixture = TestBed.createComponent(LanguageCodesConfirmationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it('should show standard message', () => {
-    const env = new TestEnvironment({ draftSources: getStandardDraftSources() });
-    expect(env.component.sourceSideLanguageCodes.length).toEqual(1);
-    expect(env.component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
+    component.draftSources = getStandardDraftSources();
+    fixture.detectChanges();
+    expect(component.sourceSideLanguageCodes.length).toEqual(1);
+    expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
   });
 
   it('shows standard message when language codes are equivalent language', () => {
@@ -52,16 +57,18 @@ describe('LanguageCodesConfirmationComponent', () => {
     // Both map to the Chinese language
     draftSources.draftingSources[0]!.writingSystem.tag = 'zh-CN';
     draftSources.trainingSources[0]!.writingSystem.tag = 'cmn-Hans';
-    const env = new TestEnvironment({ draftSources });
-    expect(env.component.sourceSideLanguageCodes.length).toEqual(1);
+    component.draftSources = draftSources;
+    fixture.detectChanges();
+    expect(component.sourceSideLanguageCodes.length).toEqual(1);
   });
 
   it('should show target and source language codes identical message', () => {
     const draftSources = getStandardDraftSources();
     draftSources.trainingTargets[0]!.writingSystem.tag = draftSources.trainingSources[0]!.writingSystem.tag;
-    const env = new TestEnvironment({ draftSources });
-    expect(env.component.sourceSideLanguageCodes.length).toEqual(1);
-    expect(env.component.showSourceAndTargetLanguagesIdenticalWarning).toBe(true);
+    component.draftSources = draftSources;
+    fixture.detectChanges();
+    expect(component.sourceSideLanguageCodes.length).toEqual(1);
+    expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(true);
   });
 
   it('should show training source language codes different message', () => {
@@ -74,31 +81,20 @@ describe('LanguageCodesConfirmationComponent', () => {
       writingSystem: { tag: 'zh' },
       texts: []
     });
-    const env = new TestEnvironment({ draftSources });
-    // Chinese as the additional training source, and Spanish for the training and drafting source
-    expect(env.component.sourceSideLanguageCodes.length).toEqual(2);
-    expect(env.component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
+    component.draftSources = draftSources;
+    fixture.detectChanges();
+    expect(component.sourceSideLanguageCodes.length).toEqual(2);
+    expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
   });
 
   it('can emit languages confirmed when checkbox is checked', () => {
-    const env = new TestEnvironment({ draftSources: getStandardDraftSources() });
-    const emitSpy = spyOn(env.component.languageCodesVerified, 'emit');
-    env.component.confirmationChanged({ checked: true } as any);
+    component.draftSources = getStandardDraftSources();
+    fixture.detectChanges();
+    const emitSpy = spyOn(component.languageCodesVerified, 'emit');
+    component.confirmationChanged({ checked: true } as any);
     expect(emitSpy).toHaveBeenCalledWith(true);
   });
 });
-
-class TestEnvironment {
-  component: LanguageCodesConfirmationComponent;
-  fixture: ComponentFixture<LanguageCodesConfirmationComponent>;
-
-  constructor(args: { draftSources: DraftSourcesAsArrays }) {
-    when(mockDraftSourcesService.getDraftProjectSources()).thenReturn(of(args.draftSources));
-    this.fixture = TestBed.createComponent(LanguageCodesConfirmationComponent);
-    this.component = this.fixture.componentInstance;
-    this.fixture.detectChanges();
-  }
-}
 
 function getStandardDraftSources(): DraftSourcesAsArrays {
   return {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
@@ -2,64 +2,55 @@ import { CommonModule } from '@angular/common';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { defaultTranslocoMarkupTranspilers, TranslocoMarkupComponent } from 'ngx-transloco-markup';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
-import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { DraftSource, DraftSourcesAsArrays, DraftSourcesService } from '../draft-sources.service';
+import { DraftSource, DraftSourcesAsArrays } from '../draft-sources.service';
 import { LanguageCodesConfirmationComponent } from './language-codes-confirmation.component';
 
-const mockDraftService = mock(DraftSourcesService);
-const mockActivatedProject = mock(ActivatedProjectService);
 const mockAuthService = mock(AuthService);
+const mockActivatedProject = mock(ActivatedProjectService);
 
-when(mockDraftService.getDraftProjectSources()).thenReturn(
-  of({
-    draftingSources: [
-      {
-        projectRef: 'alternate-drafting-source',
-        shortName: 'ADS',
-        name: 'Alternate Drafting Source',
-        paratextId: 'alternate-drafting-source',
-        writingSystem: { tag: 'es' }
-      } as DraftSource
-    ],
-    trainingSources: [
-      {
-        projectRef: 'alternate-training-source',
-        shortName: 'ATS',
-        name: 'Alternate Training Source',
-        paratextId: 'alternate-training-source',
-        writingSystem: { tag: 'es' }
-      } as DraftSource,
-      {
-        projectRef: 'additional-training-source',
-        shortName: 'ATS',
-        name: 'Additional Training Source',
-        paratextId: 'additional-training-source',
-        writingSystem: { tag: 'es' }
-      } as DraftSource
-    ],
-    trainingTargets: [
-      {
-        projectRef: 'test-proj',
-        shortName: 'TP',
-        name: 'Test Project',
-        paratextId: 'test-proj-id',
-        writingSystem: { tag: 'eng' }
-      } as DraftSource
-    ]
-  } as DraftSourcesAsArrays)
-);
+const draftSources: DraftSourcesAsArrays = {
+  draftingSources: [
+    {
+      projectRef: 'alternate-drafting-source',
+      shortName: 'ADS',
+      name: 'Alternate Drafting Source',
+      paratextId: 'alternate-drafting-source',
+      writingSystem: { tag: 'es' }
+    } as DraftSource
+  ],
+  trainingSources: [
+    {
+      projectRef: 'alternate-training-source',
+      shortName: 'ATS',
+      name: 'Alternate Training Source',
+      paratextId: 'alternate-training-source',
+      writingSystem: { tag: 'es' }
+    } as DraftSource,
+    {
+      projectRef: 'additional-training-source',
+      shortName: 'ATS',
+      name: 'Additional Training Source',
+      paratextId: 'additional-training-source',
+      writingSystem: { tag: 'es' }
+    } as DraftSource
+  ],
+  trainingTargets: [
+    {
+      projectRef: 'test-proj',
+      shortName: 'TP',
+      name: 'Test Project',
+      paratextId: 'test-proj-id',
+      writingSystem: { tag: 'eng' }
+    } as DraftSource
+  ]
+};
+
+const defaultArgs = { draftSources };
 
 when(mockActivatedProject.projectId).thenReturn('test-proj');
-when(mockActivatedProject.projectDoc).thenReturn({
-  id: 'test-proj',
-  data: createTestProjectProfile({ userRoles: { user1: SFProjectRole.ParatextAdministrator } })
-} as SFProjectProfileDoc);
 when(mockAuthService.currentUserId).thenReturn('user1');
 
 const meta: Meta = {
@@ -69,7 +60,6 @@ const meta: Meta = {
     moduleMetadata({
       imports: [CommonModule, TranslocoModule, TranslocoMarkupComponent, LanguageCodesConfirmationComponent],
       providers: [
-        { provide: DraftSourcesService, useValue: instance(mockDraftService) },
         { provide: ActivatedProjectService, useValue: instance(mockActivatedProject) },
         { provide: AuthService, useValue: instance(mockAuthService) },
         defaultTranslocoMarkupTranspilers()
@@ -85,17 +75,19 @@ interface StoryState {}
 type Story = StoryObj<StoryState>;
 
 export const Default: Story = {
-  args: {}
+  args: defaultArgs
 };
 
 export const SameSourceAndTargetCodes: Story = {
   args: {
+    ...defaultArgs,
     targetLanguageTag: 'es'
   }
 };
 
 export const DifferentSourceCodes: Story = {
   args: {
+    ...defaultArgs,
     draftingSources: [
       {
         projectRef: 'alternate-drafting-source',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
@@ -2,9 +2,12 @@ import { CommonModule } from '@angular/common';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { defaultTranslocoMarkupTranspilers, TranslocoMarkupComponent } from 'ngx-transloco-markup';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
+import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { DraftSource, DraftSourcesAsArrays } from '../draft-sources.service';
 import { LanguageCodesConfirmationComponent } from './language-codes-confirmation.component';
 
@@ -51,6 +54,10 @@ const draftSources: DraftSourcesAsArrays = {
 const defaultArgs = { draftSources };
 
 when(mockActivatedProject.projectId).thenReturn('test-proj');
+when(mockActivatedProject.projectDoc).thenReturn({
+  id: 'test-proj',
+  data: createTestProjectProfile({ userRoles: { user1: SFProjectRole.ParatextAdministrator } })
+} as SFProjectProfileDoc);
 when(mockAuthService.currentUserId).thenReturn('user1');
 
 const meta: Meta = {


### PR DESCRIPTION
This PR updates the language code confirmation component to get its drafting sources configuration from the parent component. This is preferred since the new draft configurations architecture will come from a temporary config rather than saved to the project. Most of these changes were first introduced in code review from SF-3162.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3042)
<!-- Reviewable:end -->
