### PR TITLE
dev: add updated live sass compiler recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,6 +15,7 @@
     "yzhang.markdown-all-in-one",
     "ms-azuretools.vscode-cosmosdb",
     "mongodb.mongodb-vscode",
-    "ms-azuretools.vscode-docker"
+    "ms-azuretools.vscode-docker",
+    "glenn2223.live-sass"
   ]
 }


### PR DESCRIPTION
The previous sass compiler (ritwickdey.live-sass) is deprecated. This is the recommended replacement. I've updated the [wiki page](https://github.com/sillsdev/web-xforge/wiki/Components-and-layout) that describes how this is used for our static page scss.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3226)
<!-- Reviewable:end -->
