### PR TITLE
SF-3240 Fix crashes when a draft book has an invalid book id

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1008,7 +1008,7 @@ public class ParatextService : DisposableBase, IParatextService
             ScrTextCollection.FindById(GetParatextUsername(userSecret), paratextId)
             ?? throw new DataNotFoundException("Can't get access to cloned project.");
         usfm ??= scrText.GetText(bookNum);
-        return UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
+        return UsfmToUsx.ConvertToXmlString(scrText, scrText.ScrStylesheet(bookNum), usfm, false);
     }
 
     /// <summary>
@@ -2187,7 +2187,7 @@ public class ParatextService : DisposableBase, IParatextService
     /// <returns>The delta.</returns>
     private ChapterDelta GetDeltaFromUsfm(ScrText scrText, int bookNum, string usfm)
     {
-        string usx = UsfmToUsx.ConvertToXmlString(scrText, bookNum, usfm, false);
+        string usx = UsfmToUsx.ConvertToXmlString(scrText, scrText.ScrStylesheet(bookNum), usfm, false);
         XDocument usxDoc = XDocument.Parse(usx);
         return _deltaUsxMapper.ToChapterDeltas(usxDoc).First();
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -605,6 +605,30 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public void GetBookText_OverrideUSFM_WithVariantBookId()
+    {
+        const string ruthBookUsfm =
+            "\\id Rut - ProjectNameHere\n \\c 1\n"
+            + "\\v 1 Updated Verse 1 here.\n"
+            + "\\v 2 Updated Verse 2 here.\n"
+            + "\\v 3 New Verse 3 here.";
+        const string ruthBookUsx =
+            "<usx version=\"3.0\">\r\n  <book code=\"RUT\" style=\"id\">- ProjectNameHere"
+            + "</book>\r\n  <chapter number=\"1\" style=\"c\" />\r\n  <verse number=\"1\" style=\"v\" />"
+            + "Updated Verse 1 here. <verse number=\"2\" style=\"v\" />Updated Verse 2 here. "
+            + "<verse number=\"3\" style=\"v\" />New Verse 3 here.</usx>";
+
+        var env = new TestEnvironment();
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+
+        // SUT
+        string result = env.Service.GetBookText(null, ptProjectId, 8, ruthBookUsfm);
+        Assert.That(result, Is.EqualTo(ruthBookUsx));
+    }
+
+    [Test]
     public void GetBookText_Works()
     {
         var env = new TestEnvironment();
@@ -5955,6 +5979,40 @@ public class ParatextServiceTests
 
         // SUT
         var delta = await env.Service.GetDeltaFromUsfmAsync(env.User01, project.Id, env.RuthBookUsfm, 8);
+        Assert.IsTrue(delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public async Task GetDeltaFromUsfmAsync_WithVariantBookId()
+    {
+        // Set up the test environment
+        var env = new TestEnvironment();
+        SFProject project = env.NewSFProject();
+        env.AddProjectRepository(project);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Create the expected delta
+        JToken token1 = JToken.Parse("{\"insert\": { \"chapter\": { \"number\": \"1\", \"style\": \"c\" } } }");
+        JToken token2 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"1\", \"style\": \"v\" } } }");
+        JToken token3 = JToken.Parse(
+            "{\"insert\": \"Verse 1 here. \", \"attributes\": { \"segment\": \"verse_1_1\" } }"
+        );
+        JToken token4 = JToken.Parse("{\"insert\": { \"verse\": { \"number\": \"2\", \"style\": \"v\" } } }");
+        JToken token5 = JToken.Parse(
+            "{\"insert\": \"Verse 2 here.\"," + "\"attributes\": { \"segment\": \"verse_1_2\" } }"
+        );
+        JToken token6 = JToken.Parse("{\"insert\": \"\n\" }");
+        Delta expected = new Delta([token1, token2, token3, token4, token5, token6]);
+
+        env.MockDeltaUsxMapper.ToChapterDeltas(Arg.Any<XDocument>())
+            .Returns([new ChapterDelta(-1, -1, false, expected)]);
+
+        const string ruthBookUsfm =
+            "\\id Rut - ProjectNameHere\n" + "\\c 1\n" + "\\v 1 Verse 1 here.\n" + "\\v 2 Verse 2 here.";
+        ;
+
+        // SUT
+        var delta = await env.Service.GetDeltaFromUsfmAsync(env.User01, project.Id, ruthBookUsfm, 8);
         Assert.IsTrue(delta.DeepEquals(expected));
     }
 


### PR DESCRIPTION
This PR fixes crashes that occur viewing or applying a draft, when a source book's book id is the wrong case, and the draft was generated from that source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3062)
<!-- Reviewable:end -->
