### PR TITLE
Fix project reference without a matching metadata reference warning

### DIFF
--- a/src/SIL.Converters.Usj/SIL.Converters.Usj.csproj
+++ b/src/SIL.Converters.Usj/SIL.Converters.Usj.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes the following warning that is displayed when running `dotnet watch`:
```
dotnet watch ⚠ msbuild: [Warning] Found project reference without a matching metadata reference: D:\Source\Repos\web-xforge\src\SIL.Converters.Usj\SIL.Converters.Usj.csproj
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3136)
<!-- Reviewable:end -->
