### PR TITLE
Add support for arbitrary number of sources in Serval admin components

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -127,7 +127,7 @@ describe('ServalProjectComponent', () => {
 
     it('should have a download button', fakeAsync(() => {
       const env = new TestEnvironment();
-      expect(env.downloadButtions.length).toBe(5);
+      expect(env.downloadButtions.length).toBe(4);
       expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(false);
     }));
@@ -260,18 +260,21 @@ describe('ServalProjectComponent', () => {
           ],
           translateConfig: {
             draftConfig: {
+              alternateSourceEnabled: true,
               alternateSource: {
                 paratextId: 'ptproject03',
                 projectRef: 'project03',
                 name: 'Project 03',
                 shortName: 'P3'
               },
+              alternateTrainingSourceEnabled: true,
               alternateTrainingSource: {
                 paratextId: 'ptproject04',
                 projectRef: 'project04',
                 name: 'Project 04',
                 shortName: 'P4'
               },
+              additionalTrainingSourceEnabled: true,
               additionalTrainingSource: {
                 paratextId: 'ptproject05',
                 projectRef: 'project05',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -123,20 +123,20 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
             fileName: project.shortName + '.zip'
           });
 
+          let i = 1;
           // Add the drafting source
-          if (draftSources.draftingSources[0] != null) {
-            const draftingSource: TranslateSource = draftSources.draftingSources[0];
+          for (const draftingSource of draftSources.draftingSources) {
             rows.push({
               id: draftingSource.projectRef,
               type: projectType(draftingSource),
               name: projectLabel(draftingSource),
-              category: 'Drafting Source',
+              category: 'Drafting Source ' + i++,
               fileName: draftingSource.shortName + '.zip'
             });
           }
 
           // Add the training sources
-          let i = 1;
+          i = 1;
           for (const trainingSource of draftSources.trainingSources) {
             rows.push({
               id: trainingSource.projectRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -21,6 +21,7 @@ import { booksFromScriptureRange, projectLabel } from '../shared/utils';
 import { DraftZipProgress } from '../translate/draft-generation/draft-generation';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DraftInformationComponent } from '../translate/draft-generation/draft-information/draft-information.component';
+import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
 import { ServalAdministrationService } from './serval-administration.service';
 
 interface Row {
@@ -107,6 +108,8 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           const project: SFProjectProfile = projectDoc.data;
           this.preTranslate = project.translateConfig.preTranslate;
           this.projectName = projectLabel(project);
+          const draftSources: DraftSourcesAsTranslateSourceArrays = projectToDraftSources(project);
+          const draftConfig: DraftConfig = project.translateConfig.draftConfig;
 
           // Setup the downloads table
           const rows: Row[] = [];
@@ -120,48 +123,27 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
             fileName: project.shortName + '.zip'
           });
 
-          // Add the source
-          if (project.translateConfig.source != null) {
+          // Add the drafting source
+          if (draftSources.draftingSources[0] != null) {
+            const draftingSource: TranslateSource = draftSources.draftingSources[0];
             rows.push({
-              id: project.translateConfig.source.projectRef,
-              type: projectType(project.translateConfig.source),
-              name: project.translateConfig.source.shortName + ' - ' + project.translateConfig.source.name,
-              category: 'Source Project',
-              fileName: project.translateConfig.source.shortName + '.zip'
+              id: draftingSource.projectRef,
+              type: projectType(draftingSource),
+              name: projectLabel(draftingSource),
+              category: 'Drafting Source',
+              fileName: draftingSource.shortName + '.zip'
             });
           }
 
-          const draftConfig: DraftConfig = project.translateConfig.draftConfig;
-          // Add the alternate source
-          if (draftConfig.alternateSource != null) {
+          // Add the training sources
+          let i = 1;
+          for (const trainingSource of draftSources.trainingSources) {
             rows.push({
-              id: draftConfig.alternateSource.projectRef,
-              type: projectType(draftConfig.alternateSource),
-              name: draftConfig.alternateSource.shortName + ' - ' + draftConfig.alternateSource.name,
-              category: 'Alternate Source',
-              fileName: draftConfig.alternateSource.shortName + '.zip'
-            });
-          }
-
-          // Add the alternate training source
-          if (draftConfig.alternateTrainingSource != null) {
-            rows.push({
-              id: draftConfig.alternateTrainingSource.projectRef,
-              type: projectType(draftConfig.alternateTrainingSource),
-              name: draftConfig.alternateTrainingSource.shortName + ' - ' + draftConfig.alternateTrainingSource.name,
-              category: 'Alternate Training Source',
-              fileName: draftConfig.alternateTrainingSource.shortName + '.zip'
-            });
-          }
-
-          // Add the additional training source
-          if (draftConfig.additionalTrainingSource != null) {
-            rows.push({
-              id: draftConfig.additionalTrainingSource.projectRef,
-              type: projectType(draftConfig.additionalTrainingSource),
-              name: draftConfig.additionalTrainingSource.shortName + ' - ' + draftConfig.additionalTrainingSource.name,
-              category: 'Additional Training Source',
-              fileName: draftConfig.additionalTrainingSource.shortName + '.zip'
+              id: trainingSource.projectRef,
+              type: projectType(trainingSource),
+              name: projectLabel(trainingSource),
+              category: 'Training Source  ' + i++,
+              fileName: trainingSource.shortName + '.zip'
             });
           }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -36,20 +36,24 @@
       <ng-container matColumnDef="draftingSource">
         <th mat-header-cell *matHeaderCellDef>Drafting Source</th>
         <td mat-cell *matCellDef="let row">
-          @if (row.draftingSourceId != null) {
-            <a [appRouterLink]="['/serval-administration', row.draftingSourceId]">{{ row.draftingSource }}</a>
-          } @else {
-            <span>{{ row.draftingSource }}</span>
+          @for (source of row.draftingSources; track source.id) {
+            <p>
+              <a [appRouterLink]="['/serval-administration', source.id]">{{ source.label }}</a>
+            </p>
+          } @empty {
+            <span>None</span>
           }
         </td>
       </ng-container>
       <ng-container matColumnDef="trainingSource">
         <th mat-header-cell *matHeaderCellDef>Training Source</th>
         <td mat-cell *matCellDef="let row">
-          @if (row.trainingSourceId != null) {
-            <a [appRouterLink]="['/serval-administration', row.trainingSourceId]">{{ row.trainingSource }}</a>
-          } @else {
-            <span>{{ row.trainingSource }}</span>
+          @for (source of row.trainingSources; track source.id) {
+            <p>
+              <a [appRouterLink]="['/serval-administration', source.id]">{{ source.label }}</a>
+            </p>
+          } @empty {
+            <span>None</span>
           }
         </td>
       </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -33,25 +33,23 @@
           }
         </td>
       </ng-container>
-      <ng-container matColumnDef="alternateSource">
-        <th mat-header-cell *matHeaderCellDef>Alternate Source</th>
+      <ng-container matColumnDef="draftingSource">
+        <th mat-header-cell *matHeaderCellDef>Drafting Source</th>
         <td mat-cell *matCellDef="let row">
-          @if (row.alternateSourceId != null) {
-            <a [appRouterLink]="['/serval-administration', row.alternateSourceId]">{{ row.alternateSource }}</a>
+          @if (row.draftingSourceId != null) {
+            <a [appRouterLink]="['/serval-administration', row.draftingSourceId]">{{ row.draftingSource }}</a>
           } @else {
-            <span>{{ row.alternateSource }}</span>
+            <span>{{ row.draftingSource }}</span>
           }
         </td>
       </ng-container>
-      <ng-container matColumnDef="alternateTrainingSource">
-        <th mat-header-cell *matHeaderCellDef>Alternate Training Source</th>
+      <ng-container matColumnDef="trainingSource">
+        <th mat-header-cell *matHeaderCellDef>Training Source</th>
         <td mat-cell *matCellDef="let row">
-          @if (row.alternateTrainingSourceId != null) {
-            <a [appRouterLink]="['/serval-administration', row.alternateTrainingSourceId]">{{
-              row.alternateTrainingSource
-            }}</a>
+          @if (row.trainingSourceId != null) {
+            <a [appRouterLink]="['/serval-administration', row.trainingSourceId]">{{ row.trainingSource }}</a>
           } @else {
-            <span>{{ row.alternateTrainingSource }}</span>
+            <span>{{ row.trainingSource }}</span>
           }
         </td>
       </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.spec.ts
@@ -190,12 +190,14 @@ class TestEnvironment {
           name: 'Project 01',
           translateConfig: {
             draftConfig: {
+              alternateSourceEnabled: true,
               alternateSource: {
                 paratextId: 'ptproject03',
                 projectRef: 'project03',
                 name: 'Project 03',
                 shortName: 'P3'
               },
+              alternateTrainingSourceEnabled: true,
               alternateTrainingSource: {
                 paratextId: 'ptproject04',
                 projectRef: 'project04',
@@ -232,12 +234,14 @@ class TestEnvironment {
           shortName: 'P3',
           translateConfig: {
             draftConfig: {
+              alternateSourceEnabled: true,
               alternateSource: {
                 paratextId: 'resource16char02',
                 projectRef: 'resource02',
                 name: 'Resource 02',
                 shortName: 'R2'
               },
+              alternateTrainingSourceEnabled: true,
               alternateTrainingSource: {
                 paratextId: 'resource16char03',
                 projectRef: 'resource03',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -9,31 +9,31 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
+import { projectLabel } from '../shared/utils';
+import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
 import { ServalAdministrationService } from './serval-administration.service';
 
 class Row {
-  constructor(public readonly projectDoc: SFProjectProfileDoc) {}
+  private draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
 
-  get alternateSource(): string {
-    const alternateDraftingSource = this.projectDoc.data?.translateConfig.draftConfig.alternateSource;
-    return alternateDraftingSource == null
-      ? 'None'
-      : alternateDraftingSource.shortName + ' - ' + alternateDraftingSource.name;
+  constructor(public readonly projectDoc: SFProjectProfileDoc) {
+    this.draftSources = projectDoc.data == null ? undefined : projectToDraftSources(projectDoc.data);
   }
 
-  get alternateSourceId(): string | undefined {
-    return this.projectDoc.data?.translateConfig.draftConfig.alternateSource?.projectRef;
+  get draftingSource(): string {
+    return this.draftSources?.draftingSources[0] == null ? 'None' : projectLabel(this.draftSources.draftingSources[0]);
   }
 
-  get alternateTrainingSource(): string {
-    const alternateTrainingSource = this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource;
-    return alternateTrainingSource == null
-      ? 'None'
-      : alternateTrainingSource.shortName + ' - ' + alternateTrainingSource.name;
+  get draftingSourceId(): string | undefined {
+    return this.draftSources?.draftingSources[0]?.projectRef;
   }
 
-  get alternateTrainingSourceId(): string | undefined {
-    return this.projectDoc.data?.translateConfig.draftConfig.alternateTrainingSource?.projectRef;
+  get trainingSource(): string {
+    return this.draftSources?.trainingSources[0] == null ? 'None' : projectLabel(this.draftSources.trainingSources[0]);
+  }
+
+  get trainingSourceId(): string | undefined {
+    return this.draftSources?.trainingSources[0]?.projectRef;
   }
 
   get id(): string {
@@ -66,7 +66,7 @@ class Row {
   imports: [UICommonModule]
 })
 export class ServalProjectsComponent extends DataLoadingComponent implements OnInit {
-  columnsToDisplay: string[] = ['name', 'preTranslate', 'source', 'alternateSource', 'alternateTrainingSource'];
+  columnsToDisplay: string[] = ['name', 'preTranslate', 'source', 'draftingSource', 'trainingSource'];
   rows: Row[] = [];
 
   length: number = 0;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { BehaviorSubject } from 'rxjs';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -13,6 +14,11 @@ import { projectLabel } from '../shared/utils';
 import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
 import { ServalAdministrationService } from './serval-administration.service';
 
+interface SourceData {
+  id: string;
+  label: string;
+}
+
 class Row {
   private draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
 
@@ -20,20 +26,12 @@ class Row {
     this.draftSources = projectDoc.data == null ? undefined : projectToDraftSources(projectDoc.data);
   }
 
-  get draftingSource(): string {
-    return this.draftSources?.draftingSources[0] == null ? 'None' : projectLabel(this.draftSources.draftingSources[0]);
+  get draftingSources(): SourceData[] {
+    return this.draftSources == null ? [] : this.draftSources.draftingSources.map(s => Row.sourceAsSourceData(s));
   }
 
-  get draftingSourceId(): string | undefined {
-    return this.draftSources?.draftingSources[0]?.projectRef;
-  }
-
-  get trainingSource(): string {
-    return this.draftSources?.trainingSources[0] == null ? 'None' : projectLabel(this.draftSources.trainingSources[0]);
-  }
-
-  get trainingSourceId(): string | undefined {
-    return this.draftSources?.trainingSources[0]?.projectRef;
+  get trainingSources(): SourceData[] {
+    return this.draftSources == null ? [] : this.draftSources.trainingSources.map(s => Row.sourceAsSourceData(s));
   }
 
   get id(): string {
@@ -41,7 +39,7 @@ class Row {
   }
 
   get name(): string {
-    return this.projectDoc.data == null ? 'N/A' : this.projectDoc.data.shortName + ' - ' + this.projectDoc.data.name;
+    return this.projectDoc.data == null ? 'N/A' : projectLabel(this.projectDoc.data);
   }
 
   get preTranslate(): boolean {
@@ -50,11 +48,15 @@ class Row {
 
   get source(): string {
     const source = this.projectDoc.data?.translateConfig.source;
-    return source == null ? 'None' : source.shortName + ' - ' + source.name;
+    return source == null ? 'None' : projectLabel(source);
   }
 
   get sourceId(): string | undefined {
     return this.projectDoc.data?.translateConfig.source?.projectRef;
+  }
+
+  static sourceAsSourceData(source: TranslateSource): SourceData {
+    return { id: source.projectRef, label: projectLabel(source) };
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -76,8 +76,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   additionalTrainingSourceLanguage?: string;
   additionalTrainingSourceLanguageDisplayName?: string;
 
-  trainingSourceLanguage?: string;
-  trainingSourceLanguageDisplayName?: string;
+  alternateTrainingSourceLanguage?: string;
+  alternateTrainingSourceLanguageDisplayName?: string;
 
   sourceLanguage?: string;
   sourceLanguageDisplayName?: string;
@@ -239,6 +239,21 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
             this.isSourceProjectSet = translateConfig?.source?.projectRef !== undefined;
             this.targetLanguage = projectDoc.data?.writingSystem.tag;
 
+            // If an alternate source is specified, that will be used for drafting (not training)
+            if (
+              (translateConfig?.draftConfig.alternateSourceEnabled ?? false) &&
+              translateConfig?.draftConfig.alternateSource != null
+            ) {
+              this.sourceLanguage = translateConfig?.draftConfig.alternateSource?.writingSystem.tag;
+            } else {
+              this.sourceLanguage = translateConfig?.source?.writingSystem.tag;
+            }
+
+            this.alternateTrainingSourceLanguage =
+              translateConfig?.draftConfig.alternateTrainingSource?.writingSystem.tag;
+            this.additionalTrainingSourceLanguage =
+              translateConfig?.draftConfig.additionalTrainingSource?.writingSystem.tag;
+
             this.isPreTranslationApproved = translateConfig?.preTranslate ?? false;
 
             this.projectSettingsUrl = `/projects/${projectDoc.id}/settings`;
@@ -252,10 +267,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
             this.source = draftingSources[0];
             this.trainingSource = trainingSources[0];
             this.additionalTrainingSource = trainingSources[1];
-
-            this.sourceLanguage = this.source?.writingSystem.tag;
-            this.trainingSourceLanguage = this.trainingSource?.writingSystem.tag;
-            this.additionalTrainingSourceLanguage = this.additionalTrainingSource?.writingSystem.tag;
           })
         )
       ]),
@@ -299,7 +310,9 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     this.subscribe(this.i18n.locale$, () => {
       this.targetLanguageDisplayName = this.i18n.getLanguageDisplayName(this.targetLanguage);
       this.sourceLanguageDisplayName = this.i18n.getLanguageDisplayName(this.sourceLanguage);
-      this.trainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(this.trainingSourceLanguage);
+      this.alternateTrainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(
+        this.alternateTrainingSourceLanguage
+      );
       this.additionalTrainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(
         this.additionalTrainingSourceLanguage
       );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -76,8 +76,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   additionalTrainingSourceLanguage?: string;
   additionalTrainingSourceLanguageDisplayName?: string;
 
-  alternateTrainingSourceLanguage?: string;
-  alternateTrainingSourceLanguageDisplayName?: string;
+  trainingSourceLanguage?: string;
+  trainingSourceLanguageDisplayName?: string;
 
   sourceLanguage?: string;
   sourceLanguageDisplayName?: string;
@@ -239,21 +239,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
             this.isSourceProjectSet = translateConfig?.source?.projectRef !== undefined;
             this.targetLanguage = projectDoc.data?.writingSystem.tag;
 
-            // If an alternate source is specified, that will be used for drafting (not training)
-            if (
-              (translateConfig?.draftConfig.alternateSourceEnabled ?? false) &&
-              translateConfig?.draftConfig.alternateSource != null
-            ) {
-              this.sourceLanguage = translateConfig?.draftConfig.alternateSource?.writingSystem.tag;
-            } else {
-              this.sourceLanguage = translateConfig?.source?.writingSystem.tag;
-            }
-
-            this.alternateTrainingSourceLanguage =
-              translateConfig?.draftConfig.alternateTrainingSource?.writingSystem.tag;
-            this.additionalTrainingSourceLanguage =
-              translateConfig?.draftConfig.additionalTrainingSource?.writingSystem.tag;
-
             this.isPreTranslationApproved = translateConfig?.preTranslate ?? false;
 
             this.projectSettingsUrl = `/projects/${projectDoc.id}/settings`;
@@ -267,6 +252,10 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
             this.source = draftingSources[0];
             this.trainingSource = trainingSources[0];
             this.additionalTrainingSource = trainingSources[1];
+
+            this.sourceLanguage = this.source?.writingSystem.tag;
+            this.trainingSourceLanguage = this.trainingSource?.writingSystem.tag;
+            this.additionalTrainingSourceLanguage = this.additionalTrainingSource?.writingSystem.tag;
           })
         )
       ]),
@@ -310,9 +299,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     this.subscribe(this.i18n.locale$, () => {
       this.targetLanguageDisplayName = this.i18n.getLanguageDisplayName(this.targetLanguage);
       this.sourceLanguageDisplayName = this.i18n.getLanguageDisplayName(this.sourceLanguage);
-      this.alternateTrainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(
-        this.alternateTrainingSourceLanguage
-      );
+      this.trainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(this.trainingSourceLanguage);
       this.additionalTrainingSourceLanguageDisplayName = this.i18n.getLanguageDisplayName(
         this.additionalTrainingSourceLanguage
       );


### PR DESCRIPTION
This change moves the code to use the projectToDraftSources utility function rather than accessing draft sources from the project document. Testing is not required since it is a refactoring and most changes are on the serval admin area.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3068)
<!-- Reviewable:end -->
