### PR TITLE
SF-3298 Save recording automatically (except for inline recording)

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -384,7 +384,7 @@ export class CheckingAnswersComponent implements OnInit {
     if (this.questionDoc?.data == null) return;
     const dialogRef: MatDialogRef<AudioRecorderDialogComponent, AudioRecorderDialogResult> =
       this.dialogService.openMatDialog(AudioRecorderDialogComponent, {
-        data: { countdown: true } as AudioRecorderDialogData
+        data: { countdown: true, requireSave: true } as AudioRecorderDialogData
       });
 
     const result: AudioRecorderDialogResult | undefined = await firstValueFrom(dialogRef.afterClosed());

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.html
@@ -33,7 +33,7 @@
     <div class="dialog-footer">
       @if (!hasAudioAttachment) {
         <canvas class="visualizer"></canvas>
-      } @else {
+      } @else if (_requireSave) {
         <div class="has-attachment">
           <button mat-button (click)="resetRecording()" class="remove-audio-file">
             <mat-icon>mic</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.spec.ts
@@ -127,6 +127,20 @@ describe('AudioRecorderDialogComponent', () => {
     expect(result.audio.status).toEqual('processed');
     expect(result.audio.url).toContain('blob:');
   });
+
+  it('saves after recording and processing if manual save is not required', async () => {
+    const env = new TestEnvironment(false);
+    const promiseForResult: Promise<AudioRecorderDialogResult> = firstValueFrom(env.dialogRef.afterClosed());
+
+    env.clickButton(env.recordButton);
+    await env.waitForRecorder(1000);
+    env.clickButton(env.stopRecordingButton);
+    await env.waitForRecorder(100);
+
+    const result: AudioRecorderDialogResult = await promiseForResult;
+    expect(result.audio.status).toEqual('processed');
+    expect(result.audio.url).toContain('blob:');
+  });
 });
 
 class TestEnvironment {
@@ -141,10 +155,10 @@ class TestEnvironment {
 
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
 
-  constructor(countdown: boolean = false) {
+  constructor(saveRequired: boolean = true, countdown: boolean = false) {
     this.fixture = TestBed.createComponent(ChildViewContainerComponent);
     this.dialogRef = TestBed.inject(MatDialog).open(AudioRecorderDialogComponent, {
-      data: { countdown } as AudioRecorderDialogData
+      data: { countdown, requireSave: saveRequired } as AudioRecorderDialogData
     });
     this.component = this.dialogRef.componentInstance;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -69,7 +69,8 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
   countdownTimer: number = 0;
   mediaDevicesUnsupported: boolean = false;
 
-  private _requireSave: boolean;
+  protected _requireSave: boolean;
+
   private destroyed = false;
   private stream?: MediaStream;
   private mediaRecorder?: MediaRecorder;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.stories.ts
@@ -70,7 +70,8 @@ export default {
     moduleMetadata({}),
     (story, context) => {
       context.args.data = {
-        countdown: context.args.countdown
+        countdown: context.args.countdown,
+        requireSave: true
       } as AudioRecorderDialogData;
       when(mockedNavigator.mediaDevices).thenReturn({
         getUserMedia: (_: MediaStreamConstraints): Promise<MediaStream> => {


### PR DESCRIPTION
This stemmed from a user workshop, where it was confusing that some workflows for recording audio didn't save the audio even after clicking the (first) save button. This fixes those workflows, such that users only have to click Save once, for each workflow. The dialog defaults to not requiring a manual save.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3159)
<!-- Reviewable:end -->
