### PR TITLE
SF-3232 Allow chapter numbers to have footnotes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -223,9 +223,10 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                             );
                             break;
 
-                        // according to the USX schema, a verse can only occur within a paragraph, but Paratext 8.0
-                        // can still generate USX with verses at the top-level
+                        // According to the USX schema, a verse or note should only occur within a paragraph,
+                        // but Paratext 9.0 can still generate USX with verses or notes at the chapter level.
                         case "verse":
+                        case "note":
                             ProcessChildNode(elem, chapterDelta, invalidNodes, state);
                             state.ImpliedParagraph = true;
                             break;
@@ -820,7 +821,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     {
         return charAttrs switch
         {
-            JArray array => new List<JObject>(array.Children<JObject>()),
+            JArray array => [.. array.Children<JObject>()],
             JObject obj => [obj],
             _ => [],
         };

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -77,7 +77,7 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = mapper.ToChapterDeltas(newUsxDoc).ToList();
+        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
         Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
     }
 
@@ -143,7 +143,7 @@ public class DeltaUsxMapperTests
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
         // Get the chapter deltas, which will be the valid chapters
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected1 = Delta.New().InsertChapter("1").InsertVerse("1").InsertBlank("verse_1_1").InsertText("\n");
         var expected2 = Delta.New().InsertChapter("3").InsertVerse("1").InsertBlank("verse_3_1").InsertText("\n");
@@ -881,7 +881,7 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = mapper.ToChapterDeltas(newUsxDoc).ToList();
+        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
         Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
     }
 
@@ -1074,7 +1074,7 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = mapper.ToChapterDeltas(newUsxDoc).ToList();
+        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
         Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDeltas[0].Delta));
         Assert.IsTrue(roundtrippedChapterDeltas[1].Delta.DeepEquals(chapterDeltas[1].Delta));
     }
@@ -1771,7 +1771,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1809,7 +1809,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1834,7 +1834,7 @@ public class DeltaUsxMapperTests
         XDocument usxDoc = Usx("PHM", Chapter("1", "bad"), Para("p", Verse("1"), Verse("2")));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1858,7 +1858,7 @@ public class DeltaUsxMapperTests
         XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1", "bad"), Verse("2")));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1888,7 +1888,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1921,7 +1921,7 @@ public class DeltaUsxMapperTests
         XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1"), Verse("2bad")));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -1956,7 +1956,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expectedChapter1 = Delta
             .New()
@@ -2029,7 +2029,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2086,7 +2086,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2144,7 +2144,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2191,7 +2191,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2225,7 +2225,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2253,7 +2253,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2277,7 +2277,7 @@ public class DeltaUsxMapperTests
         XDocument usxDoc = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "This is some ", Char("bd", ""), " text."));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2310,7 +2310,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         string bdCharID = _testGuidService.Generate();
         string sup1CharID = _testGuidService.Generate();
@@ -2374,7 +2374,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         string bdCharID = _testGuidService.Generate();
         string sup1CharID = _testGuidService.Generate();
@@ -2443,7 +2443,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         string bdCharID = _testGuidService.Generate();
         string sup1CharID = _testGuidService.Generate();
@@ -2529,7 +2529,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         string badCharID = _testGuidService.Generate();
         string sup1CharID = _testGuidService.Generate();
@@ -2591,7 +2591,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2637,7 +2637,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2693,7 +2693,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2749,7 +2749,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2791,7 +2791,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2819,7 +2819,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2847,7 +2847,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2881,7 +2881,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -2930,7 +2930,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3003,7 +3003,7 @@ public class DeltaUsxMapperTests
         Assert.That(XNode.DeepEquals(usxDoc, usfmToUsx));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         // Note that these expected deltas are somewhat reverse engineered, rather than known to be what should really
         // be expected.
@@ -3063,7 +3063,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3127,7 +3127,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3172,7 +3172,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected1 = Delta
             .New()
@@ -3214,7 +3214,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3243,7 +3243,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3279,7 +3279,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected1 = Delta
             .New()
@@ -3317,7 +3317,7 @@ public class DeltaUsxMapperTests
         XDocument usxDoc = Usx("PHM");
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         Assert.That(chapterDeltas.Count, Is.EqualTo(1));
         Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
@@ -3339,7 +3339,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3377,7 +3377,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3412,7 +3412,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = new Delta()
             .InsertChapter("1")
@@ -3444,7 +3444,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expectedChapter1 = Delta
             .New()
@@ -3500,7 +3500,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expectedChapter1 = Delta
             .New()
@@ -3556,7 +3556,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expectedChapter1 = Delta
             .New()
@@ -3607,7 +3607,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3634,7 +3634,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = new[]
         {
@@ -3675,7 +3675,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = new Delta()
             .InsertChapter("1")
@@ -3705,7 +3705,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(usxDoc).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
         var expected = Delta
             .New()
@@ -3720,6 +3720,54 @@ public class DeltaUsxMapperTests
         Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
         Assert.That(chapterDeltas[0].IsValid, Is.True);
         Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
+    }
+
+    [Test]
+    public void Roundtrip_FootnoteInChapterNumber()
+    {
+        AssertRoundtrips(
+            """
+            \id ESG - A
+            \c 1
+            \cp A \f + \fr 1: \ft Chapter A 1-17 corresponds to chapters 11.2—12.6 in a number of English translations.\f*
+            \s Mordecai's Strange Dream
+            \p
+            \v 1 Mordecai, a Jew who belonged to the tribe of Benjamin,
+            """
+        );
+        AssertRoundtrips(
+            """
+            \id ESG - A
+            \c 1
+            \cp A \f + \fr 1: \ft Chapter A 1-17 corresponds to chapters 11.2—12.6 in a number of English translations.\f*
+            \v 1 Mordecai, a Jew who belonged to the tribe of Benjamin,
+            """
+        );
+        AssertRoundtrips(
+            """
+            \id ESG - A
+            \c 1
+            \cp A \f + \fr 1: \ft Chapter A 1-17 corresponds to chapters 11.2—12.6 in a number of English translations.\f*
+            \v 1 Mordecai, a Jew who belonged to the tribe of Benjamin,
+            \p
+            \v 2 He was a
+            """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_FootnoteInFirstSegment()
+    {
+        AssertRoundtrips(
+            """
+            \id ESG - A
+            \c 1
+            \cp A
+            \s \f + \fr 1: \ft Chapter A 1-17 corresponds to chapters 11.2—12.6 in a number of English translations.\f* Mordecai's Strange Dream
+            \p
+            \v 1 Mordecai, a Jew who belonged to the tribe of Benjamin,
+            """
+        );
     }
 
     [Test]
@@ -3890,7 +3938,7 @@ public class DeltaUsxMapperTests
         DeltaUsxMapper mapper = new(_mapperGuidService, _logger, _exceptionHandler);
 
         // SUT part 1
-        List<ChapterDelta> chapterDeltas = mapper.ToChapterDeltas(bookUsx).ToList();
+        List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(bookUsx)];
 
         IEnumerable<XElement> chaptersToProcess = bookUsx
             .Elements("usx")


### PR DESCRIPTION
This PR fixes a bug where footnotes that are at the chapter level (i.e. were for a chapter number) were being subsumed into the para below.

I have run this fix against the [open.bible corpus](https://github.com/pmachapman/open.bible) using #3115, and no regressions were detected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3119)
<!-- Reviewable:end -->
