### PR TITLE
SF-3166b Avoid using cache when generating revision summaries

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2121,7 +2121,9 @@ public class ParatextService : DisposableBase, IParatextService
         foreach (HgRevision revision in revisionCollection)
         {
             // Get the revision summary to see if the book and chapter has changed
-            RevisionChangeInfo revisionSummary = revisionCollection.GetSummaryFor(revision);
+            // Note: revisionCollection.GetSummaryFor(revision) maintains a non-thread safe cache of the revision
+            //       summaries, so we should just instantiate RevisionChangeInfo, as we will not need the cache.
+            RevisionChangeInfo revisionSummary = new RevisionChangeInfo(revisionCollection.VersionedText, revision);
 
             // Skip the revision if this book is not modified
             if (!revisionSummary.HasChangesInBook(bookNum))


### PR DESCRIPTION
Although SF-3166 (#2965) greatly reduced the occurrence of the following error:

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
```

I notice that these still happen on bugsnag (https://app.bugsnag.com/sil-international/scripture-forge-v2-plus/errors/681c30c6d383ca457857e620). As I just had this error occur to me on dev, I was able to investigate the program state when this crash has occurred, and have determined it was caused by an internal non-thread safe cache that ParatextData's `HgRevisionCollection` uses.

As our code does not use the cache (due to only reading each revision summary once), I have updated `ParatextService.GetRevisionHistoryAsync()` to instantiate `RevisionChangeInfo` itself, and so avoid the problematic cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3196)
<!-- Reviewable:end -->
