### PR TITLE
SF-3294 Fix text overflow on share project role select

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/ui-common.module.ts
@@ -22,7 +22,7 @@ import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginato
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatSelectModule } from '@angular/material/select';
+import { MAT_SELECT_CONFIG, MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSliderModule } from '@angular/material/slider';
@@ -107,6 +107,10 @@ const modules = [
     {
       provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
       useValue: { disableTooltipInteractivity: true }
+    },
+    {
+      provide: MAT_SELECT_CONFIG,
+      useValue: { panelWidth: null }
     }
   ]
 })


### PR DESCRIPTION
This PR fixes a problem where the select for a share role has text that overflows on different languages. I looked at decreasing the size of the text, but in the end it looked a lot better configuring the select to grow with the text.

Before
![image](https://github.com/user-attachments/assets/322ffccf-a845-469c-a498-e61d085a6e54)


After
![image](https://github.com/user-attachments/assets/bb2ed489-d87d-4297-bd3e-81a164c788da)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3138)
<!-- Reviewable:end -->
