### PR TITLE
SF-3219 Add a message to drafting advertising the Serval USFM changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -7,7 +7,17 @@
         {{ t("generate_forward_translation_drafts_header") }}
       </h1>
     }
-
+    @if (showImprovedDraftGenerationNotice) {
+      <app-notice type="primary" mode="fill-dark" icon="bolt" data-test-id="improved-draft-generation-notice">
+        @for (portion of improvedDraftGenerationNotice | async; track $index) {
+          @if (portion.id === 1) {
+            <a href="mailto:{{ issueEmail }}" target="_blank" rel="noreferrer">{{ portion.text }}</a>
+          } @else if (portion.id == null) {
+            {{ portion.text }}
+          }
+        }
+      </app-notice>
+    }
     <section>
       @if (isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {
         <div class="drafting-instructions">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -34,6 +34,7 @@ import { DraftGenerationComponent } from './draft-generation.component';
 import { DraftGenerationService } from './draft-generation.service';
 import { DraftHandlingService } from './draft-handling.service';
 import { DraftSource, DraftSourcesAsArrays, DraftSourcesService } from './draft-sources.service';
+import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
 import { TrainingDataService } from './training-data/training-data.service';
 
 describe('DraftGenerationComponent', () => {
@@ -49,6 +50,7 @@ describe('DraftGenerationComponent', () => {
   let mockTextDocService: jasmine.SpyObj<TextDocService>;
   let mockNoticeService: jasmine.SpyObj<NoticeService>;
   let mockNllbLanguageService: jasmine.SpyObj<NllbLanguageService>;
+  let mockPreTranslationSignupUrlService: jasmine.SpyObj<PreTranslationSignupUrlService>;
   let mockTrainingDataService: jasmine.SpyObj<TrainingDataService>;
   let mockProgressService: jasmine.SpyObj<ProgressService>;
 
@@ -97,6 +99,7 @@ describe('DraftGenerationComponent', () => {
           { provide: NoticeService, useValue: mockNoticeService },
           { provide: NllbLanguageService, useValue: mockNllbLanguageService },
           { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+          { provide: PreTranslationSignupUrlService, useValue: mockPreTranslationSignupUrlService },
           { provide: TrainingDataService, useValue: mockTrainingDataService },
           { provide: ProgressService, useValue: mockProgressService }
         ]
@@ -151,6 +154,8 @@ describe('DraftGenerationComponent', () => {
       );
       mockNllbLanguageService = jasmine.createSpyObj<NllbLanguageService>(['isNllbLanguageAsync']);
       mockNllbLanguageService.isNllbLanguageAsync.and.returnValue(Promise.resolve(false));
+      mockPreTranslationSignupUrlService = jasmine.createSpyObj<PreTranslationSignupUrlService>(['generateSignupUrl']);
+      mockPreTranslationSignupUrlService.generateSignupUrl.and.returnValue(Promise.resolve(''));
 
       const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
       when(mockTrainingDataQuery.localChanges$).thenReturn(of());
@@ -226,6 +231,10 @@ describe('DraftGenerationComponent', () => {
       return this.getElementByTestId('download-spinner');
     }
 
+    get improvedDraftGenerationNotice(): HTMLElement | null {
+      return this.getElementByTestId('improved-draft-generation-notice');
+    }
+
     get offlineTextElement(): HTMLElement | null {
       return (this.fixture.nativeElement as HTMLElement).querySelector('.offline-text');
     }
@@ -294,6 +303,60 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.isBackTranslation).toBe(false);
       expect(env.component.isTargetLanguageSupported).toBe(false);
       expect(env.configureDraftButton).not.toBeNull();
+    }));
+  });
+
+  describe('Improved draft generation notice', () => {
+    // Do not run this test after April 1 2025
+    const shouldRunTest = new Date() < new Date('2025-04-01');
+    (shouldRunTest ? it : xit)(
+      'should show notice if back translation or pre-translate approved',
+      fakeAsync(() => {
+        const env = new TestEnvironment(() => {
+          mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
+            'FeatureFlagService',
+            {},
+            {
+              allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
+            }
+          );
+        });
+        env.component.isBackTranslation = true;
+        env.component.isPreTranslationApproved = false;
+        env.fixture.detectChanges();
+        tick();
+
+        expect(env.component.isBackTranslation).toBe(true);
+        expect(env.component.isPreTranslationApproved).toBe(false);
+        expect(env.improvedDraftGenerationNotice).not.toBeNull();
+
+        env.component.isBackTranslation = false;
+        env.component.isPreTranslationApproved = true;
+        env.fixture.detectChanges();
+        tick();
+
+        expect(env.component.isBackTranslation).toBe(false);
+        expect(env.component.isPreTranslationApproved).toBe(true);
+        expect(env.improvedDraftGenerationNotice).not.toBeNull();
+      })
+    );
+
+    it('should not show notice if not back translation nor pre-translate approved.', fakeAsync(() => {
+      const env = new TestEnvironment(() => {
+        mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>(
+          'FeatureFlagService',
+          {},
+          {
+            allowForwardTranslationNmtDrafting: createTestFeatureFlag(true)
+          }
+        );
+      });
+      env.component.isBackTranslation = false;
+      env.component.isPreTranslationApproved = false;
+      env.fixture.detectChanges();
+      tick();
+
+      expect(env.improvedDraftGenerationNotice).toBeNull();
     }));
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -124,6 +124,16 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   /** Duration to throttle large amounts of incoming project changes. 500 is a guess for what may be useful. */
   private readonly projectChangeThrottlingMs = 500;
 
+  // TODO: Remove the SF-3219 notice entirely after it has expired
+  readonly improvedDraftGenerationNotice = this.i18n.interpolate('draft_generation.improved_draft_generation_notice');
+
+  // Stop showing the improved draft generation notice 60 days after it went live
+  readonly improvedDraftGenerationNoticeExpired = new Date() > new Date('2025-05-31');
+
+  get showImprovedDraftGenerationNotice(): boolean {
+    return this.draftEnabled && !this.improvedDraftGenerationNoticeExpired;
+  }
+
   get draftEnabled(): boolean {
     return this.isBackTranslationMode || this.isPreTranslationApproved;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -196,6 +196,7 @@
     "generate_draft_button": "Generate draft",
     "generate_forward_translation_drafts_header": "Generate translation drafts",
     "generate_new_draft": "New draft",
+    "improved_draft_generation_notice": "Drafting has been upgraded! More of the USFM markers will be properly preserved when you generate a draft. Please {1}contact us{2} if you notice any issues.",
     "info_alert_last_sync_failed": "Your project failed to synchronize. It will be synchronized when you next generate a draft.",
     "info_alert_no_source_access": "You do not have access to the translation source project {{ name }}. Please contact your Paratext Administrator for access, then [link:connectProjectUrl]connect to this project[/link] before you can generate a draft.",
     "info_alert_no_training_source_access": "You do not have access to the training source project {{ name }}. Please contact your Paratext Administrator for access, then [link:connectProjectUrl]connect to this project[/link] before you can generate a draft.",


### PR DESCRIPTION
Serval on QA has updated to version 1.9 which changes how special text markers are used. We need to advertise this to the user via a notice.

I have marked this as testing not required, as developer testing will be sufficient given the straightforward nature of this notice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3099)
<!-- Reviewable:end -->
