### PR TITLE
SF-3315 Use TranslationScriptureRanges for draft generation

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -96,7 +96,14 @@
 <h3>Training data files</h3>
 <p>{{ trainingFiles.join(", ") || "None" }}</p>
 <h3>Translation books</h3>
-<p class="translation-range">{{ translationBooks.join(", ") || "None" }}</p>
+@for (book of translationBooksByProject; track book.source) {
+  <div class="translation">
+    <p>{{ book.source }}</p>
+    <p class="translation-range">{{ book.scriptureRange }}</p>
+  </div>
+} @empty {
+  <p class="translation">None</p>
+}
 
 @if (draftJob$ | async; as draftJob) {
   <h3>Diagnostic Information</h3>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -127,7 +127,7 @@ describe('ServalProjectComponent', () => {
 
     it('should have a download button', fakeAsync(() => {
       const env = new TestEnvironment();
-      expect(env.downloadButtions.length).toBe(4);
+      expect(env.downloadButtons.length).toBe(4);
       expect(env.firstDownloadButton.innerText).toContain('Download');
       expect(env.firstDownloadButton.disabled).toBe(false);
     }));
@@ -201,12 +201,14 @@ describe('ServalProjectComponent', () => {
   });
 
   describe('last draft configuration', () => {
-    it('shows the last draft configs no training books', fakeAsync(() => {
+    it('shows the last draft configs no translation or training books', fakeAsync(() => {
       const env = new TestEnvironment({ preTranslate: true, draftConfig: {} });
       const trainingSources = env.trainingSources;
       expect(trainingSources.length).toEqual(1);
       expect(trainingSources[0].textContent).toEqual('None');
-      expect(env.TranslationSourceBookNames).toEqual('Leviticus, Numbers');
+      const translationSources = env.translationSources;
+      expect(translationSources.length).toEqual(1);
+      expect(translationSources[0].textContent).toEqual('None');
     }));
 
     it('shows the last draft configs single training source', fakeAsync(() => {
@@ -214,7 +216,9 @@ describe('ServalProjectComponent', () => {
       const trainingSources = env.trainingSources;
       expect(trainingSources.length).toEqual(1);
       expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis, Exodus');
-      expect(env.TranslationSourceBookNames).toEqual('Leviticus, Numbers');
+      const translationSources = env.translationSources;
+      expect(translationSources.length).toEqual(1);
+      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus, Numbers');
     }));
 
     it('shows the last draft configs multiple training sources', fakeAsync(() => {
@@ -225,14 +229,17 @@ describe('ServalProjectComponent', () => {
           lastSelectedTrainingScriptureRanges: [
             { projectId: 'project04', scriptureRange: 'GEN;EXO' },
             { projectId: 'project05', scriptureRange: 'GEN' }
-          ]
+          ],
+          lastSelectedTranslationScriptureRanges: [{ projectId: 'project03', scriptureRange: 'LEV;NUM' }]
         } as DraftConfig
       });
       const trainingSources = env.trainingSources;
       expect(trainingSources.length).toEqual(2);
       expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis, Exodus');
       expect(env.getTrainingSourceBookNames(trainingSources[1])).toEqual('Genesis');
-      expect(env.TranslationSourceBookNames).toEqual('Leviticus, Numbers');
+      const translationSources = env.translationSources;
+      expect(translationSources.length).toEqual(1);
+      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus, Numbers');
     }));
   });
 
@@ -289,7 +296,13 @@ describe('ServalProjectComponent', () => {
                   : 'GEN;EXO'
                 : undefined,
               lastSelectedTrainingScriptureRanges: args.draftConfig?.lastSelectedTrainingScriptureRanges ?? undefined,
-              lastSelectedTranslationScriptureRange: args.preTranslate ? 'LEV;NUM' : undefined
+              lastSelectedTranslationScriptureRange: args.preTranslate
+                ? args.draftConfig != null
+                  ? args.draftConfig.lastSelectedTranslationScriptureRange
+                  : 'LEV;NUM'
+                : undefined,
+              lastSelectedTranslationScriptureRanges:
+                args.draftConfig?.lastSelectedTranslationScriptureRanges ?? undefined
             },
             preTranslate: args.preTranslate,
             source: {
@@ -338,7 +351,7 @@ describe('ServalProjectComponent', () => {
       return this.fixture.nativeElement.querySelector('td button');
     }
 
-    get downloadButtions(): NodeListOf<HTMLButtonElement> {
+    get downloadButtons(): NodeListOf<HTMLButtonElement> {
       return this.fixture.nativeElement.querySelectorAll('td button');
     }
 
@@ -350,8 +363,8 @@ describe('ServalProjectComponent', () => {
       return this.fixture.nativeElement.querySelectorAll('.training');
     }
 
-    get TranslationSourceBookNames(): string {
-      return this.fixture.nativeElement.querySelector('.translation-range').textContent;
+    get translationSources(): NodeListOf<HTMLElement> {
+      return this.fixture.nativeElement.querySelectorAll('.translation');
     }
 
     set onlineStatus(hasConnection: boolean) {
@@ -369,6 +382,10 @@ describe('ServalProjectComponent', () => {
 
     getTrainingSourceBookNames(node: HTMLElement): string {
       return node.querySelector('.training-source-range')?.textContent ?? '';
+    }
+
+    getTranslationBookNames(node: HTMLElement): string {
+      return node.querySelector('.translation-range')?.textContent ?? '';
     }
   }
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -65,7 +65,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
   trainingBooksByProject: ProjectAndRange[] = [];
   trainingFiles: string[] = [];
-  translationBooks: string[] = [];
+  translationBooksByProject: ProjectAndRange[] = [];
 
   downloadBooksProgress: number = 0;
   downloadBooksTotal: number = 0;
@@ -171,9 +171,25 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
             }
           }
           this.trainingFiles = draftConfig.lastSelectedTrainingDataFiles;
-          this.translationBooks = booksFromScriptureRange(draftConfig.lastSelectedTranslationScriptureRange ?? '').map(
-            bookNum => Canon.bookNumberToEnglishName(bookNum)
-          );
+          this.translationBooksByProject = [];
+          if (draftConfig.lastSelectedTranslationScriptureRange != null) {
+            this.translationBooksByProject.push({
+              source: 'Source 1',
+              scriptureRange: booksFromScriptureRange(draftConfig.lastSelectedTranslationScriptureRange ?? '')
+                .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
+                .join(', ')
+            });
+          } else if (draftConfig.lastSelectedTranslationScriptureRanges != null) {
+            let sourceCount = 1;
+            for (const range of draftConfig.lastSelectedTranslationScriptureRanges) {
+              this.translationBooksByProject.push({
+                source: `Source ${sourceCount++}`,
+                scriptureRange: booksFromScriptureRange(range.scriptureRange)
+                  .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
+                  .join(', ')
+              });
+            }
+          }
 
           this.draftConfig = draftConfig;
           this.draftJob$ = SFProjectService.hasDraft(project) ? this.getDraftJob(projectDoc.id) : of(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'draft_generation_steps'">
-  @if (availableTranslateBooks.length > 0) {
+  @if (allAvailableTranslateBooks.length > 0) {
     <mat-stepper linear (selectionChange)="onStepChange()" labelPosition="bottom" [disableRipple]="true">
       <!-- Icon overrides -->
       <ng-template matStepperIcon="edit" let-index="index">{{ index + 1 }}</ng-template>
@@ -24,13 +24,16 @@
           {{ t("choose_books_to_translate_header") }}
         </ng-template>
         <h1 class="mat-headline-4">{{ t("choose_books_to_translate_title") }}</h1>
-        <app-book-multi-select
-          [availableBooks]="availableTranslateBooks"
-          [selectedBooks]="booksToTranslate()"
-          [basicMode]="true"
-          (bookSelect)="onTranslateBookSelect($event)"
-          data-test-id="draft-stepper-translate-books"
-        ></app-book-multi-select>
+        @for (source of draftingSources; track source) {
+          <p class="reference-project-label">{{ projectLabel(source) }}</p>
+          <app-book-multi-select
+            [availableBooks]="selectableTranslateBooksByProj(source.projectRef)"
+            [selectedBooks]="selectedTranslateBooksByProj(source.projectRef)"
+            [basicMode]="true"
+            (bookSelect)="onTranslateBookSelect($event, source)"
+            data-test-id="draft-stepper-translate-books"
+          ></app-book-multi-select>
+        }
         @if (unusableTranslateSourceBooks.length) {
           <app-notice icon="info" mode="basic" type="light" class="unusable-translate-books">
             <div class="notice-container">
@@ -311,7 +314,7 @@
     </mat-stepper>
   }
 
-  @if (hasLoaded && availableTranslateBooks.length <= 0) {
+  @if (hasLoaded && allAvailableTranslateBooks.length <= 0) {
     <p>{{ t("no_available_books") }}</p>
   } @else if (!hasLoaded) {
     <div class="loading">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -139,12 +139,22 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
     }));
 
-    it('should set "availableTranslateBooks" correctly', fakeAsync(() => {
-      expect(component.availableTranslateBooks).toEqual([
+    it('should set "allAvailableTranslateBooks" correctly', fakeAsync(() => {
+      expect(component.allAvailableTranslateBooks).toEqual([
         { number: 1, selected: false },
         { number: 2, selected: false },
         { number: 3, selected: false }
       ]);
+    }));
+
+    it('should set "availableTranslateBooks" correctly', fakeAsync(() => {
+      expect(component.availableTranslateBooks).toEqual({
+        sourceProject: [
+          { number: 1, selected: false },
+          { number: 2, selected: false },
+          { number: 3, selected: false }
+        ]
+      });
     }));
 
     it('should set "availableTrainingBooks" correctly', fakeAsync(() => {
@@ -198,7 +208,7 @@ describe('DraftGenerationStepsComponent', () => {
       // Go to translation books
       component.tryAdvanceStep();
       fixture.detectChanges();
-      component.onTranslateBookSelect([1]);
+      component.onTranslateBookSelect([1], config.draftingSources[0]);
       fixture.detectChanges();
       // Go to training books
       component.tryAdvanceStep();
@@ -275,7 +285,7 @@ describe('DraftGenerationStepsComponent', () => {
     it('clears selected translated and reference books in training when translate book selected', () => {
       component.tryAdvanceStep();
       fixture.detectChanges();
-      component.onTranslateBookSelect([3]);
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
       component.tryAdvanceStep();
       fixture.detectChanges();
       component.onTranslatedBookSelect([1, 2]);
@@ -289,7 +299,7 @@ describe('DraftGenerationStepsComponent', () => {
       ]);
       component.stepper.selectedIndex = 1;
       fixture.detectChanges();
-      component.onTranslateBookSelect([2, 3]);
+      component.onTranslateBookSelect([2, 3], config.draftingSources[0]);
       component.tryAdvanceStep();
       fixture.detectChanges();
       expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
@@ -300,7 +310,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.tryAdvanceStep();
       fixture.detectChanges();
       // select Exodus and Leviticus
-      component.onTranslateBookSelect([2, 3]);
+      component.onTranslateBookSelect([2, 3], config.draftingSources[0]);
       component.tryAdvanceStep();
       fixture.detectChanges();
       component.onTranslatedBookSelect([1]);
@@ -310,7 +320,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.stepper.selectedIndex = 1;
       fixture.detectChanges();
       // deselect Exodus and keep Leviticus
-      component.onTranslateBookSelect([3]);
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
       component.tryAdvanceStep();
       fixture.detectChanges();
       // Exodus becomes a selectable training book
@@ -326,7 +336,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.tryAdvanceStep();
       fixture.detectChanges();
       // all books
-      component.onTranslateBookSelect([1, 2, 3]);
+      component.onTranslateBookSelect([1, 2, 3], config.draftingSources[0]);
       fixture.detectChanges();
       component.tryAdvanceStep();
       fixture.detectChanges();
@@ -338,7 +348,7 @@ describe('DraftGenerationStepsComponent', () => {
       component.stepper.selectedIndex = 1;
       fixture.detectChanges();
       // deselect Genesis and Exodus
-      component.onTranslateBookSelect([3]);
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
       component.tryAdvanceStep();
       fixture.detectChanges();
       // Genesis and Exodus becomes a selectable training book
@@ -407,12 +417,22 @@ describe('DraftGenerationStepsComponent', () => {
       tick();
     }));
 
-    it('should set "availableTranslateBooks" correctly and with canonical book order', fakeAsync(() => {
-      expect(component.availableTranslateBooks).toEqual([
+    it('should set "allAvailableTranslateBooks" correctly and with canonical book order', fakeAsync(() => {
+      expect(component.allAvailableTranslateBooks).toEqual([
         { number: 2, selected: false },
         { number: 3, selected: false },
         { number: 7, selected: false }
       ]);
+    }));
+
+    it('should set "availableTranslateBooks" correctly and with canonical book order', fakeAsync(() => {
+      expect(component.availableTranslateBooks).toEqual({
+        draftingSource: [
+          { number: 2, selected: false },
+          { number: 3, selected: false },
+          { number: 7, selected: false }
+        ]
+      });
     }));
 
     it('should set "availableTrainingBooks" correctly and with canonical book order', fakeAsync(() => {
@@ -471,7 +491,7 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should correctly emit the selected books when done', fakeAsync(() => {
-      component.onTranslateBookSelect([7]);
+      component.onTranslateBookSelect([7], config.draftingSources[0]);
       component.onTranslatedBookSelect([2, 3, 6]);
       component.onSourceTrainingBookSelect([2, 3], config.trainingSources[0]);
       component.onSourceTrainingBookSelect([2, 6], config.trainingSources[1]);
@@ -497,7 +517,7 @@ describe('DraftGenerationStepsComponent', () => {
           { projectId: 'source1', scriptureRange: 'EXO;LEV' },
           { projectId: 'source2', scriptureRange: 'EXO;JOS' }
         ],
-        translationScriptureRange: 'JDG',
+        translationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'JDG' }],
         fastTraining: false,
         useEcho: false
       } as DraftGenerationStepsResult);
@@ -515,7 +535,7 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('should allow one source to have no books selected', () => {
-      component.onTranslateBookSelect([7]);
+      component.onTranslateBookSelect([7], config.draftingSources[0]);
       component.onTranslatedBookSelect([2, 6]);
       component.onSourceTrainingBookSelect([], config.trainingSources[0]);
       component.onSourceTrainingBookSelect([2, 6], config.trainingSources[1]);
@@ -539,7 +559,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingDataFiles: [],
         trainingScriptureRanges: [{ projectId: 'source2', scriptureRange: 'EXO;JOS' }],
-        translationScriptureRange: 'JDG',
+        translationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'JDG' }],
         fastTraining: false,
         useEcho: false
       } as DraftGenerationStepsResult);
@@ -547,7 +567,7 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('show warning when both source books missing translated books', () => {
-      component.onTranslateBookSelect([7]);
+      component.onTranslateBookSelect([7], config.draftingSources[0]);
       component.onTranslatedBookSelect([2, 6]);
       component.onSourceTrainingBookSelect([2, 6], config.trainingSources[0]);
       component.onSourceTrainingBookSelect([], config.trainingSources[1]);
@@ -651,7 +671,7 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should emit the fast training value if checked', () => {
-      component.onTranslateBookSelect([2]);
+      component.onTranslateBookSelect([2], config.draftingSources[0]);
       component.onTranslatedBookSelect([3, 9, 10]);
       component.onSourceTrainingBookSelect([3, 9, 10], config.trainingSources[0]);
 
@@ -677,7 +697,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingDataFiles: [],
         trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'LEV;1SA;2SA' }],
-        translationScriptureRange: 'EXO',
+        translationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'EXO' }],
         fastTraining: true,
         useEcho: false
       } as DraftGenerationStepsResult);
@@ -685,7 +705,7 @@ describe('DraftGenerationStepsComponent', () => {
     });
 
     it('should emit the use echo value if checked', () => {
-      component.onTranslateBookSelect([2]);
+      component.onTranslateBookSelect([2], config.draftingSources[0]);
       component.onTranslatedBookSelect([3, 9, 10]);
       component.onSourceTrainingBookSelect([3, 9, 10], config.trainingSources[0]);
 
@@ -711,7 +731,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingDataFiles: [],
         trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'LEV;1SA;2SA' }],
-        translationScriptureRange: 'EXO',
+        translationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'EXO' }],
         fastTraining: false,
         useEcho: true
       } as DraftGenerationStepsResult);
@@ -762,11 +782,11 @@ describe('DraftGenerationStepsComponent', () => {
         translateConfig: {
           draftConfig: {
             lastSelectedTrainingDataFiles: [],
-            lastSelectedTranslationScriptureRange: 'EXO;LEV',
             lastSelectedTrainingScriptureRanges: [
               { projectId: 'source1', scriptureRange: 'GEN;1SA' },
               { projectId: 'source2', scriptureRange: '1SA;2SA' }
-            ]
+            ],
+            lastSelectedTranslationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'EXO;LEV' }]
           }
         }
       })
@@ -880,7 +900,7 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
       component.tryAdvanceStep();
       fixture.detectChanges();
-      component.onTranslateBookSelect([3]);
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
       fixture.detectChanges();
       component.tryAdvanceStep();
       component.onTranslatedBookSelect([2]);
@@ -905,7 +925,7 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
       component.tryAdvanceStep();
       fixture.detectChanges();
-      component.onTranslateBookSelect([3]);
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
       fixture.detectChanges();
       component.tryAdvanceStep();
       component.onTranslatedBookSelect([2]);
@@ -925,7 +945,7 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
       expect(component.done.emit).toHaveBeenCalledWith({
         trainingScriptureRanges: [{ projectId: 'source1', scriptureRange: 'EXO' }],
-        translationScriptureRange: 'LEV',
+        translationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'LEV' }],
         trainingDataFiles: fileIds,
         fastTraining: false,
         useEcho: false
@@ -981,11 +1001,11 @@ describe('DraftGenerationStepsComponent', () => {
         translateConfig: {
           draftConfig: {
             lastSelectedTrainingDataFiles: [],
-            lastSelectedTranslationScriptureRange: 'GEN;EXO',
             lastSelectedTrainingScriptureRanges: [
               { projectId: 'source1', scriptureRange: 'LEV;NUM;DEU;JOS' },
               { projectId: 'source2', scriptureRange: 'DEU;JOS;1SA' }
-            ]
+            ],
+            lastSelectedTranslationScriptureRanges: [{ projectId: 'draftingSource', scriptureRange: 'GEN;EXO' }]
           }
         }
       })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -173,8 +173,6 @@ describe('DraftGenerationComponent', () => {
               }
             },
             draftConfig: {
-              lastSelectedTrainingBooks: preTranslate ? [1] : [],
-              lastSelectedTranslationBooks: preTranslate ? [2] : [],
               lastSelectedTrainingScriptureRange: preTranslate ? 'GEN' : undefined,
               lastSelectedTranslationScriptureRange: preTranslate ? 'EXO' : undefined
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -357,9 +357,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     this.startBuild({
       projectId: sfProjectId,
       trainingDataFiles: result.trainingDataFiles,
-      trainingScriptureRange: result.trainingScriptureRange,
       trainingScriptureRanges: result.trainingScriptureRanges,
-      translationScriptureRange: result.translationScriptureRange,
       translationScriptureRanges: result.translationScriptureRanges || [],
       fastTraining: result.fastTraining,
       useEcho: result.useEcho
@@ -509,7 +507,8 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   private hasStartedBuild(projectDoc: SFProjectProfileDoc): boolean {
     return (
       projectDoc.data?.translateConfig.preTranslate === true &&
-      projectDoc.data?.translateConfig.draftConfig.lastSelectedTranslationScriptureRange != null
+      (projectDoc.data?.translateConfig.draftConfig.lastSelectedTranslationScriptureRange != null ||
+        projectDoc.data?.translateConfig.draftConfig.lastSelectedTranslationScriptureRanges != null)
     );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.ts
@@ -8,9 +8,7 @@ import { BuildStates } from '../../machine-api/build-states';
 export interface BuildConfig {
   projectId: string;
   trainingDataFiles: string[];
-  trainingScriptureRange?: string;
   trainingScriptureRanges: ProjectScriptureRange[];
-  translationScriptureRange?: string;
   translationScriptureRanges: ProjectScriptureRange[];
   fastTraining: boolean;
   useEcho: boolean;


### PR DESCRIPTION
This PR changes the draft generation steps to use the `TranslationScriptureRanges` collection instead of the `TranslationScriptureRange` string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3151)
<!-- Reviewable:end -->
