### PR TITLE
SF-3274 Update the translation engine instead of recreating on language change

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -41,7 +41,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.8" />
-    <PackageReference Include="Serval.Client" Version="1.8.4" />
+    <PackageReference Include="Serval.Client" Version="1.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -14,8 +14,12 @@ namespace SIL.XForge.Scripture.Services;
 [Intercept(typeof(EventMetricLogger))]
 public interface IMachineApiService
 {
-    [LogEventMetric(EventScope.Drafting, nameof(curUserId), nameof(sfProjectId))]
-    Task CancelPreTranslationBuildAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    [LogEventMetric(EventScope.Drafting, nameof(curUserId), nameof(sfProjectId), captureReturnValue: true)]
+    Task<string?> CancelPreTranslationBuildAsync(
+        string curUserId,
+        string sfProjectId,
+        CancellationToken cancellationToken
+    );
     Task ExecuteWebhookAsync(string json, string signature);
     Task<ServalBuildDto?> GetBuildAsync(
         string curUserId,

--- a/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/ISFProjectService.cs
@@ -17,6 +17,8 @@ public interface ISFProjectService : IProjectService
     Task<string> CreateProjectAsync(string curUserId, SFProjectCreateSettings settings);
     Task<string> CreateResourceProjectAsync(string curUserId, string paratextId, bool addUser);
     Task DeleteProjectAsync(string curUserId, string projectId);
+
+    [LogEventMetric(EventScope.Settings, nameof(curUserId))]
     Task UpdateSettingsAsync(string curUserId, string projectId, SFProjectSettings settings);
     Task AddTranslateMetricsAsync(string curUserId, string projectId, TranslateMetrics metrics);
     Task<string> SyncAsync(string curUserId, string projectId);

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -192,6 +192,9 @@ public class PreTranslationService(
             GetTextId(bookNum),
             PretranslationUsfmTextOrigin.OnlyPretranslated,
             PretranslationUsfmTemplate.Source,
+            PretranslationUsfmMarkerBehavior.Preserve,
+            PretranslationUsfmMarkerBehavior.Preserve,
+            PretranslationUsfmMarkerBehavior.Strip,
             cancellationToken
         );
 

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -187,15 +187,12 @@ public class PreTranslationService(
 
         // Get the USFM
         string usfm = await translationEnginesClient.GetPretranslatedUsfmAsync(
-            translationEngineId,
-            corpusId,
-            GetTextId(bookNum),
-            PretranslationUsfmTextOrigin.OnlyPretranslated,
-            PretranslationUsfmTemplate.Source,
-            PretranslationUsfmMarkerBehavior.Preserve,
-            PretranslationUsfmMarkerBehavior.Preserve,
-            PretranslationUsfmMarkerBehavior.Strip,
-            cancellationToken
+            id: translationEngineId,
+            corpusId: corpusId,
+            textId: GetTextId(bookNum),
+            textOrigin: PretranslationUsfmTextOrigin.OnlyPretranslated,
+            template: PretranslationUsfmTemplate.Source,
+            cancellationToken: cancellationToken
         );
 
         // Return the entire book

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -184,9 +184,9 @@
       },
       "Serval.Client": {
         "type": "Direct",
-        "requested": "[1.8.4, )",
-        "resolved": "1.8.4",
-        "contentHash": "G4uzYFcIZ7akAfFfUSCkpccVhjDN7uMzYvDjfgYztVL4rntXdPCwUw5M1qnORoaobC2DXrCu5jEpMFU+BT5L6g==",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "yWjQtF4vzsu33a/ctQHF6UDzqfgQ43qVUVs/y/f0HHANpMFVXFbGWX4185E+a4IowOoAwdrq49+Mwh+XhWDqOw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
           "System.ComponentModel.Annotations": "5.0.0"

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -92,7 +92,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
-            .Returns(Task.CompletedTask);
+            .Returns(Task.FromResult(Build01));
 
         // SUT
         ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -3098,6 +3098,7 @@ public class MachineApiServiceTests
             BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
             BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns(JobId);
             DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
+            EventMetricService = Substitute.For<IEventMetricService>();
             ExceptionHandler = Substitute.For<IExceptionHandler>();
 
             var machineProjectService = Substitute.For<IMachineProjectService>();
@@ -3203,6 +3204,7 @@ public class MachineApiServiceTests
             Service = Substitute.ForPartsOf<MachineApiService>(
                 BackgroundJobClient,
                 DeltaUsxMapper,
+                EventMetricService,
                 ExceptionHandler,
                 MockLogger,
                 machineProjectService,
@@ -3221,6 +3223,7 @@ public class MachineApiServiceTests
 
         public IBackgroundJobClient BackgroundJobClient { get; }
         public IDeltaUsxMapper DeltaUsxMapper { get; }
+        public IEventMetricService EventMetricService { get; }
         public IExceptionHandler ExceptionHandler { get; }
         public MockLogger<MachineApiService> MockLogger { get; }
         public IParatextService ParatextService { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -384,7 +384,7 @@ public class MachineProjectServiceTests
             )
             .Returns(Task.FromResult(TranslationEngine01));
         env.Service.Configure()
-            .RecreateTranslationEngineIfRequiredAsync(
+            .RecreateOrUpdateTranslationEngineIfRequiredAsync(
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: true,
@@ -439,7 +439,7 @@ public class MachineProjectServiceTests
             )
             .Returns(Task.FromResult(TranslationEngine01));
         env.Service.Configure()
-            .RecreateTranslationEngineIfRequiredAsync(
+            .RecreateOrUpdateTranslationEngineIfRequiredAsync(
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: false,
@@ -535,7 +535,7 @@ public class MachineProjectServiceTests
             )
             .Returns(Task.FromResult(TranslationEngine01));
         env.Service.Configure()
-            .RecreateTranslationEngineIfRequiredAsync(
+            .RecreateOrUpdateTranslationEngineIfRequiredAsync(
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: true,
@@ -1899,7 +1899,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task RecreateTranslationEngineIfRequiredAsync_DoNotRecreateIfNoLanguageChanges()
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_DoNotRecreateIfNoLanguageChanges()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -1929,7 +1929,7 @@ public class MachineProjectServiceTests
             );
 
         // SUT
-        await env.Service.RecreateTranslationEngineIfRequiredAsync(
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
             TranslationEngine01,
             project,
             preTranslate: true,
@@ -1944,7 +1944,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task RecreateTranslationEngineIfRequiredAsync_RecreateIfTheSourceLanguageChanges()
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_UpdateIfTheSourceLanguageChanges()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -1956,12 +1956,6 @@ public class MachineProjectServiceTests
         env.Service.Configure()
             .GetTargetLanguageAsync(project, preTranslate: true)
             .Returns(Task.FromResult(targetLanguage));
-        env.Service.Configure()
-            .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
-            .Returns(Task.FromResult(string.Empty));
-        env.Service.Configure()
-            .RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None)
-            .Returns(Task.CompletedTask);
         env.TranslationEnginesClient.GetAsync(TranslationEngine01)
             .Returns(
                 Task.FromResult(
@@ -1975,18 +1969,19 @@ public class MachineProjectServiceTests
             );
 
         // SUT
-        await env.Service.RecreateTranslationEngineIfRequiredAsync(
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
             TranslationEngine01,
             project,
             preTranslate: true,
             CancellationToken.None
         );
-        await env.Service.Received(1).RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None);
-        await env.Service.Received(1).CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        await env
+            .TranslationEnginesClient.Received(1)
+            .UpdateAsync(TranslationEngine01, Arg.Any<TranslationEngineUpdateConfig>(), CancellationToken.None);
     }
 
     [Test]
-    public async Task RecreateTranslationEngineIfRequiredAsync_RecreateIfTheTargetLanguageChanges()
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_UpdateIfTheTargetLanguageChanges()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -1998,12 +1993,6 @@ public class MachineProjectServiceTests
         env.Service.Configure()
             .GetTargetLanguageAsync(project, preTranslate: true)
             .Returns(Task.FromResult(newTargetLanguage));
-        env.Service.Configure()
-            .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
-            .Returns(Task.FromResult(string.Empty));
-        env.Service.Configure()
-            .RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None)
-            .Returns(Task.CompletedTask);
         env.TranslationEnginesClient.GetAsync(TranslationEngine01)
             .Returns(
                 Task.FromResult(
@@ -2017,18 +2006,19 @@ public class MachineProjectServiceTests
             );
 
         // SUT
-        await env.Service.RecreateTranslationEngineIfRequiredAsync(
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
             TranslationEngine01,
             project,
             preTranslate: true,
             CancellationToken.None
         );
-        await env.Service.Received(1).RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None);
-        await env.Service.Received(1).CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        await env
+            .TranslationEnginesClient.Received(1)
+            .UpdateAsync(TranslationEngine01, Arg.Any<TranslationEngineUpdateConfig>(), CancellationToken.None);
     }
 
     [Test]
-    public async Task RecreateTranslationEngineIfRequiredAsync_RecreatePreTranslationEngineIfNotFound()
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_RecreatePreTranslationEngineIfNotFound()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -2041,7 +2031,7 @@ public class MachineProjectServiceTests
         env.TranslationEnginesClient.GetAsync(TranslationEngine01).ThrowsAsync(ex);
 
         // SUT
-        await env.Service.RecreateTranslationEngineIfRequiredAsync(
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
             TranslationEngine01,
             project,
             preTranslate: true,
@@ -2053,7 +2043,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task RecreateTranslationEngineIfRequiredAsync_RecreateSmtTranslationEngineIfNotFound()
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_RecreateSmtTranslationEngineIfNotFound()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -2066,7 +2056,7 @@ public class MachineProjectServiceTests
         env.TranslationEnginesClient.GetAsync(TranslationEngine01).ThrowsAsync(ex);
 
         // SUT
-        await env.Service.RecreateTranslationEngineIfRequiredAsync(
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
             TranslationEngine01,
             project,
             preTranslate: false,

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -655,6 +655,9 @@ public class PreTranslationServiceTests
                     "MAT",
                     PretranslationUsfmTextOrigin.OnlyPretranslated,
                     PretranslationUsfmTemplate.Source,
+                    PretranslationUsfmMarkerBehavior.Preserve,
+                    PretranslationUsfmMarkerBehavior.Preserve,
+                    PretranslationUsfmMarkerBehavior.Strip,
                     CancellationToken.None
                 )
                 .Returns(MatthewBookUsfm);

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -650,15 +650,12 @@ public class PreTranslationServiceTests
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
             TranslationEnginesClient
                 .GetPretranslatedUsfmAsync(
-                    Arg.Any<string>(),
-                    Arg.Any<string>(),
-                    "MAT",
-                    PretranslationUsfmTextOrigin.OnlyPretranslated,
-                    PretranslationUsfmTemplate.Source,
-                    PretranslationUsfmMarkerBehavior.Preserve,
-                    PretranslationUsfmMarkerBehavior.Preserve,
-                    PretranslationUsfmMarkerBehavior.Strip,
-                    CancellationToken.None
+                    id: Arg.Any<string>(),
+                    corpusId: Arg.Any<string>(),
+                    textId: "MAT",
+                    textOrigin: PretranslationUsfmTextOrigin.OnlyPretranslated,
+                    template: PretranslationUsfmTemplate.Source,
+                    cancellationToken: CancellationToken.None
                 )
                 .Returns(MatthewBookUsfm);
             Service = Substitute.ForPartsOf<PreTranslationService>(

--- a/tools/ServalBuildReport/ServalBuildReport.csproj
+++ b/tools/ServalBuildReport/ServalBuildReport.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="NPOI" Version="2.7.2" />
-    <PackageReference Include="Serval.Client" Version="1.8.4" />
+    <PackageReference Include="Serval.Client" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Serval.Client" Version="1.8.4" />
+    <PackageReference Include="Serval.Client" Version="1.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds support for a new feature in Serval 1.9 to update translation engines rather than delete and recreate.

I also took the opportunity to improve logging of build cancellations, settings updates (i.e. when the build sources are configured), and when the webhook is run.

I have marked this as not requiring testing, as the changes are reflected in Mongo, not necessarily in the frontend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3104)
<!-- Reviewable:end -->
