### PR TITLE
SF-3349b Only prompt user about unsaved source changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.spec.ts
@@ -16,34 +16,16 @@ describe('DraftNavigationAuthGuard', () => {
     ]
   }));
 
-  it('can navigate away when no changes', () => {
+  it('can navigate away when no changes', async () => {
     // navigate away
     const env = new DraftNavigationTestEnvironment();
-    spyOn(window, 'confirm');
-    expect(
-      env.service.canDeactivate({ deactivationPrompt: 'unsaved changed', promptUserToDeactivate: () => false })
-    ).toBe(true);
-    expect(window.confirm).not.toHaveBeenCalled();
+    expect(await env.service.canDeactivate({ confirmLeave: () => Promise.resolve(true) })).toBe(true);
   });
 
-  it('can shows prompt and navigate away', () => {
+  it('can shows prompt and stay on page', async () => {
     // navigate away
     const env = new DraftNavigationTestEnvironment();
-    spyOn(window, 'confirm').and.returnValue(true);
-    expect(
-      env.service.canDeactivate({ deactivationPrompt: 'unsaved changed', promptUserToDeactivate: () => true })
-    ).toBe(true);
-    expect(window.confirm).toHaveBeenCalled();
-  });
-
-  it('can shows prompt and stay on page', () => {
-    // navigate away
-    const env = new DraftNavigationTestEnvironment();
-    spyOn(window, 'confirm').and.returnValue(false);
-    expect(
-      env.service.canDeactivate({ deactivationPrompt: 'unsaved changed', promptUserToDeactivate: () => true })
-    ).toBe(false);
-    expect(window.confirm).toHaveBeenCalled();
+    expect(await env.service.canDeactivate({ confirmLeave: () => Promise.resolve(false) })).toBe(false);
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -169,23 +169,20 @@ export class TranslateAuthGuard extends RouterGuard {
   }
 }
 
-export interface DeactivateAllowed {
-  deactivationPrompt: string;
-
-  promptUserToDeactivate(): boolean;
+export interface ConfirmOnLeave {
+  confirmLeave(): Promise<boolean>;
 }
 
 @Injectable({
   providedIn: 'root'
 })
-export class DraftNavigationAuthGuard extends RouterGuard implements CanDeactivate<DeactivateAllowed> {
+export class DraftNavigationAuthGuard extends RouterGuard implements CanDeactivate<ConfirmOnLeave> {
   constructor(authGuard: AuthGuard, projectService: SFProjectService) {
     super(authGuard, projectService);
   }
 
-  canDeactivate(component: DeactivateAllowed): boolean {
-    if (!component.promptUserToDeactivate()) return true;
-    return confirm(component.deactivationPrompt);
+  async canDeactivate(component: ConfirmOnLeave): Promise<boolean> {
+    return await component.confirmLeave();
   }
 
   check(_: SFProjectProfileDoc): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
@@ -96,6 +96,7 @@ describe('DraftSourcesComponent', () => {
       tick();
       env.fixture.detectChanges();
       env.clickLanguageCodesConfirmationCheckbox();
+      expect(env.component.promptUserToDeactivate()).toBe(true);
 
       // Suppose the user loads up the sources configuration page, changes no projects, and clicks Save. The settings
       // change request will just correspond to what the project already has for its settings.
@@ -119,6 +120,7 @@ describe('DraftSourcesComponent', () => {
         mockedSFProjectService.onlineUpdateSettings
       ).last()[1];
       expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+      expect(env.component.promptUserToDeactivate()).toBe(false);
     }));
 
     it('clearing second training source works', fakeAsync(() => {
@@ -126,6 +128,7 @@ describe('DraftSourcesComponent', () => {
       tick();
       env.fixture.detectChanges();
       env.clickLanguageCodesConfirmationCheckbox();
+      expect(env.component.promptUserToDeactivate()).toBe(true);
 
       // Suppose the user loads up the page, clears the second training/reference project box, and clicks Save. The
       // settings change request will show a requested change for unsetting the additional-training-source.
@@ -156,6 +159,7 @@ describe('DraftSourcesComponent', () => {
         mockedSFProjectService.onlineUpdateSettings
       ).last()[1];
       expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+      expect(env.component.promptUserToDeactivate()).toBe(false);
     }));
 
     it('clearing first training source works', fakeAsync(() => {
@@ -163,6 +167,7 @@ describe('DraftSourcesComponent', () => {
       tick();
       env.fixture.detectChanges();
       env.clickLanguageCodesConfirmationCheckbox();
+      expect(env.component.promptUserToDeactivate()).toBe(true);
 
       // Suppose the user comes to the page, leaves the second reference/training project selection alone, and clears
       // the first reference/training project selection. Let's respond by clearing the additional-training-source, and
@@ -195,6 +200,7 @@ describe('DraftSourcesComponent', () => {
         mockedSFProjectService.onlineUpdateSettings
       ).last()[1];
       expect(actualSettingsChangeRequest).toEqual(expectedSettingsChangeRequest);
+      expect(env.component.promptUserToDeactivate()).toBe(false);
     }));
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -11,6 +11,7 @@ import { Router } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { isNetworkError } from 'xforge-common/command.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
@@ -24,7 +25,7 @@ import { hasData, notNull } from '../../../../type-utils';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
 import { ParatextService, SelectableProject, SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
-import { DeactivateAllowed } from '../../../shared/project-router.guard';
+import { ConfirmOnLeave } from '../../../shared/project-router.guard';
 import { projectLabel } from '../../../shared/utils';
 import { isSFProjectSyncing } from '../../../sync/sync.component';
 import {
@@ -61,7 +62,7 @@ export interface ProjectStatus {
   templateUrl: './draft-sources.component.html',
   styleUrl: './draft-sources.component.scss'
 })
-export class DraftSourcesComponent extends DataLoadingComponent implements DeactivateAllowed {
+export class DraftSourcesComponent extends DataLoadingComponent implements ConfirmOnLeave {
   /** Indicator that a project setting change is for clearing a value. */
   static readonly projectSettingValueUnset = 'unset';
 
@@ -82,14 +83,14 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Deact
 
   languageCodeConfirmationMessageIfUserTriesToContinue: I18nKeyForComponent<'draft_sources'> | null = null;
   clearLanguageCodeConfirmationCheckbox = new EventEmitter<void>();
-  changesMade = false;
-  deactivationPrompt: string = this.i18n.translateStatic('draft_sources.discard_changes_confirmation');
 
   /** Whether some projects are syncing currently. */
   syncStatus: Map<string, ProjectStatus> = new Map<string, ProjectStatus>();
 
   /** SF projects and resources that the current user is on at SF. */
   userConnectedProjectsAndResources: SFProjectProfileDoc[] = [];
+
+  protected changesMade = false;
 
   private controlStates = new Map<string, ElementState>();
 
@@ -118,7 +119,6 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Deact
 
         this.trainingTargets = trainingTargets;
         this.draftingSources = draftingSources.map(translateSourceToSelectableProjectWithLanguageTag);
-
         this.nonSelectableProjects = [...this.trainingSources.filter(notNull), ...this.draftingSources.filter(notNull)];
 
         if (this.draftingSources.length < 1) this.draftingSources.push(undefined);
@@ -277,21 +277,19 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Deact
     );
   }
 
-  async cancel(): Promise<void> {
-    const leavePage =
-      !this.changesMade ||
-      (await this.dialogService.confirm(
+  cancel(): void {
+    this.navigateToDrafting();
+  }
+
+  confirmLeave(): Promise<boolean> {
+    if (this.changesMade && this.getControlState('projectSettings') == null) {
+      return this.dialogService.confirm(
         this.i18n.translate('draft_sources.discard_changes_confirmation'),
         this.i18n.translate('draft_sources.leave_and_discard'),
         this.i18n.translate('draft_sources.stay_on_page')
-      ));
-    if (leavePage) {
-      this.navigateToDrafting();
+      );
     }
-  }
-
-  promptUserToDeactivate(): boolean {
-    return this.changesMade && !this.allProjectsSavedAndSynced;
+    return Promise.resolve(true);
   }
 
   navigateToDrafting(): void {
@@ -337,8 +335,9 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Deact
       await updatePromise;
       this.controlStates.set(setting, ElementState.Submitted);
     } catch (error) {
-      console.error('Error updating project settings', error);
       this.controlStates.set(setting, ElementState.Error);
+      if (isNetworkError(error)) return;
+      console.error('Error updating project settings', error);
       throw error;
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -291,7 +291,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Deact
   }
 
   promptUserToDeactivate(): boolean {
-    return this.changesMade;
+    return this.changesMade && !this.allProjectsSavedAndSynced;
   }
 
   navigateToDrafting(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.stories.ts
@@ -249,10 +249,6 @@ export const SelectAllAndSave: Story = {
     );
     expect(overviewHeadings).toEqual(['Reference (Chinese)', 'Translated project (English)', 'Source (Chinese)']);
 
-    // Click cancel, and ensure settings are not accidentally lost without confirmation
-    await userEvent.click(canvas.getByRole('button', { name: /Cancel/ }));
-    await userEvent.click(canvas.getByRole('button', { name: /Stay on page/ }));
-
     // // Click save and ensure we are informed that we need to confirm language codes
     await userEvent.click(await canvas.findByRole('button', { name: /Save & sync/ }));
     canvas.getByRole('heading', { name: 'Please confirm that the language codes are correct before saving.' });


### PR DESCRIPTION
This is a follow-up PR for SF-3349. If the user has saved their changes, then they will be able to navigate away from the configure sources page without the prompt about unsaved changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3191)
<!-- Reviewable:end -->
