### PR TITLE
ci: rely on called workflow environment secrets

### DIFF
--- a/.github/workflows/release-live.yml
+++ b/.github/workflows/release-live.yml
@@ -91,21 +91,6 @@ jobs:
   deploy:
     name: "Deploy to Live"
     needs: [determine_build_commit, determine_version]
-    secrets:
-      deploy_known_hosts: ${{ secrets.deploy_known_hosts }}
-      deploy_ssh_private_key: ${{ secrets.deploy_ssh_private_key }}
-      deploy_server: ${{ secrets.deploy_server }}
-      alternate_domain: ${{ secrets.alternate_domain }}
-      paratext_client_id: ${{ secrets.paratext_client_id }}
-      serval_client_id: ${{ secrets.serval_client_id }}
-      auth_backend_secret: ${{ secrets.auth_backend_secret }}
-      auth_webhook_password: ${{ secrets.auth_webhook_password }}
-      auth_health_check_api_key: ${{ secrets.auth_health_check_api_key }}
-      paratext_api_token: ${{ secrets.paratext_api_token }}
-      paratext_resource_password_base64: ${{ secrets.paratext_resource_password_base64 }}
-      paratext_resource_password_hash: ${{ secrets.paratext_resource_password_hash }}
-      serval_client_secret: ${{ secrets.serval_client_secret }}
-      serval_webhook_secret: ${{ secrets.serval_webhook_secret }}
     uses: ./.github/workflows/release.yml
     with:
       environment: "production"

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -112,21 +112,6 @@ jobs:
   deploy:
     name: "Deploy to QA"
     needs: [determine_build_commit, determine_version]
-    secrets:
-      deploy_known_hosts: ${{ secrets.deploy_known_hosts }}
-      deploy_ssh_private_key: ${{ secrets.deploy_ssh_private_key }}
-      deploy_server: ${{ secrets.deploy_server }}
-      alternate_domain: ${{ secrets.alternate_domain }}
-      paratext_client_id: ${{ secrets.paratext_client_id }}
-      serval_client_id: ${{ secrets.serval_client_id }}
-      auth_backend_secret: ${{ secrets.auth_backend_secret }}
-      auth_webhook_password: ${{ secrets.auth_webhook_password }}
-      auth_health_check_api_key: ${{ secrets.auth_health_check_api_key }}
-      paratext_api_token: ${{ secrets.paratext_api_token }}
-      paratext_resource_password_base64: ${{ secrets.paratext_resource_password_base64 }}
-      paratext_resource_password_hash: ${{ secrets.paratext_resource_password_hash }}
-      serval_client_secret: ${{ secrets.serval_client_secret }}
-      serval_webhook_secret: ${{ secrets.serval_webhook_secret }}
     uses: ./.github/workflows/release.yml
     with:
       environment: "qa_deploy"


### PR DESCRIPTION
release-qa.yml job deploy can't access secrets without an
`environment`. But it can't use an `environment` without a `runs-on`.
But if it has a `runs-on` it can't have a `uses`.

In investigating solutions for this, I observe that release.yml job
deploy should be able to access secrets anyway from its specified
environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3045)
<!-- Reviewable:end -->
