### PR TITLE
Fix realtime server crash when querying for notes for an invalid project

### DIFF
--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -61,16 +61,18 @@ export default class SFRealtimeServer extends RealtimeServer {
           return;
         }
         const userId: string = context.agent.connectSession.userId;
-        this.getProject(context.query.projectRef).then(p => {
-          if (
-            p != null &&
-            !SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.PTNoteThreads, Operation.View) &&
-            SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.SFNoteThreads, Operation.View)
-          ) {
-            context.query = { ...context.query, publishedToSF: true };
-          }
-          next();
-        });
+        this.getProject(context.query.projectRef)
+          .then(p => {
+            if (
+              p != null &&
+              !SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.PTNoteThreads, Operation.View) &&
+              SF_PROJECT_RIGHTS.hasRight(p, userId, SFProjectDomain.SFNoteThreads, Operation.View)
+            ) {
+              context.query = { ...context.query, publishedToSF: true };
+            }
+            next();
+          })
+          .catch(err => next(err));
       } else {
         next();
       }


### PR DESCRIPTION
This PR fixes a crash that occurs when a query specifies an invalid project id. This crash results in the entire real time server stopping until it is restarted by Hangfire.

You can recreate the crash and verify the fix by running the following code on the frontend, in a component that references the RealtimeService:
```ts
    const parameters: QueryParameters = {
      [obj<NoteThread>().pathStr(t => t.projectRef)]: { $ne: null }
    };
    await this.realtimeService.subscribeQuery(NoteThreadDoc.COLLECTION, parameters, this.destroyRef);
```

As this PR is very straightforward (adding a `.catch()` to the `.then()`), no testing is necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3198)
<!-- Reviewable:end -->
