### PR TITLE
Add MongoDB query to find references to missing users

### DIFF
--- a/mongodb/Projects/FindReferencesToMissingUsers.mongodb
+++ b/mongodb/Projects/FindReferencesToMissingUsers.mongodb
@@ -1,0 +1,36 @@
+use("xforge");
+// Find projects with user roles that reference users not in the users collection
+//
+// To remove the reference, submit this op to the sf_project document using manipulate-sharedb.ts:
+//
+// await utils.submitDocOp(doc, {
+//   p: ['userRoles', 'user_id_goes_here'],
+//   od: 'sf_community_checker'
+// });
+//
+db.sf_projects.aggregate([
+  {
+    $project: {
+      userRoles: {
+        $objectToArray: "$userRoles"
+      }
+    }
+  },
+  { $unwind: "$userRoles" },
+  {
+    $lookup: {
+      from: "users",
+      localField: "userRoles.k",
+      foreignField: "_id",
+      as: "matchedUser"
+    }
+  },
+  { $match: { matchedUser: { $eq: [] } } },
+  {
+    $project: {
+      _id: 1,
+      missingUserId: "$userRoles.k",
+      role: "$userRoles.v"
+    }
+  }
+]);


### PR DESCRIPTION
This PR adds a MongoDB script that finds the references to missing users in projects. These references will stop projects from syncing.

I have run this script on QA and live, and remove the relevant references (only 1 project on QA and 1 project on live were affected). Both of these occurred at the end of October last year, so I believe these were a temporary issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3165)
<!-- Reviewable:end -->
