### PR TITLE
SF-3360 Allow Restore for chapters with invalid USFM

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
@@ -93,6 +93,96 @@ describe('TextDocService', () => {
     });
   });
 
+  describe('canRestore', () => {
+    it('should return false if the project is undefined', () => {
+      const env = new TestEnvironment();
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(undefined, 1, 1);
+      expect(actual).toBe(false);
+    });
+
+    it('should return false if user does not have general edit right', () => {
+      const env = new TestEnvironment();
+      const project = createTestProjectProfile({
+        editable: true,
+        sync: { dataInSync: true },
+        texts: [
+          { bookNum: 1, chapters: [{ number: 1, isValid: true, permissions: { user01: TextInfoPermission.Write } }] }
+        ],
+        userRoles: { user01: SFProjectRole.ParatextObserver }
+      });
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(project, 1, 1);
+      expect(actual).toBe(false);
+    });
+
+    it('should return false if user does not have chapter edit permission', () => {
+      const env = new TestEnvironment();
+      const project = createTestProjectProfile({
+        editable: true,
+        sync: { dataInSync: true },
+        texts: [
+          { bookNum: 1, chapters: [{ number: 1, isValid: true, permissions: { user01: TextInfoPermission.Read } }] }
+        ],
+        userRoles: { user01: SFProjectRole.ParatextAdministrator }
+      });
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(project, 1, 1);
+      expect(actual).toBe(false);
+    });
+
+    it('should return false if data is not in sync', () => {
+      const env = new TestEnvironment();
+      const project = createTestProjectProfile({
+        editable: true,
+        sync: { dataInSync: false },
+        texts: [
+          { bookNum: 1, chapters: [{ number: 1, isValid: true, permissions: { user01: TextInfoPermission.Write } }] }
+        ],
+        userRoles: { user01: SFProjectRole.ParatextAdministrator }
+      });
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(project, 1, 1);
+      expect(actual).toBe(false);
+    });
+
+    it('should return false if editing is disabled', () => {
+      const env = new TestEnvironment();
+      const project = createTestProjectProfile({
+        editable: false,
+        sync: { dataInSync: true },
+        texts: [
+          { bookNum: 1, chapters: [{ number: 1, isValid: true, permissions: { user01: TextInfoPermission.Write } }] }
+        ],
+        userRoles: { user01: SFProjectRole.ParatextAdministrator }
+      });
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(project, 1, 1);
+      expect(actual).toBe(false);
+    });
+
+    it('should return true if all conditions are met', () => {
+      const env = new TestEnvironment();
+      const project = createTestProjectProfile({
+        editable: true,
+        sync: { dataInSync: true },
+        texts: [
+          { bookNum: 1, chapters: [{ number: 1, isValid: true, permissions: { user01: TextInfoPermission.Write } }] }
+        ],
+        userRoles: { user01: SFProjectRole.ParatextAdministrator }
+      });
+
+      // SUT
+      const actual: boolean = env.textDocService.canRestore(project, 1, 1);
+      expect(actual).toBe(true);
+    });
+  });
+
   describe('createTextDoc', () => {
     it('should throw error if text doc already exists', fakeAsync(() => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
@@ -54,11 +54,26 @@ export class TextDocService {
    * @param {SFProjectProfile | undefined} project The project.
    * @param {number | undefined} bookNum The book number.
    * @param {number | undefined} chapterNum The chapter number.
-   * @returns {boolean} A value indicating whether the chapter can be edited by the current  user.
+   * @returns {boolean} A value indicating whether the chapter can be edited by the current user.
    */
   canEdit(project: SFProjectProfile | undefined, bookNum: number | undefined, chapterNum: number | undefined): boolean {
+    return this.isUsfmValid(project, bookNum, chapterNum) && this.canRestore(project, bookNum, chapterNum);
+  }
+
+  /**
+   * Determines if the current user can restore a previous revision for the specified chapter.
+   *
+   * @param {SFProjectProfile | undefined} project The project.
+   * @param {number | undefined} bookNum The book number.
+   * @param {number | undefined} chapterNum The chapter number.
+   * @returns {boolean} A value indicating whether the chapter can be edited via history restore by the current user.
+   */
+  canRestore(
+    project: SFProjectProfile | undefined,
+    bookNum: number | undefined,
+    chapterNum: number | undefined
+  ): boolean {
     return (
-      this.isUsfmValid(project, bookNum, chapterNum) &&
       this.userHasGeneralEditRight(project) &&
       this.hasChapterEditPermission(project, bookNum, chapterNum) &&
       this.isDataInSync(project) &&

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.spec.ts
@@ -139,9 +139,9 @@ describe('HistoryChooserComponent', () => {
     expect(env.component.selectedSnapshot).toBeUndefined();
   }));
 
-  it('should not display the revert history button if the user cannot edit', fakeAsync(() => {
+  it('should not display the revert history button if the user cannot restore', fakeAsync(() => {
     const env = new TestEnvironment();
-    when(mockedTextDocService.canEdit(anything(), 40, 1)).thenReturn(false);
+    when(mockedTextDocService.canRestore(anything(), 40, 1)).thenReturn(false);
     env.triggerNgOnChanges();
     env.wait();
     expect(env.revertHistoryButton).toBeNull();
@@ -287,7 +287,7 @@ describe('HistoryChooserComponent', () => {
       when(mockedProjectService.getProfile('project01')).thenCall(() =>
         this.realtimeService.subscribe(SFProjectProfileDoc.COLLECTION, 'project01')
       );
-      when(mockedTextDocService.canEdit(anything(), 40, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 40, 1)).thenReturn(true);
     }
 
     get historySelect(): HTMLElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -5,14 +5,14 @@ import { Canon } from '@sillsdev/scripture';
 import { Delta } from 'quill';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import {
-  BehaviorSubject,
-  Observable,
-  Subject,
   asyncScheduler,
+  BehaviorSubject,
   combineLatest,
   map,
+  Observable,
   observeOn,
   startWith,
+  Subject,
   tap
 } from 'rxjs';
 import { isNetworkError } from 'xforge-common/command.service';
@@ -76,7 +76,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
   get canRestoreSnapshot(): boolean {
     return (
       this.selectedSnapshot?.data.ops != null &&
-      this.textDocService.canEdit(this.projectDoc?.data, this.bookNum, this.chapter)
+      this.textDocService.canRestore(this.projectDoc?.data, this.bookNum, this.chapter)
     );
   }
 


### PR DESCRIPTION
I removed the requirement that a chapter have valid USFM for the history revert feature to work. This allows users to restore revisions to get themselves out of unsupported USFM situations. I also verified that restoring a revision with unsupported USFM properly removes the ability to edit.