### PR TITLE
Fix language code confirmation in draft sources component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -172,7 +172,7 @@
     class="confirm-language-codes"
     [draftSources]="draftSourcesAsArray"
     [informUserWhereToChangeDraftSources]="false"
-    (languageCodesVerified)="languageCodesConfirmed = $event"
+    [(languageCodesConfirmed)]="languageCodesConfirmed"
   ></app-language-codes-confirmation>
 
   <div class="component-footer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
@@ -361,3 +361,16 @@ export const CannotSelectSameProjectTwiceInOneStep: Story = {
     canvas.getByRole('button', { name: /Add another reference project/ });
   }
 };
+
+export const LanguageCodesConfirmationAutomaticallyCleared: Story = {
+  ...Default,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await selectSource(canvasElement, 'P_EN');
+    await userEvent.click(await canvas.findByRole('checkbox'));
+    expect(await canvas.findByRole('checkbox')).toBeChecked();
+    await clearSource(canvasElement);
+    expect(await canvas.findByRole('checkbox')).not.toBeChecked();
+  }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
@@ -19,7 +19,7 @@
           }
         </p>
       }
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">
+      <mat-checkbox [checked]="languageCodesVerified" (change)="confirmationChanged($event)">
         {{ t("i_understand_and_accept") }}
       </mat-checkbox>
     </app-notice>
@@ -48,7 +48,7 @@
           }
         </p>
       }
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">
+      <mat-checkbox [checked]="languageCodesVerified" (change)="confirmationChanged($event)">
         {{ t("i_understand_and_accept") }}
       </mat-checkbox>
     </app-notice>
@@ -59,7 +59,7 @@
       <h3>{{ t("incorrect_language_codes_reduce_quality") }}</h3>
       <p>{{ t("please_make_sure_codes_correct") }}</p>
       <p>{{ t("how_to_change_language_codes") }}</p>
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">{{
+      <mat-checkbox [checked]="languageCodesVerified" (change)="confirmationChanged($event)">{{
         t("confirm_lang_codes_correct")
       }}</mat-checkbox>
     </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -88,7 +88,7 @@ describe('LanguageCodesConfirmationComponent', () => {
   it('can emit languages confirmed when checkbox is checked', () => {
     component.draftSources = getStandardDraftSources();
     fixture.detectChanges();
-    const emitSpy = spyOn(component.languageCodesVerified, 'emit');
+    const emitSpy = spyOn(component.languageCodesConfirmedChange, 'emit');
     component.confirmationChanged({ checked: true } as any);
     expect(emitSpy).toHaveBeenCalledWith(true);
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
@@ -19,7 +19,9 @@ import { DraftSourcesAsSelectableProjectArrays, englishNameFromCode } from '../d
   styleUrl: './language-codes-confirmation.component.scss'
 })
 export class LanguageCodesConfirmationComponent {
-  @Output() languageCodesVerified = new EventEmitter<boolean>(false);
+  @Input() languageCodesConfirmed = false;
+  @Output() languageCodesConfirmedChange = new EventEmitter<boolean>();
+
   /** It makes sense to inform the user, except when the user is on the page for changing sources */
   @Input() informUserWhereToChangeDraftSources: boolean = true;
   @Input() set draftSources(value: DraftSourcesAsSelectableProjectArrays) {
@@ -31,7 +33,6 @@ export class LanguageCodesConfirmationComponent {
 
   draftingSources: SelectableProjectWithLanguageCode[] = [];
   trainingSources: SelectableProjectWithLanguageCode[] = [];
-  languageCodesConfirmed: boolean = false;
   targetLanguageTag?: string;
   projectSettingsUrl: string = '';
 
@@ -67,6 +68,6 @@ export class LanguageCodesConfirmationComponent {
 
   confirmationChanged(event: MatCheckboxChange): void {
     this.languageCodesConfirmed = event.checked;
-    this.languageCodesVerified.emit(event.checked);
+    this.languageCodesConfirmedChange.emit(this.languageCodesConfirmed);
   }
 }


### PR DESCRIPTION
Prior to this change, if the user changed the selected sources, the language code confirmation checkbox didn't get reset.

I have labeled this as testing not required as the draft source component has yet to go through testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3087)
<!-- Reviewable:end -->
