### PR TITLE
Remove a number of unneeded non-null assertions

### DIFF
--- a/.grit/patterns/remove_non_null_assertion.md
+++ b/.grit/patterns/remove_non_null_assertion.md
@@ -1,0 +1,13 @@
+# Remove non-null assertion
+
+Removes all non-null assertions, without regard to whether they're needed or not. One use for this is to remove all
+non-null assertions from certain files and then only add them back in where they're needed.
+
+```grit
+language js
+
+non_null_expression() as $nonNullAssertion where {
+  $nonNullAssertion <: contains or { member_expression(), identifier() } as $expression,
+  $nonNullAssertion => $expression
+}
+```

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
@@ -95,8 +95,8 @@ export class CheckingInputFormComponent {
     const verseRef = this._questionDoc.data.verseRef;
 
     const dialogData: TextChooserDialogData = {
-      bookNum: (this.verseRef && this.verseRef.bookNum) || verseRef!.bookNum,
-      chapterNum: (this.verseRef && this.verseRef.chapterNum) || verseRef!.chapterNum,
+      bookNum: (this.verseRef && this.verseRef.bookNum) || verseRef.bookNum,
+      chapterNum: (this.verseRef && this.verseRef.chapterNum) || verseRef.chapterNum,
       textsByBookId: this.textsByBookId,
       projectId: this._questionDoc.data.projectRef,
       isRightToLeft: this.project?.isRightToLeft,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.spec.ts
@@ -101,7 +101,7 @@ describe('CheckingQuestionComponent', () => {
         audioUrl: 'test-audio-player-b.webm',
         projectRef: 'project01',
         text: 'another question',
-        verseRef: env.component.questionDoc.data!.verseRef!
+        verseRef: env.component.questionDoc.data!.verseRef
       }
     } as QuestionDoc;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -74,7 +74,7 @@ export class QuestionDialogService {
       await questionDoc.submitJson0Op(op =>
         op
           .set(q => q.verseRef, verseRefData)
-          .set(q => q.text!, text)
+          .set(q => q.text, text)
           .set(q => q.audioUrl, audioUrl)
           .set(q => q.dateModified, currentDate)
       );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/question-doc.ts
@@ -70,12 +70,12 @@ export class QuestionDoc extends ProjectDataDoc<Question> {
 
     if (this.data.dataId === dataId) {
       // The file belongs to the question
-      return obj<Question>().path(q => q.audioUrl!);
+      return obj<Question>().path(q => q.audioUrl);
     } else {
       // otherwise, it is probably belongs to an answer
       const answerIndex = this.data.answers.findIndex(a => a.dataId === dataId && !a.deleted);
       if (answerIndex !== -1) {
-        return obj<Question>().path(q => q.answers[answerIndex].audioUrl!);
+        return obj<Question>().path(q => q.answers[answerIndex].audioUrl);
       }
     }
     return undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
@@ -91,7 +91,7 @@ function textFromMenuElement(element: Element): string | undefined {
 function activeMenuItemText(element: HTMLElement): string | undefined {
   const menuItems = element.querySelectorAll('.mdc-list-item.active, .mdc-list-item.activated-nav-item');
   expect(menuItems.length).toBe(1);
-  return textFromMenuElement(menuItems[0]!);
+  return textFromMenuElement(menuItems[0]);
 }
 
 function menuItems(element: HTMLElement): string[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-history.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-history.spec.ts
@@ -127,7 +127,7 @@ describe('Quill history', () => {
     testCases.forEach(({ name, input, expectedAttrs }) => {
       it(`should handle ${name}`, () => {
         const result = removeObsoleteSegmentAttrs(input);
-        expect(result.ops![0].attributes).toEqual(expectedAttrs);
+        expect(result.ops[0].attributes).toEqual(expectedAttrs);
       });
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.spec.ts
@@ -254,9 +254,9 @@ class TestEnvironment {
     const projectDoc = this.realtimeService.get<SFProjectDoc>(SFProjectDoc.COLLECTION, projectId);
     projectDoc.submitJson0Op(ops => {
       ops.set<number>(p => p.sync.queuedCount, 0);
-      ops.set(p => p.sync.lastSyncSuccessful!, successful);
+      ops.set(p => p.sync.lastSyncSuccessful, successful);
       if (successful) {
-        ops.set(p => p.sync.dateLastSuccessfulSync!, new Date().toJSON());
+        ops.set(p => p.sync.dateLastSuccessfulSync, new Date().toJSON());
       }
     }, false);
     this.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -486,14 +486,14 @@ describe('DraftGenerationStepsComponent', () => {
       const unusableTranslateBooks = fixture.nativeElement.querySelector('.unusable-translate-books');
       expect(unusableTranslateBooks).not.toBeNull();
       expect(unusableTranslateBooks.querySelector('.explanation')).toBeNull();
-      unusableTranslateBooks.querySelector('.books-hidden-message')!.click();
+      unusableTranslateBooks.querySelector('.books-hidden-message').click();
       tick();
       fixture.detectChanges();
       expect(unusableTranslateBooks.querySelector('.explanation')).not.toBeNull();
       const unusableTrainingBooks = fixture.nativeElement.querySelector('.unusable-training-books');
       expect(unusableTrainingBooks).not.toBeNull();
       expect(unusableTrainingBooks.querySelector('.explanation')).toBeNull();
-      unusableTrainingBooks.querySelector('.books-hidden-message')!.click();
+      unusableTrainingBooks.querySelector('.books-hidden-message').click();
       tick();
       fixture.detectChanges();
       expect(unusableTrainingBooks.querySelector('.explanation')).not.toBeNull();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -55,8 +55,8 @@ describe('LanguageCodesConfirmationComponent', () => {
   it('shows standard message when language codes are equivalent language', () => {
     const draftSources = getStandardDraftSources();
     // Both map to the Chinese language
-    draftSources.draftingSources[0]!.languageTag = 'zh-CN';
-    draftSources.trainingSources[0]!.languageTag = 'cmn-Hans';
+    draftSources.draftingSources[0].languageTag = 'zh-CN';
+    draftSources.trainingSources[0].languageTag = 'cmn-Hans';
     component.draftSources = draftSources;
     fixture.detectChanges();
     expect(component.sourceSideLanguageCodes.length).toEqual(1);
@@ -64,7 +64,7 @@ describe('LanguageCodesConfirmationComponent', () => {
 
   it('should show target and source language codes identical message', () => {
     const draftSources = getStandardDraftSources();
-    draftSources.trainingTargets[0]!.languageTag = draftSources.trainingSources[0]!.languageTag;
+    draftSources.trainingTargets[0].languageTag = draftSources.trainingSources[0].languageTag;
     component.draftSources = draftSources;
     fixture.detectChanges();
     expect(component.sourceSideLanguageCodes.length).toEqual(1);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/mock-pretranslation-machine-api.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/mock-pretranslation-machine-api.ts
@@ -144,7 +144,7 @@ export class MockPreTranslationHttpClient {
     const stepOffset: number =
       isContinue && this.mostRecentJobState?.state === BuildStates.Active
         ? activeAfter / interval +
-          Math.floor(this.mostRecentJobState!.percentCompleted * ((duration - activeAfter) / interval))
+          Math.floor(this.mostRecentJobState.percentCompleted * ((duration - activeAfter) / interval))
         : 0;
 
     const generationTimer$: Observable<number> = timer(0, interval).pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.spec.ts
@@ -60,7 +60,7 @@ describe('EditorHistoryService', () => {
       const deltaA = new Delta().insert('Hello');
       const deltaB = new Delta().insert('Hello');
       const result = service.processDiff(deltaA, deltaB);
-      expect(result.ops!.length).toBe(0);
+      expect(result.ops.length).toBe(0);
     });
 
     it('should return the expected diff when comparing two different deltas', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -353,9 +353,9 @@ class TestEnvironment {
     const items: NodeListOf<Element> = this.progressTextList.querySelectorAll('mat-list-item');
     const item: Element = items.item(index);
     const primaryElem: Element = item.querySelectorAll('.mat-mdc-list-item-title')[0];
-    expect(primaryElem!.textContent).toBe(primary);
+    expect(primaryElem.textContent).toBe(primary);
     const secondaryElem: Element = item.querySelectorAll('.mat-mdc-list-item-line')[0];
-    expect(secondaryElem!.textContent).toBe(secondary);
+    expect(secondaryElem.textContent).toBe(secondary);
   }
 
   setupProjectData(projectConfig: TestProjectConfiguration = {}): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.spec.ts
@@ -255,7 +255,7 @@ describe('CollaboratorsComponent', () => {
 
     // Uninvite Alice
     when(mockedProjectService.onlineInvitedUsers(env.project01Id)).thenResolve([]);
-    env.clickElement(env.cancelInviteItemOnRow(inviteeRow)!);
+    env.clickElement(env.cancelInviteItemOnRow(inviteeRow));
     verify(mockedProjectService.onlineUninviteUser(env.project01Id, 'alice@a.aa')).once();
 
     // Alice is not shown as in invitee

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -218,7 +218,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       data: {
         projectId: this.projectId,
         userId: row.id,
-        userProfile: { avatarUrl: row.user.avatarUrl!, displayName: row.user.displayName! }
+        userProfile: { avatarUrl: row.user.avatarUrl, displayName: row.user.displayName }
       },
       minWidth: '360px',
       maxWidth: '560px',

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -148,7 +148,7 @@ export class IndexeddbOfflineStore extends OfflineStore {
       transaction.oncomplete = () => resolve();
       // The transaction is aborted if the storage quota has been exceeded. We want to handle that if it happens.
       transaction.onabort = event => {
-        const target = event.target! as IDBTransaction;
+        const target = event.target as IDBTransaction;
         reject(target.error);
       };
     });


### PR DESCRIPTION
I applied the Grit pattern, then checked out all files that had build failures. That means there are *lots* of unneeded non-null assertions in files that also have non-null assertions that _are_ needed, and can't be automatically removed as easily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3077)
<!-- Reviewable:end -->
