### PR TITLE
SF-3259 Fix resources not showing copyright notices

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.html
@@ -1,0 +1,10 @@
+<app-notice mode="fill-dark" icon="copyright" type="warning" class="copyright-banner">
+  <div>
+    {{ banner }}
+    @if (showMoreInfo) {
+      <span class="copyright-more-info" (click)="openCopyrightNoticeDialog()">
+        {{ moreInfo }}
+      </span>
+    }
+  </div>
+</app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.scss
@@ -1,0 +1,11 @@
+.copyright-banner {
+  margin-bottom: 10px;
+}
+
+.copyright-more-info {
+  cursor: pointer;
+  font-weight: bold;
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+import { mock } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
+import { CopyrightBannerComponent } from './copyright-banner.component';
+
+const mockedDialogService = mock(DialogService);
+const mockedi18nService = mock(I18nService);
+const mockedMatDialog = mock(MatDialog);
+
+describe('CopyrightBannerComponent', () => {
+  configureTestingModule(() => ({
+    imports: [CopyrightBannerComponent, TestTranslocoModule],
+    providers: [
+      { provide: DialogService, useValue: mockedDialogService },
+      { provide: I18nService, useValue: mockedi18nService },
+      { provide: MatDialog, useValue: mockedMatDialog }
+    ]
+  }));
+
+  let component: CopyrightBannerComponent;
+  let fixture: ComponentFixture<CopyrightBannerComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CopyrightBannerComponent);
+    component = fixture.componentInstance;
+    component.notice = 'notice';
+    component.banner = 'banner';
+    const mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['afterClosed']);
+    mockDialogRef.afterClosed.and.returnValue(of(undefined));
+  });
+
+  it('should open dialog when clicking on More info', fakeAsync(() => {
+    const dialogMessage = spyOn((component as any).dialogService, 'openGenericDialog').and.callThrough();
+    fixture.detectChanges();
+    const notice = fixture.debugElement.query(By.css('.copyright-banner .copyright-more-info'));
+    (notice.nativeElement as HTMLElement).click();
+    tick();
+    expect(dialogMessage).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should not show the More info link when there is no notice info', () => {
+    component.notice = undefined;
+    component.banner = 'banner';
+    fixture.detectChanges();
+    expect(component.showMoreInfo).toBeFalse();
+    const notice = fixture.debugElement.query(By.css('.copyright-banner .copyright-more-info'));
+    expect(notice).toBeNull();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input } from '@angular/core';
+import { translate } from '@ngneat/transloco';
+import { of } from 'rxjs';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { stripHtml } from 'xforge-common/util/string-util';
+import { NoticeComponent } from '../notice/notice.component';
+
+@Component({
+  selector: 'app-copyright-banner',
+  standalone: true,
+  imports: [NoticeComponent],
+  templateUrl: './copyright-banner.component.html',
+  styleUrl: './copyright-banner.component.scss'
+})
+export class CopyrightBannerComponent {
+  @Input() notice: string | undefined;
+  @Input() banner: string | undefined;
+
+  constructor(
+    private readonly dialogService: DialogService,
+    private readonly i18n: I18nService
+  ) {}
+
+  get moreInfo(): string {
+    return translate('editor.more_info');
+  }
+
+  get showMoreInfo(): boolean {
+    return this.notice != null;
+  }
+
+  openCopyrightNoticeDialog(): void {
+    // allowing non-null assertion for this.notice as the link to open the dialog is only shown when
+    // this.notice is defined (this.showMoreInfo)
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    let copyrightNotice = this.notice!.trim();
+    if (copyrightNotice[0] !== '<') {
+      // If copyright is plain text, remove the first line and add paragraph markers.
+      const lines: string[] = copyrightNotice.split('\n');
+      copyrightNotice = '<p>' + lines.slice(1).join('</p><p>') + '</p>';
+    } else {
+      // Just remove the first paragraph that contains the notification.
+      copyrightNotice = copyrightNotice.replace(/^<p>.*?<\/p>/, '');
+    }
+
+    this.dialogService.openGenericDialog({
+      message: of(stripHtml(copyrightNotice)),
+      options: [{ value: undefined, label: this.i18n.translate('dialog.close'), highlight: true }]
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.html
@@ -1,12 +1,19 @@
 @if (projectId) {
-  <app-text
-    [id]="projectId | textDocId: bookNum : chapter"
-    [isReadOnly]="true"
-    [subscribeToUpdates]="false"
-    [highlightSegment]="highlightSegment ?? false"
-    [segmentRef]="segmentRef ?? ''"
-    [isRightToLeft]="isRightToLeft"
-    [fontSize]="fontSize"
-    [style.--project-font]="font"
-  ></app-text>
+  <div class="project-tab-container">
+    @if (hasCopyrightBanner) {
+      <app-copyright-banner [notice]="copyrightNotice" [banner]="copyrightBanner"></app-copyright-banner>
+    }
+    <div class="text-container">
+      <app-text
+        [id]="projectId | textDocId: bookNum : chapter"
+        [isReadOnly]="true"
+        [subscribeToUpdates]="false"
+        [highlightSegment]="highlightSegment ?? false"
+        [segmentRef]="segmentRef ?? ''"
+        [isRightToLeft]="isRightToLeft"
+        [fontSize]="fontSize"
+        [style.--project-font]="font"
+      ></app-text>
+    </div>
+  </div>
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.spec.ts
@@ -2,10 +2,12 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Subject } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FontService } from 'xforge-common/font.service';
-import { configureTestingModule } from 'xforge-common/test-utils';
+import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { CopyrightBannerComponent } from '../../../shared/copyright-banner/copyright-banner.component';
 import { EditorResourceComponent } from './editor-resource.component';
 
 describe('EditorResourceComponent', () => {
@@ -13,6 +15,7 @@ describe('EditorResourceComponent', () => {
   let fixture: ComponentFixture<EditorResourceComponent>;
   const mockSFProjectService = mock(SFProjectService);
   const mockFontService = mock(FontService);
+  const mockDialogService = mock(DialogService);
   const projectDoc = {
     id: 'projectId',
     data: createTestProjectProfile()
@@ -21,8 +24,10 @@ describe('EditorResourceComponent', () => {
   configureTestingModule(() => ({
     providers: [
       { provide: SFProjectService, useMock: mockSFProjectService },
-      { provide: FontService, useMock: mockFontService }
-    ]
+      { provide: FontService, useMock: mockFontService },
+      { provide: DialogService, useMock: mockDialogService }
+    ],
+    imports: [CopyrightBannerComponent, TestTranslocoModule]
   }));
 
   beforeEach(async () => {
@@ -82,5 +87,37 @@ describe('EditorResourceComponent', () => {
     component.resourceText.editorCreated.next();
     tick();
     expect(component.isRightToLeft).toBe(true);
+  }));
+
+  it('project copyright banner and copyright notice should init when they exist', fakeAsync(() => {
+    const projectId = 'proj-notice';
+    component.projectId = projectId;
+    component.bookNum = 1;
+    component.chapter = 1;
+    const projectNoticeDoc: SFProjectProfileDoc = {
+      id: projectId,
+      data: createTestProjectProfile({ copyrightBanner: 'Test copyright', copyrightNotice: 'Test notice' })
+    } as SFProjectProfileDoc;
+    when(mockSFProjectService.getProfile(projectId)).thenReturn(Promise.resolve(projectNoticeDoc));
+    component['initProjectDetails']();
+    component.resourceText.editorCreated.next();
+    tick();
+    expect(component.hasCopyrightBanner).toBe(true);
+    expect(component.copyrightBanner).toBe('Test copyright');
+    expect(component.copyrightNotice).toBe('Test notice');
+  }));
+
+  it('project copyright banner and copyright notice should not init when they do not exist', fakeAsync(() => {
+    const projectId = projectDoc.id;
+    component.projectId = projectId;
+    component.bookNum = 1;
+    component.chapter = 1;
+    when(mockSFProjectService.getProfile(projectId)).thenReturn(Promise.resolve(projectDoc));
+    component['initProjectDetails']();
+    component.resourceText.editorCreated.next();
+    tick();
+    expect(component.hasCopyrightBanner).toBe(false);
+    expect(component.copyrightBanner).toBe('');
+    expect(component.copyrightNotice).toBeFalsy();
   }));
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-resource/editor-resource.component.ts
@@ -8,7 +8,8 @@ import { TextComponent } from '../../../shared/text/text.component';
 import { formatFontSizeToRems } from '../../../shared/utils';
 @Component({
   selector: 'app-editor-resource',
-  templateUrl: './editor-resource.component.html'
+  templateUrl: './editor-resource.component.html',
+  styleUrl: '../editor.component.scss'
 })
 export class EditorResourceComponent implements AfterViewInit, OnChanges {
   @Input() projectId?: string;
@@ -22,6 +23,9 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
   isRightToLeft = false;
   fontSize?: string;
   font?: string;
+  hasCopyrightBanner: boolean = false;
+  copyrightBanner?: string;
+  copyrightNotice?: string;
 
   inputChanged$ = new Subject<void>();
 
@@ -52,6 +56,9 @@ export class EditorResourceComponent implements AfterViewInit, OnChanges {
         })
       )
       .subscribe((projectDoc: SFProjectProfileDoc) => {
+        this.hasCopyrightBanner = projectDoc.data?.copyrightBanner != null;
+        this.copyrightBanner = projectDoc.data?.copyrightBanner ?? '';
+        this.copyrightNotice = projectDoc.data?.copyrightNotice;
         this.isRightToLeft = projectDoc.data?.isRightToLeft ?? false;
         this.fontSize = formatFontSizeToRems(projectDoc.data?.defaultFontSize);
         this.font = this.fontService.getFontFamilyFromProject(projectDoc);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -92,14 +92,10 @@
               @case ("project-source") {
                 <div class="project-tab-container">
                   @if (hasSourceCopyrightBanner) {
-                    <app-notice mode="fill-dark" icon="copyright" type="warning" class="copyright-banner">
-                      <div>
-                        {{ sourceCopyrightBanner }}
-                        <span class="copyright-more-info" (click)="showCopyrightNotice('source')">{{
-                          t("more_info")
-                        }}</span>
-                      </div>
-                    </app-notice>
+                    <app-copyright-banner
+                      [notice]="sourceCopyrightNotice"
+                      [banner]="sourceCopyrightBanner"
+                    ></app-copyright-banner>
                   }
                   <div class="text-container">
                     <app-text
@@ -124,14 +120,10 @@
                     </app-notice>
                   }
                   @if (hasTargetCopyrightBanner) {
-                    <app-notice mode="fill-dark" icon="copyright" type="warning" class="copyright-banner">
-                      <div>
-                        {{ targetCopyrightBanner }}
-                        <span class="copyright-more-info" (click)="showCopyrightNotice('target')">{{
-                          t("more_info")
-                        }}</span>
-                      </div>
-                    </app-notice>
+                    <app-copyright-banner
+                      [notice]="targetCopyrightNotice"
+                      [banner]="targetCopyrightBanner"
+                    ></app-copyright-banner>
                   }
                   @if (!isUsfmValid && hasEditRight && invalidTags().length === 0) {
                     <app-notice mode="fill-dark" type="warning" icon="warning" class="formatting-invalid-warning">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -136,18 +136,6 @@ app-text {
   }
 }
 
-.copyright-banner {
-  margin-bottom: 10px;
-}
-
-.copyright-more-info {
-  cursor: pointer;
-  font-weight: bold;
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 .reverse-columns {
   #source-text-area {
     grid-column-start: 2;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -94,6 +94,7 @@ import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
 import { HttpClient } from '../../machine-api/http-client';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
+import { CopyrightBannerComponent } from '../../shared/copyright-banner/copyright-banner.component';
 import { SFTabsModule, TabFactoryService, TabGroup, TabMenuService } from '../../shared/sf-tab-group';
 import { SharedModule } from '../../shared/shared.module';
 import { getCombinedVerseTextDoc, paratextUsersFromRoles } from '../../shared/test-utils';
@@ -151,6 +152,7 @@ describe('EditorComponent', () => {
     declarations: [EditorComponent, SuggestionsComponent, TrainingProgressComponent, EditorDraftComponent],
     imports: [
       BiblicalTermsComponent,
+      CopyrightBannerComponent,
       NoopAnimationsModule,
       RouterModule.forRoot(ROUTES),
       SharedModule,
@@ -3704,26 +3706,6 @@ describe('EditorComponent', () => {
       expect(env.copyrightBanner).not.toBeNull();
       env.dispose();
     }));
-
-    it('shows the copyright notice dialog', fakeAsync(() => {
-      const env = new TestEnvironment();
-      env.setupProject({ translateConfig: defaultTranslateConfig, copyrightBanner: 'banner text' });
-      env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 3 });
-      env.routeWithParams({ projectId: 'project01', bookId: 'MAT' });
-      env.wait();
-
-      // SUT
-      const dialogMessage = spyOn((env.component as any).dialogService, 'openGenericDialog').and.callThrough();
-      env.setupDialogRef();
-
-      expect(env.copyrightBanner).not.toBeNull();
-      env.copyrightMoreInfo.nativeElement.click();
-      tick();
-      env.fixture.detectChanges();
-      expect(dialogMessage).toHaveBeenCalledTimes(1);
-
-      env.dispose();
-    }));
   });
 
   it('sets book and chapter according to route', fakeAsync(() => {
@@ -4636,15 +4618,11 @@ class TestEnvironment {
   }
 
   get copyrightBanner(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.copyright-banner'));
+    return this.fixture.debugElement.query(By.css('app-copyright-banner'));
   }
 
   get showWritingSystemWarningBanner(): DebugElement {
     return this.fixture.debugElement.query(By.css('.writing-system-warning-banner'));
-  }
-
-  get copyrightMoreInfo(): DebugElement {
-    return this.fixture.debugElement.query(By.css('.copyright-banner .copyright-more-info'));
   }
 
   get isSourceAreaHidden(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -63,7 +63,6 @@ import {
   lastValueFrom,
   merge,
   Observable,
-  of,
   Subject,
   Subscription,
   timer
@@ -198,6 +197,7 @@ const UNSUPPORTED_LANGUAGE_CODES = [
   selector: 'app-editor',
   templateUrl: './editor.component.html',
   styleUrls: ['./editor.component.scss'],
+
   providers: [
     TabStateService<EditorTabGroupType, EditorTabInfo>,
     { provide: TabFactoryService, useClass: EditorTabFactoryService },
@@ -613,12 +613,20 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return this.sourceProjectDoc?.data?.copyrightBanner ?? '';
   }
 
+  get sourceCopyrightNotice(): string | undefined {
+    return this.sourceProjectDoc?.data?.copyrightNotice;
+  }
+
   get hasTargetCopyrightBanner(): boolean {
     return this.projectDoc?.data?.copyrightBanner != null;
   }
 
   get targetCopyrightBanner(): string {
     return this.projectDoc?.data?.copyrightBanner ?? '';
+  }
+
+  get targetCopyrightNotice(): string | undefined {
+    return this.projectDoc?.data?.copyrightNotice;
   }
 
   get sourceLabel(): string | undefined {
@@ -1199,34 +1207,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   onViewerClicked(viewer: MultiCursorViewer): void {
     this.target!.scrollToViewer(viewer);
-  }
-
-  showCopyrightNotice(textType: TextType): void {
-    let copyrightNotice: string =
-      textType === 'source'
-        ? (this.sourceProjectDoc?.data?.copyrightNotice ?? '')
-        : (this.projectDoc?.data?.copyrightNotice ?? '');
-
-    // If we do not have a copyright notice, just use the copyright banner
-    if (copyrightNotice === '') {
-      copyrightNotice = textType === 'source' ? this.sourceCopyrightBanner : this.targetCopyrightBanner;
-    }
-
-    copyrightNotice = copyrightNotice.trim();
-    if (copyrightNotice[0] !== '<') {
-      // If copyright is plain text, remove the first line and add paragraph markers.
-      const lines: string[] = copyrightNotice.split('\n');
-      copyrightNotice = '<p>' + lines.slice(1).join('</p><p>') + '</p>';
-    } else {
-      // Just remove the first paragraph that contains the notification.
-      copyrightNotice = copyrightNotice.replace(/^<p>.*?<\/p>/, '');
-    }
-
-    // Show the copyright notice
-    this.dialogService.openGenericDialog({
-      message: of(stripHtml(copyrightNotice)),
-      options: [{ value: undefined, label: this.i18n.translate('dialog.close'), highlight: true }]
-    });
   }
 
   async onHistoryTabRevisionSelect(tab: EditorTabInfo, revision: Revision | undefined): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate.module.ts
@@ -6,6 +6,7 @@ import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { AvatarComponent } from 'xforge-common/avatar/avatar.component';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
+import { CopyrightBannerComponent } from '../shared/copyright-banner/copyright-banner.component';
 import { SFTabsModule } from '../shared/sf-tab-group';
 import { SharedModule } from '../shared/shared.module';
 import { BiblicalTermDialogComponent } from './biblical-terms/biblical-term-dialog.component';
@@ -57,6 +58,7 @@ import { TranslateRoutingModule } from './translate-routing.module';
     AvatarComponent,
     SFTabsModule,
     BiblicalTermsComponent,
+    CopyrightBannerComponent,
     DraftPreviewBooksComponent,
     DraftApplyProgressDialogComponent,
     FontUnsupportedMessageComponent


### PR DESCRIPTION
When a project or DBL resource has a copyright, we want the copyright notice to be displayed in the editor. Currently we show it only on the Source tab but not if it's loaded in the Resource tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3088)
<!-- Reviewable:end -->
