### PR TITLE
Change Path.Combine to Path.Join to fix CodeQL warnings

### DIFF
--- a/src/Help/UpdateHelp/Program.cs
+++ b/src/Help/UpdateHelp/Program.cs
@@ -50,15 +50,15 @@ class Program
         bool doWrite = ((args.Length >= 2 ? args[1] : "") == "write");
 
         string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        string helpDir = Path.Combine(userDir, "src", "web-sf-helps", "src");
+        string helpDir = Path.Join(userDir, "src", "web-sf-helps", "src");
         string source = "en";
-        string sourceDir = Path.Combine(helpDir, source);
-        string sourceWhxDir = Path.Combine(sourceDir, "whxdata");
+        string sourceDir = Path.Join(helpDir, source);
+        string sourceWhxDir = Path.Join(sourceDir, "whxdata");
         string parentFolderOfThisFile = Path.GetDirectoryName(Directory.GetCurrentDirectory());
-        string sourceMenuJsonPath = Path.Combine(parentFolderOfThisFile, $"menu_{source}.json");
-        string targetDir = Path.Combine(helpDir, target);
-        string targetWhxDir = Path.Combine(targetDir, "whxdata");
-        string targetMenuJsonPath = Path.Combine(targetDir, $"menu_{target}.json");
+        string sourceMenuJsonPath = Path.Join(parentFolderOfThisFile, $"menu_{source}.json");
+        string targetDir = Path.Join(helpDir, target);
+        string targetWhxDir = Path.Join(targetDir, "whxdata");
+        string targetMenuJsonPath = Path.Join(targetDir, $"menu_{target}.json");
 
         // See https://programmablesearchengine.google.com/ to create an engine for each language.
         // For the new language, copy existing setup from another language, including these 2 settings:
@@ -276,9 +276,9 @@ class Program
                 ExtractXmlElementAttributes(doc, "topic", "name", "url", topicUrlsByName);
                 if (doWrite)
                 {
-                    string idataFilePath = Path.Combine(targetPath, Path.GetFileName(file));
+                    string idataFilePath = Path.Join(targetPath, Path.GetFileName(file));
                     ReplaceTranslationsInFile(idataFilePath, topicTextInIdata, topicUrlsByName.Keys, translations);
-                    string idataNewFilePath = Path.Combine(
+                    string idataNewFilePath = Path.Join(
                         targetPath,
                         Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
                     );
@@ -327,10 +327,10 @@ class Program
                 ExtractXmlElementAttributes(doc, "item", "name", "url", itemUrlsByName);
                 if (doWrite)
                 {
-                    string tocFilePath = Path.Combine(targetPath, Path.GetFileName(file));
+                    string tocFilePath = Path.Join(targetPath, Path.GetFileName(file));
                     ReplaceTranslationsInFile(tocFilePath, bookTextInToc, bookSrcsByName.Keys, translations);
                     ReplaceTranslationsInFile(tocFilePath, itemTextInToc, itemUrlsByName.Keys, translations);
-                    string tocNewFilePath = Path.Combine(
+                    string tocNewFilePath = Path.Join(
                         targetPath,
                         Path.GetFileNameWithoutExtension(file) + ".new" + Path.GetExtension(file)
                     );
@@ -350,7 +350,7 @@ class Program
     /// </summary>
     static void ReplaceSearch(string targetPath, string searchEngineID, bool doWrite)
     {
-        string file = Path.Combine(targetPath, "index.htm");
+        string file = Path.Join(targetPath, "index.htm");
         var doc = new HtmlDocument();
         doc.Load(file);
         HtmlNode head = doc.DocumentNode.SelectSingleNode("//head");
@@ -388,7 +388,7 @@ class Program
     /// </summary>
     static void RemoveUnusedButtonsAndSearch(string targetPath, bool removeSearchButton, bool doWrite)
     {
-        string file = Path.Combine(targetPath, "index.htm");
+        string file = Path.Join(targetPath, "index.htm");
         var doc = new HtmlDocument();
         doc.Load(file);
         HtmlNode idxButton = doc.DocumentNode.SelectSingleNode("//a[@class='idx']");
@@ -420,7 +420,7 @@ class Program
             string start = "gXMLBuffer =\"";
             result = sr.ReadToEnd();
             if (result.EndsWith(end))
-                result = result.Remove(result.Length - end.Length);
+                result = result[..^end.Length];
             if (result.StartsWith(start))
                 result = result[start.Length..];
             result = result.Replace("\\\"", "\"");

--- a/src/Migrations/BackoutCommits/SyncAllService.cs
+++ b/src/Migrations/BackoutCommits/SyncAllService.cs
@@ -362,7 +362,7 @@ public class SyncAllService : ISyncAllService
 
         foreach (SFProject project in projects)
         {
-            string projectPath = Path.Combine(projectRootDir, project.ParatextId, "target");
+            string projectPath = Path.Join(projectRootDir, project.ParatextId, "target");
             string repoRevision = _hgWrapper.GetRepoRevision(projectPath);
             if (repoRevision != project.Sync.SyncedToRepositoryVersion)
             {

--- a/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
+++ b/src/Migrations/PTDDCloneAll.Tests/CloneAllServiceTests.cs
@@ -52,7 +52,7 @@ namespace PTDDCloneAll
             var env = new TestEnvironment();
             string[] projectIds = new[] { "project01", "project02" };
             IEnumerable<SFProject> projectsToClone = await env.GetSFProjects(projectIds);
-            string project01Path = Path.Combine("scriptureforge", "sync", "target01");
+            string project01Path = Path.Join("scriptureforge", "sync", "target01");
             env.FileSystemService.DirectoryExists(project01Path).Returns(true);
             await env.Service.CloneSFProjects(CloneAllService.CLONE, projectsToClone);
             env.FileSystemService.Received(2).DirectoryExists(Arg.Any<string>());

--- a/src/Migrations/PTDDCloneAll/CloneAllService.cs
+++ b/src/Migrations/PTDDCloneAll/CloneAllService.cs
@@ -72,9 +72,9 @@ namespace PTDDCloneAll
         /// </summary>
         public async Task CloneSFProjects(string mode, IEnumerable<SFProject> projectsToClone)
         {
-            string syncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
+            string syncDir = Path.Join(_siteOptions.Value.SiteDir, "sync");
 
-            string syncDirOld = Path.Combine(_siteOptions.Value.SiteDir, "sync_old");
+            string syncDirOld = Path.Join(_siteOptions.Value.SiteDir, "sync_old");
             if (mode == CLONE_AND_MOVE_OLD)
             {
                 if (!_fileSystemService.DirectoryExists(syncDirOld))
@@ -111,8 +111,8 @@ namespace PTDDCloneAll
 
                             if (mode == CLONE_AND_MOVE_OLD)
                             {
-                                string projectDir = Path.Combine(syncDir, proj.Id);
-                                string projectDirOld = Path.Combine(syncDirOld, proj.Id);
+                                string projectDir = Path.Join(syncDir, proj.Id);
+                                string projectDirOld = Path.Join(syncDirOld, proj.Id);
                                 _fileSystemService.MoveDirectory(projectDir, projectDirOld);
                             }
                             break;
@@ -141,7 +141,7 @@ namespace PTDDCloneAll
             bool pushLocal = mode == SYNCHRONIZE_PT_SF;
             bool syncMode = mode == SYNCHRONIZE_SF || mode == SYNCHRONIZE_PT_SF;
             Log($"Cloning {proj.Name} ({proj.Id}) as SF user {userId}");
-            string existingCloneDir = Path.Combine(syncDir, proj.ParatextId);
+            string existingCloneDir = Path.Join(syncDir, proj.ParatextId);
             // If the project directory already exists, no need to sync the project
             if (_fileSystemService.DirectoryExists(existingCloneDir) && !syncMode)
             {

--- a/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
+++ b/src/Migrations/PtdaSyncAll.Tests/PtdaSyncRunnerTests.cs
@@ -1061,12 +1061,12 @@ namespace PtdaSyncAll
 
             public static string GetUsxFileName(TextType textType, string bookId)
             {
-                return Path.Combine(GetProjectPath(textType), bookId + ".xml");
+                return Path.Join(GetProjectPath(textType), bookId + ".xml");
             }
 
             public static string GetProjectPath(TextType textType)
             {
-                return Path.Combine("scriptureforge", "sync", "project01", GetParatextProject(textType));
+                return Path.Join("scriptureforge", "sync", "project01", GetParatextProject(textType));
             }
 
             public Task SetUserRole(string userId, string role)

--- a/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
+++ b/src/Migrations/PtdaSyncAll/PtdaSyncRunner.cs
@@ -100,7 +100,7 @@ namespace PtdaSyncAll
             _notesMapper = notesMapper;
         }
 
-        private string WorkingDir => Path.Combine(_siteOptions.Value.SiteDir, "sync");
+        private string WorkingDir => Path.Join(_siteOptions.Value.SiteDir, "sync");
 
         private bool TranslationSuggestionsEnabled => _projectDoc.Data.TranslateConfig.TranslationSuggestionsEnabled;
         private bool CheckingEnabled => _projectDoc.Data.CheckingConfig.CheckingEnabled;
@@ -881,12 +881,12 @@ namespace PtdaSyncAll
                 default:
                     throw new InvalidEnumArgumentException(nameof(textType), (int)textType, typeof(TextType));
             }
-            return Path.Combine(WorkingDir, _projectDoc.Id, textTypeDir);
+            return Path.Join(WorkingDir, _projectDoc.Id, textTypeDir);
         }
 
         private static string GetUsxFileName(string projectPath, int bookNum)
         {
-            return Path.Combine(projectPath, Canon.BookNumberToId(bookNum) + ".xml");
+            return Path.Join(projectPath, Canon.BookNumberToId(bookNum) + ".xml");
         }
 
         private async Task<XElement> LoadXmlFileAsync(string fileName)

--- a/src/Migrations/SourceTargetSplitting/Program.cs
+++ b/src/Migrations/SourceTargetSplitting/Program.cs
@@ -46,7 +46,7 @@ namespace SourceTargetSplitting
         public static async Task Main(string[] args)
         {
             const string siteDir = "/var/lib/scriptureforge";
-            string syncDir = Path.Combine(siteDir, "sync");
+            string syncDir = Path.Join(siteDir, "sync");
             bool doWrite = (args.Length >= 1 ? args[0] : string.Empty) == "run";
             MigrationsDisabled = !doWrite;
             string sfAppDir = args.Length >= 2 ? args[1] : string.Empty;
@@ -180,7 +180,7 @@ namespace SourceTargetSplitting
                 foreach (string projectPath in projectPaths)
                 {
                     string projectId = Path.GetFileName(projectPath.TrimEnd(Path.DirectorySeparatorChar));
-                    string targetPath = Path.Combine(projectPath, "target");
+                    string targetPath = Path.Join(projectPath, "target");
                     if (Directory.Exists(targetPath))
                     {
                         projectIds.Add(projectId);
@@ -198,7 +198,7 @@ namespace SourceTargetSplitting
                     Log($"Directory {projectId}");
 
                     // Check for the target path
-                    string targetPath = Path.Combine(projectPath, "target");
+                    string targetPath = Path.Join(projectPath, "target");
                     if (!Directory.Exists(targetPath))
                     {
                         Log("\tNo target folder - skipping as this is not a project");
@@ -206,7 +206,7 @@ namespace SourceTargetSplitting
                     }
 
                     // Check for the source path
-                    string sourcePath = Path.Combine(projectPath, "source");
+                    string sourcePath = Path.Join(projectPath, "source");
                     if (!Directory.Exists(sourcePath))
                     {
                         Log("\tNo source folder - no need to split");
@@ -227,7 +227,7 @@ namespace SourceTargetSplitting
 
                     // Get the source project id (if a resource)
                     string? sourceProjectId = null;
-                    string dblIdDirectoryPath = Path.Combine(sourcePath, ".dbl", "id");
+                    string dblIdDirectoryPath = Path.Join(sourcePath, ".dbl", "id");
                     if (Directory.Exists(dblIdDirectoryPath))
                     {
                         string[] files = Directory.GetFiles(dblIdDirectoryPath, "*");
@@ -252,7 +252,7 @@ namespace SourceTargetSplitting
                     if (sourceProjectId == null)
                     {
                         // Check for the source settings file
-                        string settingsXmlPath = Path.Combine(sourcePath, "Settings.xml");
+                        string settingsXmlPath = Path.Join(sourcePath, "Settings.xml");
                         if (!File.Exists(settingsXmlPath))
                         {
                             Log("\tNo Settings.xml in the source folder - cannot split project");
@@ -273,8 +273,8 @@ namespace SourceTargetSplitting
                     if (!projectIds.Contains(sourceProjectId))
                     {
                         Log($"\tMoving source directory to its own project: {sourceProjectId}");
-                        string newProjectDirectoryPath = Path.Combine(syncDir, sourceProjectId);
-                        string newProjectTargetDirectoryPath = Path.Combine(newProjectDirectoryPath, "target");
+                        string newProjectDirectoryPath = Path.Join(syncDir, sourceProjectId);
+                        string newProjectTargetDirectoryPath = Path.Join(newProjectDirectoryPath, "target");
                         if (doWrite)
                         {
                             Directory.CreateDirectory(newProjectDirectoryPath);

--- a/src/Migrations/SourceTargetSplitting/SourceScrTextCollection.cs
+++ b/src/Migrations/SourceTargetSplitting/SourceScrTextCollection.cs
@@ -57,14 +57,14 @@ namespace SIL.XForge.Scripture.Services
                 return null;
             }
 
-            string baseProjectPath = Path.Combine(SettingsDirectory, projectId);
+            string baseProjectPath = Path.Join(SettingsDirectory, projectId);
             if (!FileSystemService.DirectoryExists(baseProjectPath))
             {
                 return null;
             }
 
-            string fullProjectPath = Path.Combine(baseProjectPath, "source");
-            string settingsFile = Path.Combine(fullProjectPath, ProjectSettings.fileName);
+            string fullProjectPath = Path.Join(baseProjectPath, "source");
+            string settingsFile = Path.Join(fullProjectPath, ProjectSettings.fileName);
             if (!FileSystemService.FileExists(settingsFile))
             {
                 // If this is an older project (most likely a resource), there will be an SSF file

--- a/src/Migrations/UsxFormat/Program.cs
+++ b/src/Migrations/UsxFormat/Program.cs
@@ -15,7 +15,7 @@ namespace Migrations
         static async Task Main(string[] args)
         {
             const string siteDir = "/var/lib/scriptureforge";
-            string syncDir = Path.Combine(siteDir, "sync");
+            string syncDir = Path.Join(siteDir, "sync");
             bool doWrite = ((args.Length >= 1 ? args[0] : "") == "run");
 
             Console.WriteLine("Migrate USX XML sync files.\n");
@@ -46,7 +46,7 @@ namespace Migrations
                     Console.WriteLine(
                         $"Project ID {projectPath.Substring(projectPath.LastIndexOf(Path.DirectorySeparatorChar) + 1)}"
                     );
-                    string targetPath = Path.Combine(projectPath, "target");
+                    string targetPath = Path.Join(projectPath, "target");
                     if (!Directory.Exists(targetPath))
                     {
                         Console.WriteLine("\tNo target folder.");
@@ -55,7 +55,7 @@ namespace Migrations
                     Console.Write("\tTarget folder: ");
                     await ProcessUsxFilesAsync(targetPath, doWrite);
 
-                    string sourcePath = Path.Combine(projectPath, "source");
+                    string sourcePath = Path.Join(projectPath, "source");
                     if (!Directory.Exists(sourcePath))
                         continue;
                     Console.Write("\tSource folder: ");

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -344,7 +344,7 @@ public class SFProjectsUploadController : ControllerBase
                     .Aggregate(fileName, (current, c) => current.Replace(c.ToString(), string.Empty));
 
                 // Get the path to the temporary file
-                path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + Path.GetExtension(fileName));
+                path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName() + Path.GetExtension(fileName));
 
                 // Write the incoming file data to the temporary file
                 await using Stream fileStream = _fileSystemService.CreateFile(path);

--- a/src/SIL.XForge.Scripture/Migrator.cs
+++ b/src/SIL.XForge.Scripture/Migrator.cs
@@ -15,14 +15,7 @@ public static class Migrator
         string version = Product.Version;
         string projectPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-        string migratorPath = Path.Combine(
-            projectPath,
-            "RealtimeServer",
-            "lib",
-            "cjs",
-            "scriptureforge",
-            "migrator.js"
-        );
+        string migratorPath = Path.Join(projectPath, "RealtimeServer", "lib", "cjs", "scriptureforge", "migrator.js");
 
         var startInfo = new ProcessStartInfo
         {

--- a/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/ApiDocumentationExtensions.cs
@@ -37,7 +37,7 @@ public static class ApiDocumentationExtensions
 
             // Add the documentation XML file, if it exists
             string xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-            string xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+            string xmlPath = Path.Join(AppContext.BaseDirectory, xmlFilename);
             if (RobustFile.Exists(xmlPath))
             {
                 options.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -39,12 +39,12 @@ public class LazyScrTextCollection : IScrTextCollection
     {
         if (projectId == null)
             return null;
-        string baseProjectPath = Path.Combine(SettingsDirectory, projectId);
+        string baseProjectPath = Path.Join(SettingsDirectory, projectId);
         if (!FileSystemService.DirectoryExists(baseProjectPath))
             return null;
 
-        string fullProjectPath = Path.Combine(baseProjectPath, "target");
-        string settingsFile = Path.Combine(fullProjectPath, ProjectSettings.fileName);
+        string fullProjectPath = Path.Join(baseProjectPath, "target");
+        string settingsFile = Path.Join(fullProjectPath, ProjectSettings.fileName);
         if (!FileSystemService.FileExists(settingsFile))
         {
             // If this is an older project (most likely a resource), there will be an SSF file

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -805,7 +805,7 @@ public class MachineProjectService(
     )
     {
         // Get the path to the Paratext directory
-        string path = Path.Combine(siteOptions.Value.SiteDir, "sync", paratextId, "target");
+        string path = Path.Join(siteOptions.Value.SiteDir, "sync", paratextId, "target");
 
         // Ensure that the path exists
         if (!fileSystemService.DirectoryExists(path))

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -171,7 +171,7 @@ public class ParatextService : DisposableBase, IParatextService
         // Stop ParatextData.dll Trace output from appearing on the server.
         System.Diagnostics.Trace.Listeners.Clear();
 
-        SyncDir = Path.Combine(_siteOptions.Value.SiteDir, "sync");
+        SyncDir = Path.Join(_siteOptions.Value.SiteDir, "sync");
         if (!_fileSystemService.DirectoryExists(SyncDir))
             _fileSystemService.CreateDirectory(SyncDir);
         // Disable caching VersionedText instances since multiple repos may exist on SF server with the same GUID
@@ -1763,8 +1763,8 @@ public class ParatextService : DisposableBase, IParatextService
         // BackupProject and RestoreProject implementations in Paratext.Data.Repository.VersionedText.
         try
         {
-            string directory = Path.Combine(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups");
-            string path = Path.Combine(directory, scrText.Guid + ".bndl");
+            string directory = Path.Join(Paratext.Data.ScrTextCollection.SettingsDirectory, "_Backups");
+            string path = Path.Join(directory, scrText.Guid + ".bndl");
             string tempPath = path + "_temp";
             _fileSystemService.CreateDirectory(directory);
 
@@ -1821,7 +1821,7 @@ public class ParatextService : DisposableBase, IParatextService
         if (BackupExistsInternal(scrText))
         {
             string source = scrText.Directory;
-            string destination = Path.Combine(
+            string destination = Path.Join(
                 Paratext.Data.ScrTextCollection.SettingsDirectory,
                 "_Backups",
                 scrText.Guid.ToString()
@@ -2305,7 +2305,7 @@ public class ParatextService : DisposableBase, IParatextService
     {
         try
         {
-            string path = Path.Combine(
+            string path = Path.Join(
                 Paratext.Data.ScrTextCollection.SettingsDirectory,
                 "_Backups",
                 $"{scrText.Guid}.bndl"
@@ -2457,7 +2457,7 @@ public class ParatextService : DisposableBase, IParatextService
             _logger.LogError(msg);
             throw new InvalidOperationException(msg);
         }
-        var hgMerge = Path.Combine(AssemblyDirectory, "ParatextMerge.py");
+        var hgMerge = Path.Join(AssemblyDirectory, "ParatextMerge.py");
         _hgHelper.SetDefault(new Hg(customHgPath, hgMerge, AssemblyDirectory));
     }
 
@@ -2467,8 +2467,8 @@ public class ParatextService : DisposableBase, IParatextService
         string[] resources = ["usfm.sty", "revisionStyle.sty", "revisionTemplate.tem", "usfm_mod.sty", "usfm_sb.sty"];
         foreach (string resource in resources)
         {
-            string target = Path.Combine(SyncDir, resource);
-            string source = Path.Combine(AssemblyDirectory, resource);
+            string target = Path.Join(SyncDir, resource);
+            string source = Path.Join(AssemblyDirectory, resource);
             if (!File.Exists(target))
             {
                 _logger.LogInformation($"Installing missing {target}");
@@ -2640,8 +2640,8 @@ public class ParatextService : DisposableBase, IParatextService
         // If the publisher updates this resource, this file will be overwritten with the fully migrated language file,
         // stopping this migration from running in the future and negating its need.
         string path = LocalProjectDir(paratextId);
-        string oldLdmlFile = Path.Combine(path, "ldml.xml");
-        string newLdmlFile = Path.Combine(path, scrText.Settings.LdmlFileName);
+        string oldLdmlFile = Path.Join(path, "ldml.xml");
+        string newLdmlFile = Path.Join(path, scrText.Settings.LdmlFileName);
         if (_fileSystemService.FileExists(oldLdmlFile) && !_fileSystemService.FileExists(newLdmlFile))
         {
             _fileSystemService.MoveFile(oldLdmlFile, newLdmlFile);
@@ -2689,7 +2689,7 @@ public class ParatextService : DisposableBase, IParatextService
         // Historically, SF used both "target" and "source" projects in adjacent directories. Then
         // moved to just using "target".
         string subDirForMainProject = "target";
-        return Path.Combine(SyncDir, paratextId, subDirForMainProject);
+        return Path.Join(SyncDir, paratextId, subDirForMainProject);
     }
 
     private void CloneProjectRepo(IInternetSharedRepositorySource source, string paratextId, SharedRepository repo)
@@ -2821,7 +2821,7 @@ public class ParatextService : DisposableBase, IParatextService
     {
         CommentList userComments = [.. commentManager.AllComments.Where(comment => comment.User == username)];
         string fileName = commentManager.GetUserFileName(username);
-        string path = Path.Combine(commentManager.ScrText.Directory, fileName);
+        string path = Path.Join(commentManager.ScrText.Directory, fileName);
         using Stream stream = _fileSystemService.CreateFile(path);
         _fileSystemService.WriteXmlFile(stream, userComments);
     }

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -157,12 +157,12 @@ public class SFInstallableDblResource : InstallableResource
             {
                 // First check the resources by ID directory
                 string fileName = Name + "." + DBLEntryUid + ProjectFileManager.resourceFileExtension;
-                string projectPath = Path.Combine(SFScrTextCollection.ResourcesByIdDirectory, fileName);
+                string projectPath = Path.Join(SFScrTextCollection.ResourcesByIdDirectory, fileName);
                 if (!_fileSystemService.FileExists(projectPath))
                 {
                     // If that does not exist, use the resources directory
                     fileName = Name + ProjectFileManager.resourceFileExtension;
-                    projectPath = Path.Combine(ScrTextCollection.ResourcesDirectory, fileName);
+                    projectPath = Path.Join(ScrTextCollection.ResourcesDirectory, fileName);
                 }
 
                 // Generate an ExistingScrText from the p8z file on disk
@@ -419,7 +419,7 @@ public class SFInstallableDblResource : InstallableResource
             if (!entry.IsFile)
                 continue; // Skip directories
 
-            string entryPath = Path.Combine(path, entry.Name);
+            string entryPath = Path.Join(path, entry.Name);
 
             if (_fileSystemService.FileExists(entryPath))
                 continue; // Don't overwrite
@@ -466,7 +466,7 @@ public class SFInstallableDblResource : InstallableResource
         }
 
         sourceDirectory = this.CreateTempSourceDirectory();
-        string filePath = Path.Combine(sourceDirectory, this.Name + ProjectFileManager.resourceFileExtension);
+        string filePath = Path.Join(sourceDirectory, this.Name + ProjectFileManager.resourceFileExtension);
         if (!this.GetFile(filePath))
         {
             if (RobustFile.Exists(filePath))
@@ -519,7 +519,7 @@ public class SFInstallableDblResource : InstallableResource
         }
         catch (ArgumentNullException)
         {
-            // Path.Combine() in ScrTextCollection will have thrown this error
+            // Path.Join() in ScrTextCollection will have thrown this error
             resourcesDirectory = string.Empty;
             resourcesByIdDirectory = string.Empty;
         }
@@ -770,10 +770,10 @@ public class SFInstallableDblResource : InstallableResource
     /// </returns>
     private string CreateTempSourceDirectory()
     {
-        string dirName = Path.Combine(temporaryDirectoryName, Name + '_' + Path.GetRandomFileName());
+        string dirName = Path.Join(temporaryDirectoryName, Name + '_' + Path.GetRandomFileName());
 
         // This following is an implementation of Paratext.Data.FileUtils.GetTemporaryDirectory(dirName)
-        string path = Path.Combine(Path.GetTempPath(), dirName);
+        string path = Path.Join(Path.GetTempPath(), dirName);
         if (!Directory.Exists(path))
         {
             // If we don't have the file system service, just ignore

--- a/src/SIL.XForge.Scripture/Services/SFProjectRights.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectRights.cs
@@ -14,7 +14,7 @@ namespace SIL.XForge.Scripture.Services;
 /// </summary>
 public class SFProjectRights : ISFProjectRights
 {
-    internal static readonly string Filename = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "rightsByRole.json");
+    internal static readonly string Filename = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "rightsByRole.json");
     private readonly Dictionary<string, string[]> _rights = [];
 
     public SFProjectRights(IFileSystemService fileSystemService)

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -96,7 +96,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         if (!userSecretAttempt.TryResult(out UserSecret userSecret))
             throw new DataNotFoundException("The user does not exist.");
 
-        string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", settings.ParatextId);
+        string projectDir = Path.Join(SiteOptions.Value.SiteDir, "sync", settings.ParatextId);
         if (FileSystemService.DirectoryExists(projectDir))
             throw new InvalidOperationException("A directory for this project already exists.");
 
@@ -291,13 +291,13 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 ptProjectId,
                 curUserId
             );
-            string projectDir = Path.Combine(SiteOptions.Value.SiteDir, "sync", ptProjectId);
+            string projectDir = Path.Join(SiteOptions.Value.SiteDir, "sync", ptProjectId);
             if (FileSystemService.DirectoryExists(projectDir))
                 FileSystemService.DeleteDirectory(projectDir);
             string audioDir = GetAudioDir(projectId);
             if (FileSystemService.DirectoryExists(audioDir))
                 FileSystemService.DeleteDirectory(audioDir);
-            string trainingDataDir = Path.Combine(
+            string trainingDataDir = Path.Join(
                 SiteOptions.Value.SiteDir,
                 TrainingDataService.DirectoryName,
                 ptProjectId

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -19,7 +19,7 @@ public class SFScrTextCollection : ScrTextCollection
     /// <summary>
     /// The location where resources reside if there is more than one resource with the same short name.
     /// </summary>
-    public static string ResourcesByIdDirectory => Path.Combine(SettingsDirectory, "_resourcesById");
+    public static string ResourcesByIdDirectory => Path.Join(SettingsDirectory, "_resourcesById");
 
     /// <summary>
     /// Adds a ScrText to the internal index. This should only be used for testing purposes!

--- a/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
@@ -149,7 +149,7 @@ public class TrainingDataService(
         MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
 
         // Ensure that the training data directory exists
-        string trainingDataDir = Path.Combine(siteOptions.Value.SiteDir, DirectoryName, projectId);
+        string trainingDataDir = Path.Join(siteOptions.Value.SiteDir, DirectoryName, projectId);
         if (!fileSystemService.DirectoryExists(trainingDataDir))
         {
             throw new DataNotFoundException("The training data directory does not exist");
@@ -174,7 +174,7 @@ public class TrainingDataService(
                 fileName = fileName.Split('?').First();
             }
 
-            string path = Path.Combine(trainingDataDir, fileName);
+            string path = Path.Join(trainingDataDir, fileName);
             if (!fileSystemService.FileExists(path))
             {
                 // Skip if the file does not exist
@@ -347,13 +347,13 @@ public class TrainingDataService(
             .Aggregate(dataId, (current, c) => current.Replace(c.ToString(), string.Empty));
 
         // Ensure that the training data directory exists
-        string trainingDataDir = Path.Combine(siteOptions.Value.SiteDir, DirectoryName, projectId);
+        string trainingDataDir = Path.Join(siteOptions.Value.SiteDir, DirectoryName, projectId);
         if (!fileSystemService.DirectoryExists(trainingDataDir))
         {
             fileSystemService.CreateDirectory(trainingDataDir);
         }
 
         // Return the full path
-        return Path.Combine(trainingDataDir, $"{userId}_{dataId}.csv");
+        return Path.Join(trainingDataDir, $"{userId}_{dataId}.csv");
     }
 }

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -54,7 +54,7 @@ public class TransceleratorService : ITransceleratorService
 
     public IEnumerable<string> QuestionFiles(string paratextId)
     {
-        string pathToFiles = Path.Combine(
+        string pathToFiles = Path.Join(
             _siteOptions.Value.SiteDir,
             "sync",
             paratextId,

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -237,7 +237,7 @@ public class Startup
         app.UseStaticFiles(
             new StaticFileOptions
             {
-                FileProvider = new PhysicalFileProvider(Path.Combine(siteOptions.Value.SiteDir, "audio")),
+                FileProvider = new PhysicalFileProvider(Path.Join(siteOptions.Value.SiteDir, "audio")),
                 RequestPath = "/assets/audio",
             }
         );
@@ -245,7 +245,7 @@ public class Startup
             new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(
-                    Path.Combine(siteOptions.Value.SiteDir, TrainingDataService.DirectoryName)
+                    Path.Join(siteOptions.Value.SiteDir, TrainingDataService.DirectoryName)
                 ),
                 RequestPath = $"/assets/{TrainingDataService.DirectoryName}",
             }

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -19,12 +19,12 @@ public class RealtimeServer : IRealtimeServer
         if (Product.RunningInContainer)
         {
             // Path to realtime server index file in the realtimeserver docker container.
-            _modulePath = Path.Combine("/app", "lib", "cjs", "common", "index.js");
+            _modulePath = Path.Join("/app", "lib", "cjs", "common", "index.js");
         }
         else
         {
             string assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            _modulePath = Path.Combine(assemblyDirectory, "RealtimeServer", "lib", "cjs", "common", "index.js");
+            _modulePath = Path.Join(assemblyDirectory, "RealtimeServer", "lib", "cjs", "common", "index.js");
         }
     }
 

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -187,7 +187,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
         string audioDir = GetAudioDir(projectId);
         if (!FileSystemService.DirectoryExists(audioDir))
             FileSystemService.CreateDirectory(audioDir);
-        string outputPath = Path.Combine(audioDir, $"{curUserId}_{dataId}.mp3");
+        string outputPath = Path.Join(audioDir, $"{curUserId}_{dataId}.mp3");
         if (await _audioService.IsMp3FileAsync(path))
         {
             // Delete the existing file, if it exists
@@ -234,7 +234,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
             throw new ForbiddenException();
 
         string audioDir = GetAudioDir(projectId);
-        string filePath = Path.Combine(audioDir, $"{ownerId}_{dataId}.mp3");
+        string filePath = Path.Join(audioDir, $"{ownerId}_{dataId}.mp3");
         if (FileSystemService.FileExists(filePath))
             FileSystemService.DeleteFile(filePath);
     }
@@ -324,7 +324,7 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
     protected bool IsProjectAdmin(TModel project, string userId) =>
         project.UserRoles.TryGetValue(userId, out string role) && role == ProjectAdminRole;
 
-    protected string GetAudioDir(string projectId) => Path.Combine(SiteOptions.Value.SiteDir, "audio", projectId);
+    protected string GetAudioDir(string projectId) => Path.Join(SiteOptions.Value.SiteDir, "audio", projectId);
 
     protected abstract Task<Attempt<string>> TryGetProjectRoleAsync(TModel project, string userId);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3946,7 +3946,7 @@ public class DeltaUsxMapperTests
 
     private async Task RoundTripTestHelper(string projectZipFilename, string projectShortName)
     {
-        string zipFilePath = Path.Combine(GetPathToTestProject(), "SampleData", $"{projectZipFilename}.zip");
+        string zipFilePath = Path.Join(GetPathToTestProject(), "SampleData", $"{projectZipFilename}.zip");
         await using FileStream zipFileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
         using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
         Assert.That(archive.Entries.Any(), "setup. unexpected input size.");

--- a/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
@@ -16,7 +16,7 @@ public class LazyScrTextCollectionTests
     [SetUp]
     public void BeforeEachTest()
     {
-        _testDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        _testDirectory = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         _fileSystemService = Substitute.For<IFileSystemService>();
         _fileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
         _fileSystemService.FileExists(Arg.Any<string>()).Returns(false);
@@ -39,7 +39,7 @@ public class LazyScrTextCollectionTests
         string projectId = "Project01";
         string username = "User";
         string projectTextName = "Proj01";
-        string path = Path.Combine(_testDirectory, projectId, "target");
+        string path = Path.Join(_testDirectory, projectId, "target");
         string content = $"<ScriptureText><Name>{projectTextName}</Name><guid>{projectId}</guid></ScriptureText>";
         _fileSystemService.FileReadText(Arg.Any<string>()).Returns(content);
         _fileSystemService.FileExists(Arg.Any<string>()).Returns(true);
@@ -48,6 +48,6 @@ public class LazyScrTextCollectionTests
         Assert.NotNull(scrText);
         Assert.AreEqual(projectTextName, scrText.Name);
         Assert.AreEqual(path, scrText.Directory);
-        _fileSystemService.Received(1).FileExists(Path.Combine(path, ProjectSettings.fileName));
+        _fileSystemService.Received(1).FileExists(Path.Join(path, ProjectSettings.fileName));
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -3944,11 +3944,11 @@ public class MachineProjectServiceTests
             FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(true);
             FileSystemService
                 .EnumerateFiles(Arg.Any<string>())
-                .Returns(callInfo => [Path.Combine(callInfo.ArgAt<string>(0), "file")]);
+                .Returns(callInfo => [Path.Join(callInfo.ArgAt<string>(0), "file")]);
             FileSystemService
                 .OpenFile(Arg.Any<string>(), FileMode.Open)
                 .Returns(callInfo => new MemoryStream(
-                    Encoding.UTF8.GetBytes(Path.Combine(callInfo.ArgAt<string>(0) + "_file_contents"))
+                    Encoding.UTF8.GetBytes(Path.Join(callInfo.ArgAt<string>(0) + "_file_contents"))
                 ));
 
             ProjectSecrets = new MemoryRepository<SFProjectSecret>(

--- a/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockCommentTags.cs
@@ -17,7 +17,7 @@ public class MockCommentTags : CommentTags
 
     public static MockCommentTags GetCommentTags(string username, string ptProjectId)
     {
-        var scrtextDir = Path.Combine(Path.GetTempPath(), ptProjectId, "target");
+        var scrtextDir = Path.Join(Path.GetTempPath(), ptProjectId, "target");
         var associatedPtUser = new SFParatextUser(username);
         ProjectName projectName = new ProjectName() { ProjectPath = scrtextDir, ShortName = "Proj" };
         MockScrText scrText = new MockScrText(associatedPtUser, projectName);

--- a/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/NotesFormatterTests.cs
@@ -655,7 +655,7 @@ public class NotesFormatterTests
 
         private MockScrText GetScrText(ParatextUser associatedPtUser, string projectId, bool hasEditPermission = true)
         {
-            string scrTextDir = Path.Combine(_syncDir, projectId, "target");
+            string scrTextDir = Path.Join(_syncDir, projectId, "target");
             ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
             var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
             scrText.Permissions.CreateFirstAdminUser();

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4200,7 +4200,7 @@ public class ParatextServiceTests
         MockScrText scrText = env.GetScrText(associatedPtUser, ptProjectId);
         env.MockScrTextCollection.FindById(env.Username01, ptProjectId).Returns(null, scrText);
 
-        string clonePath = Path.Combine(env.SyncDir, ptProjectId, "target");
+        string clonePath = Path.Join(env.SyncDir, ptProjectId, "target");
         env.MockFileSystemService.DirectoryExists(clonePath).Returns(false);
 
         // SUT
@@ -4270,7 +4270,7 @@ public class ParatextServiceTests
 
         // Replaces obsolete source project if the source project has been changed
         string newSourceProjectId = env.PTProjectIds[env.Project03].Id;
-        string sourcePath = Path.Combine(env.SyncDir, newSourceProjectId, "target");
+        string sourcePath = Path.Join(env.SyncDir, newSourceProjectId, "target");
 
         // Only set the new source ScrText when it is "cloned" to the filesystem
         env.MockFileSystemService.When(fs => fs.CreateDirectory(sourcePath))
@@ -5069,7 +5069,7 @@ public class ParatextServiceTests
         Assert.IsTrue(result);
         env.MockHgWrapper.ReceivedWithAnyArgs().RestoreRepository(default, default);
         env.MockHgWrapper.ReceivedWithAnyArgs().MarkSharedChangeSetsPublic(default);
-        string projectRepository = Path.Combine(scrtextDir, "_Backups", ptProjectId);
+        string projectRepository = Path.Join(scrtextDir, "_Backups", ptProjectId);
         string restoredRepository = projectRepository + "_Restored";
         // Removes leftover folders from a failed previous restore
         env.MockFileSystemService.Received().DeleteDirectory(projectRepository);
@@ -5388,7 +5388,7 @@ public class ParatextServiceTests
         string projectPTId = env.SetupProject(env.Project01, associatedPtUser);
         string rev = "some-desired-revision";
         env.MockHgWrapper.GetRepoRevision(
-                Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Combine(projectPTId, "target")))
+                Arg.Is<string>((string repoPath) => repoPath.EndsWith(Path.Join(projectPTId, "target")))
             )
             .Returns(rev);
         // SUT
@@ -7081,7 +7081,7 @@ public class ParatextServiceTests
             RealtimeService.AddRepository("sf_projects", OTType.Json0, new MemoryRepository<SFProject>(projects));
             MockFileSystemService
                 .DirectoryExists(
-                    Arg.Is<string>((string path) => path.EndsWith(Path.Combine(PTProjectIds[Project01].Id, "target")))
+                    Arg.Is<string>((string path) => path.EndsWith(Path.Join(PTProjectIds[Project01].Id, "target")))
                 )
                 .Returns(true);
         }
@@ -7480,7 +7480,7 @@ public class ParatextServiceTests
             string zipLanguageCode = "eng"
         )
         {
-            string scrTextDir = Path.Combine(SyncDir, $"{shortName}.p8z");
+            string scrTextDir = Path.Join(SyncDir, $"{shortName}.p8z");
             ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = shortName };
             var scrText = new MockResourceScrText(
                 projectName,
@@ -7492,14 +7492,14 @@ public class ParatextServiceTests
             };
             scrText.Settings.LanguageID = LanguageId.English;
             scrText.ZipFile.AddFile(
-                Path.Combine(ZippedProjectFileManagerBase.DBLFolderName, "language", "iso", zipLanguageCode)
+                Path.Join(ZippedProjectFileManagerBase.DBLFolderName, "language", "iso", zipLanguageCode)
             );
             return scrText;
         }
 
         public MockScrText GetScrText(ParatextUser associatedPtUser, string projectId, bool hasEditPermission = true)
         {
-            string scrTextDir = Path.Combine(SyncDir, projectId, "target");
+            string scrTextDir = Path.Join(SyncDir, projectId, "target");
             ProjectName projectName = new ProjectName { ProjectPath = scrTextDir, ShortName = "Proj" };
             var scrText = new MockScrText(associatedPtUser, projectName) { CachedGuid = HexId.FromStr(projectId) };
             scrText.Permissions.CreateFirstAdminUser();

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2810,7 +2810,7 @@ public class SFProjectServiceTests
     public async Task DeleteProjectAsync_Success()
     {
         var env = new TestEnvironment();
-        string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
+        string ptProjectDir = Path.Join("xforge", "sync", "paratext_" + Project01);
         env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
 
@@ -2841,7 +2841,7 @@ public class SFProjectServiceTests
         env.FileSystemService.Received().DeleteDirectory(ptProjectDir);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.False);
 
-        ptProjectDir = Path.Combine("xforge", "sync", "pt_source_no_suggestions");
+        ptProjectDir = Path.Join("xforge", "sync", "pt_source_no_suggestions");
         env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
         Assert.That(env.GetProject(Project03).TranslateConfig.Source, Is.Not.Null);
 
@@ -2963,7 +2963,7 @@ public class SFProjectServiceTests
             )
             .Returns(Task.FromResult(Attempt.Success(SFProjectRole.Administrator)));
         SFProject existingSfProject = env.GetProject(Project01);
-        string ptProjectDir = Path.Combine("xforge", "sync", "paratext_" + Project01);
+        string ptProjectDir = Path.Join("xforge", "sync", "paratext_" + Project01);
         env.FileSystemService.DirectoryExists(ptProjectDir).Returns(true);
         Assert.That(env.ProjectSecrets.Contains(Project01), Is.True, "setup");
         InvalidOperationException thrown = Assert.ThrowsAsync<InvalidOperationException>(

--- a/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
@@ -390,7 +390,7 @@ public class TrainingDataServiceTests
         env.FileSystemService.OpenFile(FileExcel2003, FileMode.Open).Returns(fileStream);
 
         // Create the output file
-        string path = Path.Combine(
+        string path = Path.Join(
             env.SiteOptions.Value.SiteDir,
             TrainingDataService.DirectoryName,
             Project01,
@@ -432,7 +432,7 @@ public class TrainingDataServiceTests
         env.FileSystemService.OpenFile(FileExcel2007, FileMode.Open).Returns(fileStream);
 
         // Create the output file
-        string path = Path.Combine(
+        string path = Path.Join(
             env.SiteOptions.Value.SiteDir,
             TrainingDataService.DirectoryName,
             Project01,

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -29,7 +29,7 @@ public class ProjectServiceTests
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
         const string path = "file.wav";
-        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        string filePath = Path.Join("site", "audio", Project01, $"{User01}_{dataId}.mp3");
 
         // SUT
         Uri uri = await env.Service.SaveAudioAsync(User01, Project01, dataId, path);
@@ -43,7 +43,7 @@ public class ProjectServiceTests
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
         const string path = "file.mp3";
-        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        string filePath = Path.Join("site", "audio", Project01, $"{User01}_{dataId}.mp3");
         env.AudioService.IsMp3FileAsync(path).Returns(Task.FromResult(true));
 
         // SUT
@@ -80,7 +80,7 @@ public class ProjectServiceTests
     {
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
-        string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
+        string filePath = Path.Join("site", "audio", Project01, $"{User02}_{dataId}.mp3");
         env.FileSystemService.FileExists(filePath).Returns(true);
 
         await env.Service.DeleteAudioAsync(User02, Project01, User02, dataId);
@@ -92,7 +92,7 @@ public class ProjectServiceTests
     {
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
-        string filePath = Path.Combine("site", "audio", Project01, $"{User02}_{dataId}.mp3");
+        string filePath = Path.Join("site", "audio", Project01, $"{User02}_{dataId}.mp3");
         env.FileSystemService.FileExists(filePath).Returns(true);
 
         await env.Service.DeleteAudioAsync(User01, Project01, User02, dataId);
@@ -104,7 +104,7 @@ public class ProjectServiceTests
     {
         var env = new TestEnvironment();
         const string dataId = "507f1f77bcf86cd799439011";
-        string filePath = Path.Combine("site", "audio", Project01, $"{User01}_{dataId}.mp3");
+        string filePath = Path.Join("site", "audio", Project01, $"{User01}_{dataId}.mp3");
         env.FileSystemService.FileExists(filePath).Returns(true);
 
         Assert.ThrowsAsync<ForbiddenException>(() => env.Service.DeleteAudioAsync(User02, Project01, User01, dataId));

--- a/tools/RepoInfo/Program.cs
+++ b/tools/RepoInfo/Program.cs
@@ -80,7 +80,7 @@ if (string.IsNullOrWhiteSpace(assemblyDirectory))
     return;
 }
 
-var hgMerge = Path.Combine(assemblyDirectory, "ParatextMerge.py");
+var hgMerge = Path.Join(assemblyDirectory, "ParatextMerge.py");
 Hg.Default = new Hg(customHgPath, hgMerge, assemblyDirectory);
 
 // Files which we do not calculate the information for
@@ -91,7 +91,7 @@ ScrTextCollection.Implementation = new SFScrTextCollection();
 ScrTextCollection.Initialize(projectPath);
 
 // Get the path to the project settings
-string? settingsPath = Path.Combine(projectPath, "Settings.xml");
+string? settingsPath = Path.Join(projectPath, "Settings.xml");
 if (!File.Exists(settingsPath))
 {
     settingsPath = Directory.EnumerateFiles(projectPath, "*.ssf").FirstOrDefault();

--- a/tools/Roundtrip/Program.cs
+++ b/tools/Roundtrip/Program.cs
@@ -197,7 +197,7 @@ void Roundtrip(string usfm, string fileName, string path, RoundtripMethod roundt
         if (outputAllFiles)
         {
             File.WriteAllText(
-                Path.Combine(
+                Path.Join(
                     "output",
                     $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-delta.json"
                 ),
@@ -217,10 +217,7 @@ void Roundtrip(string usfm, string fileName, string path, RoundtripMethod roundt
         if (outputAllFiles)
         {
             File.WriteAllText(
-                Path.Combine(
-                    "output",
-                    $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-usj.json"
-                ),
+                Path.Join("output", $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-usj.json"),
                 JsonConvert.SerializeObject(usj, Newtonsoft.Json.Formatting.Indented)
             );
         }
@@ -265,21 +262,21 @@ void Roundtrip(string usfm, string fileName, string path, RoundtripMethod roundt
         if (outputSfmFiles && Directory.CreateDirectory("output").Exists)
         {
             File.WriteAllText(
-                Path.Combine(
+                Path.Join(
                     "output",
                     $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-actual{Path.GetExtension(fileName)}"
                 ),
                 actualUsfm
             );
             File.WriteAllText(
-                Path.Combine(
+                Path.Join(
                     "output",
                     $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-expected{Path.GetExtension(fileName)}"
                 ),
                 expectedUsfm
             );
             File.WriteAllText(
-                Path.Combine(
+                Path.Join(
                     "output",
                     $"{Path.GetFileName(path)}-{Path.GetFileNameWithoutExtension(fileName)}-original{Path.GetExtension(fileName)}"
                 ),

--- a/tools/ServalBuildReport/Program.cs
+++ b/tools/ServalBuildReport/Program.cs
@@ -33,7 +33,7 @@ ServiceProvider services = SetupServices(environment);
 ITranslationEnginesClient translationEnginesClient = services.GetService<ITranslationEnginesClient>()!;
 
 // Set up the Spreadsheet
-string spreadsheetPath = Path.Combine(Path.GetTempPath(), $"{environment}.xlsx");
+string spreadsheetPath = Path.Join(Path.GetTempPath(), $"{environment}.xlsx");
 using XSSFWorkbook workbook = new XSSFWorkbook();
 await using FileStream fs = new FileStream(spreadsheetPath, FileMode.Create, FileAccess.Write);
 int summarySheetRow = 0;

--- a/tools/ServalDownloader/Program.cs
+++ b/tools/ServalDownloader/Program.cs
@@ -20,7 +20,7 @@ ITranslationEnginesClient translationEnginesClient = services.GetService<ITransl
 
 // Set up the translation engine directory and get the translation engine
 string translationEngineId = args[0];
-string translationEnginePath = Path.Combine(Path.GetTempPath(), translationEngineId);
+string translationEnginePath = Path.Join(Path.GetTempPath(), translationEngineId);
 Directory.CreateDirectory(translationEnginePath);
 TranslationEngine translationEngine = await translationEnginesClient.GetAsync(translationEngineId);
 if (translationEngine.Type != "nmt")
@@ -34,12 +34,12 @@ if (translationEngine.Type != "nmt")
 foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorporaAsync(translationEngineId))
 #pragma warning restore CS0612 // Type or member is obsolete
 {
-    string corpusPath = Path.Combine(translationEnginePath, corpus.Id);
+    string corpusPath = Path.Join(translationEnginePath, corpus.Id);
     Directory.CreateDirectory(corpusPath);
     foreach (TranslationCorpusFile sourceFile in corpus.SourceFiles)
     {
         // Create the source directory
-        string sourcePath = Path.Combine(corpusPath, "source");
+        string sourcePath = Path.Join(corpusPath, "source");
         Directory.CreateDirectory(sourcePath);
 
         // Get the file extension
@@ -50,7 +50,7 @@ foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorpor
         FileResponse file = await dataFilesClient.DownloadAsync(sourceFile.File.Id);
 
         // Write the file
-        string path = Path.Combine(sourcePath, $"{sourceFile.TextId}_({sourceFile.File.Id}){extension}");
+        string path = Path.Join(sourcePath, $"{sourceFile.TextId}_({sourceFile.File.Id}){extension}");
         Console.WriteLine($"Writing {path}...");
         await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
         file.Stream.CopyTo(fileStream);
@@ -58,7 +58,7 @@ foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorpor
 
     foreach (TranslationCorpusFile targetFile in corpus.TargetFiles)
     {
-        string targetPath = Path.Combine(corpusPath, "target");
+        string targetPath = Path.Join(corpusPath, "target");
         Directory.CreateDirectory(targetPath);
 
         // Get the file extension
@@ -69,7 +69,7 @@ foreach (TranslationCorpus corpus in await translationEnginesClient.GetAllCorpor
         FileResponse file = await dataFilesClient.DownloadAsync(targetFile.File.Id);
 
         // Write the file
-        string path = Path.Combine(targetPath, $"{targetFile.TextId}_({targetFile.File.Id}){extension}");
+        string path = Path.Join(targetPath, $"{targetFile.TextId}_({targetFile.File.Id}){extension}");
         Console.WriteLine($"Writing {path}...");
         await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
         file.Stream.CopyTo(fileStream);
@@ -83,12 +83,12 @@ foreach (
     )
 )
 {
-    string parallelCorpusPath = Path.Combine(translationEnginePath, parallelCorpus.Id);
+    string parallelCorpusPath = Path.Join(translationEnginePath, parallelCorpus.Id);
     Directory.CreateDirectory(parallelCorpusPath);
     foreach (ResourceLink sourceCorpus in parallelCorpus.SourceCorpora)
     {
         // Create the source directory
-        string sourcePath = Path.Combine(parallelCorpusPath, "source");
+        string sourcePath = Path.Join(parallelCorpusPath, "source");
         Directory.CreateDirectory(sourcePath);
 
         Corpus corpus = await corporaClient.GetAsync(sourceCorpus.Id);
@@ -102,7 +102,7 @@ foreach (
             FileResponse file = await dataFilesClient.DownloadAsync(corpusFile.File.Id);
 
             // Write the file
-            string path = Path.Combine(sourcePath, $"{corpusFile.TextId}_({corpusFile.File.Id}){extension}");
+            string path = Path.Join(sourcePath, $"{corpusFile.TextId}_({corpusFile.File.Id}){extension}");
             Console.WriteLine($"Writing {path}...");
             await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
             file.Stream.CopyTo(fileStream);
@@ -112,7 +112,7 @@ foreach (
     foreach (ResourceLink sourceCorpus in parallelCorpus.SourceCorpora)
     {
         // Create the target directory
-        string targetPath = Path.Combine(parallelCorpusPath, "target");
+        string targetPath = Path.Join(parallelCorpusPath, "target");
         Directory.CreateDirectory(targetPath);
 
         Corpus corpus = await corporaClient.GetAsync(sourceCorpus.Id);
@@ -126,7 +126,7 @@ foreach (
             FileResponse file = await dataFilesClient.DownloadAsync(corpusFile.File.Id);
 
             // Write the file
-            string path = Path.Combine(targetPath, $"{corpusFile.TextId}_({corpusFile.File.Id}){extension}");
+            string path = Path.Join(targetPath, $"{corpusFile.TextId}_({corpusFile.File.Id}){extension}");
             Console.WriteLine($"Writing {path}...");
             await using FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write);
             file.Stream.CopyTo(fileStream);


### PR DESCRIPTION
This PR updates the use of `Path.Combine()` to `Path.Join`, which fixes these CodeQL warnings: https://github.com/sillsdev/web-xforge/security/code-scanning?query=is%3Aopen+branch%3Amaster+System.IO.Path.Combine

Using `Path.Combine` can be problematic if path parts after the first part start with a "/", as the path will then start from that part of the path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3150)
<!-- Reviewable:end -->
