### PR TITLE
SF-3300 Retrieve the build id from the cancel build action on Serval

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -40,7 +40,7 @@
     <!-- When using a new major or minor version of ParatextData, update where dependencies.yml copies the
          InternetSettings.xml file. Also update server config scriptureforge.org_v2.yml. -->
     <PackageReference Include="ParatextData" Version="9.5.0.8" />
-    <PackageReference Include="Serval.Client" Version="1.9.0" />
+    <PackageReference Include="Serval.Client" Version="1.9.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="8.0.0" />

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -122,27 +122,14 @@ public class MachineApiService(
 
         try
         {
-            // TODO: When Serval implements https://github.com/sillsdev/serval/issues/648, this can be removed
-            TranslationBuild translationBuild;
-            try
-            {
-                translationBuild = await translationEnginesClient.GetCurrentBuildAsync(
-                    translationEngineId,
-                    minRevision: null,
-                    cancellationToken
-                );
-            }
-            catch (ServalApiException)
-            {
-                // Ignore all errors. Serious errors will be thrown in CancelBuildAsync() below
-                translationBuild = null;
-            }
-
             // Cancel the build on Serval
-            await translationEnginesClient.CancelBuildAsync(translationEngineId, cancellationToken);
+            TranslationBuild translationBuild = await translationEnginesClient.CancelBuildAsync(
+                translationEngineId,
+                cancellationToken
+            );
 
             // Return the build id so it can be logged
-            return translationBuild?.Id;
+            return translationBuild.Id;
         }
         catch (ServalApiException e) when (e.StatusCode == StatusCodes.Status404NotFound)
         {

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -172,9 +172,9 @@
       },
       "Serval.Client": {
         "type": "Direct",
-        "requested": "[1.9.0, )",
-        "resolved": "1.9.0",
-        "contentHash": "yWjQtF4vzsu33a/ctQHF6UDzqfgQ43qVUVs/y/f0HHANpMFVXFbGWX4185E+a4IowOoAwdrq49+Mwh+XhWDqOw==",
+        "requested": "[1.9.1, )",
+        "resolved": "1.9.1",
+        "contentHash": "z3/8q+IVde4Flf93+OhOzTzsm3PQATtElU67U1LLpk21/daEjc3HELkhvWMqW4OEuG2D1UssX/2XQh7/sNNvvA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
           "System.ComponentModel.Annotations": "5.0.0"

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -161,9 +161,12 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         await env.QueueBuildAsync(preTranslate: true);
+        env.TranslationEnginesClient.CancelBuildAsync(TranslationEngine01, CancellationToken.None)
+            .Returns(Task.FromResult(new TranslationBuild { Id = Build01 }));
 
         // SUT
-        await env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
+        string actual = await env.Service.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None);
+        Assert.AreEqual(Build01, actual);
 
         await env.TranslationEnginesClient.Received(1).CancelBuildAsync(TranslationEngine01, CancellationToken.None);
         env.BackgroundJobClient.Received(1).ChangeState(JobId, Arg.Any<DeletedState>(), null); // Same as Delete()

--- a/tools/ServalBuildReport/ServalBuildReport.csproj
+++ b/tools/ServalBuildReport/ServalBuildReport.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="NPOI" Version="2.7.3" />
-    <PackageReference Include="Serval.Client" Version="1.9.0" />
+    <PackageReference Include="Serval.Client" Version="1.9.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Serval.Client" Version="1.9.0" />
+    <PackageReference Include="Serval.Client" Version="1.9.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates to Serval.Client 1.9.1 (the version currently on QA), and updates the cancel build logic to use the new features of this release.

I am marking as testing not required, as testing can be completed by a developer due to the under-the-hood nature of this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3134)
<!-- Reviewable:end -->
