### PR TITLE
Use nullish coalescing assignment when possible

### DIFF
--- a/.grit/patterns/import_from_lodash_es.md
+++ b/.grit/patterns/import_from_lodash_es.md
@@ -1,5 +1,5 @@
 ---
-level: warn
+level: error
 ---
 
 Imports can safely be made directly from `lodash-es` instead of `lodash-es/...`.

--- a/.grit/patterns/missed_nullish_assignment_opportunity.md
+++ b/.grit/patterns/missed_nullish_assignment_opportunity.md
@@ -1,0 +1,13 @@
+---
+level: error
+---
+
+# Missed opportunity to use nullish assignment
+
+```grit
+language js
+
+`if ($expression == null) {
+    $expression = $value;
+}` => `$expression ??= $value;`
+```

--- a/.grit/patterns/xforge_common_absolute_only.md
+++ b/.grit/patterns/xforge_common_absolute_only.md
@@ -1,6 +1,6 @@
 ---
 tags: [precommit]
-level: warn
+level: error
 ---
 
 # Import from xforge-common, not from ../xforge-common

--- a/scripts/update_font_list.mts
+++ b/scripts/update_font_list.mts
@@ -36,9 +36,7 @@ for (const entry of Object.values(fonts)) {
 
   const defaultFileUrl = entry.files[defaultFileName]?.flourl;
 
-  if (filesByFamily[entry.family] == null) {
-    filesByFamily[entry.family] = [];
-  }
+  filesByFamily[entry.family] ??= [];
   filesByFamily[entry.family].push({
     fileName: defaultFileName,
     fileUrl: defaultFileUrl

--- a/src/RealtimeServer/common/metadata-db.ts
+++ b/src/RealtimeServer/common/metadata-db.ts
@@ -15,9 +15,7 @@ export function MetadataDB<T extends DBConstructor>(Base: T): T {
       options: any,
       callback: (...args: any[]) => any
     ): void {
-      if (options == null) {
-        options = {};
-      }
+      options ??= {};
       options.metadata = true;
       super.getOpsToSnapshot(collection, id, from, snapshot, options, callback);
     }

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -455,9 +455,7 @@ export class RealtimeServer extends ShareDB {
     }
     for (const docService of this.docServices.values()) {
       let curVersion = versionMap.get(docService.collection);
-      if (curVersion == null) {
-        curVersion = 0;
-      }
+      curVersion ??= 0;
       const version = docService.schemaVersion;
       if (curVersion === version) {
         continue;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -272,12 +272,10 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
 
     // No stored question, so use first question within route book/chapter if available.
     // Otherwise use first question.
-    if (questionToActivate == null) {
-      questionToActivate =
-        this.questionDocs.find(
-          qd => this.routeBookChapter == null || bookChapterMatchesVerseRef(this.routeBookChapter, qd.data!.verseRef)
-        ) ?? this.questionDocs[0];
-    }
+    questionToActivate ??=
+      this.questionDocs.find(
+        qd => this.routeBookChapter == null || bookChapterMatchesVerseRef(this.routeBookChapter, qd.data!.verseRef)
+      ) ?? this.questionDocs[0];
 
     if (questionToActivate != null) {
       this.activateQuestion(questionToActivate, actionSource);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -767,19 +767,17 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       case 'save':
         let answer = answerAction.answer;
         const dateNow: string = new Date().toJSON();
-        if (answer == null) {
-          answer = {
-            dataId: objectId(),
-            ownerRef: this.userService.currentUserId,
-            text: '',
-            likes: [],
-            dateCreated: dateNow,
-            dateModified: dateNow,
-            deleted: false,
-            comments: [],
-            status: AnswerStatus.None
-          };
-        }
+        answer ??= {
+          dataId: objectId(),
+          ownerRef: this.userService.currentUserId,
+          text: '',
+          likes: [],
+          dateCreated: dateNow,
+          dateModified: dateNow,
+          deleted: false,
+          comments: [],
+          status: AnswerStatus.None
+        };
         answer.text = answerAction.text;
         answer.scriptureText = answerAction.scriptureText;
         answer.verseRef = answerAction.verseRef;
@@ -848,16 +846,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         if (commentAction.answer != null) {
           let comment = commentAction.comment;
           const dateNow: string = new Date().toJSON();
-          if (comment == null) {
-            comment = {
-              dataId: objectId(),
-              ownerRef: this.userService.currentUserId,
-              text: '',
-              dateCreated: dateNow,
-              dateModified: dateNow,
-              deleted: false
-            };
-          }
+          comment ??= {
+            dataId: objectId(),
+            ownerRef: this.userService.currentUserId,
+            text: '',
+            dateCreated: dateNow,
+            dateModified: dateNow,
+            deleted: false
+          };
           comment.text = commentAction.text;
           comment.dateModified = dateNow;
           if (commentAction.audio != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/note-thread-doc.ts
@@ -20,9 +20,7 @@ import { ProjectDataDoc } from 'xforge-common/models/project-data-doc';
 
 /** Returns the given tag icon formatted for retrieval in the html template, or the default icon. */
 export function defaultNoteThreadIcon(tagIcon: string | undefined): NoteThreadIcon {
-  if (tagIcon == null) {
-    tagIcon = DEFAULT_TAG_ICON;
-  }
+  tagIcon ??= DEFAULT_TAG_ICON;
   const iconUrl = `/assets/icons/TagIcons/${tagIcon}.png`;
   return { cssVar: `--icon-file: url(${iconUrl});`, url: iconUrl };
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
@@ -73,9 +73,7 @@ export class TextDocService {
       throw new Error(`Text Doc already exists for ${textDocId}`);
     }
 
-    if (data == null) {
-      data = { ops: [] };
-    }
+    data ??= { ops: [] };
     textDoc = await this.realtimeService.create(TextDoc.COLLECTION, textDocId.toString(), data, type.uri);
     return textDoc;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -140,12 +140,10 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   }
 
   listenForTrainingStatus(): Observable<ProgressStatus> {
-    if (this.trainingStatus$ == null) {
-      this.trainingStatus$ = this.getEngine(this.projectId).pipe(
-        mergeMap(e => this.pollBuildProgress(e.id, 0)),
-        share()
-      );
-    }
+    this.trainingStatus$ ??= this.getEngine(this.projectId).pipe(
+      mergeMap(e => this.pollBuildProgress(e.id, 0)),
+      share()
+    );
     return this.trainingStatus$;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -210,9 +210,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
 
     this.lastConsolidationGroupId = into;
 
-    if (this.tabsToDeconsolidate == null) {
-      this.tabsToDeconsolidate = new Map();
-    }
+    this.tabsToDeconsolidate ??= new Map();
 
     this.groups.forEach(group => {
       if (group.groupId === into) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-history.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-history.ts
@@ -68,9 +68,7 @@ export function removeObsoleteSegmentAttrs(delta: Delta): Delta {
       const modelOp: DeltaOperation = cloneDeep(op);
       const attrs = modelOp.attributes;
       if (attrs != null && attrs['segment'] != null) {
-        if (attrs['highlight-segment'] == null) {
-          attrs['highlight-segment'] = false;
-        }
+        attrs['highlight-segment'] ??= false;
         if (attrs['commenter-selection'] != null) {
           // if this delta is applied to a verse that is not the current selection, this attribute
           // should be null so when the selection changes, the verse will be correctly selected

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/segment.ts
@@ -24,9 +24,7 @@ export class Segment {
   }
 
   get checksum(): number {
-    if (this._checksum == null) {
-      this._checksum = crc.str(this._text);
-    }
+    this._checksum ??= crc.str(this._text);
     return this._checksum;
   }
 
@@ -50,8 +48,6 @@ export class Segment {
     if (this.initialTextLen === -1) {
       this.initialTextLen = text.length;
     }
-    if (this.initialChecksum == null) {
-      this.initialChecksum = this.checksum;
-    }
+    this.initialChecksum ??= this.checksum;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -54,9 +54,7 @@ function canParaContainVerseText(style: string): boolean {
 
 function getParagraphRef(nextIds: Map<string, number>, key: string, prefix: string): string {
   let nextId = nextIds.get(key);
-  if (nextId == null) {
-    nextId = 1;
-  }
+  nextId ??= 1;
   const id = nextId++;
   nextIds.set(key, nextId);
   return prefix + '_' + id;
@@ -597,9 +595,7 @@ export class TextViewModel implements OnDestroy {
           }
         } else {
           // title/header
-          if (curSegment == null) {
-            curSegment = new SegmentInfo('', curIndex);
-          }
+          curSegment ??= new SegmentInfo('', curIndex);
           curSegment.ref = getParagraphRef(nextIds, style, style);
           [fixDelta, fixOffset] = this.fixSegment(editor, curSegment, fixDelta, fixOffset, isOnline);
           this._segments.set(curSegment.ref, { index: curSegment.index, length: curSegment.length });
@@ -627,9 +623,7 @@ export class TextViewModel implements OnDestroy {
       } else {
         // segment
         setAttribute(op, attrs, 'para-contents', true);
-        if (curSegment == null) {
-          curSegment = new SegmentInfo('', curIndex);
-        }
+        curSegment ??= new SegmentInfo('', curIndex);
         const opSegRef: string = op.attributes?.['segment'] != null ? (op.attributes['segment'] as string) : '';
         if (curSegment.origRef == null) {
           curSegment.origRef = opSegRef;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -1910,9 +1910,7 @@ class TestEnvironment {
         displayName: remotePresenceId
       }
     };
-    if (range == null) {
-      range = mock<QuillRange>();
-    }
+    range ??= mock<QuillRange>();
     // Write the presence right into the area that would be being provided by the sharedb.
     this.remoteChannelPresences[remotePresenceId] = presenceData;
     this.remoteDocPresences[remotePresenceId] = range;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -5242,15 +5242,9 @@ class TestEnvironment {
   }
 
   private addProjectUserConfig(userConfig: SFProjectUserConfig): void {
-    if (userConfig.translationSuggestionsEnabled == null) {
-      userConfig.translationSuggestionsEnabled = true;
-    }
-    if (userConfig.numSuggestions == null) {
-      userConfig.numSuggestions = 1;
-    }
-    if (userConfig.confidenceThreshold == null) {
-      userConfig.confidenceThreshold = 0.2;
-    }
+    userConfig.translationSuggestionsEnabled ??= true;
+    userConfig.numSuggestions ??= 1;
+    userConfig.confidenceThreshold ??= 0.2;
     this.realtimeService.addSnapshot<SFProjectUserConfig>(SFProjectUserConfigDoc.COLLECTION, {
       id: getSFProjectUserConfigDocId('project01', userConfig.ownerRef),
       data: userConfig

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth-http-interceptor.ts
@@ -22,9 +22,7 @@ export class AuthHttpInterceptor implements HttpInterceptor {
   constructor(private readonly injector: Injector) {}
 
   async handle(req: HttpRequest<any>, next: HttpHandler): Promise<HttpEvent<any>> {
-    if (this.authService == null) {
-      this.authService = this.injector.get<AuthService>(AuthService);
-    }
+    this.authService ??= this.injector.get<AuthService>(AuthService);
     // Make sure the user is authenticated with a valid access token
     if (!(await this.authService.isAuthenticated())) {
       // When authentication fails auth0 is already in the process of redirecting to the login screen

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -998,15 +998,13 @@ class TestEnvironment {
   }
 
   setLoginResponse(auth0Response?: AuthDetails | undefined): void {
-    if (auth0Response == null) {
-      auth0Response = {
-        token: this.validToken,
-        idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
-        loginResult: {
-          appState: this._authLoginState
-        }
-      };
-    }
+    auth0Response ??= {
+      token: this.validToken,
+      idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
+      loginResult: {
+        appState: this._authLoginState
+      }
+    };
     this.auth0Response = auth0Response;
     when(mockedWebAuth.getTokenSilently()).thenResolve(this.auth0Response!.token.access_token);
     when(mockedWebAuth.getTokenSilently(anything())).thenResolve(this.auth0Response!.token);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -563,9 +563,7 @@ export class AuthService {
   }
 
   private isCallbackUrl(callbackUrl: string | undefined = undefined): boolean {
-    if (callbackUrl == null) {
-      callbackUrl = this.locationService.href;
-    }
+    callbackUrl ??= this.locationService.href;
     if (!callbackUrl.includes('://')) {
       callbackUrl = this.locationService.origin + callbackUrl;
     }
@@ -603,67 +601,63 @@ export class AuthService {
   }
 
   private async renewTokens(): Promise<void> {
-    if (this.renewTokenPromise == null) {
-      this.renewTokenPromise = new Promise<void>(async (resolve, reject) => {
-        let success = false;
-        try {
-          const authResult = await this.checkSession();
-          if (
-            authResult != null &&
-            authResult.access_token != null &&
-            authResult.id_token != null &&
-            authResult.expires_in != null
-          ) {
-            await this.localLogIn(authResult.access_token, authResult.id_token, authResult.expires_in);
-            success = true;
-            resolve();
-          }
-        } catch (err) {
-          console.error('Error while renewing access token:', err);
-          this.reportingService.silentError(
-            'Error while renewing access token',
-            ErrorReportingService.normalizeError(err)
-          );
-          success = false;
+    this.renewTokenPromise ??= new Promise<void>(async (resolve, reject) => {
+      let success = false;
+      try {
+        const authResult = await this.checkSession();
+        if (
+          authResult != null &&
+          authResult.access_token != null &&
+          authResult.id_token != null &&
+          authResult.expires_in != null
+        ) {
+          await this.localLogIn(authResult.access_token, authResult.id_token, authResult.expires_in);
+          success = true;
+          resolve();
         }
-        if (!success) {
-          reject();
-        }
+      } catch (err) {
+        console.error('Error while renewing access token:', err);
+        this.reportingService.silentError(
+          'Error while renewing access token',
+          ErrorReportingService.normalizeError(err)
+        );
+        success = false;
+      }
+      if (!success) {
+        reject();
+      }
+    })
+      .catch(() => {
+        this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
       })
-        .catch(() => {
-          this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
-        })
-        .then(() => {
-          this.renewTokenPromise = undefined;
-        });
-    }
+      .then(() => {
+        this.renewTokenPromise = undefined;
+      });
     return this.renewTokenPromise;
   }
 
   private async checkSession(retryUponTimeout: boolean = true): Promise<GetTokenSilentlyVerboseResponse | null> {
-    if (this.checkSessionPromise == null) {
-      this.checkSessionPromise = new Promise<GetTokenSilentlyVerboseResponse | null>(async (resolve, reject) => {
-        try {
-          const tokenResponse = await this.getTokenDetails();
-          resolve(tokenResponse);
-        } catch (err) {
-          if (
-            hasPropWithValue(err, 'error', 'login_required') ||
-            hasPropWithValue(err, 'error', 'missing_refresh_token')
-          ) {
-            resolve(null);
-          } else if (retryUponTimeout && hasPropWithValue(err, 'error', 'timeout')) {
-            this.checkSessionPromise = undefined;
-            this.checkSession(false).then(resolve).catch(reject);
-          } else {
-            reject(err);
-          }
+    this.checkSessionPromise ??= new Promise<GetTokenSilentlyVerboseResponse | null>(async (resolve, reject) => {
+      try {
+        const tokenResponse = await this.getTokenDetails();
+        resolve(tokenResponse);
+      } catch (err) {
+        if (
+          hasPropWithValue(err, 'error', 'login_required') ||
+          hasPropWithValue(err, 'error', 'missing_refresh_token')
+        ) {
+          resolve(null);
+        } else if (retryUponTimeout && hasPropWithValue(err, 'error', 'timeout')) {
+          this.checkSessionPromise = undefined;
+          this.checkSession(false).then(resolve).catch(reject);
+        } else {
+          reject(err);
         }
-      }).finally(() => {
-        this.checkSessionPromise = undefined;
-      });
-    }
-    return this.checkSessionPromise;
+      }
+    }).finally(() => {
+      this.checkSessionPromise = undefined;
+    });
+    return await this.checkSessionPromise;
   }
 
   private async localLogIn(accessToken: string, idToken: string, expiresIn: number): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -126,9 +126,7 @@ export class IndexeddbOfflineStore extends OfflineStore {
         }
       }
     }
-    if (snapshots == null) {
-      snapshots = await this.getAll(collection);
-    }
+    snapshots ??= await this.getAll(collection);
     return performQuery(parameters, snapshots);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -111,9 +111,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
    * @returns {Promise<void>} Resolves when successfully subscribed to remote changes.
    */
   async subscribe(): Promise<void> {
-    if (this.subscribePromise == null) {
-      this.subscribePromise = this.subscribeToChanges();
-    }
+    this.subscribePromise ??= this.subscribeToChanges();
     return this.subscribePromise;
   }
 
@@ -244,9 +242,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
   }
 
   private async loadOfflineData(): Promise<void> {
-    if (this.loadOfflineDataPromise == null) {
-      this.loadOfflineDataPromise = this.loadFromOfflineStore();
-    }
+    this.loadOfflineDataPromise ??= this.loadFromOfflineStore();
     return this.loadOfflineDataPromise;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.spec.ts
@@ -106,9 +106,7 @@ Object.defineProperty(mockedWindow, 'preventDefault', {
 });
 Object.defineProperty(mockedWindow, 'addEventListener', {
   value: (eventName: string, listener: EventListenerOrEventListenerObject) => {
-    if (windowEvents[eventName] == null) {
-      windowEvents[eventName] = [];
-    }
+    windowEvents[eventName] ??= [];
     windowEvents[eventName].push(listener);
     return mockedWindow;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -59,16 +59,12 @@ export class RealtimeService {
     const countsByCollection: { [key: string]: { docs: number; subscribers: number; queries: number } } = {};
     for (const [id, doc] of this.docs.entries()) {
       const collection = id.split(':')[0];
-      if (countsByCollection[collection] == null) {
-        countsByCollection[collection] = { docs: 0, subscribers: 0, queries: 0 };
-      }
+      countsByCollection[collection] ??= { docs: 0, subscribers: 0, queries: 0 };
       countsByCollection[collection].docs++;
       countsByCollection[collection].subscribers += doc.subscriberCount;
     }
     for (const [collection, queries] of this.subscribeQueries.entries()) {
-      if (countsByCollection[collection] == null) {
-        countsByCollection[collection] = { docs: 0, subscribers: 0, queries: 0 };
-      }
+      countsByCollection[collection] ??= { docs: 0, subscribers: 0, queries: 0 };
       countsByCollection[collection].queries += queries.size;
     }
     return countsByCollection;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/test-realtime.service.ts
@@ -9,18 +9,10 @@ import { RealtimeService } from './realtime.service';
 import { objectId } from './utils';
 
 function addSnapshotDefaults(snapshot: Partial<Snapshot>): Snapshot {
-  if (snapshot.id == null) {
-    snapshot.id = objectId();
-  }
-  if (snapshot.data == null) {
-    snapshot.data = {};
-  }
-  if (snapshot.v == null) {
-    snapshot.v = 0;
-  }
-  if (snapshot.type == null) {
-    snapshot.type = OTJson0.type.name;
-  }
+  snapshot.id ??= objectId();
+  snapshot.data ??= {};
+  snapshot.v ??= 0;
+  snapshot.type ??= OTJson0.type.name;
   return snapshot as Snapshot;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -31,7 +31,7 @@ export function supportedBrowser(): boolean {
     chrome: '>=87',
     chromium: '>=87',
     edge: '>=87',
-    firefox: '>=78',
+    firefox: '>=79',
     safari: '>=14.1',
 
     mobile: {


### PR DESCRIPTION
- Migrated `if ($expression == null) { $expression = $value; }` => `$expression ??= $value;`
- Updated all Grit lint rules to error when they fail (I recently created a PR that broke one of the rules, and couldn't see it without deliberately going to the checks tab of the pull request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3112)
<!-- Reviewable:end -->
