### PR TITLE
SF-3205 Handle start draft requests when a job is already running

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -9,7 +9,7 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { BehaviorSubject, EMPTY, of, Subject, throwError } from 'rxjs';
-import { instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -118,7 +118,12 @@ describe('DraftGenerationComponent', () => {
         }
       );
       mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog']);
-      mockNoticeService = jasmine.createSpyObj<NoticeService>(['loadingStarted', 'loadingFinished', 'showError']);
+      mockNoticeService = jasmine.createSpyObj<NoticeService>([
+        'loadingStarted',
+        'loadingFinished',
+        'showError',
+        'show'
+      ]);
       mockDraftGenerationService = jasmine.createSpyObj<DraftGenerationService>([
         'startBuildOrGetActiveBuild',
         'cancelBuild',
@@ -1049,6 +1054,7 @@ describe('DraftGenerationComponent', () => {
   describe('startBuild', () => {
     it('should start the draft build', () => {
       const env = new TestEnvironment();
+      mockDraftGenerationService.getBuildProgress.and.returnValue(of(undefined));
 
       env.component.currentPage = 'steps';
       env.component.startBuild({
@@ -1070,6 +1076,27 @@ describe('DraftGenerationComponent', () => {
       env.startedOrActiveBuild$.next(buildDto);
       env.fixture.detectChanges();
       expect(env.component.currentPage).toBe('initial');
+    });
+
+    it('should not start a build if one is already running', () => {
+      const env = new TestEnvironment();
+      env.component['draftJob'] = undefined; //clear the known draft job
+      expect(mockDraftGenerationService.getBuildProgress(projectId)).not.toBeNull();
+
+      env.component.currentPage = 'steps';
+      env.component.startBuild({
+        trainingDataFiles: [],
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        fastTraining: false,
+        projectId: projectId
+      });
+      env.fixture.detectChanges();
+
+      expect(env.component.currentPage).toBe('initial');
+      expect(env.component['draftJob']).not.toBeNull();
+      expect(mockDraftGenerationService.startBuildOrGetActiveBuild).not.toHaveBeenCalledWith(anything());
+      expect(mockNoticeService.show).toHaveBeenCalledTimes(1);
     });
 
     it('should not attempt "cancel dialog" close for queued build', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, DestroyRef, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { MatTabGroup } from '@angular/material/tabs';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -153,7 +154,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly onlineStatusService: OnlineStatusService,
     private readonly preTranslationSignupUrlService: PreTranslationSignupUrlService,
     protected readonly noticeService: NoticeService,
-    protected readonly urlService: ExternalUrlService
+    protected readonly urlService: ExternalUrlService,
+    private readonly destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -446,6 +448,18 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   }
 
   startBuild(buildConfig: BuildConfig): void {
+    this.draftGenerationService
+      .getBuildProgress(buildConfig.projectId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(job => {
+        if (this.isDraftInProgress(job)) {
+          this.draftJob = job;
+          this.currentPage = 'initial';
+          this.noticeService.show(this.i18n.translateStatic('draft_generation.draft_already_running'));
+          return;
+        }
+      });
+
     this.jobSubscription?.unsubscribe();
     this.jobSubscription = this.subscribe(
       this.draftGenerationService.startBuildOrGetActiveBuild(buildConfig).pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -182,6 +182,7 @@
     "download_draft": "Download draft",
     "draft_active_detail": "Generating draft; this usually takes at least {{ count }} hours.",
     "draft_active_header": "Draft in progress",
+    "draft_already_running": "Draft generation has already been requested for this project. Wait until the current job finishes to start a new draft.",
     "draft_finishing_detail": "Your draft is being finalized and saved.",
     "draft_finishing_header": "Draft is finishing",
     "draft_is_ready": "Your draft is ready",


### PR DESCRIPTION
If the draft generation page hasn't been refreshed recently, the user may not know when another draft job has been queued. If he then attempts to configure and start a new job, the request will silently fail. This code changes the "startBuild" method to check if an existing build is present for the project, and if it is, it instead will show a notice, update the page with the running job, and send them back to the landing page.

We opted for this design, as opposed to a more elegant one, since the user really shouldn't be in this state. This was chosen for expediency over something like setting up cross-client notifications with project-notification.service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3043)
<!-- Reviewable:end -->
