### PR TITLE
SF-3198 Fix memory leak in RealtimeService from CheckIfRunning()

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -117,6 +117,8 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<LanguageDto> IsLanguageSupportedAsync(string languageCode, CancellationToken cancellationToken);
+
+    [Mutex]
     Task RetrievePreTranslationStatusAsync(string sfProjectId, CancellationToken cancellationToken);
 
     [LogEventMetric(EventScope.Drafting, nameof(curUserId), nameof(sfProjectId))]

--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -1,12 +1,24 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
 public interface IMachineProjectService
 {
     Task<string> AddSmtProjectAsync(string sfProjectId, CancellationToken cancellationToken);
+
+    [Mutex]
+    Task BuildProjectForBackgroundJobAsync(
+        string curUserId,
+        BuildConfig buildConfig,
+        bool preTranslate,
+        CancellationToken cancellationToken
+    );
     Task<string> GetProjectZipAsync(string sfProjectId, Stream outputStream, CancellationToken cancellationToken);
     Task RemoveProjectAsync(string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
+
+    [Mutex]
+    Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId);
 }

--- a/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextSyncRunner.cs
@@ -5,5 +5,6 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IParatextSyncRunner
 {
+    [Mutex]
     Task RunAsync(string projectId, string userId, string syncMetricsId, bool trainEngine, CancellationToken token);
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -223,7 +223,7 @@ public class MachineApiService(
         );
 
         // Run the background job
-        backgroundJobClient.Enqueue<MachineApiService>(r =>
+        backgroundJobClient.Enqueue<IMachineApiService>(r =>
             r.RetrievePreTranslationStatusAsync(projectId, CancellationToken.None)
         );
     }
@@ -912,7 +912,6 @@ public class MachineApiService(
         };
     }
 
-    [Mutex]
     public async Task RetrievePreTranslationStatusAsync(string sfProjectId, CancellationToken cancellationToken)
     {
         try
@@ -990,7 +989,7 @@ public class MachineApiService(
         string syncJobId = await projectService.SyncAsync(curUserId, sfProjectId);
 
         // Run the training after the sync has completed. If the sync failed or stopped, retrain anyway
-        string buildJobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
+        string buildJobId = backgroundJobClient.ContinueJobWith<IMachineProjectService>(
             syncJobId,
             r =>
                 r.BuildProjectForBackgroundJobAsync(
@@ -1199,7 +1198,7 @@ public class MachineApiService(
         }
 
         // Run the training after the sync has completed
-        jobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
+        jobId = backgroundJobClient.ContinueJobWith<IMachineProjectService>(
             jobId,
             r => r.BuildProjectForBackgroundJobAsync(curUserId, buildConfig, true, CancellationToken.None)
         );

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -96,7 +96,6 @@ public class MachineProjectService(
     /// <remarks>
     /// This cannot be run multiple times in different threads.
     /// </remarks>
-    [Mutex]
     public async Task BuildProjectForBackgroundJobAsync(
         string curUserId,
         BuildConfig buildConfig,
@@ -365,9 +364,8 @@ public class MachineProjectService(
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
-    /// <returns></returns>
+    /// <returns>The asynchronous task.</returns>
     /// <exception cref="DataNotFoundException">The project or user secret does not exist.</exception>
-    [Mutex]
     public async Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId)
     {
         // Get the user secret

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1944,7 +1944,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
 
             // After syncing the source project (which will take some time), ensure that the writing system matches
             // what is in the project document
-            _backgroundJobClient.ContinueJobWith<MachineProjectService>(
+            _backgroundJobClient.ContinueJobWith<IMachineProjectService>(
                 jobId,
                 r => r.UpdateTranslationSourcesAsync(curUserId, sfProjectId)
             );

--- a/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class SFServiceCollectionExtensions
         services.AddSingleton<ISFRestClientFactory, SFDblRestClientFactory>();
         services.AddSingleton<IHgWrapper, HgWrapper>();
         services.AddSingleton<ISFProjectRights, SFProjectRights>();
+        services.AddTransient<IParatextSyncRunner, ParatextSyncRunner>();
         return services;
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -93,7 +93,7 @@ public class SyncService(
                 // the job unless the queued count and job ids have been incremented appropriately.
                 // We need to sync the source first so that we can link the source texts and train the engine.
                 string sourceJobId = !string.IsNullOrWhiteSpace(syncConfig.ParentJobId)
-                    ? backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+                    ? backgroundJobClient.ContinueJobWith<IParatextSyncRunner>(
                         syncConfig.ParentJobId,
                         r =>
                             r.RunAsync(
@@ -106,7 +106,7 @@ public class SyncService(
                         null,
                         JobContinuationOptions.OnAnyFinishedState
                     )
-                    : backgroundJobClient.Schedule<ParatextSyncRunner>(
+                    : backgroundJobClient.Schedule<IParatextSyncRunner>(
                         r =>
                             r.RunAsync(
                                 sourceProjectId,
@@ -117,7 +117,7 @@ public class SyncService(
                             ),
                         TimeSpan.FromMinutes(5)
                     );
-                string targetJobId = backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+                string targetJobId = backgroundJobClient.ContinueJobWith<IParatextSyncRunner>(
                     sourceJobId,
                     r =>
                         r.RunAsync(
@@ -191,7 +191,7 @@ public class SyncService(
                 try
                 {
                     // Build the SMT suggestions after the target has synced successfully
-                    buildJobId = backgroundJobClient.ContinueJobWith<MachineProjectService>(
+                    buildJobId = backgroundJobClient.ContinueJobWith<IMachineProjectService>(
                         targetJobId,
                         r =>
                             r.BuildProjectForBackgroundJobAsync(
@@ -247,7 +247,7 @@ public class SyncService(
         // Sync the target project only, as it does not have a source, or the source cannot be synced
         // See the comments in the block above regarding scheduling for rationale on the process
         string jobId = !string.IsNullOrWhiteSpace(syncConfig.ParentJobId)
-            ? backgroundJobClient.ContinueJobWith<ParatextSyncRunner>(
+            ? backgroundJobClient.ContinueJobWith<IParatextSyncRunner>(
                 syncConfig.ParentJobId,
                 r =>
                     r.RunAsync(
@@ -260,7 +260,7 @@ public class SyncService(
                 null,
                 JobContinuationOptions.OnAnyFinishedState
             )
-            : backgroundJobClient.Schedule<ParatextSyncRunner>(
+            : backgroundJobClient.Schedule<IParatextSyncRunner>(
                 r =>
                     r.RunAsync(
                         syncConfig.ProjectId,

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -198,6 +198,7 @@ public class Startup
         containerBuilder.RegisterSFEventMetrics();
 
         ApplicationContainer = containerBuilder.Build();
+        GlobalConfiguration.Configuration.UseAutofacActivator(ApplicationContainer);
         return new AutofacServiceProvider(ApplicationContainer);
     }
 

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -349,6 +349,15 @@
           "Hangfire.NetCore": "[1.8.14]"
         }
       },
+      "Hangfire.Autofac": {
+        "type": "Transitive",
+        "resolved": "2.7.0",
+        "contentHash": "9LaNzbCMJm6yUOw+NKud5KwdQpXHR4j8V3MV0ufgmSO3SHRlzIWf+h2Qbldn8leAx9dnwtUkndMh+wF8k3Mx4w==",
+        "dependencies": {
+          "Autofac": "5.0.0",
+          "Hangfire.Core": "1.6.0"
+        }
+      },
       "Hangfire.Core": {
         "type": "Transitive",
         "resolved": "1.8.14",
@@ -1979,6 +1988,7 @@
           "Duende.IdentityModel": "[7.0.0, )",
           "EdjCase.JsonRpc.Router": "[6.1.0, )",
           "Hangfire": "[1.8.14, )",
+          "Hangfire.Autofac": "[2.7.0, )",
           "Hangfire.Mongo": "[1.10.7, )",
           "Jering.Javascript.NodeJS": "[6.3.1, )",
           "MailKit": "[4.11.0, )",

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -223,8 +223,8 @@
       },
       "Autofac": {
         "type": "Transitive",
-        "resolved": "8.2.0",
-        "contentHash": "T+4+W4byzyUOarCbIcFRbxpYKC+cndfQm/+VeWpB60P2MCN0JMsewUhZqvH5Ooe936HQjn5uHvEY9tq6BfbiIw==",
+        "resolved": "8.2.1",
+        "contentHash": "q5xYBykgdvBlcmrXzHcDWcfeVktGEraluypkC0IRTupfxk+r+z+JcXgKj5kldKGe1fflyW3Ya3y9Soe9J2CqEA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         }
@@ -1981,7 +1981,7 @@
         "type": "Project",
         "dependencies": {
           "AbrarJahin.DiffMatchPatch": "[0.1.0, )",
-          "Autofac": "[8.2.0, )",
+          "Autofac": "[8.2.1, )",
           "Autofac.Extensions.DependencyInjection": "[10.0.0, )",
           "Autofac.Extras.DynamicProxy": "[7.1.0, )",
           "Bugsnag.AspNet.Core": "[4.0.0, )",

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -8,6 +8,7 @@ public interface IRealtimeService
 {
     void StartServer();
     void StopServer();
+    void CheckIfRunning();
 
     Task<IConnection> ConnectAsync(string userId = null);
 

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -53,6 +53,8 @@ public class MemoryRealtimeService : IRealtimeService
 
     public void StopServer() { }
 
+    public void CheckIfRunning() { }
+
     public Task<IConnection> ConnectAsync(string userId = null) =>
         Task.FromResult<IConnection>(new MemoryConnection(this));
 

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -289,7 +289,7 @@ public class RealtimeService : DisposableBase, IRealtimeService
     }
 
     private void SetPingServiceSchedule(string schedule = "* * * * *") =>
-        _recurringJobManager.AddOrUpdate("ping_service", () => CheckIfRunning(), schedule);
+        _recurringJobManager.AddOrUpdate<IRealtimeService>("ping_service", s => s.CheckIfRunning(), schedule);
 
     private object CreateOptions()
     {

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Bugsnag.AspNet.Core" Version="4.0.0" />
     <PackageReference Include="EdjCase.JsonRpc.Router" Version="6.1.0" />
     <PackageReference Include="Hangfire" Version="1.8.14" />
+    <PackageReference Include="Hangfire.Autofac" Version="2.7.0" />
     <PackageReference Include="Hangfire.Mongo" Version="1.10.7" />
     <PackageReference Include="Duende.IdentityModel" Version="7.0.0" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="6.3.1" />

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -5,7 +5,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.2.0" />
+    <PackageReference Include="Autofac" Version="8.2.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Autofac.Extras.DynamicProxy" Version="7.1.0" />
     <PackageReference Include="Bugsnag.AspNet.Core" Version="4.0.0" />

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Autofac": {
         "type": "Direct",
-        "requested": "[8.2.0, )",
-        "resolved": "8.2.0",
-        "contentHash": "T+4+W4byzyUOarCbIcFRbxpYKC+cndfQm/+VeWpB60P2MCN0JMsewUhZqvH5Ooe936HQjn5uHvEY9tq6BfbiIw==",
+        "requested": "[8.2.1, )",
+        "resolved": "8.2.1",
+        "contentHash": "q5xYBykgdvBlcmrXzHcDWcfeVktGEraluypkC0IRTupfxk+r+z+JcXgKj5kldKGe1fflyW3Ya3y9Soe9J2CqEA==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         }

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -77,6 +77,16 @@
           "Hangfire.SqlServer": "[1.8.14]"
         }
       },
+      "Hangfire.Autofac": {
+        "type": "Direct",
+        "requested": "[2.7.0, )",
+        "resolved": "2.7.0",
+        "contentHash": "9LaNzbCMJm6yUOw+NKud5KwdQpXHR4j8V3MV0ufgmSO3SHRlzIWf+h2Qbldn8leAx9dnwtUkndMh+wF8k3Mx4w==",
+        "dependencies": {
+          "Autofac": "5.0.0",
+          "Hangfire.Core": "1.6.0"
+        }
+      },
       "Hangfire.Mongo": {
         "type": "Direct",
         "requested": "[1.10.7, )",


### PR DESCRIPTION
This PR fixes a memory leak when the Realtime Service checks if the Realtime Server is running.

Also, following the guidance on https://docs.hangfire.io/en/latest/background-methods/using-ioc-containers.html, I have updated the background job logic to execute jobs by their interface, and have included Hangfire.Autofac so that Hangfire uses a tagged lifetime scope, meaning the objects are correctly disposed within the object lifecycle.

This PR is marked testing not required, as a debugger with breakpoint is required to run the acceptance test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3147)
<!-- Reviewable:end -->
