### PR TITLE
SF-3401 Add format USFM option to draft history UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -1,9 +1,9 @@
 <ng-container *transloco="let t; read: 'draft_history_entry'">
   @if (entry != null) {
     <mat-expansion-panel
-      [disabled]="forceDetailsOpen || !hasDetails"
-      [expanded]="forceDetailsOpen"
-      [hideToggle]="forceDetailsOpen || !hasDetails"
+      [disabled]="isLatestDraft || !hasDetails"
+      [expanded]="isLatestDraft"
+      [hideToggle]="isLatestDraft || !hasDetails"
     >
       <mat-expansion-panel-header [collapsedHeight]="'auto'" [expandedHeight]="'auto'">
         <mat-panel-title>
@@ -23,7 +23,15 @@
           <p class="book-buttons">
             <app-draft-preview-books [build]="entry" />
           </p>
-          <app-draft-download-button [build]="entry" [flat]="true" />
+          <div class="draft-options">
+            <app-draft-download-button [build]="entry" [flat]="true" />
+            @if (featureFlags.usfmFormat.enabled && isLatestDraft) {
+              <button mat-button class="format-usfm" [routerLink]="['format']">
+                <mat-icon>settings</mat-icon>
+                {{ t("format_usfm") }}
+              </button>
+            }
+          </div>
         }
         @if (hasTrainingConfiguration) {
           @if (canDownloadBuild) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
@@ -21,6 +21,11 @@ mat-panel-description {
   font-size: 1.1em;
 }
 
+.draft-options {
+  display: flex;
+  column-gap: 8px;
+}
+
 .date {
   font-size: 0.9em;
   color: #666;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -1,9 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
+import { RouterModule } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
@@ -36,10 +39,12 @@ interface TrainingConfigurationRow {
     CommonModule,
     DraftDownloadButtonComponent,
     DraftPreviewBooksComponent,
+    MatButtonModule,
     MatExpansionModule,
     MatIconModule,
     MatTableModule,
-    TranslocoModule
+    TranslocoModule,
+    RouterModule
   ],
   templateUrl: './draft-history-entry.component.html',
   styleUrl: './draft-history-entry.component.scss'
@@ -141,7 +146,7 @@ export class DraftHistoryEntryComponent {
   }
 
   @Input() canDownloadBuild = false;
-  @Input() forceDetailsOpen = false;
+  @Input() isLatestDraft = false;
 
   trainingConfigurationOpen = false;
 
@@ -150,7 +155,8 @@ export class DraftHistoryEntryComponent {
   constructor(
     readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    readonly featureFlags: FeatureFlagService
   ) {}
 
   get bookNames(): string[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'draft_history_list'">
   @if (latestBuild != null) {
     <h2>{{ lastCompletedBuildMessage }}</h2>
-    <app-draft-history-entry [entry]="latestBuild" [forceDetailsOpen]="true" [canDownloadBuild]="true" />
+    <app-draft-history-entry [entry]="latestBuild" [isLatestDraft]="true" [canDownloadBuild]="true" />
   }
 
   @if (historicalBuilds.length > 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -271,6 +271,7 @@
     "draft_faulted": "Failed",
     "draft_pending": "Pending",
     "draft_unknown": "Unknown",
+    "format_usfm": "Format USFM",
     "hide_model_training_configuration": "Hide model training configuration",
     "show_model_training_configuration": "Show model training configuration",
     "training_model_description": "The language model was trained on this configuration"


### PR DESCRIPTION
This PR adds the option to format USFM to the new draft history view. The button will be visible on the latest draft to next to the download button to communicate that previous drafts in history are not affected by changing the USFM.
The format USFM button is already visible on the current draft preview when the feature flag is enabled.

![Format Usfm Draft history](https://github.com/user-attachments/assets/a6566dab-1932-40ab-89bd-b88324f0de35)
