### PR TITLE
Combine the fast training and echo feature flags into developer tools

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -206,27 +206,23 @@
           </div>
         </mat-step>
       }
-      @if (featureFlags.allowFastTraining.enabled || featureFlags.useEchoForPreTranslation.enabled) {
+      @if (featureFlags.showDeveloperTools.enabled) {
         <mat-step [completed]="true">
           <ng-template matStepLabel>
             {{ t("configure_advanced_settings_header") }}
           </ng-template>
           <h1 class="mat-headline-4">{{ t("configure_advanced_settings_title") }}</h1>
-          @if (featureFlags.allowFastTraining.enabled) {
-            <div>
-              <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
-            </div>
-            @if (fastTraining) {
-              <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>
-            }
+          <div>
+            <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
+          </div>
+          @if (fastTraining) {
+            <app-notice icon="warning" type="warning" class="warning">{{ t("fast_training_warning") }}</app-notice>
           }
-          @if (featureFlags.useEchoForPreTranslation.enabled) {
-            <div>
-              <mat-checkbox class="use-echo" [(ngModel)]="useEcho">{{ t("use_echo") }}</mat-checkbox>
-            </div>
-            @if (useEcho) {
-              <app-notice icon="warning" type="warning" class="warning">{{ t("use_echo_warning") }}</app-notice>
-            }
+          <div>
+            <mat-checkbox class="use-echo" [(ngModel)]="useEcho">{{ t("use_echo") }}</mat-checkbox>
+          </div>
+          @if (useEcho) {
+            <app-notice icon="warning" type="warning" class="warning">{{ t("use_echo_warning") }}</app-notice>
           }
           <div class="button-strip">
             <button mat-stroked-button matStepperPrevious>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -130,8 +130,7 @@ describe('DraftGenerationStepsComponent', () => {
         instance(mockTrainingDataQuery)
       );
       when(mockTrainingDataQuery.docs).thenReturn([]);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;
@@ -394,8 +393,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
       when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
       when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
       when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
       when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
@@ -600,7 +598,7 @@ describe('DraftGenerationStepsComponent', () => {
     });
   });
 
-  describe('allow fast training feature flag is enabled', () => {
+  describe('show developer tools feature flag is enabled', () => {
     const availableBooks = [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 9 }, { bookNum: 10 }];
     const allBooks = [{ bookNum: 1 }, ...availableBooks, { bookNum: 6 }, { bookNum: 7 }, { bookNum: 8 }];
     const config: DraftSourcesAsArrays = {
@@ -640,8 +638,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
       when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
       when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(true));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(true));
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
         instance(mockTrainingDataQuery)
       );
@@ -686,60 +683,6 @@ describe('DraftGenerationStepsComponent', () => {
       } as DraftGenerationStepsResult);
       expect(generateDraftButton['disabled']).toBe(true);
     });
-  });
-
-  describe('use echo feature flag is enabled', () => {
-    const availableBooks = [{ bookNum: 2 }, { bookNum: 3 }, { bookNum: 9 }, { bookNum: 10 }];
-    const allBooks = [{ bookNum: 1 }, ...availableBooks, { bookNum: 6 }, { bookNum: 7 }, { bookNum: 8 }];
-    const config: DraftSourcesAsArrays = {
-      trainingSources: [
-        {
-          projectRef: 'source1',
-          paratextId: 'PT_SP1',
-          name: 'Source Project 1',
-          shortName: 'sP1',
-          writingSystem: { tag: 'eng' },
-          texts: availableBooks.concat({ bookNum: 1 })
-        }
-      ],
-      trainingTargets: [
-        {
-          projectRef: mockActivatedProjectService.projectId!,
-          paratextId: 'PT_TT',
-          name: 'Target Project',
-          shortName: 'tT',
-          writingSystem: { tag: 'nllb' },
-          texts: allBooks.filter(b => b.bookNum !== 1 && b.bookNum !== 7)
-        }
-      ],
-      draftingSources: [
-        {
-          projectRef: 'draftingSource',
-          paratextId: 'PT_DS',
-          name: 'Drafting Source',
-          shortName: 'dS',
-          writingSystem: { tag: 'eng' },
-          texts: availableBooks.concat({ bookNum: 7 })
-        }
-      ]
-    };
-
-    beforeEach(fakeAsync(() => {
-      when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
-      when(mockActivatedProjectService.projectDoc$).thenReturn(of({} as any));
-      when(mockActivatedProjectService.projectDoc).thenReturn({} as any);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(true));
-      when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
-        instance(mockTrainingDataQuery)
-      );
-      when(mockTrainingDataQuery.docs).thenReturn([]);
-
-      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-      tick();
-    }));
 
     it('should emit the use echo value if checked', () => {
       component.onTranslateBookSelect([2]);
@@ -916,8 +859,7 @@ describe('DraftGenerationStepsComponent', () => {
       when(mockDraftSourceService.getDraftProjectSources()).thenReturn(of(config));
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
       when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
         instance(mockTrainingDataQuery)
       );
@@ -1059,8 +1001,7 @@ describe('DraftGenerationStepsComponent', () => {
         instance(mockTrainingDataQuery)
       );
       when(mockTrainingDataQuery.docs).thenReturn([]);
-      when(mockFeatureFlagService.allowFastTraining).thenReturn(createTestFeatureFlag(false));
-      when(mockFeatureFlagService.useEchoForPreTranslation).thenReturn(createTestFeatureFlag(false));
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
       component = fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.spec.ts
@@ -63,9 +63,7 @@ describe('FeatureFlagService', () => {
     verify(mockedAnonymousService.featureFlags()).once();
   }));
 
-  // Disabling test because the feature flag service does not give as a simple way to actually test the state where all
-  // feature flags are off, unless we assume they all default to off (which is not always the case).
-  xit('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
+  it('versionSuffix returns an empty string when no feature flags', fakeAsync(() => {
     const env = new TestEnvironment({});
     // The first call loads the remote feature flags
     expect(env.service.versionSuffix).toEqual('');

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -277,14 +277,14 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  readonly useEchoForPreTranslation: FeatureFlag = new FeatureFlagFromStorage(
+  private readonly useEchoForPreTranslation: FeatureFlag = new ServerOnlyFeatureFlag(
     'UseEchoForPreTranslation',
     'Allow Echo for Pre-Translation Drafting',
     10,
     this.featureFlagStore
   );
 
-  readonly allowFastTraining: ObservableFeatureFlag = new FeatureFlagFromStorage(
+  private readonly allowFastTraining: FeatureFlag = new ServerOnlyFeatureFlag(
     'ALLOW_FAST_TRAINING',
     'Allow Fast Pre-Translation Training',
     11,
@@ -314,7 +314,7 @@ export class FeatureFlagService {
 
   readonly darkMode: ObservableFeatureFlag = new FeatureFlagFromStorage(
     'DarkMode',
-    'Dark Mode',
+    'Dark mode',
     15,
     this.featureFlagStore
   );

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -60,8 +60,6 @@
     "TokenUrl": "https://languagetechnology.auth0.com/oauth/token"
   },
   "FeatureManagement": {
-    "Serval": true,
-    "MachineInProcess": false,
-    "UploadParatextZipForPreTranslation": false
+    "MachineInProcess": false
   }
 }


### PR DESCRIPTION
This PR is from a suggestion from @Nateowami to combine the subsume the allow fast training and use echo for pre-translation feature flags into the developer tools feature flag.

With this PR, enabling developer tools will cause the fast training and echo checkboxes to appear in the draft generation wizard.

I also took the opportunity to clean up the casing of dark mode, re-enable a disabled unit test, and clean up the feature flag server-side config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3162)
<!-- Reviewable:end -->
