### PR TITLE
SF-3318 Skip prompt when no changes made on draft source page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -219,6 +219,9 @@ export class DraftSourcesComponent extends DataLoadingComponent {
     index: number,
     paratextId: string | undefined
   ): void {
+    // When still loading projects, the project selectors will temporarily set the value to null
+    if (!this.isLoaded) return;
+
     const selectedProject: SelectableProject | null =
       this.projects?.find(p => p.paratextId === paratextId) ??
       this.resources?.find(r => r.paratextId === paratextId) ??

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -278,7 +278,7 @@
     "close": "Close",
     "configure_draft_sources": "Configure draft sources",
     "confirm_language_codes": "Please confirm that the language codes are correct before saving.",
-    "discard_changes_confirmation": "Are you sure you want leave the page with unsaved changes?",
+    "discard_changes_confirmation": "Are you sure you want to leave the page with unsaved changes?",
     "draft_source": "Draft source",
     "generate_draft_from_language_model": "Generate draft from language model",
     "language_code": "Language code: ",


### PR DESCRIPTION
These two lines used to be here and were mistakenly removed in a previous PR. See the conversation about them here:
https://github.com/sillsdev/web-xforge/pull/3133#discussion_r2035736105

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3155)
<!-- Reviewable:end -->
