### PR TITLE
Update validation schema to support ShareDB 5.1.1

### DIFF
--- a/src/RealtimeServer/common/services/doc-service.ts
+++ b/src/RealtimeServer/common/services/doc-service.ts
@@ -34,6 +34,22 @@ export abstract class DocService<T = any> {
           },
           mtime: {
             bsonType: 'number'
+          },
+          _create: {
+            bsonType: 'object',
+            required: ['src', 'seq', 'v'],
+            properties: {
+              src: {
+                bsonType: 'string'
+              },
+              seq: {
+                bsonType: 'number'
+              },
+              v: {
+                bsonType: 'number'
+              }
+            },
+            additionalProperties: false
           }
         },
         additionalProperties: false


### PR DESCRIPTION
To stop doc creation conflicts, MongoDB adds a `_create` property to the `_m` metadata in MongoDB.

This PR updates our validation schema to check for this object. It is not required as pre-5.1.1 documents will not have this object.

The code in ShareDB that writes this object is here: https://github.com/share/sharedb/blob/master/lib/submit-request.js#L213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3086)
<!-- Reviewable:end -->
