### PR TITLE
SF-3333 Reduce calls to the DBL when configuring sources

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -25,7 +25,7 @@ public interface IParatextService
     ParatextSettings? GetParatextSettings(UserSecret userSecret, string paratextId);
 
     Task<IReadOnlyList<ParatextResource>> GetResourcesAsync(string userId);
-    bool IsResource(string paratextId);
+    bool IsResource(string? paratextId);
     Task<string> GetResourcePermissionAsync(string paratextId, string userId, CancellationToken token);
     Task<IReadOnlyList<ParatextProjectUser>> GetParatextUsersAsync(
         UserSecret userSecret,

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -445,7 +445,9 @@ public class ParatextService : DisposableBase, IParatextService
     /// <summary>
     /// Is the PT project referred to by `paratextId` a DBL resource?
     /// </summary>
-    public bool IsResource(string paratextId) =>
+    /// <param name="paratextId">The Paratext identifier</param>
+    /// <returns><c>true</c> if the paratext identifier is a resource; otherwise, <c>false</c>.</returns>
+    public bool IsResource(string? paratextId) =>
         paratextId?.Length == SFInstallableDblResource.ResourceIdentifierLength;
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -150,13 +150,20 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             // This will make the source project appear after the target, if it needs to be created
             if (settings.SourceParatextId != null && settings.SourceParatextId != settings.ParatextId)
             {
+                // Get the resources if the source is a resource
+                IReadOnlyList<ParatextResource> resources = [];
+                if (_paratextService.IsResource(settings.SourceParatextId))
+                {
+                    resources = await _paratextService.GetResourcesAsync(curUserId);
+                }
+
                 TranslateSource source = await GetTranslateSourceAsync(
                     curUserId,
                     projectDoc.Id,
                     settings.SourceParatextId,
                     syncIfCreated: false,
                     ptProjects,
-                    resources: []
+                    resources
                 );
 
                 await projectDoc.SubmitJson0OpAsync(op => UpdateSetting(op, p => p.TranslateConfig.Source, source));
@@ -362,7 +369,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             settings.AdditionalTrainingSourceParatextId == ProjectSettingValueUnset;
 
         // Get the list of projects for setting the source or alternate source
-        IReadOnlyList<ParatextProject> ptProjects = new List<ParatextProject>();
+        IReadOnlyList<ParatextProject> ptProjects = [];
+        IReadOnlyList<ParatextResource> resources = [];
         if (
             (settings.SourceParatextId != null && !unsetSourceProject)
             || (settings.AlternateSourceParatextId != null && !unsetAlternateSourceProject)
@@ -375,10 +383,18 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 throw new DataNotFoundException("The user does not exist.");
 
             ptProjects = await _paratextService.GetProjectsAsync(userSecret);
-        }
 
-        // Create a variable for storing the list of resources between method calls of GetTranslateSourceAsync
-        List<ParatextResource> resources = [];
+            // Only get the resources if at least one of the paratext ids is a resource id
+            if (
+                _paratextService.IsResource(settings.SourceParatextId)
+                || _paratextService.IsResource(settings.AlternateSourceParatextId)
+                || _paratextService.IsResource(settings.AlternateTrainingSourceParatextId)
+                || _paratextService.IsResource(settings.AdditionalTrainingSourceParatextId)
+            )
+            {
+                resources = await _paratextService.GetResourcesAsync(curUserId);
+            }
+        }
 
         // Get the source - any creation or permission updates are handled in GetTranslateSourceAsync
         TranslateSource source = null;
@@ -1871,7 +1887,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     /// <param name="paratextId">The paratext identifier.</param>
     /// <param name="syncIfCreated">If <c>true</c> sync the project if it is created.</param>
     /// <param name="ptProjects">The paratext projects.</param>
-    /// <param name="resources">The paratext resources. If this is empty, this list will be populated.</param>
+    /// <param name="resources">The paratext resources.</param>
     /// <param name="userRoles">The ids and roles of the users who will need to access the source.</param>
     /// <returns>The <see cref="TranslateSource"/> object for the specified resource.</returns>
     /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
@@ -1881,7 +1897,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string paratextId,
         bool syncIfCreated,
         IEnumerable<ParatextProject> ptProjects,
-        List<ParatextResource> resources,
+        IEnumerable<ParatextResource> resources,
         IReadOnlyDictionary<string, string>? userRoles = null
     )
     {
@@ -1889,12 +1905,6 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string sourceProjectRef;
         if (sourcePTProject == null)
         {
-            // Populate resources if there are none previously specified
-            if (resources.Count == 0)
-            {
-                resources.AddRange(await _paratextService.GetResourcesAsync(curUserId));
-            }
-
             // If it is not a project, see if there is a matching resource
             sourcePTProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
             if (sourcePTProject == null)

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -155,7 +155,8 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                     projectDoc.Id,
                     settings.SourceParatextId,
                     syncIfCreated: false,
-                    ptProjects
+                    ptProjects,
+                    resources: []
                 );
 
                 await projectDoc.SubmitJson0OpAsync(op => UpdateSetting(op, p => p.TranslateConfig.Source, source));
@@ -376,6 +377,9 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             ptProjects = await _paratextService.GetProjectsAsync(userSecret);
         }
 
+        // Create a variable for storing the list of resources between method calls of GetTranslateSourceAsync
+        List<ParatextResource> resources = [];
+
         // Get the source - any creation or permission updates are handled in GetTranslateSourceAsync
         TranslateSource source = null;
         if (settings.SourceParatextId != null && !unsetSourceProject)
@@ -386,6 +390,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 settings.SourceParatextId,
                 syncIfCreated: false,
                 ptProjects,
+                resources,
                 projectDoc.Data.UserRoles
             );
             if (source.ProjectRef == projectId)
@@ -405,6 +410,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 settings.AlternateSourceParatextId,
                 syncIfCreated: true,
                 ptProjects,
+                resources,
                 projectDoc.Data.UserRoles
             );
             if (alternateSource.ProjectRef == projectId)
@@ -424,6 +430,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 settings.AlternateTrainingSourceParatextId,
                 syncIfCreated: true,
                 ptProjects,
+                resources,
                 projectDoc.Data.UserRoles
             );
             if (alternateTrainingSource.ProjectRef == projectId)
@@ -443,6 +450,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                 settings.AdditionalTrainingSourceParatextId,
                 syncIfCreated: true,
                 ptProjects,
+                resources,
                 projectDoc.Data.UserRoles
             );
             if (additionalTrainingSource.ProjectRef == projectId)
@@ -1856,13 +1864,14 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
     }
 
     /// <summary>
-    /// Gets the translate source asynchronously.
+    /// Gets the translation source asynchronously.
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="paratextId">The paratext identifier.</param>
     /// <param name="syncIfCreated">If <c>true</c> sync the project if it is created.</param>
     /// <param name="ptProjects">The paratext projects.</param>
+    /// <param name="resources">The paratext resources. If this is empty, this list will be populated.</param>
     /// <param name="userRoles">The ids and roles of the users who will need to access the source.</param>
     /// <returns>The <see cref="TranslateSource"/> object for the specified resource.</returns>
     /// <exception cref="DataNotFoundException">The source paratext project does not exist.</exception>
@@ -1872,6 +1881,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string paratextId,
         bool syncIfCreated,
         IEnumerable<ParatextProject> ptProjects,
+        List<ParatextResource> resources,
         IReadOnlyDictionary<string, string>? userRoles = null
     )
     {
@@ -1879,8 +1889,13 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         string sourceProjectRef;
         if (sourcePTProject == null)
         {
+            // Populate resources if there are none previously specified
+            if (resources.Count == 0)
+            {
+                resources.AddRange(await _paratextService.GetResourcesAsync(curUserId));
+            }
+
             // If it is not a project, see if there is a matching resource
-            IReadOnlyList<ParatextResource> resources = await _paratextService.GetResourcesAsync(curUserId);
             sourcePTProject = resources.SingleOrDefault(r => r.ParatextId == paratextId);
             if (sourcePTProject == null)
             {
@@ -1889,7 +1904,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         }
 
         // Get the users who will access this source resource or project
-        IEnumerable<string> userIds = userRoles != null ? userRoles.Keys : new string[] { curUserId };
+        IEnumerable<string> userIds = userRoles != null ? userRoles.Keys : [curUserId];
 
         // Get the project reference
         SFProject sourceProject = RealtimeService
@@ -1903,7 +1918,7 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         }
         else
         {
-            sourceProjectRef = await CreateResourceProjectAsync(curUserId, paratextId, addUser: false);
+            sourceProjectRef = await CreateResourceProjectInternalAsync(curUserId, sourcePTProject);
             projectCreated = true;
         }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -5381,9 +5381,9 @@ public class SFProjectServiceTests
                 .Returns(true);
 
             ParatextService
-                .IsResource(Arg.Any<string>())
+                .IsResource(Arg.Any<string?>())
                 .Returns(callInfo =>
-                    callInfo.ArgAt<string>(0).Length == SFInstallableDblResource.ResourceIdentifierLength
+                    callInfo.ArgAt<string?>(0)?.Length == SFInstallableDblResource.ResourceIdentifierLength
                 );
 
             Service = new SFProjectService(

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -2277,6 +2277,74 @@ public class SFProjectServiceTests
     }
 
     [Test]
+    public async Task UpdateSettingsAsync_ChangeAllDraftSources_CreatesResourceProject()
+    {
+        var env = new TestEnvironment();
+        const string newResourceParatextId = "resource_project";
+        env.ParatextService.GetResourcePermissionAsync(newResourceParatextId, Arg.Any<string>(), CancellationToken.None)
+            .Returns(Task.FromResult(TextInfoPermission.Read));
+
+        // Ensure that the new project does not exist
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Any(p => p.ParatextId == newResourceParatextId),
+            Is.False
+        );
+
+        // SUT
+        await env.Service.UpdateSettingsAsync(
+            User01,
+            Project01,
+            new SFProjectSettings
+            {
+                AdditionalTrainingSourceParatextId = newResourceParatextId,
+                AlternateSourceParatextId = newResourceParatextId,
+                AlternateTrainingSourceParatextId = newResourceParatextId,
+            }
+        );
+
+        SFProject project = env.GetProject(Project01);
+        Assert.That(project.TranslateConfig.DraftConfig.AdditionalTrainingSource?.ProjectRef, Is.Not.Null);
+        Assert.That(
+            project.TranslateConfig.DraftConfig.AdditionalTrainingSource?.ParatextId,
+            Is.EqualTo(newResourceParatextId)
+        );
+        Assert.That(project.TranslateConfig.DraftConfig.AdditionalTrainingSource?.Name, Is.EqualTo("ResourceProject"));
+        Assert.That(project.TranslateConfig.DraftConfig.AlternateSource?.ProjectRef, Is.Not.Null);
+        Assert.That(project.TranslateConfig.DraftConfig.AlternateSource?.ParatextId, Is.EqualTo(newResourceParatextId));
+        Assert.That(project.TranslateConfig.DraftConfig.AlternateSource?.Name, Is.EqualTo("ResourceProject"));
+        Assert.That(project.TranslateConfig.DraftConfig.AlternateTrainingSource?.ProjectRef, Is.Not.Null);
+        Assert.That(
+            project.TranslateConfig.DraftConfig.AlternateTrainingSource?.ParatextId,
+            Is.EqualTo(newResourceParatextId)
+        );
+        Assert.That(project.TranslateConfig.DraftConfig.AlternateTrainingSource?.Name, Is.EqualTo("ResourceProject"));
+
+        SFProject alternateSourceProject = env.GetProject(
+            project.TranslateConfig.DraftConfig.AlternateSource!.ProjectRef
+        );
+        Assert.That(alternateSourceProject.ParatextId, Is.EqualTo(newResourceParatextId));
+        Assert.That(alternateSourceProject.Name, Is.EqualTo("ResourceProject"));
+
+        await env
+            .MachineProjectService.DidNotReceive()
+            .RemoveProjectAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await env
+            .MachineProjectService.DidNotReceive()
+            .AddSmtProjectAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await env.SyncService.Received().SyncAsync(Arg.Any<SyncConfig>());
+        env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
+
+        // Check that the project was created
+        Assert.That(
+            env.RealtimeService.GetRepository<SFProject>().Query().Any(p => p.ParatextId == newResourceParatextId),
+            Is.True
+        );
+
+        // Ensure we only queried the list of resources once
+        await env.ParatextService.Received(1).GetResourcesAsync(User01);
+    }
+
+    [Test]
     public async Task UpdateSettingsAsync_ChangeAlternateSource_CannotUseTargetProject()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
This PR improves performance of the configure sources API call by only retrieving the list of resources from the DBL once per backend API call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3175)
<!-- Reviewable:end -->
