### PR TITLE
SF-3268 Fix clearing first training source

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/paratext-project.ts
@@ -4,6 +4,7 @@ export interface ParatextProject {
   name: string;
   shortName: string;
   languageTag: string;
+  /** SF project id */
   projectId?: string | null;
   isConnectable: boolean;
   isConnected: boolean;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -74,6 +74,7 @@ export class ParatextService {
       .pipe(map(r => r ?? undefined));
   }
 
+  /** Get list of projects a user has access to, whether or not the project is already at SF. */
   getProjects(): Promise<ParatextProject[] | undefined> {
     return firstValueFrom(
       this.http.get<ParatextProject[] | undefined>(`${PARATEXT_API_NAMESPACE}/projects`, { headers: this.headers })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -24,7 +24,7 @@ export const PROJECT_SELECT_VALUE_ACCESSOR: any = {
   providers: [PROJECT_SELECT_VALUE_ACCESSOR]
 })
 export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
-  @Output() valueChange: EventEmitter<string> = new EventEmitter<string>(true);
+  @Output() valueChange: EventEmitter<string | undefined> = new EventEmitter<string | undefined>(true);
   @Output() projectSelect = new EventEmitter<SelectableProject>();
 
   @Input() placeholder = '';
@@ -61,12 +61,16 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
   constructor(private destroyRef: DestroyRef) {
     this.paratextIdControl.valueChanges
       .pipe(distinctUntilChanged(), quietTakeUntilDestroyed(this.destroyRef))
-      .subscribe((value: SelectableProject) => {
-        this.valueChange.next(value.paratextId);
-
-        if (value instanceof Object) {
-          this.projectSelect.emit(value);
+      .subscribe((value: SelectableProject | string) => {
+        // When the user clears the input box, or is typing the name of a project, `value` comes in as a string. When
+        // the user selects a project from the list, `value` comes in as a SelectableProject.
+        if (typeof value === 'string') {
+          this.valueChange.next(undefined);
+          return;
         }
+
+        this.valueChange.next(value.paratextId);
+        this.projectSelect.emit(value);
       });
 
     this.projects$

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -2,8 +2,6 @@
   <h1>{{ t("configure_draft_sources") }}</h1>
 
   <mat-card class="draft-sources-stepper">
-    <!-- The value on app-project-select is intentionally set to undefined until sources load, otherwise it won't correctly load -->
-
     <div class="step" [class.active]="step === 1">
       <div class="step-header" matRipple (click)="goToStep(1)">
         <div class="step-header-description">
@@ -20,12 +18,13 @@
             [projects]="projects"
             [resources]="resources"
             [nonSelectableProjects]="nonSelectableProjects"
-            [value]="loading ? undefined : source?.paratextId"
+            [value]="source?.paratextId"
             [hiddenParatextIds]="otherParatextIds(draftingSources, source?.paratextId)"
             (valueChange)="sourceSelected(draftingSources, $index, $event)"
             [placeholder]="projectPlaceholder(source)"
           ></app-project-select>
         }
+
         <ng-container *ngTemplateOutlet="navigationButtons"></ng-container>
       </div>
     </div>
@@ -54,14 +53,13 @@
             {{ t("same_language_as_source") }}
           }
         </p>
-
         @for (source of trainingSources; track $index) {
           <app-project-select
             [isDisabled]="loading"
             [projects]="projects"
             [resources]="resources"
             [nonSelectableProjects]="nonSelectableProjects"
-            [value]="loading ? undefined : source?.paratextId"
+            [value]="source?.paratextId"
             [hiddenParatextIds]="otherParatextIds(trainingSources, source?.paratextId)"
             (valueChange)="sourceSelected(trainingSources, $index, $event)"
             [placeholder]="projectPlaceholder(source)"
@@ -107,11 +105,12 @@
             [projects]="projects"
             [resources]="resources"
             [nonSelectableProjects]="nonSelectableProjects"
-            [value]="loading ? undefined : source?.paratextId"
+            [value]="source?.paratextId"
             [hiddenParatextIds]="otherParatextIds(trainingTargets, source?.paratextId)"
             [placeholder]="projectPlaceholder(source)"
           ></app-project-select>
         }
+
         <ng-container *ngTemplateOutlet="navigationButtons"></ng-container>
       </div>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
@@ -17,7 +17,7 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
-import { hasData, isInstantiated, WithData } from '../../../../type-utils';
+import { hasData, notNull, WithData } from '../../../../type-utils';
 import { ParatextProject } from '../../../core/models/paratext-project';
 import { SFProjectDoc } from '../../../core/models/sf-project-doc';
 import { SFProjectSettings } from '../../../core/models/sf-project-settings';
@@ -28,7 +28,9 @@ import { DraftSource, DraftSourcesAsArrays, DraftSourcesService } from '../draft
 import { translateSourceToSelectableProjectWithLanguageTag } from '../draft-utils';
 import { DraftSourcesComponent, sourceArraysToSettingsChange } from './draft-sources.component';
 
-interface UltimateProjectDescription {
+/** This interface allows specification of a project using multiple types at once, to help the spec provide the
+ * different types required by the component. */
+interface MultiTypeProjectDescription {
   paratextProject: ParatextProject;
   selectableProjectWithLanguageCode: SelectableProjectWithLanguageCode;
   projectType: 'project' | 'resource';
@@ -399,7 +401,7 @@ class TestEnvironment {
     // Make some projects and resources, already on SF, that the user has access to. These will be available as a
     // variety of types.
 
-    const projects: UltimateProjectDescription[] = Array.from(
+    const projects: MultiTypeProjectDescription[] = Array.from(
       { length: userSFProjectsAndResourcesCount },
       (_, i) =>
         ({
@@ -489,11 +491,11 @@ class TestEnvironment {
     const usersSFResources: TranslateSource[] = projects
       .filter(o => o.projectType === 'resource')
       .map(o => o.translateSource)
-      .filter(isInstantiated);
+      .filter(notNull);
     const usersSFProjects: TranslateSource[] = projects
       .filter(o => o.projectType === 'project')
       .map(o => o.translateSource)
-      .filter(isInstantiated);
+      .filter(notNull);
 
     this.activatedProjectDoc = usersProjectsAndResourcesOnSF[0];
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -19,7 +19,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
-import { hasData, isInstantiated } from '../../../../type-utils';
+import { hasData, notNull } from '../../../../type-utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { ParatextService, SelectableProject, SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
@@ -115,10 +115,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
         this.trainingTargets = trainingTargets;
         this.draftingSources = draftingSources.map(translateSourceToSelectableProjectWithLanguageTag);
 
-        this.nonSelectableProjects = [
-          ...this.trainingSources.filter(isInstantiated),
-          ...this.draftingSources.filter(isInstantiated)
-        ];
+        this.nonSelectableProjects = [...this.trainingSources.filter(notNull), ...this.draftingSources.filter(notNull)];
 
         if (this.draftingSources.length < 1) this.draftingSources.push(undefined);
         if (this.trainingSources.length < 1) this.trainingSources.push(undefined);
@@ -140,13 +137,13 @@ export class DraftSourcesComponent extends DataLoadingComponent {
   }
 
   get referenceLanguageDisplayName(): string {
-    const uniqueTags = Array.from(new Set(this.trainingSources.filter(isInstantiated).map(p => p.languageTag)));
+    const uniqueTags = Array.from(new Set(this.trainingSources.filter(notNull).map(p => p.languageTag)));
     const displayNames = uniqueTags.map(tag => this.i18n.getLanguageDisplayName(tag) ?? tag);
     return this.i18n.enumerateList(displayNames);
   }
 
   get sourceLanguageDisplayName(): string | undefined {
-    const definedSources = this.draftingSources.filter(isInstantiated);
+    const definedSources = this.draftingSources.filter(notNull);
 
     if (definedSources.length > 1) throw new Error('Multiple drafting sources not supported');
     else if (definedSources.length < 1) return undefined;
@@ -164,15 +161,15 @@ export class DraftSourcesComponent extends DataLoadingComponent {
   }
 
   get sourceSubtitle(): string {
-    return this.i18n.enumerateList(this.draftingSources.filter(isInstantiated).map(s => s.shortName) ?? []);
+    return this.i18n.enumerateList(this.draftingSources.filter(notNull).map(s => s.shortName) ?? []);
   }
 
   get referencesSubtitle(): string {
-    return this.i18n.enumerateList(this.trainingSources.filter(isInstantiated).map(r => r.shortName) ?? []);
+    return this.i18n.enumerateList(this.trainingSources.filter(notNull).map(r => r.shortName) ?? []);
   }
 
   get targetSubtitle(): string {
-    return this.i18n.enumerateList(this.trainingTargets.filter(isInstantiated).map(t => t.shortName) ?? []);
+    return this.i18n.enumerateList(this.trainingTargets.filter(notNull).map(t => t.shortName) ?? []);
   }
 
   parentheses(value?: string): string {
@@ -194,10 +191,10 @@ export class DraftSourcesComponent extends DataLoadingComponent {
 
   get draftSourcesAsArray(): DraftSourcesAsSelectableProjectArrays {
     return {
-      draftingSources: this.draftingSources.filter(isInstantiated),
-      trainingSources: this.trainingSources.filter(isInstantiated),
+      draftingSources: this.draftingSources.filter(notNull),
+      trainingSources: this.trainingSources.filter(notNull),
       trainingTargets: this.trainingTargets
-        .filter(isInstantiated)
+        .filter(notNull)
         .map(t => translateSourceToSelectableProjectWithLanguageTag(t))
     };
   }
@@ -257,7 +254,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     return (
       this.featureFlags.allowAdditionalTrainingSource.enabled &&
       this.trainingSources.length < 2 &&
-      this.trainingSources.every(isInstantiated)
+      this.trainingSources.every(notNull)
     );
   }
 
@@ -289,8 +286,8 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     const currentProjectDoc: SFProjectProfileDoc | undefined = this.activatedProjectService.projectDoc;
     if (!hasData(currentProjectDoc)) throw new Error('Project doc or data is null');
 
-    const definedSources: SelectableProjectWithLanguageCode[] = this.draftingSources.filter(isInstantiated);
-    const definedReferences: SelectableProjectWithLanguageCode[] = this.trainingSources.filter(isInstantiated);
+    const definedSources: SelectableProjectWithLanguageCode[] = this.draftingSources.filter(notNull);
+    const definedReferences: SelectableProjectWithLanguageCode[] = this.trainingSources.filter(notNull);
 
     let messageKey: I18nKeyForComponent<'draft_sources'> | undefined;
     if (definedSources.length === 0 && definedReferences.length === 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
@@ -49,8 +49,8 @@ export function hasPropWithValue<X, Y extends PropertyKey>(
 }
 
 /** Guarantees that the value is not null or undefined. */
-export function isInstantiated<T>(value: T): value is NonNullable<T> {
-  return value !== null && value !== undefined;
+export function notNull<T>(value: T): value is NonNullable<T> {
+  return value != null;
 }
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts
@@ -48,6 +48,18 @@ export function hasPropWithValue<X, Y extends PropertyKey>(
   return hasProp(obj, prop) && obj[prop] === val;
 }
 
+/** Guarantees that the value is not null or undefined. */
+export function isInstantiated<T>(value: T): value is NonNullable<T> {
+  return value !== null && value !== undefined;
+}
+
+/**
+ * Guarantees that the input object has a non-null data property.
+ */
+export function hasData<T extends { data: any }>(input: T | null | undefined): input is WithData<T> {
+  return hasProp(input, 'data') && input.data != null;
+}
+
 // The CaretPosition type is no longer in the TypeScript DOM API type definitions, though it is still in Firefox,
 // as of Firefox 104.0, on 2022-09-06
 export interface CaretPosition {
@@ -101,3 +113,8 @@ export type ObjectPaths<T, Depth extends number = 10> = Depth extends never
   : T extends object
     ? { [Key in keyof T]-?: JoinWithDot<Key, ObjectPaths<T[Key], OneLessThan[Depth]>> }[keyof T]
     : '';
+
+/**
+ * This has a data field that is not null. Such as for a realtime document that has a non-null data field.
+ */
+export type WithData<T extends { data: any }> = T & { data: NonNullable<T['data']> };

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { hasData, hasFunctionProp, hasProp, hasStringProp, isInstantiated, isObj, isString } from './type-utils';
+import { hasData, hasFunctionProp, hasProp, hasStringProp, isObj, isString, notNull } from './type-utils';
 
 const miscValues = [undefined, null, NaN, true, false, Infinity, -1, 0, Symbol(), '', '\0', () => {}, BigInt(3)];
 
@@ -81,11 +81,11 @@ describe('type utils', () => {
   });
 
   it('isInstantiated works', () => {
-    expect(isInstantiated(null)).toBeFalse();
-    expect(isInstantiated(undefined)).toBeFalse();
-    expect(isInstantiated('hello')).toBeTrue();
-    expect(isInstantiated({})).toBeTrue();
-    expect(isInstantiated(1)).toBeTrue();
-    expect(isInstantiated({ a: 'b' })).toBeTrue();
+    expect(notNull(null)).toBeFalse();
+    expect(notNull(undefined)).toBeFalse();
+    expect(notNull('hello')).toBeTrue();
+    expect(notNull({})).toBeTrue();
+    expect(notNull(1)).toBeTrue();
+    expect(notNull({ a: 'b' })).toBeTrue();
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { hasFunctionProp, hasProp, hasStringProp, isObj, isString } from './type-utils';
+import { hasData, hasFunctionProp, hasProp, hasStringProp, isInstantiated, isObj, isString } from './type-utils';
 
 const miscValues = [undefined, null, NaN, true, false, Infinity, -1, 0, Symbol(), '', '\0', () => {}, BigInt(3)];
 
@@ -65,5 +65,27 @@ describe('type utils', () => {
     expect(hasFunctionProp({}, 'hello')).toBeFalse();
     expect(hasFunctionProp({ hello: 'world' }, 'hello')).toBeFalse();
     expect(hasFunctionProp({ hello: () => {} }, 'hello')).toBeTrue();
+  });
+
+  it('hasData works', () => {
+    expect(hasData({ data: 'hello' })).toBeTrue();
+    expect(hasData({ data: {} })).toBeTrue();
+    expect(hasData({ data: null })).toBeFalse();
+    expect(hasData({ data: undefined })).toBeFalse();
+    expect(hasData(null)).toBeFalse();
+    expect(hasData(undefined)).toBeFalse();
+    // These could be good expectations, but are not expected to compile
+    // at this time.
+    // expect(hasData({})).toBeFalse();
+    // expect(hasData({ a: 'b' })).toBeFalse();
+  });
+
+  it('isInstantiated works', () => {
+    expect(isInstantiated(null)).toBeFalse();
+    expect(isInstantiated(undefined)).toBeFalse();
+    expect(isInstantiated('hello')).toBeTrue();
+    expect(isInstantiated({})).toBeTrue();
+    expect(isInstantiated(1)).toBeTrue();
+    expect(isInstantiated({ a: 'b' })).toBeTrue();
   });
 });


### PR DESCRIPTION
Clearing the first training source would incorrectly set it to the
source project.

The bug fix is in draft-sources.component.ts where we now pass
`definedReferences` and `definedSources` instead of
`this.trainingSources` and `this.draftingSources`.

draft-sources.component.html:
- I didn't see that the `loading ? undefined : ..` was working as
intended and removed it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3133)
<!-- Reviewable:end -->
