### PR TITLE
Log warning when updating project settings fails

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -497,7 +497,11 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     this.controlStates.set(setting, ElementState.Submitting);
     updatePromise
       .then(() => this.controlStates.set(setting, ElementState.Submitted))
-      .catch(() => this.controlStates.set(setting, ElementState.Error));
+      .catch(err => {
+        this.controlStates.set(setting, ElementState.Error);
+        console.warn(`Error updating ${setting}`);
+        console.warn(err.message);
+      });
   }
 
   private updateSettingsInfo(): void {


### PR DESCRIPTION
Currently we have no way to see why updating a project setting fails. This will log it in the console to help investigate.

Part of the problem is that failed connections to the Project service API still returns a 200. I documented this in SF-3244. That would be the better long term fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3063)
<!-- Reviewable:end -->
