### PR TITLE
Add a USJ and Delta roundtrip tool

### DIFF
--- a/src/SIL.Converters.Usj/UsxToUsj.cs
+++ b/src/SIL.Converters.Usj/UsxToUsj.cs
@@ -73,7 +73,7 @@ namespace SIL.Converters.Usj
         public static Usj UsxXmlDocumentToUsj(XmlDocument document) => UsxDomToUsj(document?.DocumentElement);
 
         /// <summary>
-        /// Indicates whether a specified string is null, empty, or XML whitespace.
+        /// Indicates whether a specified string is null, empty, or XML whitespace that is not a single space.
         /// </summary>
         /// <param name="value">The string value.</param>
         /// <returns><c>true</c> if the string is null, empty, or XML whitespace.</returns>
@@ -81,7 +81,8 @@ namespace SIL.Converters.Usj
         /// This should be used instead of <see cref="string.IsNullOrWhiteSpace"/> for XML node values.
         /// </remarks>
         private static bool IsNullOrXmlWhitespace(string value) =>
-            string.IsNullOrEmpty(value) || value.All(c => c == '\t' || c == '\n' || c == '\r' || c == ' ');
+            string.IsNullOrEmpty(value)
+            || (value.All(c => c == '\t' || c == '\n' || c == '\r' || c == ' ') && value != " ");
 
         private static (T, bool) UsxDomToUsjRecurse<T>(XmlElement usxElement)
             where T : UsjBase, new()
@@ -145,8 +146,10 @@ namespace SIL.Converters.Usj
             }
 
             if (
-                usxElement.FirstChild?.NodeType == XmlNodeType.Text
-                && !IsNullOrXmlWhitespace(usxElement.FirstChild.Value)
+                (
+                    usxElement.FirstChild?.NodeType == XmlNodeType.Text
+                    || usxElement.FirstChild?.NodeType == XmlNodeType.Whitespace
+                ) && !IsNullOrXmlWhitespace(usxElement.FirstChild.Value)
             )
             {
                 text = usxElement.FirstChild.Value;

--- a/test/SIL.Converters.Usj.Tests/TestData.cs
+++ b/test/SIL.Converters.Usj.Tests/TestData.cs
@@ -530,4 +530,19 @@ public static partial class TestData
           <chapter eid="MRK 1" />
         </usx>
         """;
+
+    /// <summary>
+    /// Mark 1:1 in USX (with a single space in the note that should be preserved).
+    /// </summary>
+    public static readonly string UsxMrk1V1WithSingleSpace = $"""
+        <usx version="{Usx.UsxVersion}">
+          <book code="MRK" style="id" />
+          <chapter number="1" style="c" sid="MRK 1" />
+          <verse number="1" style="v" />In the
+          <note caller="+" style="f" category="dup"> <char style="fr" closed="false">1.1 </char>
+          <char style="ft" closed="false"><char style="xt" closed="false">See 2<char style="xt" closed="false" />
+          </char></char></note> beginning
+          <chapter eid="MRK 1" />
+        </usx>
+        """;
 }

--- a/test/SIL.Converters.Usj.Tests/UsxToUsjTests.cs
+++ b/test/SIL.Converters.Usj.Tests/UsxToUsjTests.cs
@@ -227,6 +227,19 @@ public class UsxToUsjTests
     }
 
     [Test]
+    public void ShouldConvertFromUsxToUsjWithSingleSpace_Roundtrip()
+    {
+        Usj usj = UsxToUsj.UsxStringToUsj(TestData.UsxMrk1V1WithSingleSpace);
+        string usx = UsjToUsx.UsjToUsxString(usj);
+        usx = TestData.RemoveXmlWhiteSpace(usx);
+
+        string expected = TestData.RemoveXmlWhiteSpace(TestData.UsxMrk1V1WithSingleSpace);
+        expected = TestData.RemoveVidAttributes(expected);
+        expected = TestData.RemoveEidElements(expected);
+        Assert.That(usx, Is.EqualTo(expected));
+    }
+
+    [Test]
     public void ShouldConvertFromUsxToUsjWithTable()
     {
         Usj usj = UsxToUsj.UsxStringToUsj(TestData.UsxGen1V1WithTable);

--- a/tools/Roundtrip/ConsoleExceptionHandler.cs
+++ b/tools/Roundtrip/ConsoleExceptionHandler.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Builder;
+using SIL.XForge;
+
+namespace Roundtrip;
+
+internal class ConsoleExceptionHandler : IExceptionHandler
+{
+    public void ReportException(Exception exception) => Console.WriteLine(exception);
+
+    public Task EnsureSuccessStatusCode(HttpResponseMessage response) => throw new NotImplementedException();
+
+    public void ReportExceptions(IApplicationBuilder app) => throw new NotImplementedException();
+
+    public void RecordEndpointInfoForException(Dictionary<string, string> metadata) =>
+        throw new NotImplementedException();
+
+    public void RecordUserIdForException(string userId) => throw new NotImplementedException();
+}

--- a/tools/Roundtrip/Program.cs
+++ b/tools/Roundtrip/Program.cs
@@ -1,0 +1,219 @@
+using System.IO.Compression;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Paratext.Data;
+using Paratext.Data.Languages;
+using Paratext.Data.Users;
+using Roundtrip;
+using SIL.Converters.Usj;
+using SIL.XForge.Scripture.Services;
+
+// The first argument must be the path containing the zip files or projects
+if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]) || !Path.Exists(args[0]))
+{
+    Console.WriteLine("You must specify a valid path to the projects or resources");
+    return;
+}
+
+// See if we are outputting the round tripped SFM files when they differ
+bool outputSfmFiles = args.Length > 1 && args[1] == "--output-sfm";
+
+// See if we are to output all created files (used to compare how much a change will affect all projects)
+bool outputAllFiles = args.Length > 1 && args[1] == "--output-all";
+if (outputAllFiles)
+{
+    Directory.CreateDirectory("output");
+}
+
+// Setup Paratext
+RegistrationInfo.Implementation = new TestRegistrationInfo();
+ICUDllLocator.Initialize();
+WritingSystemRepository.Initialize();
+ScrTextCollection.Initialize();
+using var scrText = new DummyScrText(useFakeStylesheet: false);
+ScrTextCollection.Add(scrText);
+ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+
+// Iterate over every zip file in the directory
+foreach (string zipFilePath in Directory.EnumerateFiles(args[0], "*.zip", SearchOption.AllDirectories))
+{
+    await using FileStream zipFileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
+    using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
+    foreach (ZipArchiveEntry entry in archive.Entries)
+    {
+        if (
+            entry.Name.EndsWith(".usfm", StringComparison.OrdinalIgnoreCase)
+            || entry.Name.EndsWith(".sfm", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            // Load the USFM
+            await using Stream entryStream = entry.Open();
+            using StreamReader reader = new StreamReader(entryStream);
+            string usfm = await reader.ReadToEndAsync();
+            Roundtrip(usfm, entry.Name, Path.GetFileName(zipFilePath), RoundtripMethod.Delta);
+            Roundtrip(usfm, entry.Name, Path.GetFileName(zipFilePath), RoundtripMethod.Usj);
+            Roundtrip(usfm, entry.Name, Path.GetFileName(zipFilePath), RoundtripMethod.Usx);
+        }
+    }
+}
+
+// Iterate over every SFM file in the directory.
+// This is helpful to roundtrip c:\My Paratext 9 Projects or /var/lib/scriptureforge/sync
+foreach (string sfmFile in Directory.EnumerateFiles(args[0], "*.sfm", SearchOption.AllDirectories))
+{
+    // Load the USFM
+    await using Stream entryStream = File.OpenRead(sfmFile);
+    using StreamReader reader = new StreamReader(entryStream);
+    string usfm = await reader.ReadToEndAsync();
+    Roundtrip(usfm, Path.GetFileName(sfmFile), Path.GetFullPath(sfmFile), RoundtripMethod.Delta);
+    Roundtrip(usfm, Path.GetFileName(sfmFile), Path.GetFullPath(sfmFile), RoundtripMethod.Usj);
+    Roundtrip(usfm, Path.GetFileName(sfmFile), Path.GetFullPath(sfmFile), RoundtripMethod.Usx);
+}
+
+return;
+
+void Roundtrip(string usfm, string fileName, string path, RoundtripMethod roundtripMethod)
+{
+    // Normalize the USFM
+    string normalizedUsfm = UsfmToken.NormalizeUsfm(
+        scrText.DefaultStylesheet,
+        usfm,
+        preserveWhitespace: false,
+        scrText.RightToLeft,
+        scrText
+    );
+
+    // Convert the USFM to USX
+    XmlDocument usx = UsfmToUsx.ConvertToXmlDocument(scrText, scrText.DefaultStylesheet, normalizedUsfm);
+
+    // Convert the USX to USFM to handle any variance from ParatextData
+    UsxFragmenter.FindFragments(
+        scrText.DefaultStylesheet,
+        usx.CreateNavigator(),
+        XPathExpression.Compile("*[false()]"),
+        out string cleanedUsfm,
+        allowInvisibleChars: false
+    );
+
+    // Normalize the cleaned USFM, to get the expected USFM
+    string expectedUsfm = UsfmToken.NormalizeUsfm(
+        scrText.DefaultStylesheet,
+        cleanedUsfm,
+        preserveWhitespace: false,
+        scrText.RightToLeft,
+        scrText
+    );
+
+    XDocument actualUsx;
+    if (roundtripMethod == RoundtripMethod.Delta)
+    {
+        // Convert the USX to Deltas
+        DeltaUsxMapper mapper = new DeltaUsxMapper(
+            new SequentialGuidService(),
+            loggerFactory.CreateLogger<DeltaUsxMapper>(),
+            new ConsoleExceptionHandler()
+        );
+        using XmlNodeReader nodeReader = new XmlNodeReader(usx);
+        // ReSharper disable once MethodHasAsyncOverload
+        nodeReader.MoveToContent();
+        XDocument bookUsx = XDocument.Load(nodeReader);
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(bookUsx)];
+
+        // Output the delta if requested
+        if (outputAllFiles)
+        {
+            File.WriteAllText(
+                Path.Combine(
+                    "output",
+                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-delta.json"
+                ),
+                JsonConvert.SerializeObject(chapterDeltas, Newtonsoft.Json.Formatting.Indented)
+            );
+        }
+
+        // Convert the deltas to USX
+        actualUsx = mapper.ToUsx(bookUsx, chapterDeltas);
+    }
+    else if (roundtripMethod == RoundtripMethod.Usj)
+    {
+        // Convert the USX to USJ
+        Usj usj = UsxToUsj.UsxXmlDocumentToUsj(usx);
+
+        // Output the USJ if requested
+        if (outputAllFiles)
+        {
+            File.WriteAllText(
+                Path.Combine(
+                    "output",
+                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-usj.json"
+                ),
+                JsonConvert.SerializeObject(usj, Newtonsoft.Json.Formatting.Indented)
+            );
+        }
+
+        // Convert the USJ to USX
+        actualUsx = UsjToUsx.UsjToUsxXDocument(usj);
+    }
+    else if (roundtripMethod == RoundtripMethod.Usx)
+    {
+        // Convert the XmlDocument to an XDocument
+        using XmlNodeReader nodeReader = new XmlNodeReader(usx);
+        nodeReader.MoveToContent();
+        actualUsx = XDocument.Load(nodeReader);
+    }
+    else
+    {
+        throw new ArgumentOutOfRangeException(nameof(roundtripMethod));
+    }
+
+    // Convert the USX to USFM
+    UsxFragmenter.FindFragments(
+        scrText.DefaultStylesheet,
+        actualUsx.CreateNavigator(),
+        XPathExpression.Compile("*[false()]"),
+        out string convertedUsfm,
+        allowInvisibleChars: false
+    );
+
+    // Normalize the USFM
+    string actualUsfm = UsfmToken.NormalizeUsfm(
+        scrText.DefaultStylesheet,
+        convertedUsfm,
+        preserveWhitespace: false,
+        scrText.RightToLeft,
+        scrText
+    );
+
+    // Log the file name and path if the USFM does not match
+    if (actualUsfm != expectedUsfm)
+    {
+        Console.WriteLine($"USFM to {roundtripMethod} mismatch in {fileName} in {path}");
+        if (outputSfmFiles && Directory.CreateDirectory("output").Exists)
+        {
+            File.WriteAllText(
+                Path.Combine(
+                    "output",
+                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-actual{Path.GetExtension(fileName)}"
+                ),
+                actualUsfm
+            );
+            File.WriteAllText(
+                Path.Combine(
+                    "output",
+                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-expected{Path.GetExtension(fileName)}"
+                ),
+                expectedUsfm
+            );
+            File.WriteAllText(
+                Path.Combine(
+                    "output",
+                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-original{Path.GetExtension(fileName)}"
+                ),
+                usfm
+            );
+        }
+    }
+}

--- a/tools/Roundtrip/Roundtrip.csproj
+++ b/tools/Roundtrip/Roundtrip.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!--
+    This is for compatibility between ICU4C (a dependency of ParatextData) and .NET 8.0 see:
+    https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph
+    -->
+    <UseRidGraph>true</UseRidGraph>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ParatextData.Tests" Version="9.5.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SIL.Converters.Usj\SIL.Converters.Usj.csproj" />
+    <ProjectReference Include="..\..\src\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="usfm.sty">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="usx-sf.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tools/Roundtrip/Roundtrip.sln
+++ b/tools/Roundtrip/Roundtrip.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Roundtrip", "Roundtrip.csproj", "{D9F53868-FFF4-4C4A-9AE6-502D846C96FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIL.XForge.Scripture", "..\..\src\SIL.XForge.Scripture\SIL.XForge.Scripture.csproj", "{6527A461-B8B2-3446-E258-3B52A0C5940E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIL.XForge", "..\..\src\SIL.XForge\SIL.XForge.csproj", "{CCFDA5A6-5427-F3F8-EC22-3C414368818F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SIL.Converters.Usj", "..\..\src\SIL.Converters.Usj\SIL.Converters.Usj.csproj", "{4B31F02A-BB05-2AFD-BC36-4A63632C6473}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D9F53868-FFF4-4C4A-9AE6-502D846C96FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9F53868-FFF4-4C4A-9AE6-502D846C96FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9F53868-FFF4-4C4A-9AE6-502D846C96FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9F53868-FFF4-4C4A-9AE6-502D846C96FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6527A461-B8B2-3446-E258-3B52A0C5940E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6527A461-B8B2-3446-E258-3B52A0C5940E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6527A461-B8B2-3446-E258-3B52A0C5940E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6527A461-B8B2-3446-E258-3B52A0C5940E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCFDA5A6-5427-F3F8-EC22-3C414368818F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCFDA5A6-5427-F3F8-EC22-3C414368818F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCFDA5A6-5427-F3F8-EC22-3C414368818F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCFDA5A6-5427-F3F8-EC22-3C414368818F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B31F02A-BB05-2AFD-BC36-4A63632C6473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B31F02A-BB05-2AFD-BC36-4A63632C6473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B31F02A-BB05-2AFD-BC36-4A63632C6473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B31F02A-BB05-2AFD-BC36-4A63632C6473}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5FA34BDF-6EF5-4223-B7B5-44FBC27CE267}
+	EndGlobalSection
+EndGlobal

--- a/tools/Roundtrip/RoundtripMethod.cs
+++ b/tools/Roundtrip/RoundtripMethod.cs
@@ -1,0 +1,8 @@
+namespace Roundtrip;
+
+enum RoundtripMethod
+{
+    Delta = 0,
+    Usj = 1,
+    Usx = 2,
+}

--- a/tools/Roundtrip/SequentialGuidService.cs
+++ b/tools/Roundtrip/SequentialGuidService.cs
@@ -1,0 +1,13 @@
+using MongoDB.Bson;
+using SIL.XForge.Scripture.Services;
+
+namespace Roundtrip;
+
+public class SequentialGuidService : IGuidService
+{
+    private int _seed;
+
+    public string Generate() => $"{++_seed:X16}-{Guid.Empty.ToString()[9..]}";
+
+    public string NewObjectId() => ObjectId.GenerateNewId(_seed).ToString();
+}

--- a/tools/Roundtrip/usfm.sty
+++ b/tools/Roundtrip/usfm.sty
@@ -1,0 +1,3061 @@
+# Version=3.0.0
+# ********************************************************************
+# * usfm.sty is the default stylesheet for Paratext projects         *
+# *   using USFM markup.                                             *
+# * Latest documentation and stylesheets are maintained at:          *
+# *   http://markups.paratext.org/usfm                               *
+# ********************************************************************
+
+# File Identification
+
+\Marker id
+\Name id - File - Identification
+\Description File identification information (BOOKID, FILENAME, EDITOR, MODIFICATION DATE)
+\StyleType Paragraph
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular book
+\FontSize 12
+
+\Marker usfm
+\Name ide - File - USFM Version ID
+\Description File markup version information
+\OccursUnder id
+\Rank 1
+\StyleType Paragraph
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\FontSize 12
+
+\Marker ide
+\Name ide - File - Encoding
+\Description File encoding information
+\OccursUnder id
+\Rank 1
+\StyleType Paragraph
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\FontSize 12
+
+# Headers
+
+\Marker h
+\Name h - File - Header
+\Description Running header text for a book (basic)
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker h1
+\Name DEPRECATED h1 - File - Header
+\Description Running header text
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker h2
+\Name DEPRECATED h2 - File - Left Header
+\Description Running header text, left side of page
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker h3
+\Name DEPRECATED h3 - File - Right Header
+\Description Running header text, right side of page
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker toc1
+\Name toc1 - File - Long Table of Contents Text
+\Description Long table of contents text
+\OccursUnder h h1 h2 h3 id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Bold
+\color 16384
+
+\Marker toc2
+\Name toc2 - File - Short Table of Contents Text
+\Description Short table of contents text
+\OccursUnder h h1 h2 h3 id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\color 16384
+
+\Marker toc3
+\Name toc3 - File - Book Abbreviation
+\Description Book Abbreviation
+\OccursUnder h h1 h2 h3 id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Italic
+\color 128
+
+\Marker toca1
+\Name toca1 - File - Alternative Language Long Table of Contents Text
+\Description Alternative language long table of contents text
+\OccursUnder h h1 h2 h3
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 10
+\Italic
+\Color 8421504
+
+\Marker toca2
+\Name toca2 - File - Alternative Language Short Table of Contents Text
+\Description Alternative language short table of contents text
+\OccursUnder h h1 h2 h3
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 10
+\Italic
+\Color 8421504
+
+\Marker toca3
+\Name toca3 - File - Alternative Language Book Abbreviation
+\Description Alternative language book Abbreviation
+\OccursUnder h h1 h2 h3
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 10
+\Italic
+\Color 8421504
+
+# Remarks and Comments
+
+\Marker rem
+\Name rem - File - Remark
+\Description Comments and remarks
+\OccursUnder id ide c
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\StyleType Paragraph
+\FontSize 12
+\Color 16711680
+
+\Marker sts
+\Name rem - File - Status
+\Description Status of this file
+\OccursUnder id ide c
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\StyleType Paragraph
+\FontSize 12
+\Color 16711680
+
+\Marker restore
+\Name restore - File - Restore Information
+\Description Project restore information
+\OccursUnder id
+\Rank 99
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\StyleType Paragraph
+\FontSize 12
+\Color 16711680
+
+# Introduction
+
+\Marker imt
+\Name imt - Introduction - Major Title Level 1
+\Description Introduction major title, level 1 (if single level) (basic)
+\OccursUnder id
+\Rank 5
+\TextProperties paragraph publishable vernacular level_1
+\TextType Other
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker imt1
+\Name imt1 - Introduction - Major Title Level 1
+\Description Introduction major title, level 1 (if multiple levels)
+\OccursUnder id
+\Rank 5
+\TextProperties paragraph publishable vernacular level_1
+\TextType Other
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker imt2
+\Name imt2 - Introduction - Major Title Level 2
+\Description Introduction major title, level 2
+\OccursUnder id
+\Rank 5
+\TextProperties paragraph publishable vernacular level_2
+\TextType other
+\StyleType Paragraph
+\FontSize 13
+\Italic
+\Justification Center
+\SpaceBefore 6
+\SpaceAfter 3
+
+\Marker imt3
+\Name imt3 - Introduction - Major Title Level 3
+\Description Introduction major title, level 3
+\OccursUnder id
+\Rank 5
+\TextProperties paragraph publishable vernacular level_3
+\TextType Other
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceBefore 2
+\SpaceAfter 2
+
+\Marker imt4
+\Name imt4 - Introduction - Major Title Level 4
+\Description Introduction major title, level 4 (usually within parenthesis)
+\OccursUnder id
+\Rank 5
+\TextProperties paragraph publishable vernacular level_4
+\TextType Other
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Center
+\SpaceBefore 2
+\SpaceAfter 2
+ 
+\Marker imte
+\Name imte - Introduction - [Uncommon] Major Title at Introduction End Level 1
+\Description Introduction major title at introduction end, level 1 (if single level)
+\TextProperties paragraph publishable vernacular level_1
+\TextType Other
+\OccursUnder id
+\Rank 7
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker imte1
+\Name imte1 - Introduction - [Uncommon] Major Title at Introduction End Level 1
+\Description Introduction major title at introduction end, level 1 (if multiple levels)
+\TextProperties paragraph publishable vernacular level_1
+\TextType Other
+\OccursUnder id
+\Rank 7
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker imte2
+\Name imte2 - Introduction - [Uncommon] Major Title at Introduction End Level 2
+\Description Introduction major title at introduction end, level 2
+\TextProperties paragraph publishable vernacular level_2
+\TextType Other
+\OccursUnder id
+\Rank 7
+\StyleType Paragraph
+\FontSize 16
+\Italic
+\Justification Center
+\SpaceAfter 2 
+
+\Marker is
+\Name is - Introduction - Section Heading Level 1
+\Description Introduction section heading, level 1 (if single level) (basic)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker is1 
+\Name is1 - Introduction - Section Heading Level 1
+\Description Introduction section heading, level 1 (if multiple levels)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker is2
+\Name is2 - Introduction - Section Heading Level 2
+\Description Introduction section heading, level 2 
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_2
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker iot 
+\Name iot - Introduction - Outline Title
+\Description Introduction outline title (basic)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker io
+\Name io - Introduction - Outline Level 1
+\Description Introduction outline text, level 1 (if single level)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+
+\Marker io1
+\Name io1 - Introduction - Outline Level 1
+\Description Introduction outline text, level 1 (if multiple levels) (basic)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+
+\Marker io2
+\Name io2 - Introduction - Outline Level 2
+\Description Introduction outline text, level 2 
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_2
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .75
+
+\Marker io3
+\Name io3 - Introduction - Outline Level 3
+\Description Introduction outline text, level 3 
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_3
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1
+
+\Marker io4
+\Name io4 - Introduction - Outline Level 4
+\Description Introduction outline text, level 4 
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_4
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1.25
+
+\Marker ior
+\Endmarker ior*
+\Name ior...ior* - Introduction - Outline References Range
+\Description Introduction references range for outline entry; for marking references separately
+\OccursUnder id io io1 io2 io3 io4 NEST
+\TextType Other
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker ip
+\Name ip - Introduction - Paragraph
+\Description Introduction prose paragraph (basic)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+
+\Marker im
+\Name im - Introduction - Paragraph - no first line indent
+\Description Introduction prose paragraph, with no first line indent (may occur after poetry)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker ipi
+\Name ipi - Introduction - Indented Para - first line indent
+\Description Introduction prose paragraph, indented, with first line indent
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .25
+\RightMargin .25
+
+\Marker imi
+\Name imi - Introduction - Indented Para - no first line indent
+\Description Introduction prose paragraph text, indented, with no first line indent
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+
+\Marker ili
+\Name ili - Introduction - List Entry - Level 1
+\Description A list entry, level 1 (if single level)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.375 # 1/8 inch indent, 1/2 inch wrap
+
+\Marker ili1
+\Name ili1 - Introduction - List Entry - Level 1
+\Description A list entry, level 1 (if multiple levels)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.375 # 1/8 inch indent, 1/2 inch wrap
+
+\Marker ili2
+\Name ili2 - Introduction - List Entry - Level 2
+\Description A list entry, level 2
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular level_2
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .75
+\FirstLineIndent -.375
+
+\Marker ipq
+\Name ipq - Introduction - Paragraph - quote from text
+\Description Introduction prose paragraph, quote from the body text
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+\FirstLineIndent .125   # 1/8 inch first line indent
+\Italic
+
+\Marker imq
+\Name imq - Introduction - Paragraph - quote from text - no first line indent
+\Description Introduction prose paragraph, quote from the body text, with no first line indent
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+\Italic
+
+\Marker ipr
+\Name ipr - Introduction - Paragraph - right aligned
+\Description Introduction prose paragraph, right aligned
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+\Justification Right
+\Italic
+
+\Marker ib
+\Name ib - Introduction - Blank Line
+\Description Introduction blank line
+\OccursUnder id
+\Rank 6
+\TextProperties paragraph publishable vernacular poetic
+\TextType Other
+\FontSize 10
+\StyleType paragraph
+
+\Marker iq
+\Name iq - Introduction - Poetry Level 1
+\Description Introduction poetry text, level 1 (if single level)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular poetic level_1
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.75  # 1/4 inch indent, 1 inch wrap
+\Italic
+
+\Marker iq1
+\Name iq1 - Introduction - Poetry Level 1
+\Description Introduction poetry text, level 1 (if multiple levels)
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular poetic level_1
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.75  # 1/4 inch indent, 1 inch wrap
+\Italic
+
+\Marker iq2
+\Name iq2 - Introduction - Poetry Level 2
+\Description Introduction poetry text, level 2 
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular poetic level_2
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.5  # 1/2 inch indent, 1 inch wrap
+\Italic
+
+\Marker iq3
+\Name iq3 - Introduction - Poetry Level 3
+\Description Introduction poetry text, level 3
+\OccursUnder id
+\Rank 6
+\TextType Other
+\TextProperties paragraph publishable vernacular poetic level_3
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.25 # 3/4 inch indent, 1 inch wrap
+\Italic
+
+\Marker iex
+\Name iex - Introduction - Explanatory or Bridge Text
+\Description Introduction explanatory or bridge text (e.g. explanation of missing book in Short Old Testament)
+\OccursUnder id c
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\SpaceBefore 4
+\SpaceAfter 4
+
+\Marker iqt
+\Endmarker iqt*
+\Name iqt...iqt* - Special Text - Quoted Scripture Text in Introduction
+\Description For quoted scripture text appearing in the introduction
+\OccursUnder imt imt1 imt2 imt3 imt4 ib ie ili ili1 ili2 im imi imq io io1 io2 io3 io4 iot ip ipi ipq ipr iq iq1 iq2 iq3 is is1 is2 imte imte1 imte2 iex
+\TextType Other
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker ie
+\Name ie - Introduction - End Marker
+\Description Introduction ending marker
+\OccursUnder id
+\Rank 6
+\TextProperties paragraph publishable vernacular
+\TextType Other
+\FontSize 10
+\StyleType paragraph
+
+# Chapters and Verses
+
+\Marker c
+\Name c - Chapter Number
+\Description Chapter number (necessary for normal Paratext operation)
+\OccursUnder id
+\Rank 8
+\TextType ChapterNumber
+\TextProperties chapter
+\StyleType Paragraph
+\Bold
+\FontSize 18
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker ca
+\Endmarker ca*
+\Name ca...ca* - Chapter Number - Alternate
+\Description Second (alternate) chapter number (for coding dual versification; useful for places where different traditions of chapter breaks need to be supported in the same translation)
+\OccursUnder c 
+\TextType Other
+\StyleType Character
+\Italic
+\FontSize 16
+\Color 2263842
+
+\Marker cp
+\Name cp - Chapter Number - Publishing Alternate
+\Description Published chapter number (chapter string that should appear in the published text)
+\OccursUnder c 
+\Rank 4
+\TextType Other
+\TextProperties paragraph
+\StyleType Paragraph
+\Bold
+\FontSize 18
+\SpaceBefore 8
+\SpaceAfter 4
+\Color 16711680
+
+\Marker cl
+\Name cl - Chapter - Publishing Label
+\Description Chapter label used for translations that add a word such as "Chapter" before chapter numbers (e.g. Psalms). The subsequent text is the chapter label.
+\OccursUnder id c ms ms1 ms2 ms3 mr
+\TextType Other
+\TextProperties paragraph
+\StyleType Paragraph
+\Bold
+\FontSize 18
+\SpaceBefore 8
+\SpaceAfter 4
+\Justification Center
+
+\Marker cd
+\Name cd - Chapter - Description
+\Description Chapter Description (Publishing option D, e.g. in Russian Bibles)
+\OccursUnder c
+\TextType Other
+\TextProperties paragraph
+\StyleType Paragraph
+\FontSize 11
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker v
+\Name v - Verse Number
+\Description A verse number (Necessary for normal paratext operation) (basic)
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 s3 d sp
+\TextType VerseNumber
+\TextProperties verse
+\StyleType Character
+\FontSize 12
+\Superscript
+
+\Marker va
+\Endmarker va*
+\Name va...va* - Verse Number - Alternate
+\Description Second (alternate) verse number (for coding dual numeration in Psalms; see also NRSV Exo 22.1-4)
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 s3 d sp
+\TextType Other
+\StyleType Character
+\FontSize 12
+\Superscript
+\Color 2263842
+
+\Marker vp
+\Endmarker vp*
+\Name vp...vp* - Verse Number - Publishing Alternate
+\Description Published verse marker (verse string that should appear in the published text)
+\OccursUnder cd lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 s3 d sp
+\TextType Other
+\StyleType Character
+\FontSize 12
+\Superscript
+\Color 16711680
+
+# Paragraphs
+
+\Marker p
+\Name p - Paragraph - Normal - First Line Indent
+\Description Paragraph text, with first line indent (basic)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+
+\Marker m
+\Name m - Paragraph - Margin - No First Line Indent
+\Description Paragraph text, with no first line indent (may occur after poetry) (basic)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker po
+\Name po - Paragraph - Letter Opening
+\Description Letter opening
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\SpaceBefore 4
+\SpaceAfter 4
+
+\Marker pr
+\Name pr - Paragraph - Text Refrain (right aligned)
+\Description Text refrain (paragraph text, right aligned)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\Justification Right
+\FontSize 12
+
+\Marker cls
+\Name cls - Paragraph - Letter Closing
+\Description Letter Closing
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Justification Right
+
+\Marker pmo
+\Name pmo - Paragraph - Embedded Text Opening
+\Description Embedded text opening
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr po q q1 q2 q3 q4 qc qr s1 s2 s3 s4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pm
+\Name pm - Paragraph - Embedded Text
+\Description Embedded text paragraph
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr po psi q q1 q2 q3 q4 qc qr b s1 s2 s3 s4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pmc
+\Name pmc - Paragraph - Embedded Text Closing
+\Description Embedded text closing
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr po q q1 q2 q3 q4 qc qr b s1 s2 s3 s4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pmr
+\Name pmr - Paragraph - Embedded Text Refrain
+\Description Embedded text refrain (e.g. Then all the people shall say, "Amen!")
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr po q q1 q2 q3 q4 qc qr b s1 s2 s3 s4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\Justification Right
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pi
+\Name pi - Paragraph - Indented - Level 1 - First Line Indent
+\Description Paragraph text, level 1 indent (if sinlge level), with first line indent; often used for discourse (basic)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pi1
+\Name pi1 - Paragraph - Indented - Level 1 - First Line Indent
+\Description Paragraph text, level 1 indent (if multiple levels), with first line indent; often used for discourse
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .25
+\RightMargin .25
+
+\Marker pi2
+\Name pi2 - Paragraph - Indented - Level 2 - First Line Indent
+\Description Paragraph text, level 2 indent, with first line indent; often used for discourse
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_2
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .5
+\RightMargin .25
+
+\Marker pi3
+\Name pi3 - Paragraph - Indented - Level 3 - First Line Indent
+\Description Paragraph text, level 3 indent, with first line indent; often used for discourse
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_3
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .75
+\RightMargin .25
+
+\Marker pc
+\Name pc - Paragraph - Centered (for Inscription)
+\Description Paragraph text, centered (for Inscription)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\Justification Center
+\FontSize 12
+
+\Marker mi
+\Name mi - Paragraph - Indented - No First Line Indent
+\Description Paragraph text, indented, with no first line indent; often used for discourse
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .25
+\RightMargin .25
+
+\Marker nb
+\Name nb - Paragraph - No Break with Previous Paragraph
+\Description Paragraph text, with no break from previous paragraph text (at chapter boundary) (basic)
+\OccursUnder c 
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+# Poetry
+
+\Marker q
+\Name q - Poetry - Indent Level 1 - Single Level Only
+\Description Poetry text, level 1 indent (if single level)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_1
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -1  # 1/4 inch indent, 1 inch wrap
+
+\Marker q1
+\Name q1 - Poetry - Indent Level 1
+\Description Poetry text, level 1 indent (if multiple levels) (basic)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_1
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -1  # 1/4 inch indent, 1 inch wrap
+
+\Marker q2
+\Name q2 - Poetry - Indent Level 2
+\Description Poetry text, level 2 indent (basic)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_2
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -.75  # 1/2 inch indent, 1 inch wrap
+
+\Marker q3
+\Name q3 - Poetry - Indent Level 3
+\Description Poetry text, level 3 indent
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_3
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -.5 # 3/4 inch indent, 1 inch wrap
+
+\Marker q4
+\Name q4 - Poetry - Indent Level 4
+\Description Poetry text, level 4 indent
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_3
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -.25 # 3/4 inch indent, 1 inch wrap
+
+\Marker qc
+\Name qc - Poetry - Centered
+\Description Poetry text, centered
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic
+\StyleType Paragraph
+\FontSize 12
+\Justification Center
+
+\Marker qr
+\Name qr - Poetry - Right Aligned
+\Description Poetry text, Right Aligned
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic
+\StyleType Paragraph
+\FontSize 12
+\Justification Right
+
+\Marker qs
+\Endmarker qs*
+\Name qs...qs* - Poetry Text - Selah
+\Description Poetry text, Selah
+\OccursUnder q q1 q2 q3 q4 qc qr qd NEST
+\Rank 4
+\TextType VerseText
+\TextProperties publishable vernacular poetic
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker qa
+\Name qa - Poetry - Acrostic Heading/Marker
+\Description Poetry text, Acrostic marker/heading
+\OccursUnder c
+\Rank 4
+\TextType Other
+\TextProperties paragraph publishable vernacular poetic
+\StyleType Paragraph
+\FontSize 12
+\Italic
+
+\Marker qac
+\Endmarker qac*
+\Name qac...qac* - Poetry Text - Acrostic Letter
+\Description Poetry text, Acrostic markup of the first character of a line of acrostic poetry
+\OccursUnder q q1 q2 q3 q4 qc qr  NEST
+\Rank 4
+\TextType Other
+\TextProperties publishable vernacular poetic
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker qm
+\Name qm - Poetry - Embedded Text - Indent Level 1 - Single Level Only
+\Description Poetry text, embedded, level 1 indent (if single level)
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr q q1 q2 q3 q4 qc qr b
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.75  # 1/4 inch indent, 1 inch wrap
+
+\Marker qm1
+\Name qm1 - Poetry - Embedded Text - Indent Level 1
+\Description Poetry text, embedded, level 1 indent (if multiple levels)
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr q q1 q2 q3 q4 qc qr b
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_1
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.75  # 1/4 inch indent, 1 inch wrap
+
+\Marker qm2
+\Name qm2 - Poetry - Embedded Text - Indent Level 2
+\Description Poetry text, embedded, level 2 indent
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr q q1 q2 q3 q4 qc qr b
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_2
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.5  # 1/2 inch indent, 1 inch wrap
+
+\Marker qm3
+\Name qm3 - Poetry - Embedded Text - Indent Level 3
+\Description Poetry text, embedded, level 3 indent
+\OccursUnder m mi nb p pc ph phi pi pi1 pi2 pi3 pr q q1 q2 q3 q4 qc qr b
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic level_3
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.25 # 3/4 inch indent, 1 inch wrap
+
+\Marker qd
+\Name qd - Poetry - Hebrew Note
+\Description A Hebrew musical performance annotation, similar in content to Hebrew descriptive title.
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular poetic
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\LeftMargin .25
+
+\Marker b
+\Name b - Poetry - Stanza Break (Blank Line)
+\Description Poetry text stanza break (e.g. stanza break) (basic)
+\OccursUnder c
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+# Titles & Headings
+
+\Marker mt
+\Name mt - Title - Major Title Level 1
+\Description The main title of the book (if single level)
+\OccursUnder id
+\Rank 3
+\TextProperties paragraph publishable vernacular level_1
+\TextType Title
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker mt1
+\Name mt1 - Title - Major Title Level 1
+\Description The main title of the book (if multiple levels) (basic)
+\OccursUnder id
+\Rank 3
+\TextProperties paragraph publishable vernacular level_1
+\TextType Title
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 2
+\SpaceAfter 4
+
+\Marker mt2
+\Name mt2 - Title - Major Title Level 2
+\Description A secondary title usually occurring before the main title (basic)
+\OccursUnder id
+\Rank 3
+\TextProperties paragraph publishable vernacular level_2
+\TextType Title
+\StyleType Paragraph
+\FontSize 16
+\Italic
+\Justification Center
+\SpaceAfter 2
+
+\Marker mt3
+\Name mt3 - Title - Major Title Level 3
+\Description A secondary title occurring after the main title
+\OccursUnder id
+\Rank 3
+\TextProperties paragraph publishable vernacular level_3
+\TextType Title
+\StyleType Paragraph
+\FontSize 16
+\Bold
+\Justification Center
+\SpaceBefore 2
+\SpaceAfter 2
+
+\Marker mt4
+\Name mt4 - Title - Major Title level 4
+\Description A small secondary title sometimes occuring within parentheses
+\OccursUnder id
+\Rank 3
+\TextProperties paragraph publishable vernacular level_4
+\TextType Title
+\StyleType Paragraph
+\FontSize 12
+\Justification Center
+\SpaceBefore 2
+\SpaceAfter 2
+
+\Marker mte
+\Name mte - Title - [Uncommon] Major Title Ending Level 1
+\Description The main title of the book repeated at the end of the book, level 1 (if single level)
+\TextProperties paragraph publishable vernacular level_1
+\TextType Title
+\OccursUnder c
+\Rank 2
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker mte1
+\Name mte1 - Title - [Uncommon] Major Title Ending Level 1
+\Description The main title of the book repeated at the end of the book, level 1 (if multiple levels)
+\TextProperties paragraph publishable vernacular level_1
+\TextType Title
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tc1 tc2 tc3 tc4 s3 d
+\Rank 2
+\StyleType Paragraph
+\FontSize 20
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+ 
+\Marker mte2
+\Name mte2 - Title - [Uncommon] Major Title Ending Level 2
+\Description A secondary title occurring before or after the 'ending' main title
+\TextProperties paragraph publishable vernacular level_2
+\TextType Title
+\OccursUnder mte1
+\Rank 2
+\StyleType Paragraph
+\FontSize 16
+\Italic
+\Justification Center
+\SpaceAfter 2
+
+\Marker ms
+\Name ms - Heading - Major Section Level 1
+\Description A major section division heading, level 1 (if single level) (basic)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 16
+\SpaceAfter 4
+
+\Marker ms1
+\Name ms1 - Heading - Major Section Level 1
+\Description A major section division heading, level 1 (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 16
+\SpaceAfter 4
+
+\Marker ms2
+\Name ms2 - Heading - Major Section Level 2
+\Description A major section division heading, level 2
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\Justification Center
+\SpaceBefore 16
+\SpaceAfter 4
+
+\Marker ms3
+\Name ms3 - Heading - Major Section Level 3
+\Description A major section division heading, level 3
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 14
+\Italic
+\Justification Center
+\SpaceBefore 16
+\SpaceAfter 4
+
+\Marker mr
+\Name mr - Heading - Major Section Range References
+\Description A major section division references range heading (basic)
+\OccursUnder ms ms1 ms2 ms3
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Center
+\SpaceAfter 4
+
+\Marker s
+\Name s - Heading - Section Level 1
+\Description A section heading, level 1 (if single level) (basic)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker s1
+\Name s1 - Heading - Section Level 1
+\Description A section heading, level 1 (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker s2
+\Name s2 - Heading - Section Level 2
+\Description A section heading, level 2 (e.g. Proverbs 22-24)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_2
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Center
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker s3
+\Name s3 - Heading - Section Level 3
+\Description A section heading, level 3 (e.g. Genesis "The First Day")
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_3
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Left
+\SpaceBefore 6
+\SpaceAfter 3
+
+\Marker s4
+\Name s4 - Heading - Section Level 4
+\Description A section heading, level 4
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_4
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Left
+\SpaceBefore 6
+\SpaceAfter 3
+
+\Marker sr
+\Name sr - Heading - Section Range References
+\Description A section division references range heading
+\OccursUnder s s1 s2 s3 s4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Bold
+\Justification Center
+\SpaceAfter 4
+
+\Marker r
+\Name r - Heading - Parallel References
+\Description Parallel reference(s) (basic)
+\OccursUnder c s s1 s2 s3 s4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Center
+\SpaceAfter 4
+
+\Marker sp
+\Name sp - Label - Speaker
+\Description A heading, to identify the speaker (e.g. Job)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Left
+\SpaceBefore 8
+\SpaceAfter 4
+
+\Marker d
+\Name d - Label - Descriptive Title - Hebrew Subtitle
+\Description A Hebrew text heading, to provide description (e.g. Psalms)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\FontSize 12
+\Italic
+\Justification Center
+\SpaceBefore 4
+\SpaceAfter 4
+
+\Marker sd
+\Name sd - Label - Semantic Division Location - Level 1
+\Description Vertical space used to divide the text into sections, level 1 (if single level)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\SpaceBefore 24
+\SpaceAfter 24
+
+\Marker sd1
+\Name sd1 - Label - Semantic Division Location - Level 1
+\Description Vertical space used to divide the text into sections, level 1 (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_1
+\StyleType Paragraph
+\SpaceBefore 24
+\SpaceAfter 24
+
+\Marker sd2
+\Name sd2 - Label - Semantic Division Location - Level 2
+\Description Vertical space used to divide the text into sections, level 2
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_2
+\StyleType Paragraph
+\SpaceBefore 18
+\SpaceAfter 18
+
+\Marker sd3
+\Name sd3 - Label - Semantic Division Location - Level 3
+\Description Vertical space used to divide the text into sections, level 3
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_3
+\StyleType Paragraph
+\SpaceBefore 12
+\SpaceAfter 12
+
+\Marker sd4
+\Name sd4 - Label - Semantic Division Location - Level 4
+\Description Vertical space used to divide the text into sections, level 4
+\OccursUnder c
+\Rank 4
+\TextType Section
+\TextProperties paragraph publishable vernacular level_4
+\StyleType Paragraph
+\SpaceBefore 8
+\SpaceAfter 8
+
+# Tables
+
+\Marker tr
+\Name tr - Table - Row
+\Description A new table row
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.25  # 6/16 inch
+
+\Marker th1 
+\Name th1 - Table - Column 1 Heading
+\Description A table heading, column 1
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th2
+\Name th2 - Table - Column 2 Heading
+\Description A table heading, column 2
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th3
+\Name th3 - Table - Column 3 Heading
+\Description A table heading, column 3
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th4
+\Name th4 - Table - Column 4 Heading
+\Description A table heading, column 4
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker th5
+\Name th5 - Table - Column 5 Heading
+\Description A table heading, column 5
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker tc1
+\Name tc1 - Table - Column 1 Cell
+\Description A table cell item, column 1
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc2
+\Name tc2 - Table - Column 2 Cell
+\Description A table cell item, column 2
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc3
+\Name tc3 - Table - Column 3 Cell
+\Description A table cell item, column 3
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc4
+\Name tc4 - Table - Column 4 Cell
+\Description A table cell item, column 4
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker tc5
+\Name tc5 - Table - Column 5 Cell
+\Description A table cell item, column 5
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+# Center Aligned Table Heads and Columns
+
+\Marker thc1 
+\Name thc1 - Table - Column 1 Heading - Center Aligned
+\Description A table heading, column 1, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc2
+\Name thc2 - Table - Column 2 Heading - Center Aligned
+\Description A table heading, column 2, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc3
+\Name thc3 - Table - Column 3 Heading - Center Aligned
+\Description A table heading, column 3, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc4
+\Name thc4 - Table - Column 4 Heading - Center Aligned
+\Description A table heading, column 4, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker thc5
+\Name thc5 - Table - Column 5 Heading - Center Aligned
+\Description A table heading, column 5, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Center
+
+\Marker tcc1
+\Name tcc1 - Table - Column 1 Cell - Center Aligned
+\Description A table cell item, column 1, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc2
+\Name tcc2 - Table - Column 2 Cell - Center Aligned
+\Description A table cell item, column 2, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc3
+\Name tcc3 - Table - Column 3 Cell - Center Aligned
+\Description A table cell item, column 3, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc4
+\Name tcc4 - Table - Column 4 Cell - Center Aligned
+\Description A table cell item, column 4, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+\Marker tcc5
+\Name tcc5 - Table - Column 5 Cell - Center Aligned
+\Description A table cell item, column 5, center aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Center
+
+# Right Aligned Table Heads and Columns
+
+\Marker thr1 
+\Name thr1 - Table - Column 1 Heading - Right Aligned
+\Description A table heading, column 1, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Right
+
+\Marker thr2
+\Name thr2 - Table - Column 2 Heading - Right Aligned
+\Description A table heading, column 2, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Right
+
+\Marker thr3
+\Name thr3 - Table - Column 3 Heading - Right Aligned
+\Description A table heading, column 3, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Right
+
+\Marker thr4
+\Name thr4 - Table - Column 4 Heading - Right Aligned
+\Description A table heading, column 4, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Right
+
+\Marker thr5
+\Name thr5 - Table - Column 5 Heading - Right Aligned
+\Description A table heading, column 5, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Justification Right
+
+\Marker tcr1 
+\Name tcr1 - Table - Column 1 Cell - Right Aligned
+\Description A table cell item, column 1, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Right
+
+\Marker tcr2
+\Name tcr2 - Table - Column 2 Cell - Right Aligned
+\Description A table cell item, column 2, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Right
+
+\Marker tcr3
+\Name tcr3 - Table - Column 3 Cell - Right Aligned
+\Description A table cell item, column 3, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Right
+
+\Marker tcr4
+\Name tcr4 - Table - Column 4 Cell - Right Aligned
+\Description A table cell item, column 4, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Right
+
+\Marker tcr5
+\Name tcr5 - Table - Column 5 Cell - Right Aligned
+\Description A table cell item, column 5, right aligned
+\OccursUnder tr
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Justification Right
+
+# Lists
+
+\Marker lh
+\Name lh - List Header
+\Description List header (introductory remark)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+
+\Marker li
+\Name li - List Entry - Level 1
+\Description A list entry, level 1 (if single level)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.375 # 1/8 inch indent, 1/2 inch wrap
+
+\Marker li1
+\Name li1 - List Entry - Level 1
+\Description A list entry, level 1 (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.375 # 1/8 inch indent, 1/2 inch wrap
+
+\Marker li2
+\Name li2 - List Entry - Level 2
+\Description A list entry, level 2
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_2
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .75
+\FirstLineIndent -.375
+
+\Marker li3
+\Name li3 - List Entry - Level 3
+\Description A list entry, level 3
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_3
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.375
+
+\Marker li4
+\Name li4 - List Entry - Level 4
+\Description A list entry, level 4
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_4
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -.375
+
+\Marker lf
+\Name lf - List Footer
+\Description List footer (concluding remark)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker lim
+\Name lim - Embedded List Entry - Level 1
+\Description An embedded list entry, level 1 (if single level)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .75
+\FirstLineIndent -.375
+\RightMargin .25
+
+\Marker lim1
+\Name lim1 - Embedded List Entry - Level 1
+\Description An embedded list entry, level 1 (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_1
+\StyleType paragraph
+\FontSize 12
+\LeftMargin .75
+\FirstLineIndent -.375
+\RightMargin .25
+
+\Marker lim2
+\Name lim2 - Embedded List Entry - Level 2
+\Description An embedded list entry, level 2
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_2
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1
+\FirstLineIndent -.375
+
+\Marker lim3
+\Name lim3 - Embedded List Item - Level 3
+\Description An embedded list item, level 3
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_3
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1.25
+\FirstLineIndent -.375
+
+\Marker lim4
+\Name lim4 - Embedded List Entry - Level 4
+\Description An embedded list entry, level 4
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular level_4
+\StyleType paragraph
+\FontSize 12
+\LeftMargin 1.5
+\FirstLineIndent -.375
+
+\Marker litl
+\Endmarker litl*
+\Name litl...litl* - List Entry - Total
+\Description List entry total text
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker lik
+\Endmarker lik*
+\Name lik...lik* - Structured List Entry - Key
+\Description Structured list entry key text
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker liv
+\Endmarker liv*
+\Name liv...liv* - Structured List Entry - Value 1
+\Description Structured list entry value 1 content (if single value)
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker liv1
+\Endmarker liv1*
+\Name liv1...liv1* - Structured List Entry - Value 1
+\Description Structured list entrt value 1 content (if multiple values)
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker liv2
+\Endmarker liv2*
+\Name liv2...liv2* - Structured List Entry - Value 2
+\Description Structured list entry value 2 content
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker liv3
+\Endmarker liv3*
+\Name liv3...liv3* - Structured List Entry - Value 3
+\Description Structured list entry value 3 content
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker liv4
+\Endmarker liv4*
+\Name liv4...liv4* - Structured List Entry - Value 4
+\Description Structured list entry value 4 content
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker liv5
+\Endmarker liv5*
+\Name liv5...liv5* - Structured List Entry - Value 5
+\Description Structured list entry value 5 content
+\OccursUnder li li1 li2 li3 li4 lim lim1 lim2 lim3 lim4 NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+# Footnotes
+
+\Marker f
+\Endmarker f*
+\Name f...f* - Footnote 
+\Description A Footnote text item (basic)
+\OccursUnder c cp lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 qs sp tc1 tc2 tc3 tc4 mt mt1 mt2 mt3 ms ms1 ms2 ms3 s s1 s2 s3 d ip
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Note
+\FontSize 12
+
+\Marker fe
+\Endmarker fe*
+\Name fe...fe* - Endnote
+\Description An Endnote text item
+\OccursUnder c lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tc1 tc2 tc3 tc4 ms ms1 ms2 ms3 s s1 s2 s3 d ip
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Note
+\FontSize 12
+
+\Marker fr
+\Endmarker fr*
+\Name fr - Footnote - Reference
+\Description The origin reference for the footnote (basic)
+\OccursUnder f fe
+\TextType NoteText
+\TextProperties publishable vernacular note
+\StyleType Character
+\FontSize 12
+\Bold
+
+\Marker ft
+\Endmarker ft*
+\Name ft - Footnote - Text
+\Description Footnote text, Protocanon (basic)
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker fk
+\Endmarker fk*
+\Name fk - Footnote - Keyword
+\Description A footnote keyword (basic)
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Bold
+\Italic
+
+\Marker fq
+\Endmarker fq*
+\Name fq - Footnote - Quotation or Alternate Rendering
+\Description A footnote scripture quote or alternate rendering (basic)
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker fqa
+\Endmarker fqa*
+\Name fqa - Footnote - Alternate Translation Rendering
+\Description A footnote alternate rendering for a portion of scripture text
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker fl
+\Endmarker fl*
+\Name fl - Footnote - Label Text
+\Description A footnote label text item, for marking or "labelling" the type or alternate translation being provided in the note.
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+\Bold
+
+\Marker fw
+\Endmarker fw*
+\Name fw - Footnote - Witness List
+\Description A footnote witness list, for distinguishing a list of sigla representing witnesses in critical editions.
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker fp
+\Endmarker fp*
+\Name fp - Footnote Paragraph Mark
+\Description A Footnote additional paragraph marker
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker fv
+\Endmarker fv*
+\Name fv...fv* - Footnote - Embedded Verse Number
+\Description A verse number within the footnote text
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Superscript
+
+\Marker fdc
+\Endmarker fdc*
+\Name DEPRECATED fdc...fdc* - Footnote - DC text
+\Description Footnote text, applies to Deuterocanon only
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker fm
+\Endmarker fm*
+\Name fm - Footnote - Additional Caller to Previous Note
+\Description An additional footnote marker location for a previous footnote 
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tc1 tc2 tc3 tc4 ms ms1 ms2 s s1 s2 s3 d ip
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12
+\Superscript
+
+# Cross References
+
+\Marker x
+\Endmarker x*
+\Name x...x* - Cross Reference
+\Description A list of cross references (basic)
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 qs sp tc1 tc2 tc3 tc4 mt mt1 mt2 mt3 ms ms1 ms2 s s1 s2 s3 d
+\TextProperties publishable vernacular note crossreference
+\TextType NoteText
+\StyleType Note
+\FontSize 12
+
+\Marker xo
+\Endmarker xo*
+\Name xo - Cross Reference - Origin Reference
+\Description The cross reference origin reference (basic)
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Bold
+
+\Marker xop
+\Endmarker xop*
+\Name xop - Cross Reference - Origin Reference Publishing Alternate
+\Description Published cross reference origin reference (origin reference that should appear in the published text)
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker xt
+\Endmarker xt*
+\Name xt - Cross Reference - Target References
+\Description The cross reference target reference(s), protocanon only (basic)
+\OccursUnder x f ip ipi im imi ili ili1 ili2 p pi pi1 pi2
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+#!\Attributes ?link-href
+
+\Marker xta
+\Endmarker xta*
+\Name xta - Cross Reference - Target References Added Text
+\Description Cross reference target references added text
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker xk
+\Endmarker xk*
+\Name xk - Cross Reference - Keyword
+\Description A cross reference keyword
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker xq
+\Endmarker xq*
+\Name xq - Cross Reference - Quotation
+\Description A cross-reference quotation from the scripture text
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker xot
+\Endmarker xot*
+\Name xot...xot* - Cross Reference - OT Target Refs (optional)
+\Description Cross-reference target reference(s), Old Testament only
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker xnt
+\Endmarker xnt*
+\Name xnt...xnt* - Cross Reference - NT Target Refs (optional)
+\Description Cross-reference target reference(s), New Testament only
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker xdc
+\Endmarker xdc*
+\Name DEPRECATED xdc...xdc* - Cross Reference - DC Target Refs
+\Description Cross-reference target reference(s), Deuterocanon only
+\OccursUnder x
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+
+\Marker rq
+\Endmarker rq*
+\Name rq...rq* - Cross Reference - Inline Quotation References
+\Description A cross-reference indicating the source text for the preceding quotation.
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 NEST
+\TextType Other
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 10
+\Italic
+
+# Other Special Text
+
+\Marker qt
+\Endmarker qt*
+\Name qt...qt* - Special Text - Quoted Text - OT in NT
+\Description For Old Testament quoted text appearing in the New Testament (basic)
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker nd
+\Endmarker nd*
+\Name nd...nd* - Special Text - Name of Deity
+\Description For name of deity (basic)
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Underline
+
+\Marker tl
+\Endmarker tl*
+\Name tl...tl* - Special Text - Transliterated Word
+\Description For transliterated words
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable nonvernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker dc
+\Endmarker dc*
+\Name dc...dc* - Special Text - Deuterocanonical/LXX Additions
+\Description Deuterocanonical/LXX additions or insertions in the Protocanonical text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\Italic
+
+\Marker bk
+\Endmarker bk*
+\Name bk...bk* - Special Text - Quoted book title
+\Description For the quoted name of a book
+\OccursUnder imt imt1 imt2 imt3 imt4 imte imte1 imte2 is is1 is2 ili ili1 ili2 ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker sig
+\Endmarker sig*
+\Name sig...sig* - Special Text - Author's Signature (Epistles)
+\Description For the signature of the author of an Epistle
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker pn
+\Endmarker pn*
+\Name pn...pn* - Special Text - Proper Name
+\Description For a proper name
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Bold
+\Underline
+
+\Marker png
+\Endmarker png*
+\Name png...png* - Special Text - Geographic Proper Name
+\Description For a geographic proper name
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Underline
+
+\Marker addpn
+\Endmarker addpn*
+\Name DEPRECATED addpn...addpn* - Special Text for Chinese
+\Description For chinese words to be dot underline & underline
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+#\Color 2263842
+\Bold
+\Italic
+\Underline
+
+\Marker wj
+\Endmarker wj*
+\Name wj...wj* - Special Text - Words of Jesus
+\Description For marking the words of Jesus
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Color 255
+
+\Marker k
+\Endmarker k*
+\Name k...k* - Special Text - Keyword
+\Description For a keyword
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+\Bold
+
+\Marker sls
+\Endmarker sls*
+\Name sls...sls* - Special Text - Secondary Language or Text Source
+\Description To represent where the original text is in a secondary language or from an alternate text source
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker ord
+\Endmarker ord*
+\Name ord...ord* - Special Text - Ordinal number text portion
+\Description For the text portion of an ordinal number
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Superscript
+
+\Marker add
+\Endmarker add*
+\Name add...add* - Special Text - Translational Addition
+\Description For a translational addition to the text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 cls tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+#\Color 2263842
+\Bold
+\Italic
+
+\Marker lit
+\Name lit - Special Text - Liturgical note
+\Description For a comment or note inserted for liturgical use
+\OccursUnder c
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\Justification Right
+\FontSize 12
+\Bold
+
+# Character Styling
+
+\Marker no
+\Endmarker no*
+\Name no...no* - Character - Normal Text
+\Description A character style, use normal text
+\OccursUnder is ip ipi im imi ili ili1 ili2 imq ipq iex iq iot io1 io2 io3 io4 s s1 s2 s3 NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker it
+\Endmarker it*
+\Name it...it* - Character - Italic Text
+\Description A character style, use italic text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker bd
+\Endmarker bd*
+\Name bd...bd* - Character - Bold Text
+\Description A character style, use bold text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Bold
+
+\Marker bdit
+\Endmarker bdit*
+\Name bdit...bdit* - Character - BoldItalic Text
+\Description A character style, use bold + italic text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Bold
+\Italic
+
+\Marker em
+\Endmarker em*
+\Name em...em* - Character - Emphasized Text
+\Description A character style, use emphasized text style
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker sc
+\Endmarker sc*
+\Name sc...sc* - Character - Small Caps
+\Description A character style, for small capitalization text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Smallcaps
+
+\Marker sup
+\Endmarker sup*
+\Name sup...sup* - Character - Superscript
+\Description A character style, for superscript text. Typically for use in critical edition footnotes.
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+\Superscript
+
+# Breaks
+
+\Marker pb
+\Name pb - Break - Page Break
+\Description Page Break used for new reader portions and children's bibles where content is controlled by the page
+\OccursUnder c
+\Rank 4
+\TextType Other
+\TextProperties publishable
+\StyleType Paragraph
+\FontSize 12
+
+# Special Features
+
+\Marker fig
+\Endmarker fig*
+\Name fig...fig* - Auxiliary - Figure/Illustration/Map
+\Description Illustration [Columns to span, height, filename, caption text]
+\OccursUnder lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 ms ms1 ms2 s s1 s2 s3 d ip
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12
+#!\Attributes src size ref ?alt ?loc ?copy
+
+\Marker jmp
+\Endmarker jmp*
+\Name jmp...jmp* - Link text
+\Description For associating linking attributes to a span of text
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType Other
+\StyleType Character
+\Color 16711680
+\Underline
+#!\Attributes link-href
+
+\Marker pro
+\Endmarker pro*
+\Name DEPRECATED pro...pro* - Special Text - CJK Pronunciation
+\Description For indicating pronunciation in CJK texts
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 ms ms1 ms2 s s1 s2 s3 d ip f fe NEST
+\TextType Other
+\TextProperties Nonpublishable
+\StyleType Character
+\FontSize 10
+
+\Marker rb
+\Endmarker rb*
+\Name rb...rb* - Special Text - Ruby Glossing
+\Description Most often used to provide a reading / pronunciation guide in ideographic scripts
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 sp tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 ms ms1 ms2 s s1 s2 s3 d ip f fe NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+#!\Attributes gloss
+
+# Peripheral References
+
+\Marker w
+\Endmarker w*
+\Name w...w* - Peripheral Ref - Wordlist Entry
+\Description A wordlist text item
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+#!\Attributes ?lemma ?strong ?srcloc
+
+\Marker wh
+\Endmarker wh*
+\Name wh...wh* - Peripheral Ref - Hebrew Wordlist Entry
+\Description A Hebrew wordlist text item
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker wg
+\Endmarker wg*
+\Name wg...wg* - Peripheral Ref - Greek Wordlist Entry
+\Description A Greek Wordlist text item
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker wa
+\Endmarker wa*
+\Name wa...wa* - Peripheral Ref - Aramaic Wordlist Entry
+\Description An Aramaic Wordlist text item
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker ndx
+\Endmarker ndx*
+\Name ndx...ndx* - Peripheral Ref - Subject Index Entry 
+\Description A subject index text item
+\OccursUnder ip im ipi imi ipq imq ipr iq iq1 iq2 iq3 io io1 io2 io3 io4 ms ms1 ms2 s s1 s2 s3 s4 cd sp d lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr pmo pm pmc pmr po q q1 q2 q3 q4 qc qr qd qm qm1 qm2 qm3 tr th1 th2 th3 th4 thr1 thr2 thr3 thr4 tc1 tc2 tc3 tc4 tcr1 tcr2 tcr3 tcr4 f fe x NEST
+\TextType VerseText
+\TextProperties publishable vernacular
+\StyleType Character
+\FontSize 12
+
+# Peripheral Materials
+# Content Division Marker
+
+\Marker periph
+\Name periph - Peripherals - Content Division Marker
+\Description Periheral content division marker which should be followed by an additional division argument/title.
+\TextType Section
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 14
+\Bold
+\SpaceBefore 16
+\SpaceAfter 4
+\Color 33023
+
+# Additional peripheral material extensions to existing USFM markup.
+
+\Marker p1
+\Name p1 - Periph - Front/Back Matter Paragraph Level 1
+\Description Front or back matter text paragraph, level 1 (if multiple levels)
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+
+\Marker p2
+\Name p2 - Periph - Front/Back Matter Paragraph Level 2
+\Description Front or back matter text paragraph, level 2 (if multiple levels)
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/4 inch first line indent
+\LeftMargin .125
+
+\Marker k1
+\Name k1 - Periph - Concordance Keyword Level 1
+\Description Concordance main entry text or keyword, level 1
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker k2
+\Name k2 - Periph - Concordance Keyword Level 2
+\Description Concordance main entry text or keyword, level 2
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+
+\Marker xtSee
+\Endmarker xtSee*
+\Name xtSee - Concordance and Names Index - Alternate Entry Target Reference
+\Description Concordance and Names Index markup for an alternate entry target reference.
+\OccursUnder p
+\TextProperties publishable vernacular
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+\Color 16711680
+
+\Marker xtSeeAlso
+\Endmarker xtSeeAlso*
+\Name xtSeeAlso - Concordance and Names Index - Additional Entry Target Reference
+\Description Concordance and Names Index markup for an additional entry target reference.
+\OccursUnder p
+\TextProperties publishable vernacular
+\TextType Other
+\StyleType Character
+\FontSize 12
+\Italic
+\color 16711680
+
+# Milestones - these are not compatible with USFM2, so whole entries are preceded with #!
+
+#!\Marker qt-s
+#!\Endmarker qt-e
+#!\Name Quotation start/end milestone
+#!\Description Quotation start/end milestone, level 1 (if single level)
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker qt1-s
+#!\Endmarker qt1-e
+#!\Name Quotation start/end milestone - Level 1
+#!\Description Quotation start/end milestone, level 1 (if multiple levels)
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker qt2-s
+#!\Endmarker qt2-e
+#!\Name Quotation start/end milestone - Level 2
+#!\Description Quotation start/end milestone, level 2
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker qt3-s
+#!\Endmarker qt3-e
+#!\Name Quotation start/end milestone - Level 3
+#!\Description Quotation start/end milestone, level 3
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker qt4-s
+#!\Endmarker qt4-e
+#!\Name Quotation start/end milestone - Level 4
+#!\Description Quotation start/end milestone, level 4
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker qt5-s
+#!\Endmarker qt5-e
+#!\Name Quotation start/end milestone - Level 5
+#!\Description Quotation start/end milestone, level 5
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?who ?sid ?eid
+
+#!\Marker ts-s
+#!\Endmarker ts-e
+#!\Name Translator's section start/end milestone
+#!\Description Translators's section start/end milestone
+#!\OccursUnder id
+#!\StyleType Milestone
+#!\Attributes ?sid ?eid
+
+# Other special text elements specified in USFM
+#   ~ = fixed (no-break) space
+#   // = discretionary line break
+
+# Obsolete, deprecated, or no longer officially part of USFM.
+# These markers may have existed in earlier resource and stylesheet revisions.
+
+\Marker ph
+\Name DEPRECATED ph - Paragraph - Hanging Indent - Level 1
+\Description Paragraph text, with level 1 hanging indent (if single level)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\LeftMargin .5
+\FirstLineIndent -.25  # 1/4 inch indent, 1/2 inch wrap
+\FontSize 12
+
+\Marker ph1
+\Name DEPRECATED ph1 - Paragraph - Hanging Indent - Level 1
+\Description Paragraph text, with level 1 hanging indent (if multiple levels)
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\LeftMargin .5
+\FirstLineIndent -.25  # 1/4 inch indent, 1/2 inch wrap
+\FontSize 12
+
+\Marker ph2
+\Name DEPRECATED ph2 - Paragraph - Hanging Indent - Level 2
+\Description Paragraph text, with level 2 hanging indent
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\LeftMargin .75
+\FirstLineIndent -.25  # 1/2 inch indent, 3/4 inch wrap
+\FontSize 12
+
+\Marker ph3
+\Name DEPRECATED ph3 - Paragraph - Hanging Indent - Level 3
+\Description Paragraph text, with level 3 hanging indent
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\LeftMargin 1
+\FirstLineIndent -.25  # 3/4 inch indent, 1 inch wrap
+\FontSize 12
+
+\Marker phi
+\Name DEPRECATED phi - Paragraph - Indented - Hanging Indent
+\Description Paragraph text, indented with hanging indent
+\OccursUnder c 
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\LeftMargin 1
+
+\Marker tr1
+\Name OBSOLETE tr1 - Table - Row - Level 1
+\Description A table Row
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .5
+\FirstLineIndent -.25  # 6/16 inch
+
+\Marker tr2
+\Name OBSOLETE tr2 - Table - Row - Level 2
+\Description A table Row
+\OccursUnder c
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\LeftMargin .75
+\FirstLineIndent -.25  # 6/16 inch
+
+\Marker ps
+\Name OBSOLETE ps - Paragraph - No Break with Next Paragraph
+\Description Paragraph text, no break with next paragraph text at chapter boundary
+\OccursUnder c 
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FontSize 12
+\FirstLineIndent .125   # 1/8 inch first line indent
+
+\Marker psi
+\Name OBSOLETE psi - Paragraph - Indented - No Break with Next
+\Description Paragraph text, indented, with no break with next paragraph text (at chapter boundary)
+\OccursUnder c 
+\Rank 4
+\TextType VerseText
+\TextProperties paragraph publishable vernacular
+\StyleType Paragraph
+\FirstLineIndent .125   # 1/8 inch first line indent
+\LeftMargin .25
+\RightMargin .25
+\FontSize 12
+
+\Marker fs
+\Endmarker fs*
+\Name DEPRECATED fs - Footnote - Footnote Summary
+\Description A summary text for the concept/idea/quotation from the scripture translation for which the note is being provided.
+\OccursUnder f fe
+\TextProperties publishable vernacular note
+\TextType NoteText
+\StyleType Character
+\FontSize 12
+\Italic
+
+\Marker wr
+\Endmarker wr*
+\Name OBSOLETE wr...wr* - Auxiliary - Wordlist/Glossary Reference 
+\Description A Wordlist text item
+\OccursUnder ms s lh li li1 li2 li3 li4 lf lim lim1 lim2 lim3 lim4 m mi nb p pc ph phi pi pi1 pi2 pi3 pr po q q1 q2 q3 q4 qc qr qd tc1 tc2 tc3 tc4 f fe NEST
+\TextProperties publishable vernacular
+\TextType VerseText
+\StyleType Character
+\FontSize 12
+\Italic
+
+# 2.0x peripheral markup (replaced with \periph + Content Division Title/Argument)
+
+\Marker pub
+\Name OBSOLETE pub Peripherals - Front Matter Publication Data
+\Description Front matter publication data
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker toc
+\Name OBSOLETE toc Peripherals - Front Matter Table of Contents
+\Description Front matter table of contents
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker pref
+\Name OBSOLETE pref Peripherals - Front Matter Preface
+\Description Front matter preface
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker intro
+\Name OBSOLETE intro Peripherals - Front Matter Introduction
+\Description Front matter introduction
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker conc
+\Name OBSOLETE conc Peripherals - Back Matter Concordance
+\Description Back matter concordance
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker glo
+\Name OBSOLETE glo Peripherals - Back Matter Glossary
+\Description Back matter glossary
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker idx
+\Name OBSOLETE idx Peripherals - Back Matter Index
+\Description Back matter index
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker maps
+\Name OBSOLETE maps Peripherals - Back Matter Map Index
+\Description Back matter map index
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker cov
+\Name OBSOLETE cov Peripherals - Other - Cover
+\Description Other peripheral materials - cover
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker spine
+\Name OBSOLETE spine Peripherals - Other - Spine
+\Description Other peripheral materials - spine
+\OccursUnder id
+\Rank 4
+\TextProperties paragraph publishable vernacular poetic
+\TextType VerseText
+\FontSize 10
+\StyleType paragraph
+
+\Marker pubinfo
+\Name OBSOLETE pubinfo - Publication - Information
+\Description Publication information - Lang,Credit,Version,Copies,Publisher,Id,Logo
+\OccursUnder id ide
+\TextType Other
+\TextProperties paragraph nonpublishable nonvernacular
+\StyleType Paragraph
+\FontSize 12
+\Color 16711680
+
+# Concordance/Names Index Tools - special sfms for use in Publishing Assistant
+
+\Marker zpa-xb
+\Endmarker zpa-xb*
+\Name zpa-xb - Periph - Book
+\Description Book Ref
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker zpa-xc
+\Endmarker zpa-xc*
+\Name zpa-xc - Periph - Chapter
+\Description Chapter Ref
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12
+\Bold
+
+\Marker zpa-xv
+\Endmarker zpa-xv*
+\Name zpa-xv - Periph - Verse
+\Description Verse Ref
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12
+
+\Marker zpa-d
+\Endmarker zpa-d*
+\Name zpa-d - Periph - Description
+\Description Description
+\OccursUnder id
+\Rank 1
+\TextType Other
+\TextProperties paragraph publishable vernacular
+\StyleType Character
+\FontSize 12

--- a/tools/Roundtrip/usx-sf.xsd
+++ b/tools/Roundtrip/usx-sf.xsd
@@ -1,0 +1,831 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  usx-sf.rnc
+  The USX 3.0 schema for Scripture Forge
+  This schema defines the USX data that Scripture Forge is capable of handling properly.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="usx">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="book"/>
+        <xs:group minOccurs="0" maxOccurs="unbounded" ref="ChapterContent"/>
+      </xs:sequence>
+      <xs:attribute name="version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="3"/>
+            <xs:pattern value="\d+\.\d+(\.\d+)?"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="book">
+    <xs:complexType mixed="true">
+      <xs:attribute name="code" use="required" type="BookIdentification.book.code.enum"/>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="id"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="BookIdentification.book.code.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="GEN"/>
+      <xs:enumeration value="EXO"/>
+      <xs:enumeration value="LEV"/>
+      <xs:enumeration value="NUM"/>
+      <xs:enumeration value="DEU"/>
+      <xs:enumeration value="JOS"/>
+      <xs:enumeration value="JDG"/>
+      <xs:enumeration value="RUT"/>
+      <xs:enumeration value="1SA"/>
+      <xs:enumeration value="2SA"/>
+      <xs:enumeration value="1KI"/>
+      <xs:enumeration value="2KI"/>
+      <xs:enumeration value="1CH"/>
+      <xs:enumeration value="2CH"/>
+      <xs:enumeration value="EZR"/>
+      <xs:enumeration value="NEH"/>
+      <xs:enumeration value="EST"/>
+      <xs:enumeration value="JOB"/>
+      <xs:enumeration value="PSA"/>
+      <xs:enumeration value="PRO"/>
+      <xs:enumeration value="ECC"/>
+      <xs:enumeration value="SNG"/>
+      <xs:enumeration value="ISA"/>
+      <xs:enumeration value="JER"/>
+      <xs:enumeration value="LAM"/>
+      <xs:enumeration value="EZK"/>
+      <xs:enumeration value="DAN"/>
+      <xs:enumeration value="HOS"/>
+      <xs:enumeration value="JOL"/>
+      <xs:enumeration value="AMO"/>
+      <xs:enumeration value="OBA"/>
+      <xs:enumeration value="JON"/>
+      <xs:enumeration value="MIC"/>
+      <xs:enumeration value="NAM"/>
+      <xs:enumeration value="HAB"/>
+      <xs:enumeration value="ZEP"/>
+      <xs:enumeration value="HAG"/>
+      <xs:enumeration value="ZEC"/>
+      <xs:enumeration value="MAL"/>
+      <xs:enumeration value="MAT"/>
+      <xs:enumeration value="MRK"/>
+      <xs:enumeration value="LUK"/>
+      <xs:enumeration value="JHN"/>
+      <xs:enumeration value="ACT"/>
+      <xs:enumeration value="ROM"/>
+      <xs:enumeration value="1CO"/>
+      <xs:enumeration value="2CO"/>
+      <xs:enumeration value="GAL"/>
+      <xs:enumeration value="EPH"/>
+      <xs:enumeration value="PHP"/>
+      <xs:enumeration value="COL"/>
+      <xs:enumeration value="1TH"/>
+      <xs:enumeration value="2TH"/>
+      <xs:enumeration value="1TI"/>
+      <xs:enumeration value="2TI"/>
+      <xs:enumeration value="TIT"/>
+      <xs:enumeration value="PHM"/>
+      <xs:enumeration value="HEB"/>
+      <xs:enumeration value="JAS"/>
+      <xs:enumeration value="1PE"/>
+      <xs:enumeration value="2PE"/>
+      <xs:enumeration value="1JN"/>
+      <xs:enumeration value="2JN"/>
+      <xs:enumeration value="3JN"/>
+      <xs:enumeration value="JUD"/>
+      <xs:enumeration value="REV"/>
+      <xs:enumeration value="TOB"/>
+      <xs:enumeration value="JDT"/>
+      <xs:enumeration value="ESG"/>
+      <xs:enumeration value="WIS"/>
+      <xs:enumeration value="SIR"/>
+      <xs:enumeration value="BAR"/>
+      <xs:enumeration value="LJE"/>
+      <xs:enumeration value="S3Y"/>
+      <xs:enumeration value="SUS"/>
+      <xs:enumeration value="BEL"/>
+      <xs:enumeration value="1MA"/>
+      <xs:enumeration value="2MA"/>
+      <xs:enumeration value="3MA"/>
+      <xs:enumeration value="4MA"/>
+      <xs:enumeration value="1ES"/>
+      <xs:enumeration value="2ES"/>
+      <xs:enumeration value="MAN"/>
+      <xs:enumeration value="PS2"/>
+      <xs:enumeration value="ODA"/>
+      <xs:enumeration value="PSS"/>
+      <xs:enumeration value="EZA"/>
+      <xs:enumeration value="5EZ"/>
+      <xs:enumeration value="6EZ"/>
+      <xs:enumeration value="DAG"/>
+      <xs:enumeration value="PS3"/>
+      <xs:enumeration value="2BA"/>
+      <xs:enumeration value="LBA"/>
+      <xs:enumeration value="JUB"/>
+      <xs:enumeration value="ENO"/>
+      <xs:enumeration value="1MQ"/>
+      <xs:enumeration value="2MQ"/>
+      <xs:enumeration value="3MQ"/>
+      <xs:enumeration value="REP"/>
+      <xs:enumeration value="4BA"/>
+      <xs:enumeration value="LAO"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="para">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ref"/>
+        <xs:element ref="note"/>
+        <xs:group ref="Char"/>
+        <xs:element ref="ms"/>
+        <xs:element ref="figure"/>
+        <xs:element ref="verse"/>
+        <xs:element ref="optbreak"/>
+        <xs:element ref="unmatched"/>
+      </xs:choice>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:union memberTypes="Para.para.style.enum BookHeaders.para.style.enum BookTitles.para.style.enum BookIntroduction.para.style.enum List.para.style.enum">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value=""/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="vid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-4]{3} ?[a-z0-9\-,:]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="status"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="Para.para.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="restore"/>
+      <xs:enumeration value="cls"/>
+      <xs:enumeration value="iex"/>
+      <xs:enumeration value="ip"/>
+      <xs:enumeration value="lit"/>
+      <xs:enumeration value="m"/>
+      <xs:enumeration value="mi"/>
+      <xs:enumeration value="nb"/>
+      <xs:enumeration value="p"/>
+      <xs:enumeration value="pb"/>
+      <xs:enumeration value="pc"/>
+      <xs:enumeration value="pi"/>
+      <xs:enumeration value="pi1"/>
+      <xs:enumeration value="pi2"/>
+      <xs:enumeration value="pi3"/>
+      <xs:enumeration value="po"/>
+      <xs:enumeration value="pr"/>
+      <xs:enumeration value="pmo"/>
+      <xs:enumeration value="pm"/>
+      <xs:enumeration value="pmc"/>
+      <xs:enumeration value="pmr"/>
+      <xs:enumeration value="q"/>
+      <xs:enumeration value="q1"/>
+      <xs:enumeration value="q2"/>
+      <xs:enumeration value="q3"/>
+      <xs:enumeration value="q4"/>
+      <xs:enumeration value="qa"/>
+      <xs:enumeration value="qc"/>
+      <xs:enumeration value="qr"/>
+      <xs:enumeration value="qm"/>
+      <xs:enumeration value="qm1"/>
+      <xs:enumeration value="qm2"/>
+      <xs:enumeration value="qm3"/>
+      <xs:enumeration value="qd"/>
+      <xs:enumeration value="b"/>
+      <xs:enumeration value="d"/>
+      <xs:enumeration value="ms"/>
+      <xs:enumeration value="ms1"/>
+      <xs:enumeration value="ms2"/>
+      <xs:enumeration value="ms3"/>
+      <xs:enumeration value="mr"/>
+      <xs:enumeration value="r"/>
+      <xs:enumeration value="s"/>
+      <xs:enumeration value="s1"/>
+      <xs:enumeration value="s2"/>
+      <xs:enumeration value="s3"/>
+      <xs:enumeration value="s4"/>
+      <xs:enumeration value="sr"/>
+      <xs:enumeration value="sp"/>
+      <xs:enumeration value="sd"/>
+      <xs:enumeration value="sd1"/>
+      <xs:enumeration value="sd2"/>
+      <xs:enumeration value="sd3"/>
+      <xs:enumeration value="sd4"/>
+      <xs:enumeration value="ts"/>
+      <xs:enumeration value="lh"/>
+      <xs:enumeration value="li"/>
+      <xs:enumeration value="li1"/>
+      <xs:enumeration value="li2"/>
+      <xs:enumeration value="li3"/>
+      <xs:enumeration value="li4"/>
+      <xs:enumeration value="lf"/>
+      <xs:enumeration value="lim"/>
+      <xs:enumeration value="lim1"/>
+      <xs:enumeration value="lim2"/>
+      <xs:enumeration value="lim3"/>
+      <xs:enumeration value="lim4"/>
+      <xs:enumeration value="cp"/>
+      <xs:enumeration value="cl"/>
+      <xs:enumeration value="cd"/>
+      <xs:enumeration value="mte"/>
+      <xs:enumeration value="mte1"/>
+      <xs:enumeration value="mte2"/>
+      <xs:enumeration value="p"/>
+      <xs:enumeration value="p1"/>
+      <xs:enumeration value="p2"/>
+      <xs:enumeration value="k1"/>
+      <xs:enumeration value="k2"/>
+      <xs:enumeration value="rem"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BookHeaders.para.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="ide"/>
+      <xs:enumeration value="h"/>
+      <xs:enumeration value="h1"/>
+      <xs:enumeration value="h2"/>
+      <xs:enumeration value="h3"/>
+      <xs:enumeration value="toc1"/>
+      <xs:enumeration value="toc2"/>
+      <xs:enumeration value="toc3"/>
+      <xs:enumeration value="toca1"/>
+      <xs:enumeration value="toca2"/>
+      <xs:enumeration value="toca3"/>
+      <xs:enumeration value="rem"/>
+      <xs:enumeration value="usfm"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BookTitles.para.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="mt"/>
+      <xs:enumeration value="mt1"/>
+      <xs:enumeration value="mt2"/>
+      <xs:enumeration value="mt3"/>
+      <xs:enumeration value="mt4"/>
+      <xs:enumeration value="imt"/>
+      <xs:enumeration value="imt1"/>
+      <xs:enumeration value="imt2"/>
+      <xs:enumeration value="rem"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BookIntroduction.para.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="imt"/>
+      <xs:enumeration value="imt1"/>
+      <xs:enumeration value="imt2"/>
+      <xs:enumeration value="imt3"/>
+      <xs:enumeration value="imt4"/>
+      <xs:enumeration value="ib"/>
+      <xs:enumeration value="ie"/>
+      <xs:enumeration value="ili"/>
+      <xs:enumeration value="ili1"/>
+      <xs:enumeration value="ili2"/>
+      <xs:enumeration value="im"/>
+      <xs:enumeration value="imi"/>
+      <xs:enumeration value="imq"/>
+      <xs:enumeration value="io"/>
+      <xs:enumeration value="io1"/>
+      <xs:enumeration value="io2"/>
+      <xs:enumeration value="io3"/>
+      <xs:enumeration value="io4"/>
+      <xs:enumeration value="iot"/>
+      <xs:enumeration value="ip"/>
+      <xs:enumeration value="ipi"/>
+      <xs:enumeration value="ipq"/>
+      <xs:enumeration value="ipr"/>
+      <xs:enumeration value="iq"/>
+      <xs:enumeration value="iq1"/>
+      <xs:enumeration value="iq2"/>
+      <xs:enumeration value="iq3"/>
+      <xs:enumeration value="is"/>
+      <xs:enumeration value="is1"/>
+      <xs:enumeration value="is2"/>
+      <xs:enumeration value="imte"/>
+      <xs:enumeration value="imte1"/>
+      <xs:enumeration value="imte2"/>
+      <xs:enumeration value="iex"/>
+      <xs:enumeration value="rem"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="ChapterContent">
+    <xs:sequence>
+      <xs:choice minOccurs="0">
+        <xs:element ref="chapter"/>
+        <xs:element ref="para"/>
+        <xs:element ref="table"/>
+        <xs:element ref="note"/>
+        <xs:element ref="verse"/>
+        <xs:element ref="unmatched"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="List.para.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="lh"/>
+      <xs:enumeration value="li"/>
+      <xs:enumeration value="li1"/>
+      <xs:enumeration value="li2"/>
+      <xs:enumeration value="li3"/>
+      <xs:enumeration value="li4"/>
+      <xs:enumeration value="lf"/>
+      <xs:enumeration value="lim"/>
+      <xs:enumeration value="lim1"/>
+      <xs:enumeration value="lim2"/>
+      <xs:enumeration value="lim3"/>
+      <xs:enumeration value="lim4"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="table">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="row"/>
+      </xs:sequence>
+      <xs:attribute name="vid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-4]{3} ?[a-z0-9\-,:]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="row">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="verse"/>
+        <xs:element ref="cell"/>
+      </xs:choice>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="tr"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cell">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="note"/>
+        <xs:group ref="Char"/>
+        <xs:element ref="ms"/>
+        <xs:element ref="figure"/>
+        <xs:element ref="verse"/>
+        <xs:element ref="optbreak"/>
+        <xs:element ref="unmatched"/>
+      </xs:choice>
+      <xs:attribute name="style" use="required" type="cell.style.enum"/>
+      <xs:attribute name="align" use="required" type="cell.align.enum"/>
+      <xs:attribute name="colspan" type="xs:integer"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="cell.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="th"/>
+      <xs:enumeration value="tc"/>
+      <xs:enumeration value="thr"/>
+      <xs:enumeration value="tcr"/>
+      <xs:enumeration value="thc"/>
+      <xs:enumeration value="tcc"/>
+      <xs:enumeration value="th1"/>
+      <xs:enumeration value="tc1"/>
+      <xs:enumeration value="thr1"/>
+      <xs:enumeration value="tcr1"/>
+      <xs:enumeration value="th2"/>
+      <xs:enumeration value="tc2"/>
+      <xs:enumeration value="thr2"/>
+      <xs:enumeration value="tcr2"/>
+      <xs:enumeration value="th3"/>
+      <xs:enumeration value="tc3"/>
+      <xs:enumeration value="thr3"/>
+      <xs:enumeration value="tcr3"/>
+      <xs:enumeration value="th4"/>
+      <xs:enumeration value="tc4"/>
+      <xs:enumeration value="thr4"/>
+      <xs:enumeration value="tcr4"/>
+      <xs:enumeration value="th5"/>
+      <xs:enumeration value="tc5"/>
+      <xs:enumeration value="thr5"/>
+      <xs:enumeration value="tcr5"/>
+      <xs:enumeration value="rem"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="cell.align.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="start"/>
+      <xs:enumeration value="center"/>
+      <xs:enumeration value="end"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:group name="Char">
+    <xs:sequence>
+      <xs:element name="char">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="ref"/>
+            <xs:group ref="Char"/>
+            <xs:element ref="ms"/>
+            <xs:element ref="note"/>
+            <xs:element ref="optbreak"/>
+            <xs:element ref="unmatched"/>
+          </xs:choice>
+          <xs:attribute name="style" use="required">
+            <xs:simpleType>
+              <xs:union memberTypes="Char.char.style.enum IntroChar.char.style.enum ListChar.char.style.enum">
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="w"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="rb"/>
+                  </xs:restriction>
+                </xs:simpleType>
+                <xs:simpleType>
+                  <xs:restriction base="xs:token">
+                    <xs:enumeration value="fv"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:union>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attributeGroup ref="char.link"/>
+          <xs:attribute name="closed" type="xs:boolean"/>
+          <xs:attribute name="lemma">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="strong">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="[HG]\d{4,5}(:[a-z])?"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="srcloc">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="[a-z]{3,5}\d?:\d+\.\d+\.\d+\.\d+"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="gloss">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:minLength value="1"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="Char.char.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="va"/>
+      <xs:enumeration value="vp"/>
+      <xs:enumeration value="ca"/>
+      <xs:enumeration value="qac"/>
+      <xs:enumeration value="qs"/>
+      <xs:enumeration value="add"/>
+      <xs:enumeration value="addpn"/>
+      <xs:enumeration value="bk"/>
+      <xs:enumeration value="dc"/>
+      <xs:enumeration value="efm"/>
+      <xs:enumeration value="fm"/>
+      <xs:enumeration value="k"/>
+      <xs:enumeration value="nd"/>
+      <xs:enumeration value="ndx"/>
+      <xs:enumeration value="ord"/>
+      <xs:enumeration value="pn"/>
+      <xs:enumeration value="png"/>
+      <xs:enumeration value="pro"/>
+      <xs:enumeration value="qt"/>
+      <xs:enumeration value="rq"/>
+      <xs:enumeration value="sig"/>
+      <xs:enumeration value="sls"/>
+      <xs:enumeration value="tl"/>
+      <xs:enumeration value="wg"/>
+      <xs:enumeration value="wh"/>
+      <xs:enumeration value="wa"/>
+      <xs:enumeration value="wj"/>
+      <xs:enumeration value="xt"/>
+      <xs:enumeration value="jmp"/>
+      <xs:enumeration value="no"/>
+      <xs:enumeration value="it"/>
+      <xs:enumeration value="bd"/>
+      <xs:enumeration value="bdit"/>
+      <xs:enumeration value="em"/>
+      <xs:enumeration value="sc"/>
+      <xs:enumeration value="sup"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="IntroChar.char.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="ior"/>
+      <xs:enumeration value="iqt"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ListChar.char.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="litl"/>
+      <xs:enumeration value="lik"/>
+      <xs:enumeration value="liv"/>
+      <xs:enumeration value="liv1"/>
+      <xs:enumeration value="liv2"/>
+      <xs:enumeration value="liv3"/>
+      <xs:enumeration value="liv4"/>
+      <xs:enumeration value="liv5"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:attributeGroup name="char.link">
+    <xs:attribute name="link-href">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="(.*///?(.*/?)+)|((prj:[A-Za-z\-0-9]{3,8} )?[A-Z1-4]{3} \d+:\d+(\-\d+)?)|(#[^\s]+)"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="link-title" type="xs:string"/>
+    <xs:attribute name="link-id">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[\w_\-\.:]+"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <!-- Unique identifier for this location in the text -->
+  <xs:attributeGroup name="char.closed">
+    <xs:attribute name="closed" use="required" type="xs:boolean"/>
+  </xs:attributeGroup>
+  <!-- Present to allow roundtripping to USFM, not needed for publishing -->
+  <xs:element name="ms">
+    <xs:complexType>
+      <xs:attribute name="style" use="required" type="Milestone.ms.style.enum"/>
+      <xs:attribute name="sid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[\w_\-\.:]+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="eid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[\w_\-\.:]+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="who">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="2"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="Milestone.ms.style.enum">
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="ts?(\-[se])?"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[Zz].+"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="qt[1-5]?(\-[se])?"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+  <xs:element name="chapter">
+    <xs:complexType>
+      <xs:attribute name="number" use="required" type="xs:integer"/>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="c"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="sid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value="[A-Z1-4]{3} ?[0-9]+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="altnumber">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value="[0-9]+\w?(‏?[\-,][0-9]+\w?)*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="pubnumber">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="eid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value="[A-Z1-4]{3} ?[0-9]+"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!--
+    E.g. <chapter number="1" style="c" altnumber="2" pubnumber="A" />
+    This schema will not support a chapter:verse string within altnumber
+  -->
+  <xs:element name="verse">
+    <xs:complexType>
+      <xs:attribute name="number" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value="[0-9]+\w?(‏?[\-,][0-9]+\w?)*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="v"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="altnumber">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value="[0-9]+\w?(‏?[\-,:][0-9]+\w?)*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="pubnumber">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="sid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-4]{3} ?[a-z0-9\-,:]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="eid">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-4]{3} ?[a-z0-9\-,:]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- E.g. <verse number="1" style="v" altnumber="2" pubnumber="B" sid="GEN 1:22" /> -->
+  <xs:element name="note">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:group ref="NoteChar"/>
+        <xs:element ref="unmatched"/>
+      </xs:choice>
+      <xs:attribute name="style" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="f"/>
+            <xs:enumeration value="fe"/>
+            <xs:enumeration value="ef"/>
+            <xs:enumeration value="x"/>
+            <xs:enumeration value="ex"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="caller" use="required"/>
+      <xs:attribute name="category"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:group name="NoteChar">
+    <xs:sequence>
+      <xs:element name="char">
+        <xs:complexType mixed="true">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="Char"/>
+            <xs:element ref="ref"/>
+            <xs:element ref="unmatched"/>
+          </xs:choice>
+          <xs:attribute name="style" use="required">
+            <xs:simpleType>
+              <xs:union memberTypes="FootnoteChar.char.style.enum CrossReferenceChar.char.style.enum"/>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attributeGroup ref="char.link"/>
+          <xs:attribute name="closed" type="xs:boolean"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="FootnoteChar.char.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="fr"/>
+      <xs:enumeration value="cat"/>
+      <xs:enumeration value="ft"/>
+      <xs:enumeration value="fk"/>
+      <xs:enumeration value="fq"/>
+      <xs:enumeration value="fqa"/>
+      <xs:enumeration value="fl"/>
+      <xs:enumeration value="fw"/>
+      <xs:enumeration value="fp"/>
+      <xs:enumeration value="fv"/>
+      <xs:enumeration value="fdc"/>
+      <xs:enumeration value="xt"/>
+      <xs:enumeration value="it"/>
+      <xs:enumeration value="bd"/>
+      <xs:enumeration value="bdit"/>
+      <xs:enumeration value="em"/>
+      <xs:enumeration value="sc"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CrossReferenceChar.char.style.enum">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="xo"/>
+      <xs:enumeration value="xop"/>
+      <xs:enumeration value="xt"/>
+      <xs:enumeration value="xta"/>
+      <xs:enumeration value="xk"/>
+      <xs:enumeration value="xq"/>
+      <xs:enumeration value="xot"/>
+      <xs:enumeration value="xnt"/>
+      <xs:enumeration value="xdc"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="figure">
+    <xs:complexType mixed="true">
+      <xs:attribute name="style" use="required"/>
+      <xs:attribute name="alt"/>
+      <xs:attribute name="file"/>
+      <xs:attribute name="src"/>
+      <xs:attribute name="size" use="required"/>
+      <xs:attribute name="loc"/>
+      <xs:attribute name="copy"/>
+      <xs:attribute name="ref" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ref">
+    <xs:complexType mixed="true">
+      <xs:attribute name="loc" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z1-4]{3} ?[a-z0-9\-,:]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="optbreak">
+    <xs:complexType/>
+  </xs:element>
+  <xs:element name="unmatched">
+    <xs:complexType>
+      <xs:attribute name="marker" use="required"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This PR adds a tool that lets you test roundtripping of USFM to and from Deltas, and to and from USJ. This tool can be run against a directory that either contains SFM files (for example /var/lib/scriptureforge/sync/), or a directory containing zip files containing SFM files.

I ran this tool against the open.bible corpus (https://github.com/pmachapman/open.bible), and found 3 issues with the roundtripping:

 * A bug with USJ conversion for USFM files with footnotes that contain a space between the footnote category and footnote reference, i.e. `\v 1 In the\f + \cat dup\cat* \fr 1.1`
 * A bug with Delta conversion for USFM files containing only some chapters: https://jira.sil.org/browse/SF-3286
 * A bug with Delta converison for USFM files containing alternate chapter numbers and a footnote for the alternate chapter number: https://jira.sil.org/browse/SF-3232

**Usage**

* `dotnet run [directory]` Will list any SFM files that fail roundtripping.
* `dotnet run [directory]  --output-sfm` Will list any SFM files that fail roundtripping, and output these files into an `output` directory, so you can investigate the cause of the roundtripping failure.
* `dotnet run [directory]  --output-all` Will output all generated Delta andUSJ files into an `output` directory, so the output can be stored and compared to the output from a change to the USJ or Delta generation code.

I have marked this PR as not requiring testing, as it is a developer tool, and the fix included can be validated by running the tool against the [open.bible Paratext zip files](https://github.com/pmachapman/open.bible).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3115)
<!-- Reviewable:end -->
