### PR TITLE
SF-3241 Correctly handle when a Paratext user is downgraded to Observer

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using Paratext.Data;
 using Paratext.Data.Repository;
 
@@ -8,6 +9,14 @@ public class ParatextDataHelper : IParatextDataHelper
 {
     public void CommitVersionedText(ScrText scrText, string comment)
     {
+        // Commit() will fail silently if the user is an Observer,
+        // so throw an error if the user is an Observer.
+        if (!scrText.Permissions.HaveRoleNotObserver)
+        {
+            throw new InvalidOperationException("User does not have permission to commit.");
+        }
+
+        // Write the commit to the repository
         VersionedText vText = VersioningManager.Get(scrText);
         vText.Commit(comment, null, false);
     }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2728,6 +2728,7 @@ public class ParatextService : DisposableBase, IParatextService
         catch (Exception e)
         {
             _logger.LogError(e, "Exception while updating notes: {0}", e.Message);
+            throw;
         }
 
         return syncMetricInfo;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -845,7 +845,7 @@ public class ParatextService : DisposableBase, IParatextService
         else
         {
             // Get the scripture text so we can retrieve the permissions from the XML
-            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret), sfProject.ParatextId);
+            using ScrText scrText = ScrTextCollection.FindById(GetParatextUsername(userSecret)!, sfProject.ParatextId);
 
             // Calculate the project and resource permissions
             foreach (string uid in sfProject.UserRoles.Keys)
@@ -854,7 +854,7 @@ public class ParatextService : DisposableBase, IParatextService
                 if (
                     !ptUsernameMapping.TryGetValue(uid, out string userName)
                     || string.IsNullOrWhiteSpace(userName)
-                    || scrText.Permissions.GetRole(userName) == UserRoles.None
+                    || scrText!.Permissions.GetRole(userName) == UserRoles.None
                 )
                 {
                     permissions.Add(uid, TextInfoPermission.None);
@@ -862,39 +862,46 @@ public class ParatextService : DisposableBase, IParatextService
                 else
                 {
                     string textInfoPermission = TextInfoPermission.Read;
-                    if (book == 0)
+
+                    // Observers and Consultants can have EditAllBooks set to true,
+                    // so we must check whether the role is read-only.
+                    // NOTE: We check for UserRoles.None in the block above.
+                    if (scrText.Permissions.GetRole(userName) is not (UserRoles.Observer or UserRoles.Consultant))
                     {
-                        // Project level
-                        if (scrText.Permissions.CanEditAllBooks(userName))
+                        if (book == 0)
                         {
-                            textInfoPermission = TextInfoPermission.Write;
+                            // Project level
+                            if (scrText.Permissions.CanEditAllBooks(userName))
+                            {
+                                textInfoPermission = TextInfoPermission.Write;
+                            }
                         }
-                    }
-                    else if (chapter == 0)
-                    {
-                        // Book level
-                        IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
-                            PermissionSet.Merged,
-                            userName
-                        );
-                        // Check if they can edit all books or the specified book
-                        if (scrText.Permissions.CanEditAllBooks(userName) || editable.Contains(book))
+                        else if (chapter == 0)
                         {
-                            textInfoPermission = TextInfoPermission.Write;
+                            // Book level
+                            IEnumerable<int> editable = scrText.Permissions.GetEditableBooks(
+                                PermissionSet.Merged,
+                                userName
+                            );
+                            // Check if they can edit all books or the specified book
+                            if (scrText.Permissions.CanEditAllBooks(userName) || editable.Contains(book))
+                            {
+                                textInfoPermission = TextInfoPermission.Write;
+                            }
                         }
-                    }
-                    else
-                    {
-                        // Chapter level
-                        IEnumerable<int> editable = scrText.Permissions.GetEditableChapters(
-                            book,
-                            scrText.Settings.Versification,
-                            userName,
-                            PermissionSet.Merged
-                        );
-                        if (editable?.Contains(chapter) ?? false)
+                        else
                         {
-                            textInfoPermission = TextInfoPermission.Write;
+                            // Chapter level
+                            IEnumerable<int> editable = scrText.Permissions.GetEditableChapters(
+                                book,
+                                scrText.Settings.Versification,
+                                userName,
+                                PermissionSet.Merged
+                            );
+                            if (editable?.Contains(chapter) ?? false)
+                            {
+                                textInfoPermission = TextInfoPermission.Write;
+                            }
                         }
                     }
 

--- a/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
 
@@ -15,7 +16,17 @@ public class SharingLogicWrapper : ISharingLogicWrapper
         SharedRepositorySource source,
         out List<SendReceiveResult> results,
         IList<SharedProject> reviewProjects
-    ) => SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
+    )
+    {
+        // ShareChanges() will fail silently if the user is an Observer,
+        // so throw an error if the user is an Observer in the Registry.
+        if (!sharedProjects.All(s => s.Permissions.HaveRoleNotObserver))
+        {
+            throw new InvalidOperationException("User does not have permission to share changes.");
+        }
+
+        return SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
+    }
 
     public bool HandleErrors(Action action, bool throwExceptions = false) =>
         SharingLogic.HandleErrors(action, throwExceptions);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextDataHelperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextDataHelperTests.cs
@@ -1,0 +1,56 @@
+using System;
+using NUnit.Framework;
+using Paratext.Data;
+using Paratext.Data.Repository;
+using SIL.WritingSystems;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ParatextDataHelperTests
+{
+    private const string ParatextUser01 = "ParatextUser01";
+
+    [Test]
+    public void CommitVersionedText_Success()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        using MockScrText scrText = new MockScrText(new SFParatextUser(ParatextUser01), new ProjectName());
+        scrText.CachedGuid = HexId.CreateNew();
+        scrText.Permissions.CreateFirstAdminUser();
+
+        // SUT
+        Assert.DoesNotThrow(() => env.Service.CommitVersionedText(scrText, "comment text"));
+    }
+
+    [Test]
+    public void CommitVersionedText_ThrowsExceptionIfObserver()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        using MockScrText scrText = new MockScrText(new SFParatextUser(ParatextUser01), new ProjectName());
+        scrText.Permissions.CreateUser(ParatextUser01); // A user is an observer by default
+
+        // SUT
+        Assert.Throws<InvalidOperationException>(() => env.Service.CommitVersionedText(scrText, "comment text"));
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            // Ensure that the SLDR is initialized for LanguageID.Code to be retrieved correctly
+            if (!Sldr.IsInitialized)
+                Sldr.Initialize(true);
+
+            // Setup Mercurial for tests
+            Hg.DefaultRunnerCreationFunc = (_, _, _) => new MockHgRunner();
+            Hg.Default = new MockHg();
+            VersionedText.AllCommitsDisabled = true;
+        }
+
+        public ParatextDataHelper Service { get; } = new ParatextDataHelper();
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -397,7 +397,7 @@ public class ParatextServiceTests
     {
         var env = new TestEnvironment();
         const int lengthOfDblResourceId = 16;
-        string id = "1234567890abcdef";
+        const string id = "1234567890abcdef";
         Assert.That(id.Length, Is.EqualTo(lengthOfDblResourceId), "setup. Use an ID of DBL-Resource-ID-length.");
         // SUT
         Assert.That(env.Service.IsResource(id), Is.True);
@@ -429,7 +429,7 @@ public class ParatextServiceTests
             { env.User01, SFProjectRole.Administrator },
             { env.User02, SFProjectRole.CommunityChecker },
         };
-        var ptUsernameMapping = new Dictionary<string, string>()
+        var ptUsernameMapping = new Dictionary<string, string>
         {
             { env.User01, env.Username01 },
             { env.User02, env.Username02 },
@@ -451,7 +451,7 @@ public class ParatextServiceTests
         var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
         SFProject project = projects.First();
 
-        var ptUsernameMapping = new Dictionary<string, string>() { { env.User01, env.Username01 } };
+        var ptUsernameMapping = new Dictionary<string, string> { { env.User01, env.Username01 } };
         ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
         scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, true);
         // Give User01 automatic permission to Mark but not Matthew
@@ -473,6 +473,38 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public async Task GetPermissionsAsync_AllBooksAndAutomaticBooks_IsConsultant()
+    {
+        // Set up environment
+        var env = new TestEnvironment();
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // Set up mock project
+        var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
+        SFProject project = projects.First();
+
+        var ptUsernameMapping = new Dictionary<string, string> { { env.User01, env.Username01 } };
+        ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
+        // Give User01 automatic permission to all books
+        scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Automatic, true);
+        // Make User01 a consultant
+        scrText.Permissions.ChangeUserRole(env.Username01, UserRoles.Consultant);
+        env.MockScrTextCollection.FindById(env.Username01, project.ParatextId).Returns(scrText);
+
+        // SUT
+        Dictionary<string, string> permissions = await env.Service.GetPermissionsAsync(
+            user01Secret,
+            project,
+            ptUsernameMapping,
+            40
+        );
+
+        // Ensure the user has read only access to Matthew and Mark
+        string[] expected = [TextInfoPermission.Read, TextInfoPermission.None, TextInfoPermission.None];
+        Assert.That(permissions.Values, Is.EquivalentTo(expected));
+    }
+
+    [Test]
     public async Task GetPermissionsAsync_AutomaticBooks_HasBookLevelPermission()
     {
         // Set up environment
@@ -483,7 +515,7 @@ public class ParatextServiceTests
         var projects = await env.RealtimeService.GetRepository<SFProject>().GetAllAsync();
         SFProject project = projects.First();
 
-        var ptUsernameMapping = new Dictionary<string, string>() { { env.User01, env.Username01 } };
+        var ptUsernameMapping = new Dictionary<string, string> { { env.User01, env.Username01 } };
         ScrText scrText = env.GetScrText(new SFParatextUser(env.Username01), project.ParatextId);
         scrText.Permissions.SetPermission(env.Username01, 0, PermissionSet.Manual, false);
         // Give automatic permission to User01 to Mark but not Matthew

--- a/test/SIL.XForge.Scripture.Tests/Services/SharingLogicWrapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SharingLogicWrapperTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Paratext.Data;
+using Paratext.Data.Repository;
+using Paratext.Data.Users;
+using SIL.XForge.Scripture.Models;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class SharingLogicWrapperTests
+{
+    private const string ParatextUser01 = "ParatextUser01";
+
+    [Test]
+    public void HandleErrors_DoesNotThrowByDefault()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.DoesNotThrow(() => env.Service.HandleErrors(() => throw new CannotConnectException()));
+    }
+
+    [Test]
+    public void HandleErrors_ThrowsWhenSpecified()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.Throws<CannotConnectException>(
+            () => env.Service.HandleErrors(() => throw new CannotConnectException(), throwExceptions: true)
+        );
+    }
+
+    [Test]
+    public void SearchForBestProjectUsersData_Success()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        PermissionManager actual = env.Service.SearchForBestProjectUsersData(
+            new SharedRepositorySource(),
+            new SharedProject()
+        );
+        Assert.That(actual, Is.Not.Null);
+    }
+
+    [Test]
+    public void ShareChanges_Success()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // SUT
+        bool actual = env.Service.ShareChanges(
+            sharedProjects: [],
+            new SharedRepositorySource(),
+            out List<SendReceiveResult> results,
+            reviewProjects: []
+        );
+        Assert.That(actual, Is.True);
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public void ShareChanges_ThrowsExceptionIfObserver()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // Create a shared project with a user that is an observer
+        var sharedProject = new SharedProject { Permissions = new ParatextRegistryPermissionManager(ParatextUser01) };
+        sharedProject.Permissions.CreateUser(ParatextUser01);
+
+        // SUT
+        Assert.Throws<InvalidOperationException>(
+            () =>
+                env.Service.ShareChanges(
+                    sharedProjects: [sharedProject],
+                    new SharedRepositorySource(),
+                    out List<SendReceiveResult> _,
+                    reviewProjects: []
+                )
+        );
+    }
+
+    private class TestEnvironment
+    {
+        public SharingLogicWrapper Service { get; } = new SharingLogicWrapper();
+    }
+}


### PR DESCRIPTION
This PR fixes issues when a user is downgraded to an observer by correctly trapping this error before data is written to Mercurial or sent to the Paratext Send/Receive sever.