### PR TITLE
Add DBL resource support to the roundtrip tool

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -11,7 +11,11 @@ using SIL.XForge.Realtime.RichText;
 
 namespace SIL.XForge.Scripture.Services;
 
-public class DeltaUsxMapper : IDeltaUsxMapper
+public class DeltaUsxMapper(
+    IGuidService guidService,
+    ILogger<DeltaUsxMapper> logger,
+    IExceptionHandler exceptionHandler
+) : IDeltaUsxMapper
 {
     private static readonly XmlSchemaSet Schemas = CreateSchemaSet();
 
@@ -57,21 +61,19 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         "li",
         "lf",
         "lim",
+        // Should not contain verse text, but sometimes do
+        "b",
     ];
-
-    private IGuidService GuidService;
-    private ILogger<DeltaUsxMapper> Logger;
-    private readonly IExceptionHandler ExceptionHandler;
 
     private class ParseState
     {
-        public string CurRef { get; set; }
-        public string CurChapter { get; set; }
+        public string? CurRef { get; set; }
+        public string? CurChapter { get; set; }
         public bool CurChapterIsValid { get; set; } = true;
         public int TableIndex { get; set; }
         public bool ImpliedParagraph { get; set; }
         public int LastVerse { get; set; }
-        public string LastVerseStr
+        public string? LastVerseStr
         {
             set
             {
@@ -81,26 +83,12 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     int dashIndex = value.IndexOf('-');
                     if (dashIndex != -1)
                         value = value[(dashIndex + 1)..];
-                    if (
-                        int.TryParse(
-                            value,
-                            System.Globalization.NumberStyles.Integer,
-                            CultureInfo.InvariantCulture,
-                            out int _lastVerse
-                        )
-                    )
-                        lastVerse = _lastVerse;
+                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int lastVerseInt))
+                        lastVerse = lastVerseInt;
                     LastVerse = lastVerse;
                 }
             }
         }
-    }
-
-    public DeltaUsxMapper(IGuidService guidService, ILogger<DeltaUsxMapper> logger, IExceptionHandler exceptionHandler)
-    {
-        GuidService = guidService;
-        Logger = logger;
-        ExceptionHandler = exceptionHandler;
     }
 
     public static bool CanParaContainVerseText(string style)
@@ -135,7 +123,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         var invalidNodes = new HashSet<XNode>();
         usxDoc.Validate(
             Schemas,
-            (o, e) =>
+            (o, _) =>
             {
                 XNode node;
                 if (o is XAttribute attr)
@@ -151,7 +139,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
         var nextIds = new Dictionary<string, int>();
         var state = new ParseState();
         bool bookIsValid = true;
-        foreach (XNode node in usxDoc.Element("usx").Nodes())
+        foreach (XNode node in usxDoc.Element("usx")!.Nodes())
         {
             switch (node)
             {
@@ -184,13 +172,6 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                                 {
                                     state.CurRef = GetParagraphRef(nextIds, style, style);
                                 }
-                            }
-                            else if (style == "b")
-                            {
-                                // insert the line break and continue processing with the current verse ref
-                                ProcessChildNodes(elem, chapterDelta, invalidNodes);
-                                InsertPara(elem, chapterDelta, invalidNodes, state);
-                                break;
                             }
                             else
                             {
@@ -300,7 +281,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                         JToken existingCharAttrs = newChildAttributes["char"];
                         JObject newCharAttrs = GetAttributes(elem);
                         if (!newCharAttrs.ContainsKey("cid"))
-                            newCharAttrs.Add("cid", GuidService.Generate());
+                            newCharAttrs.Add("cid", guidService.Generate());
 
                         if (existingCharAttrs == null)
                             newChildAttributes.Add(new JProperty(elem.Name.LocalName, newCharAttrs));
@@ -521,10 +502,10 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                         + $"(just one 'chapter' with a Delta.Ops.Count of 0), and USX with {usxChapterCount} "
                         + "chapters. This may indicate corrupt data in the SF DB. Handling by ignoring "
                         + "chapterDeltas and returning the input USX.";
-                    Logger.LogWarning(errorExplanation);
+                    logger.LogWarning(errorExplanation);
                     // Report to bugsnag, but don't throw.
                     var report = new ArgumentException(errorExplanation);
-                    ExceptionHandler.ReportException(report);
+                    exceptionHandler.ReportException(report);
                 }
                 return oldUsxDoc;
             }
@@ -615,15 +596,15 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     /// <summary>
     /// Make USX from a Delta's ops.
     /// </summary>
-    private static IEnumerable<XNode> ProcessDelta(Delta delta)
+    private static List<XNode> ProcessDelta(Delta delta)
     {
         // Output XML.
-        var content = new List<XNode>();
+        List<XNode> content = [];
         // Outer-to-inner set of nested character formatting, which applies to top childNodes elements.
-        var curCharAttrs = new List<JObject>();
+        List<JObject> curCharAttrs = [];
         // In-progress nested text and formatting, with the top of the stack representing the inner part of the nesting.
         // Each element contains a first-to-last set of XML nodes.
-        var childNodes = new Stack<List<XNode>>();
+        Stack<List<XNode>> childNodes = [];
         childNodes.Push([]);
         JObject curTableAttrs = null;
         JObject curRowAttrs = null;
@@ -636,12 +617,12 @@ public class DeltaUsxMapper : IDeltaUsxMapper
             // If we were tracking character attributes for childNodes, but the text being inserted by the current op
             // does not have any character attributes, then record char XML elements for all tracked character
             // attributes.
-            if (curCharAttrs.Count > 0 && (attrs == null || attrs["char"] == null))
+            if (curCharAttrs.Count > 0 && attrs?["char"] == null)
             {
                 while (curCharAttrs.Count > 0)
                     CharEnded(childNodes, curCharAttrs);
             }
-            else if (attrs != null && attrs["char"] != null)
+            else if (attrs?["char"] != null)
             {
                 List<JObject> charAttrs = GetCharAttributes(attrs["char"]);
                 // Record character formatting for existing text if it does not apply to the text being inserted in the
@@ -664,7 +645,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                 var text = (string)op[Delta.InsertType];
                 // If we were recently working with table information, but the current op doesn't describe the end of a
                 // table cell, and we seem to be done with the table, then end the table.
-                if (curTableAttrs != null && (attrs == null || attrs["table"] == null) && text == "\n")
+                if (curTableAttrs != null && attrs?["table"] == null && text == "\n")
                 {
                     List<XNode> nextBlockNodes = RowEnded(childNodes, ref curRowAttrs);
                     TableEnded(content, childNodes, ref curTableAttrs);
@@ -674,7 +655,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                 // observed. Take the top childNodes node-set and put it into a cell XML element. Leave childNodes with
                 // an empty node-set at the top for upcoming content, followed by a node-set with the cell XML element appended,
                 // followed by at least one more node-set (possibly being existing content).
-                else if (attrs != null && attrs["table"] != null)
+                else if (attrs?["table"] != null)
                 {
                     var cellAttrs = (JObject)attrs["cell"];
                     XElement cellElem;
@@ -763,6 +744,13 @@ public class DeltaUsxMapper : IDeltaUsxMapper
                     switch (prop.Name)
                     {
                         case "chapter":
+                            // If there is a table before the chapter (i.e. in an introduction), end it
+                            if (curTableAttrs != null)
+                            {
+                                RowEnded(childNodes, ref curRowAttrs);
+                                TableEnded(content, childNodes, ref curTableAttrs);
+                            }
+
                             XElement chapterElem = new XElement("chapter");
                             AddAttributes(chapterElem, prop.Value);
                             content.Add(chapterElem);
@@ -830,7 +818,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     /// <summary>
     /// Create XML element of a given name, with attributes and optional children content.
     /// </summary>
-    private static XElement CreateContainerElement(string name, JToken attributes, object content = null)
+    private static XElement CreateContainerElement(string name, JToken attributes, object? content = null)
     {
         var elem = new XElement(name);
         AddAttributes(elem, attributes);
@@ -879,7 +867,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     /// append it to the bottom `childNodes` node-set. Return the top node-set if there were 3. Leave
     /// childNodes as only the bottom node-set.
     /// </summary>
-    private static List<XNode> RowEnded(Stack<List<XNode>> childNodes, ref JObject curRowAttrs)
+    private static List<XNode>? RowEnded(Stack<List<XNode>> childNodes, ref JObject? curRowAttrs)
     {
         if (childNodes.Count > 3)
             throw new InvalidOperationException("A table is not valid in the current location.");
@@ -898,7 +886,7 @@ public class DeltaUsxMapper : IDeltaUsxMapper
     /// Create an XML table element using the top `childNodes` node-set as content, and append it to
     /// `content`.
     /// </summary>
-    private static void TableEnded(List<XNode> content, Stack<List<XNode>> childNodes, ref JObject curTableAttrs)
+    private static void TableEnded(List<XNode> content, Stack<List<XNode>> childNodes, ref JObject? curTableAttrs)
     {
         content.Add(CreateContainerElement("table", curTableAttrs, childNodes.Peek()));
         childNodes.Peek().Clear();

--- a/src/SIL.XForge.Scripture/Services/ParatextZippedResourcePasswordProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextZippedResourcePasswordProvider.cs
@@ -1,0 +1,38 @@
+using Paratext.Data.ProjectFileAccess;
+using PtxUtils;
+using SIL.XForge.Configuration;
+
+namespace SIL.XForge.Scripture.Services;
+
+/// <summary>
+/// An implementation of the Paratext zipped resource password provider.
+/// </summary>
+/// <seealso cref="IZippedResourcePasswordProvider" />
+/// <param name="paratextOptions">The Paratext options.</param>
+public class ParatextZippedResourcePasswordProvider(ParatextOptions? paratextOptions) : IZippedResourcePasswordProvider
+{
+    /// <summary>
+    /// The cached password value.
+    /// </summary>
+    private string? _cachedValue;
+
+    /// <inheritdoc />
+    public string GetPassword()
+    {
+        // We can handle zip files with no password (for testing)
+        if (
+            string.IsNullOrWhiteSpace(paratextOptions?.ResourcePasswordBase64)
+            || string.IsNullOrWhiteSpace(paratextOptions.ResourcePasswordHash)
+        )
+        {
+            return string.Empty;
+        }
+
+        _cachedValue ??= StringUtils.DecryptStringFromBase64(
+            paratextOptions.ResourcePasswordBase64,
+            paratextOptions.ResourcePasswordHash
+        );
+
+        return _cachedValue!;
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -11,7 +11,6 @@ using Paratext.Data;
 using Paratext.Data.Archiving;
 using Paratext.Data.Languages;
 using Paratext.Data.ProjectFileAccess;
-using PtxUtils;
 using PtxUtils.Http;
 using SIL.Extensions;
 using SIL.IO;
@@ -848,51 +847,6 @@ public class SFInstallableDblResource : InstallableResource
             {
                 return langIdDbl;
             }
-        }
-    }
-
-    /// <summary>
-    /// An implementation of the Paratext zipped resource password provider.
-    /// </summary>
-    /// <seealso cref="Paratext.Data.ProjectFileAccess.IZippedResourcePasswordProvider" />
-    private class ParatextZippedResourcePasswordProvider : IZippedResourcePasswordProvider
-    {
-        /// <summary>
-        /// The cached password value.
-        /// </summary>
-        private string cachedValue;
-
-        /// <summary>
-        /// The paratext options.
-        /// </summary>
-        private readonly ParatextOptions _paratextOptions;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParatextZippedResourcePasswordProvider"/> class.
-        /// </summary>
-        /// <param name="paratextOptions">The paratext options.</param>
-        internal ParatextZippedResourcePasswordProvider(ParatextOptions paratextOptions) =>
-            this._paratextOptions = paratextOptions;
-
-        /// <inheritdoc />
-        public string GetPassword()
-        {
-            // We can handle zip files with no password (for testing)
-            if (
-                this._paratextOptions == null
-                || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordBase64)
-                || string.IsNullOrWhiteSpace(this._paratextOptions.ResourcePasswordHash)
-            )
-            {
-                return string.Empty;
-            }
-
-            cachedValue ??= StringUtils.DecryptStringFromBase64(
-                this._paratextOptions.ResourcePasswordBase64,
-                this._paratextOptions.ResourcePasswordHash
-            );
-
-            return cachedValue;
         }
     }
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -3388,8 +3388,9 @@ public class DeltaUsxMapperTests
             .InsertVerse("2")
             .InsertBlank("verse_1_2")
             .InsertPara("p")
+            .InsertBlank("verse_1_2/b_1")
             .InsertPara("b")
-            .InsertBlank("verse_1_2/p_1")
+            .InsertBlank("verse_1_2/p_2")
             .InsertVerse("3")
             .InsertBlank("verse_1_3")
             .InsertPara("p");
@@ -3420,9 +3421,9 @@ public class DeltaUsxMapperTests
             .InsertVerse("1")
             .InsertText("Verse text.", "verse_1_1")
             .InsertPara("p")
-            .InsertText("Text in line break")
+            .InsertText("Text in line break", "verse_1_1/b_1")
             .InsertPara("b")
-            .InsertText("second segment in verse.", "verse_1_1/p_1")
+            .InsertText("second segment in verse.", "verse_1_1/p_2")
             .InsertPara("p");
 
         Assert.That(chapterDeltas.Count, Is.EqualTo(1));
@@ -3685,10 +3686,11 @@ public class DeltaUsxMapperTests
             .InsertPara("q")
             .InsertText("Poetry second line", "verse_1_1/q_1")
             .InsertPara("q")
+            .InsertBlank("verse_1_1/b_2")
             .InsertPara("b")
-            .InsertText("Poetry third line", "verse_1_1/q_2")
+            .InsertText("Poetry third line", "verse_1_1/q_3")
             .InsertPara("q")
-            .InsertText("Poetry fourth line.", "verse_1_1/q_3")
+            .InsertText("Poetry fourth line.", "verse_1_1/q_4")
             .InsertPara("q");
 
         Assert.That(chapterDeltas.Count, Is.EqualTo(1));
@@ -3867,6 +3869,71 @@ public class DeltaUsxMapperTests
             \v 1 My son, if thou wilt...
             \c 3
             \v 1 My son, forget not...
+            """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_BlankLineAndTableInIntroduction()
+    {
+        AssertRoundtrips(
+            """
+            \id PSA - A
+            \ip The book of Psalms...
+            \ib
+            \tr \th1 MT \th2 LXX
+            \tr \tc1 1-8 \tc2 1-8
+            \c 1
+            \q \v 1 Blessed is the man...
+            """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_TableInIntroduction()
+    {
+        AssertRoundtrips(
+            """
+            \id PSA - A
+            \ip The book of Psalms...
+            \tr \th1 MT \th2 LXX
+            \tr \tc1 1-8 \tc2 1-8
+            \c 1
+            \q \v 1 Blessed is the man...
+            """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_TwoTablesInIntroduction()
+    {
+        AssertRoundtrips(
+            """
+            \id PSA - A
+            \ip The book of Psalms...
+            \tr \th1 MT \th2 LXX
+            \tr \tc1 1-8 \tc2 1-8
+            \ib
+            \tr \th1 Book \th2 Psalms
+            \tr \tc1 1 \tc2 1-41
+            \c 1
+            \q \v 1 Blessed is the man...
+            """
+        );
+    }
+
+    [Test]
+    public void Roundtrip_TextWithBlankLines()
+    {
+        AssertRoundtrips(
+            """
+            \id PSA - A
+            \c 1
+            \q \v 1 
+            \b
+            Blessed is the man...
+            \b
+            \q \v 2 But his delight
             """
         );
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1576,11 +1576,11 @@ public class ParatextServiceTests
         var associatedPtUser = new SFParatextUser(env.Username01);
         UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
         string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
-        string threadId = "thread1";
-        string text1 = "Text in first verse ";
-        string text2 = "text after ";
-        string selected = "stanza";
-        string text3 = " break";
+        const string threadId = "thread1";
+        const string text1 = "Text in first verse ";
+        const string text2 = "text after ";
+        const string selected = "stanza";
+        const string text3 = " break";
 
         var comment = new Paratext.Data.ProjectComments.Comment(associatedPtUser)
         {
@@ -1591,7 +1591,7 @@ public class ParatextServiceTests
             ContextAfter = text3,
             StartPosition = text1.Length + text2.Length,
             Contents = null,
-            Date = $"2019-12-31T08:00:00.0000000+00:00",
+            Date = "2019-12-31T08:00:00.0000000+00:00",
             Deleted = false,
             Status = NoteStatus.Todo,
             Type = NoteType.Normal,
@@ -1604,7 +1604,12 @@ public class ParatextServiceTests
         {
             IEnumerable<IDocument<NoteThread>> noteThreadDocs = Array.Empty<IDocument<NoteThread>>();
             Dictionary<int, ChapterDelta> chapterDeltas = [];
-            string chapterText =
+            // These deltas represent the following USFM:
+            // \c 1
+            // \q
+            // \v 1 Text in first verse
+            // \b text after stanza break
+            const string chapterText =
                 "[ { \"insert\": { \"chapter\": { \"style\": \"c\", \"number\": \"1\" } } }, "
                 + "{ \"insert\": { \"blank\": true }, \"attributes\": { \"segment\": \"q_1\" } },"
                 + "{ \"insert\": { \"verse\": { \"style\": \"v\", \"number\": \"1\" } } }, "
@@ -1612,12 +1617,12 @@ public class ParatextServiceTests
                 + text1
                 + "\", \"attributes\": { \"segment\": \"verse_1_1\" } }, "
                 + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"q\" } } }, "
-                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } }, "
                 + "{ \"insert\": \""
                 + text2
                 + selected
                 + text3
-                + "\", \"attributes\": { \"segment\": \"verse_1_1/q_1\" } } ]";
+                + "\", \"attributes\": { \"segment\": \"verse_1_1/b_1\" } }, "
+                + "{ \"insert\": \"\n\", \"attributes\": { \"para\": { \"style\": \"b\" } } } ]";
             var delta = new Delta(JToken.Parse(chapterText));
             ChapterDelta chapterDelta = new ChapterDelta(1, 1, true, delta);
             chapterDeltas.Add(1, chapterDelta);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextZippedResourcePasswordProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextZippedResourcePasswordProviderTests.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using Paratext.Data.ProjectFileAccess;
+using PtxUtils;
+using SIL.XForge.Configuration;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class ParatextZippedResourcePasswordProviderTests
+{
+    [Test]
+    public void GetPassword_ParatextOptionsNull()
+    {
+        var env = new TestEnvironment(paratextOptions: null);
+        string expected = string.Empty;
+        string actual = env.Service.GetPassword();
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void GetPassword_MissingResourcePasswordBase64()
+    {
+        var paratextOptions = new ParatextOptions { ResourcePasswordHash = "test" };
+        var env = new TestEnvironment(paratextOptions);
+        string expected = string.Empty;
+        string actual = env.Service.GetPassword();
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void GetPassword_MissingResourcePasswordHash()
+    {
+        var paratextOptions = new ParatextOptions { ResourcePasswordBase64 = "test" };
+        var env = new TestEnvironment(paratextOptions);
+        string expected = string.Empty;
+        string actual = env.Service.GetPassword();
+        Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
+    public void GetPassword_Success()
+    {
+        const string expected = "String to encode";
+        const string resourcePasswordHash = "secret password hash";
+        string resourcePasswordBase64 = StringUtils.EncryptStringToBase64(expected, resourcePasswordHash);
+        var paratextOptions = new ParatextOptions
+        {
+            ResourcePasswordBase64 = resourcePasswordBase64,
+            ResourcePasswordHash = resourcePasswordHash,
+        };
+        var env = new TestEnvironment(paratextOptions);
+        string actual = env.Service.GetPassword();
+        Assert.AreEqual(expected, actual);
+    }
+
+    private class TestEnvironment(ParatextOptions? paratextOptions)
+    {
+        public readonly IZippedResourcePasswordProvider Service = new ParatextZippedResourcePasswordProvider(
+            paratextOptions
+        );
+    }
+}

--- a/tools/Roundtrip/README.md
+++ b/tools/Roundtrip/README.md
@@ -1,0 +1,34 @@
+# USFM Roundtrip Tool
+
+This tool will round trip the USFM files in a directory, including inside subdirectories, zip files and DBL resources.
+
+## Running
+
+To run on the Scripture Forge directory:
+
+```sh
+dotnet run /var/lib/scriptureforge/sync/
+```
+
+Or to run on your Paratext directory on Windows:
+
+```sh
+dotnet run "C:\My Paratext 9 Projects"
+```
+
+To export the output for all files that fail to roundtrip:
+
+```sh
+dotnet run /var/lib/scriptureforge/sync/ --output-sfm
+```
+
+Or, to export all of the files that the tool roundtrips:
+
+```sh
+dotnet run /var/lib/scriptureforge/sync/ --output-all
+```
+
+## Notes
+
+- Unlike **ServalDownloader**, this tool does not utilize the user secrets you have configured for Scripture Forge.
+- To view a time series graph of the builds, select all of the data on the Summary sheet, and create a 2-D Line Graph.

--- a/tools/Roundtrip/Roundtrip.csproj
+++ b/tools/Roundtrip/Roundtrip.csproj
@@ -10,6 +10,7 @@
     https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph
     -->
     <UseRidGraph>true</UseRidGraph>
+    <UserSecretsId>4d0606c3-0fc7-4d76-b43b-236485004e81</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds support for roundtripping DBL resources to the round trip tool. I also took the opportunity to add unit test to the zipped resource password provider, as this class was needed by the round trip tool.

Running the tool on the `_Resources` directory on resulted in three resources that have roundtrip issues, which I have included a fix for. I then ran these fixes against the open.bible dataset, and the DBL resources on SF live.

I have marked this as not requiring testing, as it doesn't change the behvaiour of the SF internal logic, only exposes the `ParatextZippedResourcePasswordProvider` as a `public` class instead of a `private` class.

If you wish to test this, run against your Paratext projects directory (`/var/lib/scriptureforge/sync/` or `C:\My Paratext 9 Projects\`), and the Resources within that directory will be round tripped too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3157)
<!-- Reviewable:end -->
