### PR TITLE
SF-3189 Fix project deleted dialog appearing more than necessary

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -66,9 +66,6 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     navigateToProject$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       if (userDoc.data?.sites[environment.siteId].projects?.includes(projectId)) {
         this.navigateToProject(projectId);
-      } else {
-        await this.dialogService.message('app.project_has_been_deleted');
-        this.router.navigateByUrl('/projects', { replaceUrl: true });
       }
     });
   }


### PR DESCRIPTION
This PR fixes an issue where the project deleted or user no longer has access dialog appears multiple times when a user is removed from a project. This is because both the project component and app component had logic to show the dialog when the project doc is updated. This PR removes the logic from the project component so that the app component can handle showing the dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3124)
<!-- Reviewable:end -->
