### PR TITLE
Improve draft sources accordion UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -6,8 +6,11 @@
 
     <div class="step" [class.active]="step === 1">
       <div class="step-header" matRipple (click)="goToStep(1)">
-        <span class="step-title">{{ t("draft_source") }}</span>
-        <span class="step-subtitle">{{ sourceSubtitle }}</span>
+        <div class="step-header-description">
+          <span class="step-title">{{ t("draft_source") }}</span>
+          <span class="step-subtitle">{{ sourceSubtitle }}</span>
+        </div>
+        <mat-icon>{{ step === 1 ? "expand_less" : "expand_more" }}</mat-icon>
       </div>
       <div class="step-body">
         <p>{{ t("select_project_to_translate") }}</p>
@@ -29,8 +32,11 @@
 
     <div class="step" [class.active]="step === 2">
       <div class="step-header" matRipple (click)="goToStep(2)">
-        <span class="step-title">{{ t("reference_projects") }}</span>
-        <span class="step-subtitle">{{ referencesSubtitle }}</span>
+        <div class="step-header-description">
+          <span class="step-title">{{ t("reference_projects") }}</span>
+          <span class="step-subtitle">{{ referencesSubtitle }}</span>
+        </div>
+        <mat-icon>{{ step === 2 ? "expand_less" : "expand_more" }}</mat-icon>
       </div>
       <div class="step-body">
         <p>
@@ -78,8 +84,11 @@
 
     <div class="step" [class.active]="step === 3">
       <div class="step-header" matRipple (click)="goToStep(3)">
-        <span class="step-title">{{ t("target_language_data") }}</span>
-        <span class="step-subtitle">{{ targetSubtitle }}</span>
+        <div class="step-header-description">
+          <span class="step-title">{{ t("target_language_data") }}</span>
+          <span class="step-subtitle">{{ targetSubtitle }}</span>
+        </div>
+        <mat-icon>{{ step === 3 ? "expand_less" : "expand_more" }}</mat-icon>
       </div>
       <div class="step-body">
         <p>
@@ -237,15 +246,11 @@
   <ng-template #navigationButtons>
     <div class="step-button-wrapper">
       @if (step !== 1) {
-        <button mat-stroked-button (click)="goToStep(step - 1)">
-          <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon> {{ t("back") }}
-        </button>
+        <button mat-stroked-button (click)="goToStep(step - 1)">{{ t("previous") }}</button>
       }
       <span class="spacer"></span>
       @if (step !== 3) {
-        <button mat-flat-button color="primary" (click)="goToStep(step + 1)">
-          {{ t("next") }} <mat-icon iconPositionEnd>chevron_{{ i18n.forwardDirectionWord }}</mat-icon>
-        </button>
+        <button mat-flat-button color="primary" (click)="goToStep(step + 1)">{{ t("next") }}</button>
       }
     </div>
   </ng-template>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
@@ -42,6 +42,12 @@ strong {
 
 .step-header {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.step-header-description {
+  display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
@@ -294,9 +294,9 @@ export const NavigateAllSteps: Story = {
     expect(currentStep(canvasElement)).toBe(2);
     await userEvent.click(canvas.getByRole('button', { name: /Next/ }));
     expect(currentStep(canvasElement)).toBe(3);
-    await userEvent.click(within(canvasElement).getByRole('button', { name: /Back/ }));
+    await userEvent.click(within(canvasElement).getByRole('button', { name: /Previous/ }));
     expect(currentStep(canvasElement)).toBe(2);
-    await userEvent.click(within(canvasElement).getByRole('button', { name: /Back/ }));
+    await userEvent.click(within(canvasElement).getByRole('button', { name: /Previous/ }));
     expect(currentStep(canvasElement)).toBe(1);
     // Go to each step by clicking on the stepper
     for (let step = 1; step <= 3; step++) {
@@ -356,7 +356,7 @@ export const CannotSelectSameProjectTwiceInOneStep: Story = {
 
     // Verify empty project select is removed when leaving and coming back to step
     await userEvent.click(canvas.getByRole('button', { name: /Next/ }));
-    await userEvent.click(canvas.getByRole('button', { name: /Back/ }));
+    await userEvent.click(canvas.getByRole('button', { name: /Previous/ }));
     expect(canvas.getAllByRole('combobox').length).toBe(1);
     canvas.getByRole('button', { name: /Add another reference project/ });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -269,7 +269,6 @@
   "draft_sources": {
     "add_another_reference_project": "Add another reference project",
     "all_changes_saved": "All changes saved",
-    "back": "Back",
     "cancel": "Cancel",
     "close": "Close",
     "configure_draft_sources": "Configure draft sources",
@@ -283,6 +282,7 @@
     "overview_reference": "Reference",
     "overview_source": "Source",
     "overview_translated_project": "Translated project",
+    "previous": "Previous",
     "project_always_used": "Your project ({{ currentProjectShortName }}) will always be used to train the language model.",
     "reference_projects": "Reference projects",
     "same_language_as_given_language": "All these should be in the same language as the draft source ({{sourceLanguageDisplayName}}).",


### PR DESCRIPTION
See Chromatic/Storybook for the visual change

- Add open/close indicators to accordion headers
- Remove arrows from next/back buttons since they point horizontally and the actual direction they go is vertical
- Change the text on the back button to previous

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3094)
<!-- Reviewable:end -->
