### PR TITLE
Update workflows to support merge queues

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [develop, master, sf-qa, sf-live]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,7 @@ permissions: {}
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
   push:
     branches: [master]

--- a/.github/workflows/ci-lint-prettier.yml
+++ b/.github/workflows/ci-lint-prettier.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [master, develop, sf-qa, sf-live]
   pull_request:
-    branches: [master, develop]
+  merge_group:
 
 jobs:
   test:

--- a/.github/workflows/ci-production-build.yml
+++ b/.github/workflows/ci-production-build.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master, develop]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches: ["master", "develop", "sf-live", "sf-qa"]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["master", "develop"]
+  merge_group:
   schedule:
     - cron: "34 18 * * 2"
 

--- a/.github/workflows/grit.yml
+++ b/.github/workflows/grit.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [master, develop, sf-qa, sf-live]
   pull_request:
-    branches: [master, develop]
+  merge_group:
 
 jobs:
   grit-check:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["master"]
   pull_request:
-    branches: ["**"]
+  merge_group:
 
 jobs:
   zizmor:


### PR DESCRIPTION
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions:

> If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.

- I've updated every workflow that runs on PRs to run on merge queues
- I've also updated all pull request workflows to run on all PRs, since I can't think of a reason to only run them when PRs are against certain branches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3222)
<!-- Reviewable:end -->
