### PR TITLE
Fix selector in editor component test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4616,9 +4616,7 @@ class TestEnvironment {
   }
 
   get sourceTextEditorPlaceholder(): HTMLElement {
-    return this.sourceTextEditor.querySelector(
-      '#source-text-area > app-tab-body > div > div > app-text > quill-editor > div > div.ql-editor.ql-blank'
-    )!;
+    return this.sourceTextEditor.querySelector('.ql-editor.ql-blank')!;
   }
 
   get invalidWarning(): DebugElement {


### PR DESCRIPTION
This addresses the querySelector made for querying the source quill editor placeholder text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3067)
<!-- Reviewable:end -->
