### PR TITLE
Show chapter number when archiving questions in chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.html
@@ -115,7 +115,9 @@
                                   class="archive-btn"
                                 >
                                   <mat-icon>archive</mat-icon>
-                                  <span>{{ t("archive_multiple", { location: getBookName(text) }) }}</span>
+                                  <span>
+                                    {{ t("archive_multiple", { location: getBookName(text) + " " + chapter.number }) }}
+                                  </span>
                                 </button>
                               }
                               @if (!chapter.hasAudio && canCreateScriptureAudio) {


### PR DESCRIPTION
The chapter number got dropped at some point.

### Before
![](https://github.com/user-attachments/assets/c1871410-e917-4be4-be61-dc01575d13b4)


### After
![](https://github.com/user-attachments/assets/317995c7-3608-4246-8e3b-8067a4ae38ac)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3142)
<!-- Reviewable:end -->
