### PR TITLE
Fix project select track expression

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -18,14 +18,14 @@
     >
       @if (nullableLength(projects$ | async) > 0) {
         <mat-optgroup [label]="t('projects')">
-          @for (project of projects$ | async; track project) {
+          @for (project of projects$ | async; track project.paratextId) {
             <mat-option [value]="project">{{ projectLabel(project) }}</mat-option>
           }
         </mat-optgroup>
       }
       @if (nullableLength(resources$ | async) > 0) {
         <mat-optgroup [label]="t('resources')">
-          @for (resource of resources$ | async; track resource) {
+          @for (resource of resources$ | async; track resource.paratextId) {
             <mat-option [value]="resource">{{ projectLabel(resource) }}</mat-option>
           }
         </mat-optgroup>


### PR DESCRIPTION
Angular prints this warning due to this component's track expression:
> NG0956: The configured tracking expression (track by identity) caused re-creation of the entire collection of size 25. This is an expensive operation requiring destruction and subsequent creation of DOM nodes, directives, components etc. Please review the "track expression" and make sure that it uniquely identifies items in a collection. Find more at https://angular.dev/errors/NG0956

This change addresses that warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3103)
<!-- Reviewable:end -->
