### PR TITLE
SF-3245 Fix quill editor scroll and hidden app notice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -92,7 +92,7 @@
               @case ("project-source") {
                 <div class="project-tab-container">
                   @if (hasSourceCopyrightBanner) {
-                    <app-notice icon="copyright" type="warning" class="copyright-banner">
+                    <app-notice mode="fill-dark" icon="copyright" type="warning" class="copyright-banner">
                       <div>
                         {{ sourceCopyrightBanner }}
                         <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{
@@ -119,12 +119,12 @@
               @case ("project-target") {
                 <div class="project-tab-container">
                   @if (writingSystemWarningBanner) {
-                    <app-notice icon="warning" type="warning" class="writing-system-warning-banner">
+                    <app-notice mode="fill-dark" icon="warning" type="warning" class="writing-system-warning-banner">
                       <span [innerHtml]="writingSystemWarningMessage"></span>
                     </app-notice>
                   }
                   @if (hasTargetCopyrightBanner) {
-                    <app-notice icon="copyright" type="warning" class="copyright-banner">
+                    <app-notice mode="fill-dark" icon="copyright" type="warning" class="copyright-banner">
                       <div>
                         {{ targetCopyrightBanner }}
                         <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{
@@ -134,35 +134,35 @@
                     </app-notice>
                   }
                   @if (!isUsfmValid && hasEditRight && invalidTags().length === 0) {
-                    <app-notice type="warning" icon="warning" class="formatting-invalid-warning">
+                    <app-notice mode="fill-dark" type="warning" icon="warning" class="formatting-invalid-warning">
                       {{ t("cannot_edit_chapter_formatting_invalid") }}
                     </app-notice>
                   }
                   @if (!isUsfmValid && hasEditRight && invalidTags().length > 0) {
-                    <app-notice type="warning" icon="warning" class="formatting-invalid-warning">
+                    <app-notice mode="fill-dark" type="warning" icon="warning" class="formatting-invalid-warning">
                       <span
                         [innerHTML]="t('cannot_edit_chapter_unsupported_usfm', { tags: invalidTags().join(', ') })"
                       ></span>
                     </app-notice>
                   }
                   @if (!dataInSync && hasEditRight) {
-                    <app-notice type="warning" icon="warning" class="out-of-sync-warning">
+                    <app-notice mode="fill-dark" type="warning" icon="warning" class="out-of-sync-warning">
                       {{ t("project_data_out_of_sync") }}
                     </app-notice>
                   }
                   @if (target.areOpsCorrupted && hasEditRight) {
-                    <app-notice type="error" icon="error" class="doc-corrupted-warning">
+                    <app-notice mode="fill-dark" type="error" icon="error" class="doc-corrupted-warning">
                       {{ t("text_doc_corrupted") }}
                       <span [innerHTML]="t('to_report_issue_email', { issueEmailLink: issueEmailLink })"></span>
                     </app-notice>
                   }
                   @if (projectTextNotEditable && hasEditRight) {
-                    <app-notice type="info" icon="info" class="project-text-not-editable">
+                    <app-notice mode="fill-dark" type="info" icon="info" class="project-text-not-editable">
                       {{ t("project_text_not_editable") }}
                     </app-notice>
                   }
                   @if (showNoEditPermissionMessage) {
-                    <app-notice type="info" icon="info" class="no-edit-permission-message">
+                    <app-notice mode="fill-dark" type="info" icon="info" class="no-edit-permission-message">
                       {{ t("no_permission_edit_chapter", { userRole: userRoleStr }) }}
                     </app-notice>
                   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -162,16 +162,13 @@ app-text {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-
-  app-notice {
-    margin: 1em;
-  }
 }
 
 .text-container {
   display: flex;
   position: relative;
   height: 100%;
+  overflow: hidden;
 }
 
 .text-area {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3447,7 +3447,7 @@ describe('EditorComponent', () => {
 
       // Set window size to be narrow to test scrolling
       const contentContainer: HTMLElement = document.getElementsByClassName('content')[0] as HTMLElement;
-      Object.assign(contentContainer.style, { width: '360px', height: '300px' });
+      Object.assign(contentContainer.style, { width: '680px', height: '300px' });
 
       // Verse near bottom of scroll container
       const segmentRef = 'verse_1_6';


### PR DESCRIPTION
This PR addresses two bugs related to the same issue of overflow within the editor container. The quill editor overflowed below the text container causing the last few lines to be hidden in cases the target chapter had a lot of text. This also created an issue where if the user scrolled down and selected a verse at the bottom when refreshing or navigating back to the editor it would hide any app notices above the text container.

This change updates the notice to remain at the top of the editor and only scroll the quill editor. One test needed updated as the width of the editor was set extremely narrow (beyond real-world cases) and failed with this change. By setting the width and heigh to a more reasonable size the testing performs as expected. Updating the app notices to `mode="fill-dark"` removes the border and creates a cleaner look as they now remain fixed at the top of the editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3085)
<!-- Reviewable:end -->
