### PR TITLE
SF-3269 Show a warning dialog when draft request is already queued

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -117,7 +117,7 @@ describe('DraftGenerationComponent', () => {
           allowForwardTranslationNmtDrafting: createTestFeatureFlag(false)
         }
       );
-      mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog']);
+      mockDialogService = jasmine.createSpyObj<DialogService>(['openGenericDialog', 'message']);
       mockNoticeService = jasmine.createSpyObj<NoticeService>([
         'loadingStarted',
         'loadingFinished',
@@ -1014,7 +1014,7 @@ describe('DraftGenerationComponent', () => {
       expect(env.component.currentPage).toBe('initial');
       expect(env.component['draftJob']).not.toBeNull();
       expect(mockDraftGenerationService.startBuildOrGetActiveBuild).not.toHaveBeenCalledWith(anything());
-      expect(mockNoticeService.show).toHaveBeenCalledTimes(1);
+      expect(mockDialogService.message).toHaveBeenCalledTimes(1);
     });
 
     it('should not attempt "cancel dialog" close for queued build', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -434,7 +434,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         if (this.isDraftInProgress(job)) {
           this.draftJob = job;
           this.currentPage = 'initial';
-          this.noticeService.show(this.i18n.translateStatic('draft_generation.draft_already_running'));
+          this.dialogService.message('draft_generation.draft_already_running');
           return;
         }
       });


### PR DESCRIPTION
This PR changes the snackbar message to a dialog when a draft request is already queued. Developer tester is sufficient to merge this since it is a simple change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3128)
<!-- Reviewable:end -->
