### PR TITLE
SF-3260 Show error when draft fails because source is not specified

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -519,6 +519,7 @@ public class MachineProjectService(
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An asynchronous task.</returns>
     /// <exception cref="DataNotFoundException">The project or project secret could not be found.</exception>
+    /// <exception cref="InvalidDataException">The language of the source project was not specified.</exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
     protected internal virtual async Task BuildProjectAsync(
         string curUserId,
@@ -944,7 +945,7 @@ public class MachineProjectService(
                 // This error can occur if the project source is cleared while the build is running
                 if (projectDoc.Data.TranslateConfig.Source is null)
                 {
-                    throw new DataNotFoundException("The project source is not specified.");
+                    throw new InvalidDataException("The project source is not specified.");
                 }
 
                 // Update the source writing system tag
@@ -1015,7 +1016,7 @@ public class MachineProjectService(
         // This error can occur if the project source is cleared while the build is running
         if (project.TranslateConfig.Source is null)
         {
-            throw new DataNotFoundException("The project source is not specified.");
+            throw new InvalidDataException("The project source is not specified.");
         }
 
         string alternateSourceLanguage = project.TranslateConfig.DraftConfig.AlternateSource?.WritingSystem.Tag;
@@ -1024,7 +1025,8 @@ public class MachineProjectService(
             && !string.IsNullOrWhiteSpace(alternateSourceLanguage);
         return useAlternateSourceLanguage
             ? alternateSourceLanguage
-            : project.TranslateConfig.Source?.WritingSystem.Tag ?? throw new ArgumentNullException(nameof(project));
+            : project.TranslateConfig.Source?.WritingSystem.Tag
+                ?? throw new InvalidDataException("The source project's language is not specified.");
     }
 
     /// <summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -498,6 +498,24 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    public async Task BuildProjectAsync_ThrowsExceptionWhenSourceProjectMissing()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<InvalidDataException>(
+            () =>
+                env.Service.BuildProjectAsync(
+                    User01,
+                    new BuildConfig { ProjectId = Project04 },
+                    preTranslate: false,
+                    CancellationToken.None
+                )
+        );
+    }
+
+    [Test]
     public async Task BuildProjectAsync_ThrowsExceptionWhenServalDataMissing()
     {
         // Set up test environment
@@ -3819,6 +3837,7 @@ public class MachineProjectServiceTests
                         },
                     },
                     new SFProjectSecret { Id = Project03 },
+                    new SFProjectSecret { Id = Project04 },
                 ]
             );
 
@@ -3920,6 +3939,16 @@ public class MachineProjectServiceTests
                             TranslationSuggestionsEnabled = true,
                             Source = new TranslateSource { ProjectRef = Project01, ParatextId = Paratext01 },
                         },
+                    },
+                    new SFProject
+                    {
+                        Id = Project04,
+                        Name = "project04",
+                        ShortName = "P04",
+                        ParatextId = Paratext04,
+                        CheckingConfig = new CheckingConfig(),
+                        UserRoles = [],
+                        TranslateConfig = new TranslateConfig { PreTranslate = true, DraftConfig = { } },
                     },
                 ]
             );

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -498,7 +498,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task BuildProjectAsync_ThrowsExceptionWhenSourceProjectMissing()
+    public void BuildProjectAsync_ThrowsExceptionWhenSourceProjectMissing()
     {
         // Set up test environment
         var env = new TestEnvironment();


### PR DESCRIPTION
When a project without a source starts a pretranslation build, the build never starts because there is a silent error. This change reports the error and shows the draft as failed.
I have marked this as testing not required since developer testing should be sufficient.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3098)
<!-- Reviewable:end -->
