### PR TITLE
Show error state when failing to save draft sources config

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -190,15 +190,15 @@
         <mat-card-title>{{ t("saving_draft_sources") }}</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        @if (getControlState("projectSettings") === ElementState.Submitting) {
-          <div class="saving-indicator">
+        <div class="saving-indicator">
+          @if (getControlState("projectSettings") === ElementState.Submitting) {
             <mat-spinner [diameter]="24" color="primary"></mat-spinner> {{ t("saving") }}
-          </div>
-        } @else {
-          <div class="saving-indicator">
+          } @else if (getControlState("projectSettings") === ElementState.Submitted) {
             <mat-icon class="success">checkmark</mat-icon> {{ t("all_changes_saved") }}
-          </div>
-        }
+          } @else {
+            <mat-icon class="failure">error</mat-icon> Failed to save changes
+          }
+        </div>
         @for (entry of syncStatus | keyvalue; track entry.key) {
           <div>
             @if (entry.value.knownToBeOnSF) {
@@ -209,7 +209,8 @@
                   <mat-icon class="success">check</mat-icon> {{ entry.value.shortName }} -
                   {{ t("state_sync_successful") }}
                 } @else {
-                  <mat-icon class="failure">error</mat-icon> {{ entry.value.shortName }} - {{ t("state_sync_failed") }}
+                  <mat-icon class="failure">error</mat-icon> {{ entry.value.shortName }} -
+                  {{ t("state_sync_failed") }}
                 }
               }
             } @else {
@@ -218,7 +219,7 @@
           </div>
         }
       </mat-card-content>
-      @if (allProjectsSavedAndSynced) {
+      @if (allProjectsSavedAndSynced || getControlState("projectSettings") === ElementState.Error) {
         <mat-card-actions align="end">
           <button mat-button (click)="navigateToDrafting()"><mat-icon>close</mat-icon> {{ t("close") }}</button>
         </mat-card-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -335,6 +335,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     } catch (error) {
       console.error('Error updating project settings', error);
       this.controlStates.set(setting, ElementState.Error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
**NOTE:** This is a PR against `task/sf-3238`, not `master`

To test this, try saving both as an admin (which does have permission), and as a translator (which does not have permission).

Stopping translators from getting to this page will be a separate task.

The implementation here feels quite bad to me, and it doesn't feel like we're handling all the save/sync states completely properly, but it seems to work for the scenarios I'm testing. We will likely need to revisit this later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3091)
<!-- Reviewable:end -->
