### PR TITLE
SF-3288 Handle draft source projects that lack language codes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
@@ -4,7 +4,7 @@ export interface ParatextProject {
   name: string;
   shortName: string;
   languageTag: string;
-  projectId?: string;
+  projectId?: string | null;
   isConnectable: boolean;
   isConnected: boolean;
   hasUserRoleChanged?: boolean;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -68,8 +68,8 @@ export class ConfirmSourcesComponent {
     return this.i18nService.enumerateList(this.draftingSources.filter(p => p != null).map(p => p.shortName));
   }
 
-  displayNameForProjectsLanguages(projects: { languageTag: string }[]): string {
-    const uniqueTags = Array.from(new Set(projects.filter(p => p != null).map(p => p.languageTag)));
+  displayNameForProjectsLanguages(projects: { languageTag?: string }[]): string {
+    const uniqueTags = [...new Set(projects.map(p => p.languageTag).filter(t => t != null))];
     const displayNames = uniqueTags.map(tag => this.i18nService.getLanguageDisplayName(tag) ?? tag);
     return this.i18nService.enumerateList(displayNames);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -131,9 +131,7 @@
             } @else {
               <div class="project">
                 <span class="project-name">{{ project.name }}</span>
-                <span class="language-code">
-                  {{ t("language_code") }} <strong>{{ project.languageTag }}</strong>
-                </span>
+                <ng-container *ngTemplateOutlet="languageCode; context: { code: project.languageTag }"></ng-container>
               </div>
             }
           }
@@ -144,9 +142,8 @@
           @for (project of trainingTargets; track $index) {
             <div class="project">
               <span class="project-name">{{ project.name }}</span>
-              <span class="language-code">
-                {{ t("language_code") }} <strong>{{ project.writingSystem.tag }}</strong>
-              </span>
+              <ng-container *ngTemplateOutlet="languageCode; context: { code: project.writingSystem.tag }">
+              </ng-container>
             </div>
           }
         </div>
@@ -166,9 +163,7 @@
             } @else {
               <div class="project">
                 <span class="project-name">{{ project.name }}</span>
-                <span class="language-code">
-                  {{ t("language_code") }} <strong>{{ project.languageTag }}</strong>
-                </span>
+                <ng-container *ngTemplateOutlet="languageCode; context: { code: project.languageTag }"></ng-container>
               </div>
             }
           }
@@ -253,5 +248,16 @@
         <button mat-flat-button color="primary" (click)="goToStep(step + 1)">{{ t("next") }}</button>
       }
     </div>
+  </ng-template>
+
+  <ng-template #languageCode let-code="code">
+    <span class="language-code">
+      {{ t("language_code") }}
+      @if (code == null || code === "") {
+        <em>{{ t("unknown_language_code") }}</em>
+      } @else {
+        <strong>{{ code }}</strong>
+      }
+    </span>
   </ng-template>
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.ts
@@ -61,7 +61,9 @@ export class LanguageCodesConfirmationComponent {
   }
 
   get sourceSideLanguageCodes(): string[] {
-    return [...this.draftingSources, ...this.trainingSources].filter(s => s != null).map(s => s.languageTag);
+    return [...this.draftingSources, ...this.trainingSources]
+      .map(s => s.languageTag)
+      .filter(t => t != null && t !== '');
   }
 
   get uniqueSourceSideLanguageCodes(): string[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -303,7 +303,8 @@
     "state_syncing": "Syncing",
     "stay_on_page": "Stay on page",
     "target_language_data": "Target language data",
-    "training_language_model": "Training the language model"
+    "training_language_model": "Training the language model",
+    "unknown_language_code": "unknown"
   },
   "editor": {
     "add_comment": "Add Comment",


### PR DESCRIPTION
Certain projects, including back translations, don't have known language codes until after they are connected (because the Paratext registry API does not provide it)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3126)
<!-- Reviewable:end -->
