### PR TITLE
SF-3247b Switch to quietTakeUntilDestroyed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -1,6 +1,5 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import Bugsnag from '@bugsnag/js';
 import { translate } from '@ngneat/transloco';
@@ -33,7 +32,9 @@ import {
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UserService } from 'xforge-common/user.service';
-import { issuesEmailTemplate, QuietDestroyRef, supportedBrowser } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
+
 import versionData from '../../../version.json';
 import { environment } from '../environments/environment';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
@@ -88,22 +89,22 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     readonly featureFlags: FeatureFlagService,
     private readonly pwaService: PwaService,
     onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.breakpointObserver
       .observe(this.breakpointService.width('>', Breakpoint.LG))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((value: BreakpointState) => (this.isDrawerPermanent = value.matches));
 
     this.breakpointObserver
       .observe(this.breakpointService.width('<', Breakpoint.SM))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((state: BreakpointState) => (this.isScreenTiny = state.matches));
 
     // Check full online status changes
     this.isAppOnline = onlineStatusService.isOnline;
-    onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(status => {
+    onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(status => {
       if (status !== this.isAppOnline) {
         this.isAppOnline = status;
         this.checkDeviceStorage();
@@ -111,7 +112,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     });
 
     // Check browser online status to allow checks with Auth0
-    onlineStatusService.onlineBrowserStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(status => {
+    onlineStatusService.onlineBrowserStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(status => {
       // Check authentication when coming back online
       // This is also run on first load when the websocket connects for the first time
       if (status && !this.isAppLoading) {
@@ -119,7 +120,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       }
     });
 
-    pwaService.hasUpdate$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => (this.hasUpdate = true));
+    pwaService.hasUpdate$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => (this.hasUpdate = true));
 
     // Google Analytics - send data at end of navigation so we get data inside the SPA client-side routing
     if (environment.releaseStage === 'live') {
@@ -127,7 +128,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         filter(e => e instanceof NavigationEnd),
         map(e => e as NavigationEnd)
       );
-      navEndEvent$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(e => {
+      navEndEvent$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(e => {
         if (this.isAppOnline) {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           gtag('config', 'UA-22170471-15', { page_path: e.urlAfterRedirects });
@@ -265,7 +266,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
     // Monitor current project
     this.activatedProjectService.projectDoc$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async (selectedProjectDoc?: SFProjectProfileDoc) => {
         this._selectedProjectDoc = selectedProjectDoc;
         if (this._selectedProjectDoc == null || !this._selectedProjectDoc.isLoaded) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -1,5 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Canon } from '@sillsdev/scripture';
 import { cloneDeep, reject } from 'lodash-es';
@@ -15,7 +14,8 @@ import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { objectId } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextAudioDoc } from '../../core/models/text-audio-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -65,7 +65,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
   private _loadingAudio: boolean = false;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     readonly i18n: I18nService,
     @Inject(MAT_DIALOG_DATA) public data: ChapterAudioDialogData,
     private readonly csvService: CsvService,
@@ -472,7 +472,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
     this.textAudioQuery.ready$
       .pipe(
         filter(ready => ready),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         const textAudioId: string = getTextAudioId(this.data.projectId, this.book, this.chapter);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
@@ -18,7 +17,7 @@ import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
@@ -36,7 +35,6 @@ import {
 } from '../import-questions-dialog/import-questions-dialog.component';
 import { QuestionDialogData } from '../question-dialog/question-dialog.component';
 import { QuestionDialogService } from '../question-dialog/question-dialog.service';
-
 @Component({
   selector: 'app-checking-overview',
   templateUrl: './checking-overview.component.html',
@@ -54,7 +52,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   private questionsQuery?: RealtimeQuery<QuestionDoc>;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly activatedRoute: ActivatedRoute,
     private readonly dialogService: DialogService,
     readonly featureFlags: FeatureFlagService,
@@ -206,7 +204,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       }),
       map(params => params['projectId'] as string)
     );
-    projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
+    projectId$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       this.loadingStarted();
       this.projectId = projectId;
       try {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -1,5 +1,14 @@
-import { Component, EventEmitter, Input, OnInit, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  QueryList,
+  ViewChild,
+  ViewChildren
+} from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
@@ -17,7 +26,7 @@ import { FileType } from 'xforge-common/models/file-offline-data';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
@@ -123,7 +132,7 @@ export class CheckingAnswersComponent implements OnInit {
     private readonly fileService: FileService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   get project(): SFProjectProfile | undefined {
@@ -140,7 +149,7 @@ export class CheckingAnswersComponent implements OnInit {
       return;
     }
     this.projectProfileDocChangesSubscription = projectProfileDoc.changes$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.setProjectAdmin();
       });
@@ -165,7 +174,7 @@ export class CheckingAnswersComponent implements OnInit {
       this.questionChangeSubscription!.unsubscribe();
     }
     this.questionChangeSubscription = questionDoc.remoteChanges$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(ops => {
         this.updateQuestionDocAudioUrls();
         // If the user hasn't added an answer yet and is able to, then
@@ -291,7 +300,7 @@ export class CheckingAnswersComponent implements OnInit {
 
   ngOnInit(): void {
     this.fileService.fileSyncComplete$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateQuestionDocAudioUrls());
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-input-form/checking-input-form.component.ts
@@ -1,6 +1,5 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { Answer } from 'realtime-server/lib/esm/scriptureforge/models/answer';
 import { Comment } from 'realtime-server/lib/esm/scriptureforge/models/comment';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -9,7 +8,7 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
 import { NoticeService } from 'xforge-common/notice.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { TextsByBookId } from '../../../../core/models/texts-by-book-id';
 import {
@@ -20,7 +19,6 @@ import {
 import { CheckingUtils } from '../../../checking.utils';
 import { TextAndAudioComponent } from '../../../text-and-audio/text-and-audio.component';
 import { AudioAttachment } from '../../checking-audio-player/checking-audio-player.component';
-
 export interface CheckingInput {
   text?: string;
   audio?: AudioAttachment;
@@ -64,11 +62,11 @@ export class CheckingInputFormComponent {
     private readonly i18n: I18nService,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly mediaBreakpointService: MediaBreakpointService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.breakpointObserver
       .observe(this.mediaBreakpointService.width('<', Breakpoint.MD))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((state: BreakpointState) => {
         this.isScreenSmall = state.matches;
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
@@ -1,4 +1,14 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
@@ -12,7 +22,6 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
-import { QuietDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../../../core/models/question-doc';
 import { TextAudioDoc } from '../../../../core/models/text-audio-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
@@ -54,7 +63,7 @@ export class CheckingQuestionComponent extends SubscriptionDisposable implements
   private isDestroyed = false;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly projectService: SFProjectService,
     private readonly i18n: I18nService
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-audio-player/checking-audio-player.component.ts
@@ -1,9 +1,7 @@
-import { AfterViewInit, Component, Input, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, Input, ViewChild } from '@angular/core';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
-
 export interface AudioAttachment {
   status?: 'denied' | 'processed' | 'recording' | 'reset' | 'stopped' | 'uploaded';
   url?: string;
@@ -23,11 +21,11 @@ export class CheckingAudioPlayerComponent implements AfterViewInit {
 
   constructor(
     readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngAfterViewInit(): void {
-    this.audioPlayer!.isAudioAvailable$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(newValue => {
+    this.audioPlayer!.isAudioAvailable$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(newValue => {
       setTimeout(() => (this._isAudioAvailable = newValue));
     });
     this._isAudioAvailable = this.audioPlayer!.isAudioAvailable$.value;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { merge } from 'lodash-es';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { Answer, AnswerStatus } from 'realtime-server/lib/esm/scriptureforge/models/answer';
@@ -10,7 +10,6 @@ import { FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { ComparisonOperator, PropertyFilter, QueryParameters, Sort } from 'xforge-common/query-parameters';
 import { RealtimeService } from 'xforge-common/realtime.service';
-import { IDestroyRef } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 
 export enum QuestionFilter {
@@ -54,7 +53,7 @@ export class CheckingQuestionsService {
   queryQuestions(
     projectId: string,
     options: { bookNum?: number; chapterNum?: number; activeOnly?: boolean; sort?: boolean } = {},
-    destroyRef: IDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<QuestionDoc>> {
     const queryParams: QueryParameters = {
       [obj<Question>().pathStr(q => q.projectRef)]: projectId
@@ -92,7 +91,7 @@ export class CheckingQuestionsService {
     relativeTo: Question | VerseRefData,
     questionFilter: QuestionFilter,
     prevOrNext: 'prev' | 'next',
-    destroyRef: IDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<QuestionDoc>> {
     const verseRef: VerseRefData = this.isVerseRefData(relativeTo) ? relativeTo : relativeTo.verseRef;
     const currentQuestion: Question | undefined = this.isVerseRefData(relativeTo) ? undefined : relativeTo;
@@ -159,7 +158,7 @@ export class CheckingQuestionsService {
   async queryFirstUnansweredQuestion(
     projectId: string,
     userId: string,
-    destroyRef: IDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<QuestionDoc>> {
     const queryParams: QueryParameters = {
       [obj<Question>().pathStr(q => q.projectRef)]: projectId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   Input,
@@ -12,7 +13,6 @@ import {
   SimpleChanges,
   ViewChildren
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatListItem } from '@angular/material/list';
 import { sortBy } from 'lodash-es';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -26,14 +26,13 @@ import { Subject, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { QuestionDoc } from '../../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../../core/models/sf-project-user-config-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TranslationEngineService } from '../../../core/translation-engine.service';
 import { BookChapter, bookChapterMatchesVerseRef, CheckingUtils } from '../../checking.utils';
-
 export interface QuestionChangeActionSource {
   /** True during events due to a questions doc change such as with a filter. */
   isQuestionListChange?: boolean;
@@ -76,7 +75,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
       return;
     }
     this.projectProfileDocChangesSubscription = projectProfileDoc.changes$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.changeDetector.markForCheck();
         this.setProjectAdmin();
@@ -90,7 +89,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     this._projectUserConfigDoc = projectUserConfigDoc;
     if (projectUserConfigDoc != null) {
       this.projectUserConfigDocChangesSubscription = projectUserConfigDoc.changes$
-        .pipe(takeUntilDestroyed(this.destroyRef))
+        .pipe(quietTakeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           this.changeDetector.markForCheck();
         });
@@ -134,14 +133,16 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     private readonly changeDetector: ChangeDetectorRef,
     private readonly projectService: SFProjectService,
     private readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngOnInit(): void {
     // Only mark as read if it has been viewed for a set period of time and not an accidental click
-    this.activeQuestionDoc$.pipe(debounceTime(2000), takeUntilDestroyed(this.destroyRef)).subscribe(questionDoc => {
-      this.updateElementsRead(questionDoc);
-    });
+    this.activeQuestionDoc$
+      .pipe(debounceTime(2000), quietTakeUntilDestroyed(this.destroyRef))
+      .subscribe(questionDoc => {
+        this.updateElementsRead(questionDoc);
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -1,16 +1,14 @@
-import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, first, map } from 'rxjs/operators';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../../core/models/text-doc';
 import { AudioPlayer } from '../../../shared/audio/audio-player';
 import { AudioPlayerComponent } from '../../../shared/audio/audio-player/audio-player.component';
 import { AudioHeadingRef, AudioTextRef, CheckingUtils } from '../../checking.utils';
-
 @Component({
   selector: 'app-checking-scripture-audio-player',
   templateUrl: './checking-scripture-audio-player.component.html',
@@ -52,7 +50,7 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
 
   constructor(
     readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngAfterViewInit(): void {
@@ -187,7 +185,7 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
         .pipe(
           filter(a => a),
           first(),
-          takeUntilDestroyed(this.destroyRef)
+          quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false })
         )
         .subscribe(() => {
           if (audioPlayer.audio == null) {
@@ -208,7 +206,7 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
       .pipe(
         map(() => this.getCurrentIndexInTimings(audio.currentTime)),
         distinctUntilChanged(),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         if (this._textDocId == null) return;
@@ -239,7 +237,7 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
   private subscribeToAudioFinished(audio: AudioPlayer): void {
     this.finishedSubscription?.unsubscribe();
     this.finishedSubscription = audio.finishedPlaying$
-      .pipe(first(), takeUntilDestroyed(this.destroyRef))
+      .pipe(first(), quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         if (this.canClose) this.close();
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-text/checking-text.component.ts
@@ -1,16 +1,14 @@
-import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { VerseRef } from '@sillsdev/scripture';
 import { IOutputAreaSizes } from 'angular-split';
 import { clone } from 'lodash-es';
 import { fromEvent, Observable, Subscription } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../../core/models/text-doc';
 import { TextComponent } from '../../../shared/text/text.component';
 import { verseRefFromMouseEvent } from '../../../shared/utils';
-
 @Component({
   selector: 'app-checking-text',
   templateUrl: './checking-text.component.html',
@@ -32,12 +30,12 @@ export class CheckingTextComponent implements AfterViewInit {
 
   constructor(
     readonly fontService: FontService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngAfterViewInit(): void {
     if (this.resizableContainer != null) {
-      this.resizableContainer.transitionEnd.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.resizableContainer.transitionEnd.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
         this.scrollToVerse(this.activeVerse);
       });
     }
@@ -143,7 +141,7 @@ export class CheckingTextComponent implements AfterViewInit {
       }
       this.clickSubs.push(
         fromEvent<MouseEvent>(element, 'click')
-          .pipe(takeUntilDestroyed(this.destroyRef))
+          .pipe(quietTakeUntilDestroyed(this.destroyRef))
           .subscribe(event => {
             if (this._id == null) {
               return;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -1,7 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Location } from '@angular/common';
-import { DebugElement, NgZone } from '@angular/core';
+import { DebugElement, DestroyRef, NgZone } from '@angular/core';
 import { ComponentFixture, discardPeriodicTasks, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogRef } from '@angular/material/dialog';
@@ -54,7 +54,7 @@ import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, getAudioBlob, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { IDestroyRef, objectId } from 'xforge-common/utils';
+import { objectId } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
@@ -2512,7 +2512,7 @@ class TestEnvironment {
       spyOn(checkingQuestionsService, 'queryQuestions').and.callFake((...args: any[]) =>
         // Call real function
         realQueryQuestions
-          .apply(checkingQuestionsService, args as [projectId: string, options: any, destroyRef: IDestroyRef])
+          .apply(checkingQuestionsService, args as [projectId: string, options: any, destroyRef: DestroyRef])
           .then(
             // Then alter `query.ready$` to emit false and complete
             (query: RealtimeQuery<QuestionDoc>) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1,6 +1,5 @@
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, NavigationBehaviorOptions, Router } from '@angular/router';
 import { Canon, VerseRef } from '@sillsdev/scripture';
 import { SplitComponent } from 'angular-split';
@@ -26,7 +25,8 @@ import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { objectId } from 'xforge-common/utils';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_DEFAULT_SHARE_ROLE } from '../../core/models/sf-project-role-info';
@@ -160,7 +160,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   private _showScriptureAudioPlayer: boolean = false;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly activatedRoute: ActivatedRoute,
     private readonly projectService: SFProjectService,
     private readonly checkingQuestionsService: CheckingQuestionsService,
@@ -476,7 +476,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
   ngOnInit(): void {
     combineLatest([this.activatedRoute.params, this.activatedRoute.queryParams])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async ([params, queryParams]) => {
         this.loadingStarted();
 
@@ -532,7 +532,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             // Subscribe to the projectDoc now that it is defined
             this.projectRemoteChangesSub?.unsubscribe();
             this.projectRemoteChangesSub = this.projectDoc.remoteChanges$
-              .pipe(takeUntilDestroyed(this.destroyRef))
+              .pipe(quietTakeUntilDestroyed(this.destroyRef))
               .subscribe(() => {
                 if (this.projectDoc != null && this.projectDoc.data != null) {
                   const roles = this.projectDoc.data.userRoles;
@@ -551,7 +551,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
                 map(() => this.projectDoc?.data?.checkingConfig.hideCommunityCheckingText),
                 startWith(this.projectDoc.data.checkingConfig.hideCommunityCheckingText),
                 distinctUntilChanged(),
-                takeUntilDestroyed(this.destroyRef)
+                quietTakeUntilDestroyed(this.destroyRef)
               )
               .subscribe(() => {
                 if (this.hideChapterText) this.showScriptureAudioPlayer = true;
@@ -560,7 +560,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
             this.projectDeleteSub?.unsubscribe();
             this.projectDeleteSub = this.projectDoc.delete$
-              .pipe(takeUntilDestroyed(this.destroyRef))
+              .pipe(quietTakeUntilDestroyed(this.destroyRef))
               .subscribe(() => this.onRemovedFromProject());
 
             this.projectService
@@ -620,7 +620,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             );
             if (this.projectDoc != null) {
               this.textAudioSub = merge(this.questionsQuery.ready$, this.projectDoc.remoteChanges$)
-                .pipe(takeUntilDestroyed(this.destroyRef))
+                .pipe(quietTakeUntilDestroyed(this.destroyRef))
                 .subscribe(() => this.updateAudioMissingWarning());
             }
 
@@ -628,7 +628,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             this.projectService.queryAudioText(routeProjectId, this.destroyRef).then(query => {
               this.textAudioQuery = query;
               this.audioChangedSub = merge(this.textAudioQuery.remoteChanges$, this.textAudioQuery.localChanges$)
-                .pipe(takeUntilDestroyed(this.destroyRef))
+                .pipe(quietTakeUntilDestroyed(this.destroyRef))
                 .subscribe(() => {
                   if (this.chapterAudioSource === '') {
                     this.hideChapterAudio();
@@ -638,7 +638,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
             // TODO: check for remote changes to file data more generically
             this.questionsRemoteChangesSub = this.questionsQuery.remoteDocChanges$
-              .pipe(takeUntilDestroyed(this.destroyRef))
+              .pipe(quietTakeUntilDestroyed(this.destroyRef))
               .subscribe((qd: QuestionDoc) => {
                 const isActiveQuestionDoc: boolean = qd.id === this.questionsList!.activeQuestionDoc?.id;
 
@@ -688,7 +688,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
                 // Throttle burst of events, such as when local and remote change events are emitted
                 // at the same time when question is added within scope.
                 throttleTime(100, asyncScheduler, { leading: false, trailing: true }),
-                takeUntilDestroyed(this.destroyRef)
+                quietTakeUntilDestroyed(this.destroyRef)
               )
               .subscribe(() => {
                 this.updateAudioMissingWarning();
@@ -711,14 +711,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     // Get hook on pre-creation of question so that we can check if will be in scope
     // before deciding to update visible questions.
     this.checkingQuestionsService.beforeQuestionCreated$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((data: PreCreationQuestionData) => {
         this.questionToBeCreated = data;
       });
 
     // Pre-creation question object is no longer needed after question is actually created
     this.checkingQuestionsService.afterQuestionCreated$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((data: QuestionDoc) => {
         if (data.id === this.questionToBeCreated?.docId) {
           this.questionToBeCreated = undefined;
@@ -730,7 +730,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     // Allows scrolling to the active question in the question list once it becomes visible
     this.breakpointObserver
       .observe(this.mediaBreakpointService.width('>', Breakpoint.SM, this.questionsPanel?.nativeElement))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((state: BreakpointState) => {
         this.calculateScriptureSliderPosition();
 
@@ -744,7 +744,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     // Allows hiding the prev/next chapter buttons for small screens
     this.breakpointObserver
       .observe(this.mediaBreakpointService.width('<', Breakpoint.MD))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((state: BreakpointState) => {
         this.isScreenSmall = state.matches;
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -1,5 +1,4 @@
-import { Component, ElementRef, Inject, NgZone, OnDestroy, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ElementRef, Inject, NgZone, OnDestroy, ViewChild } from '@angular/core';
 import { AbstractControl, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
@@ -14,7 +13,8 @@ import { ExternalUrlService } from 'xforge-common/external-url.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { RetryingRequest } from 'xforge-common/retrying-request.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { objectId } from 'xforge-common/utils';
 import { environment } from '../../../environments/environment';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { TextsByBookId } from '../../core/models/texts-by-book-id';
@@ -104,7 +104,7 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
   transceleratorInfo = this.i18n.interpolate('import_questions_dialog.transcelerator_paratext');
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     @Inject(MAT_DIALOG_DATA) public readonly data: ImportQuestionsDialogData,
     projectService: SFProjectService,
     private readonly checkingQuestionsService: CheckingQuestionsService,
@@ -116,7 +116,7 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
     readonly i18n: I18nService,
     readonly urls: ExternalUrlService
   ) {
-    this.filterForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.filterForm.valueChanges.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
       const searchTerm: string = (this.filterControl.value || '').toLowerCase();
       const fromRef = VerseRef.tryParse(this.fromControl.value || '');
       const toRef = VerseRef.tryParse(this.toControl.value || '');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -1,5 +1,4 @@
-import { Component, Inject, OnInit, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
@@ -9,7 +8,7 @@ import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question
 import { toStartAndEndVerseRefs } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { QuestionDoc } from '../../core/models/question-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
@@ -22,7 +21,6 @@ import { ParentAndStartErrorStateMatcher, SFValidators } from '../../shared/sfva
 import { combineVerseRefStrs } from '../../shared/utils';
 import { AudioAttachment } from '../checking/checking-audio-player/checking-audio-player.component';
 import { TextAndAudioComponent } from '../text-and-audio/text-and-audio.component';
-
 export interface QuestionDialogData {
   questionDoc?: QuestionDoc;
   projectDoc: SFProjectProfileDoc;
@@ -65,7 +63,7 @@ export class QuestionDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) private data: QuestionDialogData,
     readonly i18n: I18nService,
     readonly dialogService: DialogService,
-    private readonly destroyRef: QuietDestroyRef
+    private readonly destroyRef: DestroyRef
   ) {}
 
   get scriptureStart(): AbstractControl {
@@ -138,7 +136,7 @@ export class QuestionDialogComponent implements OnInit {
     // set initial enabled/disabled state for scriptureEnd
     this.updateScriptureEndEnabled();
 
-    this.scriptureStart.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.scriptureStart.valueChanges.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.scriptureStart.valid) {
         this.updateSelection();
       } else {
@@ -147,7 +145,7 @@ export class QuestionDialogComponent implements OnInit {
       // update enabled/disabled state for scriptureEnd
       this.updateScriptureEndEnabled();
     });
-    this.scriptureEnd.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.scriptureEnd.valueChanges.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.scriptureEnd.valid) {
         this.updateSelection();
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, ErrorHandler, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ErrorHandler, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
@@ -9,7 +8,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { hasStringProp } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectCreateSettings } from '../core/models/sf-project-create-settings';
@@ -17,7 +16,6 @@ import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { ParatextService, SelectableProject } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { compareProjectsForSorting, projectLabel } from '../shared/utils';
-
 interface ConnectProjectFormValues {
   settings: {
     checking: boolean;
@@ -59,7 +57,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
     private readonly onlineStatusService: OnlineStatusService,
     private readonly errorHandler: ErrorHandler,
     private readonly translocoService: TranslocoService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.connectProjectForm.disable();
@@ -114,7 +112,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       this.router.navigate(['/projects']);
     }
 
-    this.onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
+    this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
       this.isAppOnline = isOnline;
       if (isOnline) {
         if (this.projectsFromParatext == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
@@ -21,7 +21,6 @@ import { ProjectService } from 'xforge-common/project.service';
 import { QueryParameters, QueryResults } from 'xforge-common/query-parameters';
 import { RealtimeService } from 'xforge-common/realtime.service';
 import { RetryingRequest, RetryingRequestService } from 'xforge-common/retrying-request.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
 import { TransceleratorQuestion } from '../checking/import-questions-dialog/import-questions-dialog.component';
 import { EventMetric } from '../event-metrics/event-metric';
 import { ShareLinkType } from '../shared/share/share-dialog.component';
@@ -139,7 +138,7 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     sfProjectId: string,
     bookNum: number,
     chapterNum: number,
-    destroyRef: QuietDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<NoteThreadDoc>> {
     const queryParams: QueryParameters = {
       [obj<NoteThread>().pathStr(t => t.projectRef)]: sfProjectId,
@@ -150,24 +149,21 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, queryParams, destroyRef);
   }
 
-  queryAudioText(sfProjectId: string, destroyRef: QuietDestroyRef): Promise<RealtimeQuery<TextAudioDoc>> {
+  queryAudioText(sfProjectId: string, destroyRef: DestroyRef): Promise<RealtimeQuery<TextAudioDoc>> {
     const queryParams: QueryParameters = {
       [obj<TextAudio>().pathStr(t => t.projectRef)]: sfProjectId
     };
     return this.realtimeService.subscribeQuery(TextAudioDoc.COLLECTION, queryParams, destroyRef);
   }
 
-  queryBiblicalTerms(sfProjectId: string, destroyRef: QuietDestroyRef): Promise<RealtimeQuery<BiblicalTermDoc>> {
+  queryBiblicalTerms(sfProjectId: string, destroyRef: DestroyRef): Promise<RealtimeQuery<BiblicalTermDoc>> {
     const queryParams: QueryParameters = {
       [obj<BiblicalTerm>().pathStr(t => t.projectRef)]: sfProjectId
     };
     return this.realtimeService.subscribeQuery(BiblicalTermDoc.COLLECTION, queryParams, destroyRef);
   }
 
-  queryBiblicalTermNoteThreads(
-    sfProjectId: string,
-    destroyRef: QuietDestroyRef
-  ): Promise<RealtimeQuery<NoteThreadDoc>> {
+  queryBiblicalTermNoteThreads(sfProjectId: string, destroyRef: DestroyRef): Promise<RealtimeQuery<NoteThreadDoc>> {
     const parameters: QueryParameters = {
       [obj<NoteThread>().pathStr(t => t.projectRef)]: sfProjectId,
       [obj<NoteThread>().pathStr(t => t.biblicalTermId)]: { $ne: null }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { InteractiveTranslator, InteractiveTranslatorFactory, LatinWordTokenizer } from '@sillsdev/machine';
 import { Canon } from '@sillsdev/scripture';
@@ -12,12 +11,11 @@ import { filter, share } from 'rxjs/operators';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OfflineData, OfflineStore } from 'xforge-common/offline-store';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { HttpClient } from '../machine-api/http-client';
 import { RemoteTranslationEngine } from '../machine-api/remote-translation-engine';
 import { EDITED_SEGMENTS, EditedSegmentData } from './models/edited-segment-data';
 import { SFProjectService } from './sf-project.service';
-
 /**
  * A service to access features for translation suggestions and training the translation engine
  */
@@ -40,7 +38,7 @@ export class TranslationEngineService {
     private readonly machineHttp: HttpClient,
     private readonly noticeService: NoticeService,
     private readonly router: Router,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.onlineStatus$ = this.onlineStatusService.onlineStatus$.pipe(
       filter(online => online),
@@ -183,7 +181,7 @@ export class TranslationEngineService {
   }
 
   private onlineCallback(callback: () => any): void {
-    this.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(callback);
+    this.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(callback);
   }
 
   private translationSuggestionId(projectRef: string, bookNum: number, segment: string): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { MatDialogConfig } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
@@ -13,12 +12,10 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectService } from '../core/sf-project.service';
 import { EventMetric } from './event-metric';
 import { EventMetricDialogComponent } from './event-metric-dialog.component';
-
 interface Row {
   dialogData: EventMetric;
   eventType: string;
@@ -73,7 +70,7 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
     private readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -114,7 +111,7 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
           }
           this.loadingFinished();
         }),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, ErrorHandler } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ErrorHandler } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest } from 'rxjs';
@@ -15,11 +14,10 @@ import { en, I18nService } from 'xforge-common/i18n.service';
 import { LocationService } from 'xforge-common/location.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { ObjectPaths } from '../../type-utils';
 import { SFProjectService } from '../core/sf-project.service';
-
 export interface AnonymousShareKeyDetails {
   projectName: string;
   role: string;
@@ -60,7 +58,7 @@ export class JoinComponent extends DataLoadingComponent {
     private readonly router: Router,
     private readonly errorHandler: ErrorHandler,
     noticeService: NoticeService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     const joining$ = this.route.params.pipe(
@@ -75,7 +73,7 @@ export class JoinComponent extends DataLoadingComponent {
       map(([joining, _]) => joining),
       distinctUntilChanged()
     );
-    checkLinkSharing$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(joining => {
+    checkLinkSharing$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(joining => {
       // Set locale only if not logged in
       if (this.authService.currentUserId == null) {
         this.i18nService.setLocale(joining.locale);
@@ -83,7 +81,7 @@ export class JoinComponent extends DataLoadingComponent {
       this.initialize(joining.shareKey);
     });
     this.onlineStatusService.onlineStatus$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateOfflineJoiningStatus());
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { isPTUser } from 'realtime-server/lib/esm/common/models/user';
@@ -12,7 +11,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../../environments/environment';
 import { ObjectPaths } from '../../type-utils';
 import { ParatextProject } from '../core/models/paratext-project';
@@ -21,7 +20,6 @@ import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { ParatextService } from '../core/paratext.service';
 import { PermissionsService } from '../core/permissions.service';
 import { SFProjectService } from '../core/sf-project.service';
-
 /** Presents user with list of available projects to open or connect to. */
 @Component({
   selector: 'app-my-projects',
@@ -55,7 +53,7 @@ export class MyProjectsComponent implements OnInit {
     private readonly permissions: PermissionsService,
     private readonly noticeService: NoticeService,
     private readonly router: Router,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   /** If we are aware of any SF or PT projects that the user can access. */
@@ -83,7 +81,7 @@ export class MyProjectsComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     await this.loadUser();
     this.userProjectsService.projectDocs$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((projects?: SFProjectProfileDoc[]) => {
         if (projects == null) return;
         this.userConnectedProjects = projects.filter(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.component.ts
@@ -1,5 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { Canon } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -12,14 +11,13 @@ import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.ser
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
 import { SFProjectService } from '../core/sf-project.service';
 import { NmtDraftAuthGuard, SettingsAuthGuard, SyncAuthGuard, UsersAuthGuard } from '../shared/project-router.guard';
-
 @Component({
   selector: 'app-navigation',
   templateUrl: './navigation.component.html',
@@ -86,9 +84,9 @@ export class NavigationComponent {
     private readonly router: Router,
     private readonly activatedProjectService: ActivatedProjectService,
     readonly featureFlags: FeatureFlagService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
-    this.activatedProjectService.projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(projectId => {
+    this.activatedProjectService.projectId$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(projectId => {
       this.updateProjectUserConfig(projectId);
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -1,16 +1,14 @@
-import { Component, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, forwardRef, Input, OnDestroy, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, UntypedFormControl, ValidatorFn } from '@angular/forms';
 import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { translate } from '@ngneat/transloco';
 import { BehaviorSubject, combineLatest, fromEvent, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith, takeUntil, tap } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SelectableProject } from '../core/paratext.service';
 import { SFValidators } from '../shared/sfvalidators';
 import { projectLabel } from '../shared/utils';
-
 // A value accessor is necessary in order to create a custom form control
 export const PROJECT_SELECT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -25,7 +23,7 @@ export const PROJECT_SELECT_VALUE_ACCESSOR: any = {
   styleUrls: ['project-select.component.scss'],
   providers: [PROJECT_SELECT_VALUE_ACCESSOR]
 })
-export class ProjectSelectComponent implements ControlValueAccessor {
+export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
   @Output() valueChange: EventEmitter<string> = new EventEmitter<string>(true);
   @Output() projectSelect = new EventEmitter<SelectableProject>();
 
@@ -60,9 +58,9 @@ export class ProjectSelectComponent implements ControlValueAccessor {
 
   projectLabel = projectLabel;
 
-  constructor(private destroyRef: QuietDestroyRef) {
+  constructor(private destroyRef: DestroyRef) {
     this.paratextIdControl.valueChanges
-      .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+      .pipe(distinctUntilChanged(), quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((value: SelectableProject) => {
         this.valueChange.next(value.paratextId);
 
@@ -79,7 +77,7 @@ export class ProjectSelectComponent implements ControlValueAccessor {
             typeof this.paratextIdControl.value === 'string' &&
             p[0].name.toLowerCase() === this.paratextIdControl.value.toLowerCase()
         ),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(projects => this.paratextIdControl.setValue(projects[0]));
     this.resources$
@@ -90,7 +88,7 @@ export class ProjectSelectComponent implements ControlValueAccessor {
             typeof this.paratextIdControl.value === 'string' &&
             r[0].name.toLowerCase() === this.paratextIdControl.value.toLowerCase()
         ),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(resources => this.paratextIdControl.setValue(resources[0]));
   }
@@ -152,12 +150,21 @@ export class ProjectSelectComponent implements ControlValueAccessor {
     this.value = value;
   }
 
+  destroyed = false;
+  ngOnDestroy(): void {
+    this.destroyed = true;
+  }
+
   registerOnChange(fn: any): void {
-    this.valueChange.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
+    // Angular calls registerOnChange during tear-down to "remove" the callback. Make this a noop to prevent NG0911
+    // https://angular.dev/api/forms/ControlValueAccessor#registerOnChange
+    if (!this.destroyed) this.valueChange.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   registerOnTouched(fn: any): void {
-    this.valueChange.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
+    // Angular calls registerOnTouched during tear-down to "remove" the callback. Make this a noop to prevent NG0911
+    // https://angular.dev/api/forms/ControlValueAccessor#registerOnTouched
+    if (!this.destroyed) this.valueChange.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   autocompleteOpened(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Canon } from '@sillsdev/scripture';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -10,12 +9,11 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../../environments/environment';
 import { ResumeCheckingService } from '../checking/checking/resume-checking.service';
 import { PermissionsService } from '../core/permissions.service';
 import { SFProjectService } from '../core/sf-project.service';
-
 type TaskType = 'translate' | 'checking';
 
 @Component({
@@ -33,7 +31,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     private readonly resumeCheckingService: ResumeCheckingService,
     private readonly dialogService: DialogService,
     noticeService: NoticeService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -56,16 +54,16 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     const userDoc = await this.userService.getCurrentUser();
     const navigateToProject$: Observable<string> = new Observable(subscriber => {
       let projectId: string | undefined;
-      projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(id => {
+      projectId$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(id => {
         projectId = id;
         subscriber.next(projectId);
       });
-      userDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      userDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
         subscriber.next(projectId);
       });
     });
 
-    navigateToProject$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
+    navigateToProject$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       if (userDoc.data?.sites[environment.siteId].projects?.includes(projectId)) {
         this.navigateToProject(projectId);
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Input, OnInit } from '@angular/core';
 import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -11,8 +10,7 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
@@ -25,7 +23,6 @@ import { DraftGenerationService } from '../translate/draft-generation/draft-gene
 import { DraftInformationComponent } from '../translate/draft-generation/draft-information/draft-information.component';
 import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
 import { ServalAdministrationService } from './serval-administration.service';
-
 interface Row {
   id: string;
   type: string;
@@ -85,7 +82,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
     private readonly servalAdministrationService: ServalAdministrationService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -188,7 +185,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
             return of(undefined);
           }
         }),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe((build: BuildDto | undefined) => {
         this.lastCompletedBuild = build;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject, SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -10,12 +9,11 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { projectLabel } from '../shared/utils';
 import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../translate/draft-generation/draft-utils';
 import { ServalAdministrationService } from './serval-administration.service';
-
 interface SourceData {
   id: string;
   label: string;
@@ -86,7 +84,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly servalAdministrationService: ServalAdministrationService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.searchTerm$ = new BehaviorSubject<string>('');
@@ -104,7 +102,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
         obj<Project>().pathStr(p => p.name),
         obj<SFProjectProfile>().pathStr(p => p.shortName)
       ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(searchResults => {
         this.projectDocs = searchResults.docs;
         this.length = searchResults.unpagedCount;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatDialogConfig } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -24,14 +23,13 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ParatextProject } from '../core/models/paratext-project';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { SFProjectSettings } from '../core/models/sf-project-settings';
 import { ParatextService, SelectableProject } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { DeleteProjectDialogComponent } from './delete-project-dialog/delete-project-dialog.component';
-
 /** Allows user to configure high-level settings of how SF will use their Paratext project. */
 @Component({
   selector: 'app-settings',
@@ -116,7 +114,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     readonly featureFlags: FeatureFlagService,
     readonly externalUrls: ExternalUrlService,
     private readonly activatedProjectService: ActivatedProjectService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.loading = true;
@@ -204,7 +202,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
       map(params => params['projectId'] as string)
     );
     combineLatest([this.onlineStatusService.onlineStatus$, projectId$])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async ([isOnline, projectId]) => {
         this.isAppOnline = isOnline;
         if (isOnline && this.projects == null) {
@@ -222,7 +220,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
             if (this.projectDoc != null) {
               this.updateSettingsInfo();
               this.updateNonSelectableProjects();
-              this.projectDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+              this.projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
                 this.updateNonSelectableProjects();
                 this.setIndividualControlDisabledStates();
               });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -1,10 +1,19 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslocoModule, translate } from '@ngneat/transloco';
-import { Observable, Subscription, interval, timer } from 'rxjs';
+import { translate, TranslocoModule } from '@ngneat/transloco';
+import { interval, Observable, Subscription, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -14,7 +23,8 @@ import {
   SupportedBrowsersDialogComponent
 } from 'xforge-common/supported-browsers-dialog/supported-browsers-dialog.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef, audioRecordingMimeType, objectId } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { audioRecordingMimeType, objectId } from 'xforge-common/utils';
 import { SingleButtonAudioPlayerComponent } from '../../checking/checking/single-button-audio-player/single-button-audio-player.component';
 import { SharedModule } from '../shared.module';
 
@@ -77,7 +87,7 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
     private readonly noticeService: NoticeService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
     private readonly dialogService: DialogService,
-    private readonly destroyRef: QuietDestroyRef
+    private readonly destroyRef: DestroyRef
   ) {
     this.showCountdown = data?.countdown ?? false;
     if (data?.audio != null) {
@@ -115,11 +125,11 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
   }
 
   registerOnChange(fn: ((value: AudioAttachment) => void) | undefined): void {
-    this.status.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
+    this.status.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   registerOnTouched(fn: ((value: AudioAttachment) => void) | undefined): void {
-    this._onTouched.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(fn);
+    this._onTouched.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(fn);
   }
 
   processAudio(): void {
@@ -259,7 +269,7 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
     };
 
     const refreshRate: Observable<number> = interval(150);
-    this.refreshWaveformSub = refreshRate.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(_ => drawWaveForm());
+    this.refreshWaveformSub = refreshRate.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(_ => drawWaveForm());
   }
 
   private initCanvasContext(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -1,18 +1,15 @@
-import { Injectable, OnDestroy } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable, OnDestroy } from '@angular/core';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-import { Subscription, asyncScheduler, merge, startWith, tap, throttleTime } from 'rxjs';
+import { asyncScheduler, merge, startWith, Subscription, tap, throttleTime } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
-
 export class Progress {
   translated: number = 0;
   blank: number = 0;
@@ -52,7 +49,7 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
     private readonly permissionsService: PermissionsService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
 
@@ -64,7 +61,7 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
           this.initialize(project.id);
         }),
         throttleTime(1000, asyncScheduler, { leading: false, trailing: true }),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(project => {
         this.initialize(project.id);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-group-header.component.ts
@@ -2,6 +2,7 @@ import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   ElementRef,
   EventEmitter,
   Input,
@@ -13,7 +14,6 @@ import {
   SimpleChanges,
   ViewChildren
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   BehaviorSubject,
   debounceTime,
@@ -24,12 +24,11 @@ import {
   Subscription
 } from 'rxjs';
 import { LocaleDirection } from 'xforge-common/models/i18n-locale';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TabMenuItem, TabMenuService } from '../../sf-tab-group';
 import { TabHeaderPointerEvent, TabLocation, TabMoveEvent } from '../sf-tabs.types';
 import { TabHeaderComponent } from '../tab-header/tab-header.component';
 import { TabComponent } from '../tab/tab.component';
-
 @Component({
   selector: 'app-tab-group-header',
   templateUrl: './tab-group-header.component.html',
@@ -58,7 +57,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
   direction: LocaleDirection = 'ltr';
 
   // Used to time scroll movements while scrolling via left/right scroll buttons
-  private scrollTimer$ = interval(20).pipe(takeUntilDestroyed(this.destroyRef));
+  private scrollTimer$ = interval(20).pipe(quietTakeUntilDestroyed(this.destroyRef));
 
   private scrollButtonSubscription?: Subscription;
   private intersectionObserver?: IntersectionObserver;
@@ -67,7 +66,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
   private tabsWrapper!: HTMLElement;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly elementRef: ElementRef<HTMLElement>,
     private readonly tabMenuService: TabMenuService<string>
   ) {}
@@ -96,12 +95,12 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
 
     // Check if scroll is at the start or end to enable/disable scroll buttons
     fromEvent(this.tabsWrapper, 'scroll')
-      .pipe(takeUntilDestroyed(this.destroyRef), debounceTime(50))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef), debounceTime(50))
       .subscribe(() => this.detectScrollLimit());
 
     // Check if scroll is at the start or end to enable/disable scroll buttons
     fromEvent(this.tabsWrapper, 'wheel')
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((e: Event) => this.scrollOnWheel(e as WheelEvent));
   }
 
@@ -213,18 +212,20 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
 
   private initOverflowHandler(): void {
     // Handle tab overflow
-    this.overflowing$.pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged()).subscribe(isOverflowing => {
-      const host = this.elementRef.nativeElement;
+    this.overflowing$
+      .pipe(quietTakeUntilDestroyed(this.destroyRef), distinctUntilChanged())
+      .subscribe(isOverflowing => {
+        const host = this.elementRef.nativeElement;
 
-      if (isOverflowing) {
-        host.classList.add('overflowing');
-      } else {
-        host.classList.remove('overflowing');
-      }
+        if (isOverflowing) {
+          host.classList.add('overflowing');
+        } else {
+          host.classList.remove('overflowing');
+        }
 
-      // Enable or disable scroll buttons
-      this.detectScrollLimit();
-    });
+        // Enable or disable scroll buttons
+        this.detectScrollLimit();
+      });
   }
 
   private detectOverflow(): void {
@@ -258,7 +259,7 @@ export class TabGroupHeaderComponent implements OnChanges, OnInit, AfterViewInit
 
   private startButtonScrolling(which: 'start' | 'end'): void {
     this.scrollButtonSubscription?.unsubscribe();
-    this.scrollButtonSubscription = this.scrollTimer$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.scrollButtonSubscription = this.scrollTimer$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.scroll(which);
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-scroll-button/tab-scroll-button.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group-header/tab-scroll-button/tab-scroll-button.component.ts
@@ -1,9 +1,7 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, HostBinding, Inject, Input, OnInit, Output } from '@angular/core';
 import { BehaviorSubject, distinctUntilChanged, fromEvent, merge } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
-
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 @Component({
   selector: 'app-tab-scroll-button',
   templateUrl: './tab-scroll-button.component.html',
@@ -22,20 +20,20 @@ export class TabScrollButtonComponent implements OnInit {
   scroll$ = new BehaviorSubject(false);
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     @Inject(DOCUMENT) private readonly document: Document
   ) {}
 
   ngOnInit(): void {
     // Stop button scrolling on mouseup or when mouse leaves the document
     merge(fromEvent(this.document, 'mouseup'), fromEvent(this.document, 'mouseleave'))
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.isMouseDown = false;
         this.scroll$.next(false);
       });
 
-    this.scroll$.pipe(takeUntilDestroyed(this.destroyRef), distinctUntilChanged()).subscribe(scroll => {
+    this.scroll$.pipe(quietTakeUntilDestroyed(this.destroyRef), distinctUntilChanged()).subscribe(scroll => {
       if (scroll) {
         this.scrollStart.emit();
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -1,12 +1,10 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { isEqual } from 'lodash-es';
 import { BehaviorSubject, distinctUntilChanged, filter, map, Observable, Subject, takeUntil } from 'rxjs';
 import { moveItemInReadonlyArray, transferItemAcrossReadonlyArrays } from 'xforge-common/util/array-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TabLocation } from '../sf-tabs.types';
 import { TabGroup } from './tab-group';
-
 export type FlatTabInfo<TGroupId extends string, T extends TabInfo<string>> = T & {
   groupId: TGroupId;
   isSelected: boolean;
@@ -56,7 +54,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
 
   tabsConsolidated$ = this.tabsConsolidatedSource$.asObservable();
 
-  constructor(private readonly destroyRef: QuietDestroyRef) {}
+  constructor(private readonly destroyRef: DestroyRef) {}
 
   setTabGroups(tabGroups: TabGroup<TGroupId, T>[]): void {
     this.groups.clear();
@@ -229,7 +227,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
         group.tabsAdded$
           .pipe(
             takeUntil(this.tabsConsolidated$.pipe(filter(consolidated => !consolidated))),
-            takeUntilDestroyed(this.destroyRef)
+            quietTakeUntilDestroyed(this.destroyRef)
           )
           .subscribe(({ tabs, selectedAddTab }) => {
             const deconsolidationGroupTabs: readonly T[] = this.tabsToDeconsolidate!.get(group.groupId)!;
@@ -268,7 +266,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
     intoGroup.tabRemoved$
       .pipe(
         takeUntil(this.tabsConsolidated$.pipe(filter(consolidated => !consolidated))),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(({ tab }) => {
         if (this.tabsToDeconsolidate == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -1,5 +1,13 @@
-import { ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { FormGroupDirective, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -10,12 +18,11 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectService } from '../../core/sf-project.service';
 import { ShareBaseComponent } from './share-base.component';
-
 /** UI to share project access with new users, such as by sending an invitation email. */
 @Component({
   selector: 'app-share-control',
@@ -51,11 +58,11 @@ export class ShareControlComponent extends ShareBaseComponent {
     private readonly onlineStatusService: OnlineStatusService,
     private readonly changeDetector: ChangeDetectorRef,
     userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(userService);
     combineLatest([this.projectId$, this.onlineStatusService.onlineStatus$])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async ([projectId]) => {
         if (projectId === '') {
           return;
@@ -68,11 +75,11 @@ export class ShareControlComponent extends ShareBaseComponent {
           this.roleControl.setValue(this.defaultShareRole);
         }
         this.projectDoc.remoteChanges$
-          .pipe(takeUntilDestroyed(this.destroyRef))
+          .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
           .subscribe(() => this.updateFormEnabledStateAndLinkSharingKey());
       });
     combineLatest([this.onlineStatusService.onlineStatus$, this.roleControl.valueChanges])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateFormEnabledStateAndLinkSharingKey());
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -1,5 +1,4 @@
-import { Component, Inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -12,12 +11,11 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../../../environments/environment';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SFProjectService } from '../../core/sf-project.service';
 import { ShareBaseComponent } from './share-base.component';
-
 export interface ShareDialogData {
   projectId: string;
   defaultRole: SFProjectRole;
@@ -62,7 +60,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     private readonly projectService: SFProjectService,
     private readonly onlineStatusService: OnlineStatusService,
     userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(userService);
     this.projectId = this.data.projectId;
@@ -72,7 +70,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     ]).then(value => {
       this.projectDoc = value[0];
       this.isProjectAdmin = value[1];
-      this.projectDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
         if (this.shareLinkUsageOptions.length === 0) {
           this.dialogRef.close();
         } else if (!this.shareLinkUsageOptions.includes(this.shareLinkType)) {
@@ -86,7 +84,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
         this.shareLinkType = this.shareLinkUsageOptions[0];
       }
       this.onlineStatusService.onlineStatus$
-        .pipe(takeUntilDestroyed(this.destroyRef))
+        .pipe(quietTakeUntilDestroyed(this.destroyRef))
         .subscribe(() => this.updateSharingKey());
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -1,5 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Input, Output } from '@angular/core';
 import { ProgressBarMode } from '@angular/material/progress-bar';
 import { OtJson0Op } from 'ot-json0';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -7,11 +6,10 @@ import { BehaviorSubject, map, merge, Observable } from 'rxjs';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectDoc } from '../../core/models/sf-project-doc';
 import { ProjectNotificationService } from '../../core/project-notification.service';
 import { SFProjectService } from '../../core/sf-project.service';
-
 export class ProgressState {
   constructor(
     public progressValue: number,
@@ -70,7 +68,7 @@ export class SyncProgressComponent {
     private readonly featureFlags: FeatureFlagService,
     private readonly errorReportingService: ErrorReportingService,
     private readonly onlineStatus: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.projectNotificationService.setNotifySyncProgressHandler((projectId: string, progressState: ProgressState) => {
       this.updateProgressState(projectId, progressState);
@@ -131,7 +129,7 @@ export class SyncProgressComponent {
       this.sourceProjectDoc == null
         ? this._projectDoc.remoteChanges$
         : merge(this._projectDoc.remoteChanges$, this.sourceProjectDoc.remoteChanges$);
-    checkSyncStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.checkSyncStatus());
+    checkSyncStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => this.checkSyncStatus());
 
     // Subscribe to SignalR notifications for the target project
     await this.projectNotificationService.subscribeToProject(this._projectDoc.id);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -12,12 +11,11 @@ import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../../environments/environment';
 import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
-
 /** Reports as to whether a given project is actively syncing right now. */
 export function isSFProjectSyncing(project: SFProjectProfile): boolean {
   return project.sync.queuedCount > 0;
@@ -52,7 +50,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     private readonly onlineStatusService: OnlineStatusService,
     private readonly dialogService: DialogService,
     private readonly authService: AuthService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -144,7 +142,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
+    this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
       this.isAppOnline = isOnline;
       if (this.isAppOnline && this.paratextUsername == null) {
         const username = await firstValueFrom(this.paratextService.getParatextUsername());
@@ -165,14 +163,14 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
       map(params => params['projectId'] as string)
     );
 
-    projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
+    projectId$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       this.projectDoc = await this.projectService.get(projectId);
       this.checkSyncStatus();
       this.loadingFinished();
 
       // Check to see if a sync has started when the project document changes
       // TODO Clean up the use of nested subscribe()
-      this.projectDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
         if (!this.syncActive) {
           this.checkSyncStatus();
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/text-chooser-dialog/text-chooser-dialog.component.ts
@@ -1,5 +1,4 @@
-import { Component, ElementRef, Inject, Optional, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ElementRef, Inject, Optional, ViewChild } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { VerseRef } from '@sillsdev/scripture';
 import { toVerseRef, VerseRefData } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
@@ -8,7 +7,7 @@ import { auditTime } from 'rxjs/operators';
 import { DOCUMENT } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../core/models/text-doc';
 import { TextsByBookId } from '../core/models/texts-by-book-id';
 import {
@@ -16,7 +15,6 @@ import {
   ScriptureChooserDialogData
 } from '../scripture-chooser-dialog/scripture-chooser-dialog.component';
 import { TextComponent } from '../shared/text/text.component';
-
 export interface TextChooserDialogData {
   bookNum: number;
   chapterNum: number;
@@ -60,14 +58,14 @@ export class TextChooserDialogComponent {
     private readonly i18n: I18nService,
     @Inject(DOCUMENT) private readonly document: Document,
     @Optional() @Inject(MAT_DIALOG_DATA) private readonly data: TextChooserDialogData,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     // caniuse doesn't have complete data for the selection events api, but testing on BrowserStack shows the event is
     // fired at least as far back as iOS v7 on Safari 7.
     // Edge 42 with EdgeHTML 17 also fires the events.
     // Firefox and Chrome also support it. We can degrade gracefully by getting the selection when the dialog closes.
     fromEvent(this.document, 'selectionchange')
-      .pipe(auditTime(100), takeUntilDestroyed(this.destroyRef))
+      .pipe(auditTime(100), quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateSelection());
 
     this.bookNum = this.data.bookNum;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ElementRef, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Sort } from '@angular/material/sort';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon, VerseRef } from '@sillsdev/scripture';
@@ -27,7 +26,8 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { UserService } from 'xforge-common/user.service';
-import { objectId, QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { objectId } from 'xforge-common/utils';
 import { BiblicalTermDoc } from '../../core/models/biblical-term-doc';
 import { NoteThreadDoc } from '../../core/models/note-thread-doc';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
@@ -202,7 +202,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
   @ViewChild('biblicalTerms', { read: ElementRef }) biblicalTerms?: ElementRef;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly dialogService: DialogService,
@@ -311,7 +311,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
     this.projectId$
       .pipe(
         filter(projectId => projectId !== ''),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async projectId => {
         this.projectDoc = await this.projectService.getProfile(projectId);
@@ -333,7 +333,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
         ])
           .pipe(
             filter(([bookNum, chapter, verse]) => bookNum !== 0 && chapter !== 0 && verse !== null),
-            takeUntilDestroyed(this.destroyRef)
+            quietTakeUntilDestroyed(this.destroyRef)
           )
           .subscribe(([bookNum, chapter, verse]) => {
             this.filterBiblicalTerms(bookNum, chapter, verse);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -1,11 +1,10 @@
-import { Component, EventEmitter, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Output } from '@angular/core';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import {
   DraftSourcesAsSelectableProjectArrays,
@@ -13,7 +12,6 @@ import {
   projectToDraftSources
 } from '../draft-utils';
 import { LanguageCodesConfirmationComponent } from '../language-codes-confirmation/language-codes-confirmation.component';
-
 @Component({
   selector: 'app-confirm-sources',
   standalone: true,
@@ -31,11 +29,11 @@ export class ConfirmSourcesComponent {
   };
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly i18nService: I18nService,
     private readonly activatedProject: ActivatedProjectService
   ) {
-    this.activatedProject.projectDoc$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
+    this.activatedProject.projectDoc$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
       if (projectDoc?.data != null) {
         this.draftSources = draftSourcesAsTranslateSourceArraysToDraftSourcesAsSelectableProjectArrays(
           projectToDraftSources(projectDoc?.data)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
@@ -1,13 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component, Inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Observable } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
-import { QuietDestroyRef } from 'xforge-common/utils';
-
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 export interface DraftApplyProgress {
   bookNum: number;
   chapters: number[];
@@ -29,10 +27,10 @@ export class DraftApplyProgressDialogComponent {
     @Inject(MatDialogRef) private readonly dialogRef: MatDialogRef<DraftApplyProgressDialogComponent>,
     @Inject(MAT_DIALOG_DATA) data: { draftApplyProgress$: Observable<DraftApplyProgress | undefined> },
     private readonly i18n: I18nService,
-    destroyRef: QuietDestroyRef
+    destroyRef: DestroyRef
   ) {
     data.draftApplyProgress$
-      .pipe(takeUntilDestroyed(destroyRef))
+      .pipe(quietTakeUntilDestroyed(destroyRef))
       .subscribe(progress => (this.draftApplyProgress = progress));
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
@@ -18,7 +17,7 @@ import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { NoticeService } from 'xforge-common/notice.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectSettings } from '../../../core/models/sf-project-settings';
@@ -32,7 +31,6 @@ import {
   translateSourceToSelectableProjectWithLanguageTag
 } from '../draft-utils';
 import { LanguageCodesConfirmationComponent } from '../language-codes-confirmation/language-codes-confirmation.component';
-
 /** Status for a project, which may or may not be at SF. */
 export interface ProjectStatus {
   shortName: string;
@@ -92,7 +90,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly paratextService: ParatextService,
     private readonly dialogService: DialogService,
     private readonly projectService: SFProjectService,
@@ -104,7 +102,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
   ) {
     super(noticeService);
 
-    this.activatedProjectService.changes$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
+    this.activatedProjectService.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
       if (projectDoc?.data != null) {
         const { trainingSources, trainingTargets, draftingSources } = projectToDraftSources(projectDoc.data);
         if (trainingSources.length > 2) throw new Error('More than 2 training sources is not supported');
@@ -127,7 +125,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     });
 
     this.userProjectsService.projectDocs$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe((projects?: SFProjectProfileDoc[]) => {
         if (projects == null) return;
         this.userConnectedProjectsAndResources = projects.filter(project => project.data != null);
@@ -373,7 +371,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
           };
 
           updateSyncStatusForProject(projectDoc);
-          projectDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+          projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
             updateSyncStatusForProject(projectDoc);
           });
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatDialogConfig } from '@angular/material/dialog';
@@ -14,14 +13,13 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SharedModule } from '../../../shared/shared.module';
 import {
   TrainingDataUploadDialogComponent,
   TrainingDataUploadDialogData
 } from './training-data-upload-dialog.component';
 import { TrainingDataService } from './training-data.service';
-
 export interface TrainingDataOption {
   value: TrainingData;
   selected: boolean;
@@ -48,11 +46,11 @@ export class TrainingDataMultiSelectComponent implements OnChanges, OnInit {
     private readonly i18n: I18nService,
     private readonly trainingDataService: TrainingDataService,
     private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngOnInit(): void {
-    this.i18n.locale$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.i18n.locale$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.sourceLanguage = this.getLanguageDisplayName('source');
       this.targetLanguage = this.getLanguageDisplayName('target');
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
@@ -1,11 +1,10 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { getTrainingDataId, TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { FileType } from 'xforge-common/models/file-offline-data';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { QueryParameters } from 'xforge-common/query-parameters';
 import { RealtimeService } from 'xforge-common/realtime.service';
-import { IDestroyRef } from 'xforge-common/utils';
 import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 
 @Injectable({
@@ -30,7 +29,7 @@ export class TrainingDataService {
     await trainingDataDoc.delete();
   }
 
-  queryTrainingDataAsync(projectId: string, destroyRef: IDestroyRef): Promise<RealtimeQuery<TrainingDataDoc>> {
+  queryTrainingDataAsync(projectId: string, destroyRef: DestroyRef): Promise<RealtimeQuery<TrainingDataDoc>> {
     const queryParams: QueryParameters = {
       [obj<TrainingData>().pathStr(t => t.projectRef)]: projectId
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -1,5 +1,4 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnChanges, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, OnChanges, ViewChild } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
@@ -27,15 +26,13 @@ import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { isString } from '../../../../type-utils';
 import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextComponent } from '../../../shared/text/text.component';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { DraftHandlingService } from '../../draft-generation/draft-handling.service';
-
 @Component({
   selector: 'app-editor-draft',
   templateUrl: './editor-draft.component.html',
@@ -65,7 +62,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly dialogService: DialogService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly draftHandlingService: DraftHandlingService,
@@ -98,7 +95,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       this.inputChanged$.pipe(startWith(undefined))
     ])
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
+        quietTakeUntilDestroyed(this.destroyRef),
         filter(([isOnline]) => isOnline),
         tap(() => this.setInitialState()),
         switchMap(() => this.draftExists()),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.ts
@@ -1,11 +1,20 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AfterViewInit,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { Delta } from 'quill';
 import { combineLatest, startWith, tap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { TextDoc } from '../../../core/models/text-doc';
 import { Revision } from '../../../core/paratext.service';
@@ -13,7 +22,6 @@ import { SFProjectService } from '../../../core/sf-project.service';
 import { TextComponent } from '../../../shared/text/text.component';
 import { EditorHistoryService } from './editor-history.service';
 import { HistoryChooserComponent, RevisionSelectEvent } from './history-chooser/history-chooser.component';
-
 @Component({
   selector: 'app-editor-history',
   templateUrl: './editor-history.component.html',
@@ -36,7 +44,7 @@ export class EditorHistoryComponent implements OnChanges, OnInit, AfterViewInit 
   projectDoc: SFProjectProfileDoc | undefined;
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly editorHistoryService: EditorHistoryService,
     readonly fontService: FontService,
     private readonly i18nService: I18nService,
@@ -57,7 +65,7 @@ export class EditorHistoryComponent implements OnChanges, OnInit, AfterViewInit 
   ngOnInit(): void {
     // When the locale changes, emit the loaded Revision again, as the date formatting will need to update
     this.i18nService.locale$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.revisionSelect.emit(this.loadedRevision));
   }
 
@@ -79,7 +87,7 @@ export class EditorHistoryComponent implements OnChanges, OnInit, AfterViewInit 
       ),
       this.historyChooser.showDiffChange.pipe(startWith(this.historyChooser.showDiff))
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async ([e, showDiff]: [RevisionSelectEvent, boolean]) => {
         const snapshotContents: Delta = new Delta(e.snapshot?.data.ops);
         this.snapshotText?.setContents(snapshotContents, 'api');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -1,13 +1,11 @@
-import { AfterViewInit, Component, Input, OnChanges, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { EMPTY, Subject, combineLatest, startWith, switchMap } from 'rxjs';
+import { AfterViewInit, Component, DestroyRef, Input, OnChanges, ViewChild } from '@angular/core';
+import { combineLatest, EMPTY, startWith, Subject, switchMap } from 'rxjs';
 import { FontService } from 'xforge-common/font.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextComponent } from '../../../shared/text/text.component';
 import { formatFontSizeToRems } from '../../../shared/utils';
-
 @Component({
   selector: 'app-editor-resource',
   templateUrl: './editor-resource.component.html'
@@ -28,7 +26,7 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
   inputChanged$ = new Subject<void>();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly projectService: SFProjectService,
     private readonly fontService: FontService
   ) {}
@@ -44,7 +42,7 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
   private initProjectDetails(): void {
     combineLatest([this.resourceText.editorCreated, this.inputChanged$.pipe(startWith(undefined))])
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
+        quietTakeUntilDestroyed(this.destroyRef),
         switchMap(() => {
           if (this.projectId == null || this.bookNum == null || this.chapter == null) {
             return EMPTY;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -4,6 +4,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
   Inject,
   OnDestroy,
@@ -13,7 +14,6 @@ import {
   ViewChild,
   ViewChildren
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
@@ -83,16 +83,9 @@ import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { stripHtml } from 'xforge-common/util/string-util';
-import {
-  browserLinks,
-  getLinkHTML,
-  isBlink,
-  issuesEmailTemplate,
-  objectId,
-  QuietDestroyRef
-} from 'xforge-common/utils';
+import { browserLinks, getLinkHTML, isBlink, issuesEmailTemplate, objectId } from 'xforge-common/utils';
 import { XFValidators } from 'xforge-common/xfvalidators';
 import { environment } from '../../../environments/environment';
 import { isString } from '../../../type-utils';
@@ -300,7 +293,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly editorTabPersistenceService: EditorTabPersistenceService,
     private readonly textDocService: TextDocService,
     private readonly draftGenerationService: DraftGenerationService,
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly breakpointObserver: BreakpointObserver,
     private readonly mediaBreakpointService: MediaBreakpointService,
     private readonly permissionsService: PermissionsService
@@ -312,7 +305,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     this.segmentUpdated$ = new Subject<void>();
     this.segmentUpdated$
-      .pipe(debounceTime(UPDATE_SUGGESTIONS_TIMEOUT), takeUntilDestroyed(this.destroyRef))
+      .pipe(debounceTime(UPDATE_SUGGESTIONS_TIMEOUT), quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.updateSuggestions());
     this.mobileNoteControl.setValidators([Validators.required, XFValidators.someNonWhitespace]);
   }
@@ -673,7 +666,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   ngOnInit(): void {
     this.activatedProject.projectDoc$
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
+        quietTakeUntilDestroyed(this.destroyRef),
         filterNullish(),
         switchMap(doc => this.initEditorTabs(doc))
       )
@@ -682,7 +675,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   ngAfterViewInit(): void {
     fromEvent(window, 'resize')
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.positionInsertNoteFab();
       });
@@ -691,7 +684,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.activatedRoute.params.pipe(filter(params => params['projectId'] != null && params['bookId'] != null)),
       this.targetTextComponent!.changes
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async ([params, components]) => {
         this.target = components.first;
         this.showSuggestions = false;
@@ -819,7 +812,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     // Throttle bursts of sync scroll requests
     this.syncScrollRequested$
-      .pipe(takeUntilDestroyed(this.destroyRef), throttleTime(100, asyncScheduler, { leading: true, trailing: true }))
+      .pipe(
+        quietTakeUntilDestroyed(this.destroyRef),
+        throttleTime(100, asyncScheduler, { leading: true, trailing: true })
+      )
       .subscribe(() => {
         this.syncScroll();
       });
@@ -830,7 +826,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.tabStateInitialized$.pipe(filter(initialized => initialized)),
       this.targetEditorLoaded$.pipe(take(1))
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(([breakpointState]) => {
         if (breakpointState.matches && this.showSource) {
           this.tabState.consolidateTabGroups('target');
@@ -1920,7 +1916,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         segment,
         Array.from(elements).map((element: Element) =>
           fromEvent<MouseEvent>(element, 'click')
-            .pipe(takeUntilDestroyed(this.destroyRef))
+            .pipe(quietTakeUntilDestroyed(this.destroyRef))
             .subscribe(event => {
               if (this.bookNum == null) {
                 return;
@@ -1952,7 +1948,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
       this.selectionClickSubs.push(
         fromEvent<MouseEvent>(segmentElement, 'click')
-          .pipe(takeUntilDestroyed(this.destroyRef))
+          .pipe(quietTakeUntilDestroyed(this.destroyRef))
           .subscribe(event => {
             if (this.bookNum == null || this.target == null) return;
             const verseRef: VerseRef | undefined = verseRefFromMouseEvent(event, this.bookNum);
@@ -1985,7 +1981,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.noteThreadQuery.remoteChanges$,
       this.noteThreadQuery.remoteDocChanges$
     )
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.toggleNoteThreadVerses(false);
         this.toggleNoteThreadVerses(true);
@@ -2543,7 +2539,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private subscribeScroll(scrollContainer: Element): void {
     this.scrollSubscription?.unsubscribe();
     this.scrollSubscription = fromEvent(scrollContainer, 'scroll')
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.keepInsertNoteFabInView(scrollContainer);
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/multi-viewer/multi-viewer.component.ts
@@ -1,13 +1,11 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { slice } from 'lodash-es';
 import { UserProfile } from 'realtime-server/lib/esm/common/models/user';
 import { combineLatest } from 'rxjs';
 import { Breakpoint, MediaBreakpointService } from 'xforge-common/media-breakpoints/media-breakpoint.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
-
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 export interface MultiCursorViewer extends UserProfile {
   cursorColor: string;
   activeInEditor: boolean;
@@ -27,7 +25,7 @@ export class MultiViewerComponent implements OnInit {
   constructor(
     private readonly breakpointObserver: BreakpointObserver,
     private readonly breakpointService: MediaBreakpointService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   get avatarViewers(): MultiCursorViewer[] {
@@ -45,7 +43,7 @@ export class MultiViewerComponent implements OnInit {
       this.breakpointObserver.observe(this.breakpointService.width('>', Breakpoint.SM)),
       this.breakpointObserver.observe(this.breakpointService.width('<=', Breakpoint.XS))
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(([bigger, xs]) => {
         // initialize to 3, but if > SM then set to 6, else if <= XS then set to 1
         this.maxAvatars = bigger.matches ? 6 : xs.matches ? 1 : 3;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions-settings-dialog.component.ts
@@ -1,14 +1,12 @@
-import { Component, Inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { BehaviorSubject } from 'rxjs';
 import { debounceTime, map, skip } from 'rxjs/operators';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectUserConfigDoc } from '../../core/models/sf-project-user-config-doc';
-
 export const CONFIDENCE_THRESHOLD_TIMEOUT = 500;
 
 export interface SuggestionsSettingsDialogData {
@@ -30,7 +28,7 @@ export class SuggestionsSettingsDialogComponent {
   constructor(
     @Inject(MAT_DIALOG_DATA) data: SuggestionsSettingsDialogData,
     readonly onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.projectDoc = data.projectDoc;
     this.projectUserConfigDoc = data.projectUserConfigDoc;
@@ -57,7 +55,7 @@ export class SuggestionsSettingsDialogComponent {
         skip(1),
         debounceTime(CONFIDENCE_THRESHOLD_TIMEOUT),
         map(value => value / 100),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(threshold =>
         this.projectUserConfigDoc.submitJson0Op(op => op.set(puc => puc.confidenceThreshold, threshold))

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/suggestions.component.ts
@@ -1,13 +1,11 @@
-import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { MatListOption, MatSelectionList } from '@angular/material/list';
 import { isEqual } from 'lodash-es';
 import Quill from 'quill';
 import { fromEvent } from 'rxjs';
 import { filter, first } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextComponent } from '../../shared/text/text.component';
-
 export interface SuggestionSelectedEvent {
   suggestionIndex: number;
   wordIndex: number;
@@ -39,7 +37,7 @@ export class SuggestionsComponent {
 
   constructor(
     private readonly elemRef: ElementRef,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.show = false;
     this.root.style.left = '0px';
@@ -134,7 +132,7 @@ export class SuggestionsComponent {
       return;
     }
 
-    this.text.updated.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.setPosition());
+    this.text.updated.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => this.setPosition());
 
     this.initEditor();
     if (this.editor == null) {
@@ -149,12 +147,12 @@ export class SuggestionsComponent {
 
     this.observeResize(this.editor);
     fromEvent(this.editor.root, 'scroll')
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.setPosition());
     fromEvent<KeyboardEvent>(this.editor.root, 'keydown')
       .pipe(
         filter(event => this.isSuggestionEvent(event)),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(event => {
         if (this.list == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -1,17 +1,15 @@
-import { Component, Inject, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { map, repeat, take, timer } from 'rxjs';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { SelectableProject } from '../../../../core/paratext.service';
 import { PermissionsService } from '../../../../core/permissions.service';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { EditorTabAddResourceDialogService } from './editor-tab-add-resource-dialog.service';
-
 export interface EditorTabAddResourceDialogData {
   excludedParatextIds: string[];
 }
@@ -37,7 +35,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
 
   // Placed after 'Loading' when syncing
   animatedEllipsis$ = timer(500, 300).pipe(
-    takeUntilDestroyed(this.destroyRef),
+    quietTakeUntilDestroyed(this.destroyRef),
     map(i => '.'.repeat(i % 4)),
     take(4),
     repeat()
@@ -48,7 +46,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
   });
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     readonly onlineStatus: OnlineStatusService,
     private readonly editorTabAddResourceDialogService: EditorTabAddResourceDialogService,
     private readonly projectService: SFProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.service.ts
@@ -1,10 +1,8 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ParatextProject } from '../../../../core/models/paratext-project';
 import { ParatextService, SelectableProject } from '../../../../core/paratext.service';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -16,9 +14,9 @@ export class EditorTabAddResourceDialogService {
   constructor(
     private readonly paratextService: ParatextService,
     private readonly userProjectsService: SFUserProjectsService,
-    private readonly destroyRef: QuietDestroyRef
+    private readonly destroyRef: DestroyRef
   ) {
-    this.userProjectsService.projectDocs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projects => {
+    this.userProjectsService.projectDocs$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projects => {
       if (projects == null) return;
       this.projects = await this.paratextService.getProjects();
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import {
   EditorTabGroupType,
   EditorTabType,
@@ -12,21 +11,19 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { PermissionsService } from '../../../core/permissions.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TabMenuItem, TabMenuService, TabStateService } from '../../../shared/sf-tab-group';
 import { EditorTabInfo } from './editor-tabs.types';
-
 @Injectable()
 export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> {
   private readonly menuItems$: Observable<TabMenuItem[]> = this.initMenuItems();
 
   constructor(
-    private readonly destroyRef: QuietDestroyRef,
+    private readonly destroyRef: DestroyRef,
     private readonly userService: UserService,
     private readonly activatedProject: ActivatedProjectService,
     private readonly onlineStatus: OnlineStatusService,
@@ -45,7 +42,7 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
       this.activatedProject.projectDoc$.pipe(filterNullish()),
       this.onlineStatus.onlineStatus$
     ]).pipe(
-      takeUntilDestroyed(this.destroyRef),
+      quietTakeUntilDestroyed(this.destroyRef),
       switchMap(([projectDoc, isOnline]) => {
         return combineLatest([of(projectDoc), of(isOnline), this.tabState.tabs$]);
       }),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -1,19 +1,17 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Input, OnDestroy, OnInit } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { BehaviorSubject, Subscription, timer } from 'rxjs';
 import { filter, repeat, retry, tap } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
-
 @Component({
   selector: 'app-training-progress',
   templateUrl: './training-progress.component.html',
@@ -37,7 +35,7 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
     private readonly projectService: SFProjectService,
     private readonly translationEngineService: TranslationEngineService,
     private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -51,7 +49,7 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
   }
 
   ngOnInit(): void {
-    this.projectId$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
+    this.projectId$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       if (projectId === '') {
         return;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -1,16 +1,15 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { ANY_INDEX, obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { SFProjectDomain, SF_PROJECT_RIGHTS } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
+import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-import { Subscription, asyncScheduler, firstValueFrom, timer } from 'rxjs';
+import { asyncScheduler, firstValueFrom, Subscription, timer } from 'rxjs';
 import { filter, map, repeat, retry, tap, throttleTime } from 'rxjs/operators';
 import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -18,13 +17,12 @@ import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
 import { ProgressService, TextProgress } from '../../shared/progress-service/progress.service';
-
 const ENGINE_QUALITY_STAR_COUNT = 3;
 const TEXT_PATH_TEMPLATE = obj<SFProject>().pathTemplate(p => p.texts[ANY_INDEX]);
 
@@ -56,7 +54,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     private readonly userService: UserService,
     public readonly progressService: ProgressService,
     readonly i18n: I18nService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.engineQualityStars = [];
@@ -97,7 +95,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     this.activatedRoute.params
       .pipe(
         map(params => params['projectId']),
-        takeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(async projectId => {
         this.projectDoc = await this.projectService.getProfile(projectId);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -1,17 +1,15 @@
-import { Inject, Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Inject, Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivationEnd, Router } from '@angular/router';
 import ObjectID from 'bson-objectid';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, map, startWith, switchMap } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
 import { PermissionsService } from '../app/core/permissions.service';
 import { SFProjectService } from '../app/core/sf-project.service';
 import { CacheService } from '../app/shared/cache-service/cache.service';
 import { noopDestroyRef } from './realtime.service';
-
 interface IActiveProjectIdService {
   /** SF project id */
   projectId$: Observable<string | undefined>;
@@ -60,10 +58,10 @@ export class ActivatedProjectService {
     private readonly projectService: SFProjectService,
     private readonly cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     activeProjectIdService.projectId$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(projectId => this.selectProject(projectId));
   }
 
@@ -134,7 +132,7 @@ export class TestActivatedProjectService extends ActivatedProjectService {
     cacheService: CacheService,
     @Inject(ActiveProjectIdService) activeProjectIdService: IActiveProjectIdService
   ) {
-    super(projectService, cacheService, activeProjectIdService, noopDestroyRef as QuietDestroyRef);
+    super(projectService, cacheService, activeProjectIdService, noopDestroyRef);
   }
 
   static withProjectId(projectId: string): TestActivatedProjectService {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/donut-chart/donut-chart.component.ts
@@ -1,8 +1,15 @@
-import { AfterViewInit, Component, ElementRef, Input, NgZone, QueryList, ViewChildren } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AfterViewInit,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Input,
+  NgZone,
+  QueryList,
+  ViewChildren
+} from '@angular/core';
 import { isEqual } from 'lodash-es';
-import { QuietDestroyRef } from 'xforge-common/utils';
-
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 const DEFAULT_SIZE = 100;
 
 function easeOutQuart(currentTime: number, startValue: number, delta: number, duration: number): number {
@@ -39,13 +46,13 @@ export class DonutChartComponent implements AfterViewInit {
 
   constructor(
     private readonly ngZone: NgZone,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   ngAfterViewInit(): void {
     this.animateChange();
     if (this.segmentCircles != null) {
-      this.segmentCircles.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.animateChange());
+      this.segmentCircles.changes.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => this.animateChange());
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/edit-name-dialog/edit-name-dialog.component.ts
@@ -1,12 +1,10 @@
-import { Component, Inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, Inject } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XFValidators } from 'xforge-common/xfvalidators';
-
 export interface EditNameDialogResult {
   displayName: string;
 }
@@ -27,12 +25,12 @@ export class EditNameDialogComponent {
     public i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
     @Inject(MAT_DIALOG_DATA) public data: { name: string; isConfirmation: boolean },
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.name.setValidators([Validators.required, XFValidators.someNonWhitespace]);
     this.name.setValue(data.name);
     this.onlineStatusService.onlineStatus$
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(isOnline => (this.isOnline = isOnline));
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -1,10 +1,8 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { AnonymousService } from 'xforge-common/anonymous.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
-
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 export interface FeatureFlag {
   readonly key: string;
   readonly description: string;
@@ -36,10 +34,10 @@ export class FeatureFlagStore implements IFeatureFlagStore {
   constructor(
     private readonly anonymousService: AnonymousService,
     private readonly onlineStatusService: OnlineStatusService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     // Cause the flags to be reloaded when coming online
-    onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(status => {
+    onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(status => {
       if (status) this.remoteFlagCacheExpiry = new Date();
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -1,8 +1,7 @@
 import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { lastValueFrom, Observable, Subject } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../environments/environment';
 import { AuthService } from './auth.service';
 import { CommandService } from './command.service';
@@ -20,7 +19,6 @@ import { OnlineStatusService } from './online-status.service';
 import { RealtimeService } from './realtime.service';
 import { TypeRegistry } from './type-registry';
 import { COMMAND_API_NAMESPACE, PROJECTS_URL } from './url-constants';
-
 /**
  * Formats the name of a file stored on the server into a URL that a http client can use to request the data.
  */
@@ -57,7 +55,7 @@ export class FileService {
     private readonly authService: AuthService,
     private readonly commandService: CommandService,
     private readonly dialogService: DialogService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {}
 
   get fileSyncComplete$(): Observable<void> {
@@ -66,7 +64,7 @@ export class FileService {
 
   init(realtimeService: RealtimeService): void {
     this.realtimeService = realtimeService;
-    this.onlineStatusService.onlineStatus$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(isOnline => {
+    this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(isOnline => {
       if (isOnline) {
         this.syncFiles();
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.spec.ts
@@ -1,9 +1,8 @@
 import { HttpClient } from '@angular/common/http';
-import { DestroyRef } from '@angular/core';
 import { fakeAsync, flush } from '@angular/core/testing';
 import { instance, mock, when } from 'ts-mockito';
 import { OnlineStatusService } from './online-status.service';
-import { QuietDestroyRef } from './utils';
+import { noopDestroyRef } from './realtime.service';
 
 const mockedHttpClient = mock(HttpClient);
 const mockedNavigator = mock(Navigator);
@@ -13,14 +12,12 @@ describe('OnlineStatusService', () => {
     const env = new TestEnvironment();
     env.onlineStatus = false;
     expect(env.onlineStatusService.isOnline).toBe(false);
-    env.dispose();
   }));
 
   it('online when navigator is set to online', fakeAsync(() => {
     const env = new TestEnvironment();
     env.onlineStatus = true;
     expect(env.onlineStatusService.isOnline).toBe(true);
-    env.dispose();
   }));
 
   it('switch to offline when navigator changes status', fakeAsync(() => {
@@ -29,7 +26,6 @@ describe('OnlineStatusService', () => {
     expect(env.onlineStatusService.isOnline).toBe(true);
     env.onlineStatus = false;
     expect(env.onlineStatusService.isOnline).toBe(false);
-    env.dispose();
   }));
 
   it('switch to online when navigator changes status', fakeAsync(() => {
@@ -38,7 +34,6 @@ describe('OnlineStatusService', () => {
     expect(env.onlineStatusService.isOnline).toBe(false);
     env.onlineStatus = true;
     expect(env.onlineStatusService.isOnline).toBe(true);
-    env.dispose();
   }));
 
   it('informs the caller when the user is back online', fakeAsync(() => {
@@ -61,7 +56,6 @@ describe('OnlineStatusService', () => {
     env.onlineStatusService.online.then(() => onlineFiredCount++);
     flush();
     expect(onlineFiredCount).toBe(2);
-    env.dispose();
   }));
 
   it('switch to offline when navigator is online but websocket status is false', fakeAsync(() => {
@@ -70,7 +64,6 @@ describe('OnlineStatusService', () => {
     expect(env.onlineStatusService.isOnline).toBe(true);
     env.onlineStatusService.webSocketResponse = false;
     expect(env.onlineStatusService.isOnline).toBe(false);
-    env.dispose();
   }));
 
   it('switch to online when navigator is online and websocket comes back online', fakeAsync(() => {
@@ -81,37 +74,24 @@ describe('OnlineStatusService', () => {
     expect(env.onlineStatusService.isOnline).toBe(false);
     env.onlineStatusService.webSocketResponse = true;
     expect(env.onlineStatusService.isOnline).toBe(true);
-    env.dispose();
   }));
 });
 
 class TestEnvironment {
   readonly onlineStatusService: OnlineStatusService;
   private navigatorOnline: boolean = true;
-  private onDestroyCallback;
-  private destroyRef: DestroyRef = {
-    onDestroy: _callback => {
-      this.onDestroyCallback = _callback;
-      return () => {};
-    }
-  };
-  private quietDestroyRef: QuietDestroyRef = new QuietDestroyRef(this.destroyRef);
 
   constructor() {
     when(mockedNavigator.onLine).thenCall(() => this.navigatorOnline);
     this.onlineStatusService = new OnlineStatusService(
       instance(mockedHttpClient),
       instance(mockedNavigator),
-      this.quietDestroyRef
+      noopDestroyRef
     );
   }
 
   set onlineStatus(status: boolean) {
     this.navigatorOnline = status;
     window.dispatchEvent(new Event(status ? 'online' : 'offline'));
-  }
-
-  dispose(): void {
-    this.onDestroyCallback();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
@@ -1,11 +1,9 @@
 import { HttpClient } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Inject, Injectable } from '@angular/core';
 import { BehaviorSubject, firstValueFrom, fromEvent, merge, Observable, of } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { NAVIGATOR } from './browser-globals';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -19,7 +17,7 @@ export class OnlineStatusService {
   constructor(
     protected readonly http: HttpClient,
     @Inject(NAVIGATOR) protected readonly navigator: Navigator,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.appOnlineStatus$ = new BehaviorSubject<boolean>(this.navigator.onLine);
     this.windowOnLineStatus$ = new BehaviorSubject<boolean>(this.navigator.onLine);
@@ -31,7 +29,7 @@ export class OnlineStatusService {
       fromEvent(window, 'online').pipe(map(() => true)),
       fromEvent(window, 'offline').pipe(map(() => false))
     )
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(status => {
         // Note that this isn't 100% as accurate as it sounds. "Online" simply means a valid network connection
         // and not a valid Internet connection. The websocket is another fallback which is constantly polled
@@ -40,7 +38,7 @@ export class OnlineStatusService {
 
     // Check for changes to the online status or from the web socket status
     merge(this.windowOnLineStatus$.asObservable(), this.webSocketStatus$.asObservable())
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         // The app is "online" if the browser/network thinks it's online AND
         // we have a valid web socket connection OR

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.spec.ts
@@ -1,7 +1,7 @@
+import { DestroyRef } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
-import { IDestroyRef } from 'xforge-common/utils';
 import { SF_TYPE_REGISTRY } from '../app/core/models/sf-type-registry';
 import { RealtimeDoc } from './models/realtime-doc';
 import { RealtimeQuery } from './models/realtime-query';
@@ -16,7 +16,7 @@ describe('RealtimeService', () => {
 
   describe('manageQuery', () => {
     let service: RealtimeService;
-    let destroyRef: IDestroyRef;
+    let destroyRef: DestroyRef;
     let mockQuery: RealtimeQuery<RealtimeDoc>;
     let queryInstance: RealtimeQuery<RealtimeDoc>;
     let ready$: BehaviorSubject<boolean>;
@@ -34,7 +34,7 @@ describe('RealtimeService', () => {
         onDestroy: (callback: () => void) => {
           onDestroyCallback = callback;
         }
-      } as IDestroyRef;
+      } as DestroyRef;
     });
 
     afterEach(() => {
@@ -57,7 +57,7 @@ describe('RealtimeService', () => {
         onDestroy: () => {
           throw new Error('View destroyed');
         }
-      } as IDestroyRef;
+      } as DestroyRef;
 
       service['manageQuery'](queryPromise, destroyedRef);
       tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -1,7 +1,6 @@
 import { DestroyRef, Injectable, Optional } from '@angular/core';
 import { filter, race, take, timer } from 'rxjs';
 import { AppError } from 'xforge-common/exception-handling.service';
-import { IDestroyRef } from 'xforge-common/utils';
 import { FileService } from './file.service';
 import { RealtimeDoc } from './models/realtime-doc';
 import { RealtimeQuery } from './models/realtime-query';
@@ -149,7 +148,7 @@ export class RealtimeService {
   async subscribeQuery<T extends RealtimeDoc>(
     collection: string,
     parameters: QueryParameters,
-    destroyRef: IDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<T>> {
     const query = this.createQuery<T>(collection, parameters);
     return this.manageQuery(
@@ -215,7 +214,7 @@ export class RealtimeService {
    */
   private manageQuery<T extends RealtimeDoc>(
     queryPromise: Promise<RealtimeQuery<T>>,
-    destroyRef: IDestroyRef
+    destroyRef: DestroyRef
   ): Promise<RealtimeQuery<T>> {
     try {
       destroyRef.onDestroy(() =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -1,11 +1,10 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, HostBinding, OnInit } from '@angular/core';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { SFProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { BehaviorSubject } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectDoc } from '../../app/core/models/sf-project-doc';
 import { SFProjectService } from '../../app/core/sf-project.service';
 import { DataLoadingComponent } from '../data-loading-component';
@@ -13,7 +12,6 @@ import { NONE_ROLE, ProjectRoleInfo } from '../models/project-role-info';
 import { NoticeService } from '../notice.service';
 import { QueryParameters } from '../query-parameters';
 import { UserService } from '../user.service';
-
 class Row {
   isUpdatingRole: boolean = false;
 
@@ -81,7 +79,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
     readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
     private readonly userService: UserService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
     this.searchTerm$ = new BehaviorSubject<string>('');
@@ -103,7 +101,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
         obj<Project>().pathStr(p => p.name),
         obj<SFProject>().pathStr(p => p.shortName)
       ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(searchResults => {
         this.loadingStarted();
         this.projectDocs = searchResults.docs;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -1,5 +1,4 @@
-import { Component, HostBinding, OnInit } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, HostBinding, OnInit } from '@angular/core';
 import { MatDialogConfig } from '@angular/material/dialog';
 import { Project } from 'realtime-server/lib/esm/common/models/project';
 import { User } from 'realtime-server/lib/esm/common/models/user';
@@ -7,7 +6,7 @@ import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { BehaviorSubject } from 'rxjs';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { environment } from '../../environments/environment';
 import { DataLoadingComponent } from '../data-loading-component';
 import { DialogService } from '../dialog.service';
@@ -17,7 +16,6 @@ import { ProjectService } from '../project.service';
 import { QueryParameters } from '../query-parameters';
 import { UserService } from '../user.service';
 import { SaDeleteDialogComponent, SaDeleteUserDialogData } from './sa-delete-dialog.component';
-
 interface ProjectInfo {
   id: string;
   name: string;
@@ -52,7 +50,7 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
     noticeService: NoticeService,
     private readonly userService: UserService,
     private readonly projectService: ProjectService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     super(noticeService);
   }
@@ -65,7 +63,7 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
     this.loadingStarted();
     this.userService
       .onlineQuery(this.searchTerm$, this.queryParameters$, this.reload$)
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async searchResults => {
         // Process the query for users into Rows that can be displayed.
         this.loadingStarted();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-online-status.service.ts
@@ -1,9 +1,8 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { anything, instance, spy, when } from 'ts-mockito';
 import { OnlineStatusService } from './online-status.service';
-import { QuietDestroyRef } from './utils';
 
 /** This class is a helper for tests. */
 @Injectable({
@@ -13,7 +12,7 @@ export class TestOnlineStatusService extends OnlineStatusService {
   constructor(
     public readonly httpClient: HttpClient,
     public readonly mockedNavigator: Navigator,
-    destroyRef: QuietDestroyRef
+    destroyRef: DestroyRef
   ) {
     super(httpClient, instance(mockedNavigator), destroyRef);
     this.setIsOnline(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
@@ -1,7 +1,6 @@
-import { Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { QuietDestroyRef } from 'xforge-common/utils';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../app/core/models/sf-project-profile-doc';
 import { SFProjectService } from '../app/core/sf-project.service';
 import { compareProjectsForSorting } from '../app/shared/utils';
@@ -9,7 +8,6 @@ import { environment } from '../environments/environment';
 import { AuthService, LoginResult } from './auth.service';
 import { UserDoc } from './models/user-doc';
 import { UserService } from './user.service';
-
 /** Service that maintains an up-to-date set of SF project docs that the current user has access to. */
 @Injectable({
   providedIn: 'root'
@@ -22,7 +20,7 @@ export class SFUserProjectsService {
     private readonly userService: UserService,
     private readonly projectService: SFProjectService,
     private readonly authService: AuthService,
-    private destroyRef: QuietDestroyRef
+    private destroyRef: DestroyRef
   ) {
     this.setup();
   }
@@ -33,14 +31,18 @@ export class SFUserProjectsService {
   }
 
   private async setup(): Promise<void> {
-    this.authService.loggedInState$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(async (state: LoginResult) => {
-      if (!state.loggedIn) {
-        return;
-      }
-      const userDoc = await this.userService.getCurrentUser();
-      this.updateProjectList(userDoc);
-      userDoc.remoteChanges$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.updateProjectList(userDoc));
-    });
+    this.authService.loggedInState$
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
+      .subscribe(async (state: LoginResult) => {
+        if (!state.loggedIn) {
+          return;
+        }
+        const userDoc = await this.userService.getCurrentUser();
+        this.updateProjectList(userDoc);
+        userDoc.remoteChanges$
+          .pipe(quietTakeUntilDestroyed(this.destroyRef))
+          .subscribe(() => this.updateProjectList(userDoc));
+      });
   }
 
   /** Updates our provided set of SF project docs for the current user based on the userdoc's list of SF projects the

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/rxjs-util.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/rxjs-util.spec.ts
@@ -1,5 +1,7 @@
-import { from, Observable } from 'rxjs';
-import { filterNullish } from './rxjs-util';
+import { Component, DestroyRef, OnDestroy } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, from, Observable } from 'rxjs';
+import { filterNullish, quietTakeUntilDestroyed } from './rxjs-util';
 
 describe('filterNullUndefined', () => {
   it('should filter out only null and undefined values', () => {
@@ -27,3 +29,59 @@ describe('filterNullUndefined', () => {
     expect(result).toEqual(expected);
   });
 });
+
+describe('quietTakeUntilDestroyed', () => {
+  it('should unsubscribe observables when the destroyRef callback is called', () => {
+    let onDestroyCallback: () => void;
+    const destroyRef: DestroyRef = {
+      onDestroy: (callback: () => void) => {
+        onDestroyCallback = callback;
+        return () => {};
+      }
+    };
+
+    let completed = false;
+
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(destroyRef)).subscribe({
+      complete: () => {
+        completed = true;
+      }
+    });
+
+    expect(completed).toBeFalse();
+    onDestroyCallback!();
+    expect(completed).toBeTrue();
+  });
+
+  it('should unsubscribe when the component is destroyed', () => {
+    const fixture = TestBed.createComponent(QuietTakeUntilDestroyedTestComponent);
+    const component = fixture.componentInstance;
+    expect(component.mainSubjectCompleted).toBeFalse();
+    expect(component.subjectCreatedAfterDestroyCompleted).toBeFalse();
+    fixture.destroy();
+    expect(component.mainSubjectCompleted).toBeTrue();
+    expect(component.subjectCreatedAfterDestroyCompleted).toBeTrue();
+  });
+});
+
+@Component({})
+class QuietTakeUntilDestroyedTestComponent implements OnDestroy {
+  mainSubjectCompleted = false;
+  subjectCreatedAfterDestroyCompleted = false;
+
+  constructor(private destroyRef: DestroyRef) {
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe({
+      complete: () => {
+        this.mainSubjectCompleted = true;
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false })).subscribe({
+      complete: () => {
+        this.subjectCreatedAfterDestroyCompleted = true;
+      }
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/rxjs-util.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/rxjs-util.ts
@@ -1,5 +1,8 @@
-import { OperatorFunction } from 'rxjs';
+import { DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MonoTypeOperatorFunction, OperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { hasStringProp } from '../../type-utils';
 
 /**
  * Rxjs pipeable operator function to filters out null and undefined values.
@@ -8,4 +11,30 @@ import { filter } from 'rxjs/operators';
  */
 export function filterNullish<T>(): OperatorFunction<T | undefined | null, T> {
   return filter((value): value is T => value != null);
+}
+
+/**
+ * Like `takeUntilDestroyed`, but catches and logs NG0911 errors (unless `options.logWarnings` is false).
+ */
+export function quietTakeUntilDestroyed<T>(
+  destroyRef: DestroyRef,
+  options = { logWarnings: true }
+): MonoTypeOperatorFunction<T> {
+  const stack = new Error().stack;
+  const wrappedDestroyRef = {
+    onDestroy(callback: () => void): () => void {
+      try {
+        return destroyRef.onDestroy(callback);
+      } catch (error) {
+        const isNG0911 = hasStringProp(error, 'message') && error.message.includes('NG0911');
+        if (isNG0911 && options.logWarnings) {
+          console.warn('NG0911 error caught and ignored. Original stack: ', stack);
+        }
+        if (!isNG0911) throw error;
+        callback();
+        return () => {};
+      }
+    }
+  };
+  return takeUntilDestroyed(wrappedDestroyRef);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.spec.ts
@@ -1,3 +1,7 @@
+import { Component, DestroyRef, OnDestroy } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { quietTakeUntilDestroyed } from './util/rxjs-util';
 import { getAspCultureCookieLanguage, getLinkHTML } from './utils';
 
 describe('xforge-common utils', () => {
@@ -24,3 +28,59 @@ describe('xforge-common utils', () => {
     );
   });
 });
+
+describe('quietTakeUntilDestroyed', () => {
+  it('should unsubscribe observables when the destroyRef callback is called', () => {
+    let onDestroyCallback: () => void;
+    const destroyRef: DestroyRef = {
+      onDestroy: (callback: () => void) => {
+        onDestroyCallback = callback;
+        return () => {};
+      }
+    };
+
+    let completed = false;
+
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(destroyRef)).subscribe({
+      complete: () => {
+        completed = true;
+      }
+    });
+
+    expect(completed).toBeFalse();
+    onDestroyCallback!();
+    expect(completed).toBeTrue();
+  });
+
+  it('should unsubscribe when the component is destroyed', () => {
+    const fixture = TestBed.createComponent(QuietTakeUntilDestroyedTestComponent);
+    const component = fixture.componentInstance;
+    expect(component.mainSubjectCompleted).toBeFalse();
+    expect(component.subjectCreatedAfterDestroyCompleted).toBeFalse();
+    fixture.destroy();
+    expect(component.mainSubjectCompleted).toBeTrue();
+    expect(component.subjectCreatedAfterDestroyCompleted).toBeTrue();
+  });
+});
+
+@Component({})
+class QuietTakeUntilDestroyedTestComponent implements OnDestroy {
+  mainSubjectCompleted = false;
+  subjectCreatedAfterDestroyCompleted = false;
+
+  constructor(private destroyRef: DestroyRef) {
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe({
+      complete: () => {
+        this.mainSubjectCompleted = true;
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    new BehaviorSubject(1).pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false })).subscribe({
+      complete: () => {
+        this.subjectCreatedAfterDestroyCompleted = true;
+      }
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -1,12 +1,9 @@
-import { DestroyRef, Injectable, Optional } from '@angular/core';
 import { translate } from '@ngneat/transloco';
 import Bowser from 'bowser';
 import ObjectID from 'bson-objectid';
 import locales from '../../../locales.json';
 import versionData from '../../../version.json';
 import { environment } from '../environments/environment';
-import { hasStringProp } from '../type-utils';
-import { ErrorReportingService } from './error-reporting.service';
 import { Locale } from './models/i18n-locale';
 
 const BROWSER = Bowser.getParser(window.navigator.userAgent);
@@ -181,39 +178,5 @@ export function tryParseJSON(data: unknown): unknown {
     return JSON.parse(data);
   } catch {
     return null;
-  }
-}
-
-export interface IDestroyRef {
-  onDestroy(callback: () => void): () => void;
-}
-
-/**
- * Like {@link DestroyRef}, but with two distinct advantages:
- * - Catches and logs NG0911 rather than throwing it, preventing it from being annoying to the user
- * - Logs the location where the `QuietDestroyRef` is used, rather than the location where the error is thrown
- * - Reports the error to the error reporting service (if an injected instance of the reporting service is available)
- *
- * This could either be seen as a temporary workaround to ease the migration to using `DestroyRef`, or a more robust
- * permanent solution to the problem of `DestroyRef` throwing errors if the component is destroyed before it is used.
- */
-@Injectable({ providedIn: 'root' })
-export class QuietDestroyRef {
-  constructor(
-    private readonly destroyRef: DestroyRef,
-    @Optional() private readonly errorReportingService?: ErrorReportingService
-  ) {}
-
-  onDestroy(callback: () => void): () => void {
-    const originalStack = new Error().stack;
-    try {
-      return this.destroyRef.onDestroy(callback);
-    } catch (error) {
-      if (hasStringProp(error, 'message') && error.message.includes('NG0911')) {
-        console.warn('NG0911 error caught and ignored. Original stack: ', originalStack);
-        this.errorReportingService?.silentError('NG0911 error caught and ignored', { originalStack });
-      } else throw error;
-    }
-    return () => {};
   }
 }


### PR DESCRIPTION
- Implementing `quietTakeUntilDestroyed` was my original approach, before I made the mistake of creating a `QuietDestroyRef`.
- It allows us to store the line number where `quietTakeUntilDestroyed` was called, which is much more useful than knowing where the `DestroyRef` was injected.
- It allows us to suppress warnings for certain uses of `quietTakeUntilDestroyed`, so our tests and/or application aren't spammed with warnings for instances of NG0911 we already know about.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3083)
<!-- Reviewable:end -->
