### PR TITLE
SF-3231 Correctly bubble invalid email errors to the user

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -434,6 +434,7 @@
     "link_copied": "Link copied to clipboard",
     "link_sharing": "Links can also be shared to users without an email address via social media platforms.",
     "not_inviting_already_member": "Not inviting: User is already a member of this project",
+    "not_inviting_email_invalid": "Not inviting: Invalid email address",
     "resend": "Resend",
     "send_a_link": "Send a link",
     "select_invitation_language": "Select a language for the invitation email",

--- a/src/SIL.XForge/Services/IEmailService.cs
+++ b/src/SIL.XForge/Services/IEmailService.cs
@@ -5,4 +5,5 @@ namespace SIL.XForge.Services;
 public interface IEmailService
 {
     Task SendEmailAsync(string email, string subject, string body);
+    bool ValidateEmail(string? email);
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/EmailServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/EmailServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NUnit.Framework;
+using SIL.XForge.Configuration;
+using SIL.XForge.Services;
+
+namespace SIL.XForge.Scripture.Services;
+
+[TestFixture]
+public class EmailServiceTests
+{
+    [Test]
+    public async Task SendEmailAsync_Success()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        await env.Service.SendEmailAsync("test@example.com", "Subject", "Body");
+        env.MockLogger.AssertHasEvent(e => e.Message!.Contains("Email Sent"));
+    }
+
+    [Test]
+    public void ValidateEmail_InvalidEmail()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        bool actual = env.Service.ValidateEmail("@test@example.com");
+        Assert.IsFalse(actual);
+    }
+
+    [Test]
+    public void ValidateEmail_NullEmail()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        bool actual = env.Service.ValidateEmail(null);
+        Assert.IsFalse(actual);
+    }
+
+    [Test]
+    public void ValidateEmail_ValidEmail()
+    {
+        var env = new TestEnvironment();
+
+        // SUT
+        bool actual = env.Service.ValidateEmail("test@example.com");
+        Assert.IsTrue(actual);
+    }
+
+    private class TestEnvironment
+    {
+        public TestEnvironment()
+        {
+            MockLogger = new MockLogger<EmailService>();
+            var options = Substitute.For<IOptions<SiteOptions>>();
+            options.Value.Returns(
+                new SiteOptions
+                {
+                    EmailFromAddress = "test@localhost",
+                    Name = "Scripture Forge Unit Test",
+                    PortNumber = "25",
+                    SendEmail = false,
+                    SmtpServer = "localhost",
+                }
+            );
+            Service = new EmailService(options, MockLogger);
+        }
+
+        public MockLogger<EmailService> MockLogger { get; }
+
+        public IEmailService Service { get; }
+    }
+}

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -58,6 +58,18 @@ public class SFProjectServiceTests
     ];
 
     [Test]
+    public void InviteAsync_InvalidEmail()
+    {
+        var env = new TestEnvironment();
+        const string email = "newuser@example.com";
+        const string role = SFProjectRole.CommunityChecker;
+        env.EmailService.ValidateEmail(email).Returns(false);
+        Assert.ThrowsAsync<DataNotFoundException>(
+            () => env.Service.InviteAsync(User01, Project03, email, "en", role, TestEnvironment.WebsiteUrl)
+        );
+    }
+
+    [Test]
     public async Task InviteAsync_ProjectAdminSharingDisabled_UserInvited()
     {
         var env = new TestEnvironment();
@@ -216,9 +228,7 @@ public class SFProjectServiceTests
         invitees = await env.Service.InvitedUsersAsync(User01, Project03);
         Assert.That(
             invitees.Select(i => i.Email),
-            Is.EquivalentTo(
-                new[] { "bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com" }
-            )
+            Is.EquivalentTo(["bob@example.com", "expired@example.com", "user03@example.com", "bill@example.com"])
         );
     }
 
@@ -262,7 +272,6 @@ public class SFProjectServiceTests
     public async Task InviteAsync_LinkSharingEnabled_UserInvited()
     {
         var env = new TestEnvironment();
-        SFProject project = env.GetProject(Project02);
         const string email = "newuser@example.com";
         const string role = SFProjectRole.CommunityChecker;
         // SUT
@@ -5031,6 +5040,7 @@ public class SFProjectServiceTests
             );
             var audioService = Substitute.For<IAudioService>();
             EmailService = Substitute.For<IEmailService>();
+            EmailService.ValidateEmail(Arg.Any<string>()).Returns(true);
             var currentTime = DateTime.Now;
             ProjectSecrets = new MemoryRepository<SFProjectSecret>(
                 [


### PR DESCRIPTION
This PR properly shows an invalid email address notice to the user when they enter an email address that MimeKit flags as invalid.