### PR TITLE
SF-3400 Show draft history in descending order

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -266,28 +266,22 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
   private findClosestRevision(date: Date, revisions: Revision[]): Revision | undefined {
     const targetTime: number = date.getTime();
-    const oneHour: number = 60 * 60 * 1000;
 
-    let closestBefore: Revision | undefined;
-    let closestAfter: Revision | undefined;
+    let closestLater: Revision | undefined;
+    let closestEarlier: Revision | undefined;
 
     // The revisions are sorted in descending order
     for (const rev of revisions) {
       const revTime = new Date(rev.timestamp).getTime();
       if (revTime > targetTime) {
-        closestBefore = rev;
+        closestLater = rev;
       } else {
-        closestAfter = rev;
+        closestEarlier = rev;
         break;
       }
     }
 
-    // If there is no revision after, or it's too far in the future, prefer the one before
-    if (closestAfter == null || new Date(closestAfter.timestamp).getTime() - targetTime > oneHour) {
-      return closestBefore;
-    }
-
-    return closestAfter;
+    return closestEarlier ?? closestLater;
   }
 
   private hasContent(delta?: DeltaOperation[]): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -137,7 +137,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
                 .pipe(
                   map(revisions => {
                     if (revisions != null) {
-                      this.draftRevisions = revisions;
+                      // Sort revisions by timestamp descending
+                      this.draftRevisions = [...revisions].sort((a, b) => {
+                        return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+                      });
                       const date = this.timestamp ?? new Date();
                       // Don't emit this.selectedRevision$, as the merge will handle this
                       this.selectedRevision = this.findClosestRevision(date, this.draftRevisions);
@@ -261,16 +264,17 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     return this.draftGenerationService.draftExists(this.projectId!, this.bookNum!, this.chapter!);
   }
 
-  private findClosestRevision(date: Date, revisions: Revision[]): Revision {
+  private findClosestRevision(date: Date, revisions: Revision[]): Revision | undefined {
     const targetTime: number = date.getTime();
     const oneHour: number = 60 * 60 * 1000;
 
-    let closestBefore: Revision | null = null;
-    let closestAfter: Revision | null = null;
+    let closestBefore: Revision | undefined;
+    let closestAfter: Revision | undefined;
 
+    // The revisions are sorted in descending order
     for (const rev of revisions) {
       const revTime = new Date(rev.timestamp).getTime();
-      if (revTime <= targetTime) {
+      if (revTime > targetTime) {
         closestBefore = rev;
       } else {
         closestAfter = rev;
@@ -280,7 +284,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
     // If there is no revision after, or it's too far in the future, prefer the one before
     if (closestAfter == null || new Date(closestAfter.timestamp).getTime() - targetTime > oneHour) {
-      return closestBefore!;
+      return closestBefore;
     }
 
     return closestAfter;

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -877,6 +877,8 @@ public class MachineApiService(
             }
         }
 
+        // Display the revisions in descending order to match the history API endpoint
+        revisions.Reverse();
         return revisions;
     }
 


### PR DESCRIPTION
This PR:

 * Updates the frontend to show the draft revisions in descending order
 * Updates the backend to return the draft revisions in descending order

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3229)
<!-- Reviewable:end -->
