### PR TITLE
SF-3398 Fix blank drafts showing for chapters that do not have drafts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -156,7 +156,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
           ])
         ),
         switchMap(([timestamp, draftExists]) => {
-          if (!draftExists && timestamp == null) {
+          // As getGeneratedDraftHistory() will always return a draft, we should not show a draft if the user does not
+          // have a timestamp in the query string. If a query string was specified, the user was sent from the draft
+          // history component.
+          if (!draftExists && (this.timestamp == null || timestamp == null)) {
             this.draftCheckState = 'draft-empty';
             return EMPTY;
           }


### PR DESCRIPTION
This PR fixes a regression from SF-3306 Add initial draft history UI (#3180).

Developer testing is sufficient for this PR.