### PR TITLE
SF-3386 Don't initialize translator factory if suggestions are disabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -617,8 +617,7 @@ describe('EditorComponent', () => {
       });
       env.wait();
       expect(env.component.target!.segmentRef).toBe('verse_1_5');
-      // showSuggestions being true doesn't mean suggestions are shown, only that they could be if visible
-      expect(env.component.showSuggestions).toBe(true);
+      expect(env.component.showSuggestions).toBe(false);
 
       // Change to the long verse
       const range = env.component.target!.getSegmentRange('verse_1_6');
@@ -629,6 +628,31 @@ describe('EditorComponent', () => {
       expect(env.component.target!.segmentRef).toBe('verse_1_6');
       expect(env.component.showSuggestions).toBe(false);
       verify(mockedNoticeService.show(anything())).never();
+
+      env.dispose();
+    }));
+
+    it('should not call getWordGraph if user has suggestions disabled', fakeAsync(() => {
+      const env = new TestEnvironment();
+      env.setProjectUserConfig({
+        selectedBookNum: 40,
+        selectedChapterNum: 1,
+        selectedSegment: 'verse_1_5',
+        translationSuggestionsEnabled: false
+      });
+      env.wait();
+      expect(env.component.target!.segmentRef).toBe('verse_1_5');
+      expect(env.component.showSuggestions).toBe(false);
+
+      // Change to the long verse
+      const range = env.component.target!.getSegmentRange('verse_1_6');
+      env.targetEditor.setSelection(range!.index + range!.length, 0, 'user');
+      env.wait();
+
+      // Verify an error did not display
+      expect(env.component.target!.segmentRef).toBe('verse_1_6');
+      expect(env.component.showSuggestions).toBe(false);
+      verify(env.mockedRemoteTranslationEngine.getWordGraph(anything())).never();
 
       env.dispose();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1758,8 +1758,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
 
-    const translator: InteractiveTranslator | undefined =
-      await this.interactiveTranslatorFactory?.create(sourceSegment);
+    let translator: InteractiveTranslator | undefined;
+    if (this.translationSuggestionsEnabled) {
+      translator = await this.interactiveTranslatorFactory?.create(sourceSegment);
+    }
     if (translator == null) {
       this.translator = undefined;
       return;


### PR DESCRIPTION
This fixes a bug where getWordGraph was still called (and throwing errors) if the user had suggestions disabled via their user config. Now, showSuggestions should also be false in this case, which makes sense. (Having showSuggestions be true when the user disables it doesn't make sense to me, but maybe I'm missing a use case?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3218)
<!-- Reviewable:end -->
