### PR TITLE
SF-3271 Prevent Save & Sync of draft sources when offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -179,9 +179,14 @@
   ></app-language-codes-confirmation>
 
   <div class="component-footer">
+    @if (!appOnline) {
+      <mat-error id="offline-message">
+        {{ t("offline_message") }}
+      </mat-error>
+    }
     <div class="page-actions">
       <button mat-button (click)="cancel()"><mat-icon>close</mat-icon>{{ t("cancel") }}</button>
-      <button mat-flat-button color="primary" (click)="save()">
+      <button id="save_button" mat-flat-button color="primary" (click)="save()" [disabled]="!appOnline">
         <mat-icon>check</mat-icon>{{ t("save_and_sync") }}
       </button>
     </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
@@ -172,6 +172,13 @@ strong {
   background: var(--sf-draft-source-active-blank-background);
 }
 
+#offline-message {
+  display: flex;
+  justify-self: flex-end;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+
 .page-actions {
   display: flex;
   gap: 0.5em;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatRippleModule } from '@angular/material/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Router } from '@angular/router';
@@ -16,6 +17,7 @@ import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.ser
 import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { XForgeCommonModule } from 'xforge-common/xforge-common.module';
@@ -45,6 +47,7 @@ export interface ProjectStatus {
   standalone: true,
   imports: [
     MatButtonModule,
+    MatFormFieldModule,
     MatIconModule,
     XForgeCommonModule,
     MatRippleModule,
@@ -98,6 +101,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     private readonly userProjectsService: SFUserProjectsService,
     private readonly router: Router,
     private readonly featureFlags: FeatureFlagService,
+    private readonly onlineStatus: OnlineStatusService,
     readonly i18n: I18nService,
     noticeService: NoticeService
   ) {
@@ -130,6 +134,10 @@ export class DraftSourcesComponent extends DataLoadingComponent {
       });
 
     this.loadProjects();
+  }
+
+  get appOnline(): boolean {
+    return this.onlineStatus.isOnline;
   }
 
   get loading(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -284,6 +284,7 @@
     "language_code": "Language code: ",
     "leave_and_discard": "Leave & discard changes",
     "next": "Next",
+    "offline_message": "You are offline. Please connect to the internet to save and sync your draft sources.",
     "overview_reference": "Reference",
     "overview_source": "Source",
     "overview_translated_project": "Translated project",


### PR DESCRIPTION
If the app goes offline while configuring draft sources clicking the "Save & Sync" button will error out as internet connection is required. Following the behavior of adding a resource tab to the editor the "Save & Sync" button will be disabled and a message displayed letting the user know to connect to the internet to save the draft source configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3148)
<!-- Reviewable:end -->
