### PR TITLE
SF-3285 Remove SMS login logic from app

### DIFF
--- a/src/RealtimeServer/common/models/user.ts
+++ b/src/RealtimeServer/common/models/user.ts
@@ -11,8 +11,7 @@ export enum AuthType {
   Paratext,
   Google,
   Facebook,
-  Account,
-  SMS
+  Account
 }
 
 export function getAuthType(authId: string): AuthType {
@@ -32,9 +31,6 @@ export function getAuthType(authId: string): AuthType {
   }
   if (authIdType.includes('auth0')) {
     return AuthType.Account;
-  }
-  if (authIdType.includes('sms')) {
-    return AuthType.SMS;
   }
   return AuthType.Unknown;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.html
@@ -66,8 +66,7 @@
     @if (isLinkSharingEnabled) {
       <div class="invite-by-link">
         <h3>{{ t("share_a_link") }}</h3>
-        <p class="mat-hint">{{ t("link_sharing") }}</p>
-        <app-share-button [iconOnlyButton]="false"></app-share-button>
+        <p class="mat-hint">{{ t("link_sharing") }} <app-share-button [iconOnlyButton]="false"></app-share-button></p>
       </div>
     }
   </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.scss
@@ -1,5 +1,16 @@
 @use 'src/breakpoints';
 
+p.mat-hint {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-block-start: 0;
+  @include breakpoints.media-breakpoint-down(sm) {
+    flex-direction: column;
+  }
+}
+
 .invite-forms {
   display: flex;
   flex-direction: column;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -427,7 +427,7 @@
     "invite_people": "Invite people",
     "invite_people_intro": "You can invite people outside of Paratext to help contribute to your project.",
     "link_copied": "Link copied to clipboard",
-    "link_sharing": "Links can also be shared to users without an email address via social media platforms or SMS messages.",
+    "link_sharing": "Links can also be shared to users without an email address via social media platforms.",
     "not_inviting_already_member": "Not inviting: User is already a member of this project",
     "resend": "Resend",
     "send_a_link": "Send a link",

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -112,20 +112,6 @@ public class AuthService : DisposableBase, IAuthService
         return CallApiAsync(HttpMethod.Patch, $"users/{authId}", content);
     }
 
-    /// <summary>
-    /// Used for SMS authentication as the user has their name and nickname set to their phone number which may get
-    /// exposed in future user requests. This method sets both values to "Anonymous" and is intended to be run once.
-    /// </summary>
-    public async Task<string> UpdateUserToAnonymous(string authId)
-    {
-        var content = new JObject(
-            new JProperty("name", "Anonymous"),
-            new JProperty("nickname", "Anonymous"),
-            new JProperty("picture", "https://cdn.auth0.com/avatars/a.png")
-        );
-        return await CallApiAsync(HttpMethod.Patch, $"users/{authId}", content);
-    }
-
     private async Task<string> CallApiAsync(
         HttpMethod method,
         string url,

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -13,5 +13,4 @@ public interface IAuthService
     Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
     Task UpdateAvatar(string authId, string url);
     Task UpdateInterfaceLanguage(string authId, string language);
-    Task<string> UpdateUserToAnonymous(string authId);
 }

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -60,16 +60,9 @@ public class UserService : IUserService
         bool displayNameSetAtSignup = identities
             .OfType<JObject>()
             .Any(i => (string)i["connection"] == "Transparent-Authentication");
-        bool hasSMSConnection = identities.OfType<JObject>().Any(i => (string)i["connection"] == "sms");
         Regex emailRegex = new Regex(EMAIL_PATTERN);
         await using (IConnection conn = await _realtimeService.ConnectAsync(curUserId))
         {
-            // New SMS connection users have their name and nickname to the phone number which we need to change
-            // to anonymous. Users will be asked to set their display name once they start adding content.
-            if (hasSMSConnection && (string)userProfile["name"] == (string)userProfile["phone_number"])
-            {
-                userProfile = JObject.Parse(await _authService.UpdateUserToAnonymous((string)userProfile["user_id"]));
-            }
             string name = (string)userProfile["name"];
             IDocument<User> userDoc = await conn.FetchOrCreateAsync<User>(
                 curUserId,

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -104,27 +104,6 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_NewUser_SMS()
-    {
-        var env = new TestEnvironment();
-
-        JObject userProfile = TestEnvironment.CreateSMSUserProfile("user03", "auth03");
-        JObject expectedProfile = (JObject)userProfile.DeepClone();
-        expectedProfile["name"] = "Anonymous";
-        expectedProfile["nickname"] = "Anonymous";
-        expectedProfile["picture"] = "https://cdn.auth0.com/avatars/a.png";
-        env.AuthService.UpdateUserToAnonymous("auth03").Returns(Task.FromResult<string>(expectedProfile.ToString()));
-
-        // SUT
-        await env.Service.UpdateUserFromProfileAsync("user03", userProfile.ToString());
-
-        User user3 = env.GetUser("user03");
-        Assert.That(user3.Name, Is.EqualTo("Anonymous"));
-        Assert.That(user3.DisplayName, Is.EqualTo("Anonymous"));
-        Assert.That(user3.AvatarUrl, Is.EqualTo("https://cdn.auth0.com/avatars/a.png"));
-    }
-
-    [Test]
     public async Task PushAuthUserProfile_Metadata_AvatarSet()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
As we no longer support login with SMS, this PR removes the logic and references to that feature from the code.

This issue requires a change to Auth0 that I do not have access to - [see comments](https://jira.sil.org/browse/SF-3279).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3108)
<!-- Reviewable:end -->
