### PR TITLE
Improve theme support for translate editing

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -23,6 +23,9 @@
   --sf-usx-verse-background: #{mat.get-theme-color($theme, neutral, 95)};
   --sf-usx-readonly-verse-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 80, 10))};
   --sf-usx-readonly-verse-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 30, 95))};
+
+  --sf-text-color: #{if($is-dark, black, rgba(0, 0, 0, 0.8))};
+  --sf-text-background: #{if($is-dark, mat.get-theme-color($theme, neutral-variant, 80), white)};
 }
 
 @mixin theme($theme) {
@@ -231,8 +234,8 @@ quill-editor.rtl {
 
         box-decoration-break: clone;
 
-        color: rgba(0, 0, 0, 0.8);
-        background-color: white;
+        color: var(--sf-text-color);
+        background-color: var(--sf-text-background);
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -1,7 +1,18 @@
 @use 'src/variables';
 @use 'src/breakpoints';
+@use '@angular/material' as mat;
 @import 'quill/dist/quill.snow.css';
 @import 'usx';
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}
 
 quill-editor {
   height: 100%;

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -6,6 +6,23 @@
 
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-quill-background: #{if($is-dark, mat.get-theme-color($theme, neutral, 20), #f5f3ef)};
+  --sf-quill-highlight-marker-color: #{mat.get-theme-color($theme, tertiary, 80)};
+  --sf-quill-highlight-segment-background: #ffeb3b;
+  --sf-quill-highlight-segment-color: #{mat.get-theme-color($theme, neutral, 10)};
+  --sf-quill-question-count-background: #{mat.get-theme-color($theme, primary, 50)};
+  --sf-quill-question-count-color: #{mat.get-theme-color($theme, primary, 98)};
+  --sf-quill-insert-segment-background: #cce8cc;
+  --sf-quill-insert-segment-color: #{mat.get-theme-color($theme, neutral, 10)};
+  --sf-quill-delete-segment-background: #e8cccc;
+  --sf-quill-delete-segment-color: #{mat.get-theme-color($theme, neutral, 10)};
+
+  --sf-usx-chapter-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 70, 40))};
+  --sf-usx-verse-color: #{mat.get-theme-color($theme, neutral, 10)};
+  --sf-usx-verse-background: #{mat.get-theme-color($theme, neutral, 95)};
+  --sf-usx-readonly-verse-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 80, 10))};
+  --sf-usx-readonly-verse-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 30, 95))};
 }
 
 @mixin theme($theme) {
@@ -29,7 +46,7 @@ quill-editor {
 }
 
 .ql-container.ql-snow {
-  border: 1px solid variables.$border-color;
+  border: 1px solid var(--sf-border-color);
 }
 
 .has-draft {
@@ -49,16 +66,19 @@ quill-editor {
     }
 
     .highlight-segment {
-      background-color: #ffeb3b;
+      background-color: var(--sf-quill-highlight-segment-background);
+      color: var(--sf-quill-highlight-segment-color);
     }
 
     .insert-segment {
-      background-color: #cce8cc;
+      background-color: var(--sf-quill-insert-segment-background);
+      color: var(--sf-quill-insert-segment-color);
       padding: 0;
     }
 
     .delete-segment {
-      background-color: #e8cccc;
+      background-color: var(--sf-quill-delete-segment-background);
+      color: var(--sf-quill-delete-segment-color);
       padding: 0;
       text-decoration: line-through;
 
@@ -88,8 +108,8 @@ quill-editor {
           display: flex;
           align-content: center;
           justify-content: center;
-          background: variables.$questions;
-          color: #fff;
+          background: var(--sf-quill-question-count-background);
+          color: var(--sf-quill-question-count-color);
           font-weight: bold;
           position: absolute;
           top: 0.2em;
@@ -197,7 +217,7 @@ quill-editor.rtl {
 
 .template-editor > .ql-container {
   > .ql-editor {
-    background-color: #f5f3ef;
+    background-color: var(--sf-quill-background);
 
     usx-para,
     p {
@@ -228,9 +248,9 @@ quill-editor.rtl {
   > .highlight-marker {
     width: 0;
     height: 0;
-    border-left: 4px solid #a9ca25;
+    border-left: 4px solid var(--sf-quill-highlight-marker-color);
     position: absolute;
-    top: 0px;
+    top: 0;
     left: 6px;
   }
 }
@@ -246,7 +266,7 @@ quill-editor.rtl {
   }
 
   .highlight-para > usx-para-contents {
-    box-shadow: 1px 1px 0px 1px #ede6de;
+    box-shadow: 1px 1px 0 1px #ede6de;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -7,7 +7,7 @@
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
-  --sf-quill-background: #{if($is-dark, mat.get-theme-color($theme, neutral, 20), #f5f3ef)};
+  --sf-quill-background: #{if($is-dark, mat.get-theme-color($theme, neutral, 6), #f5f3ef)};
   --sf-quill-highlight-marker-color: #{mat.get-theme-color($theme, tertiary, 80)};
   --sf-quill-highlight-segment-background: #ffeb3b;
   --sf-quill-highlight-segment-color: #{mat.get-theme-color($theme, neutral, 10)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -247,7 +247,7 @@ quill-editor.rtl {
     }
 
     &[data-style='io2'] {
-      margin-right-left: 15%;
+      margin-right: 15%;
     }
 
     &[data-style='io3'] {
@@ -359,7 +359,7 @@ usx-chapter {
   font-size: 1.5em;
   margin-top: 8pt;
   margin-bottom: 4pt;
-  color: #7c7c7c;
+  color: var(--sf-usx-chapter-color);
 }
 
 usx-verse {
@@ -371,11 +371,11 @@ usx-verse {
     position: relative;
     font-size: 75%;
     padding: 0.2em 0.4em;
-    background-color: #f5f3ef;
+    background-color: var(--sf-usx-verse-background);
     border-radius: 8px;
     white-space: nowrap;
     margin: 0 0.2em 0 0.3em;
-    color: #7c7c7c;
+    color: var(--sf-usx-verse-color);
     span[data-style='va'] {
       font-size: 85%;
       color: #5faa5f;
@@ -471,5 +471,12 @@ usx-unmatched {
       margin-top: 0.5em;
       margin-bottom: 0.5em;
     }
+  }
+}
+
+quill-editor.read-only-editor {
+  usx-verse > span > span > span {
+    background-color: var(--sf-usx-readonly-verse-background);
+    color: var(--sf-usx-readonly-verse-color);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
@@ -18,7 +18,7 @@ $likes: #578cff;
 $questions: $purpleLight;
 $answers: $greenLight;
 $comments: $orange;
-$border-color: rgba(0, 0, 0, 0.12);
+$border-color: rgb(227, 227, 227);
 $disabled-text-color: $greyLight;
 /* A text color that is somewhat muted compared to the primary text color. Note that #666666 is used to match
  * how mat-hint looks on a white background.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.scss
@@ -1,7 +1,3 @@
-.copyright-banner {
-  margin-bottom: 10px;
-}
-
 .copyright-more-info {
   cursor: pointer;
   font-weight: bold;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -8,7 +8,7 @@ $colors: (
   secondary: (sfColors.$purpleDark, #d6d4e8),
   success:   (#125235, #c4ead9),
   warning:   (#6a5117, #fff3d0),
-  error:     (sfColors.$errorColor, #f8d7da),
+  error:     (sfColors.$errorColor, #fdafaf),
   info:      (#345564, #d0f4fb),
   light:     (#6a6b6b, #f7f7f7),
   dark:      (#181a1d, #d3d3d4),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -1,6 +1,9 @@
 @use 'sass:color';
 @use 'sass:list';
+@use 'sass:map';
+@use '@angular/material' as mat;
 @use 'src/variables' as sfColors;
+@use 'src/themes/default' as default;
 
 // prettier-ignore
 $colors: (
@@ -17,6 +20,27 @@ $colors: (
 // Helper function just to clean up the syntax
 @function scaleLightness($color, $lightness) {
   @return color.scale($color, $lightness: $lightness);
+}
+
+@function create-dark-palette($base-color) {
+  @return (
+    0: scaleLightness($base-color, -95%),
+    10: scaleLightness($base-color, -90%),
+    20: scaleLightness($base-color, -80%),
+    25: scaleLightness($base-color, -75%),
+    30: scaleLightness($base-color, -70%),
+    35: scaleLightness($base-color, -65%),
+    40: scaleLightness($base-color, -60%),
+    50: scaleLightness($base-color, -50%),
+    60: scaleLightness($base-color, -40%),
+    70: scaleLightness($base-color, -30%),
+    80: scaleLightness($base-color, -25%),
+    90: scaleLightness($base-color, -10%),
+    95: scaleLightness($base-color, -5%),
+    98: scaleLightness($base-color, -2%),
+    99: scaleLightness($base-color, -1%),
+    100: $base-color
+  );
 }
 
 :host {
@@ -59,6 +83,20 @@ $colors: (
       --notice-color-button-bg-alt: #{scaleLightness($colorLight, 20%)};
       --notice-color-button-hover-bg-alt: #{scaleLightness($colorLight, 80%)};
       --notice-color-button-text-alt: #{scaleLightness($colorLight, -60%)};
+
+      // prettier-ignore
+      &.mode-fill-dark,
+      &.mode-fill-light {
+        $_notice_theme: mat.define-theme(
+          (
+            color: (
+                primary: map.merge(create-dark-palette($colorLight), default.$rest)
+              )
+          )
+        );
+
+        @include mat.checkbox-color($_notice_theme);
+      }
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/_sf-tab-group-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/_sf-tab-group-theme.scss
@@ -5,9 +5,9 @@
 
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
-  $background: #{mat.get-theme-color($theme, primary, if($is-dark, 30, 100))};
-  $background-inactive: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 98))};
-  $background-hover-inactive: #{mat.get-theme-color($theme, primary, if($is-dark, 20, 95))};
+  $background: #{mat.get-theme-color($theme, neutral, if($is-dark, 6, 100))};
+  $background-inactive: #{mat.get-theme-color($theme, neutral, if($is-dark, 12, 98))};
+  $background-hover-inactive: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 95))};
   $background-button-hover-inactive: #{mat.get-theme-color($theme, primary, if($is-dark, 30, 90))};
 
   --sf-tab-header-active-tab-accent-color: #{mat.get-theme-color($theme, primary, 20)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/_sf-tab-group-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/_sf-tab-group-theme.scss
@@ -23,6 +23,8 @@
   --sf-tab-group-border-width: 1px;
   --sf-tab-header-border-width: 1px;
   --sf-tab-header-top-offset: 1px;
+
+  --sf-tab-toolbar-background-color: #{$background};
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-header/tab-header.component.scss
@@ -32,7 +32,7 @@ $tabHeaderBorderRadius: var(--sf-tab-header-border-radius);
       top: 0;
       left: 0;
       right: 0;
-      height: 0.1em;
+      height: 0.15em;
       background-color: var(--sf-tab-header-active-tab-accent-color);
       animation: tab-header-active-accent-grow 0.2s;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/_biblical-terms-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/_biblical-terms-theme.scss
@@ -1,0 +1,13 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-biblical-terms-tabler-header-background: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 95))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
@@ -16,9 +16,17 @@
 }
 
 /* Fix the menu appearing below the table header */
-.mat-mdc-header-cell {
+:host .mat-mdc-header-cell {
   padding: 5px;
   z-index: 2 !important;
+}
+
+.mat-mdc-header-row:first-child {
+  background: var(--sf-tab-toolbar-background-color);
+}
+
+.mat-mdc-header-row:last-child {
+  background: var(--sf-biblical-terms-tabler-header-background);
 }
 
 /* Stretch the table across the page */
@@ -78,7 +86,6 @@
   align-items: center;
   justify-content: flex-start;
   padding: 1em 0.5em 0.75em 0.5em;
-  background: #fff;
 }
 
 .biblical-terms-select {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/language-codes-confirmation/language-codes-confirmation.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'language_codes_confirmation'">
   @if (showSourceLanguagesDifferError) {
-    <app-notice mode="fill-dark" type="error">
+    <app-notice mode="fill-light" type="error">
       <h3>{{ t("all_sources_must_be_same_language") }}</h3>
       {{ t("sources_in_following_languages") }}
       <ul>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/_editor-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/_editor-theme.scss
@@ -1,0 +1,14 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-editor-note-fab-background-color: #{mat.get-theme-color($theme, tertiary, 80)};
+  --sf-editor-note-fab-foreground-color: #{mat.get-theme-color($theme, tertiary, 10)};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/_editor-draft-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/_editor-draft-theme.scss
@@ -1,0 +1,13 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-draft-applied-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 80, 70))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
@@ -1,5 +1,3 @@
-@use 'src/variables';
-
 :host {
   display: flex;
   flex-direction: column;
@@ -17,7 +15,7 @@ app-notice {
 .toolbar {
   position: sticky;
   top: 0;
-  background: #fff;
+  background: var(--sf-tab-toolbar-background-color);
   z-index: 1;
   display: flex; //fill vertical space
 }
@@ -31,7 +29,7 @@ app-notice {
 }
 
 .draft-indicator {
-  color: variables.$greenDark;
+  color: var(--sf-draft-applied-color);
   font-style: italic;
   font-size: 18px;
   font-weight: 400;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.component.scss
@@ -12,10 +12,10 @@ mat-progress-bar {
 
 app-history-chooser {
   padding: 0.5em;
-  border-bottom: 1px solid var(--sf-tab-group-border-color);
+  border-bottom: 1px solid var(--sf-border-color);
   position: sticky;
   top: 0;
-  background: #fff;
+  background: var(--sf-tab-toolbar-background-color);
   z-index: 1;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -101,12 +101,13 @@ app-text {
   overflow: hidden;
 }
 
+app-copyright-banner,
 .formatting-invalid-warning,
 .out-of-sync-warning,
 .doc-corrupted-warning,
 .project-text-not-editable,
 .no-edit-permission-message {
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .both-editors-wrapper {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -56,7 +56,7 @@
   margin-bottom: 10px;
   border-width: 1px;
   border-style: solid;
-  border-color: vars.$border-color;
+  border-color: var(--sf-border-color);
   padding: 5px 10px;
   grid-column: 1 / span 2;
   display: flex;
@@ -76,7 +76,7 @@
 }
 
 .toolbar-separator {
-  border-left: 1px solid vars.$border-color;
+  border-left: 1px solid var(--sf-border-color);
   margin: 6px 4px;
   width: 0;
 }
@@ -117,7 +117,8 @@ app-text {
   position: absolute;
   visibility: hidden;
   inset-inline-end: 10px;
-  background-color: vars.$greenLight;
+  background-color: var(--sf-editor-note-fab-background-color);
+  color: var(--sf-editor-note-fab-foreground-color);
 }
 
 .fab-bottom-sheet {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/_note-dialog-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/_note-dialog-theme.scss
@@ -1,0 +1,14 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-note-dialog-reference-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 30, 98))};
+  --sf-note-dialog-reference-text-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 80, 70))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/_note-dialog-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/_note-dialog-theme.scss
@@ -4,7 +4,7 @@
   $is-dark: mat.get-theme-type($theme) == dark;
 
   --sf-note-dialog-reference-background: #{mat.get-theme-color($theme, neutral, if($is-dark, 30, 98))};
-  --sf-note-dialog-reference-text-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 80, 70))};
+  --sf-note-dialog-reference-text-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 80, 50))};
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -123,12 +123,18 @@ h1 {
 mat-button-toggle-group {
   border: 0;
 }
+
 .save-options {
   background-color: var(--mdc-filled-button-container-color);
   color: var(--mdc-filled-button-label-text-color) !important;
   ::ng-deep .mat-button-toggle-label-content {
     line-height: 36px;
   }
+}
+
+mat-dialog-actions {
+  display: flex;
+  column-gap: 4px;
 }
 
 .close-button {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -31,15 +31,15 @@ h1 {
   display: flex;
   min-height: 30px;
   .text {
-    color: variables.$greenDark;
-    background: rgba(0, 0, 0, 0.05);
+    color: var(--sf-note-dialog-reference-text-color);
+    background: var(--sf-note-dialog-reference-background);
     padding: 6px;
     border-radius: 4px;
     font-size: 0.9em;
     flex: 1;
     .segment-text {
       padding-top: 6px;
-      border-top: 2px solid variables.$greenDark;
+      border-top: 2px solid var(--sf-note-dialog-reference-text-color);
       margin-top: 6px;
       white-space: pre-wrap;
     }
@@ -51,14 +51,13 @@ h1 {
     display: flex;
     flex-wrap: wrap;
     .content {
-      color: #000;
       flex: 1 1 100%;
     }
     &:first-child {
       padding-top: 10px;
     }
     &:not(:last-child) {
-      border-bottom: 1px solid variables.$greyLight;
+      border-bottom: 1px solid var(--sf-border-color);
     }
     app-owner {
       display: block;
@@ -121,9 +120,12 @@ h1 {
   }
 }
 
+mat-button-toggle-group {
+  border: 0;
+}
 .save-options {
-  background-color: variables.$sf_grey !important;
-  color: white !important;
+  background-color: var(--mdc-filled-button-container-color);
+  color: var(--mdc-filled-button-label-text-color) !important;
   ::ng-deep .mat-button-toggle-label-content {
     line-height: 36px;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.scss
@@ -1,129 +1,144 @@
+@use '@angular/material' as mat;
 @import 'src/variables';
 
-.title {
-  margin-bottom: 20px;
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-list-item-hover-color: #{if($is-dark, mat.get-theme-color($theme, neutral, 17), lighten($sf_grey, 75%))};
 }
 
-mat-card {
-  min-height: 278px;
-  padding: 0;
-  mat-card-actions {
-    margin: 0;
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
   }
 }
 
-.card-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 20px 40px;
-  padding-block-end: 10px;
-}
-
-.translation-suggestions-info {
-  color: $lighterTextColor;
-  padding: 16px;
-}
-
-.books-card {
-  width: 18rem;
-
-  .progress-header {
-    display: flex;
-    place-content: center space-between;
+:host {
+  .title {
+    margin-bottom: 20px;
   }
 
-  .books-card-title ::ng-deep {
-    margin-top: 4px;
-    padding: 0 16px;
-    > .mat-mdc-card-header-text {
-      width: 100%;
-      mat-card-title {
-        margin-block: 8px;
-      }
-    }
-  }
-
-  mat-list {
-    overflow-y: auto;
-    mat-list-item {
-      cursor: pointer;
-      &:hover {
-        background-color: lighten($sf_grey, 75%);
-      }
-      .mat-icon {
-        color: rgba(0, 0, 0, 0.6);
-        margin-block: 0;
-        margin-inline: 16px;
-        align-self: center;
-      }
-    }
-  }
-}
-
-.progress {
-  display: flex !important;
-  align-self: center !important;
-  width: 32px;
-  height: 32px;
-}
-
-.engine-card {
-  width: 16rem;
-  overflow: hidden;
-
-  mat-card-header {
-    padding: 0 16px;
-  }
-
-  .engine-card-title {
-    margin-block: 8px;
-  }
-
-  .engine-card-content {
-    display: flex;
-    flex-direction: column;
+  mat-card {
+    min-height: 278px;
     padding: 0;
-    font-size: 14px;
+    mat-card-actions {
+      margin: 0;
+    }
+  }
 
-    .engine-card-quality {
+  .card-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 20px 40px;
+    padding-block-end: 10px;
+  }
+
+  .translation-suggestions-info {
+    color: $lighterTextColor;
+    padding: 16px;
+  }
+
+  .books-card {
+    width: 18rem;
+
+    .progress-header {
+      display: flex;
+      place-content: center space-between;
+    }
+
+    .books-card-title ::ng-deep {
+      margin-top: 4px;
+      padding: 0 16px;
+      > .mat-mdc-card-header-text {
+        width: 100%;
+        mat-card-title {
+          margin-block: 8px;
+        }
+      }
+    }
+
+    mat-list {
+      overflow-y: auto;
+      mat-list-item {
+        cursor: pointer;
+        &:hover {
+          background-color: var(--sf-list-item-hover-color);
+        }
+        .mat-icon {
+          color: rgba(0, 0, 0, 0.6);
+          margin-block: 0;
+          margin-inline: 16px;
+          align-self: center;
+        }
+      }
+    }
+  }
+
+  .progress {
+    display: flex !important;
+    align-self: center !important;
+    width: 32px;
+    height: 32px;
+  }
+
+  .engine-card {
+    width: 16rem;
+    overflow: hidden;
+
+    mat-card-header {
+      padding: 0 16px;
+    }
+
+    .engine-card-title {
+      margin-block: 8px;
+    }
+
+    .engine-card-content {
       display: flex;
       flex-direction: column;
-      align-self: stretch;
-      background-color: $greenLight;
-      padding: 26px 16px 15px 16px;
+      padding: 0;
+      font-size: 14px;
 
-      .engine-card-quality-stars {
-        align-self: center;
-        mat-icon {
-          font-size: 3.5em;
-          height: unset;
-          width: unset;
+      .engine-card-quality {
+        display: flex;
+        flex-direction: column;
+        align-self: stretch;
+        background-color: $greenLight;
+        padding: 26px 16px 15px 16px;
+
+        .engine-card-quality-stars {
+          align-self: center;
+          mat-icon {
+            font-size: 3.5em;
+            height: unset;
+            width: unset;
+          }
+
+          // the half star icon doesn't render reversed in RTL, so render the stars LTR and then rotate them
+          direction: ltr;
         }
 
-        // the half star icon doesn't render reversed in RTL, so render the stars LTR and then rotate them
-        direction: ltr;
+        .engine-card-quality-subtitle {
+          align-self: flex-end;
+          padding-right: 28px;
+        }
       }
 
-      .engine-card-quality-subtitle {
-        align-self: flex-end;
-        padding-right: 28px;
-      }
-    }
+      .engine-card-segments {
+        align-self: center;
+        padding: 15px 16px;
 
-    .engine-card-segments {
-      align-self: center;
-      padding: 15px 16px;
-
-      .engine-card-segments-count {
-        font-size: 2.25em;
-        margin-right: 8px;
+        .engine-card-segments-count {
+          font-size: 2.25em;
+          margin-right: 8px;
+        }
       }
     }
-  }
 
-  .mat-card-actions {
-    margin: 0;
-    padding: 8px;
+    .mat-card-actions {
+      margin: 0;
+      padding: 8px;
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -13,6 +13,7 @@
   sf-draft-generation-steps;
 @use 'src/app/translate/draft-generation/confirm-sources/confirm-sources-theme' as sf-confirm-sources;
 @use 'src/app/translate/draft-generation/draft-sources/draft-sources-theme' as sf-draft-sources;
+@use 'text' as sf-text;
 
 @mixin theme($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
@@ -33,6 +34,7 @@
   @include sf-my-projects.theme($theme);
   @include sf-navigation.theme($theme);
   @include sf-tab-group.theme($theme);
+  @include sf-text.theme($theme);
 
   // Custom variables
   --sf-disabled-foreground: #{mat.get-theme-color($theme, neutral, 70)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -54,7 +54,7 @@
   --sf-language-font-family: language_picker, language_picker_fallback, Arial, Helvetica, sans-serif;
 
   a:not(.mdc-button):not(.mat-mdc-menu-item) {
-    color: mat.get-theme-color($theme, primary, if($is-dark, 80, 40));
+    color: mat.get-theme-color($theme, primary, 50);
     &:hover {
       color: mat.get-theme-color($theme, primary, 60);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -13,6 +13,10 @@
   sf-draft-generation-steps;
 @use 'src/app/translate/draft-generation/confirm-sources/confirm-sources-theme' as sf-confirm-sources;
 @use 'src/app/translate/draft-generation/draft-sources/draft-sources-theme' as sf-draft-sources;
+@use 'src/app/translate/editor/editor-theme' as sf-editor;
+@use 'src/app/translate/editor/note-dialog/note-dialog-theme' as sf-note-dialog;
+@use 'src/app/translate/editor/editor-draft/editor-draft-theme' as sf-editor-draft;
+@use 'src/app/translate/biblical-terms/biblical-terms-theme' as sf-biblical-terms;
 @use 'text' as sf-text;
 
 @mixin theme($theme) {
@@ -24,6 +28,7 @@
   // Custom components
   @include sf-app.theme($theme);
   @include sf-book-multi-select.theme($theme);
+  @include sf-biblical-terms.theme($theme);
   @include sf-checking.theme($theme);
   @include sf-checking-answer.theme($theme);
   @include sf-checking-comments.theme($theme);
@@ -31,8 +36,11 @@
   @include sf-confirm-sources.theme($theme);
   @include sf-draft-generation-steps.theme($theme);
   @include sf-draft-sources.theme($theme);
+  @include sf-editor.theme($theme);
+  @include sf-editor-draft.theme($theme);
   @include sf-my-projects.theme($theme);
   @include sf-navigation.theme($theme);
+  @include sf-note-dialog.theme($theme);
   @include sf-tab-group.theme($theme);
   @include sf-text.theme($theme);
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -17,6 +17,8 @@
 @use 'src/app/translate/editor/note-dialog/note-dialog-theme' as sf-note-dialog;
 @use 'src/app/translate/editor/editor-draft/editor-draft-theme' as sf-editor-draft;
 @use 'src/app/translate/biblical-terms/biblical-terms-theme' as sf-biblical-terms;
+@use 'src/app/translate/translate-overview/translate-overview.component' as sf-translate-overview;
+
 @use 'text' as sf-text;
 
 @mixin theme($theme) {
@@ -43,6 +45,7 @@
   @include sf-note-dialog.theme($theme);
   @include sf-tab-group.theme($theme);
   @include sf-text.theme($theme);
+  @include sf-translate-overview.theme($theme);
 
   // Custom variables
   --sf-disabled-foreground: #{mat.get-theme-color($theme, neutral, 70)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/themes/_default.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/themes/_default.scss
@@ -98,7 +98,7 @@ $palettes: (
     50: #7d7483,
     60: #978d9e,
     70: #b2a7b8,
-    80: #cec3d4,
+    80: #cfc7d3,
     90: #eadef1,
     95: #f9edff,
     98: #fff7ff,

--- a/src/SIL.XForge.Scripture/ClientApp/src/themes/_default.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/themes/_default.scss
@@ -4,7 +4,7 @@
 
 // Styles for angular material components. Refer to https://material.angular.io/guide/theming
 // Note: Color palettes are generated from primary: #BECC63, secondary: #9BA26D, tertiary: #F3D479
-$_palettes: (
+$palettes: (
   primary: (
     0: #000000,
     10: #2b0053,
@@ -124,14 +124,14 @@ $_palettes: (
     100: #ffffff
   )
 );
-$_rest: (
-  secondary: map.get($_palettes, secondary),
-  neutral: map.get($_palettes, neutral),
-  neutral-variant: map.get($_palettes, neutral-variant),
-  error: map.get($_palettes, error)
+$rest: (
+  secondary: map.get($palettes, secondary),
+  neutral: map.get($palettes, neutral),
+  neutral-variant: map.get($palettes, neutral-variant),
+  error: map.get($palettes, error)
 );
-$_primary: map.merge(map.get($_palettes, primary), $_rest);
-$_tertiary: map.merge(map.get($_palettes, tertiary), $_rest);
+$_primary: map.merge(map.get($palettes, primary), $rest);
+$_tertiary: map.merge(map.get($palettes, tertiary), $rest);
 
 $default-theme: mat.define-theme(
   (


### PR DESCRIPTION
This PR improves theme support for a number of components used in the translation editor part of SF.

A number of colors in Quill have also been updated but not everything. Some colors will not be related to the main theme palette but do need attention to better support dark themes. This work could be done at a similar time as working on the notice component which also needs better support for dark mode.

One area in dark mode I didn't complete is the background color of Quill when not in read only mode. Currently it is still the same as light mode. This could be changed to a lighter neutral tone but that will also require changing other elements to better suit the new background - I made an initial start on supporting different colors in Quill based on read only mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3161)
<!-- Reviewable:end -->
