### PR TITLE
Fix language code confirmation in draft sources component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -47,6 +47,6 @@
   <app-language-codes-confirmation
     class="confirm-codes"
     [draftSources]="draftSources"
-    (languageCodesVerified)="confirmationChanged($event)"
+    (languageCodesConfirmedChange)="confirmationChanged($event)"
   ></app-language-codes-confirmation>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -172,7 +172,7 @@
     class="confirm-language-codes"
     [draftSources]="draftSourcesAsArray"
     [informUserWhereToChangeDraftSources]="false"
-    (languageCodesVerified)="languageCodesConfirmed = $event"
+    [(languageCodesConfirmed)]="languageCodesConfirmed"
   ></app-language-codes-confirmation>
 
   <div class="component-footer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
@@ -361,3 +361,22 @@ export const CannotSelectSameProjectTwiceInOneStep: Story = {
     canvas.getByRole('button', { name: /Add another reference project/ });
   }
 };
+
+export const LanguageCodesConfirmationAutomaticallyCleared: Story = {
+  ...Default,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await selectSource(canvasElement, 'P_EN');
+    await userEvent.click(await canvas.findByRole('checkbox'));
+    expect(await canvas.findByRole('checkbox')).toBeChecked();
+
+    // Clearing the source doesn't clear the checkbox
+    await clearSource(canvasElement);
+    expect(await canvas.findByRole('checkbox')).toBeChecked();
+
+    // Selecting a source does clear the checkbox
+    await selectSource(canvasElement, 'P_EN');
+    expect(await canvas.findByRole('checkbox')).not.toBeChecked();
+  }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -88,7 +88,7 @@ describe('LanguageCodesConfirmationComponent', () => {
   it('can emit languages confirmed when checkbox is checked', () => {
     component.draftSources = getStandardDraftSources();
     fixture.detectChanges();
-    const emitSpy = spyOn(component.languageCodesVerified, 'emit');
+    const emitSpy = spyOn(component.languageCodesConfirmedChange, 'emit');
     component.confirmationChanged({ checked: true } as any);
     expect(emitSpy).toHaveBeenCalledWith(true);
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
@@ -19,7 +19,9 @@ import { DraftSourcesAsSelectableProjectArrays, englishNameFromCode } from '../d
   styleUrl: './language-codes-confirmation.component.scss'
 })
 export class LanguageCodesConfirmationComponent {
-  @Output() languageCodesVerified = new EventEmitter<boolean>(false);
+  @Input() languageCodesConfirmed = false;
+  @Output() languageCodesConfirmedChange = new EventEmitter<boolean>();
+
   /** It makes sense to inform the user, except when the user is on the page for changing sources */
   @Input() informUserWhereToChangeDraftSources: boolean = true;
   @Input() set draftSources(value: DraftSourcesAsSelectableProjectArrays) {
@@ -31,7 +33,6 @@ export class LanguageCodesConfirmationComponent {
 
   draftingSources: SelectableProjectWithLanguageCode[] = [];
   trainingSources: SelectableProjectWithLanguageCode[] = [];
-  languageCodesConfirmed: boolean = false;
   targetLanguageTag?: string;
   projectSettingsUrl: string = '';
 
@@ -67,6 +68,6 @@ export class LanguageCodesConfirmationComponent {
 
   confirmationChanged(event: MatCheckboxChange): void {
     this.languageCodesConfirmed = event.checked;
-    this.languageCodesVerified.emit(event.checked);
+    this.languageCodesConfirmedChange.emit(this.languageCodesConfirmed);
   }
 }


### PR DESCRIPTION
**NOTE:** This PR is against an un-merged branch, not against master.

Prior to this change, if the user changed the selected sources, the language code confirmation checkbox didn't get reset.

The meat of this change is in `language-codes-confirmation.component.ts`, where I made the value be able to be set and also have the value emitted.

This allowed the use of [the banana-in-a-box syntax](https://v18.angular.dev/guide/templates/two-way-binding) for two-way data binding:
```html
[(languageCodesConfirmed)]="languageCodesConfirmed"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3089)
<!-- Reviewable:end -->
