### PR TITLE
Fix docker compose build and correct the .dockerignore location

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,11 +20,10 @@
 **/dist
 **/docker-compose*
 **/Dockerfile*
-**/lib
 **/node_modules
 **/npm-debug.log
 **/obj
-**/RealtimeServer/lib/
+*/src/RealtimeServer/lib/
 **/secrets.dev.yaml
 **/tmp
 **/values.dev.yaml

--- a/src/SIL.XForge.Scripture/Dockerfile
+++ b/src/SIL.XForge.Scripture/Dockerfile
@@ -64,6 +64,7 @@ COPY src/SIL.XForge.Scripture/version.json /src/SIL.XForge.Scripture/version.jso
 COPY src/SIL.XForge.Scripture/fonts.json /src/SIL.XForge.Scripture/fonts.json
 COPY src/SIL.XForge.Scripture/ClientApp/ /src/SIL.XForge.Scripture/ClientApp/
 # Build the .NET Backend
+COPY src/SIL.Converters.Usj/ /src/SIL.Converters.Usj/
 COPY src/SIL.XForge/ /src/SIL.XForge/
 COPY src/SIL.XForge.Scripture/ /src/SIL.XForge.Scripture/
 WORKDIR /src/SIL.XForge.Scripture


### PR DESCRIPTION
This PR fixes building of the docker image, and moves the .dockerignore file to the correct location, modifying it to work correctly.

The best way to test this PR would be to merge it, then run the "Build Docker development images" GHA manually via https://github.com/sillsdev/web-xforge/actions/workflows/docker-dev.yml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3176)
<!-- Reviewable:end -->
