### PR TITLE
SF-3384 Refresh Roles and Permissions form when network connection changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/roles-and-permissions/roles-and-permissions-dialog.spec.ts
@@ -71,17 +71,21 @@ describe('RolesAndPermissionsComponent', () => {
     env.closeDialog();
   }));
 
-  it('disables the form when offline', fakeAsync(() => {
-    env.setupProjectData();
+  it('updates the form when the network connection changes', fakeAsync(() => {
+    env.setupProjectData(rolesByUser);
     env.openDialog();
 
+    expect(env.component?.isParatextUser()).toBe(true);
+    expect(env.component?.roles.disabled).toBe(true);
     expect(env.component?.form.disabled).toBe(false);
 
     env.isOnline$.next(false);
     expect(env.component?.form.disabled).toBe(true);
+    expect(env.component?.roles.disabled).toBe(true);
 
     env.isOnline$.next(true);
     expect(env.component?.form.disabled).toBe(false);
+    expect(env.component?.roles.disabled).toBe(true);
   }));
 
   it('initializes values from the project', fakeAsync(() => {


### PR DESCRIPTION
Beforehand, network changes would change the parent form's editability. What wasn't obvious was that changes to the parent's editability was overwriting the values of the child controls. So those need to be refreshed after the parent form is updated.

I also brought up the online subscription to our current best practices.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3217)
<!-- Reviewable:end -->
