### PR TITLE
SF-3322 Allow selecting book and chapter in community checking

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -296,12 +296,15 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
           }
         }
       }
-    } else if (
-      this.routeBookChapter == null ||
-      (this.activeQuestionDoc?.data != null &&
-        bookChapterMatchesVerseRef(this.routeBookChapter, this.activeQuestionDoc.data.verseRef))
-    ) {
-      questionToActivate = this.activeQuestionDoc;
+    } else {
+      // If there is an active question, check if it matches the route book/chapter
+      const useActiveQuestion: boolean =
+        this.routeBookChapter == null ||
+        (this.activeQuestionDoc?.data != null &&
+          bookChapterMatchesVerseRef(this.routeBookChapter, this.activeQuestionDoc.data.verseRef));
+      if (useActiveQuestion) {
+        questionToActivate = this.activeQuestionDoc;
+      }
     }
 
     // No stored question, so use first question within route book/chapter if available.
@@ -313,6 +316,8 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
 
     if (questionToActivate != null) {
       this.activateQuestion(questionToActivate, actionSource);
+    } else {
+      this.activeQuestionDoc = undefined;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -166,7 +166,8 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     // Handle changes to questionDocs in ngOnChanges instead of setter to ensure other @Inputs are set
     // when 'activateStoredQuestion' is called, such as 'routeBookChapter'.
     const questionDocs: Readonly<QuestionDoc[] | undefined> = changes.questionDocs?.currentValue;
-    if (questionDocs != null) {
+    if (questionDocs != null && this.activeQuestionDoc == null) {
+      // Only activate the stored question if no previous question was selected
       if (questionDocs.length > 0) {
         this.activateStoredQuestion({ isQuestionListChange: true });
       } else {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -311,8 +311,6 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     questionToActivate ??= this.questionDocs.find(
       qd => this.routeBookChapter == null || bookChapterMatchesVerseRef(this.routeBookChapter, qd.data!.verseRef)
     );
-    // If no question was previously active, choose the first question
-    questionToActivate ??= this.activeQuestionDoc == null ? this.questionDocs[0] : undefined;
 
     if (questionToActivate != null) {
       this.activateQuestion(questionToActivate, actionSource);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.html
@@ -71,9 +71,7 @@
                 [book]="book"
                 [chapters]="chapters"
                 [chapter]="chapter"
-                [bookSelectDisabled]="activeQuestionScope === 'all'"
-                [chapterSelectDisabled]="activeQuestionScope !== 'chapter'"
-                [prevNextHidden]="activeQuestionScope !== 'chapter' || isScreenSmall"
+                [prevNextHidden]="isScreenSmall"
                 (bookChange)="onBookSelect($event)"
                 (chapterChange)="onChapterSelect($event)"
               >

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -392,6 +392,36 @@ describe('CheckingComponent', () => {
       discardPeriodicTasks();
     }));
 
+    it('updates active question when route book/chapter changes', fakeAsync(() => {
+      const env = new TestEnvironment({
+        user: CHECKER_USER,
+        projectBookRoute: 'JHN',
+        projectChapterRoute: 1,
+        questionScope: 'book'
+      });
+      expect(env.component.questionsList!.activeQuestionDoc!.data!.dataId).toBe('q5Id');
+      env.setBookChapter('JHN', 2);
+      env.fixture.detectChanges();
+      expect(env.component.questionsList!.activeQuestionDoc!.data!.dataId).toBe('q15Id');
+      flush();
+      discardPeriodicTasks();
+    }));
+
+    it('clears active question when route book/chapter changes to chapter without questions', fakeAsync(() => {
+      const env = new TestEnvironment({
+        user: CHECKER_USER,
+        projectBookRoute: 'MAT',
+        projectChapterRoute: 1,
+        questionScope: 'book'
+      });
+      expect(env.component.questionsList!.activeQuestionDoc!.data!.dataId).toBe('q16Id');
+      env.setBookChapter('MAT', 2);
+      env.fixture.detectChanges();
+      expect(env.component.questionsList!.activeQuestionDoc).toBe(undefined);
+      flush();
+      discardPeriodicTasks();
+    }));
+
     it('can select a question', fakeAsync(() => {
       const env = new TestEnvironment({ user: CHECKER_USER });
       const question = env.selectQuestion(1);
@@ -2795,7 +2825,10 @@ class TestEnvironment {
         {
           bookNum: 40,
           hasSource: false,
-          chapters: [{ number: 1, lastVerse: 28, isValid: true, permissions: {} }],
+          chapters: [
+            { number: 1, lastVerse: 28, isValid: true, permissions: {} },
+            { number: 2, lastVerse: 23, isValid: true, permissions: {} }
+          ],
           permissions: {}
         }
       ],
@@ -3292,6 +3325,11 @@ class TestEnvironment {
       {
         id: getTextDocId(projectId, 40, 1),
         data: this.createTextDataForChapter(1),
+        type: RichText.type.name
+      },
+      {
+        id: getTextDocId(projectId, 40, 2),
+        data: this.createTextDataForChapter(2),
         type: RichText.type.name
       }
     ]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -418,6 +418,9 @@ describe('CheckingComponent', () => {
       env.setBookChapter('MAT', 2);
       env.fixture.detectChanges();
       expect(env.component.questionsList!.activeQuestionDoc).toBe(undefined);
+      env.setBookChapter('MAT', 3);
+      env.fixture.detectChanges();
+      expect(env.component.questionsList!.activeQuestionDoc).toBe(undefined);
       flush();
       discardPeriodicTasks();
     }));
@@ -2827,7 +2830,8 @@ class TestEnvironment {
           hasSource: false,
           chapters: [
             { number: 1, lastVerse: 28, isValid: true, permissions: {} },
-            { number: 2, lastVerse: 23, isValid: true, permissions: {} }
+            { number: 2, lastVerse: 23, isValid: true, permissions: {} },
+            { number: 3, lastVerse: 26, isValid: true, permissions: {} }
           ],
           permissions: {}
         }
@@ -3330,6 +3334,11 @@ class TestEnvironment {
       {
         id: getTextDocId(projectId, 40, 2),
         data: this.createTextDataForChapter(2),
+        type: RichText.type.name
+      },
+      {
+        id: getTextDocId(projectId, 40, 3),
+        data: this.createTextDataForChapter(3),
         type: RichText.type.name
       }
     ]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -418,9 +418,11 @@ describe('CheckingComponent', () => {
       env.setBookChapter('MAT', 2);
       env.fixture.detectChanges();
       expect(env.component.questionsList!.activeQuestionDoc).toBe(undefined);
+      expect(env.component.chapter).toEqual(2);
       env.setBookChapter('MAT', 3);
       env.fixture.detectChanges();
       expect(env.component.questionsList!.activeQuestionDoc).toBe(undefined);
+      expect(env.component.chapter).toEqual(3);
       flush();
       discardPeriodicTasks();
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -851,7 +851,7 @@ describe('CheckingComponent', () => {
       env.waitForQuestionTimersToComplete();
     }));
 
-    it('resets filter after a user changes chapter', fakeAsync(() => {
+    it('should not reset scope after a user changes chapter', fakeAsync(() => {
       const env = new TestEnvironment({
         user: ADMIN_USER,
         projectBookRoute: 'JHN',
@@ -859,27 +859,27 @@ describe('CheckingComponent', () => {
         questionScope: 'chapter'
       });
       expect(env.questions.length).toEqual(14);
-      env.setQuestionScope('all');
+      env.component.onChapterSelect(2);
       env.setBookChapter('JHN', 2);
       tick();
       env.fixture.detectChanges();
-      expect(env.component.activeQuestionScope).toEqual('all');
+      expect(env.component.activeQuestionScope).toEqual('chapter');
       env.waitForQuestionTimersToComplete();
     }));
 
-    it('resets filter after a user changes book', fakeAsync(() => {
+    it('should not reset scope after a user changes book', fakeAsync(() => {
       const env = new TestEnvironment({
         user: ADMIN_USER,
         projectBookRoute: 'JHN',
         projectChapterRoute: 1,
-        questionScope: 'chapter'
+        questionScope: 'book'
       });
-      expect(env.questions.length).toEqual(14);
-      env.setQuestionScope('all');
+      expect(env.questions.length).toEqual(15);
+      env.component.onBookSelect(40);
       env.setBookChapter('MAT', 1);
       tick();
       env.fixture.detectChanges();
-      expect(env.component.activeQuestionScope).toEqual('all');
+      expect(env.component.activeQuestionScope).toEqual('book');
       env.waitForQuestionTimersToComplete();
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -602,8 +602,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
           if (
             routeProjectId !== prevProjectId ||
             routeScope !== prevScope ||
-            (routeBookNum !== prevBookNum && prevScope !== 'all') ||
-            ((routeChapter == null ? undefined : parseInt(routeChapter)) !== prevChapterNum && prevScope === 'chapter')
+            (routeScope !== 'all' && routeBookNum !== prevBookNum) ||
+            (routeScope === 'chapter' && (routeChapter == null ? undefined : parseInt(routeChapter)) !== prevChapterNum)
           ) {
             this.cleanup();
             this.questionsQuery = await this.checkingQuestionsService.queryQuestions(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1077,23 +1077,17 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   }
 
   /**
-   * Navigate to book/chapter of specified question if necessary and select question.
+   * Activate a question which should automatically navigate to the book/chapter
    */
   activateQuestion(questionDoc: QuestionDoc | undefined, { withFilterReset = false } = {}): void {
     if (questionDoc == null) {
       return;
     }
 
-    if (!this.navigateQuestionChapter(questionDoc)) {
-      if (withFilterReset) {
-        this.resetFilter();
-      }
-
-      this.questionsList?.activateQuestion(questionDoc);
-    } else if (withFilterReset) {
-      // Reset filter, but don't update visible questions yet if navigating
-      this.activeQuestionFilter = QuestionFilter.None;
+    if (withFilterReset) {
+      this.resetFilter();
     }
+    this.questionsList?.activateQuestion(questionDoc);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -690,9 +690,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
                 this.updateVisibleQuestions();
               });
           } else {
-            // Visible questions didn't change, but active question must update on route change
-            // this.questionsList?.activateStoredQuestion();
-
             // Ensure refs updated if book changed, but no new questions query (scope is 'all')
             if (routeBookNum !== prevBookNum) {
               this.updateQuestionRefs();
@@ -1091,11 +1088,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       if (withFilterReset) {
         this.resetFilter();
       }
+
+      this.questionsList?.activateQuestion(questionDoc);
     } else if (withFilterReset) {
       // Reset filter, but don't update visible questions yet if navigating
       this.activeQuestionFilter = QuestionFilter.None;
     }
-    this.questionsList?.activateQuestion(questionDoc);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -602,8 +602,8 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
           if (
             routeProjectId !== prevProjectId ||
             routeScope !== prevScope ||
-            routeBookNum !== prevBookNum ||
-            (routeChapter == null ? undefined : parseInt(routeChapter)) !== prevChapterNum
+            (routeBookNum !== prevBookNum && prevScope !== 'all') ||
+            ((routeChapter == null ? undefined : parseInt(routeChapter)) !== prevChapterNum && prevScope === 'chapter')
           ) {
             this.cleanup();
             this.questionsQuery = await this.checkingQuestionsService.queryQuestions(
@@ -646,9 +646,6 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
                 if (this.onlineStatusService.isOnline) {
                   qd.updateFileCache();
-                  if (isActiveQuestionDoc) {
-                    qd.updateAnswerFileCache();
-                  }
                 }
 
                 this.updateAdjacentQuestions(this.questionsList!.activeQuestionDoc!);
@@ -694,7 +691,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
               });
           } else {
             // Visible questions didn't change, but active question must update on route change
-            this.questionsList?.activateStoredQuestion();
+            // this.questionsList?.activateStoredQuestion();
 
             // Ensure refs updated if book changed, but no new questions query (scope is 'all')
             if (routeBookNum !== prevBookNum) {
@@ -898,11 +895,11 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
 
   onBookSelect(book: number): void {
     const navChapterNum: number = this.projectDoc!.data!.texts.find(t => t.bookNum === book)?.chapters[0].number ?? 1;
-    this.navigateBookChapter(this.projectDoc!.id, 'all', book, navChapterNum);
+    this.navigateBookChapter(this.projectDoc!.id, this.activeQuestionScope!, book, navChapterNum);
   }
 
   onChapterSelect(chapter: number): void {
-    this.navigateBookChapter(this.projectDoc!.id, 'all', this.book!, chapter);
+    this.navigateBookChapter(this.projectDoc!.id, this.activeQuestionScope!, this.book!, chapter);
   }
 
   questionUpdated(_questionDoc: QuestionDoc): void {


### PR DESCRIPTION
This PR allows users on the community checking app to select the book and chapter they want to navigate to without requiring the user to be on the "all books" scope. If the user does select a chapter or book with the select, the scope is automatically reset to all books and they will need to set the filter again to their preference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3223)
<!-- Reviewable:end -->
