### PR TITLE
SF-3388 Fix 524 errors when viewing chapter history

### DIFF
--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -5785,48 +5785,6 @@ public class ParatextServiceTests
     }
 
     [Test]
-    public async Task GetRevisionHistoryAsync_NoChapterChangesInMercurial()
-    {
-        var env = new TestEnvironment();
-        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
-        var associatedPtUser = new SFParatextUser(env.Username01);
-        env.SetupProject(env.Project01, associatedPtUser);
-        SFProject project = env.NewSFProject();
-        project.UserRoles = new Dictionary<string, string> { { env.User01, SFProjectRole.PTObserver } };
-        env.AddProjectRepository(project);
-        env.AddTextDataOps(project.Id, "RUT", 1);
-        env.ProjectHgRunner.SetStandardOutput(env.RuthBookUsfm, false);
-
-        // SUT
-        bool historyExists = false;
-        int count = 0;
-        await foreach (
-            DocumentRevision revision in env.Service.GetRevisionHistoryAsync(userSecret, project.Id, "RUT", 1)
-        )
-        {
-            // This will loop through the 4 valid ops (combined to 3) in MemoryConnection.GetOpsAsync()
-            // and skip the 1 revision in MockHg._log
-            historyExists = true;
-            count++;
-
-            // Check the op sources
-            if (count == 1)
-            {
-                // The first revision has a valid source
-                Assert.AreEqual(revision.Source, OpSource.Draft);
-            }
-            else
-            {
-                // The others do not
-                Assert.IsNull(revision.Source);
-            }
-        }
-
-        Assert.AreEqual(3, count);
-        Assert.IsTrue(historyExists);
-    }
-
-    [Test]
     public async Task GetRevisionHistoryAsync_Success()
     {
         var env = new TestEnvironment();

--- a/tools/CommitGenerator/CommitGenerator.csproj
+++ b/tools/CommitGenerator/CommitGenerator.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <!--
+    This is for compatibility between ICU4C (a dependency of ParatextData) and .NET 8.0 see:
+    https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph
+    -->
+    <UseRidGraph>true</UseRidGraph>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!--
+      Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+      not report warnings for missing comments.
+      CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+      CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'type_parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
+    -->
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\src\SIL.XForge.Scripture\changedChapter.py" Link="changedChapter.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\ParatextMerge.py" Link="ParatextMerge.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\revisionStyle.sty" Link="revisionStyle.sty">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\src\SIL.XForge.Scripture\revisionTemplate.tem" Link="revisionTemplate.tem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ParatextData" Version="9.5.0.12" />
+  </ItemGroup>
+
+</Project>

--- a/tools/CommitGenerator/CommitGenerator.sln
+++ b/tools/CommitGenerator/CommitGenerator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36109.1 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommitGenerator", "CommitGenerator.csproj", "{980BD3CD-0D42-4B0F-868E-00C8392C78F9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{980BD3CD-0D42-4B0F-868E-00C8392C78F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{980BD3CD-0D42-4B0F-868E-00C8392C78F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{980BD3CD-0D42-4B0F-868E-00C8392C78F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{980BD3CD-0D42-4B0F-868E-00C8392C78F9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2ED223C6-268D-4184-9F68-A08D349DE095}
+	EndGlobalSection
+EndGlobal

--- a/tools/CommitGenerator/Program.cs
+++ b/tools/CommitGenerator/Program.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using Paratext.Data;
+using Paratext.Data.Languages;
+using Paratext.Data.Repository;
+using SIL.Scripture;
+
+#nullable enable
+
+Console.WriteLine("Paratext Commit Generator");
+Console.WriteLine();
+
+if (args.Length < 4)
+{
+    Console.WriteLine("This will generate 200 commits in the specified repository alternating between two files");
+    Console.WriteLine();
+    Console.WriteLine("Usage: dotnet run project_name file_to_commit first_version second_version");
+    Console.WriteLine();
+    Console.WriteLine(
+        "For example: dotnet run TDT 642JNTDT.SFM \"C:\\My Paratext 9 Projects\\MP1\\642JNMP1.SFM\""
+            + " \"C:\\My Paratext 9 Projects\\BSB\\642JNBSB.SFM\""
+    );
+    Console.WriteLine(
+        "If on Linux, set the PARATEXT_PROJECTS environment variable to your Paratext project directory."
+    );
+    Console.WriteLine();
+    return;
+}
+
+string projectName = args[0];
+string fileToCommit = args[1];
+string firstVersionFileName = args[2];
+string secondVersionFileName = args[3];
+
+// Load the first and second versions of the file
+string firstVersion = await File.ReadAllTextAsync(firstVersionFileName);
+string secondVersion = await File.ReadAllTextAsync(secondVersionFileName);
+
+// Set up Mercurial
+string customHgPath = Environment.GetEnvironmentVariable("HG_PATH") ?? "/usr/local/bin/hg";
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+{
+    customHgPath = Path.GetExtension(customHgPath.ToLowerInvariant()) != ".exe" ? customHgPath + ".exe" : customHgPath;
+}
+
+if (!File.Exists(customHgPath))
+{
+    Console.WriteLine($"Error: Could not find hg executable at {customHgPath}. Please install hg 4.7 or greater.");
+    return;
+}
+
+string? assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+if (string.IsNullOrWhiteSpace(assemblyDirectory))
+{
+    Console.WriteLine("The assembly directory could not be determined.");
+    return;
+}
+
+string hgMerge = Path.Join(assemblyDirectory, "ParatextMerge.py");
+Hg.Default = new Hg(customHgPath, hgMerge, assemblyDirectory);
+
+// Setup Paratext
+ICUDllLocator.Initialize();
+WritingSystemRepository.Initialize();
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+ScrTextCollection.Initialize(Environment.GetEnvironmentVariable("PARATEXT_PROJECTS"));
+ScrTextCollection.RefreshScrTexts(allowMigration: false);
+
+using ScrText scrText = ScrTextCollection.Get(projectName);
+for (int i = 0; i < 100; i++)
+{
+    // Write the first version
+    int bookNum = scrText.Settings.GetBookNumberFromFilename(fileToCommit);
+    scrText.PutText(bookNum, 0, false, firstVersion, null);
+    VersionedText versionedText = VersioningManager.Get(scrText);
+    versionedText.Commit(
+        $"Update to {Canon.BookNumberToId(bookNum)} by CommitGenerator",
+        dblRevisionNumber: null,
+        forceCommit: false
+    );
+
+    // Write the second version
+    scrText.PutText(bookNum, 0, false, secondVersion, null);
+    versionedText = VersioningManager.Get(scrText);
+    versionedText.Commit(
+        $"Update to {Canon.BookNumberToId(bookNum)} by CommitGenerator",
+        dblRevisionNumber: null,
+        forceCommit: false
+    );
+}


### PR DESCRIPTION
This PR fixes the 524 (HTTP timeout) errors thrown by Cloudflare, by removing the logic that checks if a revision had a change in a specific chapter. The reasons on why this logic should not be used are given in the code comment.

I've also included the tool I used to create the lots of revisions in a project, which I used to recreate the same environment as the projects on live that were encountering this issue.

I have marked this as testing not required, as the only real testing required is opening a history tab on the frontend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3216)
<!-- Reviewable:end -->
