### PR TITLE
Fix appearance of draft generation error button

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -154,7 +154,7 @@
                       }"
                     ></transloco
                   ></span>
-                  <a mat-button target="_blank" [href]="issueMailTo">
+                  <a mat-flat-button target="_blank" [href]="issueMailTo">
                     {{ t("report_problem") }}
                   </a>
                 </div>


### PR DESCRIPTION
This has been bugging me for a long time. The button has always been red on hover, but until this change wasn't red before hover.

### Before

![draft_error_button_before](https://github.com/user-attachments/assets/604eed70-8e9d-4622-a9b8-2d11aea8d6ca)

### After

![draft_error_button_after](https://github.com/user-attachments/assets/a58e9b5d-0b11-4c50-8ef9-a7725e2e2fb6)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3093)
<!-- Reviewable:end -->
