### PR TITLE
SF-3303 Allow selection of the echo translation engine

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -202,17 +202,27 @@
           </div>
         </mat-step>
       }
-      @if (featureFlags.allowFastTraining.enabled) {
+      @if (featureFlags.allowFastTraining.enabled || featureFlags.useEchoForPreTranslation.enabled) {
         <mat-step [completed]="true">
           <ng-template matStepLabel>
             {{ t("configure_advanced_settings_header") }}
           </ng-template>
           <h1 class="mat-headline-4">{{ t("configure_advanced_settings_title") }}</h1>
-          <div>
-            <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
-          </div>
-          @if (fastTraining) {
-            <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>
+          @if (featureFlags.allowFastTraining.enabled) {
+            <div>
+              <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
+            </div>
+            @if (fastTraining) {
+              <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>
+            }
+          }
+          @if (featureFlags.useEchoForPreTranslation.enabled) {
+            <div>
+              <mat-checkbox class="use-echo" [(ngModel)]="useEcho">{{ t("use_echo") }}</mat-checkbox>
+            </div>
+            @if (useEcho) {
+              <app-notice icon="warning" type="warning" class="warning">{{ t("use_echo_warning") }}</app-notice>
+            }
           }
           <div class="button-strip">
             <button mat-stroked-button matStepperPrevious>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -137,6 +137,7 @@ describe('DraftGenerationStepsComponent', () => {
       );
       when(mockTrainingDataQuery.docs).thenReturn([]);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -202,6 +203,7 @@ describe('DraftGenerationStepsComponent', () => {
       );
       when(mockTrainingDataQuery.docs).thenReturn([]);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -437,6 +439,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
       when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
       when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
       when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
@@ -541,7 +544,8 @@ describe('DraftGenerationStepsComponent', () => {
           { projectId: 'source2', scriptureRange: 'EXO;JOS' }
         ],
         translationScriptureRange: 'JDG',
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       } as DraftGenerationStepsResult);
       expect(component.isStepsCompleted).toBe(true);
     }));
@@ -582,7 +586,8 @@ describe('DraftGenerationStepsComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [{ projectId: 'source2', scriptureRange: 'EXO;JOS' }],
         translationScriptureRange: 'JDG',
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       } as DraftGenerationStepsResult);
       expect(component.isStepsCompleted).toBe(true);
     });
@@ -680,6 +685,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
       when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(true));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
         instance(mockTrainingDataQuery)
       );
@@ -719,7 +725,96 @@ describe('DraftGenerationStepsComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'LEV;1SA;2SA' }],
         translationScriptureRange: 'EXO',
-        fastTraining: true
+        fastTraining: true,
+        useEcho: false
+      } as DraftGenerationStepsResult);
+      expect(generateDraftButton['disabled']).toBe(true);
+    });
+  });
+
+  describe('use echo feature flag is enabled', () => {
+    const availableBooks = [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 9 }, { bookNum: 10 }];
+    const allBooks = [{ bookNum: 1 }, ...availableBooks, { bookNum: 6 }, { bookNum: 7 }, { bookNum: 8 }];
+    const config: DraftSourcesAsArrays = {
+      trainingSources: [
+        {
+          projectRef: 'source1',
+          paratextId: 'PT_SP1',
+          name: 'Source Project 1',
+          shortName: 'sP1',
+          writingSystem: { tag: 'eng' },
+          texts: availableBooks.concat({ bookNum: 1 })
+        }
+      ],
+      trainingTargets: [
+        {
+          projectRef: mockActivatedProjectService.projectId!,
+          paratextId: 'PT_TT',
+          name: 'Target Project',
+          shortName: 'tT',
+          writingSystem: { tag: 'nllb' },
+          texts: allBooks.filter(b => b.bookNum !== 1 && b.bookNum !== 7)
+        }
+      ],
+      draftingSources: [
+        {
+          projectRef: 'draftingSource',
+          paratextId: 'PT_DS',
+          name: 'Drafting Source',
+          shortName: 'dS',
+          writingSystem: { tag: 'eng' },
+          texts: availableBooks.concat({ bookNum: 7 })
+        }
+      ]
+    };
+
+    beforeEach(fakeAsync(() => {
+      when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
+      when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
+      when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
+      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(true));
+      when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
+        instance(mockTrainingDataQuery)
+      );
+      when(mockTrainingDataQuery.docs).thenReturn([]);
+
+      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+    }));
+
+    it('should emit the use echo value if checked', () => {
+      component.onTranslateBookSelect([2]);
+      component.onTranslatedBookSelect([3, 9, 10]);
+      component.onSourceTrainingBookSelect([3, 9, 10], config.trainingSources[0]);
+
+      spyOn(component.done, 'emit');
+
+      fixture.detectChanges();
+      const step = fixture.debugElement.queryAll(By.css('mat-step-header'));
+      step[3].nativeElement.click(); //click the next step
+      fixture.detectChanges();
+      component.tryAdvanceStep();
+
+      // Tick the checkbox
+      const useEchoCheckbox = fixture.nativeElement.querySelector('mat-checkbox.use-echo input');
+      useEchoCheckbox.click();
+
+      // Click next on the final step to generate the draft
+      fixture.detectChanges();
+      const generateDraftButton: HTMLElement = fixture.nativeElement.querySelector('.advance-button');
+      expect(generateDraftButton['disabled']).toBe(false);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+
+      expect(component.done.emit).toHaveBeenCalledWith({
+        trainingDataFiles: [],
+        trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'LEV;1SA;2SA' }],
+        translationScriptureRange: 'EXO',
+        fastTraining: false,
+        useEcho: true
       } as DraftGenerationStepsResult);
       expect(generateDraftButton['disabled']).toBe(true);
     });
@@ -866,6 +961,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
         instance(mockTrainingDataQuery)
       );
@@ -933,7 +1029,8 @@ describe('DraftGenerationStepsComponent', () => {
         trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'EXO' }],
         translationScriptureRange: 'LEV',
         trainingDataFiles: fileIds,
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
     });
   });
@@ -1007,6 +1104,7 @@ describe('DraftGenerationStepsComponent', () => {
       );
       when(mockTrainingDataQuery.docs).thenReturn([]);
       when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -32,6 +32,7 @@ export interface DraftGenerationStepsResult {
   translationScriptureRange?: string;
   translationScriptureRanges?: ProjectScriptureRange[];
   fastTraining: boolean;
+  useEcho: boolean;
 }
 
 export interface Book {
@@ -89,6 +90,7 @@ export class DraftGenerationStepsComponent implements OnInit {
 
   trainingDataFilesAvailable = false;
   fastTraining: boolean = false;
+  useEcho: boolean = false;
 
   expandUnusableTranslateBooks = false;
   expandUnusableTrainingBooks = false;
@@ -464,7 +466,8 @@ export class DraftGenerationStepsComponent implements OnInit {
         translationScriptureRange: this.booksToTranslate()
           .map(b => Canon.bookNumberToId(b.number))
           .join(';'),
-        fastTraining: this.fastTraining
+        fastTraining: this.fastTraining,
+        useEcho: this.useEcho
       });
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -1043,6 +1043,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.fixture.detectChanges();
@@ -1052,7 +1053,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       env.startedOrActiveBuild$.next(buildDto);
       env.fixture.detectChanges();
@@ -1070,6 +1072,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.fixture.detectChanges();
@@ -1091,6 +1094,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Queued });
@@ -1099,7 +1103,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
@@ -1116,6 +1121,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Pending });
@@ -1124,7 +1130,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
@@ -1141,6 +1148,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Active });
@@ -1149,7 +1157,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       verify(mockDialogRef.getState()).never();
       verify(mockDialogRef.close()).never();
@@ -1167,6 +1176,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       env.startedOrActiveBuild$.next({ ...buildDto, state: BuildStates.Canceled });
@@ -1175,7 +1185,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       verify(mockDialogRef.close()).once();
     });
@@ -1235,6 +1246,7 @@ describe('DraftGenerationComponent', () => {
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
         fastTraining: false,
+        useEcho: false,
         projectId: projectId
       });
       tick();
@@ -1244,7 +1256,8 @@ describe('DraftGenerationComponent', () => {
         trainingDataFiles: [],
         trainingScriptureRanges: [],
         translationScriptureRanges: [],
-        fastTraining: false
+        fastTraining: false,
+        useEcho: false
       });
       expect(mockAuthService.requestParatextCredentialUpdate).toHaveBeenCalled();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -379,7 +379,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
       trainingScriptureRanges: result.trainingScriptureRanges,
       translationScriptureRange: result.translationScriptureRange,
       translationScriptureRanges: result.translationScriptureRanges || [],
-      fastTraining: result.fastTraining
+      fastTraining: result.fastTraining,
+      useEcho: result.useEcho
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -34,7 +34,8 @@ describe('DraftGenerationService', () => {
     trainingDataFiles: [],
     translationScriptureRanges: [],
     trainingScriptureRanges: [],
-    fastTraining: false
+    fastTraining: false,
+    useEcho: false
   };
   const buildDto: BuildDto = {
     id: 'testId',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -13,6 +13,7 @@ export interface BuildConfig {
   translationScriptureRange?: string;
   translationScriptureRanges: ProjectScriptureRange[];
   fastTraining: boolean;
+  useEcho: boolean;
 }
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -259,7 +259,9 @@
     "training_books_will_appear": "Training books will appear as you select books under translated books",
     "translated_books": "Translated books",
     "translated_book_selected_no_training_pair": "Some of the training books you selected have no matching reference books selected. Please select matching reference books.",
-    "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project."
+    "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project.",
+    "use_echo_warning": "Enabling this will echo your source text instead of translating it.",
+    "use_echo": "Use Echo Translation Engine"
   },
   "draft_preview_books": {
     "add_to_project": "Add to project",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -277,9 +277,9 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  private readonly useEchoForPreTranslation: FeatureFlag = new ServerOnlyFeatureFlag(
+  readonly useEchoForPreTranslation: FeatureFlag = new FeatureFlagFromStorage(
     'UseEchoForPreTranslation',
-    'Use Echo for Pre-Translation Drafting',
+    'Allow Echo for Pre-Translation Drafting',
     10,
     this.featureFlagStore
   );

--- a/src/SIL.XForge.Scripture/Models/BuildConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/BuildConfig.cs
@@ -92,4 +92,13 @@ public class BuildConfig
     /// A fast training build will be very inaccurate. Only use this value if you are testing or debugging.
     /// </remarks>
     public bool FastTraining { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value that configures the Serval build to use the Echo translation engine
+    /// </summary>
+    /// <value><c>true</c> if we are using the echo translation engine; otherwise, <c>false</c>.</value>
+    /// <remarks>
+    /// A build made using echo will just echo the source text. Only use this value if you are testing or debugging.
+    /// </remarks>
+    public bool UseEcho { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
+++ b/src/SIL.XForge.Scripture/Models/FeatureFlags.cs
@@ -1,9 +1,0 @@
-namespace SIL.XForge.Scripture.Models;
-
-/// <summary>
-/// Definitions for feature flags set in the FeatureManagement configuration section.
-/// </summary>
-public static class FeatureFlags
-{
-    public const string UseEchoForPreTranslation = "UseEchoForPreTranslation";
-}

--- a/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
+++ b/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
@@ -72,6 +72,12 @@ public class BuildConfigJsonConverter : JsonConverter<BuildConfig>
             serializer.Serialize(writer, value.FastTraining);
         }
 
+        if (value.UseEcho)
+        {
+            writer.WritePropertyName(nameof(value.UseEcho));
+            serializer.Serialize(writer, value.UseEcho);
+        }
+
         writer.WritePropertyName(nameof(value.ProjectId));
         serializer.Serialize(writer, value.ProjectId);
 

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -8,6 +8,5 @@ public interface IMachineProjectService
 {
     Task<string> AddSmtProjectAsync(string sfProjectId, CancellationToken cancellationToken);
     Task<string> GetProjectZipAsync(string sfProjectId, Stream outputStream, CancellationToken cancellationToken);
-    Task<string> GetTranslationEngineTypeAsync(bool preTranslate);
     Task RemoveProjectAsync(string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -36,7 +36,6 @@ public class MachineApiService(
     IEventMetricService eventMetricService,
     IExceptionHandler exceptionHandler,
     ILogger<MachineApiService> logger,
-    IMachineProjectService machineProjectService,
     IParatextService paratextService,
     IPreTranslationService preTranslationService,
     IRepository<SFProjectSecret> projectSecrets,
@@ -800,9 +799,8 @@ public class MachineApiService(
 
     public async Task<LanguageDto> IsLanguageSupportedAsync(string languageCode, CancellationToken cancellationToken)
     {
-        string engineType = await machineProjectService.GetTranslationEngineTypeAsync(preTranslate: true);
         LanguageInfo languageInfo = await translationEngineTypesClient.GetLanguageInfoAsync(
-            engineType,
+            engineType: MachineProjectService.Nmt,
             languageCode,
             cancellationToken
         );

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -62,7 +62,6 @@
   "FeatureManagement": {
     "Serval": true,
     "MachineInProcess": false,
-    "UploadParatextZipForPreTranslation": false,
-    "UseEchoForPreTranslation": false
+    "UploadParatextZipForPreTranslation": false
   }
 }

--- a/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
@@ -22,12 +22,14 @@ namespace SIL.XForge.Scripture.Controllers;
 [TestFixture]
 public class AnonymousControllerTests
 {
+    private const string TestFeatureFlag = "test_feature_flag";
+
     [Test]
     public async Task FeatureFlags_ReturnsFeatureFlags()
     {
         var env = new TestEnvironment();
         env.FeatureManager.GetFeatureNamesAsync().Returns(TestEnvironment.GetFeatureFlags());
-        env.FeatureManager.IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation).Returns(Task.FromResult(true));
+        env.FeatureManager.IsEnabledAsync(TestFeatureFlag).Returns(Task.FromResult(true));
 
         // SUT
         var actual = await env.Controller.FeatureFlags();
@@ -36,7 +38,7 @@ public class AnonymousControllerTests
         Assert.IsInstanceOf<JsonResult>(actual.Result);
         Dictionary<string, bool> featureFlags = (actual.Result as JsonResult)?.Value as Dictionary<string, bool>;
         Assert.IsNotNull(featureFlags);
-        Assert.IsTrue(featureFlags![FeatureFlags.UseEchoForPreTranslation]);
+        Assert.IsTrue(featureFlags![TestFeatureFlag]);
     }
 
     [Test]
@@ -193,7 +195,7 @@ public class AnonymousControllerTests
 
         public static async IAsyncEnumerable<string> GetFeatureFlags()
         {
-            yield return FeatureFlags.UseEchoForPreTranslation;
+            yield return TestFeatureFlag;
             await Task.CompletedTask;
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/BuildConfigJsonConverterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/BuildConfigJsonConverterTests.cs
@@ -23,6 +23,7 @@ public class BuildConfigJsonConverterTests
         var buildConfig = new BuildConfig
         {
             FastTraining = true,
+            UseEcho = true,
             TrainingBooks = [1, 2, 3],
             TranslationBooks = [4, 5, 6],
             ProjectId = Project01,
@@ -34,6 +35,8 @@ public class BuildConfigJsonConverterTests
         writer.Received().WriteStartObject();
         writer.Received().WritePropertyName(nameof(buildConfig.FastTraining));
         serializer.Received().Serialize(writer, buildConfig.FastTraining);
+        writer.Received().WritePropertyName(nameof(buildConfig.UseEcho));
+        serializer.Received().Serialize(writer, buildConfig.UseEcho);
         writer.Received().WritePropertyName(nameof(buildConfig.TrainingBooks));
         serializer.Received().Serialize(writer, buildConfig.TrainingBooks);
         writer.Received().WritePropertyName(nameof(buildConfig.TranslationBooks));
@@ -44,7 +47,7 @@ public class BuildConfigJsonConverterTests
     }
 
     [Test]
-    public void WriteJson_Serializes_BuildConfigWithoutFastTraining()
+    public void WriteJson_Serializes_BuildConfigWithoutFastTrainingOrEcho()
     {
         var converter = new BuildConfigJsonConverter();
         var writer = Substitute.For<JsonWriter>();
@@ -61,6 +64,7 @@ public class BuildConfigJsonConverterTests
 
         writer.Received().WriteStartObject();
         writer.DidNotReceive().WritePropertyName(nameof(buildConfig.FastTraining));
+        writer.DidNotReceive().WritePropertyName(nameof(buildConfig.UseEcho));
         writer.Received().WritePropertyName(nameof(buildConfig.TrainingBooks));
         serializer.Received().Serialize(writer, buildConfig.TrainingBooks);
         writer.Received().WritePropertyName(nameof(buildConfig.TranslationBooks));
@@ -261,7 +265,8 @@ public class BuildConfigJsonConverterTests
             "{{nameof(BuildConfig.ProjectId)}}":"{{Project01}}",
             "{{nameof(BuildConfig.TrainingBooks)}}":[1,2,3],
             "{{nameof(BuildConfig.TranslationBooks)}}":[4,5,6],
-            "{{nameof(BuildConfig.FastTraining)}}":true
+            "{{nameof(BuildConfig.FastTraining)}}":true,
+            "{{nameof(BuildConfig.UseEcho)}}":true
             }
             """;
         using var stringReader = new StringReader(jsonString);
@@ -274,13 +279,14 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsTrue(buildConfig!.FastTraining);
+        Assert.IsTrue(buildConfig.UseEcho);
         CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, buildConfig.TrainingBooks);
         CollectionAssert.AreEqual(new List<int> { 4, 5, 6 }, buildConfig.TranslationBooks);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
     }
 
     [Test]
-    public void ReadJson_Deserializes_JSON_Object_WithoutFastConfig()
+    public void ReadJson_Deserializes_JSON_Object_WithoutFastTrainingOrEchoConfig()
     {
         var converter = new BuildConfigJsonConverter();
         const string jsonString = $$"""
@@ -300,6 +306,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         CollectionAssert.AreEqual(new List<int> { 1, 2, 3 }, buildConfig.TrainingBooks);
         CollectionAssert.AreEqual(new List<int> { 4, 5, 6 }, buildConfig.TranslationBooks);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
@@ -325,6 +332,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         CollectionAssert.AreEqual(new List<string> { Data01, Data02 }, buildConfig.TrainingDataFiles);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
     }
@@ -350,6 +358,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         Assert.AreEqual(scriptureRange, buildConfig.TrainingScriptureRange);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
     }
@@ -375,6 +384,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         Assert.AreEqual(scriptureRange, buildConfig.TranslationScriptureRange);
         Assert.AreEqual(Project01, buildConfig.ProjectId);
     }
@@ -406,6 +416,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         CollectionAssert.AreEqual(
             new List<ProjectScriptureRange>
             {
@@ -443,6 +454,7 @@ public class BuildConfigJsonConverterTests
         Assert.IsNotNull(buildConfig);
         Assert.IsInstanceOf<BuildConfig>(buildConfig);
         Assert.IsFalse(buildConfig!.FastTraining);
+        Assert.IsFalse(buildConfig.UseEcho);
         CollectionAssert.AreEqual(
             new List<ProjectScriptureRange>
             {

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -3103,11 +3103,6 @@ public class MachineApiServiceTests
             DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
             EventMetricService = Substitute.For<IEventMetricService>();
             ExceptionHandler = Substitute.For<IExceptionHandler>();
-
-            var machineProjectService = Substitute.For<IMachineProjectService>();
-            machineProjectService
-                .GetTranslationEngineTypeAsync(preTranslate: true)
-                .Returns(Task.FromResult(Services.MachineProjectService.Nmt));
             MockLogger = new MockLogger<MachineApiService>();
             ParatextService = Substitute.For<IParatextService>();
             PreTranslationService = Substitute.For<IPreTranslationService>();
@@ -3210,7 +3205,6 @@ public class MachineApiServiceTests
                 EventMetricService,
                 ExceptionHandler,
                 MockLogger,
-                machineProjectService,
                 ParatextService,
                 PreTranslationService,
                 ProjectSecrets,

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.FeatureManagement;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -89,7 +88,7 @@ public class MachineProjectServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: false, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: false, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine01));
 
         // SUT
@@ -238,7 +237,8 @@ public class MachineProjectServiceTests
         env.ExceptionHandler.DidNotReceive().ReportException(Arg.Any<Exception>());
     }
 
-    public static async Task BuildProjectForBackgroundJobAsync_InvalidDataException()
+    [Test]
+    public async Task BuildProjectForBackgroundJobAsync_InvalidDataException()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -380,6 +380,7 @@ public class MachineProjectServiceTests
                 Arg.Any<IDocument<SFProject>>(),
                 Arg.Any<SFProjectSecret>(),
                 preTranslate: true,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.FromResult(TranslationEngine01));
@@ -388,6 +389,7 @@ public class MachineProjectServiceTests
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: true,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.CompletedTask);
@@ -435,6 +437,7 @@ public class MachineProjectServiceTests
                 Arg.Any<IDocument<SFProject>>(),
                 Arg.Any<SFProjectSecret>(),
                 preTranslate: false,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.FromResult(TranslationEngine01));
@@ -443,6 +446,7 @@ public class MachineProjectServiceTests
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: false,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.CompletedTask);
@@ -531,6 +535,7 @@ public class MachineProjectServiceTests
                 Arg.Any<IDocument<SFProject>>(),
                 Arg.Any<SFProjectSecret>(),
                 preTranslate: true,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.FromResult(TranslationEngine01));
@@ -539,6 +544,7 @@ public class MachineProjectServiceTests
                 TranslationEngine01,
                 Arg.Any<SFProject>(),
                 preTranslate: true,
+                useEcho: false,
                 CancellationToken.None
             )
             .Returns(Task.CompletedTask);
@@ -667,7 +673,12 @@ public class MachineProjectServiceTests
         await env.SetupProjectSecretAsync(Project01, new ServalData { PreTranslationEngineId = TranslationEngine01 });
 
         // SUT
-        string actual = await env.Service.CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        string actual = await env.Service.CreateServalProjectAsync(
+            project,
+            preTranslate: true,
+            useEcho: false,
+            CancellationToken.None
+        );
         Assert.AreEqual(TranslationEngine01, actual);
         await env.TranslationEnginesClient.DidNotReceiveWithAnyArgs().CreateAsync(Arg.Any<TranslationEngineConfig>());
     }
@@ -680,12 +691,17 @@ public class MachineProjectServiceTests
         await env.SetupProjectSecretAsync(Project01, new ServalData());
         var project = new SFProject { Id = Project01 };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns("de");
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
         // SUT
-        string actual = await env.Service.CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        string actual = await env.Service.CreateServalProjectAsync(
+            project,
+            preTranslate: true,
+            useEcho: false,
+            CancellationToken.None
+        );
         Assert.AreEqual(TranslationEngine01, actual);
         Assert.AreEqual(TranslationEngine01, env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationEngineId);
     }
@@ -698,7 +714,7 @@ public class MachineProjectServiceTests
         await env.SetupProjectSecretAsync(Project01, new ServalData());
         var project = new SFProject { Id = Project01 };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: false).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: false).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: false, useEcho: false).Returns("de");
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -706,6 +722,7 @@ public class MachineProjectServiceTests
         string actual = await env.Service.CreateServalProjectAsync(
             project,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine01, actual);
@@ -724,6 +741,7 @@ public class MachineProjectServiceTests
         string actual = await env.Service.CreateServalProjectAsync(
             project,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine01, actual);
@@ -737,12 +755,17 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns("de");
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
         // SUT
-        string actual = await env.Service.CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        string actual = await env.Service.CreateServalProjectAsync(
+            project,
+            preTranslate: true,
+            useEcho: false,
+            CancellationToken.None
+        );
         Assert.AreEqual(TranslationEngine01, actual);
         Assert.AreEqual(TranslationEngine01, env.ProjectSecrets.Get(Project01).ServalData?.PreTranslationEngineId);
     }
@@ -754,7 +777,7 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: false).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: false).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: false, useEcho: false).Returns("de");
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine { Id = TranslationEngine01 }));
 
@@ -762,6 +785,7 @@ public class MachineProjectServiceTests
         string actual = await env.Service.CreateServalProjectAsync(
             project,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine01, actual);
@@ -775,13 +799,19 @@ public class MachineProjectServiceTests
         var env = new TestEnvironment();
         var project = new SFProject { Id = Project01 };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns("de");
         env.TranslationEnginesClient.CreateAsync(Arg.Any<TranslationEngineConfig>())
             .Returns(Task.FromResult(new TranslationEngine()));
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(
-            () => env.Service.CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
+            () =>
+                env.Service.CreateServalProjectAsync(
+                    project,
+                    preTranslate: true,
+                    useEcho: false,
+                    CancellationToken.None
+                )
         );
     }
 
@@ -895,6 +925,7 @@ public class MachineProjectServiceTests
             projectDoc,
             projectSecret,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine01, actual);
@@ -925,6 +956,7 @@ public class MachineProjectServiceTests
                     projectDoc,
                     projectSecret,
                     preTranslate: true,
+                    useEcho: false,
                     CancellationToken.None
                 )
         );
@@ -960,6 +992,7 @@ public class MachineProjectServiceTests
                     projectDoc,
                     projectSecret,
                     preTranslate: true,
+                    useEcho: false,
                     CancellationToken.None
                 )
         );
@@ -991,6 +1024,7 @@ public class MachineProjectServiceTests
                     projectDoc,
                     projectSecret,
                     preTranslate: false,
+                    useEcho: false,
                     CancellationToken.None
                 )
         );
@@ -1008,7 +1042,7 @@ public class MachineProjectServiceTests
             .TranslationEngineExistsAsync(Project03, TranslationEngine01, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(false));
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine02));
         env.ParatextService.GetWritingSystem(Arg.Any<UserSecret>(), Paratext01)
             .Returns(new WritingSystem { Tag = sourceLanguage });
@@ -1027,6 +1061,7 @@ public class MachineProjectServiceTests
             projectDoc,
             projectSecret,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine02, actual);
@@ -1046,7 +1081,7 @@ public class MachineProjectServiceTests
             .TranslationEngineExistsAsync(Project03, TranslationEngine01, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(false));
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine02));
         env.ParatextService.GetWritingSystem(Arg.Any<UserSecret>(), Paratext03)
             .Returns(new WritingSystem { Tag = targetLanguage });
@@ -1064,6 +1099,7 @@ public class MachineProjectServiceTests
             projectDoc,
             projectSecret,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine02, actual);
@@ -1083,7 +1119,7 @@ public class MachineProjectServiceTests
             .TranslationEngineExistsAsync(Project03, TranslationEngine01, preTranslate: false, CancellationToken.None)
             .Returns(Task.FromResult(false));
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: false, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: false, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(TranslationEngine02));
         env.ParatextService.GetWritingSystem(Arg.Any<UserSecret>(), Paratext01)
             .Returns(new WritingSystem { Tag = sourceLanguage });
@@ -1102,6 +1138,7 @@ public class MachineProjectServiceTests
             projectDoc,
             projectSecret,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine02, actual);
@@ -1133,6 +1170,7 @@ public class MachineProjectServiceTests
             projectDoc,
             projectSecret,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.AreEqual(TranslationEngine01, actual);
@@ -1148,7 +1186,7 @@ public class MachineProjectServiceTests
             .TranslationEngineExistsAsync(Project01, TranslationEngine01, preTranslate: true, CancellationToken.None)
             .Returns(Task.FromResult(false));
         env.Service.Configure()
-            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(Arg.Any<SFProject>(), preTranslate: true, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult<string?>(null));
 
         // Retrieve required objects
@@ -1165,6 +1203,7 @@ public class MachineProjectServiceTests
                     projectDoc,
                     projectSecret,
                     preTranslate: true,
+                    useEcho: false,
                     CancellationToken.None
                 )
         );
@@ -1195,6 +1234,7 @@ public class MachineProjectServiceTests
                     projectDoc,
                     projectSecret,
                     preTranslate: true,
+                    useEcho: false,
                     CancellationToken.None
                 )
         );
@@ -1417,21 +1457,21 @@ public class MachineProjectServiceTests
     }
 
     [Test]
-    public async Task GetTargetLanguageAsync_ReturnSourceIfEcho()
+    public void GetTargetLanguage_ReturnSourceIfEcho()
     {
         // Set up test environment
-        var env = new TestEnvironment(new TestEnvironmentOptions { UseEchoForPreTranslation = true });
+        var env = new TestEnvironment();
         const string sourceWritingSystemTag = "source_writing_system_tag";
         var project = new SFProject();
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceWritingSystemTag);
 
         // SUT
-        string actual = await env.Service.GetTargetLanguageAsync(project, preTranslate: true);
+        string actual = env.Service.GetTargetLanguage(project, preTranslate: true, useEcho: true);
         Assert.AreEqual(sourceWritingSystemTag, actual);
     }
 
     [Test]
-    public async Task GetTargetLanguageAsync_Success()
+    public void GetTargetLanguage_Success()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -1439,7 +1479,7 @@ public class MachineProjectServiceTests
         var project = new SFProject { WritingSystem = new WritingSystem { Tag = targetWritingSystemTag } };
 
         // SUT
-        string actual = await env.Service.GetTargetLanguageAsync(project, preTranslate: true);
+        string actual = env.Service.GetTargetLanguage(project, preTranslate: true, useEcho: false);
         Assert.AreEqual(targetWritingSystemTag, actual);
     }
 
@@ -1851,37 +1891,18 @@ public class MachineProjectServiceTests
         );
     }
 
-    [Test]
-    public async Task GetTranslationEngineTypeAsync_Echo()
-    {
-        // Set up test environment
-        var env = new TestEnvironment(new TestEnvironmentOptions { UseEchoForPreTranslation = true });
-
-        // SUT
-        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: true);
-        Assert.AreEqual(MachineProjectService.Echo, actual);
-    }
-
-    [Test]
-    public async Task GetTranslationEngineTypeAsync_Nmt()
+    [TestCase(false, false, MachineProjectService.SmtTransfer)]
+    [TestCase(false, true, MachineProjectService.SmtTransfer)]
+    [TestCase(true, false, MachineProjectService.Nmt)]
+    [TestCase(true, true, MachineProjectService.Echo)]
+    public void GetTranslationEngineType(bool preTranslate, bool useEcho, string expected)
     {
         // Set up test environment
         var env = new TestEnvironment();
 
         // SUT
-        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: true);
-        Assert.AreEqual(MachineProjectService.Nmt, actual);
-    }
-
-    [Test]
-    public async Task GetTranslationEngineTypeAsync_Smt()
-    {
-        // Set up test environment
-        var env = new TestEnvironment();
-
-        // SUT
-        var actual = await env.Service.GetTranslationEngineTypeAsync(preTranslate: false);
-        Assert.AreEqual(MachineProjectService.SmtTransfer, actual);
+        var actual = env.Service.GetTranslationEngineType(preTranslate, useEcho);
+        Assert.AreEqual(expected, actual);
     }
 
     [Test]
@@ -1893,11 +1914,9 @@ public class MachineProjectServiceTests
         const string targetLanguage = "en";
         const string sourceLanguage = "de";
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns(targetLanguage);
         env.Service.Configure()
-            .GetTargetLanguageAsync(project, preTranslate: true)
-            .Returns(Task.FromResult(targetLanguage));
-        env.Service.Configure()
-            .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
         env.Service.Configure()
             .RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None)
@@ -1910,6 +1929,7 @@ public class MachineProjectServiceTests
                         Id = TranslationEngine01,
                         SourceLanguage = sourceLanguage,
                         TargetLanguage = targetLanguage,
+                        Type = MachineProjectService.Nmt,
                     }
                 )
             );
@@ -1919,6 +1939,7 @@ public class MachineProjectServiceTests
             TranslationEngine01,
             project,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         await env
@@ -1926,7 +1947,7 @@ public class MachineProjectServiceTests
             .RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None);
         await env
             .Service.DidNotReceiveWithAnyArgs()
-            .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: false, CancellationToken.None);
     }
 
     [Test]
@@ -1939,9 +1960,7 @@ public class MachineProjectServiceTests
         const string oldSourceLanguage = "de";
         const string newSourceLanguage = "fr";
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(oldSourceLanguage);
-        env.Service.Configure()
-            .GetTargetLanguageAsync(project, preTranslate: true)
-            .Returns(Task.FromResult(targetLanguage));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns(targetLanguage);
         env.TranslationEnginesClient.GetAsync(TranslationEngine01)
             .Returns(
                 Task.FromResult(
@@ -1950,6 +1969,7 @@ public class MachineProjectServiceTests
                         Id = TranslationEngine01,
                         SourceLanguage = newSourceLanguage,
                         TargetLanguage = targetLanguage,
+                        Type = MachineProjectService.Nmt,
                     }
                 )
             );
@@ -1959,6 +1979,7 @@ public class MachineProjectServiceTests
             TranslationEngine01,
             project,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         await env
@@ -1977,8 +1998,8 @@ public class MachineProjectServiceTests
         const string sourceLanguage = "de";
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
         env.Service.Configure()
-            .GetTargetLanguageAsync(project, preTranslate: true)
-            .Returns(Task.FromResult(newTargetLanguage));
+            .GetTargetLanguage(project, preTranslate: true, useEcho: false)
+            .Returns(newTargetLanguage);
         env.TranslationEnginesClient.GetAsync(TranslationEngine01)
             .Returns(
                 Task.FromResult(
@@ -1987,6 +2008,7 @@ public class MachineProjectServiceTests
                         Id = TranslationEngine01,
                         SourceLanguage = sourceLanguage,
                         TargetLanguage = oldTargetLanguage,
+                        Type = MachineProjectService.Nmt,
                     }
                 )
             );
@@ -1996,6 +2018,7 @@ public class MachineProjectServiceTests
             TranslationEngine01,
             project,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         await env
@@ -2012,7 +2035,7 @@ public class MachineProjectServiceTests
         var project = new SFProject { Id = Project01 };
         ServalApiException ex = ServalApiExceptions.NotFound;
         env.Service.Configure()
-            .CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None)
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
         env.TranslationEnginesClient.GetAsync(TranslationEngine01).ThrowsAsync(ex);
 
@@ -2021,11 +2044,61 @@ public class MachineProjectServiceTests
             TranslationEngine01,
             project,
             preTranslate: true,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData!.PreTranslationEngineId);
-        await env.Service.Received(1).CreateServalProjectAsync(project, preTranslate: true, CancellationToken.None);
+        await env
+            .Service.Received(1)
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: false, CancellationToken.None);
         env.MockLogger.AssertHasEvent(l => l.Exception == ex && l.LogLevel == LogLevel.Information);
+    }
+
+    [Test]
+    public async Task RecreateOrUpdateTranslationEngineIfRequiredAsync_RecreatePreTranslationEngineIfEngineChanges()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupProjectSecretAsync(Project01, new ServalData { PreTranslationEngineId = TranslationEngine01 });
+        var project = new SFProject { Id = Project01 };
+        const string oldTargetLanguage = "en";
+        const string newTargetLanguage = "fr";
+        const string sourceLanguage = "de";
+        env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
+        env.Service.Configure()
+            .GetTargetLanguage(project, preTranslate: true, useEcho: false)
+            .Returns(newTargetLanguage);
+        env.Service.Configure()
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: false, CancellationToken.None)
+            .Returns(Task.FromResult(string.Empty));
+        env.Service.Configure()
+            .RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None)
+            .Returns(Task.CompletedTask);
+        env.TranslationEnginesClient.GetAsync(TranslationEngine01)
+            .Returns(
+                Task.FromResult(
+                    new TranslationEngine
+                    {
+                        Id = TranslationEngine01,
+                        SourceLanguage = sourceLanguage,
+                        TargetLanguage = oldTargetLanguage,
+                        Type = MachineProjectService.Nmt,
+                    }
+                )
+            );
+
+        // SUT
+        await env.Service.RecreateOrUpdateTranslationEngineIfRequiredAsync(
+            TranslationEngine01,
+            project,
+            preTranslate: true,
+            useEcho: true,
+            CancellationToken.None
+        );
+        await env.Service.Received(1).RemoveProjectAsync(Project01, preTranslate: true, CancellationToken.None);
+        await env
+            .Service.Received(1)
+            .CreateServalProjectAsync(project, preTranslate: true, useEcho: true, CancellationToken.None);
     }
 
     [Test]
@@ -2037,7 +2110,7 @@ public class MachineProjectServiceTests
         var project = new SFProject { Id = Project01 };
         ServalApiException ex = ServalApiExceptions.NotFound;
         env.Service.Configure()
-            .CreateServalProjectAsync(project, preTranslate: false, CancellationToken.None)
+            .CreateServalProjectAsync(project, preTranslate: false, useEcho: false, CancellationToken.None)
             .Returns(Task.FromResult(string.Empty));
         env.TranslationEnginesClient.GetAsync(TranslationEngine01).ThrowsAsync(ex);
 
@@ -2046,10 +2119,13 @@ public class MachineProjectServiceTests
             TranslationEngine01,
             project,
             preTranslate: false,
+            useEcho: false,
             CancellationToken.None
         );
         Assert.IsNull(env.ProjectSecrets.Get(Project01).ServalData!.TranslationEngineId);
-        await env.Service.Received(1).CreateServalProjectAsync(project, preTranslate: false, CancellationToken.None);
+        await env
+            .Service.Received(1)
+            .CreateServalProjectAsync(project, preTranslate: false, useEcho: false, CancellationToken.None);
         env.MockLogger.AssertHasEvent(l => l.Exception == ex && l.LogLevel == LogLevel.Information);
     }
 
@@ -2664,7 +2740,7 @@ public class MachineProjectServiceTests
             TargetCorpusId = Corpus02,
         };
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns("en");
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns("de");
         env.Service.Configure()
             .CreateOrUpdateParallelCorpusAsync(
                 TranslationEngine01,
@@ -2720,7 +2796,7 @@ public class MachineProjectServiceTests
         var buildConfig = new BuildConfig { TrainingDataFiles = [Data01] };
         var additionalTrainingData = new ServalAdditionalTrainingData();
         env.Service.Configure().GetSourceLanguage(project, preTranslate: true).Returns(sourceLanguage);
-        env.Service.Configure().GetTargetLanguageAsync(project, preTranslate: true).Returns(Task.FromResult("de"));
+        env.Service.Configure().GetTargetLanguage(project, preTranslate: true, useEcho: false).Returns("de");
         env.Service.Configure()
             .CreateOrUpdateParallelCorpusAsync(
                 TranslationEngine01,
@@ -3783,7 +3859,6 @@ public class MachineProjectServiceTests
         public bool LegacyCorpora { get; init; }
         public bool PreTranslate { get; init; }
         public bool Source { get; init; }
-        public bool UseEchoForPreTranslation { get; init; }
 
         /// <summary>
         /// Determines if the test has the minimum required configuration to succeed.
@@ -3860,11 +3935,6 @@ public class MachineProjectServiceTests
             ParatextService
                 .GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
                 .Returns(new ParatextSettings { IsRightToLeft = true, LanguageTag = LanguageTag });
-
-            FeatureManager = Substitute.For<IFeatureManager>();
-            FeatureManager
-                .IsEnabledAsync(FeatureFlags.UseEchoForPreTranslation)
-                .Returns(Task.FromResult(options.UseEchoForPreTranslation));
 
             FileSystemService = Substitute.For<IFileSystemService>();
             FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
@@ -4057,7 +4127,6 @@ public class MachineProjectServiceTests
                 CorporaClient,
                 DataFilesClient,
                 ExceptionHandler,
-                FeatureManager,
                 FileSystemService,
                 MockLogger,
                 ParatextService,
@@ -4073,7 +4142,6 @@ public class MachineProjectServiceTests
         public MachineProjectService Service { get; }
         public ICorporaClient CorporaClient { get; }
         public IDataFilesClient DataFilesClient { get; }
-        public IFeatureManager FeatureManager { get; }
         public IFileSystemService FileSystemService { get; }
         public IParatextService ParatextService { get; }
         public SFMemoryRealtimeService RealtimeService { get; }


### PR DESCRIPTION
This PR changes the echo translation engine from being a feature flag configured on the server via user secrets, to a settings that can be set per build, like fast training.

**Notes**
If the "Allow Echo for Pre-Translation Drafting" feature flag is disabled, edit your user secrets and ensure that this secret is not present:
```
"FeatureManagement:UseEchoForPreTranslation": "false",
```