### PR TITLE
Update build-angular to fix vite dependabot alerts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -225,17 +225,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.16.tgz",
-      "integrity": "sha512-+Thjb83odOLoflpzV5pduxZAU/pwqGyt+RYkdwWtLTelYJvnbmiX5kYCpPDF+iNvNbZpJzrA5qi07JQxOLlRng==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-18.2.18.tgz",
+      "integrity": "sha512-yNw5b46BB27YW2lgP9pAt15xtfTS8F1JdWR79bLci0MYL7VPmRBrRtZk+sozRCziit1+oNAVpOUT8QyvDmvAZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.16",
-        "@angular-devkit/build-webpack": "0.1802.16",
-        "@angular-devkit/core": "18.2.16",
-        "@angular/build": "18.2.16",
+        "@angular-devkit/architect": "0.1802.18",
+        "@angular-devkit/build-webpack": "0.1802.18",
+        "@angular-devkit/core": "18.2.18",
+        "@angular/build": "18.2.18",
         "@babel/core": "7.26.10",
         "@babel/generator": "7.26.10",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -246,7 +246,7 @@
         "@babel/preset-env": "7.26.9",
         "@babel/runtime": "7.26.10",
         "@discoveryjs/json-ext": "0.6.1",
-        "@ngtools/webpack": "18.2.16",
+        "@ngtools/webpack": "18.2.18",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
         "babel-loader": "9.1.3",
@@ -352,13 +352,13 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
-      "version": "0.1802.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.16.tgz",
-      "integrity": "sha512-uWJ40EGhdgNbg8i60EzXErqOrv5aLmLMGp2OUt6XBF6GQiK4Y6nETG9QyD6TTv0rhZ0gt9JEeHA5N1lGt+WqWw==",
+      "version": "0.1802.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.18.tgz",
+      "integrity": "sha512-3OitvTddHp7bSqEGOJlH7Zqv07DdmZHktU2jsekjcbUxmoC1WIpWSYy+Bqyu7HjidJc0xVP7wyE/NPYkrwT5SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.16",
+        "@angular-devkit/core": "18.2.18",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.16.tgz",
-      "integrity": "sha512-RsBHUPdDYREpE7sOfGrQXMbuBCShJnpuuA4ndVZ6zzOW5HZgG0bOXjYNPvFHmqnES9BE/sJTFiLIXmFiQjglug==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.18.tgz",
+      "integrity": "sha512-gncn8QN73mi4in7oAfoWnJglLx5iI8d87796h1LTuAxULSkfzhW3E03NZU764FBiIAWFxuty4PWmrHxMlmbtbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -812,13 +812,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1802.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.16.tgz",
-      "integrity": "sha512-bKbl5y8TMkQZcS0esXD25Gs773OOw0/WppwOCHjwsVi1HCz+kkyNm8pc9p8XrSVnGtKHI1WyQujjXX7Us+5QdQ==",
+      "version": "0.1802.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1802.18.tgz",
+      "integrity": "sha512-xSiUC2EeELKgs70aceet/iK57y2nk6VobgeeQzGzTtE5HXWX0n5/g9FIOVM1rznv/tj+9VFZpQKCdLqiP7JmCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.16",
+        "@angular-devkit/architect": "0.1802.18",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -832,13 +832,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
-      "version": "0.1802.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.16.tgz",
-      "integrity": "sha512-uWJ40EGhdgNbg8i60EzXErqOrv5aLmLMGp2OUt6XBF6GQiK4Y6nETG9QyD6TTv0rhZ0gt9JEeHA5N1lGt+WqWw==",
+      "version": "0.1802.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.18.tgz",
+      "integrity": "sha512-3OitvTddHp7bSqEGOJlH7Zqv07DdmZHktU2jsekjcbUxmoC1WIpWSYy+Bqyu7HjidJc0xVP7wyE/NPYkrwT5SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.16",
+        "@angular-devkit/core": "18.2.18",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.16.tgz",
-      "integrity": "sha512-RsBHUPdDYREpE7sOfGrQXMbuBCShJnpuuA4ndVZ6zzOW5HZgG0bOXjYNPvFHmqnES9BE/sJTFiLIXmFiQjglug==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.18.tgz",
+      "integrity": "sha512-gncn8QN73mi4in7oAfoWnJglLx5iI8d87796h1LTuAxULSkfzhW3E03NZU764FBiIAWFxuty4PWmrHxMlmbtbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,14 +1101,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.16.tgz",
-      "integrity": "sha512-W5KkhAm2GBpXWrM7BK7fwOQnMajq9yiJmFJ3XwMfoA2M+H18/FP1SCfTFrTLy+2a1CJY35oDXYstMwJw4UPedA==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-18.2.18.tgz",
+      "integrity": "sha512-8PEhrkS1t9xpvBLaLVgi0OWt/0B72ENKKVc6BAKEZ5gg+SD7uf47sJcT1d23r7d/V6FaOJnWim6BrqgFs4rW9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1802.16",
+        "@angular-devkit/architect": "0.1802.18",
         "@babel/core": "7.25.2",
         "@babel/helper-annotate-as-pure": "7.24.7",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -1130,7 +1130,7 @@
         "rollup": "4.22.4",
         "sass": "1.77.6",
         "semver": "7.6.3",
-        "vite": "5.4.15",
+        "vite": "~5.4.17",
         "watchpack": "2.4.1"
       },
       "engines": {
@@ -1170,13 +1170,13 @@
       }
     },
     "node_modules/@angular/build/node_modules/@angular-devkit/architect": {
-      "version": "0.1802.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.16.tgz",
-      "integrity": "sha512-uWJ40EGhdgNbg8i60EzXErqOrv5aLmLMGp2OUt6XBF6GQiK4Y6nETG9QyD6TTv0rhZ0gt9JEeHA5N1lGt+WqWw==",
+      "version": "0.1802.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.18.tgz",
+      "integrity": "sha512-3OitvTddHp7bSqEGOJlH7Zqv07DdmZHktU2jsekjcbUxmoC1WIpWSYy+Bqyu7HjidJc0xVP7wyE/NPYkrwT5SA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.16",
+        "@angular-devkit/core": "18.2.18",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@angular/build/node_modules/@angular-devkit/core": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.16.tgz",
-      "integrity": "sha512-RsBHUPdDYREpE7sOfGrQXMbuBCShJnpuuA4ndVZ6zzOW5HZgG0bOXjYNPvFHmqnES9BE/sJTFiLIXmFiQjglug==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.18.tgz",
+      "integrity": "sha512-gncn8QN73mi4in7oAfoWnJglLx5iI8d87796h1LTuAxULSkfzhW3E03NZU764FBiIAWFxuty4PWmrHxMlmbtbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5944,9 +5944,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "18.2.16",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.16.tgz",
-      "integrity": "sha512-5FD7dd3OGTdEqB0eGSeTBp4x6HVBcKcNxgw6CFWfYsQaNcHkG29WrkYHcuXC1cG3Ov+F9j+TJ53UNOigp2denQ==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-18.2.18.tgz",
+      "integrity": "sha512-rFTf3zrAMp7KJF8F/sOn0SNits+HhRaNKw4g20Pxk4QG5XZsXChsQIKrrzAnmlCfMb3nQmBnElAhr1rvBmzZWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12920,14 +12920,14 @@
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-      "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz",
+      "integrity": "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0"
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12938,9 +12938,9 @@
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/types": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-      "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.1.tgz",
+      "integrity": "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12952,14 +12952,14 @@
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-      "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz",
+      "integrity": "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -12979,16 +12979,16 @@
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/utils": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-      "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.1.tgz",
+      "integrity": "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0"
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13003,13 +13003,13 @@
       }
     },
     "node_modules/eslint-plugin-storybook/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-      "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz",
+      "integrity": "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
+        "@typescript-eslint/types": "8.30.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -28744,9 +28744,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
-      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
+      "version": "5.4.18",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.18.tgz",
+      "integrity": "sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -29636,10 +29636,11 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -29704,10 +29705,11 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/open": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.1.tgz",
+      "integrity": "sha512-zy1wx4+P3PfhXSEPJNtZmJXfhkkIaxU1VauWIrDZw1O7uJRDRJtKr9n3Ic4NgbA16KyOxOXO2ng9gYwCdXuSXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",


### PR DESCRIPTION
This PR fixes the following dependabot alerts:

 * https://github.com/sillsdev/web-xforge/security/dependabot/202
 * https://github.com/sillsdev/web-xforge/security/dependabot/203
 * https://github.com/sillsdev/web-xforge/security/dependabot/204

I also took the opportunity to run a `npm dedupe`.

As these dependencies are dev dependencies, no testing is required beyond successfully PR build and test GHA execution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3166)
<!-- Reviewable:end -->
