### PR TITLE
SF-3273 Require all source-side languages to be the same

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -43,10 +43,4 @@
       </div>
     }
   </div>
-
-  <app-language-codes-confirmation
-    class="confirm-codes"
-    [draftSources]="draftSources"
-    (languageCodesConfirmedChange)="confirmationChanged($event)"
-  ></app-language-codes-confirmation>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, EventEmitter, Output } from '@angular/core';
+import { Component, DestroyRef } from '@angular/core';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
@@ -11,17 +11,15 @@ import {
   draftSourcesAsTranslateSourceArraysToDraftSourcesAsSelectableProjectArrays,
   projectToDraftSources
 } from '../draft-utils';
-import { LanguageCodesConfirmationComponent } from '../language-codes-confirmation/language-codes-confirmation.component';
+
 @Component({
   selector: 'app-confirm-sources',
   standalone: true,
-  imports: [TranslocoModule, MatCheckboxModule, MatIconModule, LanguageCodesConfirmationComponent],
+  imports: [TranslocoModule, MatCheckboxModule, MatIconModule],
   templateUrl: './confirm-sources.component.html',
   styleUrl: './confirm-sources.component.scss'
 })
 export class ConfirmSourcesComponent {
-  @Output() languageCodesVerified = new EventEmitter<boolean>(false);
-
   draftSources: DraftSourcesAsSelectableProjectArrays = {
     trainingSources: [],
     trainingTargets: [],
@@ -68,10 +66,6 @@ export class ConfirmSourcesComponent {
 
   get draftingSourceShortNames(): string {
     return this.i18nService.enumerateList(this.draftingSources.filter(p => p != null).map(p => p.shortName));
-  }
-
-  confirmationChanged(checked: boolean): void {
-    this.languageCodesVerified.emit(checked);
   }
 
   displayNameForProjectsLanguages(projects: { languageTag: string }[]): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -4,12 +4,9 @@
       <!-- Icon overrides -->
       <ng-template matStepperIcon="edit" let-index="index">{{ index + 1 }}</ng-template>
 
-      <mat-step [completed]="languagesVerified">
+      <mat-step [completed]="true">
         <ng-template matStepLabel>{{ t("overview") }}</ng-template>
-        <app-confirm-sources (languageCodesVerified)="languagesVerified = $event"></app-confirm-sources>
-        @if (nextClickedOnLanguageVerification && !languagesVerified) {
-          <app-notice type="error">{{ t("confirm_codes_correct_to_continue") }}</app-notice>
-        }
+        <app-confirm-sources></app-confirm-sources>
         <div class="button-strip">
           <button mat-stroked-button class="backout-button" (click)="cancel.emit()">
             <mat-icon>chevron_{{ i18n.backwardDirectionWord }}</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -345,7 +344,6 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('clears selected translated and reference books in training when translate book selected', () => {
-      clickConfirmLanguages(fixture);
       component.tryAdvanceStep();
       fixture.detectChanges();
       component.onTranslateBookSelect([3]);
@@ -370,7 +368,6 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('shows unselected translate book on training page', () => {
-      clickConfirmLanguages(fixture);
       component.tryAdvanceStep();
       fixture.detectChanges();
       // select Exodus and Leviticus
@@ -525,7 +522,6 @@ describe('DraftGenerationStepsComponent', () => {
 
       spyOn(component.done, 'emit');
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       expect(component.isStepsCompleted).toBe(false);
       // Advance to the next step when at last step should emit books result
       fixture.detectChanges();
@@ -569,7 +565,6 @@ describe('DraftGenerationStepsComponent', () => {
 
       spyOn(component.done, 'emit');
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       // Advance to the next step when at last step should emit books result
       fixture.detectChanges();
       component.tryAdvanceStep();
@@ -601,7 +596,6 @@ describe('DraftGenerationStepsComponent', () => {
 
       spyOn(component.done, 'emit');
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       // Advance to the next step when at last step should emit books result
       fixture.detectChanges();
       component.tryAdvanceStep();
@@ -705,7 +699,6 @@ describe('DraftGenerationStepsComponent', () => {
       spyOn(component.done, 'emit');
 
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       const step = fixture.debugElement.queryAll(By.css('mat-step-header'));
       step[3].nativeElement.click(); //click the next step
       fixture.detectChanges();
@@ -891,7 +884,6 @@ describe('DraftGenerationStepsComponent', () => {
 
     it('updates available training data file after uploaded or deleted', () => {
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       component.tryAdvanceStep();
       fixture.detectChanges();
       component.onTranslateBookSelect([3]);
@@ -917,7 +909,6 @@ describe('DraftGenerationStepsComponent', () => {
 
     it('generates draft with training data file', () => {
       fixture.detectChanges();
-      clickConfirmLanguages(fixture);
       component.tryAdvanceStep();
       fixture.detectChanges();
       component.onTranslateBookSelect([3]);
@@ -1039,12 +1030,4 @@ describe('DraftGenerationStepsComponent', () => {
       expect(trainingGroups[1].ranges[1]).toEqual('1 Samuel');
     });
   });
-
-  function clickConfirmLanguages(fixture: ComponentFixture<DraftGenerationStepsComponent>): void {
-    const notice: DebugElement = fixture.debugElement.query(By.css('app-notice'));
-    const checkboxDebug = notice.query(By.css('input[type="checkbox"]'));
-    const checkbox = checkboxDebug.nativeElement as HTMLInputElement;
-    checkbox.click();
-    fixture.detectChanges();
-  }
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -94,7 +94,6 @@ export class DraftGenerationStepsComponent implements OnInit {
   expandUnusableTrainingBooks = false;
   isStepsCompleted = false;
 
-  protected languagesVerified = false;
   protected nextClickedOnLanguageVerification = false;
   protected hasLoaded = false;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -179,9 +179,9 @@
 
   <app-language-codes-confirmation
     class="confirm-language-codes"
-    [draftSources]="draftSourcesAsArray"
-    [informUserWhereToChangeDraftSources]="false"
-    [(languageCodesConfirmed)]="languageCodesConfirmed"
+    [sources]="draftSourcesAsArray"
+    [clearCheckbox]="clearLanguageCodeConfirmationCheckbox"
+    (messageIfUserTriesToContinue)="languageCodeConfirmationMessageIfUserTriesToContinue = $event"
   ></app-language-codes-confirmation>
 
   <div class="component-footer">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
@@ -1,27 +1,25 @@
 <ng-container *transloco="let t; read: 'language_codes_confirmation'">
-  @if (sourceSideLanguageCodes.length > 1) {
-    <app-notice mode="fill-dark" type="warning">
-      <h3>{{ t("all_sources_should_be_same_language") }}</h3>
+  @if (showSourceLanguagesDifferError) {
+    <app-notice mode="fill-dark" type="error">
+      <h3>{{ t("all_sources_must_be_same_language") }}</h3>
+      {{ t("sources_in_following_languages") }}
+      <ul>
+        @for (code of uniqueSourceSideLanguageCodes; track code) {
+          <li>
+            <strong>{{ code }}</strong> - {{ i18n.getLanguageDisplayName(code) }}
+          </li>
+        }
+      </ul>
       <p>
-        {{
-          t("source_and_reference_languages_different", { languageCodes: i18n.enumerateList(sourceSideLanguageCodes) })
-        }}
-      </p>
-      @if (informUserWhereToChangeDraftSources) {
-        <p>
-          @if (isProjectAdmin) {
-            <transloco
-              key="language_codes_confirmation.change_source_projects_on_draft_sources_configuration_page"
-              [params]="{ configSourcesUrl: { route: configSourcesUrl } }"
-            ></transloco>
-          } @else {
-            {{ t("contact_project_administrator_to_change_settings") }}
+        {{ t("select_different_sources") }}
+        @for (part of i18n.interpolateVariables("language_codes_confirmation.if_unsure_contact_us"); track $index) {
+          @if (part.id == null) {
+            {{ part.text }}
+          } @else if (part.id === "email") {
+            <a [href]="issueMailTo" target="_blank" rel="noreferrer">{{ issueEmail }}</a>
           }
-        </p>
-      }
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">
-        {{ t("i_understand_and_accept") }}
-      </mat-checkbox>
+        }
+      </p>
     </app-notice>
   }
 
@@ -36,30 +34,18 @@
           [params]="{ languageCode: targetLanguageTag }"
         ></transloco>
       </p>
-      @if (informUserWhereToChangeDraftSources) {
-        <p>
-          @if (isProjectAdmin) {
-            <transloco
-              key="language_codes_confirmation.change_source_projects_on_draft_sources_configuration_page"
-              [params]="{ configSourcesUrl: { route: configSourcesUrl } }"
-            ></transloco>
-          } @else {
-            {{ t("contact_project_administrator_to_change_settings") }}
-          }
-        </p>
-      }
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">
+      <mat-checkbox [checked]="languageCodesConfirmed" (change)="checkboxChanged($event)">
         {{ t("i_understand_and_accept") }}
       </mat-checkbox>
     </app-notice>
   }
 
-  @if (sourceSideLanguageCodes.length === 1 && !showSourceAndTargetLanguagesIdenticalWarning) {
+  @if (showStandardNotice) {
     <app-notice mode="fill-dark">
       <h3>{{ t("incorrect_language_codes_reduce_quality") }}</h3>
       <p>{{ t("please_make_sure_codes_correct") }}</p>
       <p>{{ t("how_to_change_language_codes") }}</p>
-      <mat-checkbox [checked]="languageCodesConfirmed" (change)="confirmationChanged($event)">{{
+      <mat-checkbox [checked]="languageCodesConfirmed" (change)="checkboxChanged($event)">{{
         t("confirm_lang_codes_correct")
       }}</mat-checkbox>
     </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.spec.ts
@@ -46,28 +46,18 @@ describe('LanguageCodesConfirmationComponent', () => {
   });
 
   it('should show standard message', () => {
-    component.draftSources = getStandardDraftSources();
+    component.sources = getStandardDraftSources();
     fixture.detectChanges();
-    expect(component.sourceSideLanguageCodes.length).toEqual(1);
+    expect(component.uniqueNormalizedSourceSideLanguageCodes.length).toEqual(1);
     expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
-  });
-
-  it('shows standard message when language codes are equivalent language', () => {
-    const draftSources = getStandardDraftSources();
-    // Both map to the Chinese language
-    draftSources.draftingSources[0].languageTag = 'zh-CN';
-    draftSources.trainingSources[0].languageTag = 'cmn-Hans';
-    component.draftSources = draftSources;
-    fixture.detectChanges();
-    expect(component.sourceSideLanguageCodes.length).toEqual(1);
   });
 
   it('should show target and source language codes identical message', () => {
     const draftSources = getStandardDraftSources();
     draftSources.trainingTargets[0].languageTag = draftSources.trainingSources[0].languageTag;
-    component.draftSources = draftSources;
+    component.sources = draftSources;
     fixture.detectChanges();
-    expect(component.sourceSideLanguageCodes.length).toEqual(1);
+    expect(component.uniqueNormalizedSourceSideLanguageCodes.length).toEqual(1);
     expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(true);
   });
 
@@ -79,18 +69,18 @@ describe('LanguageCodesConfirmationComponent', () => {
       paratextId: 'pt-sp2',
       languageTag: 'zh'
     });
-    component.draftSources = draftSources;
+    component.sources = draftSources;
     fixture.detectChanges();
-    expect(component.sourceSideLanguageCodes.length).toEqual(2);
+    expect(component.uniqueNormalizedSourceSideLanguageCodes.length).toEqual(2);
     expect(component.showSourceAndTargetLanguagesIdenticalWarning).toBe(false);
   });
 
-  it('can emit languages confirmed when checkbox is checked', () => {
-    component.draftSources = getStandardDraftSources();
+  it('emits blank error message when codes confirmed', () => {
+    component.sources = getStandardDraftSources();
     fixture.detectChanges();
-    const emitSpy = spyOn(component.languageCodesConfirmedChange, 'emit');
-    component.confirmationChanged({ checked: true } as any);
-    expect(emitSpy).toHaveBeenCalledWith(true);
+    const emitSpy = spyOn(component.messageIfUserTriesToContinue, 'emit');
+    component.checkboxChanged({ checked: true } as any);
+    expect(emitSpy).toHaveBeenCalledWith(null);
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
@@ -1,73 +1,114 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, EventEmitter, Input, Output } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { TranslocoModule } from '@ngneat/transloco';
 import { TranslocoMarkupComponent } from 'ngx-transloco-markup';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { AuthService } from 'xforge-common/auth.service';
-import { I18nService } from 'xforge-common/i18n.service';
+import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+import { issuesEmailTemplate } from 'xforge-common/utils';
+import { environment } from '../../../../environments/environment';
 import { SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import { NoticeComponent } from '../../../shared/notice/notice.component';
-import { DraftSourcesAsSelectableProjectArrays, englishNameFromCode } from '../draft-utils';
+import { DraftSourcesAsSelectableProjectArrays } from '../draft-utils';
+
+// TODO implement better normalization logic
+function normalizeLanguageCode(code: string): string {
+  return code.split('-')[0];
+}
 
 @Component({
   selector: 'app-language-codes-confirmation',
   standalone: true,
-  imports: [TranslocoModule, TranslocoMarkupComponent, UICommonModule, NoticeComponent],
+  imports: [CommonModule, TranslocoModule, TranslocoMarkupComponent, UICommonModule, NoticeComponent],
   templateUrl: './language-codes-confirmation.component.html',
   styleUrl: './language-codes-confirmation.component.scss'
 })
 export class LanguageCodesConfirmationComponent {
-  @Input() languageCodesConfirmed = false;
-  @Output() languageCodesConfirmedChange = new EventEmitter<boolean>();
-
-  /** It makes sense to inform the user, except when the user is on the page for changing sources */
-  @Input() informUserWhereToChangeDraftSources: boolean = true;
-  @Input() set draftSources(value: DraftSourcesAsSelectableProjectArrays) {
+  @Input() set sources(value: DraftSourcesAsSelectableProjectArrays) {
     if (value == null) return;
+
     this.draftingSources = value.draftingSources;
     this.trainingSources = value.trainingSources;
     this.targetLanguageTag = value.trainingTargets[0]?.languageTag;
+    this.updateMessageForContinuing();
   }
+  @Input() set clearCheckbox(eventEmitter: EventEmitter<void>) {
+    eventEmitter.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.languageCodesConfirmed = false;
+      this.updateMessageForContinuing();
+    });
+  }
+
+  /**
+   * A localization key for what message should be shown if the user attempts to continue. This will be null if the user
+   * has confirmed the language codes.
+   */
+  @Output() messageIfUserTriesToContinue = new EventEmitter<I18nKeyForComponent<'draft_sources'> | null>();
+
+  languageCodesConfirmed = false;
 
   draftingSources: SelectableProjectWithLanguageCode[] = [];
   trainingSources: SelectableProjectWithLanguageCode[] = [];
   targetLanguageTag?: string;
-  configSourcesUrl: string = '';
 
   constructor(
     readonly i18n: I18nService,
-    private readonly activatedProject: ActivatedProjectService,
-    private readonly authService: AuthService
-  ) {
-    this.configSourcesUrl = `/projects/${this.activatedProject.projectId}/draft-generation/sources`;
+    private readonly destroyRef: DestroyRef
+  ) {}
+
+  get issueMailTo(): string {
+    return issuesEmailTemplate();
+  }
+
+  get issueEmail(): string {
+    return environment.issueEmail;
   }
 
   get sourceSideLanguageCodes(): string[] {
-    const sourceLanguagesCodes: string[] = [...this.draftingSources, ...this.trainingSources]
-      .filter(s => s != null)
-      .map(s => s.languageTag);
-    const languageNames: string[] = Array.from(new Set(sourceLanguagesCodes.map(s => englishNameFromCode(s))));
-    if (languageNames.length < 2) {
-      return [sourceLanguagesCodes[0]];
-    }
-    return Array.from(new Set(sourceLanguagesCodes));
+    return [...this.draftingSources, ...this.trainingSources].filter(s => s != null).map(s => s.languageTag);
+  }
+
+  get uniqueSourceSideLanguageCodes(): string[] {
+    return Array.from(new Set(this.sourceSideLanguageCodes));
+  }
+
+  get normalizedSourceSideLanguageCodes(): string[] {
+    return this.sourceSideLanguageCodes.map(normalizeLanguageCode);
+  }
+
+  get uniqueNormalizedSourceSideLanguageCodes(): string[] {
+    return Array.from(new Set(this.normalizedSourceSideLanguageCodes));
+  }
+
+  checkboxChanged(event: MatCheckboxChange): void {
+    this.languageCodesConfirmed = event.checked;
+    this.updateMessageForContinuing();
+  }
+
+  updateMessageForContinuing(): void {
+    if (this.showSourceLanguagesDifferError) {
+      this.messageIfUserTriesToContinue.emit('source_side_language_codes_differ');
+    } else if (!this.languageCodesConfirmed) {
+      this.messageIfUserTriesToContinue.emit('confirm_language_codes');
+    } else this.messageIfUserTriesToContinue.emit(null);
+  }
+
+  // SECTION: Logic for each notice
+
+  get showStandardNotice(): boolean {
+    return !this.showSourceLanguagesDifferError && !this.showSourceAndTargetLanguagesIdenticalWarning;
   }
 
   get showSourceAndTargetLanguagesIdenticalWarning(): boolean {
-    const sourceCodes: string[] = this.sourceSideLanguageCodes;
-    return sourceCodes.length === 1 && sourceCodes[0] === this.targetLanguageTag;
+    return (
+      this.targetLanguageTag != null &&
+      this.uniqueNormalizedSourceSideLanguageCodes.length === 1 &&
+      this.uniqueNormalizedSourceSideLanguageCodes[0] === normalizeLanguageCode(this.targetLanguageTag)
+    );
   }
 
-  get isProjectAdmin(): boolean {
-    const userId = this.authService.currentUserId;
-    if (userId == null) return false;
-    return this.activatedProject.projectDoc?.data?.userRoles[userId] === SFProjectRole.ParatextAdministrator;
-  }
-
-  confirmationChanged(event: MatCheckboxChange): void {
-    this.languageCodesConfirmed = event.checked;
-    this.languageCodesConfirmedChange.emit(this.languageCodesConfirmed);
+  get showSourceLanguagesDifferError(): boolean {
+    return this.uniqueNormalizedSourceSideLanguageCodes.length > 1;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.stories.ts
@@ -1,21 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { expect, within } from '@storybook/test';
 import { defaultTranslocoMarkupTranspilers, TranslocoMarkupComponent } from 'ngx-transloco-markup';
-import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { instance, mock, when } from 'ts-mockito';
+import { instance, mock } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
-import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import { DraftSourcesAsSelectableProjectArrays } from '../draft-utils';
 import { LanguageCodesConfirmationComponent } from './language-codes-confirmation.component';
 
 const mockAuthService = mock(AuthService);
 const mockActivatedProject = mock(ActivatedProjectService);
 
-const draftSources: DraftSourcesAsSelectableProjectArrays = {
+const defaultDraftSources: DraftSourcesAsSelectableProjectArrays = {
   draftingSources: [
     {
       shortName: 'ADS',
@@ -48,15 +45,6 @@ const draftSources: DraftSourcesAsSelectableProjectArrays = {
   ]
 };
 
-const defaultArgs = { draftSources };
-
-when(mockActivatedProject.projectId).thenReturn('test-proj');
-when(mockActivatedProject.projectDoc).thenReturn({
-  id: 'test-proj',
-  data: createTestProjectProfile({ userRoles: { user1: SFProjectRole.ParatextAdministrator } })
-} as SFProjectProfileDoc);
-when(mockAuthService.currentUserId).thenReturn('user1');
-
 const meta: Meta = {
   title: 'Translate/LanguageCodesConfirmation',
   component: LanguageCodesConfirmationComponent,
@@ -69,7 +57,13 @@ const meta: Meta = {
         defaultTranslocoMarkupTranspilers()
       ]
     })
-  ]
+  ],
+  render: args => {
+    return {
+      props: args,
+      template: '<app-language-codes-confirmation [sources]="draftSources"></app-language-codes-confirmation>'
+    };
+  }
 };
 
 export default meta;
@@ -79,26 +73,51 @@ interface StoryState {}
 type Story = StoryObj<StoryState>;
 
 export const Default: Story = {
-  args: defaultArgs
+  args: { defaultDraftSources },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    canvas.getByRole('heading', { name: 'Incorrect language codes will dramatically reduce draft quality.' });
+    expect(canvas.queryByRole('checkbox')).toBeTruthy();
+  }
 };
 
 export const SameSourceAndTargetCodes: Story = {
   args: {
-    ...defaultArgs,
-    targetLanguageTag: 'es'
+    draftSources: {
+      draftingSources: defaultDraftSources.draftingSources,
+      trainingSources: defaultDraftSources.trainingSources,
+      trainingTargets: [
+        {
+          ...defaultDraftSources.trainingTargets[0],
+          languageTag: 'es'
+        }
+      ]
+    } satisfies DraftSourcesAsSelectableProjectArrays
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    canvas.getByRole('heading', { name: 'Source and target languages are both Spanish' });
+    expect(canvas.queryByRole('checkbox')).toBeTruthy();
   }
 };
 
 export const DifferentSourceCodes: Story = {
   args: {
-    ...defaultArgs,
-    draftingSources: [
-      {
-        shortName: 'ADS',
-        name: 'Alternate Drafting Source',
-        paratextId: 'alternate-drafting-source',
-        languageTag: 'cat'
-      } satisfies SelectableProjectWithLanguageCode
-    ]
+    draftSources: {
+      draftingSources: defaultDraftSources.draftingSources,
+      trainingSources: [
+        defaultDraftSources.trainingSources[0],
+        {
+          ...defaultDraftSources.trainingSources[1],
+          languageTag: 'fr'
+        }
+      ],
+      trainingTargets: defaultDraftSources.trainingTargets
+    } satisfies DraftSourcesAsSelectableProjectArrays
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    canvas.getByRole('heading', { name: 'All source and reference projects must be in the same language' });
+    expect(canvas.queryByRole('checkbox')).toBeNull();
   }
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -295,6 +295,7 @@
     "select_at_least_one_source": "Please select at least one source project before saving.",
     "select_project_to_translate": "Select the project to translate.",
     "select_reference_project_considering_back_translation": "Select projects that should be used on the source side when training the language model. Choosing a back translation often improves the model.",
+    "source_side_language_codes_differ": "All source and reference projects must be in the same language. Please select different source or reference projects.",
     "state_connecting": "Connecting",
     "state_sync_failed": "There was an error syncing",
     "state_sync_successful": "Sync successful",
@@ -442,17 +443,20 @@
     "update_transcelerator": "The version of Transcelerator used in this project is not supported. Please update to at least Transcelerator version 1.5.3."
   },
   "language_codes_confirmation": {
-    "all_sources_should_be_same_language": "All source and reference projects should be in the same language",
-    "change_source_projects_on_draft_sources_configuration_page": "Source projects can be changed on the [link:configSourcesUrl]draft sources configure page[/link]",
+    "all_sources_must_be_same_language": "All source and reference projects must be in the same language",
+    "change_source_projects_on_draft_sources_configuration_page": "Source projects can be changed on the [link:configSourcesUrl]configure draft sources page[/link]",
     "confirm_lang_codes_correct": "All the language codes are correct",
     "contact_project_administrator_to_change_settings": "Contact your project administrator if language settings need to be updated",
     "how_to_change_language_codes": "Language codes can be changed in Paratext by going to Project Settings > Project Properties > Language.",
-    "incorrect_language_codes_reduce_quality": "Incorrect language codes will dramatically reduce draft quality.",
     "i_understand_and_accept": "I understand the problem and want to continue anyways",
+    "if_unsure_contact_us": "If you're not sure how to fix this problem, please contact us at {{ email }}",
+    "incorrect_language_codes_reduce_quality": "Incorrect language codes will dramatically reduce draft quality.",
     "please_make_sure_codes_correct": "Before continuing, please make sure all language codes accurately represent the language of each project or resource.",
-    "source_and_reference_languages_different": "Source and reference projects currently have the following language codes: {{ languageCodes }}. Using source and reference projects that are not in the same language, or that are marked with inaccurate language codes, may significantly reduce the draft quality.",
+    "select_different_sources": "Please select different source or reference projects.",
+    "source_and_reference_languages_different": "Source and reference projects currently have the following language codes: {{ languageCodes }}.",
     "source_and_target_languages_same": "Source and target languages are both {{ displayLanguage }}",
     "source_and_target_projects_all_have_language_code": "The source and target projects all have the [b]{{ languageCode }}[/b] language code. If you are translating into a dialect or related language that does not have a separate ISO code, these settings may be correct. For all other projects, having the source and target projects set to the same language may significantly reduce the draft quality.",
+    "sources_in_following_languages": "Currently the source projects are in the following languages:",
     "sources_must_be_same_language": "The training source must be the same language as the drafting source. You can update your source texts on the [link:projectSettingsUrl]settings page[/link]"
   },
   "multi_viewer": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -305,7 +305,7 @@ export class I18nService {
   }
 
   enumerateList(list: string[]): string {
-    return new (Intl as any).ListFormat(this.localeCode, { style: 'long', type: 'conjunction' }).format(list) as string;
+    return new (Intl as any).ListFormat(this.localeCode, { style: 'long', type: 'conjunction' }).format(list);
   }
 
   translateTextAroundTemplateTags(key: I18nKey, params: object = {}): TextAroundTemplate | undefined {


### PR DESCRIPTION
- Show error instead of warnings when source-side languages are not all the same
- Show distinct error message if the user tries to save when languages are not all the same
- Remove language code confirmation from the first drafting step

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3101)
<!-- Reviewable:end -->
