### PR TITLE
Update query to find a project's most recent sync failures

### DIFF
--- a/mongodb/Projects/SyncFailureCause.mongodb
+++ b/mongodb/Projects/SyncFailureCause.mongodb
@@ -1,6 +1,7 @@
 use("xforge");
 
 const shortName = "";
+const since = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7); // 7 days ago
 
 const project = db.sf_projects.findOne({
   shortName: shortName
@@ -16,7 +17,8 @@ const metrics = db.sync_metrics.aggregate([
   {
     $match: {
       projectRef: id,
-      errorDetails: { $exists: true }
+      errorDetails: { $exists: true },
+      dateStarted: { $gte: since }
     }
   },
   {


### PR DESCRIPTION
Previously this query found all sync errors a project has encountered. In practice, usually we want to investigate the most recent error or errors. I've updated the query so we can easily filter for only errors that have occurred within the past n days.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3194)
<!-- Reviewable:end -->
