### PR TITLE
SF-3027 Consistent Page Title Styling

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.scss
@@ -13,7 +13,8 @@
 
 h1 {
   font-weight: 500;
-  margin: 0;
+  margin: 8px 0 0 0;
+  font-size: 2.5rem;
 }
 h2 {
   font-weight: 500;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -6,10 +6,6 @@
   padding: 0;
   max-width: 800px;
   padding-block-end: 10px;
-
-  .mat-headline-4 {
-    margin-bottom: 32px;
-  }
 }
 
 .mat-mdc-card {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'confirm_draft_sources'">
-  <h1 class="mat-headline-4">{{ t("review_draft_setup") }}</h1>
+  <h1>{{ t("review_draft_setup") }}</h1>
   <h2>{{ t("training_language_model") }}</h2>
   <div class="training-data">
     <div class="source-description">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -23,7 +23,7 @@
         <ng-template matStepLabel>
           {{ t("choose_books_to_translate_header") }}
         </ng-template>
-        <h1 class="mat-headline-4">{{ t("choose_books_to_translate_title") }}</h1>
+        <h1>{{ t("choose_books_to_translate_title") }}</h1>
         @for (source of draftingSources; track source) {
           <p class="reference-project-label">{{ projectLabel(source) }}</p>
           <app-book-multi-select
@@ -90,7 +90,7 @@
         <ng-template matStepLabel>
           {{ t("choose_books_for_training_header") }}
         </ng-template>
-        <h1 class="mat-headline-4">{{ t("choose_books_for_training_title") }}</h1>
+        <h1>{{ t("choose_books_for_training_title") }}</h1>
         <h2>{{ t("translated_books") }}</h2>
         <app-book-multi-select
           [availableBooks]="selectableTrainingBooksByProj(activatedProject.projectId)"
@@ -184,7 +184,7 @@
           <ng-template matStepLabel>
             {{ t("choose_additional_training_data_files_header") }}
           </ng-template>
-          <h1 class="mat-headline-4">{{ t("choose_additional_training_data_files_title") }}</h1>
+          <h1>{{ t("choose_additional_training_data_files_title") }}</h1>
           <app-training-data-multi-select
             [availableTrainingData]="availableTrainingFiles"
             [selectedTrainingDataIds]="selectedTrainingFileIds"
@@ -214,7 +214,7 @@
           <ng-template matStepLabel>
             {{ t("configure_advanced_settings_header") }}
           </ng-template>
-          <h1 class="mat-headline-4">{{ t("configure_advanced_settings_title") }}</h1>
+          <h1>{{ t("configure_advanced_settings_title") }}</h1>
           <div>
             <mat-checkbox class="fast-training" [(ngModel)]="fastTraining">{{ t("fast_training") }}</mat-checkbox>
           </div>
@@ -249,7 +249,7 @@
         <ng-template matStepLabel>
           {{ t("summary_header") }}
         </ng-template>
-        <h1 class="mat-headline-4">{{ t("summary_title") }}</h1>
+        <h1>{{ t("summary_title") }}</h1>
 
         <h2>{{ t("summary_training_title") }}</h2>
         <mat-card class="confirm-section mat-elevation-z2">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -12,10 +12,6 @@
   padding-block-end: 10px;
 }
 
-.mat-headline-4 {
-  margin: 0;
-}
-
 // Manually center over cancel button
 app-working-animated-indicator {
   margin-inline-start: 24px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.scss
@@ -26,7 +26,6 @@ h1 {
   margin: 0;
 }
 
-h1,
 h2,
 h3,
 strong {


### PR DESCRIPTION
Our h1's are currently using the default Material typography fairly pretty consistently. I removed one place, in draft sources, that differed, and I cleaned up a number of old/dangling rules and classes. For example, mat-headline-4 is not used in our current version of Angular that I can tell, it's been replaced with mat-headline-large.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3193)
<!-- Reviewable:end -->
