### PR TITLE
Remove permanently enabled feature flags

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -10,7 +10,6 @@ import { asyncScheduler, merge, Subscription } from 'rxjs';
 import { map, tap, throttleTime } from 'rxjs/operators';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { L10nNumberPipe } from 'xforge-common/l10n-number.pipe';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
@@ -55,7 +54,6 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     private readonly destroyRef: DestroyRef,
     private readonly activatedRoute: ActivatedRoute,
     private readonly dialogService: DialogService,
-    readonly featureFlags: FeatureFlagService,
     noticeService: NoticeService,
     readonly i18n: I18nService,
     private readonly projectService: SFProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/navigation/navigation.stories.ts
@@ -58,8 +58,6 @@ function setUpMocks(args: StoryState): void {
   when(mockedAuthService.isLoggedIn).thenResolve(true);
   when(mockedUserService.currentUserId).thenReturn(userId);
   when(onlineStatusService.isOnline).thenReturn(args.online);
-  when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(true));
-  when(mockedFeatureFlagService.allowForwardTranslationNmtDrafting).thenReturn(createTestFeatureFlag(true));
   when(mockedFeatureFlagService.stillness).thenReturn(createTestFeatureFlag(false));
   when(mockedRouter.url).thenReturn(`/projects/${projectId}/${args.path}`);
   when(mockedRouter.createUrlTree(anything(), anything())).thenCall((portions: any[]) => portions.join('/'));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -22,7 +22,6 @@ import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/trans
 import { of } from 'rxjs';
 import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import { AuthService } from 'xforge-common/auth.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { QueryParameters } from 'xforge-common/query-parameters';
@@ -53,7 +52,6 @@ const mockedParatextService = mock(ParatextService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 const mockedDialog = mock(MatDialog);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 
 @Component({
   template: `<div>Mock</div>`
@@ -83,7 +81,6 @@ describe('SettingsComponent', () => {
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: FeatureFlagService, useValue: instance(mockedFeatureFlagService) },
       { provide: MatDialog, useMock: mockedDialog }
     ]
   }));
@@ -258,16 +255,6 @@ describe('SettingsComponent', () => {
         env.wait();
         env.wait();
         expect(env.servalConfigTextArea).not.toBeNull();
-      }));
-
-      it('should not display for serval administrators when the feature flag is disabled', fakeAsync(() => {
-        const env = new TestEnvironment();
-        env.setupProject();
-        when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(false));
-        when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
-        env.wait();
-        env.wait();
-        expect(env.servalConfigTextArea).toBeNull();
       }));
 
       it('should display for serval administrators on forward translations when not approved', fakeAsync(() => {
@@ -980,7 +967,6 @@ class TestEnvironment {
         languageTag: 'en'
       }
     ]);
-    when(mockedFeatureFlagService.showNmtDrafting).thenReturn(createTestFeatureFlag(true));
 
     when(mockedSFProjectService.queryAudioText(anything(), anything())).thenCall(sfProjectId => {
       const queryParams: QueryParameters = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -16,7 +16,6 @@ import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService, TextAroundTemplate } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { UserDoc } from 'xforge-common/models/user-doc';
@@ -105,7 +104,6 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly onlineStatusService: OnlineStatusService,
     readonly i18n: I18nService,
     readonly authService: AuthService,
-    readonly featureFlags: FeatureFlagService,
     readonly externalUrls: ExternalUrlService,
     private readonly activatedProjectService: ActivatedProjectService,
     private destroyRef: DestroyRef
@@ -136,7 +134,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
 
   get showPreTranslationSettings(): boolean {
     const translateConfig = this.projectDoc?.data?.translateConfig;
-    if (translateConfig == null || !this.featureFlags.showNmtDrafting.enabled) {
+    if (translateConfig == null) {
       return false;
     } else if (this.authService.currentUserRoles.includes(SystemRole.ServalAdmin)) {
       return true;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -3,11 +3,9 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/ro
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { combineLatest, from, Observable, of } from 'rxjs';
+import { from, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { AuthGuard } from 'xforge-common/auth.guard';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { PermissionsService } from '../core/permissions.service';
@@ -108,31 +106,13 @@ export class NmtDraftAuthGuard extends RouterGuard {
   constructor(
     authGuard: AuthGuard,
     projectService: SFProjectService,
-    private userService: UserService,
-    private readonly featureFlagService: FeatureFlagService
+    private userService: UserService
   ) {
     super(authGuard, projectService);
   }
 
-  allowTransition(projectId: string): Observable<boolean> {
-    // Re-run check when feature flags change
-    return combineLatest([
-      this.featureFlagService.showNmtDrafting.enabled$,
-      this.featureFlagService.allowForwardTranslationNmtDrafting.enabled$
-    ]).pipe(switchMap(() => super.allowTransition(projectId)));
-  }
-
   check(projectDoc: SFProjectProfileDoc): boolean {
     if (projectDoc.data == null) {
-      return false;
-    }
-
-    if (!this.featureFlagService.showNmtDrafting.enabled) {
-      return false;
-    }
-
-    const isBackTranslationProject = projectDoc.data.translateConfig?.projectType === ProjectType.BackTranslation;
-    if (!isBackTranslationProject && !this.featureFlagService.allowForwardTranslationNmtDrafting.enabled) {
       return false;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'draft_generation'">
   @if (currentPage === "initial") {
-    @if (isBackTranslationMode) {
+    @if (isBackTranslation) {
       <h1>{{ t("generate_back_translation_drafts_header") }}</h1>
     } @else {
       <h1>
@@ -21,7 +21,7 @@
     <section>
       @if (isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {
         <div class="drafting-instructions">
-          @if (isBackTranslationMode) {
+          @if (isBackTranslation) {
             <div>
               <p>
                 <b>{{ t("instructions_scripture_forge_assist_back_translation") }}</b>
@@ -60,7 +60,7 @@
         </div>
       }
 
-      @if (isBackTranslationMode && !isTargetLanguageSupported) {
+      @if (isBackTranslation && !isTargetLanguageSupported) {
         <app-notice type="warning" class="requirements">
           <p>
             <transloco

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
@@ -10,7 +10,6 @@ import { of } from 'rxjs';
 import { anything, capture, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -50,7 +49,6 @@ const mockedI18nService = mock(I18nService);
 const mockedDraftSourcesService = mock(DraftSourcesService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedSFUserProjectsService = mock(SFUserProjectsService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedAuthService = mock(AuthService);
 
 describe('DraftSourcesComponent', () => {
@@ -70,7 +68,6 @@ describe('DraftSourcesComponent', () => {
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: DraftSourcesService, useMock: mockedDraftSourcesService },
       { provide: SFUserProjectsService, useMock: mockedSFUserProjectsService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
       { provide: AuthService, useMock: mockedAuthService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService }
     ]
@@ -564,7 +561,6 @@ class TestEnvironment {
     when(mockedActivatedProjectService.projectDoc).thenReturn(this.activatedProjectDoc);
     when(mockedActivatedProjectService.projectId).thenReturn(this.activatedProjectDoc.id);
     when(mockedActivatedProjectService.projectDoc).thenReturn(this.activatedProjectDoc);
-    when(mockedFeatureFlagService.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(true));
 
     this.fixture = TestBed.createComponent(DraftSourcesComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -13,7 +13,6 @@ import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -100,7 +99,6 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     private readonly projectService: SFProjectService,
     private readonly userProjectsService: SFUserProjectsService,
     private readonly router: Router,
-    private readonly featureFlags: FeatureFlagService,
     private readonly onlineStatus: OnlineStatusService,
     readonly i18n: I18nService,
     noticeService: NoticeService
@@ -259,11 +257,7 @@ export class DraftSourcesComponent extends DataLoadingComponent {
   }
 
   get allowAddingATrainingSource(): boolean {
-    return (
-      this.featureFlags.allowAdditionalTrainingSource.enabled &&
-      this.trainingSources.length < 2 &&
-      this.trainingSources.every(notNull)
-    );
+    return this.trainingSources.length < 2 && this.trainingSources.every(notNull);
   }
 
   get allProjectsSavedAndSynced(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
@@ -10,7 +10,6 @@ import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
 import { ParatextProject } from '../../../core/models/paratext-project';
@@ -25,7 +24,6 @@ const mockedParatextService = mock(ParatextService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserProjectsService = mock(SFUserProjectsService);
 const mockedRouter = mock(Router);
-const mockedFeatureFlags = mock(FeatureFlagService);
 const mockedAuthService = mock(AuthService);
 const mockedOnlineStatusService = mock(OnlineStatusService);
 
@@ -77,7 +75,6 @@ const projectDocWithExistingSources = {
 function setUpMocks(args: DraftSourcesComponentStoryState): void {
   when(mockedActivatedProjectService.changes$).thenReturn(of(args.project));
   when(mockedActivatedProjectService.projectDoc).thenReturn(args.project);
-  when(mockedFeatureFlags.allowAdditionalTrainingSource).thenReturn(createTestFeatureFlag(args.mixedSource));
   when(mockedAuthService.currentUserId).thenReturn('user1');
 
   when(mockedOnlineStatusService.onlineStatus$).thenReturn(of(args.online));
@@ -154,7 +151,6 @@ export default {
         { provide: SFProjectService, useValue: instance(mockedProjectService) },
         { provide: SFUserProjectsService, useValue: instance(mockedUserProjectsService) },
         { provide: Router, useValue: instance(mockedRouter) },
-        { provide: FeatureFlagService, useValue: instance(mockedFeatureFlags) },
         { provide: AuthService, useValue: instance(mockedAuthService) },
         { provide: OnlineStatusService, useValue: instance(mockedOnlineStatusService) },
         defaultTranslocoMarkupTranspilers()

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -221,25 +221,25 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  readonly showNmtDrafting: ObservableFeatureFlag = new FeatureFlagFromStorage(
+  private readonly showNmtDrafting: FeatureFlag = new ServerOnlyFeatureFlag(
     'SHOW_NMT_DRAFTING',
     'Show NMT drafting',
     2,
-    new StaticFeatureFlagStore(true, { readonly: true })
+    this.featureFlagStore
   );
 
-  readonly allowForwardTranslationNmtDrafting: ObservableFeatureFlag = new FeatureFlagFromStorage(
+  private readonly allowForwardTranslationNmtDrafting: FeatureFlag = new ServerOnlyFeatureFlag(
     'ALLOW_FORWARD_TRANSLATION_NMT_DRAFTING',
     'Allow Forward Translation NMT drafting',
     3,
-    new StaticFeatureFlagStore(true, { readonly: true })
+    this.featureFlagStore
   );
 
-  private readonly scriptureAudio: ObservableFeatureFlag = new FeatureFlagFromStorage(
+  private readonly scriptureAudio: FeatureFlag = new ServerOnlyFeatureFlag(
     'SCRIPTURE_AUDIO',
     'Scripture audio',
     4,
-    new StaticFeatureFlagStore(true, { readonly: true })
+    this.featureFlagStore
   );
 
   readonly preventOpSubmission: ObservableFeatureFlag = new FeatureFlagFromStorage(
@@ -298,11 +298,11 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  readonly allowAdditionalTrainingSource: FeatureFlag = new FeatureFlagFromStorage(
+  private readonly allowAdditionalTrainingSource: FeatureFlag = new ServerOnlyFeatureFlag(
     'AllowAdditionalTrainingSource',
     'Allow mixing in an additional training source',
     13,
-    new StaticFeatureFlagStore(true, { readonly: true })
+    this.featureFlagStore
   );
 
   private readonly updatedLearningRateForServal: FeatureFlag = new ServerOnlyFeatureFlag(


### PR DESCRIPTION
This PR removes (by making private) some feature flags that have been permanently enabled for some time now.

As these feature flags refer to drafting, only basic testing of drafting functionality is required by a developer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3152)
<!-- Reviewable:end -->
