### PR TITLE
Fix QA site mistakenly linking to wrong help site

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.staging.ts
@@ -9,7 +9,7 @@ export const environment = {
   scope: 'sf_data',
   siteId: 'sf',
   assets: '/assets/',
-  helps: 'https://github-action-preview--scriptureforgehelp.netlify.app',
+  helps: 'https://help.scriptureforge.org',
   bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
   realtimePort: 0,
   realtimeSecurePort: 0,


### PR DESCRIPTION
QA is supposed to be a simulation of live, with the proposed changes to be shipped to live being the only variable we are testing (to the degree that it's possible/practical to do so).

The staging URL became unavailable, and this resulted in a test failure during the test team's full regression run.

(See https://jira.sil.org/browse/SF-3383. I didn't mark this as fixing that issue because really there isn't an issue, other than QA using the development help site when it shouldn't, and that incorrectly failing tests).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3212)
<!-- Reviewable:end -->
