### PR TITLE
Rework deprecated mat tree classes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.html
@@ -1,16 +1,14 @@
 <ng-container *transloco="let t; read: 'lynx_insights_panel'">
   <app-lynx-insights-panel-header />
 
-  <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
-    <!-- Template for leaf nodes -->
-    <mat-tree-node *matTreeNodeDef="let node" class="level-{{ node.level }}">
-      <!-- Use a disabled button to provide padding for tree leaf -->
-      <button
-        matRipple
-        [class.dismissed]="node.isDismissed"
-        class="tree-toggle leaf"
-        (click)="onNodeClick(node, $event)"
-      >
+  <mat-tree [dataSource]="treeDataSource" [childrenAccessor]="getChildrenAccessor">
+    <!-- Template for leaf nodes (actual insights) -->
+    <mat-tree-node
+      *matTreeNodeDef="let node; let currentLevel = level"
+      class="level-{{ currentLevel }}"
+      [isExpandable]="false"
+    >
+      <button matRipple [class.dismissed]="node.isDismissed" class="tree-toggle leaf" (click)="onLeafNodeClick(node)">
         <div class="level-ref">
           <span>
             {{ node.description }}
@@ -23,14 +21,20 @@
       </button>
     </mat-tree-node>
 
-    <!-- Template for expandable nodes -->
-    <mat-tree-node *matTreeNodeDef="let node; when: hasChild" class="level-{{ node.level }}">
-      <button matTreeNodeToggle matRipple class="tree-toggle" (click)="onNodeClick(node, $event)">
+    <!-- Template for expandable group nodes -->
+    <mat-tree-node
+      #parentNodeRef="matTreeNode"
+      *matTreeNodeDef="let node; let currentLevel = level; when: isExpandableNodePredicate"
+      (expandedChange)="onNodeExpansionChange(node, $event)"
+      class="level-{{ currentLevel }}"
+      [isExpandable]="true"
+    >
+      <button matTreeNodeToggle matRipple class="tree-toggle">
         <mat-icon class="tree-toggle-icon mat-icon-rtl-mirror">
-          {{ treeControl.isExpanded(node) ? "expand_more" : "chevron_right" }}
+          {{ parentNodeRef.isExpanded ? "expand_more" : "chevron_right" }}
         </mat-icon>
 
-        @switch (node.level) {
+        @switch (currentLevel) {
           @case (0) {
             <div class="level-desc">
               <mat-icon [svgIcon]="'lynx_' + node.type" [class.dismissed]="node.isDismissed" [ngClass]="node.type" />


### PR DESCRIPTION
`FlatTreeControl`, `MatTreeFlatDataSource`, and `MatTreeFlattener` were deprecated.  This PR refactors the code to use the suggested `childrenAccessor` on MatTree instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3206)
<!-- Reviewable:end -->
