### PR TITLE
SF-3226 Clarify wording for canceling draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -171,7 +171,7 @@
     "back_translation_requirement": "Back translation drafts can only be generated into the roughly 200 [link:supportedLanguagesUrl]supported languages[/link].",
     "cancel_generation_button": "Cancel",
     "criteria_project_language_not_in_nllb_with_language": "Your project language of [em]\"{{ targetLanguageDisplayName }}\"[/em] is not a supported language.",
-    "dialog_confirm_draft_cancellation_message": "Canceling will reset progress for this draft request. Any previously generated draft will still be accessible.",
+    "dialog_confirm_draft_cancellation_message": "Canceling will reset progress for this draft request. The previous completed draft will still be accessible.",
     "dialog_confirm_draft_cancellation_no": "No",
     "dialog_confirm_draft_cancellation_title": "Cancel generating draft?",
     "dialog_confirm_draft_cancellation_yes": "Yes, cancel",


### PR DESCRIPTION
I toyed with the wording a bit here, but I believe what's there is a good improvement and addresses JoEllen's concern

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3076)
<!-- Reviewable:end -->
