### PR TITLE
Fix editor NG0955 warning

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.html
@@ -11,7 +11,7 @@
   (tabMove)="moveTab($event)"
 ></app-tab-group-header>
 
-@for (tab of tabs; track tab; let i = $index) {
+@for (tab of tabs; track tab.id; let i = $index) {
   <app-tab-body [active]="selectedIndex === i">
     <ng-container *ngTemplateOutlet="tab.contentTemplate"></ng-container>
   </app-tab-body>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -1,13 +1,14 @@
 import { QueryList } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
+import { v4 as uuid } from 'uuid';
 import { TestTranslocoModule } from 'xforge-common/test-utils';
 import { TabMenuService } from '../../shared/sf-tab-group';
 import { TabAddRequestService } from './base-services/tab-add-request.service';
 import { TabFactoryService } from './base-services/tab-factory.service';
 import { SFTabsModule } from './sf-tabs.module';
 import { TabGroupComponent } from './tab-group.component';
-import { TabStateService } from './tab-state/tab-state.service';
+import { TabInfo, TabStateService } from './tab-state/tab-state.service';
 import { TabComponent } from './tab/tab.component';
 
 describe('TabGroupComponent', () => {
@@ -59,7 +60,8 @@ describe('TabGroupComponent', () => {
 
   it('should add tab using TabFactory and TabStateService when addTab is called', async () => {
     const newTabType = 'test';
-    const tab = {
+    const tab: TabInfo<string> = {
+      id: uuid(),
       type: 'test',
       headerText: 'Tab Header',
       closeable: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { Observable, of } from 'rxjs';
+import { v4 as uuid } from 'uuid';
 import {
   SFTabsModule,
   TabFactoryService,
@@ -27,13 +28,13 @@ import {
     `
   ],
   template: `
-    @for (tabGroup of tabState.tabGroups$ | async | keyvalue; track tabGroup) {
+    @for (tabGroup of tabState.tabGroups$ | async | keyvalue; track tabGroup.key) {
       <app-tab-group
         [groupId]="tabGroup.key"
         [selectedIndex]="tabGroup.value.selectedIndex"
         [connectedTo]="tabState.groupIds$ | async"
       >
-        @for (tab of tabGroup.value.tabs; track tab) {
+        @for (tab of tabGroup.value.tabs; track tab.id) {
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable">
             <ng-template sf-tab-header><div [innerHTML]="tab.headerText"></div></ng-template>
             <p><span [innerHTML]="tab.headerText"></span> in {{ tabGroup.key }}</p>
@@ -92,6 +93,7 @@ export default {
               switch (tabType) {
                 case 'blank':
                   tab = {
+                    id: uuid(),
                     type: 'blank',
                     headerText: 'New tab',
                     closeable: true,
@@ -100,6 +102,7 @@ export default {
                   break;
                 case 'type-a':
                   tab = {
+                    id: uuid(),
                     type: 'type-a',
                     headerText: 'Tab A',
                     closeable: true,
@@ -109,6 +112,7 @@ export default {
                 case 'type-b':
                 default:
                   tab = {
+                    id: uuid(),
                     type: 'type-b',
                     headerText: 'Tab B',
                     closeable: true,
@@ -131,18 +135,21 @@ type Story = StoryObj<SFTabGroupStoriesComponent>;
 const tabGroups: TabGroup<string, TabInfo<string>>[] = [
   new TabGroup<string, TabInfo<string>>('group-1', [
     {
+      id: uuid(),
       type: 'type-a',
       headerText: 'Uncloseable, unmovable Tab 1 is great!',
       closeable: false,
       movable: false
     },
     {
+      id: uuid(),
       type: 'type-b',
       headerText: 'Tab 2 <em>wow!</em>',
       closeable: true,
       movable: true
     },
     {
+      id: uuid(),
       type: 'type-c',
       headerText: 'Tab 3',
       icon: 'book',
@@ -180,14 +187,15 @@ export const TabReorderAndMove: Story = {
       ...tabGroups,
       new TabGroup<string, TabInfo<string>>('group-2', [
         {
+          id: uuid(),
           type: 'type-a',
           headerText: 'Uncloseable, unmovable Tab 1',
           closeable: false,
           movable: false
         },
-        { type: 'type-b', headerText: 'Tab 2', closeable: true, movable: true },
-        { type: 'type-c', headerText: 'Tab 3', closeable: true, movable: true },
-        { type: 'type-c', headerText: 'Tab 4', closeable: true, movable: true }
+        { id: uuid(), type: 'type-b', headerText: 'Tab 2', closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText: 'Tab 3', closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText: 'Tab 4', closeable: true, movable: true }
       ])
     ]
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { take } from 'rxjs';
+import { v4 as uuid } from 'uuid';
 import { TabGroup } from './tab-group';
 import { TabInfo, TabStateService } from './tab-state.service';
 
@@ -7,8 +8,8 @@ describe('TabStateService', () => {
   let service: TabStateService<string, TabInfo<string>>;
   const groupId = 'testGroup';
   const tabs: TabInfo<string>[] = [
-    { type: 'tab1', headerText: 'Tab 1', closeable: true, movable: true },
-    { type: 'tab2', headerText: 'Tab 2', closeable: false, movable: true }
+    { id: uuid(), type: 'tab1', headerText: 'Tab 1', closeable: true, movable: true },
+    { id: uuid(), type: 'tab2', headerText: 'Tab 2', closeable: false, movable: true }
   ];
 
   beforeEach(() => {
@@ -48,8 +49,8 @@ describe('TabStateService', () => {
         const groupId1: string = 'group1';
         const groupId2: string = 'group2';
         const tabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
         ];
         service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
         service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
@@ -71,12 +72,12 @@ describe('TabStateService', () => {
       const groupId1: string = 'group1';
       const groupId2: string = 'group2';
       const tabs1: TabInfo<string>[] = [
-        { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-        { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
       ];
       const tabs2: TabInfo<string>[] = [
-        { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-        { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true }
+        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true }
       ];
       service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs1));
       service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs2));
@@ -89,8 +90,8 @@ describe('TabStateService', () => {
       const groupId1: string = 'group1';
       const groupId2: string = 'group2';
       const tabs: TabInfo<string>[] = [
-        { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-        { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
       ];
       service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
       service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
@@ -104,6 +105,7 @@ describe('TabStateService', () => {
     it('should add a tab', () => {
       const groupId: string = 'source';
       const tab: TabInfo<string> = {
+        id: uuid(),
         type: 'type-a',
         headerText: 'Header',
         closeable: true,
@@ -117,6 +119,7 @@ describe('TabStateService', () => {
     it('should remove a tab', () => {
       const groupId: string = 'source';
       const tab: TabInfo<string> = {
+        id: uuid(),
         type: 'type-a',
         headerText: 'Header',
         closeable: true,
@@ -132,12 +135,14 @@ describe('TabStateService', () => {
       const groupId: string = 'source';
       const tabs: TabInfo<string>[] = [
         {
+          id: uuid(),
           type: 'type-a',
           headerText: 'Header 1',
           closeable: true,
           movable: true
         },
         {
+          id: uuid(),
           type: 'type-a',
           headerText: 'Header 2',
           closeable: true,
@@ -153,9 +158,9 @@ describe('TabStateService', () => {
       it('should move a tab within the same group', () => {
         const groupId: string = 'source';
         const tabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
         ];
         service['groups'].set(groupId, new TabGroup<string, any>(groupId, tabs));
         service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
@@ -165,9 +170,9 @@ describe('TabStateService', () => {
       it('should update selected index when moving a tab within the same group', () => {
         const groupId: string = 'source';
         const tabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
         ];
         const group = new TabGroup<string, any>(groupId, tabs);
         service['groups'].set(groupId, group);
@@ -193,12 +198,12 @@ describe('TabStateService', () => {
         const fromGroupId: string = 'source';
         const toGroupId: string = 'target';
         const fromTabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
         ];
         const toTabs: TabInfo<string>[] = [
-          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
-          { type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
+          { id: uuid(), type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
         ];
         service['groups'].set(fromGroupId, new TabGroup<string, any>(fromGroupId, fromTabs));
         service['groups'].set(toGroupId, new TabGroup<string, any>(toGroupId, toTabs));
@@ -211,14 +216,14 @@ describe('TabStateService', () => {
         const fromGroupId: string = 'source';
         const toGroupId: string = 'target';
         const fromTabs: TabInfo<string>[] = [
-          { type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 3', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 3', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Header 4', closeable: true, movable: true }
         ];
         const toTabs: TabInfo<string>[] = [
-          { type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
-          { type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
+          { id: uuid(), type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
         ];
         const fromGroup = new TabGroup<string, any>(fromGroupId, fromTabs);
         const toGroup = new TabGroup<string, any>(toGroupId, toTabs);
@@ -246,17 +251,17 @@ describe('TabStateService', () => {
 
       beforeEach(() => {
         sourceTabs = [
-          { type: 'type-a', headerText: 'Source Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Source Header 2', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Source Header 3', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Source Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Source Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Source Header 2', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Source Header 3', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Source Header 4', closeable: true, movable: true }
         ];
 
         targetTabs = [
-          { type: 'type-a', headerText: 'Target Header 1', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Target Header 2', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Target Header 3', closeable: true, movable: true },
-          { type: 'type-b', headerText: 'Target Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText: 'Target Header 1', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Target Header 2', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Target Header 3', closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText: 'Target Header 4', closeable: true, movable: true }
         ];
 
         service['groups'].set('source', new TabGroup<string, any>('source', sourceTabs));
@@ -289,9 +294,9 @@ describe('TabStateService', () => {
       });
 
       it('should add tabs to restore list and consolidated group when tabs are added after consolidation and before deconsolidation', () => {
-        const tabsToAdd = [
-          { type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true },
-          { type: 'type-c', headerText: 'added source Source Header 6', closeable: true, movable: true }
+        const tabsToAdd: TabInfo<string>[] = [
+          { id: uuid(), type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true },
+          { id: uuid(), type: 'type-c', headerText: 'added source Source Header 6', closeable: true, movable: true }
         ];
 
         service.consolidateTabGroups('target');
@@ -305,7 +310,13 @@ describe('TabStateService', () => {
       });
 
       it('should select added tab when tab with selection is added after consolidation and before deconsolidation', () => {
-        const tabToAdd = { type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true };
+        const tabToAdd: TabInfo<string> = {
+          id: uuid(),
+          type: 'type-c',
+          headerText: 'added source Source Header 5',
+          closeable: true,
+          movable: true
+        };
 
         service.consolidateTabGroups('target');
         service['groups'].get('source')?.addTab(tabToAdd);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -12,6 +12,7 @@ export type FlatTabInfo<TGroupId extends string, T extends TabInfo<string>> = T 
 };
 
 export interface TabInfo<TType extends string> {
+  id: string;
   type: TType;
   headerText: string;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab/tab.component.ts
@@ -1,4 +1,5 @@
 import { Component, ContentChild, Input, TemplateRef, ViewChild } from '@angular/core';
+import { v4 as uuid } from 'uuid';
 import { TabHeaderDirective } from '../tab-header/tab-header.directive';
 
 @Component({
@@ -12,4 +13,7 @@ export class TabComponent {
   @Input() tooltip?: string;
   @ViewChild(TemplateRef) contentTemplate!: TemplateRef<any>;
   @ContentChild(TabHeaderDirective, { read: TemplateRef }) tabHeaderTemplate?: any;
+
+  // An id will allow angular to track the tab in the DOM
+  readonly id: string = uuid();
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -60,7 +60,7 @@
         [selectedIndex]="tabGroup.value.selectedIndex"
         [connectedTo]="(tabState.groupIds$ | async) ?? []"
       >
-        @for (tab of tabGroup.value.tabs; track tab) {
+        @for (tab of tabGroup.value.tabs; track tab.type + tab.headerText) {
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable" [tooltip]="tab.tooltip">
             <ng-template sf-tab-header>
               @if (tab.svgIcon) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -60,7 +60,7 @@
         [selectedIndex]="tabGroup.value.selectedIndex"
         [connectedTo]="(tabState.groupIds$ | async) ?? []"
       >
-        @for (tab of tabGroup.value.tabs; track tab.type + tab.headerText) {
+        @for (tab of tabGroup.value.tabs; track tab.id) {
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable" [tooltip]="tab.tooltip">
             <ng-template sf-tab-header>
               @if (tab.svgIcon) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -60,7 +60,7 @@
         [selectedIndex]="tabGroup.value.selectedIndex"
         [connectedTo]="(tabState.groupIds$ | async) ?? []"
       >
-        @for (tab of tabGroup.value.tabs; track tab.type) {
+        @for (tab of tabGroup.value.tabs; track tab) {
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable" [tooltip]="tab.tooltip">
             <ng-template sf-tab-header>
               @if (tab.svgIcon) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -21,7 +21,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "biblical terms" tab', async () => {
     const tab = await service.createTab('biblical-terms');
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('biblical-terms');
     expect(tab.svgIcon).toEqual('biblical_terms');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -32,7 +32,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "history" tab', async () => {
     const tab = await service.createTab('history');
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('history');
     expect(tab.icon).toEqual('history');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -43,7 +43,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "draft" tab', async () => {
     const tab = await service.createTab('draft');
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('draft');
     expect(tab.icon).toEqual('auto_awesome');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -54,7 +54,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-target" tab', async () => {
     const tab = await service.createTab('project-target', { projectId: 'project1', headerText: 'Project 1' });
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-target');
     expect(tab.icon).toEqual('book');
@@ -66,7 +66,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-source" tab', async () => {
     const tab = await service.createTab('project-source', { projectId: 'project1', headerText: 'Project 1' });
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-source');
     expect(tab.icon).toEqual('book');
@@ -78,7 +78,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-resource" tab', async () => {
     const tab = await service.createTab('project-resource', { projectId: 'project1', headerText: 'Project 1' });
-    expect(tab.id?.length).toBeTruthy();
+    expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-resource');
     expect(tab.icon).toEqual('library_books');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -21,6 +21,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "biblical terms" tab', async () => {
     const tab = await service.createTab('biblical-terms');
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.type).toEqual('biblical-terms');
     expect(tab.svgIcon).toEqual('biblical_terms');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -31,6 +32,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "history" tab', async () => {
     const tab = await service.createTab('history');
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.type).toEqual('history');
     expect(tab.icon).toEqual('history');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -41,6 +43,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "draft" tab', async () => {
     const tab = await service.createTab('draft');
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.type).toEqual('draft');
     expect(tab.icon).toEqual('auto_awesome');
     expect(tab.headerText).toEqual('Test Header Text');
@@ -51,6 +54,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-target" tab', async () => {
     const tab = await service.createTab('project-target', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-target');
     expect(tab.icon).toEqual('book');
@@ -62,6 +66,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-source" tab', async () => {
     const tab = await service.createTab('project-source', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-source');
     expect(tab.icon).toEqual('book');
@@ -73,6 +78,7 @@ describe('EditorTabFactoryService', () => {
 
   it('should create a "project-resource" tab', async () => {
     const tab = await service.createTab('project-resource', { projectId: 'project1', headerText: 'Project 1' });
+    expect(tab.id?.length).toBeTruthy();
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-resource');
     expect(tab.icon).toEqual('library_books');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { isUndefined, omitBy } from 'lodash-es';
 import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { firstValueFrom } from 'rxjs';
+import { v4 as uuid } from 'uuid';
 import { I18nService } from 'xforge-common/i18n.service';
 import { TabFactoryService } from '../../../shared/sf-tab-group';
 import { EditorTabInfo } from './editor-tabs.types';
@@ -15,10 +16,14 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
     // Remove undefined options
     tabOptions = omitBy(tabOptions, isUndefined);
 
+    // An id will allow angular to track the tab in the DOM
+    const id: string = uuid();
+
     switch (tabType) {
       case 'biblical-terms':
         return Object.assign(
           {
+            id,
             type: 'biblical-terms',
             svgIcon: 'biblical_terms',
             headerText: await firstValueFrom(
@@ -34,6 +39,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
       case 'history':
         return Object.assign(
           {
+            id,
             type: 'history',
             icon: 'history',
             headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_history_tab_header')),
@@ -46,6 +52,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
       case 'draft':
         return Object.assign(
           {
+            id,
             type: 'draft',
             icon: 'auto_awesome',
             headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.draft_tab_header')),
@@ -63,6 +70,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
 
         return Object.assign(
           {
+            id,
             type: tabType,
             icon: 'book',
             headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_project_tab_header')),
@@ -79,6 +87,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
 
         return Object.assign(
           {
+            id,
             type: tabType,
             icon: 'library_books',
             headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_resource_tab_header')),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -4,6 +4,7 @@ import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scripture
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { of, take } from 'rxjs';
 import { mock, when } from 'ts-mockito';
+import { v4 as uuid } from 'uuid';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
@@ -36,7 +37,7 @@ describe('EditorTabMenuService', () => {
 
   it('should get "history", "draft", and "project-resource" menu items', done => {
     const env = new TestEnvironment();
-    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
+    env.setExistingTabs([{ id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
     service['canShowBiblicalTerms'] = () => false;
@@ -53,9 +54,9 @@ describe('EditorTabMenuService', () => {
   it('should get "history", "project-resource", and not "draft" (tab already exists) menu items', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([
-      { type: 'history', headerText: 'History', closeable: true, movable: true },
-      { type: 'draft', headerText: 'Draft', closeable: true, movable: true, unique: true },
-      { type: 'project-resource', headerText: 'ABC', closeable: true, movable: true }
+      { id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true },
+      { id: uuid(), type: 'draft', headerText: 'Draft', closeable: true, movable: true, unique: true },
+      { id: uuid(), type: 'project-resource', headerText: 'ABC', closeable: true, movable: true }
     ]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
@@ -71,7 +72,7 @@ describe('EditorTabMenuService', () => {
 
   it('should get "history" (enabled), not "draft" (no draft build), and not "project-resource" menu items', done => {
     const env = new TestEnvironment(TestEnvironment.projectDocNoDraft);
-    env.setExistingTabs([{ type: 'history', headerText: 'History', closeable: true, movable: true }]);
+    env.setExistingTabs([{ id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => false;
     service['canShowBiblicalTerms'] = () => false;


### PR DESCRIPTION
This PR fixes NG0955 warnings due to loop track expression targeting `tab.type`, since there can be multiple tabs of the same type, such as multiple resource tabs.  You can reproduce this warning by adding multiple resource tabs.

Added an `id` prop to `TabInfo` for angular to track instead.  The `id` prop is assigned a UUID upon tab creation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3047)
<!-- Reviewable:end -->
