### PR TITLE
SF-3216 Warn user when no training books are available

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -141,7 +141,11 @@
             ></app-book-multi-select>
           }
         }
-        @if (!translatedBooksSelectedInTrainingSources) {
+        @if (!isTrainingOptional && selectableTrainingBooksByProj(activatedProject.projectId).length === 0) {
+          <app-notice class="error-no-translated-books" type="error">
+            {{ t("choose_books_for_training_no_books_error") }}
+          </app-notice>
+        } @else if (!translatedBooksSelectedInTrainingSources) {
           <app-notice class="error-translated-books-unselected" type="error">
             {{ t("translated_book_selected_no_training_pair") }}
           </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -231,6 +231,7 @@
     "choose_additional_training_data_files_header": "Additional training",
     "choose_additional_training_data_files_title": "Choose additional files for training the language model",
     "choose_books_for_training_error": "No books selected. Select training books to continue.",
+    "choose_books_for_training_no_books_error": "No books are available for training. Your project must have at least one translated book to use for training.",
     "choose_books_for_training_title": "Select books to train on",
     "choose_books_for_training_header": "Training",
     "choose_books_to_translate_error": "No books selected. Select books to translate to continue.",


### PR DESCRIPTION
This PR detects when a user has no translated books available for training and warns the user. This can occur if the user only has 1 books on the project or all of the books were selected on the previous step. This also cleans up some dead code in the spec file.
![image](https://github.com/user-attachments/assets/589085d4-2756-46f0-b710-d942cbe4bfec)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3125)
<!-- Reviewable:end -->
