### PR TITLE
SF-3242 Show option to add draft to a different project to translators

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -12,11 +12,9 @@
       <button mat-menu-item (click)="chooseProjectToAddDraft(book, projectParatextId)">
         <mat-icon>input</mat-icon>{{ book.draftApplied ? t("readd_to_project") : t("add_to_project") }}
       </button>
-      @if ((isProjectAdmin$ | async) === true) {
-        <button mat-menu-item (click)="chooseProjectToAddDraft(book)">
-          <mat-icon>output</mat-icon>{{ t("add_to_different_project") }}
-        </button>
-      }
+      <button mat-menu-item (click)="chooseProjectToAddDraft(book)">
+        <mat-icon>output</mat-icon>{{ t("add_to_different_project") }}
+      </button>
     </mat-menu>
   } @empty {
     <strong>{{ t("no_books_have_drafts") }}</strong>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -155,7 +155,8 @@ describe('DraftPreviewBooks', () => {
     when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
       instance(mockedDialogRef)
     );
-    env.component.chooseProjectToAddDraft(env.booksWithDrafts[0], 'project01');
+    expect(env.component['projectParatextId']).toEqual(env.paratextId);
+    env.component.chooseProjectToAddDraft(env.booksWithDrafts[0], env.paratextId);
     tick();
     env.fixture.detectChanges();
     verify(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).once();
@@ -169,7 +170,7 @@ describe('DraftPreviewBooks', () => {
     env = new TestEnvironment();
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
     const mockedDialogRef: MatDialogRef<DraftApplyDialogComponent> = mock(MatDialogRef<DraftApplyDialogComponent>);
-    when(mockedDialogRef.afterClosed()).thenReturn(of({ projectId: 'project01' }));
+    when(mockedDialogRef.afterClosed()).thenReturn(of({ projectId: 'otherProject' }));
     when(mockedDialogService.openMatDialog(DraftApplyDialogComponent, anything())).thenReturn(
       instance(mockedDialogRef)
     );
@@ -180,10 +181,10 @@ describe('DraftPreviewBooks', () => {
     verify(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything())).times(
       env.booksWithDrafts[0].chaptersWithDrafts.length
     );
-    verify(mockedProjectService.onlineAddChapters('project01', anything(), anything())).never();
+    verify(mockedProjectService.onlineAddChapters('otherProject', anything(), anything())).never();
   }));
 
-  it('does not show add draft to different project option if user is not an admin', fakeAsync(async () => {
+  it('translators can add draft to different project', fakeAsync(async () => {
     env = new TestEnvironment();
     when(mockedUserService.currentUserId).thenReturn('user02');
     const moreButton: HTMLElement = env.getBookButtonAtIndex(0).querySelector('.book-more')!;
@@ -192,7 +193,7 @@ describe('DraftPreviewBooks', () => {
     env.fixture.detectChanges();
     const harness: MatMenuHarness = await env.moreMenuHarness();
     const items = await harness.getItems();
-    expect(items.length).toEqual(1);
+    expect(items.length).toEqual(2);
     harness.close();
     tick();
     env.fixture.detectChanges();
@@ -294,8 +295,10 @@ class TestEnvironment {
   draftApplyProgress?: DraftApplyProgress;
   progressSubscription?: Subscription;
   loader: HarnessLoader;
+  readonly paratextId = 'pt01';
   mockProjectDoc: SFProjectProfileDoc = {
     data: createTestProjectProfile({
+      paratextId: this.paratextId,
       texts: [
         {
           bookNum: 1,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -5,7 +5,6 @@ import { Router, RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { BehaviorSubject, firstValueFrom, map, Observable, tap } from 'rxjs';
@@ -47,6 +46,8 @@ export interface BookWithDraft {
 })
 export class DraftPreviewBooksComponent {
   booksWithDrafts$: Observable<BookWithDraft[]> = this.activatedProjectService.changes$.pipe(
+    filterNullish(),
+    tap(p => (this.projectParatextId = p.data?.paratextId)),
     map(projectDoc => {
       if (projectDoc?.data == null) {
         return [];
@@ -85,14 +86,6 @@ export class DraftPreviewBooksComponent {
     private readonly errorReportingService: ErrorReportingService,
     private readonly router: Router
   ) {}
-
-  get isProjectAdmin$(): Observable<boolean> {
-    return this.activatedProjectService.changes$.pipe(
-      filterNullish(),
-      tap(p => (this.projectParatextId = p.data?.paratextId)),
-      map(p => p.data?.userRoles[this.userService.currentUserId] === SFProjectRole.ParatextAdministrator)
-    );
-  }
 
   get numChaptersApplied(): number {
     return this.chaptersApplied.length;


### PR DESCRIPTION
This change shows the add to different project option for translator users. Originally only admins could do that, but now we want to open the feature up to all admins and translators on a project.
The user must still choose projects they have permission to edit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3065)
<!-- Reviewable:end -->
