### PR TITLE
SF-3204 Do not show project deleted for Serval Admin viewing Event Log

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -323,6 +323,19 @@ describe('AppComponent', () => {
     verify(mockedDialogService.message(anything())).never();
   }));
 
+  it('response to remote project change for serval admin viewing event log', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setCurrentUser('user05');
+    env.navigate(['/serval-administration', 'project01']);
+    when(mockedLocationService.pathname).thenReturn('/projects/project01/event-log');
+    env.init();
+
+    expect(env.selectedProjectId).toEqual('project01');
+    // Simulate an op coming from another source
+    env.updatePreTranslate('project01');
+    verify(mockedDialogService.message(anything())).never();
+  }));
+
   it('response to Commenter project role changed', fakeAsync(() => {
     const env = new TestEnvironment();
     env.navigate(['/projects', 'project01']);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -291,10 +291,12 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         this.permissionsChangedSub?.unsubscribe();
         this.permissionsChangedSub = this._selectedProjectDoc?.remoteChanges$.subscribe(() => {
           if (this._selectedProjectDoc?.data != null && this.currentUserDoc != null) {
-            // If the user is in the Serval administration page, do not check access,
-            // as they will be modifying the project's properties
+            // If the user is in the Serval administration area, do not check access, as they will be modifying the
+            // project's properties. We suppress this in the event log, as if a sync occurs while a serval admin is
+            // viewing it, it will result in the project deleted dialog erroneously being shown.
+            const servalAdminAreaRegex = /serval-administration|event-log/;
             if (
-              this.locationService.pathname.includes('serval-administration') &&
+              servalAdminAreaRegex.test(this.locationService.pathname) &&
               this.currentUser?.roles.includes(SystemRole.ServalAdmin)
             ) {
               return;


### PR DESCRIPTION
This PR fixes a bug where a Serval Administrator can receive "this project has been deleted" popup when viewing the event log in the Serval Administration area.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3122)
<!-- Reviewable:end -->
