### PR TITLE
Use alternate logo when web host is not Scripture Forge

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -398,20 +398,24 @@ describe('AuthService', () => {
     }
   }));
 
-  it('should login with defined logo', fakeAsync(() => {
+  it('should login with appropriate logo', fakeAsync(() => {
     const env = new TestEnvironment();
-    when(mockedLocationService.origin).thenReturn('https://scriptureforge.org');
+    const sfLogoUrl = 'https://auth0.languagetechnology.org/assets/sf.svg';
+    when(mockedLocationService.hostname).thenReturn('scriptureforge.org');
 
     env.service.logIn({ returnUrl: 'test-returnUrl' });
 
     verify(mockedWebAuth.loginWithRedirect(anything())).once();
-    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
+    let authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
       mockedWebAuth.loginWithRedirect
     ).last()[0];
-    expect(authOptions).toBeDefined();
-    if (authOptions != null) {
-      expect(authOptions.authorizationParams!.logo).toBeDefined();
-    }
+    expect(authOptions!.authorizationParams!.logo).toEqual(sfLogoUrl);
+
+    // a different domain
+    when(mockedLocationService.hostname).thenReturn('other.domain.org');
+    env.service.logIn({ returnUrl: 'test-returnUrl' });
+    authOptions = capture<RedirectLoginOptions | undefined>(mockedWebAuth.loginWithRedirect).last()[0];
+    expect(authOptions!.authorizationParams!.logo).not.toEqual(sfLogoUrl);
   }));
 
   it('should link with Paratext', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -243,11 +243,16 @@ export class AuthService {
     const state: AuthState = { returnUrl };
     const language: string = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
     const ui_locales: string = language;
+    const sfHosts = ['scriptureforge.org', 'qa.scriptureforge.org', 'localhost'];
+    const useBranding: boolean = sfHosts.includes(this.locationService.hostname);
+
     const auth0Parameters: xForgeAuth0Parameters = {
       ui_locales: language,
       language,
       login_hint: ui_locales,
-      logo: 'https://auth0.languagetechnology.org/assets/sf.svg'
+      logo: useBranding
+        ? 'https://auth0.languagetechnology.org/assets/sf.svg'
+        : 'https://auth0.languagetechnology.org/assets/sd.svg'
     };
 
     if (signUp || this.isJoining) {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4a980cac-2cf0-4ec1-adf5-604c4428933d)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3170)
<!-- Reviewable:end -->
