### PR TITLE
SF-3211 Show source panel in editor if project has source selected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.spec.ts
@@ -197,7 +197,16 @@ class TestEnvironment {
     this.addTextDoc(new TextDocId('project01', 40, 2, 'target'));
     this.addCombinedVerseTextDoc(new TextDocId('project01', 41, 1, 'target'));
     this.setupProject();
-    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, { id: 'user01', data: createTestUser() });
+    this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+      id: 'user01',
+      data: createTestUser({
+        sites: {
+          sf: {
+            projects: ['project01']
+          }
+        }
+      })
+    });
     when(mockedSFProjectService.getProfile('project01')).thenCall(() =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, 'project01')
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -104,6 +104,11 @@ function createUser(idSuffix: number, role: string, nameConfirmed: boolean = tru
     id: 'user' + idSuffix,
     user: createTestUser(
       {
+        sites: {
+          sf: {
+            projects: ['project01']
+          }
+        },
         isDisplayNameConfirmed: nameConfirmed
       },
       idSuffix

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.spec.ts
@@ -646,7 +646,13 @@ class TestEnvironment {
     };
     this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
       id: 'user01',
-      data: createTestUser()
+      data: createTestUser({
+        sites: {
+          sf: {
+            projects: ['project01']
+          }
+        }
+      })
     });
 
     this.dialogRef = TestBed.inject(MatDialog).open(QuestionDialogComponent, config);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -136,6 +136,13 @@ describe('PermissionsService', () => {
     expect(await env.service.isUserOnProject('project01')).toBe(false);
   }));
 
+  it('checks the project doc to determine if user has a Paratext role on the project', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    expect(await env.service.userHasParatextRoleOnProject('project01')).toBe(true);
+    env.setCurrentUser('other');
+    expect(await env.service.userHasParatextRoleOnProject('project01')).toBe(false);
+  }));
+
   describe('canSync', () => {
     it('returns false when projectDoc.data is undefined', fakeAsync(() => {
       const env = new TestEnvironment();
@@ -225,6 +232,10 @@ class TestEnvironment {
     this.service = TestBed.inject(PermissionsService);
 
     when(mockedProjectService.getProfile(anything())).thenCall(id =>
+      this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)
+    );
+
+    when(mockedProjectService.get(anything())).thenCall(id =>
       this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, id)
     );
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -51,6 +51,12 @@ export class PermissionsService {
     return currentUserDoc?.data?.sites[environment.siteId].projects.includes(projectId) ?? false;
   }
 
+  async userHasParatextRoleOnProject(projectId: string): Promise<boolean> {
+    const currentUserDoc = await this.userService.getCurrentUser();
+    const currentProject = await this.projectService.get(projectId);
+    return isParatextRole(currentProject?.data?.userRoles[currentUserDoc.id] ?? SFProjectRole.None);
+  }
+
   async canAccessText(textDocId: TextDocId): Promise<boolean> {
     // Get the project doc, if the user is on that project
     let projectDoc: SFProjectProfileDoc | undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -142,6 +142,21 @@ describe('TextComponent', () => {
     env.id = undefined;
     env.waitForEditor();
     expect(env.component.placeholder).toEqual('text.book_does_not_exist');
+
+    const callback: (env: TestEnvironment) => void = (env: TestEnvironment) => {
+      env.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
+        id: 'user02',
+        data: createTestUser({}, 2)
+      });
+      when(mockedUserService.getCurrentUser()).thenCall(() =>
+        env.realtimeService.subscribe(UserDoc.COLLECTION, 'user02')
+      );
+    };
+    const env2: TestEnvironment = new TestEnvironment({ callback });
+    env2.fixture.detectChanges();
+    env2.id = env2.matTextDocId;
+    env2.waitForEditor();
+    expect(env2.component.placeholder).toEqual('text.permission_denied');
   }));
 
   it('placeholder uses specified placeholder input', fakeAsync(() => {
@@ -584,7 +599,7 @@ describe('TextComponent', () => {
       const callback: (env: TestEnvironment) => void = (env: TestEnvironment) => {
         env.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
           id: 'user02',
-          data: createTestUser({ displayName: '' }, 2)
+          data: createTestUser({ displayName: '', sites: { sf: { projects: ['project01'] } } }, 2)
         });
         when(mockedUserService.getCurrentUser()).thenCall(() =>
           env.realtimeService.subscribe(UserDoc.COLLECTION, 'user02')
@@ -1704,7 +1719,16 @@ class TestEnvironment {
     ]);
     this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
       id: 'user01',
-      data: createTestUser({}, 1)
+      data: createTestUser(
+        {
+          sites: {
+            sf: {
+              projects: ['project01']
+            }
+          }
+        },
+        1
+      )
     });
 
     when(mockedProjectService.getText(anything())).thenCall(id =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1002,7 +1002,7 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('no source', fakeAsync(() => {
+    it('source is missing book/text', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 1, selectedSegment: 'verse_1_1' });
       env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
@@ -1017,7 +1017,6 @@ describe('EditorComponent', () => {
       expect(selection!.length).toBe(0);
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -1058,7 +1057,8 @@ describe('EditorComponent', () => {
       let selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
-      expect(env.isSourceAreaHidden).toBe(true);
+      let sourceText = env.sourceTextEditorPlaceholder.getAttribute('data-placeholder');
+      expect(sourceText).toEqual('This book does not exist.');
 
       env.routeWithParams({ projectId: 'project01', bookId: 'ACT' });
       env.wait();
@@ -1070,7 +1070,8 @@ describe('EditorComponent', () => {
       selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
-      expect(env.isSourceAreaHidden).toBe(false);
+      sourceText = env.sourceTextEditorPlaceholder.getAttribute('data-placeholder');
+      expect(sourceText).not.toEqual('This book does not exist.');
 
       env.dispose();
     }));
@@ -1088,7 +1089,6 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -1107,7 +1107,8 @@ describe('EditorComponent', () => {
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
       expect(env.outOfSyncWarning).toBeNull();
-      expect(env.isSourceAreaHidden).toBe(true);
+      const sourceText = env.sourceTextEditorPlaceholder.getAttribute('data-placeholder');
+      expect(sourceText).toEqual('This book is empty. Add chapters in Paratext.');
 
       env.setDataInSync('project01', false);
       expect(env.component.canEdit).toBe(false);
@@ -1140,7 +1141,6 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -1249,7 +1249,7 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
-      expect(env.isSourceAreaHidden).toBe(true);
+      expect(env.isSourceAreaHidden).toBe(false);
       env.dispose();
     }));
 
@@ -1264,7 +1264,8 @@ describe('EditorComponent', () => {
       expect(env.component.targetLabel).toEqual('TRG');
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
+      const sourceText = env.sourceTextEditorPlaceholder.getAttribute('data-placeholder');
+      expect(sourceText).not.toEqual('This book does not exist.');
       expect(env.component.target!.readOnlyEnabled).toBe(true);
       env.dispose();
     }));
@@ -3485,7 +3486,6 @@ describe('EditorComponent', () => {
       expect(env.component.target!.segmentRef).toEqual('');
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -3504,7 +3504,6 @@ describe('EditorComponent', () => {
       expect(selection!.length).toBe(0);
       verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
       expect(env.component.showSuggestions).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -3523,7 +3522,6 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -3542,7 +3540,6 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -3563,7 +3560,7 @@ describe('EditorComponent', () => {
       expect(env.component.userHasGeneralEditRight).toBe(true);
       expect(env.component.hasChapterEditPermission).toBe(false);
       expect(env.component.canEdit).toBe(false);
-      expect(env.isSourceAreaHidden).toBe(true);
+      expect(env.isSourceAreaHidden).toBe(false);
       expect(env.noChapterEditPermissionMessage).toBeTruthy();
       env.dispose();
     }));
@@ -3602,7 +3599,6 @@ describe('EditorComponent', () => {
       const selection = env.targetEditor.getSelection();
       expect(selection).toBeNull();
       expect(env.component.canEdit).toBe(true);
-      expect(env.isSourceAreaHidden).toBe(true);
       env.dispose();
     }));
 
@@ -4617,6 +4613,12 @@ class TestEnvironment {
 
   get sourceTextEditor(): HTMLElement {
     return this.sourceTextArea.query(By.css('.ql-container')).nativeElement;
+  }
+
+  get sourceTextEditorPlaceholder(): HTMLElement {
+    return this.sourceTextEditor.querySelector(
+      '#source-text-area > app-tab-body > div > div > app-text > quill-editor > div > div.ql-editor.ql-blank'
+    )!;
   }
 
   get invalidWarning(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -47,7 +47,7 @@ import {
 } from 'realtime-server/lib/esm/scriptureforge/models/note-thread';
 import { ParatextUserProfile } from 'realtime-server/lib/esm/scriptureforge/models/paratext-user-profile';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
@@ -240,6 +240,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   projectDoc?: SFProjectProfileDoc;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private paratextUsers: ParatextUserProfile[] = [];
+  private isParatextUserRole: boolean = false;
   private projectUserConfigChangesSub?: Subscription;
   private text?: TextInfo;
   private sourceText?: TextInfo;
@@ -436,7 +437,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   get hasSourceViewRight(): boolean {
     const sourceProject = this.sourceProjectDoc?.data;
     if (sourceProject == null) {
-      return false;
+      return this.isParatextUserRole;
     }
 
     if (
@@ -446,13 +447,13 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       const chapter = this.sourceText?.chapters.find(c => c.number === this._chapter);
       // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
       // is accessed after migration
-      if (chapter != null && chapter.permissions != null) {
+      if (chapter != null && chapter.permissions != null && !this.isParatextUserRole) {
         const chapterPermission: string = chapter.permissions[this.userService.currentUserId];
         return chapterPermission === TextInfoPermission.Write || chapterPermission === TextInfoPermission.Read;
       }
     }
 
-    return false;
+    return this.isParatextUserRole;
   }
 
   get canEdit(): boolean {
@@ -575,11 +576,17 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   private get hasSource(): boolean {
-    if (this.text == null || this.currentUser === undefined || this.sourceProjectId === undefined) {
+    if (
+      (this.text == null && !this.isParatextUserRole) ||
+      this.currentUser === undefined ||
+      this.sourceProjectId === undefined
+    ) {
       return false;
     } else {
+      // The case where user is paratext role but does not have source in user projects due
+      // to permissions issue we want to show the source
       const projects = this.currentUser.sites[environment.siteId].projects;
-      return this.text.hasSource && projects.includes(this.sourceProjectId);
+      return (this.text?.hasSource && projects.includes(this.sourceProjectId)) || this.isParatextUserRole;
     }
   }
 
@@ -695,7 +702,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         if (projectId !== prevProjectId) {
           this.projectDoc = await this.projectService.getProfile(projectId);
 
-          const userRole: string | undefined = this.projectDoc?.data?.userRoles[this.userService.currentUserId];
+          const userRole: string | undefined = this.userRole;
           if (userRole != null) {
             const projectDoc: SFProjectDoc | undefined = await this.projectService.tryGetForRole(projectId, userRole);
             if (projectDoc?.data?.paratextUsers != null) {
@@ -703,6 +710,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             }
           }
           this.isProjectAdmin = await this.projectService.isProjectAdmin(projectId, this.userService.currentUserId);
+          this.isParatextUserRole = isParatextRole(this.userRole);
           this.projectUserConfigDoc = await this.projectService.getUserConfig(
             projectId,
             this.userService.currentUserId
@@ -780,7 +788,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           if (this.metricsSession != null) {
             this.metricsSession.dispose();
           }
-          if (this.target != null && this.source != null) {
+          if (
+            this.target != null &&
+            this.source != null &&
+            this.sourceProjectDoc?.data?.userRoles[this.userService.currentUserId] != null
+          ) {
             this.metricsSession = new TranslateMetricsSession(
               this.projectService,
               this.projectDoc.id,
@@ -997,7 +1009,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         break;
     }
 
-    if ((!this.hasSource || this.sourceLoaded) && this.targetLoaded) {
+    if ((!this.hasSource || this.sourceLoaded || this.isParatextUserRole) && this.targetLoaded) {
       this.loadingFinished();
       // Toggle the segment the cursor is focused in - the timeout allows for Quill to get its focus set
       setTimeout(() => {
@@ -1265,7 +1277,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
         let canViewSource = false;
         if (projectSource != null) {
-          canViewSource = await this.permissionsService.isUserOnProject(projectSource?.projectRef);
+          canViewSource =
+            (await this.permissionsService.isUserOnProject(projectSource?.projectRef)) ||
+            (await this.permissionsService.userHasParatextRoleOnProject(projectDoc.id));
         }
 
         if (projectSource != null && canViewSource) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.spec.ts
@@ -459,7 +459,13 @@ class TestEnvironment {
 
     this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
       id: 'user01',
-      data: createTestUser()
+      data: createTestUser({
+        sites: {
+          sf: {
+            projects: ['project01', 'project02']
+          }
+        }
+      })
     });
 
     when(mockedSFProjectService.getText(anything())).thenCall(id =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -479,7 +479,8 @@
     "book_does_not_exist": "This book does not exist.",
     "book_is_empty": "This book is empty. Add chapters in Paratext.",
     "loading": "Loading...",
-    "not_available_offline": "This text is not available offline. Connect to the Internet to see the text."
+    "not_available_offline": "This text is not available offline. Connect to the Internet to see the text.",
+    "permission_denied": "You do not have permission to view this text. Please contact the project's administrator to get permission."
   },
   "text_chooser_dialog": {
     "cancel": "Cancel",


### PR DESCRIPTION
This PR addresses the source panel not being displayed at times. If the project has a selected source and the user is a Paratext user we want to always display the source side panel (except on small screens where the source and target are both tabs). Cases where the source panel would automatically hide were if there was a permissions issue for the user on the source or no book found in the source. We now keep the source panel open and display a message to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3051)
<!-- Reviewable:end -->
