### PR TITLE
SF-3195 Allow resources from DBL to be downloaded by Serval Admins

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -54,14 +54,14 @@ public class ParatextController : ControllerBase
     }
 
     /// <summary>
-    /// Download a project as a Paratext zip file.
+    /// Download a project or resource as a Paratext zip file.
     /// </summary>
     /// <param name="projectId">The Scripture Forge project identifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The zip data for the project, if present in Scripture Forge.</returns>
     /// <response code="200">The zip file was successfully downloaded.</response>
     /// <response code="403">The user is not a system administrator or serval administrator.</response>
-    /// <response code="404">The project does not exist, is a resource, or could not be found on disk.</response>
+    /// <response code="404">The project does not exist, or could not be found on disk.</response>
     [HttpGet("projects/{projectId}/download")]
     [ProducesResponseType(typeof(FileStreamResult), 200)]
     public async Task<ActionResult> DownloadProjectAsync(string projectId, CancellationToken cancellationToken)

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -188,14 +188,14 @@ public class MachineProjectService(
     }
 
     /// <summary>
-    /// Gets the project as a zip file, writing it to <paramref name="outputStream"/>.
+    /// Gets the project or resource as a zip file, writing it to <paramref name="outputStream"/>.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="outputStream">The output stream.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The name of the zip file, e.g. <c>ABC.zip</c>.</returns>
     /// <exception cref="DataNotFoundException">
-    /// The project does not exist, is a resource, or could not be found on disk.
+    /// The project does not exist, or could not be found on disk.
     /// </exception>
     public async Task<string> GetProjectZipAsync(
         string sfProjectId,
@@ -208,12 +208,6 @@ public class MachineProjectService(
         if (!attempt.TryResult(out SFProject project))
         {
             throw new DataNotFoundException("The project does not exist.");
-        }
-
-        // Ensure that the project is not a resource
-        if (paratextService.IsResource(project.ParatextId))
-        {
-            throw new DataNotFoundException("You cannot download a resource.");
         }
 
         // Create the zip file from the directory in memory

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -1265,20 +1265,6 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public void GetProjectZipAsync_ThrowsExceptionWhenProjectIsAResource()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-        env.ParatextService.IsResource(Arg.Any<string>()).Returns(true);
-        MemoryStream outputStream = new MemoryStream();
-
-        // SUT
-        Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.GetProjectZipAsync(Project01, outputStream, CancellationToken.None)
-        );
-    }
-
-    [Test]
     public void GetSourceLanguage_DoesNotUseTheAlternateSourceIfItIsDisabled()
     {
         // Set up test environment


### PR DESCRIPTION
This PR grants the ability for serval administrators and system administrators to download DBL resources.

I have marked as testing not required, as this is a straightforward admin change, and not facing most users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3123)
<!-- Reviewable:end -->
