### PR TITLE
SF-3333b Reduce calls to the DBL, PT, and RTS when configuring sources

### DIFF
--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -46,6 +46,11 @@ public abstract class ProjectService<TModel, TSecret> : IProjectService
     public async Task AddUserAsync(string curUserId, string projectId, string? projectRole)
     {
         await using IConnection conn = await RealtimeService.ConnectAsync(curUserId);
+        await AddUserAsync(conn, curUserId, projectId, projectRole);
+    }
+
+    protected async Task AddUserAsync(IConnection conn, string curUserId, string projectId, string? projectRole)
+    {
         IDocument<TModel> projectDoc = await GetProjectDocAsync(projectId, conn);
 
         IDocument<User> userDoc = await GetUserDocAsync(curUserId, conn);


### PR DESCRIPTION
This PR:

 * Improves real time server connection reuse when updating settings
 * Reduces the calls made to ParatextData (for Projects) or the DBL (for Resources) for scenarios when:
   * More than one user is on a project or resource
   * A resource or project is used for both the training and translation sources.

Testing Notes:

 * Retesting the SF-3333 (#3175) acceptance test will be sufficient. This can be done by a developer.
 * I have re-run the SF-3208 (#3013) acceptance test for regressions (it passed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3187)
<!-- Reviewable:end -->
