### PR TITLE
SF-3280 Fix login redirect loop

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -539,7 +539,10 @@ export class AuthService {
       try {
         await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
       } catch (err) {
-        console.error(err);
+        // Display error dialog to pause login loop.
+        // Error details will be sent to Bugsnag and logged to the console.
+        await this.handleLoginError('handleOnlineAuth', err);
+
         return false;
       }
     }


### PR DESCRIPTION
When backend cannot update user from Auth0 profile, user is sent into a endless redirect loop.

This PR adds a dialog to pause the retry loop.  Error details will be sent to Bugsnag and logged to the console.  The dialog, itself, currently doesn't contain error details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3107)
<!-- Reviewable:end -->
