### PR TITLE
Update supported versions list

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/utils.ts
@@ -27,20 +27,21 @@ export function supportedBrowser(): boolean {
   // https://caniuse.com/mdn-css_properties_column-gap_flex_context
   // https://caniuse.com/mdn-css_properties_inset-inline-start
   // https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start#browser_compatibility
+  // ES2022 (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks)
   const isSupportedBrowser = BROWSER.satisfies({
-    chrome: '>=87',
-    chromium: '>=87',
-    edge: '>=87',
-    firefox: '>=79',
-    safari: '>=14.1',
+    chrome: '>=94',
+    chromium: '>=94',
+    edge: '>=94',
+    firefox: '>=93',
+    safari: '>=16.4',
 
     mobile: {
-      chrome: '>=87',
-      firefox: '>=79',
-      opera: '>=73',
-      safari: '>=14.5',
-      'android browser': '>=87',
-      'samsung internet': '>=14.0'
+      chrome: '>=94',
+      firefox: '>=93',
+      opera: '>=80',
+      safari: '>=16.4',
+      'android browser': '>=94',
+      'samsung internet': '>=17.0'
     }
   });
   return isSupportedBrowser ? true : false;


### PR DESCRIPTION
Angular 18 uses ES2022 syntax that older browsers (like Safari 15) don't support. When I say don't support, I mean the user gets stuck on a "Loading..." screen. (i.e. really doesn't support!)

This is done by code in the polyfills, so we could potentially reduce the version of generated code to an earlier version of ES, or create a browserlistrc file to generate code for older browsers.

That said, although this dialog will not be shown on these older devices, I think it is helpful to document our supported versions here, so that we know what browsers will run Scripture Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3118)
<!-- Reviewable:end -->
