### PR TITLE
Highlight generate draft nav item when editing draft sources

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.html
@@ -13,7 +13,7 @@
         {{ t("edit_review") }}
       </a>
       @if (canGenerateDraft$ | async) {
-        <a mat-list-item [appRouterLink]="draftGenerationLink">
+        <a mat-list-item [appRouterLink]="draftGenerationLink" [class.active]="draftGenerationActive">
           <mat-icon class="mirror-rtl">auto_awesome</mat-icon>
           {{ t("generate_draft") }} <span class="nav-label">{{ t("beta") }}</span>
         </a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
@@ -168,8 +168,9 @@ export class NavigationComponent extends SubscriptionDisposable {
     return this.getProjectLink('draft-generation');
   }
 
-  // draftReviewActive and answerQuestionsActive are needed because appRouterLink only highlights the link if the url
-  // matches exactly. These two modes do not match to a single url, so appRouterLink does not mark them active.
+  // draftReviewActive, answerQuestionsActive, draftGenerationActive are needed because appRouterLink only highlights
+  // the link if the url matches exactly. These modes do not match to a single url, so appRouterLink does not mark them
+  // active.
 
   get draftReviewActive(): boolean {
     return this.urlStartsWithAndHasAnotherPortion(this.getProjectLink('translate').join('/'));
@@ -177,6 +178,10 @@ export class NavigationComponent extends SubscriptionDisposable {
 
   get answerQuestionsActive(): boolean {
     return this.urlStartsWithAndHasAnotherPortion(this.getProjectLink('checking').join('/'));
+  }
+
+  get draftGenerationActive(): boolean {
+    return this.router.url.startsWith(this.getProjectLink('draft-generation').join('/'));
   }
 
   private urlStartsWithAndHasAnotherPortion(link: string): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -91,7 +91,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   }
 
   get draftSourcesLink(): string[] {
-    return ['/projects', this.activatedProjectService.projectId!, 'draft-sources'];
+    return ['/projects', this.activatedProjectService.projectId!, 'draft-generation', 'sources'];
   }
 
   get isOnline(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-routing.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-routing.module.ts
@@ -20,7 +20,7 @@ const routes: Routes = [
     canActivate: [NmtDraftAuthGuard]
   },
   {
-    path: 'projects/:projectId/draft-sources',
+    path: 'projects/:projectId/draft-generation/sources',
     component: DraftSourcesComponent,
     canActivate: [NmtDraftAuthGuard]
   }


### PR DESCRIPTION
This PR:
- Changes the draft sources UI from `projects/:projectId/draft-sources` to `projects/:projectId/draft-generation/sources`
- Updates the navigation component to ensure the draft generation nav item is highlighted when on this page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3053)
<!-- Reviewable:end -->
