### PR TITLE
Only show configure drafting button to admins

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -179,12 +179,14 @@
                     <mat-icon>auto_awesome</mat-icon>
                     {{ t("generate_draft_button") }}
                   </button>
-                  <button mat-flat-button [routerLink]="['sources']">
-                    <mat-icon>settings</mat-icon>
-                    {{ t("configure_sources") }}
-                  </button>
-                } @else {
-                  <button mat-flat-button color="primary" [routerLink]="['sources']">
+                  @if (isProjectAdmin) {
+                    <button mat-flat-button data-test-id="configure-button" [routerLink]="['sources']">
+                      <mat-icon>settings</mat-icon>
+                      {{ t("configure_sources") }}
+                    </button>
+                  }
+                } @else if (isProjectAdmin) {
+                  <button mat-flat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
                     <mat-icon>settings</mat-icon>
                     {{ t("configure_sources") }}
                   </button>
@@ -314,20 +316,21 @@
           <mat-icon>add</mat-icon>
           {{ t("generate_new_draft") }}
         </button>
-
-        <button mat-flat-button [routerLink]="['sources']">
-          <mat-icon>settings</mat-icon>
-          {{ t("configure_sources") }}
-        </button>
-      } @else {
+        @if (isProjectAdmin) {
+          <button mat-flat-button data-test-id="configure-button" [routerLink]="['sources']">
+            <mat-icon>settings</mat-icon>
+            {{ t("configure_sources") }}
+          </button>
+        }
+      } @else if (isProjectAdmin) {
         <!-- Show Configure sources button when we don't have permission to the current sources and when there is not a
         prior draft job. But don't show it if it's already been shown above or if the user is not signed up for
         drafting.
 
         This first check regards what leads up to the first configure button. -->
-        @if (!(isOnline && isGenerationSupported && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild)) {
-          @if (draftEnabled) {
-            <button mat-flat-button color="primary" [routerLink]="['sources']">
+        @if (!isGenerationSupported || isDraftInProgress(draftJob) || hasAnyCompletedBuild) {
+          @if (draftEnabled && isOnline) {
+            <button mat-flat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
               <mat-icon>settings</mat-icon>
               {{ t("configure_sources") }}
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -179,13 +179,13 @@
                     <mat-icon>auto_awesome</mat-icon>
                     {{ t("generate_draft_button") }}
                   </button>
-                  @if (isProjectAdmin) {
-                    <button mat-flat-button data-test-id="configure-button" [routerLink]="['sources']">
+                  @if (hasConfigureSourcePermission) {
+                    <button mat-button data-test-id="configure-button" [routerLink]="['sources']">
                       <mat-icon>settings</mat-icon>
                       {{ t("configure_sources") }}
                     </button>
                   }
-                } @else if (isProjectAdmin) {
+                } @else if (hasConfigureSourcePermission) {
                   <button mat-flat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
                     <mat-icon>settings</mat-icon>
                     {{ t("configure_sources") }}
@@ -316,13 +316,13 @@
           <mat-icon>add</mat-icon>
           {{ t("generate_new_draft") }}
         </button>
-        @if (isProjectAdmin) {
-          <button mat-flat-button data-test-id="configure-button" [routerLink]="['sources']">
+        @if (hasConfigureSourcePermission) {
+          <button mat-button data-test-id="configure-button" [routerLink]="['sources']">
             <mat-icon>settings</mat-icon>
             {{ t("configure_sources") }}
           </button>
         }
-      } @else if (isProjectAdmin) {
+      } @else if (hasConfigureSourcePermission) {
         <!-- Show Configure sources button when we don't have permission to the current sources and when there is not a
         prior draft job. But don't show it if it's already been shown above or if the user is not signed up for
         drafting.
@@ -330,7 +330,7 @@
         This first check regards what leads up to the first configure button. -->
         @if (!isGenerationSupported || isDraftInProgress(draftJob) || hasAnyCompletedBuild) {
           @if (draftEnabled && isOnline) {
-            <button mat-flat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
+            <button mat-button data-test-id="configure-button" color="primary" [routerLink]="['sources']">
               <mat-icon>settings</mat-icon>
               {{ t("configure_sources") }}
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -214,6 +214,10 @@ describe('DraftGenerationComponent', () => {
       });
     }
 
+    get configureDraftButton(): HTMLElement | null {
+      return this.getElementByTestId('configure-button');
+    }
+
     get downloadButton(): HTMLElement | null {
       return this.getElementByTestId('download-button');
     }
@@ -249,6 +253,12 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isBackTranslation).toBe(true);
       expect(env.component.isTargetLanguageSupported).toBe(true);
       expect(env.component.targetLanguage).toBe('en');
+      expect(env.configureDraftButton).not.toBeNull();
+    });
+
+    it('should not show configure drafting source button for translators', () => {
+      const env = new TestEnvironment(() => TestEnvironment.initProject('user02'));
+      expect(env.configureDraftButton).toBeNull();
     });
 
     it('does not subscribe to build when project does not have drafting enabled', () => {
@@ -265,7 +275,8 @@ describe('DraftGenerationComponent', () => {
           },
           translateConfig: {
             projectType: ProjectType.Standard
-          }
+          },
+          userRoles: { user01: SFProjectRole.ParatextAdministrator }
         })
       } as SFProjectProfileDoc;
       const env = new TestEnvironment(() => {
@@ -282,6 +293,7 @@ describe('DraftGenerationComponent', () => {
 
       expect(env.component.isBackTranslation).toBe(false);
       expect(env.component.isTargetLanguageSupported).toBe(false);
+      expect(env.configureDraftButton).not.toBeNull();
     }));
   });
 
@@ -291,6 +303,7 @@ describe('DraftGenerationComponent', () => {
       env.testOnlineStatusService.setIsOnline(false);
       env.fixture.detectChanges();
       expect(env.offlineTextElement).not.toBeNull();
+      expect(env.configureDraftButton).toBeNull();
 
       env.component.currentPage = 'steps';
       env.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -167,9 +167,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
 
   get isPreviewSupported(): boolean {
     return (
-      (!this.isBackTranslationMode || this.isBackTranslation) &&
-      this.isTargetLanguageSupported &&
-      (this.isBackTranslationMode || this.isPreTranslationApproved)
+      (!this.isBackTranslationMode || this.isBackTranslation) && this.isTargetLanguageSupported && this.draftEnabled
     );
   }
 
@@ -254,7 +252,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         this.isTargetLanguageSupported =
           !this.isBackTranslationMode || (await this.nllbService.isNllbLanguageAsync(this.targetLanguage));
 
-        if (!this.isBackTranslationMode && !this.isPreTranslationApproved) {
+        if (!this.draftEnabled) {
           this.signupFormUrl = await this.preTranslationSignupUrlService.generateSignupUrl();
         }
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -195,17 +195,21 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return this.activatedProject.projectDoc?.data?.sync.lastSyncSuccessful ?? false;
   }
 
-  get isProjectAdmin(): boolean {
+  /** Have drafting sources been adequately configured that a draft can be generated? */
+  get isSourcesConfigurationComplete(): boolean {
+    return this.source != null && (this.trainingSource != null || this.additionalTrainingSource != null);
+  }
+
+  get hasConfigureSourcePermission(): boolean {
+    return this.isProjectAdmin;
+  }
+
+  private get isProjectAdmin(): boolean {
     const userId = this.authService.currentUserId;
     if (userId != null) {
       return this.activatedProject.projectDoc?.data?.userRoles[userId] === SFProjectRole.ParatextAdministrator;
     }
     return false;
-  }
-
-  /** Have drafting sources been adequately configured that a draft can be generated? */
-  get isSourcesConfigurationComplete(): boolean {
-    return this.source != null && (this.trainingSource != null || this.additionalTrainingSource != null);
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Note: This PR is against the feature branch `task/sf-3238`
This PR will hide the button to configure draft sources if the user is not an admin or if the user is offline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3092)
<!-- Reviewable:end -->
