### PR TITLE
Add missing indexes to MongoDB

### DIFF
--- a/src/RealtimeServer/common/models/user.ts
+++ b/src/RealtimeServer/common/models/user.ts
@@ -1,10 +1,16 @@
+import { obj } from '../utils/obj-path';
 import { Site } from './site';
 
 export const USER_PROFILES_COLLECTION = 'user_profiles';
 export const USER_PROFILE_INDEX_PATHS: string[] = [];
 
 export const USERS_COLLECTION = 'users';
-export const USER_INDEX_PATHS: string[] = USER_PROFILE_INDEX_PATHS;
+export const USER_INDEX_PATHS = [
+  // Index for ParatextService.GetBiblicalTermsAsync() in .NET
+  obj<User>().pathStr(u => u.email),
+  // Index for SFProjectService.InviteAsync() in .NET
+  obj<User>().pathStr(u => u.paratextId)
+];
 
 export enum AuthType {
   Unknown,

--- a/src/RealtimeServer/common/services/doc-service.ts
+++ b/src/RealtimeServer/common/services/doc-service.ts
@@ -1,4 +1,4 @@
-import { Db, IndexSpecification } from 'mongodb';
+import { CreateIndexesOptions, Db, IndexSpecification } from 'mongodb';
 import { ConnectSession } from '../connect-session';
 import { Migration, MigrationConstructor } from '../migration';
 import { ValidationSchema } from '../models/validation-schema';
@@ -70,7 +70,7 @@ export abstract class DocService<T = any> {
   }
 
   abstract get collection(): string;
-  protected abstract get indexPaths(): (string | IndexSpecification)[];
+  protected abstract get indexPaths(): (string | IndexSpecification | [string, CreateIndexesOptions])[];
   validationSchema: ValidationSchema | undefined = undefined;
 
   init(server: RealtimeServer): void {
@@ -96,6 +96,8 @@ export abstract class DocService<T = any> {
       const collection = db.collection(this.collection);
       if (typeof path === 'string') {
         await collection.createIndex({ [path]: 1 });
+      } else if (Array.isArray(path)) {
+        await collection.createIndex({ [path[0]]: 1 }, path[1] as CreateIndexesOptions);
       } else {
         await collection.createIndex(path);
       }

--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -13,9 +13,11 @@ export const SF_PROJECT_PROFILES_COLLECTION = 'sf_projects_profile';
 export const SF_PROJECT_PROFILES_INDEX_PATHS: string[] = [];
 
 export const SF_PROJECTS_COLLECTION = 'sf_projects';
-export const SF_PROJECT_INDEX_PATHS: string[] = [
-  obj<SFProject>().pathStr(q => q.name),
-  obj<SFProject>().pathStr(q => q.paratextId)
+export const SF_PROJECT_INDEX_PATHS = [
+  obj<SFProject>().pathStr(p => p.name),
+  obj<SFProject>().pathStr(p => p.paratextId),
+  // Index for ParatextService.GetBiblicalTermsAsync() in .NET
+  obj<SFProject>().pathStr(p => p.shortName)
 ];
 
 /** Length of id for a DBL resource. */

--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -1,3 +1,4 @@
+import { CreateIndexesOptions } from 'mongodb';
 import { Project } from '../../common/models/project';
 import { WritingSystem } from '../../common/models/writing-system';
 import { obj } from '../../common/utils/obj-path';
@@ -13,11 +14,16 @@ export const SF_PROJECT_PROFILES_COLLECTION = 'sf_projects_profile';
 export const SF_PROJECT_PROFILES_INDEX_PATHS: string[] = [];
 
 export const SF_PROJECTS_COLLECTION = 'sf_projects';
-export const SF_PROJECT_INDEX_PATHS = [
+export const SF_PROJECT_INDEX_PATHS: (string | [string, CreateIndexesOptions])[] = [
   obj<SFProject>().pathStr(p => p.name),
   obj<SFProject>().pathStr(p => p.paratextId),
   // Index for ParatextService.GetBiblicalTermsAsync() in .NET
-  obj<SFProject>().pathStr(p => p.shortName)
+  obj<SFProject>().pathStr(p => p.shortName),
+  // Indexes for SFProjectService.IsSourceProject() in .NET
+  [obj<SFProject>().pathStr(p => p.translateConfig.source!.projectRef), { sparse: true }],
+  [obj<SFProject>().pathStr(p => p.translateConfig.draftConfig.additionalTrainingSource!.projectRef), { sparse: true }],
+  [obj<SFProject>().pathStr(p => p.translateConfig.draftConfig.alternateSource!.projectRef), { sparse: true }],
+  [obj<SFProject>().pathStr(p => p.translateConfig.draftConfig.alternateTrainingSource!.projectRef), { sparse: true }]
 ];
 
 /** Length of id for a DBL resource. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/indexeddb-offline-store.ts
@@ -35,13 +35,16 @@ function getKeyRange(filter: PropertyFilter): IDBKeyRange | undefined {
 function createObjectStore(
   db: IDBDatabase,
   collection: string,
-  indexPaths?: (string | { [x: string]: number | string })[]
+  indexPaths?: (string | { [x: string]: number | string } | [string, unknown])[]
 ): void {
   const objectStore = db.createObjectStore(collection, { keyPath: 'id' });
   if (indexPaths != null) {
     for (const path of indexPaths) {
       if (typeof path === 'string') {
         objectStore.createIndex(path, `data.${path}`);
+      } else if (Array.isArray(path)) {
+        // Index options are not supported in IndexedDB, so we ignore them.
+        objectStore.createIndex(path[0], `data.${path[0]}`);
       } else {
         objectStore.createIndex(
           Object.keys(path).join('_'),

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -10,7 +10,7 @@ export interface RealtimeDocConstructor {
   readonly COLLECTION: string;
 
   // string is the legacy one column index format, the associative array corresponds to MongoDB's IndexSpecification
-  readonly INDEX_PATHS: (string | { [x: string]: number | string })[];
+  readonly INDEX_PATHS: (string | { [x: string]: number | string } | [string, unknown])[];
 
   new (realtimeService: RealtimeService, adapter: RealtimeDocAdapter): RealtimeDoc;
 }


### PR DESCRIPTION
This PR adds missing indexes to MongoDB to stop specific functions from running a COLLSCAN (i.e. reading every document in the collection). These functions are documented in the comment above each new index.

When SF is rebuilt and run, these indexes will be created automatically by the real time server.

I also added a feature to specify index options, as I needed to specify that the indexes for `SFProjectService.IsSourceProject()` were sparse, meaning that the properties were only indexed if they had a value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3189)
<!-- Reviewable:end -->
