### PR TITLE
Add url links for Indonesian on Help Site

### DIFF
--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -17,6 +17,7 @@
     "localName": "Bahasa Indonesia",
     "englishName": "Indonesian",
     "tags": ["id", "id-ID"],
+    "helps": "id",
     "production": true
   },
   {


### PR DESCRIPTION
Indonesian has been published to the Help Site and this PR updates the help links to navigate to `https://help.scriptureforge.org/id`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3144)
<!-- Reviewable:end -->
