### PR TITLE
SF-3354 Update the new draft UI via SignalR

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/package-lock.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/service-worker": "^18.2.8",
         "@auth0/auth0-spa-js": "^2.1.3",
         "@bugsnag/js": "^7.23.0",
-        "@microsoft/signalr": "^7.0.0",
+        "@microsoft/signalr": "^8.0.7",
         "@ngneat/transloco": "^4.3.0",
         "@ngneat/transloco-locale": "^4.1.0",
         "@sillsdev/lynx": "^0.3.4",
@@ -5791,9 +5791,10 @@
       }
     },
     "node_modules/@microsoft/signalr": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-7.0.14.tgz",
-      "integrity": "sha512-dnS7gSJF5LxByZwJaj82+F1K755ya7ttPT+JnSeCBef3sL8p8FBkHePXphK8NSuOquIb7vsphXWa28A+L2SPpw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.7.tgz",
+      "integrity": "sha512-PHcdMv8v5hJlBkRHAuKG5trGViQEkPYee36LnJQx4xHOQ5LL4X0nEWIxOp5cCtZ7tu+30quz5V3k0b1YNuc6lw==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",

--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -47,7 +47,7 @@
     "@angular/service-worker": "^18.2.8",
     "@auth0/auth0-spa-js": "^2.1.3",
     "@bugsnag/js": "^7.23.0",
-    "@microsoft/signalr": "^7.0.0",
+    "@microsoft/signalr": "^8.0.7",
     "@ngneat/transloco": "^4.3.0",
     "@ngneat/transloco-locale": "^4.1.0",
     "@sillsdev/lynx": "^0.3.4",

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/project-notification.service.ts
@@ -23,6 +23,10 @@ export class ProjectNotificationService {
     return this.onlineService.isOnline && this.onlineService.isBrowserOnline;
   }
 
+  setNotifyBuildProgressHandler(handler: any): void {
+    this.connection.on('notifyBuildProgress', handler);
+  }
+
   setNotifySyncProgressHandler(handler: any): void {
     this.connection.on('notifySyncProgress', handler);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
@@ -8,6 +8,7 @@ import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
 import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
+import { ProjectNotificationService } from '../../../core/project-notification.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { BuildDto } from '../../../machine-api/build-dto';
 import { BuildStates } from '../../../machine-api/build-states';
@@ -17,6 +18,7 @@ import { DraftHistoryListComponent } from './draft-history-list.component';
 const mockedActivatedProjectService = mock(ActivatedProjectService);
 const mockedDraftGenerationService = mock(DraftGenerationService);
 const mockedI18nService = mock(I18nService);
+const mockedProjectNotificationService = mock(ProjectNotificationService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
 
@@ -27,6 +29,7 @@ describe('DraftHistoryListComponent', () => {
       { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
       { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
       { provide: I18nService, useMock: mockedI18nService },
+      { provide: ProjectNotificationService, useMock: mockedProjectNotificationService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService }
     ]

--- a/src/SIL.XForge.Scripture/Models/ServalBuildState.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildState.cs
@@ -1,0 +1,7 @@
+namespace SIL.XForge.Scripture.Models;
+
+public class ServalBuildState
+{
+    public string? BuildId { get; set; }
+    public string? State { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Services/INotifier.cs
+++ b/src/SIL.XForge.Scripture/Services/INotifier.cs
@@ -5,6 +5,7 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface INotifier
 {
+    Task NotifyBuildProgress(string sfProjectId, ServalBuildState buildState);
     Task NotifySyncProgress(string sfProjectId, ProgressState progressState);
     Task SubscribeToProject(string projectId);
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Hangfire;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -36,6 +37,7 @@ public class MachineApiService(
     IDeltaUsxMapper deltaUsxMapper,
     IEventMetricService eventMetricService,
     IExceptionHandler exceptionHandler,
+    IHubContext<NotificationHub, INotifier> hubContext,
     ILogger<MachineApiService> logger,
     IParatextService paratextService,
     IPreTranslationService preTranslationService,
@@ -170,15 +172,6 @@ public class MachineApiService(
         };
         var delivery = JsonConvert.DeserializeAnonymousType(json, anonymousType);
 
-        // We only support translation build finished events for completed builds
-        if (
-            delivery.Event != nameof(WebhookEvent.TranslationBuildFinished)
-            || delivery.Payload.BuildState != nameof(JobState.Completed)
-        )
-        {
-            return;
-        }
-
         // Retrieve the translation engine id from the delivery
         string translationEngineId = delivery.Payload?.Engine?.Id;
         if (string.IsNullOrWhiteSpace(translationEngineId))
@@ -204,11 +197,22 @@ public class MachineApiService(
             return;
         }
 
+        // Notify any SignalR clients subscribed to the project
+        string buildId = delivery.Payload.Build.Id;
+        string buildState = delivery.Payload.BuildState;
+        await hubContext.NotifyBuildProgress(projectId, new ServalBuildState { BuildId = buildId, State = buildState });
+
+        // We only support translation build finished events for completed builds
+        if (delivery.Event != nameof(WebhookEvent.TranslationBuildFinished) || buildState != nameof(JobState.Completed))
+        {
+            return;
+        }
+
         // Record that the webhook was run successfully
         var arguments = new Dictionary<string, object>
         {
-            { "buildId", delivery.Payload.Build.Id },
-            { "buildState", delivery.Payload.BuildState },
+            { "buildId", buildId },
+            { "buildState", buildState },
             { "event", delivery.Event },
             { "translationEngineId", delivery.Payload.Engine.Id },
         };
@@ -218,7 +222,7 @@ public class MachineApiService(
             nameof(ExecuteWebhookAsync),
             EventScope.Drafting,
             arguments,
-            result: delivery.Payload.Build.Id,
+            result: buildId,
             exception: null
         );
 
@@ -1098,6 +1102,16 @@ public class MachineApiService(
                 await projectSecrets.UpdateAsync(
                     sfProjectId,
                     u => u.Set(p => p.ServalData.PreTranslationsRetrieved, true)
+                );
+
+                // Notify any SignalR clients subscribed to the project
+                await hubContext.NotifyBuildProgress(
+                    sfProjectId,
+                    new ServalBuildState
+                    {
+                        BuildId = translationBuild?.Id,
+                        State = nameof(ServalData.PreTranslationsRetrieved),
+                    }
                 );
 
                 // Return the build id

--- a/src/SIL.XForge.Scripture/Services/NotificationHub.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHub.cs
@@ -9,6 +9,19 @@ namespace SIL.XForge.Scripture.Services;
 public class NotificationHub : Hub<INotifier>, INotifier
 {
     /// <summary>
+    /// Notifies subscribers to a project of draft build progress.
+    /// </summary>
+    /// <param name="projectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildState">The build state from Serval.</param>
+    /// <returns>The asynchronous task.</returns>
+    /// <remarks>
+    /// This will currently be emitted on the TranslationBuildStarted and TranslationBuildFinished webhooks,
+    /// and when the draft pre-translations have been retrieved.
+    /// </remarks>
+    public async Task NotifyBuildProgress(string projectId, ServalBuildState buildState) =>
+        await Clients.Group(projectId).NotifyBuildProgress(projectId, buildState);
+
+    /// <summary>
     /// Notifies subscribers to a project of sync progress.
     /// </summary>
     /// <param name="projectId">The Scripture Forge project identifier.</param>

--- a/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/NotificationHubExtensions.cs
@@ -6,6 +6,12 @@ namespace SIL.XForge.Scripture.Services;
 
 public static class NotificationHubExtensions
 {
+    public static Task NotifyBuildProgress(
+        this IHubContext<NotificationHub, INotifier> hubContext,
+        string projectId,
+        ServalBuildState buildState
+    ) => hubContext.Clients.Groups(projectId).NotifyBuildProgress(projectId, buildState);
+
     public static Task NotifySyncProgress(
         this IHubContext<NotificationHub, INotifier> hubContext,
         string projectId,

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -7,6 +7,7 @@ using System.Xml.Linq;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -3498,6 +3499,7 @@ public class MachineApiServiceTests
             DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
             EventMetricService = Substitute.For<IEventMetricService>();
             ExceptionHandler = Substitute.For<IExceptionHandler>();
+            var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
             MockLogger = new MockLogger<MachineApiService>();
             ParatextService = Substitute.For<IParatextService>();
             PreTranslationService = Substitute.For<IPreTranslationService>();
@@ -3603,6 +3605,7 @@ public class MachineApiServiceTests
                 DeltaUsxMapper,
                 EventMetricService,
                 ExceptionHandler,
+                hubContext,
                 MockLogger,
                 ParatextService,
                 PreTranslationService,


### PR DESCRIPTION
This PR updates the new draft UI to use SignalR to update the frontend whenever Serval calls a webhook or when the pre-translations retrieval from Serval finishes when a build completes.

This also updates the SignalR client to the latest version.

I added a buildState object to the SignalR notifier, even though I don't yet need it, as it is a [breaking change](https://learn.microsoft.com/en-au/aspnet/core/signalr/api-design?view=aspnetcore-8.0#use-custom-object-parameters-to-ensure-backwards-compatibility) to add an object like this to a notification channel's signature after the fact, and the other issues dependent on this will likely need the info in this `ServalBuildState` object.