### PR TITLE
Improve theme support for community checking

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/_checking-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/_checking-theme.scss
@@ -1,12 +1,10 @@
 @use '@angular/material' as mat;
-@use 'src/_variables' as variables;
 
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
-  .scripture-audio-player-wrapper {
-    background: #{mat.get-theme-color($theme, neutral, if($is-dark, 20, 98))};
-  }
+  --sf-community-checking-questions-nav-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 20, 95))};
+  --sf-community-checking-audio-player-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 20, 98))};
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/_checking-answers-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/_checking-answers-theme.scss
@@ -1,0 +1,19 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-community-checking-new-answer-background: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 98))};
+  --sf-community-checking-new-answer-fade-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 6, 100))};
+  --sf-community-checking-answer-exportable-background: #{mat.get-theme-color($theme, primary, 40)};
+  --sf-community-checking-answer-exportable-text-color: #{mat.get-theme-color($theme, neutral, 98)};
+  --sf-community-checking-answer-resolved-background: #{mat.get-theme-color($theme, tertiary, 70)};
+  --sf-community-checking-answer-resolved-text-color: #{mat.get-theme-color($theme, neutral, 98)};
+  --sf-community-checking-answer-scripture-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 20, 95))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.scss
@@ -1,4 +1,3 @@
-@use 'src/variables';
 @use '../checking-global-vars' as checking-vars;
 @use 'src/breakpoints';
 
@@ -30,7 +29,7 @@
 .answers-container {
   .answer {
     display: flex;
-    border-top: 1px solid checking-vars.$borderColor;
+    border-top: 1px solid var(--sf-border-color);
     padding-top: 10px;
     &:not(:last-child) {
       padding-bottom: 10px;
@@ -43,10 +42,10 @@
 
       @keyframes attention {
         from {
-          background: checking-vars.$attention;
+          background: var(--sf-community-checking-new-answer-background);
         }
         to {
-          background: #fff;
+          background: var(--sf-community-checking-new-answer-fade-background);
         }
       }
     }
@@ -79,17 +78,14 @@
         button {
           &.answer-status {
             &.status-exportable {
-              background: checking-vars.$answerExportable;
-              color: #fff;
+              background: var(--sf-community-checking-answer-exportable-background);
+              color: var(--sf-community-checking-answer-exportable-text-color);
             }
 
             &.status-resolved {
-              background: checking-vars.$answerResolved;
-              color: #fff;
+              background: var(--sf-community-checking-answer-resolved-background);
+              color: var(--sf-community-checking-answer-resolved-text-color);
             }
-          }
-          &.answer-delete {
-            color: variables.$errorColor;
           }
         }
         .delete-divider {
@@ -131,9 +127,6 @@
 
           button {
             height: 40px;
-            &:not(:hover) {
-              color: rgba(0, 0, 0, 0.7);
-            }
           }
         }
       }
@@ -145,7 +138,7 @@
 .scripture-text {
   display: flex;
   align-items: center;
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--sf-community-checking-answer-scripture-background);
   padding-inline-start: 6px;
   border-radius: 4px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/_checking-comments-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/_checking-comments-theme.scss
@@ -1,0 +1,15 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-community-checking-new-comment-background: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 98))};
+  --sf-community-checking-new-comment-fade-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 6, 100))};
+  --sf-community-checking-comment-alt-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 10, 98))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.scss
@@ -19,16 +19,16 @@
 
     @keyframes comment-unread {
       from {
-        background: $commentUnread;
+        background: var(--sf-community-checking-new-comment-background);
       }
       to {
-        background: #fff;
+        background: var(--sf-community-checking-new-comment-fade-background);
       }
     }
   }
 
   &.shaded {
-    background-color: $shadedBackgroundColor;
+    background-color: var(--sf-community-checking-comment-alt-background);
   }
 
   .comment-text {
@@ -43,10 +43,6 @@
 
     .mat-icon {
       @include md-icon-size(18px);
-    }
-
-    button:not(:hover) {
-      color: rgba(0, 0, 0, 0.7);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.scss
@@ -1,15 +1,12 @@
-@import 'src/variables';
-
 .scripture-audio,
 .question-text {
   display: flex;
   flex-direction: row;
   align-items: center;
   column-gap: 8px;
-  color: $greyLight;
   min-height: 30px;
   p {
-    margin: 0px;
+    margin: 0;
     transition: color 0.3s;
   }
 }
@@ -32,7 +29,6 @@
 .scripture-audio.scripture-audio-label,
 .question-text.question-audio-label {
   font-weight: bold;
-  color: black;
   span {
     display: none;
   }
@@ -40,6 +36,7 @@
 
 .scripture-audio.question-audio-label,
 .question-text.scripture-audio-label {
+  opacity: 0.6;
   p {
     cursor: pointer;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
@@ -1,18 +1,21 @@
 @use '@angular/material' as mat;
-@use 'src/_variables' as variables;
 
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
-  --mat-badge-background-color: #{mat.get-theme-color($theme, primary, if($is-dark, 60, 20))};
-  --mat-badge-text-color: #{mat.get-theme-color($theme, primary, 98)};
-  --mat-badge-small-size-text-size: 9px;
-  --sf-list-hover-background-color: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 95))};
-  --sf-list-selected-background-color: #{mat.get-theme-color($theme, primary, if($is-dark, 20, 30))};
-
-  .view-answers mat-icon {
-    color: #{mat.get-theme-color($theme, primary, if($is-dark, 40, 60))};
-  }
+  --sf-community-checking-badge-background-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 20))};
+  --sf-community-checking-badge-text-color: #{mat.get-theme-color($theme, primary, 98)};
+  --sf-community-checking-badge-text-size: 9px;
+  --sf-community-checking-question-list-hover-background: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 95))};
+  --sf-community-checking-question-list-selected-background: #{mat.get-theme-color(
+      $theme,
+      primary,
+      if($is-dark, 20, 30)
+    )};
+  --sf-community-checking-answered-question-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 80))};
+  --sf-community-checking-new-comment-icon-color: #{mat.get-theme-color($theme, primary, if($is-dark, 40, 80))};
+  --sf-community-checking-question-unread-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 10, 99))};
+  --sf-community-checking-question-list-divider-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 80, 70))}1f;
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
@@ -14,7 +14,7 @@
     )};
   --sf-community-checking-answered-question-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 80))};
   --sf-community-checking-new-comment-icon-color: #{mat.get-theme-color($theme, primary, if($is-dark, 40, 80))};
-  --sf-community-checking-question-unread-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 10, 99))};
+  --sf-community-checking-question-unread-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 10, 98))};
   --sf-community-checking-question-list-divider-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 80, 70))}1f;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
@@ -1,5 +1,3 @@
-@use '../checking-global-vars' as vars;
-
 :host {
   position: absolute;
   width: 100%;
@@ -57,6 +55,10 @@ mat-icon {
   padding: 0;
 
   .mat-mdc-list-item {
+    --mat-badge-background-color: var(--sf-community-checking-badge-background-color);
+    --mat-badge-text-color: var(--sf-community-checking-badge-text-color);
+    --mat-badge-small-size-text-size: var(--sf-community-checking-badge-text-size);
+
     cursor: pointer;
     height: auto;
 
@@ -64,20 +66,18 @@ mat-icon {
     // Use inset box-shadow instead of border to avoid border showing under the 'answered question' marker.
     // This color flattened would be #eceff1, but using alpha channel allows the background color to show through,
     // which improves the separator look for 'selected' and 'read' backgrounds.
-    box-shadow: inset 0 -1px 0 0 #64798f1f;
+    box-shadow: inset 0 -1px 0 0 var(--sf-community-checking-question-list-divider-color);
 
     &.question-read {
-      background-color: vars.$questionReadBGColor;
-      color: vars.$questionReadTextColor;
-
       .question-text {
         font-weight: normal;
       }
     }
 
     &.question-unread {
+      background: var(--sf-community-checking-question-unread-background);
       .question-item {
-        font-weight: bold;
+        font-weight: 500;
       }
 
       // Don't bold the selected verse, as the inverted colors with the small font makes it hard to see
@@ -91,23 +91,17 @@ mat-icon {
     &.question-answered {
       .question-item {
         &:before {
-          background-color: vars.$questionAnswered;
+          background-color: var(--sf-community-checking-answered-question-color);
         }
       }
     }
 
     &.selected {
-      background-color: var(--sf-list-selected-background-color);
+      background-color: var(--sf-community-checking-question-list-selected-background);
       color: #fff;
 
       ::ng-deep .mdc-list-item__primary-text {
         color: unset;
-      }
-
-      .view-answers {
-        mat-icon {
-          color: #fff;
-        }
       }
     }
 
@@ -118,6 +112,9 @@ mat-icon {
       transition: 0.25s;
       position: relative;
       top: 4px; // Give some space for answer count badge
+      mat-icon {
+        color: var(--sf-community-checking-new-comment-icon-color);
+      }
     }
 
     &.question-has-answers {
@@ -127,10 +124,10 @@ mat-icon {
     }
 
     &:hover {
-      background-color: var(--sf-list-hover-background-color);
+      background-color: var(--sf-community-checking-question-list-hover-background);
 
       &.selected {
-        background-color: var(--sf-list-selected-background-color);
+        background-color: var(--sf-community-checking-question-list-selected-background);
         opacity: 0.9;
       }
     }
@@ -144,5 +141,4 @@ mat-icon {
 
 .loading-text {
   font-style: italic;
-  color: vars.$questionsLoadingTextColor;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
@@ -77,7 +77,7 @@ mat-icon {
     &.question-unread {
       background: var(--sf-community-checking-question-unread-background);
       .question-item {
-        font-weight: 500;
+        font-weight: bold;
       }
 
       // Don't bold the selected verse, as the inverted colors with the small font makes it hard to see

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -215,7 +215,7 @@ header {
   }
 
   #question-nav {
-    background-color: lighten(vars.$sf_grey, 70%);
+    background-color: var(--sf-community-checking-questions-nav-background);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -304,11 +304,6 @@ header {
 }
 
 .menu-list {
-  h2 {
-    color: #000;
-    font-weight: bold;
-  }
-
   :not(.selected) mat-icon {
     visibility: hidden;
   }
@@ -320,6 +315,7 @@ header {
 }
 
 .scripture-audio-player-wrapper {
+  background: var(--sf-community-checking-audio-player-background);
   padding: 0.25rem;
 }
 
@@ -329,7 +325,6 @@ header {
 
 .active-question-scope-button ::ng-deep {
   font-size: 13px;
-  color: vars.$blueMedium !important;
   font-weight: 400;
   align-self: flex-start;
   height: 26px;
@@ -346,7 +341,6 @@ header {
     height: 18px;
     width: 18px;
     margin-inline-end: 4px;
-    color: lighten(vars.$blueMedium, 15%);
   }
 
   .divider {

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -3,6 +3,8 @@
 @use 'src/app/my-projects/my-projects-theme' as sf-my-projects;
 @use 'src/app/app-theme' as sf-app;
 @use 'src/app/checking/checking/checking-theme' as sf-checking;
+@use 'src/app/checking/checking/checking-answers/checking-answers-theme' as sf-checking-answer;
+@use 'src/app/checking/checking/checking-answers/checking-comments/checking-comments-theme' as sf-checking-comments;
 @use 'src/app/checking/checking/checking-questions/checking-questions-theme' as sf-checking-questions;
 @use 'src/app/navigation/navigation-theme' as sf-navigation;
 @use 'src/app/shared/sf-tab-group/sf-tab-group-theme' as sf-tab-group;
@@ -22,6 +24,8 @@
   @include sf-app.theme($theme);
   @include sf-book-multi-select.theme($theme);
   @include sf-checking.theme($theme);
+  @include sf-checking-answer.theme($theme);
+  @include sf-checking-comments.theme($theme);
   @include sf-checking-questions.theme($theme);
   @include sf-confirm-sources.theme($theme);
   @include sf-draft-generation-steps.theme($theme);
@@ -32,6 +36,7 @@
 
   // Custom variables
   --sf-disabled-foreground: #{mat.get-theme-color($theme, neutral, 70)};
+  --sf-border-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 60, 90))};
   --sf-error-foreground: #{mat.get-theme-color($theme, error, if($is-dark, 80, 40))};
   --sf-language-font-family: language_picker, language_picker_fallback, Arial, Helvetica, sans-serif;
 


### PR DESCRIPTION
This touches most community checking related components where needed.

It does **not** update include any updates to the Quill editor.

There are some colors left which need to be addressed separately i.e. the blue color of the like icon. There is also a mixin for icon size which needs to be refactored in a different way.

Dark mode improvements have been made.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3153)
<!-- Reviewable:end -->
