### PR TITLE
Fix use of QuietDestroyRef

### DIFF
--- a/.grit/patterns/migrate_quiet_destroy_ref.md
+++ b/.grit/patterns/migrate_quiet_destroy_ref.md
@@ -102,7 +102,7 @@ export class EditorTabAddResourceDialogService {
   constructor(
     private readonly paratextService: ParatextService,
     private readonly userProjectsService: SFUserProjectsService,
-    private readonly destroyRef: QuietDestroyRef
+    private destroyRef = getQuietDestroyRef();
   ) {
     this.userProjectsService.projectDocs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projects => {
       if (projects == null) return;

--- a/.grit/patterns/take_until_destroyed.md
+++ b/.grit/patterns/take_until_destroyed.md
@@ -49,7 +49,7 @@ pattern removeExtends() {
 }
 
 pattern addProperty() {
-  maybe `constructor( $args ){  $body }` => `constructor( $args, private destroyRef: QuietDestroyRef ){$body}` where {
+  maybe `constructor( $args ){  $body }` => `constructor( $args, private destroyRef = getQuietDestroyRef(); ){$body}` where {
     $body <: within classSubscriptionDisposable(),
     $args <: not contains `QuietDestroyRef`
   }
@@ -203,7 +203,7 @@ export class SFUserProjectsService {
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
     private readonly authService: AuthService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef = getQuietDestroyRef();
   ) {
     this.setup();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -33,7 +33,7 @@ import {
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UserService } from 'xforge-common/user.service';
-import { issuesEmailTemplate, QuietDestroyRef, supportedBrowser } from 'xforge-common/utils';
+import { issuesEmailTemplate, getQuietDestroyRef, supportedBrowser } from 'xforge-common/utils';
 import versionData from '../../../version.json';
 import { environment } from '../environments/environment';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
@@ -67,6 +67,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   private selectedProjectDeleteSub?: Subscription;
   private permissionsChangedSub?: Subscription;
   private _isDrawerPermanent: boolean = true;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly router: Router,
@@ -87,8 +88,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     readonly urls: ExternalUrlService,
     readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService,
-    onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    onlineStatusService: OnlineStatusService
   ) {
     super(noticeService);
     this.breakpointObserver

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -15,7 +15,7 @@ import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, objectId, QuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextAudioDoc } from '../../core/models/text-audio-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -63,9 +63,9 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
   private _timingErrorKey?: I18nKeyForComponent<'chapter_audio_dialog'>;
   private _timingParseErrorKey?: I18nKeyForComponent<'chapter_audio_dialog'>;
   private _loadingAudio: boolean = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     readonly i18n: I18nService,
     @Inject(MAT_DIALOG_DATA) public data: ChapterAudioDialogData,
     private readonly csvService: CsvService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -18,7 +18,7 @@ import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
@@ -52,9 +52,9 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   private dataChangesSub?: Subscription;
   private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private questionsQuery?: RealtimeQuery<QuestionDoc>;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly activatedRoute: ActivatedRoute,
     private readonly dialogService: DialogService,
     readonly featureFlags: FeatureFlagService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -17,7 +17,7 @@ import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
@@ -113,6 +113,7 @@ export class CheckingAnswersComponent implements OnInit {
   private isProjectAdmin: boolean = false;
   private projectProfileDocChangesSubscription?: Subscription;
   isScreenSmall: boolean = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly userService: UserService,
@@ -122,8 +123,7 @@ export class CheckingAnswersComponent implements OnInit {
     private readonly i18n: I18nService,
     private readonly fileService: FileService,
     private readonly onlineStatusService: OnlineStatusService,
-    private readonly projectService: SFProjectService,
-    private destroyRef: QuietDestroyRef
+    private readonly projectService: SFProjectService
   ) {}
 
   get project(): SFProjectProfile | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
@@ -9,7 +9,7 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
 import { NoticeService } from 'xforge-common/notice.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { TextsByBookId } from '../../../../core/models/texts-by-book-id';
 import {
@@ -57,14 +57,14 @@ export class CheckingInputFormComponent {
   private selectionEndClipped?: boolean = false;
   private _questionDoc?: QuestionDoc;
   private textAndAudioInput?: { text?: string; audioUrl?: string };
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     readonly noticeService: NoticeService,
     private readonly dialogService: DialogService,
     private readonly i18n: I18nService,
     private readonly breakpointObserver: BreakpointObserver,
-    private readonly mediaBreakpointService: MediaBreakpointService,
-    private destroyRef: QuietDestroyRef
+    private readonly mediaBreakpointService: MediaBreakpointService
   ) {
     this.breakpointObserver
       .observe(this.mediaBreakpointService.width('<', Breakpoint.MD))

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
@@ -12,7 +12,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
@@ -52,9 +52,9 @@ export class CheckingQuestionComponent extends SubscriptionDisposable implements
   private _versesListenedTo = new Set<string>();
   private questionDocSub?: Subscription;
   private isDestroyed = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly projectService: SFProjectService,
     private readonly i18n: I18nService
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
 
 export interface AudioAttachment {
@@ -20,11 +20,9 @@ export class CheckingAudioPlayerComponent implements AfterViewInit {
   private _isAudioAvailable = false;
   @ViewChild(AudioPlayerComponent) audioPlayer?: AudioPlayerComponent;
   @Input() source?: string = '';
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(
-    readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
-  ) {}
+  constructor(readonly i18n: I18nService) {}
 
   ngAfterViewInit(): void {
     this.audioPlayer!.isAudioAvailable$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(newValue => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -26,7 +26,7 @@ import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
@@ -127,14 +127,14 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
 
   private projectProfileDocChangesSubscription?: Subscription;
   private projectUserConfigDocChangesSubscription?: Subscription;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly userService: UserService,
     private readonly translationEngineService: TranslationEngineService,
     private readonly changeDetector: ChangeDetectorRef,
     private readonly projectService: SFProjectService,
-    private readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    private readonly i18n: I18nService
   ) {}
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -5,7 +5,7 @@ import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, first, map } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TextDocId } from '../../../core/models/text-doc';
 import { AudioPlayer } from '../../../shared/audio/audio-player';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
@@ -49,11 +49,9 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
   private finishedSubscription?: Subscription;
   private verseChangeSubscription?: Subscription;
   private audioSubscription?: Subscription;
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(
-    readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
-  ) {}
+  constructor(readonly i18n: I18nService) {}
 
   ngAfterViewInit(): void {
     this.doAudioSubscriptions();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -5,7 +5,7 @@ import { IOutputAreaSizes } from 'angular-split';
 import { clone } from 'lodash-es';
 import { fromEvent, Observable, Subscription } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../../core/models/text-doc';
 import { TextComponent } from '../../../shared/text/text.component';
@@ -29,11 +29,9 @@ export class CheckingTextComponent implements AfterViewInit {
   private _id?: TextDocId;
   private _questionVerses?: VerseRef[];
   private _placeholder?: string;
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(
-    readonly fontService: FontService,
-    private destroyRef: QuietDestroyRef
-  ) {}
+  constructor(readonly fontService: FontService) {}
 
   ngAfterViewInit(): void {
     if (this.resizableContainer != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -26,7 +26,7 @@ import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, objectId, QuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_DEFAULT_SHARE_ROLE } from '../../core/models/sf-project-role-info';
@@ -158,9 +158,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   private isProjectAdmin: boolean = false;
   private _scriptureAudioPlayer?: CheckingScriptureAudioPlayerComponent;
   private _showScriptureAudioPlayer: boolean = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly activatedRoute: ActivatedRoute,
     private readonly projectService: SFProjectService,
     private readonly checkingQuestionsService: CheckingQuestionsService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -14,7 +14,7 @@ import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { RetryingRequest } from 'xforge-common/retrying-request.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, objectId, QuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../../environments/environment';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -102,9 +102,9 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
   promiseForQuestionDocQuery: Promise<RealtimeQuery<QuestionDoc>>;
   helpInstructions = this.i18n.interpolate('import_questions_dialog.help_options');
   transceleratorInfo = this.i18n.interpolate('import_questions_dialog.transcelerator_paratext');
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     @Inject(MAT_DIALOG_DATA) public readonly data: ImportQuestionsDialogData,
     projectService: SFProjectService,
     private readonly checkingQuestionsService: CheckingQuestionsService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -9,7 +9,7 @@ import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question
 import { toStartAndEndVerseRefs } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
@@ -59,13 +59,13 @@ export class QuestionDialogComponent implements OnInit {
   _selection?: VerseRef;
 
   private _question: Readonly<Question | undefined>;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly dialogRef: MatDialogRef<QuestionDialogComponent, QuestionDialogResult | 'close'>,
     @Inject(MAT_DIALOG_DATA) private data: QuestionDialogData,
     readonly i18n: I18nService,
-    readonly dialogService: DialogService,
-    private readonly destroyRef: QuietDestroyRef
+    readonly dialogService: DialogService
   ) {}
 
   get scriptureStart(): AbstractControl {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -9,7 +9,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { hasStringProp } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectCreateSettings } from '../core/models/sf-project-create-settings';
@@ -48,6 +48,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
   private _isAppOnline: boolean = false;
   private projectsFromParatext?: ParatextProject[];
   private projectMetadata?: SelectableProject;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly authService: AuthService,
@@ -58,8 +59,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
     noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly errorHandler: ErrorHandler,
-    private readonly translocoService: TranslocoService,
-    private destroyRef: QuietDestroyRef
+    private readonly translocoService: TranslocoService
   ) {
     super(noticeService);
     this.connectProjectForm.disable();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -12,7 +12,7 @@ import { filter, share } from 'rxjs/operators';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OfflineData, OfflineStore } from 'xforge-common/offline-store';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { HttpClient } from '../machine-api/http-client';
 import { RemoteTranslationEngine } from '../machine-api/remote-translation-engine';
 import { EDITED_SEGMENTS, EditedSegmentData } from './models/edited-segment-data';
@@ -32,6 +32,7 @@ export class TranslationEngineService {
     string,
     InteractiveTranslatorFactory
   >();
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly offlineStore: OfflineStore,
@@ -39,8 +40,7 @@ export class TranslationEngineService {
     private readonly projectService: SFProjectService,
     private readonly machineHttp: HttpClient,
     private readonly noticeService: NoticeService,
-    private readonly router: Router,
-    private destroyRef: QuietDestroyRef
+    private readonly router: Router
   ) {
     this.onlineStatus$ = this.onlineStatusService.onlineStatus$.pipe(
       filter(online => online),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
@@ -14,7 +14,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectService } from '../core/sf-project.service';
 import { EventMetric } from './event-metric';
 import { EventMetricDialogComponent } from './event-metric-dialog.component';
@@ -65,6 +65,8 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
 
   private eventMetrics?: EventMetric[];
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     noticeService: NoticeService,
     private readonly activatedProjectService: ActivatedProjectService,
@@ -72,8 +74,7 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
     private readonly dialogService: DialogService,
     private readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
-    private readonly projectService: SFProjectService,
-    private destroyRef: QuietDestroyRef
+    private readonly projectService: SFProjectService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -15,7 +15,7 @@ import { en, I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { ObjectPaths } from '../../type-utils';
 import { SFProjectService } from '../core/sf-project.service';
@@ -46,6 +46,7 @@ export class JoinComponent extends DataLoadingComponent {
   name: FormControl<string | null> = new FormControl<string | null>('');
   status: 'input' | 'joining' | 'unavailable' = 'unavailable';
   private joiningResponse?: AnonymousShareKeyResponse;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly anonymousService: AnonymousService,
@@ -59,8 +60,7 @@ export class JoinComponent extends DataLoadingComponent {
     private readonly route: ActivatedRoute,
     private readonly router: Router,
     private readonly errorHandler: ErrorHandler,
-    noticeService: NoticeService,
-    private destroyRef: QuietDestroyRef
+    noticeService: NoticeService
   ) {
     super(noticeService);
     const joining$ = this.route.params.pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -12,7 +12,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 import { ObjectPaths } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
@@ -45,6 +45,7 @@ export class MyProjectsComponent implements OnInit {
   initialLoadingSFProjects: boolean = true;
   userIsPTUser: boolean = false;
   joiningProjects: string[] = [];
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly projectService: SFProjectService,
@@ -54,8 +55,7 @@ export class MyProjectsComponent implements OnInit {
     private readonly userService: UserService,
     private readonly permissions: PermissionsService,
     private readonly noticeService: NoticeService,
-    private readonly router: Router,
-    private destroyRef: QuietDestroyRef
+    private readonly router: Router
   ) {}
 
   /** If we are aware of any SF or PT projects that the user can access. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
@@ -12,7 +12,7 @@ import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.ser
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
@@ -73,6 +73,8 @@ export class NavigationComponent {
     delay(0)
   );
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     readonly i18n: I18nService,
     private readonly nmtDraftAuthGuard: NmtDraftAuthGuard,
@@ -85,8 +87,7 @@ export class NavigationComponent {
     private readonly resumeCheckingService: ResumeCheckingService,
     private readonly router: Router,
     private readonly activatedProjectService: ActivatedProjectService,
-    readonly featureFlags: FeatureFlagService,
-    private destroyRef: QuietDestroyRef
+    readonly featureFlags: FeatureFlagService
   ) {
     this.activatedProjectService.projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(projectId => {
       this.updateProjectUserConfig(projectId);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -6,7 +6,7 @@ import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { translate } from '@ngneat/transloco';
 import { BehaviorSubject, combineLatest, fromEvent, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, takeUntil, tap } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SelectableProject } from '../core/paratext.service';
 import { SFValidators } from '../shared/sfvalidators';
 import { projectLabel } from '../shared/utils';
@@ -59,8 +59,9 @@ export class ProjectSelectComponent implements ControlValueAccessor {
   ]).pipe(map(value => this.filterGroup(value[0], this.resources || [], value[1])));
 
   projectLabel = projectLabel;
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(private destroyRef: QuietDestroyRef) {
+  constructor() {
     this.paratextIdControl.valueChanges
       .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value: SelectableProject) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -10,7 +10,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { PermissionsService } from '../core/permissions.service';
@@ -24,6 +24,8 @@ type TaskType = 'translate' | 'checking';
   styleUrls: ['./project.component.scss']
 })
 export class ProjectComponent extends DataLoadingComponent implements OnInit {
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly route: ActivatedRoute,
     private readonly projectService: SFProjectService,
@@ -32,8 +34,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     private readonly permissions: PermissionsService,
     private readonly resumeCheckingService: ResumeCheckingService,
     private readonly dialogService: DialogService,
-    noticeService: NoticeService,
-    private destroyRef: QuietDestroyRef
+    noticeService: NoticeService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -12,7 +12,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
@@ -77,6 +77,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   draftJob$: Observable<BuildDto | undefined> = new Observable<BuildDto | undefined>();
   lastCompletedBuild: BuildDto | undefined;
   zipSubscription: Subscription | undefined;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
@@ -84,8 +85,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
     noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    private readonly servalAdministrationService: ServalAdministrationService,
-    private destroyRef: QuietDestroyRef
+    private readonly servalAdministrationService: ServalAdministrationService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -10,7 +10,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { projectLabel } from '../shared/utils';
 import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
@@ -81,12 +81,12 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
 
   private readonly searchTerm$: BehaviorSubject<string>;
   private readonly queryParameters$: BehaviorSubject<QueryParameters>;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     noticeService: NoticeService,
     readonly i18n: I18nService,
-    private readonly servalAdministrationService: ServalAdministrationService,
-    private destroyRef: QuietDestroyRef
+    private readonly servalAdministrationService: ServalAdministrationService
   ) {
     super(noticeService);
     this.searchTerm$ = new BehaviorSubject<string>('');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -24,7 +24,7 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { SFProjectSettings } from '../core/models/sf-project-settings';
@@ -101,6 +101,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
   private controlStates = new Map<keyof SFProjectSettings, ElementState>();
   private previousFormValues: SFProjectSettings = {};
   private _isAppOnline: boolean = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -115,8 +116,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     readonly authService: AuthService,
     readonly featureFlags: FeatureFlagService,
     readonly externalUrls: ExternalUrlService,
-    private readonly activatedProjectService: ActivatedProjectService,
-    private destroyRef: QuietDestroyRef
+    private readonly activatedProjectService: ActivatedProjectService
   ) {
     super(noticeService);
     this.loading = true;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -14,7 +14,7 @@ import {
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef, audioRecordingMimeType, objectId } from 'xforge-common/utils';
+import { QuietDestroyRef, audioRecordingMimeType, objectId, getQuietDestroyRef } from 'xforge-common/utils';
 import { SingleButtonAudioPlayerComponent } from '../../checking/checking/single-button-audio-player/single-button-audio-player.component';
 import { SharedModule } from '../shared.module';
 
@@ -70,14 +70,14 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
   private visualizerHeight = 150;
   private visualizerWidth = 300;
   private audioWaveformBase = 128;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     public readonly dialogRef: MatDialogRef<AudioRecorderDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: AudioRecorderDialogData,
     private readonly noticeService: NoticeService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
-    private readonly dialogService: DialogService,
-    private readonly destroyRef: QuietDestroyRef
+    private readonly dialogService: DialogService
   ) {
     this.showCountdown = data?.countdown ?? false;
     if (data?.audio != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -7,7 +7,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
@@ -45,14 +45,14 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
   private _projectDoc?: SFProjectProfileDoc;
   private _allChaptersChangeSub?: Subscription;
   private _canTrainSuggestions: boolean = false;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     readonly noticeService: NoticeService,
     private readonly activatedProject: ActivatedProjectService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    private readonly permissionsService: PermissionsService,
-    private destroyRef: QuietDestroyRef
+    private readonly permissionsService: PermissionsService
   ) {
     super(noticeService);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
@@ -24,7 +24,7 @@ import {
   Subscription
 } from 'rxjs';
 import { LocaleDirection } from 'xforge-common/models/i18n-locale';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TabMenuItem, TabMenuService } from '../../sf-tab-group';
 import { TabHeaderPointerEvent, TabLocation, TabMoveEvent } from '../sf-tabs.types';
 import { TabHeaderComponent } from '../tab-header/tab-header.component';
@@ -57,6 +57,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
   isScrollBoundsEnd = false;
   direction: LocaleDirection = 'ltr';
 
+  private destroyRef = getQuietDestroyRef();
   // Used to time scroll movements while scrolling via left/right scroll buttons
   private scrollTimer$ = interval(20).pipe(takeUntilDestroyed(this.destroyRef));
 
@@ -67,7 +68,6 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
   private tabsWrapper!: HTMLElement;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly elementRef: ElementRef<HTMLElement>,
     private readonly tabMenuService: TabMenuService<string>
   ) {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-scroll-button/tab-scroll-button.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-scroll-button/tab-scroll-button.component.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, distinctUntilChanged, fromEvent, merge } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 
 @Component({
   selector: 'app-tab-scroll-button',
@@ -20,11 +20,9 @@ export class TabScrollButtonComponent implements OnInit {
 
   isMouseDown = false;
   scroll$ = new BehaviorSubject(false);
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(
-    private readonly destroyRef: QuietDestroyRef,
-    @Inject(DOCUMENT) private readonly document: Document
-  ) {}
+  constructor(@Inject(DOCUMENT) private readonly document: Document) {}
 
   ngOnInit(): void {
     // Stop button scrolling on mouseup or when mouse leaves the document

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isEqual } from 'lodash-es';
 import { BehaviorSubject, distinctUntilChanged, filter, map, Observable, Subject, takeUntil } from 'rxjs';
 import { moveItemInReadonlyArray, transferItemAcrossReadonlyArrays } from 'xforge-common/util/array-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TabLocation } from '../sf-tabs.types';
 import { TabGroup } from './tab-group';
 
@@ -55,8 +55,9 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
   groupIds$: Observable<TGroupId[]> = this.tabGroupsSource$.pipe(map(groups => Array.from(groups.keys())));
 
   tabsConsolidated$ = this.tabsConsolidatedSource$.asObservable();
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(private readonly destroyRef: QuietDestroyRef) {}
+  constructor() {}
 
   setTabGroups(tabGroups: TabGroup<TGroupId, T>[]): void {
     this.groups.clear();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -10,7 +10,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -43,6 +43,7 @@ export class ShareControlComponent extends ShareBaseComponent {
 
   private _projectId?: string;
   private projectId$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     readonly i18n: I18nService,
@@ -50,8 +51,7 @@ export class ShareControlComponent extends ShareBaseComponent {
     private readonly projectService: SFProjectService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly changeDetector: ChangeDetectorRef,
-    userService: UserService,
-    private destroyRef: QuietDestroyRef
+    userService: UserService
   ) {
     super(userService);
     combineLatest([this.projectId$, this.onlineStatusService.onlineStatus$])

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -12,7 +12,7 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../../environments/environment';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -52,6 +52,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
   private linkSharingKey: string | undefined;
   private linkSharingReady: boolean = false;
   private _error: string | undefined;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     readonly dialogRef: MatDialogRef<ShareDialogComponent>,
@@ -61,8 +62,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     private readonly noticeService: NoticeService,
     private readonly projectService: SFProjectService,
     private readonly onlineStatusService: OnlineStatusService,
-    userService: UserService,
-    private destroyRef: QuietDestroyRef
+    userService: UserService
   ) {
     super(userService);
     this.projectId = this.data.projectId;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -28,7 +28,7 @@ import { LocaleDirection } from 'xforge-common/models/i18n-locale';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { getBrowserEngine, objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { getBrowserEngine, getQuietDestroyRef, objectId, QuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../../environments/environment';
 import { isString } from '../../../type-utils';
 import { NoteThreadIcon } from '../../core/models/note-thread-doc';
@@ -265,6 +265,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
   private presenceActiveEditor$: Subject<boolean> = new Subject<boolean>();
   private onPresenceDocReceive = (_presenceId: string, _range: Range | null): void => {};
   private onPresenceChannelReceive = (_presenceId: string, _presenceData: PresenceData | null): void => {};
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly changeDetector: ChangeDetectorRef,
@@ -274,8 +275,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     private readonly transloco: TranslocoService,
     private readonly userService: UserService,
     private readonly viewModel: TextViewModel,
-    private readonly textDocService: TextDocService,
-    private destroyRef: QuietDestroyRef
+    private readonly textDocService: TextDocService
   ) {
     let localCursorColor = localStorage.getItem(this.cursorColorStorageKey);
     if (localCursorColor == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject, map, merge, Observable } from 'rxjs';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { ProjectNotificationService } from '../../core/project-notification.service';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -63,14 +63,14 @@ export class SyncProgressComponent {
 
   private sourceProjectDoc?: SFProjectDoc;
   private _projectDoc?: SFProjectDoc;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly projectService: SFProjectService,
     private readonly projectNotificationService: ProjectNotificationService,
     private readonly featureFlags: FeatureFlagService,
     private readonly errorReportingService: ErrorReportingService,
-    private readonly onlineStatus: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private readonly onlineStatus: OnlineStatusService
   ) {
     this.projectNotificationService.setNotifySyncProgressHandler((projectId: string, progressState: ProgressState) => {
       this.updateProgressState(projectId, progressState);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -12,7 +12,7 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { ParatextService } from '../core/paratext.service';
@@ -42,6 +42,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
   private isSyncCancelled = false;
   private paratextUsername?: string;
   private previousLastSyncDate?: Date;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -51,8 +52,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly dialogService: DialogService,
-    private readonly authService: AuthService,
-    private destroyRef: QuietDestroyRef
+    private readonly authService: AuthService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -8,7 +8,7 @@ import { auditTime } from 'rxjs/operators';
 import { DOCUMENT } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TextDocId } from '../core/models/text-doc';
 import { TextsByBookId } from '../core/models/texts-by-book-id';
 import {
@@ -53,14 +53,14 @@ export class TextChooserDialogComponent {
   private selectedVerses?: VerseRefData;
   private selectionChanged = false;
   private readonly verseSegmentSelector = 'usx-segment[data-segment^=verse_]';
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly dialogRef: MatDialogRef<TextChooserDialogComponent>,
     readonly dialogService: DialogService,
     private readonly i18n: I18nService,
     @Inject(DOCUMENT) private readonly document: Document,
-    @Optional() @Inject(MAT_DIALOG_DATA) private readonly data: TextChooserDialogData,
-    private destroyRef: QuietDestroyRef
+    @Optional() @Inject(MAT_DIALOG_DATA) private readonly data: TextChooserDialogData
   ) {
     // caniuse doesn't have complete data for the selection events api, but testing on BrowserStack shows the event is
     // fired at least as far back as iOS v7 on Safari 7.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
@@ -27,7 +27,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, objectId, QuietDestroyRef } from 'xforge-common/utils';
 import { BiblicalTermDoc } from '../../core/models/biblical-term-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
@@ -200,9 +200,9 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
   private verse$: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
   @ViewChild('biblicalTerms', { read: ElementRef }) biblicalTerms?: ElementRef;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly dialogService: DialogService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -5,7 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import {
   DraftSourcesAsSelectableProjectArrays,
@@ -30,8 +30,9 @@ export class ConfirmSourcesComponent {
     draftingSources: []
   };
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly i18nService: I18nService,
     private readonly activatedProject: ActivatedProjectService
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
@@ -6,7 +6,7 @@ import { TranslocoModule } from '@ngneat/transloco';
 import { Observable } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 
 export interface DraftApplyProgress {
   bookNum: number;
@@ -24,15 +24,15 @@ export interface DraftApplyProgress {
 })
 export class DraftApplyProgressDialogComponent {
   draftApplyProgress?: DraftApplyProgress;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     @Inject(MatDialogRef) private readonly dialogRef: MatDialogRef<DraftApplyProgressDialogComponent>,
     @Inject(MAT_DIALOG_DATA) data: { draftApplyProgress$: Observable<DraftApplyProgress | undefined> },
-    private readonly i18n: I18nService,
-    destroyRef: QuietDestroyRef
+    private readonly i18n: I18nService
   ) {
     data.draftApplyProgress$
-      .pipe(takeUntilDestroyed(destroyRef))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(progress => (this.draftApplyProgress = progress));
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -16,7 +16,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
 import { ProgressService, TextProgress } from '../../../shared/progress-service/progress.service';
@@ -111,8 +111,9 @@ export class DraftGenerationStepsComponent implements OnInit {
   private trainingDataQuerySubscription?: Subscription;
   private isTrainingDataInitialized: boolean = false;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     protected readonly activatedProject: ActivatedProjectService,
     private readonly draftSourcesService: DraftSourcesService,
     protected readonly featureFlags: FeatureFlagService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -24,7 +24,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { issuesEmailTemplate, QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, issuesEmailTemplate, QuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../../environments/environment';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -140,6 +140,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return environment.issueEmail;
   }
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
@@ -154,8 +156,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly onlineStatusService: OnlineStatusService,
     private readonly preTranslationSignupUrlService: PreTranslationSignupUrlService,
     protected readonly noticeService: NoticeService,
-    protected readonly urlService: ExternalUrlService,
-    private destroyRef: QuietDestroyRef
+    protected readonly urlService: ExternalUrlService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -18,7 +18,7 @@ import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectSettings } from '../../../core/models/sf-project-settings';
@@ -90,9 +90,10 @@ export class DraftSourcesComponent extends DataLoadingComponent {
 
   private controlStates = new Map<string, ElementState>();
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly destroyRef: QuietDestroyRef,
     private readonly paratextService: ParatextService,
     private readonly dialogService: DialogService,
     private readonly projectService: SFProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -14,7 +14,7 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SharedModule } from '../../../shared/shared.module';
 import {
   TrainingDataUploadDialogComponent,
@@ -42,13 +42,15 @@ export class TrainingDataMultiSelectComponent implements OnChanges, OnInit {
   sourceLanguage?: string;
   targetLanguage?: string;
   trainingDataOptions: TrainingDataOption[] = [];
+
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly dialogService: DialogService,
     private readonly i18n: I18nService,
     private readonly trainingDataService: TrainingDataService,
-    private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private readonly userService: UserService
   ) {}
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -24,7 +24,7 @@ import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { isString } from '../../../../type-utils';
 import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -59,9 +59,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   private draftDelta?: Delta;
   private targetDelta?: Delta;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly destroyRef: QuietDestroyRef,
     private readonly dialogService: DialogService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly draftHandlingService: DraftHandlingService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
@@ -5,7 +5,7 @@ import { combineLatest, startWith, tap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { TextDoc } from '../../../core/models/text-doc';
 import { Revision } from '../../../core/paratext.service';
@@ -35,8 +35,9 @@ export class EditorHistoryComponent implements OnChanges, OnInit, AfterViewInit 
   isViewInitialized = false;
   projectDoc: SFProjectProfileDoc | undefined;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly editorHistoryService: EditorHistoryService,
     readonly fontService: FontService,
     private readonly i18nService: I18nService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnChanges, ViewChild } from '@angular/
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EMPTY, Subject, combineLatest, startWith, switchMap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextComponent } from '../../../shared/text/text.component';
@@ -27,8 +27,9 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
 
   inputChanged$ = new Subject<void>();
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly projectService: SFProjectService,
     private readonly fontService: FontService
   ) {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -88,6 +88,7 @@ import { stripHtml } from 'xforge-common/util/string-util';
 import {
   browserLinks,
   getLinkHTML,
+  getQuietDestroyRef,
   isBlink,
   issuesEmailTemplate,
   objectId,
@@ -277,6 +278,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private readonly fabDiameter = 40;
   readonly fabVerticalCushion = 5;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly activatedRoute: ActivatedRoute,
     private readonly userService: UserService,
@@ -300,7 +303,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly editorTabPersistenceService: EditorTabPersistenceService,
     private readonly textDocService: TextDocService,
     private readonly draftGenerationService: DraftGenerationService,
-    private readonly destroyRef: QuietDestroyRef,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly mediaBreakpointService: MediaBreakpointService,
     private readonly permissionsService: PermissionsService

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -6,7 +6,7 @@ import { slice } from 'lodash-es';
 import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
 import { combineLatest } from 'rxjs';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 
 export interface MultiCursorViewer extends UserProfile {
   cursorColor: string;
@@ -24,10 +24,11 @@ export class MultiViewerComponent implements OnInit {
   maxAvatars: number = 3;
   isMenuOpen: boolean = false;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly breakpointObserver: BreakpointObserver,
-    private readonly breakpointService: MediaBreakpointService,
-    private destroyRef: QuietDestroyRef
+    private readonly breakpointService: MediaBreakpointService
   ) {}
 
   get avatarViewers(): MultiCursorViewer[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -5,7 +5,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
 
@@ -27,10 +27,11 @@ export class SuggestionsSettingsDialogComponent {
   private readonly projectUserConfigDoc: SFProjectUserConfigDoc;
   private confidenceThreshold$ = new BehaviorSubject<number>(20);
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     @Inject(MAT_DIALOG_DATA) data: SuggestionsSettingsDialogData,
-    readonly onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    readonly onlineStatusService: OnlineStatusService
   ) {
     this.projectDoc = data.projectDoc;
     this.projectUserConfigDoc = data.projectUserConfigDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -5,7 +5,7 @@ import { isEqual } from 'lodash-es';
 import Quill from 'quill';
 import { fromEvent } from 'rxjs';
 import { filter, first } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { TextComponent } from '../../shared/text/text.component';
 
 export interface SuggestionSelectedEvent {
@@ -37,10 +37,9 @@ export class SuggestionsComponent {
   private resizeObserver?: ResizeObserver;
   private top: number = 0;
 
-  constructor(
-    private readonly elemRef: ElementRef,
-    private destroyRef: QuietDestroyRef
-  ) {
+  private destroyRef = getQuietDestroyRef();
+
+  constructor(private readonly elemRef: ElementRef) {
     this.show = false;
     this.root.style.left = '0px';
     this.root.style.top = '0px';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -4,7 +4,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { map, repeat, take, timer } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { SelectableProject } from '../../../../core/paratext.service';
@@ -35,6 +35,8 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
   projectFetchFailed = false;
   syncFailed = false;
 
+  private destroyRef = getQuietDestroyRef();
+
   // Placed after 'Loading' when syncing
   animatedEllipsis$ = timer(500, 300).pipe(
     takeUntilDestroyed(this.destroyRef),
@@ -48,7 +50,6 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
   });
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     readonly onlineStatus: OnlineStatusService,
     private readonly editorTabAddResourceDialogService: EditorTabAddResourceDialogService,
     private readonly projectService: SFProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
 
@@ -13,10 +13,11 @@ export class EditorTabAddResourceDialogService {
   private projects?: ParatextProject[];
   private resources?: SelectableProject[];
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly paratextService: ParatextService,
-    private readonly userProjectsService: SFUserProjectsService,
-    private readonly destroyRef: QuietDestroyRef
+    private readonly userProjectsService: SFUserProjectsService
   ) {
     this.userProjectsService.projectDocs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projects => {
       if (projects == null) return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -13,7 +13,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { PermissionsService } from '../../../core/permissions.service';
@@ -25,8 +25,9 @@ import { EditorTabInfo } from './editor-tabs.types';
 export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> {
   private readonly menuItems$: Observable<TabMenuItem[]> = this.initMenuItems();
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
     private readonly userService: UserService,
     private readonly activatedProject: ActivatedProjectService,
     private readonly onlineStatus: OnlineStatusService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -8,7 +8,7 @@ import { filter, repeat, retry, tap } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
@@ -32,12 +32,13 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
   private trainingSub?: Subscription;
   private translationEngine?: RemoteTranslationEngine;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     noticeService: NoticeService,
     private readonly projectService: SFProjectService,
     private readonly translationEngineService: TranslationEngineService,
-    private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private readonly userService: UserService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -18,7 +18,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
@@ -45,6 +45,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   private translationEngine?: RemoteTranslationEngine;
   private projectDoc?: SFProjectProfileDoc;
   private projectDataChangesSub?: Subscription;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -55,8 +56,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     private readonly translationEngineService: TranslationEngineService,
     private readonly userService: UserService,
     public readonly progressService: ProgressService,
-    readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    readonly i18n: I18nService
   ) {
     super(noticeService);
     this.engineQualityStars = [];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -14,7 +14,7 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -58,6 +58,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
   private projectDoc?: SFProjectDoc;
   private term: string = '';
   private _userRows?: Row[];
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -68,8 +69,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
     private readonly onlineStatusService: OnlineStatusService,
     private readonly changeDetector: ChangeDetectorRef,
     private readonly dialogService: DialogService,
-    readonly urls: ExternalUrlService,
-    private destroyRef: QuietDestroyRef
+    readonly urls: ExternalUrlService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -5,7 +5,7 @@ import { ActivationEnd, Router } from '@angular/router';
 import ObjectID from 'bson-objectid';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, map, startWith, switchMap } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef, QuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
 import { PermissionsService } from '../app/core/permissions.service';
 import { SFProjectService } from '../app/core/sf-project.service';
@@ -55,12 +55,12 @@ export class ActiveProjectIdService implements IActiveProjectIdService {
 export class ActivatedProjectService {
   private _projectId$ = new BehaviorSubject<string | undefined>(undefined);
   private _projectDoc$ = new BehaviorSubject<SFProjectProfileDoc | undefined>(undefined);
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly projectService: SFProjectService,
     private readonly cacheService: CacheService,
-    @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService,
-    private destroyRef: QuietDestroyRef
+    @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
     activeProjectIdService.projectId$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -134,7 +134,7 @@ export class TestActivatedProjectService extends ActivatedProjectService {
     cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
-    super(projectService, cacheService, activeProjectIdService, noopDestroyRef as QuietDestroyRef);
+    super(projectService, cacheService, activeProjectIdService);
   }
 
   static withProjectId(projectId: string): TestActivatedProjectService {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, Input, NgZone, QueryList, ViewChildren } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isEqual } from 'lodash-es';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 
 const DEFAULT_SIZE = 100;
 
@@ -36,11 +36,9 @@ export class DonutChartComponent implements AfterViewInit {
   private _data: number[] = [];
   private _colors: string[] = [];
   private lastAnimationId: number = -1;
+  private destroyRef = getQuietDestroyRef();
 
-  constructor(
-    private readonly ngZone: NgZone,
-    private destroyRef: QuietDestroyRef
-  ) {}
+  constructor(private readonly ngZone: NgZone) {}
 
   ngAfterViewInit(): void {
     this.animateChange();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -4,7 +4,7 @@ import { UntypedFormControl, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 
 export interface EditNameDialogResult {
@@ -21,13 +21,13 @@ export class EditNameDialogComponent {
 
   name: UntypedFormControl = new UntypedFormControl('');
   isOnline: boolean = true;
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     public dialogRef: MatDialogRef<EditNameDialogComponent, EditNameDialogResult | 'close'>,
     public i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
-    @Inject(MAT_DIALOG_DATA) public data: { name: string; isConfirmation: boolean },
-    private destroyRef: QuietDestroyRef
+    @Inject(MAT_DIALOG_DATA) public data: { name: string; isConfirmation: boolean }
   ) {
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     this.name.setValue(data.name);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { AnonymousService } from 'xforge-common/anonymous.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 
 export interface FeatureFlag {
   readonly key: string;
@@ -33,10 +33,11 @@ export class FeatureFlagStore implements IFeatureFlagStore {
   private remoteFlags: { [key: string]: boolean } = {};
   private remoteFlagCacheExpiry: Date = new Date();
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly anonymousService: AnonymousService,
-    private readonly onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private readonly onlineStatusService: OnlineStatusService
   ) {
     // Cause the flags to be reloaded when coming online
     onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(status => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { lastValueFrom, Observable, Subject } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
@@ -49,6 +49,8 @@ export class FileService {
   private limitedStorageDialogPromise?: Promise<void>;
   private realtimeService?: RealtimeService;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     private readonly typeRegistry: TypeRegistry,
     private readonly offlineStore: OfflineStore,
@@ -56,8 +58,7 @@ export class FileService {
     private readonly http: HttpClient,
     private readonly authService: AuthService,
     private readonly commandService: CommandService,
-    private readonly dialogService: DialogService,
-    private destroyRef: QuietDestroyRef
+    private readonly dialogService: DialogService
   ) {}
 
   get fileSyncComplete$(): Observable<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, firstValueFrom, fromEvent, merge, Observable, of } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { NAVIGATOR } from './browser-globals';
 
 @Injectable({
@@ -16,10 +16,11 @@ export class OnlineStatusService {
   protected windowOnLineStatus$: BehaviorSubject<boolean>;
   private webSocketStatus$: BehaviorSubject<boolean | null> = new BehaviorSubject<boolean | null>(null);
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     protected readonly http: HttpClient,
-    @Inject(NAVIGATOR) protected readonly navigator: Navigator,
-    private destroyRef: QuietDestroyRef
+    @Inject(NAVIGATOR) protected readonly navigator: Navigator
   ) {
     this.appOnlineStatus$ = new BehaviorSubject<boolean>(this.navigator.onLine);
     this.windowOnLineStatus$ = new BehaviorSubject<boolean>(this.navigator.onLine);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -5,7 +5,7 @@ import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { BehaviorSubject } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectDoc } from '../../app/core/models/sf-project-doc';
 import { SFProjectService } from '../../app/core/sf-project.service';
 import { DataLoadingComponent } from '../data-loading-component';
@@ -76,12 +76,13 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
   private readonly searchTerm$: BehaviorSubject<string>;
   private readonly queryParameters$: BehaviorSubject<QueryParameters>;
 
+  private destroyRef = getQuietDestroyRef();
+
   constructor(
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
-    private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private readonly userService: UserService
   ) {
     super(noticeService);
     this.searchTerm$ = new BehaviorSubject<string>('');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -7,7 +7,7 @@ import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { BehaviorSubject } from 'rxjs';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { environment } from '../../environments/environment';
 import { DataLoadingComponent } from '../data-loading-component';
 import { DialogService } from '../dialog.service';
@@ -46,13 +46,13 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
   private readonly searchTerm$ = new BehaviorSubject<string>('');
   private readonly queryParameters$ = new BehaviorSubject<QueryParameters>(this.getQueryParameters());
   private readonly reload$ = new BehaviorSubject<void>(undefined);
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private dialogService: DialogService,
     noticeService: NoticeService,
     private readonly userService: UserService,
-    private readonly projectService: ProjectService,
-    private destroyRef: QuietDestroyRef
+    private readonly projectService: ProjectService
   ) {
     super(noticeService);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
@@ -12,10 +12,9 @@ import { QuietDestroyRef } from './utils';
 export class TestOnlineStatusService extends OnlineStatusService {
   constructor(
     public readonly httpClient: HttpClient,
-    public readonly mockedNavigator: Navigator,
-    destroyRef: QuietDestroyRef
+    public readonly mockedNavigator: Navigator
   ) {
-    super(httpClient, instance(mockedNavigator), destroyRef);
+    super(httpClient, instance(mockedNavigator));
     this.setIsOnline(true);
     this.setRealtimeServerSocketIsOnline(true);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { getQuietDestroyRef } from 'xforge-common/utils';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
 import { SFProjectService } from '../app/core/sf-project.service';
 import { compareProjectsForSorting } from '../app/shared/utils';
@@ -17,12 +17,12 @@ import { UserService } from './user.service';
 export class SFUserProjectsService {
   private projectDocs: Map<string, SFProjectProfileDoc> = new Map();
   private _projectDocs$ = new BehaviorSubject<SFProjectProfileDoc[] | undefined>(undefined);
+  private destroyRef = getQuietDestroyRef();
 
   constructor(
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
-    private readonly authService: AuthService,
-    private destroyRef: QuietDestroyRef
+    private readonly authService: AuthService
   ) {
     this.setup();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Optional } from '@angular/core';
+import { DestroyRef, inject, Injectable, Optional } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import Bowser from 'bowser';
 import ObjectID from 'bson-objectid';
@@ -216,4 +216,8 @@ export class QuietDestroyRef {
     }
     return () => {};
   }
+}
+
+export function getQuietDestroyRef(): QuietDestroyRef {
+  return new QuietDestroyRef(inject(DestroyRef), inject(ErrorReportingService, { optional: true }) ?? undefined);
 }


### PR DESCRIPTION
Having QuietDestroyRef inject DestroyRef does not produce a DestroyRef that is tied to the component injecting QuietDestroyRef. Instead, the DestroyRef needs to be injected in the context of the component or service actually needing the QuietDestroyRef.