### PR TITLE
Fix border radius on draft sources stepper

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
@@ -35,6 +35,7 @@ strong {
 
 .draft-sources-stepper {
   grid-area: accordion;
+  overflow: hidden;
 }
 
 .step-header {


### PR DESCRIPTION
See Chromatic for the before/after.

For a while I was confused why this mat-card didn't have the border radius applied properly, but the other cards on the page did, and there didn't appear to be any CSS difference. Eventually I concluded:
- If you set a background on an element, and a border-radius, that background follows the border radius
- If you have an element with a border radius, and inside another element with a background (but no border radius), you need to set `overflow: hidden` for the parent to constrain the background of the child elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3169)
<!-- Reviewable:end -->
