### PR TITLE
SF-3314 Fix installation of new DBL resources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2515,7 +2515,7 @@ public class ParatextService : DisposableBase, IParatextService
     /// <remarks>
     ///   <paramref name="targetParatextId" /> is required because the resource may be a source or target.
     /// </remarks>
-    async private Task InstallResourceAsync(
+    private async Task InstallResourceAsync(
         string username,
         ParatextResource resource,
         string targetParatextId,

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -377,31 +377,36 @@ public class SFInstallableDblResource : InstallableResource
     /// <remarks>
     /// After the resource is extracted, it can be a source or target.
     /// </remarks>
-    async public Task ExtractToDirectoryAsync(string path)
+    public async Task ExtractToDirectoryAsync(string path)
     {
         // Check parameters
         if (string.IsNullOrWhiteSpace(path))
         {
             throw new ArgumentNullException(nameof(path));
         }
-        else if (string.IsNullOrWhiteSpace(this.DBLEntryUid.Id))
+        else if (string.IsNullOrWhiteSpace(DBLEntryUid.Id))
         {
-            throw new ArgumentNullException(nameof(this.DBLEntryUid.Id));
+            throw new ArgumentNullException(nameof(DBLEntryUid.Id));
         }
-        else if (string.IsNullOrWhiteSpace(this.Name))
+        else if (string.IsNullOrWhiteSpace(Name))
         {
-            throw new ArgumentNullException(nameof(this.Name));
+            throw new ArgumentNullException(nameof(Name));
         }
 
         string resourceFile = ScrTextCollection.GetResourcePath(
-            this.ExistingScrText,
-            this.Name,
-            this.DBLEntryUid,
+            ExistingScrText,
+            Name,
+            DBLEntryUid,
             ProjectFileManager.resourceFileExtension
         );
         if (_fileSystemService.FileExists(resourceFile))
         {
-            await using Stream stream = _fileSystemService.OpenFile(resourceFile, FileMode.Open);
+            await using Stream stream = _fileSystemService.OpenFile(
+                resourceFile,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            );
             using ZipFile zipFile = new ZipFile(stream);
             zipFile.Password = _passwordProvider?.GetPassword();
             await ExtractAllAsync(zipFile, path);
@@ -534,7 +539,12 @@ public class SFInstallableDblResource : InstallableResource
                 // See if this a zip file, and if it contains the correct ID
                 try
                 {
-                    await using var stream = new FileStream(resourceFile, FileMode.Open);
+                    await using var stream = new FileStream(
+                        resourceFile,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read
+                    );
                     using var zipFile = new ZipFile(stream);
                     // Zip files use forward slashes, even on Windows
                     const string idSearchPath = DblFolderName + "/id/";

--- a/src/SIL.XForge/Services/FileSystemService.cs
+++ b/src/SIL.XForge/Services/FileSystemService.cs
@@ -14,6 +14,9 @@ public class FileSystemService : IFileSystemService
 
     public Stream OpenFile(string path, FileMode mode) => File.Open(path, mode);
 
+    public Stream OpenFile(string path, FileMode mode, FileAccess access, FileShare share) =>
+        File.Open(path, mode, access, share);
+
     public string FileReadText(string path) => File.ReadAllText(path);
 
     public void DeleteFile(string path) => File.Delete(path);

--- a/src/SIL.XForge/Services/IFileSystemService.cs
+++ b/src/SIL.XForge/Services/IFileSystemService.cs
@@ -8,6 +8,7 @@ public interface IFileSystemService
     Stream CreateFile(string path);
     bool FileExists(string path);
     Stream OpenFile(string path, FileMode mode);
+    Stream OpenFile(string path, FileMode mode, FileAccess access, FileShare share);
     string FileReadText(string path);
     void DeleteFile(string path);
     void CreateDirectory(string path);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4372,7 +4372,13 @@ public class ParatextServiceTests
             .Returns(resourceScrText);
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith(".p8z"))).Returns(true);
         await using var zipStream = await TestEnvironment.CreateZipStubAsync();
-        env.MockFileSystemService.OpenFile(Arg.Is<string>(p => p.EndsWith(".p8z")), FileMode.Open).Returns(zipStream);
+        env.MockFileSystemService.OpenFile(
+                Arg.Is<string>(p => p.EndsWith(".p8z")),
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            )
+            .Returns(zipStream);
         await using var stream = new MemoryStream();
         env.MockFileSystemService.CreateFile(Arg.Any<string>()).Returns(stream);
 
@@ -4426,7 +4432,13 @@ public class ParatextServiceTests
             .Returns(resourceScrText);
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith(".p8z"))).Returns(true);
         await using var zipStream = await TestEnvironment.CreateZipStubAsync();
-        env.MockFileSystemService.OpenFile(Arg.Is<string>(p => p.EndsWith(".p8z")), FileMode.Open).Returns(zipStream);
+        env.MockFileSystemService.OpenFile(
+                Arg.Is<string>(p => p.EndsWith(".p8z")),
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            )
+            .Returns(zipStream);
         await using var stream = new MemoryStream();
         env.MockFileSystemService.CreateFile(Arg.Any<string>()).Returns(stream);
 
@@ -4493,7 +4505,13 @@ public class ParatextServiceTests
         env.MockFileSystemService.When(f => f.CreateDirectory(Arg.Any<string>())).Do(_ => resourceDownloaded = true);
         env.MockFileSystemService.FileExists(Arg.Is<string>(p => p.EndsWith(".p8z"))).Returns(_ => resourceDownloaded);
         await using var zipStream = await TestEnvironment.CreateZipStubAsync();
-        env.MockFileSystemService.OpenFile(Arg.Is<string>(p => p.EndsWith(".p8z")), FileMode.Open).Returns(zipStream);
+        env.MockFileSystemService.OpenFile(
+                Arg.Is<string>(p => p.EndsWith(".p8z")),
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read
+            )
+            .Returns(zipStream);
         await using var stream = new MemoryStream();
         env.MockFileSystemService.CreateFile(Arg.Any<string>()).Returns(stream);
 


### PR DESCRIPTION
This PR fixes an a regression from #2967 I noticed on QA and localhost where DBL resources that have not been installed before fail to install. This likely occurs on production too, although has not yet been reported.