### PR TITLE
SF-3267 Show notice to translator when draft sources not set

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -72,8 +72,13 @@
         </app-notice>
       }
 
+      @if (draftEnabled && !hasConfigureSourcePermission && !isSourcesConfigurationComplete) {
+        <app-notice type="warning" icon="warning" data-test-id="warning-admin-must-configure-sources">
+          <span>{{ t("info_alert_please_have_admin_configure_sources") }}</span>
+        </app-notice>
+      }
       <!-- Only show warnings if target language is supported and sources have been configured -->
-      @if (draftEnabled && isTargetLanguageSupported && isSourcesConfigurationComplete) {
+      @else if (draftEnabled && isTargetLanguageSupported && isSourcesConfigurationComplete) {
         @if (!canAccessDraftSourceIfAvailable(source)) {
           <app-notice type="warning" icon="warning" data-test-id="warning-source-no-access">
             <transloco

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -420,6 +420,22 @@ describe('DraftGenerationComponent', () => {
         expect(env.getElementByTestId('warning-source-no-access')).toBeNull();
       });
 
+      it('should show warning when source project is not set and user is a translator', () => {
+        const env = new TestEnvironment(() => {
+          mockDraftSourcesService.getDraftProjectSources.and.returnValue(
+            of({
+              draftingSources: [],
+              trainingSources: [{} as DraftSource],
+              trainingTargets: [{} as DraftSource]
+            } as DraftSourcesAsArrays)
+          );
+          TestEnvironment.initProject('user02');
+        });
+        env.component.isTargetLanguageSupported = true;
+        env.fixture.detectChanges();
+        expect(env.getElementByTestId('warning-admin-must-configure-sources')).not.toBeNull();
+      });
+
       it('should not show warning when access to source project', () => {
         const env = new TestEnvironment(() => {
           mockDraftSourcesService.getDraftProjectSources.and.returnValue(

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -201,6 +201,7 @@
     "info_alert_no_training_source_access": "You do not have access to the training source project {{ name }}. Please contact your Paratext Administrator for access, then [link:connectProjectUrl]connect to this project[/link] before you can generate a draft.",
     "info_alert_download_error": "There was a problem downloading your draft. Please check your Internet connection and try again in several minutes.",
     "info_alert_no_additional_training_source_access": "You do not have access to the additional training source project {{ name }}. Please contact your Paratext Administrator for access, then [link:connectProjectUrl]connect to this project[/link] before you can generate a draft.",
+    "info_alert_please_have_admin_configure_sources": "Please have a project administrator configure the draft sources. Then you will be able to generate drafts.",
     "instructions_draft_process": "Generating a draft usually takes at least {{ count }} hours.",
     "instructions_draft_process_subtext": "It can take much longer when the system is busy.",
     "instructions_help": "For more information, { 1 } see the help site{ 2 }.",


### PR DESCRIPTION
This PR adds a notice to direct users to ask an admin to configure draft sources for translators since translators have no way to configure sources on a project that has no sources.
![Translator notice sources need configured](https://github.com/user-attachments/assets/def03c5a-a2c1-4e19-9de7-53af680071e7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3102)
<!-- Reviewable:end -->
