### PR TITLE
SF-3212 Create 'unknown' blot as fallback blot

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -288,3 +288,14 @@ usx-segment {
     font-family: Roboto, sans-serif;
   }
 }
+
+// Embed blot for unknown attributes
+sf-unknown {
+  display: inline-block;
+  color: #999;
+  background: #f0f0f0;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-style: italic;
+  user-select: none;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.spec.ts
@@ -15,6 +15,7 @@ import {
   RefInline,
   SegmentInline,
   TextAnchorInline,
+  UnknownBlot,
   UnmatchedEmbed,
   VerseEmbed
 } from './quill-blots';
@@ -25,6 +26,20 @@ describe('Quill blots', () => {
       const nfdText = 'e\u0301'; // é as NFD
       const textNode = document.createTextNode(nfdText);
       expect(NotNormalizedText.value(textNode)).toBe(nfdText);
+    });
+  });
+
+  describe('UnknownBlot', () => {
+    it('should create node with unknown format message', () => {
+      const value = {
+        origBlotName: 'test-format',
+        data: 'test-data'
+      };
+
+      const node = UnknownBlot.create(value) as HTMLElement;
+
+      expect(node.tagName.toLowerCase()).toBe('sf-unknown');
+      expect(node.innerText).toBe(`[Unknown format: 'test-format']`);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
@@ -44,8 +44,6 @@ export class NotNormalizedText extends QuillTextBlot {
  * If an unregistered blot type is encountered, it will be rendered as the 'unknown' blot type.
  */
 export class ScrollBlot extends QuillScrollBlot {
-  static unknownBlots: Set<string> = new Set<string>();
-
   create(input: Node | string | Scope, value?: any): Blot {
     // Try to create the blot.  If blot type not registered, fallback to the custom 'unknown' blot
     try {
@@ -56,26 +54,7 @@ export class ScrollBlot extends QuillScrollBlot {
         throw e;
       }
 
-      // Add to list for error reporting
-      ScrollBlot.unknownBlots.add(input);
-
-      // Throw error after render with message including list of unknown blot types
-      setTimeout(() => {
-        // Ensure this only runs once
-        if (ScrollBlot.unknownBlots.size === 0) {
-          return;
-        }
-
-        try {
-          const unknownBlotList = Array.from(ScrollBlot.unknownBlots)
-            .map(name => `'${name}'`)
-            .join(', ');
-          throw new Error(`Unable to create blot${ScrollBlot.unknownBlots.size > 1 ? 's' : ''}: ${unknownBlotList}.`);
-        } finally {
-          // Clear unrendered blot list after reporting error
-          ScrollBlot.unknownBlots.clear();
-        }
-      });
+      console.error(`Unable to create blot: '${input}'.`);
 
       // Pass name of attempted blot
       value[UnknownBlot.origBlotNameProp] = input;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
@@ -34,8 +34,10 @@ import {
   ParaBlock,
   ParaInline,
   RefInline,
+  ScrollBlot,
   SegmentInline,
   TextAnchorInline,
+  UnknownBlot,
   UnmatchedEmbed,
   VerseEmbed
 } from './quill-formats/quill-blots';
@@ -58,6 +60,7 @@ export function registerScripture(): string[] {
     FigureEmbed,
     UnmatchedEmbed,
     ChapterEmbed,
+    UnknownBlot,
 
     // Inline Blots
     CharInline,
@@ -101,6 +104,7 @@ export function registerScripture(): string[] {
     return name;
   });
 
+  Quill.register('blots/scroll', ScrollBlot, true);
   Quill.register('blots/text', NotNormalizedText, true);
   Quill.register('modules/clipboard', DisableHtmlClipboard, true);
   Quill.register('modules/cursors', QuillCursors);


### PR DESCRIPTION
This PR creates a custom `ScrollBlot` to override Quill's scroll blot and an `UnknownBlot` to render when an unknown blot type is attempted.

If an unknown blot type creation is attempted, the custom `ScrollBlot` catches the error and creates the `UnknownBlot`.  After the editor renders (via `setTimeout()`), an error is thrown displaying the name of the failed attempted blot.

`UnknownBlot` uses `tagName = 'sf-unknown'`, ('span' was causing it to be incorrectly matched from a quill registry query and throw an `after.appendChild not a function` error).

You can test this blot by adding TNN as a resource.

Example:
![image](https://github.com/user-attachments/assets/d14c3d6a-573c-4668-a61a-d90fa4a0ad53)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3052)
<!-- Reviewable:end -->
