### PR TITLE
SF-3279 Replace SMS login with basic options on login with share links

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -381,24 +381,7 @@ describe('AuthService', () => {
     }
   }));
 
-  it('should login with passwordless enabled', fakeAsync(() => {
-    const env = new TestEnvironment();
-    const returnUrl = 'test-returnUrl';
-
-    env.service.logIn({ returnUrl });
-
-    verify(mockedWebAuth.loginWithRedirect(anything())).once();
-    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
-      mockedWebAuth.loginWithRedirect
-    ).last()[0];
-    expect(authOptions).toBeDefined();
-    if (authOptions != null) {
-      expect(authOptions.authorizationParams!.enablePasswordless).toEqual(true);
-      expect(authOptions.authorizationParams!.promptPasswordlessLogin).toBeUndefined();
-    }
-  }));
-
-  it('should login with passwordless enabled and prompt for passwordless login', fakeAsync(() => {
+  it('should prompt for basic login', fakeAsync(() => {
     const env = new TestEnvironment();
     const returnUrl = 'test-returnUrl';
     when(mockedLocationService.pathname).thenReturn('/join/sharekey');
@@ -411,8 +394,7 @@ describe('AuthService', () => {
     ).last()[0];
     expect(authOptions).toBeDefined();
     if (authOptions != null) {
-      expect(authOptions.authorizationParams!.enablePasswordless).toEqual(true);
-      expect(authOptions.authorizationParams!.promptPasswordlessLogin).toEqual(true);
+      expect(authOptions.authorizationParams!.promptBasicLogin).toEqual(true);
     }
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -78,8 +78,7 @@ interface xForgeAuth0Parameters extends AuthorizationParams {
   logo?: string;
   login_hint?: string;
   language?: string;
-  enablePasswordless?: boolean;
-  promptPasswordlessLogin?: boolean;
+  promptBasicLogin?: boolean;
 }
 
 @Injectable({
@@ -246,7 +245,6 @@ export class AuthService {
     const ui_locales: string = language;
     const auth0Parameters: xForgeAuth0Parameters = {
       ui_locales: language,
-      enablePasswordless: true,
       language,
       login_hint: ui_locales,
       logo: 'https://auth0.languagetechnology.org/assets/sf.svg'
@@ -256,7 +254,7 @@ export class AuthService {
       if (signUp) auth0Parameters.mode = 'signUp';
       auth0Parameters.login_hint = locale ?? ui_locales;
       if (this.isJoining) {
-        auth0Parameters.promptPasswordlessLogin = true;
+        auth0Parameters.promptBasicLogin = true;
       }
     }
     const authOptions: RedirectLoginOptions = {


### PR DESCRIPTION
This PR updates the configuration on the Auth0 login page that comes up when using a share link to join a project. Uses will now be prompted to login with google, facebook, or email/password rather than being prompted to use SMS as the default option. The Auth0 changes are on the development tenant so you can checkout this branch and try it.
![image](https://github.com/user-attachments/assets/05552ce3-c04c-4499-b9f6-5723de21184e)

