### PR TITLE
SF-3286 Fix sync failed when chapters missing

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.Schema;
@@ -558,6 +559,13 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     else
                     {
                         isFirstChapterFound = true;
+                        var numberStr = (string)((XElement)curNode).Attribute("number");
+                        if (!int.TryParse(numberStr, out int number))
+                        {
+                            // we cannot handle if the first chapter is invalid because we have no way to determine
+                            // how to update the content before this chapter
+                            throw new InvalidDataException("The first chapter number was invalid");
+                        }
                     }
                 }
 
@@ -583,6 +591,10 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     newUsxDoc.Root.Add(ProcessDelta(chapterDeltaArray[i].Delta));
             }
             return newUsxDoc;
+        }
+        catch (InvalidDataException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1316,6 +1316,113 @@ public class DeltaUsxMapperTests
     }
 
     [Test]
+    public void ToUsx_NewChapter_AddedBetweenChapters()
+    {
+        var chapterDeltas = new[]
+        {
+            new ChapterDelta(
+                1,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("1")
+                    .InsertVerse("1")
+                    .InsertText("This is verse 1.", "verse_1_1")
+                    .InsertVerse("2")
+                    .InsertText("This is verse 2.", "verse_1_2")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                2,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("2")
+                    .InsertVerse("1")
+                    .InsertText("New chapter verse 1.", "verse_2_1")
+                    .InsertVerse("2")
+                    .InsertText("New chapter verse 2.", "verse_2_2")
+                    .InsertPara("p")
+            ),
+            new ChapterDelta(
+                3,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertChapter("3")
+                    .InsertVerse("1")
+                    .InsertText("This is verse 1.", "verse_3_1")
+                    .InsertVerse("2")
+                    .InsertText("This is verse 2.", "verse_3_2")
+                    .InsertPara("p")
+            ),
+        };
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+
+        XDocument original = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2."),
+            Chapter("3"),
+            Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2.")
+        );
+
+        XDocument expected = Usx(
+            "PHM",
+            Chapter("1"),
+            Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2."),
+            Chapter("2"),
+            Para("p", Verse("1"), "New chapter verse 1.", Verse("2"), "New chapter verse 2."),
+            Chapter("3"),
+            Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2.")
+        );
+
+        // SUT
+        XDocument newUsxDoc = mapper.ToUsx(original, chapterDeltas);
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
+    public void ToUsx_FirstChapterMissing()
+    {
+        var chapterDeltas = new[]
+        {
+            new ChapterDelta(
+                2,
+                2,
+                true,
+                Delta
+                    .New()
+                    .InsertText("Introductory material")
+                    .InsertPara("toc1")
+                    .InsertChapter("2")
+                    .InsertVerse("1")
+                    .InsertText("This is verse 1.", "verse_2_1")
+                    .InsertVerse("2")
+                    .InsertText("This is verse 2.", "verse_2_2")
+                    .InsertPara("p")
+            ),
+        };
+
+        var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
+
+        XDocument expected = Usx(
+            "PHM",
+            Para("toc1", "Introductory material"),
+            Chapter("2"),
+            Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2.")
+        );
+
+        // SUT
+        XDocument newUsxDoc = mapper.ToUsx(expected, chapterDeltas);
+        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+    }
+
+    [Test]
     public void ToUsx_BlankLine()
     {
         var chapterDelta = new ChapterDelta(
@@ -3701,6 +3808,20 @@ public class DeltaUsxMapperTests
 \p E
 \v 2 F \nd ND\nd*
 """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_MissingChapters()
+    {
+        AssertRoundtrips(
+            """
+            \id PRO - A
+            \c 2
+            \v 1 My son, if thou wilt...
+            \c 3
+            \v 1 My son, forget not...
+            """
         );
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1748,16 +1748,7 @@ public class DeltaUsxMapperTests
         XDocument oldUsxDoc = Usx("PHM", Chapter("bad"), Para("p", Verse("1"), Verse("2")), Chapter("2"));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(oldUsxDoc, new[] { chapterDelta });
-
-        XDocument expected = Usx(
-            "PHM",
-            Chapter("bad"),
-            Para("p", Verse("1"), Verse("2")),
-            Chapter("2"),
-            Para("p", Verse("1"), Verse("2"))
-        );
-        Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
+        Assert.Throws<InvalidDataException>(() => mapper.ToUsx(oldUsxDoc, new[] { chapterDelta }));
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1401,24 +1401,31 @@ public class DeltaUsxMapperTests
                     .InsertPara("toc1")
                     .InsertChapter("2")
                     .InsertVerse("1")
-                    .InsertText("This is verse 1.", "verse_2_1")
+                    .InsertText("This is verse 1 (edited).", "verse_2_1")
                     .InsertVerse("2")
-                    .InsertText("This is verse 2.", "verse_2_2")
+                    .InsertText("This is verse 2 (edited).", "verse_2_2")
                     .InsertPara("p")
             ),
         };
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
-        XDocument expected = Usx(
+        XDocument original = Usx(
             "PHM",
             Para("toc1", "Introductory material"),
             Chapter("2"),
             Para("p", Verse("1"), "This is verse 1.", Verse("2"), "This is verse 2.")
         );
 
+        XDocument expected = Usx(
+            "PHM",
+            Para("toc1", "Introductory material"),
+            Chapter("2"),
+            Para("p", Verse("1"), "This is verse 1 (edited).", Verse("2"), "This is verse 2 (edited).")
+        );
+
         // SUT
-        XDocument newUsxDoc = mapper.ToUsx(expected, chapterDeltas);
+        XDocument newUsxDoc = mapper.ToUsx(original, chapterDeltas);
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
     }
 


### PR DESCRIPTION
This PR fixes a regression where a project will fail to sync when there are missing chapters in a text. The sync will fail due to a problem where the DeltaUsxMapper toUsx() algorithm assumes that the first chapter is chapter 1, but if chapter 1 does not exist in the usx document, it will skip over all chapters, then it will attempt to append chapters to the end of the usx doc. Thankfully the scrText does not allow creating duplicate chapters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3116)
<!-- Reviewable:end -->
