### PR TITLE
SF-3214 Allow project to start a draft when alternate training or drafting source is set

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -6,7 +6,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IMachineProjectService
 {
-    Task<string> AddProjectAsync(string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
+    Task<string> AddSmtProjectAsync(string sfProjectId, CancellationToken cancellationToken);
     Task<string> GetProjectZipAsync(string sfProjectId, Stream outputStream, CancellationToken cancellationToken);
     Task<string> GetTranslationEngineTypeAsync(bool preTranslate);
     Task RemoveProjectAsync(string sfProjectId, bool preTranslate, CancellationToken cancellationToken);

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -728,8 +728,8 @@ public class MachineProjectService(
             TranslationEngineConfig engineConfig = new TranslationEngineConfig
             {
                 Name = sfProject.Id,
-                SourceLanguage = GetSourceLanguage(sfProject),
-                TargetLanguage = await GetTargetLanguageAsync(sfProject),
+                SourceLanguage = GetSourceLanguage(sfProject, preTranslate),
+                TargetLanguage = await GetTargetLanguageAsync(sfProject, preTranslate),
                 Type = await GetTranslationEngineTypeAsync(preTranslate),
             };
 
@@ -999,13 +999,14 @@ public class MachineProjectService(
     /// Gets the drafting source language for the project.
     /// </summary>
     /// <param name="project">The project.</param>
+    /// <param name="preTranslate">If <c>true</c> use NMT; otherwise if <c>false</c> use SMT.</param>
     /// <returns>The source language.</returns>
     /// <exception cref="DataNotFoundException">
     /// The project does not exist.
     /// </exception>
     /// <exception cref="InvalidDataException">The language of the source project was not specified.</exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
-    protected internal virtual string GetSourceLanguage(SFProject? project)
+    protected internal virtual string GetSourceLanguage(SFProject? project, bool preTranslate)
     {
         // This error can occur if the project is deleted while the build is running
         if (project is null)
@@ -1016,7 +1017,8 @@ public class MachineProjectService(
         string alternateSourceLanguage = project.TranslateConfig.DraftConfig.AlternateSource?.WritingSystem.Tag;
         bool useAlternateSourceLanguage =
             project.TranslateConfig.DraftConfig.AlternateSourceEnabled
-            && !string.IsNullOrWhiteSpace(alternateSourceLanguage);
+            && !string.IsNullOrWhiteSpace(alternateSourceLanguage)
+            && preTranslate;
         return useAlternateSourceLanguage
             ? alternateSourceLanguage
             : project.TranslateConfig.Source?.WritingSystem.Tag
@@ -1027,6 +1029,7 @@ public class MachineProjectService(
     /// Gets the target language for the project
     /// </summary>
     /// <param name="project">The project.</param>
+    /// <param name="preTranslate">If <c>true</c> use NMT; otherwise if <c>false</c> use SMT.</param>
     /// <returns>The target language.</returns>
     /// <exception cref="DataNotFoundException">
     /// The source was not specified for the project, or the project does not exist.
@@ -1036,11 +1039,11 @@ public class MachineProjectService(
     /// If Echo is enabled, the source language will be returned.
     /// This can be mocked in unit tests.
     /// </remarks>
-    protected internal virtual async Task<string> GetTargetLanguageAsync(SFProject project)
+    protected internal virtual async Task<string> GetTargetLanguageAsync(SFProject project, bool preTranslate)
     {
         // Echo requires the target and source language to be the same, as it outputs your source texts
         bool useEcho = await featureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation);
-        return useEcho ? GetSourceLanguage(project) : project.WritingSystem.Tag!;
+        return useEcho ? GetSourceLanguage(project, preTranslate) : project.WritingSystem.Tag!;
     }
 
     /// <summary>
@@ -1240,7 +1243,7 @@ public class MachineProjectService(
             bool recreateTranslationEngine = false;
 
             // See if the target language has changed
-            string projectTargetLanguage = await GetTargetLanguageAsync(project);
+            string projectTargetLanguage = await GetTargetLanguageAsync(project, preTranslate);
             if (translationEngine.TargetLanguage != projectTargetLanguage)
             {
                 string message =
@@ -1250,7 +1253,7 @@ public class MachineProjectService(
             }
 
             // See if the source language has changed
-            string projectSourceLanguage = GetSourceLanguage(project);
+            string projectSourceLanguage = GetSourceLanguage(project, preTranslate);
             if (translationEngine.SourceLanguage != projectSourceLanguage)
             {
                 string message =
@@ -1418,7 +1421,7 @@ public class MachineProjectService(
             additionalTrainingData.TargetCorpusId = await UploadAdditionalTrainingDataAsync(
                 project.Id,
                 additionalTrainingData.TargetCorpusId,
-                languageCode: await GetTargetLanguageAsync(project),
+                languageCode: await GetTargetLanguageAsync(project, preTranslate: true),
                 targetCorpusFiles,
                 targetTexts,
                 cancellationToken
@@ -1429,7 +1432,7 @@ public class MachineProjectService(
             additionalTrainingData.SourceCorpusId = await UploadAdditionalTrainingDataAsync(
                 project.Id,
                 additionalTrainingData.SourceCorpusId,
-                GetSourceLanguage(project),
+                GetSourceLanguage(project, preTranslate: true),
                 sourceCorpusFiles,
                 sourceTexts,
                 cancellationToken
@@ -1565,7 +1568,7 @@ public class MachineProjectService(
             && project.TranslateConfig.DraftConfig.AdditionalTrainingSource is not null
             && project.TranslateConfig.PreTranslate;
 
-        // Ensure we have a source if we are running an SMT build or do not have an alternate source when NMT
+        // Ensure we have a source if we are running an SMT build or have a source or an alternate source when NMT
         if ((!preTranslate || !hasAlternateSource) && project.TranslateConfig.Source is null)
         {
             throw new InvalidDataException("The project source is not specified.");

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -54,18 +54,13 @@ public class MachineProjectService(
     internal const string SmtTransfer = "smt-transfer";
 
     /// <summary>
-    /// Adds the project to Serval, if the required data is present.
+    /// Adds the SMT project to Serval, if the required data is present.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
-    /// <param name="preTranslate">If <c>true</c> use NMT; otherwise if <c>false</c> use SMT.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The translation engine identifier.</returns>
     /// <exception cref="DataNotFoundException">The project does not exist.</exception>
-    public async Task<string> AddProjectAsync(
-        string sfProjectId,
-        bool preTranslate,
-        CancellationToken cancellationToken
-    )
+    public async Task<string> AddSmtProjectAsync(string sfProjectId, CancellationToken cancellationToken)
     {
         // Load the project from the realtime service
         Attempt<SFProject> attempt = await realtimeService.TryGetSnapshotAsync<SFProject>(sfProjectId);
@@ -82,7 +77,7 @@ public class MachineProjectService(
             && !string.IsNullOrWhiteSpace(project.WritingSystem.Tag)
         )
         {
-            return await CreateServalProjectAsync(project, preTranslate, cancellationToken);
+            return await CreateServalProjectAsync(project, preTranslate: false, cancellationToken);
         }
 
         logger.LogInformation("The source or target language is missing from the project");

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -877,6 +877,7 @@ public class MachineProjectService(
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The translation engine identifier.</returns>
     /// <exception cref="DataNotFoundException">The project, user, or translation engine does not exist.</exception>
+    /// <exception cref="InvalidDataException">The source project does not exist and is required.</exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
     protected internal virtual async Task<string> EnsureTranslationEngineExistsAsync(
         string curUserId,
@@ -897,7 +898,10 @@ public class MachineProjectService(
             // We do not need to do this for the alternate source as this would have been populated correctly
             if (
                 string.IsNullOrWhiteSpace(projectDoc.Data?.WritingSystem.Tag)
-                || string.IsNullOrWhiteSpace(projectDoc.Data?.TranslateConfig.Source?.WritingSystem.Tag)
+                || (
+                    projectDoc.Data?.TranslateConfig.Source is not null
+                    && string.IsNullOrWhiteSpace(projectDoc.Data?.TranslateConfig.Source?.WritingSystem.Tag)
+                )
             )
             {
                 // Get the user secret
@@ -938,13 +942,16 @@ public class MachineProjectService(
                 }
 
                 // This error can occur if the project source is cleared while the build is running
-                if (projectDoc.Data.TranslateConfig.Source is null)
+                if (!preTranslate && projectDoc.Data.TranslateConfig.Source is null)
                 {
                     throw new InvalidDataException("The project source is not specified.");
                 }
 
                 // Update the source writing system tag
-                if (string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag))
+                if (
+                    projectDoc.Data.TranslateConfig.Source is not null
+                    && string.IsNullOrWhiteSpace(projectDoc.Data.TranslateConfig.Source.WritingSystem.Tag)
+                )
                 {
                     WritingSystem writingSystem = paratextService.GetWritingSystem(
                         userSecret,
@@ -976,7 +983,7 @@ public class MachineProjectService(
             );
 
             // Create the Serval project, and get the translation engine id
-            translationEngineId = await CreateServalProjectAsync(projectDoc.Data, preTranslate, cancellationToken);
+            translationEngineId = await CreateServalProjectAsync(projectDoc.Data!, preTranslate, cancellationToken);
         }
 
         // Ensure a translation engine id is present
@@ -993,12 +1000,10 @@ public class MachineProjectService(
     /// </summary>
     /// <param name="project">The project.</param>
     /// <returns>The source language.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// The writing system tag was not specified for the source project.
-    /// </exception>
     /// <exception cref="DataNotFoundException">
-    /// The source was not specified for the project, or the project does not exist.
+    /// The project does not exist.
     /// </exception>
+    /// <exception cref="InvalidDataException">The language of the source project was not specified.</exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
     protected internal virtual string GetSourceLanguage(SFProject? project)
     {
@@ -1006,12 +1011,6 @@ public class MachineProjectService(
         if (project is null)
         {
             throw new DataNotFoundException("The project does not exist.");
-        }
-
-        // This error can occur if the project source is cleared while the build is running
-        if (project.TranslateConfig.Source is null)
-        {
-            throw new InvalidDataException("The project source is not specified.");
         }
 
         string alternateSourceLanguage = project.TranslateConfig.DraftConfig.AlternateSource?.WritingSystem.Tag;
@@ -1029,12 +1028,10 @@ public class MachineProjectService(
     /// </summary>
     /// <param name="project">The project.</param>
     /// <returns>The target language.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// The writing system tag was not specified for the source project.
-    /// </exception>
     /// <exception cref="DataNotFoundException">
     /// The source was not specified for the project, or the project does not exist.
     /// </exception>
+    /// <exception cref="InvalidDataException">The language of the source project was not specified.</exception>
     /// <remarks>
     /// If Echo is enabled, the source language will be returned.
     /// This can be mocked in unit tests.
@@ -1508,7 +1505,10 @@ public class MachineProjectService(
     /// excluding the additional data corpora.
     /// </returns>
     /// <exception cref="DataNotFoundException">
-    /// The project, project source, or project secret could not be found.
+    /// The project or project secret could not be found.
+    /// </exception>
+    /// <exception cref="InvalidDataException">
+    /// The project source could not be found.
     /// </exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
     protected internal virtual async Task<IList<ServalCorpusSyncInfo>> SyncProjectCorporaAsync(
@@ -1523,12 +1523,6 @@ public class MachineProjectService(
         if (!attempt.TryResult(out SFProject project))
         {
             throw new DataNotFoundException("The project does not exist.");
-        }
-
-        // Ensure we have a source
-        if (project.TranslateConfig.Source is null)
-        {
-            throw new DataNotFoundException("The project source is not specified.");
         }
 
         // Load the project secrets, so we can get the corpus files
@@ -1571,18 +1565,30 @@ public class MachineProjectService(
             && project.TranslateConfig.DraftConfig.AdditionalTrainingSource is not null
             && project.TranslateConfig.PreTranslate;
 
+        // Ensure we have a source if we are running an SMT build or do not have an alternate source when NMT
+        if ((!preTranslate || !hasAlternateSource) && project.TranslateConfig.Source is null)
+        {
+            throw new InvalidDataException("The project source is not specified.");
+        }
+
         // Build the list of corpora and files to upload
         List<(string projectId, string paratextId, string writingSystemTag)> projects =
         [
             // Target Project
             (project.Id, project.ParatextId, project.WritingSystem.Tag),
-            // Source Project
-            (
-                project.TranslateConfig.Source.ProjectRef,
-                project.TranslateConfig.Source.ParatextId,
-                project.TranslateConfig.Source.WritingSystem.Tag
-            ),
         ];
+
+        if (project.TranslateConfig.Source is not null)
+        {
+            projects.Add(
+                (
+                    project.TranslateConfig.Source.ProjectRef,
+                    project.TranslateConfig.Source.ParatextId,
+                    project.TranslateConfig.Source.WritingSystem.Tag
+                )
+            );
+        }
+
         if (hasAlternateSource)
         {
             projects.Add(
@@ -1705,9 +1711,10 @@ public class MachineProjectService(
         if (preTranslate)
         {
             // Build the source corpus ids for training
+            // First try the alternate training source, then the source, then the source specified for translation above
             sourceProjectId = hasAlternateTrainingSource
                 ? project.TranslateConfig.DraftConfig.AlternateTrainingSource.ProjectRef
-                : project.TranslateConfig.Source.ProjectRef;
+                : (project.TranslateConfig.Source?.ProjectRef ?? sourceProjectId);
 
             sourceCorpora = [servalCorpusFiles.Single(f => f.ProjectId == sourceProjectId)];
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -535,11 +535,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                     }
 
                     await EnsureWritingSystemTagIsSetAsync(curUserId, projectDoc, ptProjects);
-                    await _machineProjectService.AddProjectAsync(
-                        projectId,
-                        preTranslate: false,
-                        CancellationToken.None
-                    );
+                    await _machineProjectService.AddSmtProjectAsync(projectId, CancellationToken.None);
                     trainEngine = true;
                 }
                 else if (hasExistingMachineProject)

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -61,39 +61,39 @@ public class MachineProjectServiceTests
     private const string LanguageTag = "he";
 
     [Test]
-    public async Task AddProjectAsync_DoesNotCreateIfLanguageMissing()
+    public async Task AddSmtProjectAsync_DoesNotCreateIfLanguageMissing()
     {
         // Set up test environment
         var env = new TestEnvironment();
 
         // SUT
-        string actual = await env.Service.AddProjectAsync(Project03, preTranslate: false, CancellationToken.None);
+        string actual = await env.Service.AddSmtProjectAsync(Project03, CancellationToken.None);
         Assert.IsEmpty(actual);
     }
 
     [Test]
-    public void AddProjectAsync_ThrowsExceptionWhenProjectSecretMissing()
+    public void AddSmtProjectAsync_ThrowsExceptionWhenProjectSecretMissing()
     {
         // Set up test environment
         var env = new TestEnvironment();
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.AddProjectAsync("invalid_project_id", preTranslate: false, CancellationToken.None)
+            () => env.Service.AddSmtProjectAsync("invalid_project_id", CancellationToken.None)
         );
     }
 
     [Test]
-    public async Task AddProjectAsync_Success()
+    public async Task AddSmtProjectAsync_Success()
     {
         // Set up test environment
         var env = new TestEnvironment();
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine01));
 
         // SUT
-        string actual = await env.Service.AddProjectAsync(Project01, preTranslate: true, CancellationToken.None);
+        string actual = await env.Service.AddSmtProjectAsync(Project01, CancellationToken.None);
         Assert.AreEqual(TranslationEngine01, actual);
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -679,8 +679,8 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
         await env.SetupProjectSecretAsync(Project01, new ServalData());
         var project = new SFProject { Id = Project01 };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -697,8 +697,8 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
         await env.SetupProjectSecretAsync(Project01, new ServalData());
         var project = new SFProject { Id = Project01 };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: false).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: false).Returns(Task.FromResult("de"));
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -736,8 +736,8 @@ public class MachineProjectServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -753,8 +753,8 @@ public class MachineProjectServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: false).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: false).Returns(Task.FromResult("de"));
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -774,8 +774,8 @@ public class MachineProjectServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine()));
 
@@ -1302,7 +1302,7 @@ public class MachineProjectServiceTests
         };
 
         // SUT
-        string actual = env.Service.GetSourceLanguage(project);
+        string actual = env.Service.GetSourceLanguage(project, preTranslate: true);
         Assert.AreEqual(sourceWritingSystemTag, actual);
     }
 
@@ -1322,7 +1322,35 @@ public class MachineProjectServiceTests
         };
 
         // SUT
-        string actual = env.Service.GetSourceLanguage(project);
+        string actual = env.Service.GetSourceLanguage(project, preTranslate: true);
+        Assert.AreEqual(sourceWritingSystemTag, actual);
+    }
+
+    [Test]
+    public void GetSourceLanguage_UsesTheAlternateSourceIfPreTranslateIsFalse()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        const string alternateSourceWritingSystemTag = "alternate_source_writing_system_tag";
+        const string sourceWritingSystemTag = "source_writing_system_tag";
+        var project = new SFProject
+        {
+            TranslateConfig =
+            {
+                DraftConfig = new DraftConfig
+                {
+                    AlternateSourceEnabled = true,
+                    AlternateSource = new TranslateSource
+                    {
+                        WritingSystem = new WritingSystem { Tag = alternateSourceWritingSystemTag },
+                    },
+                },
+                Source = new TranslateSource { WritingSystem = new WritingSystem { Tag = sourceWritingSystemTag } },
+            },
+        };
+
+        // SUT
+        string actual = env.Service.GetSourceLanguage(project, preTranslate: false);
         Assert.AreEqual(sourceWritingSystemTag, actual);
     }
 
@@ -1334,7 +1362,7 @@ public class MachineProjectServiceTests
         var project = new SFProject { TranslateConfig = { Source = null } };
 
         // SUT
-        Assert.Throws<InvalidDataException>(() => env.Service.GetSourceLanguage(project));
+        Assert.Throws<InvalidDataException>(() => env.Service.GetSourceLanguage(project, preTranslate: true));
     }
 
     [Test]
@@ -1344,7 +1372,7 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        Assert.Throws<DataNotFoundException>(() => env.Service.GetSourceLanguage(null));
+        Assert.Throws<DataNotFoundException>(() => env.Service.GetSourceLanguage(null, preTranslate: true));
     }
 
     [Test]
@@ -1371,7 +1399,7 @@ public class MachineProjectServiceTests
         };
 
         // SUT
-        string actual = env.Service.GetSourceLanguage(project);
+        string actual = env.Service.GetSourceLanguage(project, preTranslate: true);
         Assert.AreEqual(alternateSourceWritingSystemTag, actual);
     }
 
@@ -1386,7 +1414,7 @@ public class MachineProjectServiceTests
         };
 
         // SUT
-        Assert.Throws<InvalidDataException>(() => env.Service.GetSourceLanguage(project));
+        Assert.Throws<InvalidDataException>(() => env.Service.GetSourceLanguage(project, preTranslate: false));
     }
 
     [Test]
@@ -1409,10 +1437,10 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment(new TestEnvironmentOptions { UseEchoForPreTranslation = true });
         const string sourceWritingSystemTag = "source_writing_system_tag";
         var project = new SFProject();
-        env.Service.Configure().GetSourceLanguage(project).Returns(sourceWritingSystemTag);
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceWritingSystemTag);
 
         // SUT
-        string actual = await env.Service.GetTargetLanguageAsync(project);
+        string actual = await env.Service.GetTargetLanguageAsync(project, preTranslate: true);
         Assert.AreEqual(sourceWritingSystemTag, actual);
     }
 
@@ -1425,7 +1453,7 @@ public class MachineProjectServiceTests
         var project = new SFProject { WritingSystem = new WritingSystem { Tag = targetWritingSystemTag } };
 
         // SUT
-        string actual = await env.Service.GetTargetLanguageAsync(project);
+        string actual = await env.Service.GetTargetLanguageAsync(project, preTranslate: true);
         Assert.AreEqual(targetWritingSystemTag, actual);
     }
 
@@ -1878,8 +1906,10 @@ public class MachineProjectServiceTests
         var project = new SFProject { Id = Project01 };
         const string targetLanguage = "en";
         const string sourceLanguage = "de";
-        env.Service.Configure().GetSourceLanguage(project).Returns(sourceLanguage);
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult(targetLanguage));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
+        env.Service.Configure()
+            .GetTargetLanguageAsync(project, preTranslate: true)
+            .Returns(Task.FromResult(targetLanguage));
         env.Service.Configure()
             .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
@@ -1922,8 +1952,10 @@ public class MachineProjectServiceTests
         const string targetLanguage = "en";
         const string oldSourceLanguage = "de";
         const string newSourceLanguage = "fr";
-        env.Service.Configure().GetSourceLanguage(project).Returns(oldSourceLanguage);
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult(targetLanguage));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(oldSourceLanguage);
+        env.Service.Configure()
+            .GetTargetLanguageAsync(project, preTranslate: true)
+            .Returns(Task.FromResult(targetLanguage));
         env.Service.Configure()
             .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
@@ -1962,8 +1994,10 @@ public class MachineProjectServiceTests
         const string oldTargetLanguage = "en";
         const string newTargetLanguage = "fr";
         const string sourceLanguage = "de";
-        env.Service.Configure().GetSourceLanguage(project).Returns(sourceLanguage);
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult(newTargetLanguage));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
+        env.Service.Configure()
+            .GetTargetLanguageAsync(project, preTranslate: true)
+            .Returns(Task.FromResult(newTargetLanguage));
         env.Service.Configure()
             .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
@@ -2653,8 +2687,8 @@ public class MachineProjectServiceTests
             SourceCorpusId = Corpus01,
             TargetCorpusId = Corpus02,
         };
-        env.Service.Configure().GetSourceLanguage(project).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
         env.Service.Configure()
             .CreateOrUpdateParallelCorpusAsync(
                 TranslationEngine01,
@@ -2709,8 +2743,8 @@ public class MachineProjectServiceTests
         var project = new SFProject { Id = Project01 };
         var buildConfig = new BuildConfig { TrainingDataFiles = [Data01] };
         var additionalTrainingData = new ServalAdditionalTrainingData();
-        env.Service.Configure().GetSourceLanguage(project).Returns(sourceLanguage);
-        env.Service.Configure().GetTargetLanguageAsync(project).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
+        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
         env.Service.Configure()
             .CreateOrUpdateParallelCorpusAsync(
                 TranslationEngine01,

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2298,7 +2298,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2337,7 +2337,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
 
@@ -2371,7 +2371,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2409,7 +2409,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
 
@@ -2441,7 +2441,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2483,7 +2483,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
         env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
 
@@ -2513,7 +2513,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2536,7 +2536,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2559,7 +2559,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.DidNotReceive().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2654,9 +2654,7 @@ public class SFProjectServiceTests
         await env
             .MachineProjectService.Received()
             .RemoveProjectAsync(Project01, preTranslate: false, CancellationToken.None);
-        await env
-            .MachineProjectService.Received()
-            .AddProjectAsync(Project01, preTranslate: false, CancellationToken.None);
+        await env.MachineProjectService.Received().AddSmtProjectAsync(Project01, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2680,7 +2678,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2701,9 +2699,7 @@ public class SFProjectServiceTests
         await env
             .MachineProjectService.DidNotReceive()
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-        await env
-            .MachineProjectService.Received()
-            .AddProjectAsync(Project03, preTranslate: false, CancellationToken.None);
+        await env.MachineProjectService.Received().AddSmtProjectAsync(Project03, CancellationToken.None);
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2730,7 +2726,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Project01, preTranslate: false, CancellationToken.None);
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
 
@@ -2749,7 +2745,7 @@ public class SFProjectServiceTests
             .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await env
             .MachineProjectService.DidNotReceive()
-            .AddProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
     }
 


### PR DESCRIPTION
This PR removes the requirement for source project to be set for NMT drafting. However, a training source or alternate source must be set for a build to start successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3100)
<!-- Reviewable:end -->
