### PR TITLE
SF-3391 Store \id in the text document

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -222,6 +222,7 @@ quill-editor.rtl {
   > .ql-editor {
     background-color: var(--sf-quill-background);
 
+    usx-book,
     usx-para,
     p {
       margin-bottom: 1em;
@@ -237,6 +238,11 @@ quill-editor.rtl {
         color: var(--sf-text-color);
         background-color: var(--sf-text-background);
       }
+    }
+
+    usx-book[data-code]:first-child:before {
+      content: attr(data-code);
+      color: var(--sf-usx-chapter-color);
     }
 
     .highlight-segment {
@@ -261,6 +267,7 @@ quill-editor.rtl {
 // workaround for Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1569107
 // using "box-decoration-break: clone" or blur radius in a "box-shadow" with RTL text can cause weird behavior
 .template-editor.rtl[data-browser-engine='gecko'] > .ql-container > .ql-editor {
+  usx-book,
   usx-para,
   p {
     > usx-para-contents {

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -4,6 +4,7 @@
   counter-reset: note;
 }
 
+usx-book,
 usx-para {
   display: block;
 
@@ -179,6 +180,7 @@ usx-para {
   }
 }
 quill-editor.ltr {
+  usx-book,
   usx-para {
     &[data-style='li'],
     &[data-style='li1'] {
@@ -240,6 +242,7 @@ quill-editor.ltr {
   }
 }
 quill-editor.rtl {
+  usx-book,
   usx-para {
     &[data-style='io'],
     &[data-style='io1'] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blot-value-types.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blot-value-types.ts
@@ -9,6 +9,10 @@ export interface Para extends UsxStyle {
   status?: string;
 }
 
+export interface Book extends UsxStyle {
+  code: string;
+}
+
 export interface Chapter extends UsxStyle {
   number: number;
   altnumber?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.spec.ts
@@ -2,6 +2,7 @@ import QuillScrollBlot from 'quill/blots/scroll';
 import { instance, mock } from 'ts-mockito';
 import {
   BlankEmbed,
+  BookBlock,
   ChapterEmbed,
   CharInline,
   EmptyEmbed,
@@ -67,6 +68,45 @@ describe('Quill blots', () => {
     it('should return undefined formats when not initial', () => {
       const node = BlankEmbed.create(true) as HTMLElement;
       expect(BlankEmbed.formats(node)).toBeUndefined();
+    });
+  });
+
+  describe('BookBlock', () => {
+    let mockScroll: QuillScrollBlot;
+
+    beforeEach(() => {
+      mockScroll = instance(mock(QuillScrollBlot));
+    });
+
+    it('should create book block', () => {
+      const value = { style: 'id', code: 'MAT' };
+      const node = BookBlock.create(value);
+
+      expect(node.getAttribute('data-style')).toBe('id');
+      expect(node.getAttribute('data-code')).toBe('MAT');
+    });
+
+    it('should format existing book block', () => {
+      const value = { style: 'id', code: 'MAT' };
+      const node = BookBlock.create({ style: 'id', code: 'MRK' }) as HTMLElement;
+      const paraBlock = new BookBlock(mockScroll, node);
+
+      paraBlock.format('book', value);
+
+      expect(node.getAttribute('data-style')).toBe('id');
+      expect(node.getAttribute('data-code')).toBe('MAT');
+    });
+
+    it('should handle null value', () => {
+      const node = BookBlock.create(null as any);
+      expect(node.hasAttribute('data-style')).toBe(false);
+    });
+
+    it('should return stored value', () => {
+      const value = { style: 'id', code: 'MAT' };
+      const node = BookBlock.create(value);
+      expect(BookBlock.value(node)).toEqual(value);
+      expect(BookBlock.formats(node)).toEqual(value);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
@@ -6,7 +6,18 @@ import QuillInlineBlot from 'quill/blots/inline';
 import QuillScrollBlot from 'quill/blots/scroll';
 import QuillTextBlot from 'quill/blots/text';
 import { isString } from '../../../../../type-utils';
-import { Chapter, Figure, Note, NoteThread, Para, Ref, Unmatched, UsxStyle, Verse } from './quill-blot-value-types';
+import {
+  Book,
+  Chapter,
+  Figure,
+  Note,
+  NoteThread,
+  Para,
+  Ref,
+  Unmatched,
+  UsxStyle,
+  Verse
+} from './quill-blot-value-types';
 
 /** Zero-width space */
 const ZWSP = '\u200b';
@@ -506,5 +517,40 @@ export class ChapterEmbed extends QuillBlockEmbedBlot {
 
   static value(node: HTMLElement): Chapter {
     return getUsxValue(node);
+  }
+}
+
+export class BookBlock extends QuillBlockBlot {
+  static blotName = 'book';
+  static tagName = 'usx-book';
+
+  static create(value: Book): HTMLElement {
+    const node = super.create(value);
+    if (value != null && value.style != null) {
+      node.setAttribute(customAttributeName('style'), value.style);
+      node.setAttribute(customAttributeName('code'), value.code);
+      setUsxValue(node, value);
+    }
+    return node;
+  }
+
+  static formats(node: HTMLElement): Book {
+    return BookBlock.value(node);
+  }
+
+  static value(node: HTMLElement): Book {
+    return getUsxValue(node);
+  }
+
+  format(name: string, value: any): void {
+    const book = value as Book;
+    if (name === BookBlock.blotName && value != null && book.style != null) {
+      const elem = this.domNode as HTMLElement;
+      elem.setAttribute(customAttributeName('style'), book.style);
+      elem.setAttribute(customAttributeName('code'), book.code);
+      setUsxValue(elem, book);
+    } else {
+      super.format(name, value);
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
@@ -23,6 +23,7 @@ import {
 } from './quill-formats/quill-attributors';
 import {
   BlankEmbed,
+  BookBlock,
   ChapterEmbed,
   CharInline,
   EmptyEmbed,
@@ -65,6 +66,7 @@ export function registerScriptureFormats(formatRegistry: QuillFormatRegistryServ
     TextAnchorInline,
 
     // Block Blots
+    BookBlock,
     ParaBlock,
 
     // Class Attributors

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -271,7 +271,7 @@ export function getUnsupportedTags(deltaOp: DeltaOperation): string[] {
       if (style !== undefined) {
         invalidTags.add(style);
       } else {
-        style = (deltaOp.attributes?.para as any)?.style;
+        style = (deltaOp.attributes?.para ?? (deltaOp.attributes?.book as any))?.style;
         if (style !== undefined) {
           invalidTags.add(style);
         }

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -5,14 +5,14 @@ namespace SIL.XForge.Scripture.Services;
 
 public static class DeltaUsxExtensions
 {
-    public static Delta InsertPara(this Delta delta, JObject paraAttributes, JObject attributes = null)
+    public static Delta InsertPara(this Delta delta, JObject paraAttributes, JObject? attributes = null)
     {
         attributes = (JObject)attributes?.DeepClone() ?? [];
         attributes.Add(new JProperty("para", paraAttributes));
         return delta.Insert("\n", attributes);
     }
 
-    public static Delta InsertText(this Delta delta, string text, string segRef = null, JObject attributes = null)
+    public static Delta InsertText(this Delta delta, string text, string? segRef = null, JObject? attributes = null)
     {
         if (segRef != null)
         {
@@ -28,7 +28,7 @@ public static class DeltaUsxExtensions
         return delta.Insert(new { blank = true }, attrs);
     }
 
-    public static Delta InsertEmpty(this Delta delta, string segRef, JObject attributes = null)
+    public static Delta InsertEmpty(this Delta delta, string segRef, JObject? attributes = null)
     {
         attributes = (JObject)attributes?.DeepClone() ?? [];
         attributes.Add(new JProperty("segment", segRef));
@@ -39,8 +39,8 @@ public static class DeltaUsxExtensions
         this Delta delta,
         string type,
         JObject obj,
-        string segRef = null,
-        JObject attributes = null
+        string? segRef = null,
+        JObject? attributes = null
     )
     {
         var embed = new JObject(new JProperty(type, obj));

--- a/src/SIL.XForge.Scripture/Services/IDeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IDeltaUsxMapper.cs
@@ -4,20 +4,12 @@ using SIL.XForge.Realtime.RichText;
 
 namespace SIL.XForge.Scripture.Services;
 
-public class ChapterDelta
+public class ChapterDelta(int number, int lastVerse, bool isValid, Delta delta)
 {
-    public ChapterDelta(int number, int lastVerse, bool isValid, Delta delta)
-    {
-        Number = number;
-        LastVerse = lastVerse;
-        IsValid = isValid;
-        Delta = delta;
-    }
-
-    public int Number { get; }
-    public int LastVerse { get; }
-    public bool IsValid { get; }
-    public Delta Delta { get; }
+    public int Number { get; } = number;
+    public int LastVerse { get; } = lastVerse;
+    public bool IsValid { get; } = isValid;
+    public Delta Delta { get; } = delta;
 }
 
 public interface IDeltaUsxMapper

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -36,7 +36,7 @@ public class Delta
 
     public List<JToken> Ops { get; set; }
 
-    public Delta Insert(object text, object attributes = null)
+    public Delta Insert(object text, object? attributes = null)
     {
         if (text is not JToken textToken)
             textToken = JToken.FromObject(text);

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -19,10 +19,10 @@ using SIL.XForge.Scripture.Models;
 namespace SIL.XForge.Scripture.Services;
 
 [TestFixture]
-public class DeltaUsxMapperTests
+public partial class DeltaUsxMapperTests
 {
-    private IGuidService _mapperGuidService;
-    private IGuidService _testGuidService;
+    private TestGuidService _mapperGuidService;
+    private TestGuidService _testGuidService;
     private ILogger<DeltaUsxMapper> _logger;
     private IExceptionHandler _exceptionHandler;
     private ScrText _scrText;
@@ -48,7 +48,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx("PHM", Para("h", "Philemon"));
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
@@ -63,6 +63,7 @@ public class DeltaUsxMapperTests
             true,
             Delta
                 .New()
+                .InsertBook("PHM")
                 .InsertChapter("1")
                 .InsertBlank("p_1")
                 .InsertVerse("1")
@@ -71,14 +72,14 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "Verse text."));
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
-        Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
+        List<ChapterDelta> roundTrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
+        Assert.IsTrue(roundTrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
     }
 
     [Test]
@@ -109,7 +110,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -145,8 +146,14 @@ public class DeltaUsxMapperTests
         // Get the chapter deltas, which will be the valid chapters
         List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
-        var expected1 = Delta.New().InsertChapter("1").InsertVerse("1").InsertBlank("verse_1_1").InsertText("\n");
-        var expected2 = Delta.New().InsertChapter("3").InsertVerse("1").InsertBlank("verse_3_1").InsertText("\n");
+        Delta expected1 = Delta
+            .New()
+            .InsertBook("RUT")
+            .InsertChapter("1")
+            .InsertVerse("1")
+            .InsertBlank("verse_1_1")
+            .InsertText("\n");
+        Delta expected2 = Delta.New().InsertChapter("3").InsertVerse("1").InsertBlank("verse_3_1").InsertText("\n");
 
         Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
         Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(1));
@@ -183,7 +190,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -213,7 +220,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -247,7 +254,7 @@ public class DeltaUsxMapperTests
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         // SUT
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -290,7 +297,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -336,7 +343,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -402,7 +409,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -465,7 +472,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -552,7 +559,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -594,7 +601,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -638,7 +645,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -696,7 +703,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -739,7 +746,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -768,7 +775,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -807,7 +814,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -832,6 +839,7 @@ public class DeltaUsxMapperTests
             true,
             Delta
                 .New()
+                .InsertBook("PHM")
                 .InsertChapter("1")
                 // Table 1 begins
                 // Row 1 begins
@@ -864,7 +872,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -881,8 +889,8 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
-        Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
+        List<ChapterDelta> roundTrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
+        Assert.IsTrue(roundTrippedChapterDeltas[0].Delta.DeepEquals(chapterDelta.Delta));
     }
 
     [Test]
@@ -930,7 +938,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -995,8 +1003,8 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDocA = mapper.ToUsx(Usx("PHM"), new[] { chapterDeltaA });
-        XDocument newUsxDocB = mapper.ToUsx(Usx("PHM"), new[] { chapterDeltaB });
+        XDocument newUsxDocA = mapper.ToUsx(Usx("PHM"), [chapterDeltaA]);
+        XDocument newUsxDocB = mapper.ToUsx(Usx("PHM"), [chapterDeltaB]);
 
         XDocument expected = Usx("PHM", Chapter("1"), Para("p", Verse("1"), "Verse text."));
         // The implied paragraphs are combined.
@@ -1015,7 +1023,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx("PHM", Para("p"), Para("p"));
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
@@ -1024,14 +1032,15 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_NoParagraphs()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 3,
                 true,
                 Delta
                     .New()
+                    .InsertBook("PHM")
                     .InsertChapter("1")
                     .InsertVerse("1")
                     .InsertText("This is verse 1.", "verse_1_1")
@@ -1054,7 +1063,7 @@ public class DeltaUsxMapperTests
                     .InsertBlank("verse_2_2")
                     .Insert("\n")
             ),
-        };
+        ];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
@@ -1074,9 +1083,9 @@ public class DeltaUsxMapperTests
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
 
         // And we should be able to roundtrip it back.
-        List<ChapterDelta> roundtrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
-        Assert.IsTrue(roundtrippedChapterDeltas[0].Delta.DeepEquals(chapterDeltas[0].Delta));
-        Assert.IsTrue(roundtrippedChapterDeltas[1].Delta.DeepEquals(chapterDeltas[1].Delta));
+        List<ChapterDelta> roundTrippedChapterDeltas = [.. mapper.ToChapterDeltas(newUsxDoc)];
+        Assert.IsTrue(roundTrippedChapterDeltas[0].Delta.DeepEquals(chapterDeltas[0].Delta));
+        Assert.IsTrue(roundTrippedChapterDeltas[1].Delta.DeepEquals(chapterDeltas[1].Delta));
     }
 
     [Test]
@@ -1098,7 +1107,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -1130,7 +1139,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -1161,7 +1170,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -1175,8 +1184,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_NoParagraphsImpliedParagraph()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 3,
@@ -1206,7 +1215,7 @@ public class DeltaUsxMapperTests
                     .InsertBlank("verse_2_2")
                     .Insert("\n")
             ),
-        };
+        ];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         XDocument newUsxDoc = mapper.ToUsx(Usx("PHM", Chapter("1"), "Text", Chapter("2"), "Text"), chapterDeltas);
@@ -1230,7 +1239,7 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_EmptyBook()
     {
-        var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
+        ChapterDelta[] chapterDeltas = [new ChapterDelta(1, 0, true, Delta.New())];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), chapterDeltas);
@@ -1243,7 +1252,7 @@ public class DeltaUsxMapperTests
     public void ToUsx_MismatchNoChapters_UnchangedUsx()
     {
         _exceptionHandler.ClearReceivedCalls();
-        var chapterDeltas = new[] { new ChapterDelta(1, 0, true, new Delta()) };
+        ChapterDelta[] chapterDeltas = [new ChapterDelta(1, 0, true, Delta.New())];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
@@ -1262,16 +1271,14 @@ public class DeltaUsxMapperTests
 
         XDocument expected = input;
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
-        _exceptionHandler
-            .Received()
-            .ReportException(Arg.Is<Exception>((Exception e) => e.Message.Contains("no real chapters")));
+        _exceptionHandler.Received().ReportException(Arg.Is((Exception e) => e.Message.Contains("no real chapters")));
     }
 
     [Test]
     public void ToUsx_NewChapter_Added()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 2,
@@ -1298,7 +1305,7 @@ public class DeltaUsxMapperTests
                     .InsertText("New chapter verse 2", "verse_2_2")
                     .InsertPara("p")
             ),
-        };
+        ];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
@@ -1318,8 +1325,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_NewChapter_AddedBetweenChapters()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 2,
@@ -1359,7 +1366,7 @@ public class DeltaUsxMapperTests
                     .InsertText("This is verse 2.", "verse_3_2")
                     .InsertPara("p")
             ),
-        };
+        ];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
@@ -1389,8 +1396,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_FirstChapterMissing()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 2,
                 2,
@@ -1406,7 +1413,7 @@ public class DeltaUsxMapperTests
                     .InsertText("This is verse 2 (edited).", "verse_2_2")
                     .InsertPara("p")
             ),
-        };
+        ];
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
 
@@ -1453,7 +1460,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -1483,7 +1490,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("XXA", Book("PHM"), Chapter("1")), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("XXA", Book("PHM"), Chapter("1")), [chapterDelta]);
 
         XDocument expected = Usx("XXA", Book("PHM"), Chapter("1"), Para("p", Verse("1"), "Verse text."));
         Assert.IsTrue(XNode.DeepEquals(newUsxDoc, expected));
@@ -1492,8 +1499,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_InvalidParaInFirstChapter()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 1,
@@ -1532,7 +1539,7 @@ public class DeltaUsxMapperTests
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("p")
             ),
-        };
+        ];
 
         var oldUsxDoc = Usx(
             "PHM",
@@ -1564,8 +1571,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_InvalidParaInMiddleChapter()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 1,
@@ -1604,7 +1611,7 @@ public class DeltaUsxMapperTests
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("p")
             ),
-        };
+        ];
 
         var oldUsxDoc = Usx(
             "PHM",
@@ -1636,8 +1643,8 @@ public class DeltaUsxMapperTests
     [Test]
     public void ToUsx_InvalidParaInLastChapter()
     {
-        var chapterDeltas = new[]
-        {
+        ChapterDelta[] chapterDeltas =
+        [
             new ChapterDelta(
                 1,
                 1,
@@ -1676,7 +1683,7 @@ public class DeltaUsxMapperTests
                     .InsertText("New verse text.", "verse_3_1")
                     .InsertPara("bad", true)
             ),
-        };
+        ];
 
         var oldUsxDoc = Usx(
             "PHM",
@@ -1724,7 +1731,7 @@ public class DeltaUsxMapperTests
         );
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), new[] { chapterDelta });
+        XDocument newUsxDoc = mapper.ToUsx(Usx("PHM"), [chapterDelta]);
 
         XDocument expected = Usx(
             "PHM",
@@ -1755,7 +1762,7 @@ public class DeltaUsxMapperTests
         XDocument oldUsxDoc = Usx("PHM", Chapter("bad"), Para("p", Verse("1"), Verse("2")), Chapter("2"));
 
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
-        Assert.Throws<InvalidDataException>(() => mapper.ToUsx(oldUsxDoc, new[] { chapterDelta }));
+        Assert.Throws<InvalidDataException>(() => mapper.ToUsx(oldUsxDoc, [chapterDelta]));
     }
 
     [Test]
@@ -1775,6 +1782,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -1838,6 +1846,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1", "bad", true)
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -1862,6 +1871,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1", "bad", true)
@@ -1892,6 +1902,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -1925,6 +1936,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -1960,6 +1972,7 @@ public class DeltaUsxMapperTests
 
         var expectedChapter1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertText("Philemon", "mt_1")
             .InsertPara("mt")
             .InsertChapter("1")
@@ -2033,6 +2046,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2090,6 +2104,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2148,6 +2163,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2195,6 +2211,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2229,6 +2246,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2257,6 +2275,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2281,6 +2300,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2318,6 +2338,7 @@ public class DeltaUsxMapperTests
         string sup3CharID = _testGuidService.Generate();
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2382,6 +2403,7 @@ public class DeltaUsxMapperTests
         string sup3CharID = _testGuidService.Generate();
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2453,6 +2475,7 @@ public class DeltaUsxMapperTests
         string sup4CharID = _testGuidService.Generate();
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2537,6 +2560,7 @@ public class DeltaUsxMapperTests
         string sup3CharID = _testGuidService.Generate();
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2595,6 +2619,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2641,6 +2666,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2697,6 +2723,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2753,6 +2780,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2795,6 +2823,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2823,6 +2852,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2851,6 +2881,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -2885,6 +2916,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertText("Before verse.", "cell_1_1_1")
             .InsertVerse("1")
@@ -2934,6 +2966,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertText("Before verse.", "cell_1_1_1")
             .InsertVerse("1")
@@ -2971,7 +3004,7 @@ public class DeltaUsxMapperTests
     {
         string ndCharID = _testGuidService.Generate();
 
-        string bookUsfm = """
+        const string bookUsfm = """
 \id PHM
 \c 1
 \p
@@ -3009,6 +3042,7 @@ public class DeltaUsxMapperTests
         // be expected.
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -3067,6 +3101,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("cell_1_1_1")
             .InsertVerse("1")
@@ -3131,6 +3166,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertText("Before verse.", "cell_1_1_1")
             .InsertVerse("1")
@@ -3176,6 +3212,7 @@ public class DeltaUsxMapperTests
 
         var expected1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertVerse("1")
             .InsertText("This is verse 1.", "verse_1_1")
@@ -3218,6 +3255,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .Insert("This is an implied paragraph before the first verse.")
             .Insert("\n")
@@ -3247,6 +3285,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .Insert("This is an implied paragraph before the first verse.")
             .Insert("\n")
@@ -3283,6 +3322,7 @@ public class DeltaUsxMapperTests
 
         var expected1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .Insert("This is an implied paragraph before the first verse.")
             .InsertVerse("1")
@@ -3319,11 +3359,13 @@ public class DeltaUsxMapperTests
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
+        var expected = Delta.New().InsertBook("PHM");
+
         Assert.That(chapterDeltas.Count, Is.EqualTo(1));
         Assert.That(chapterDeltas[0].Number, Is.EqualTo(1));
         Assert.That(chapterDeltas[0].LastVerse, Is.EqualTo(0));
         Assert.That(chapterDeltas[0].IsValid, Is.True);
-        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(new Delta()));
+        Assert.IsTrue(chapterDeltas[0].Delta.DeepEquals(expected));
     }
 
     [Test]
@@ -3343,6 +3385,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -3381,6 +3424,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -3415,7 +3459,9 @@ public class DeltaUsxMapperTests
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
-        var expected = new Delta()
+        var expected = Delta
+            .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -3449,6 +3495,7 @@ public class DeltaUsxMapperTests
 
         var expectedChapter1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertText("Book title", "imt_1")
             .InsertPara("imt")
             .InsertChapter("1")
@@ -3505,6 +3552,7 @@ public class DeltaUsxMapperTests
 
         var expectedChapter1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertText("Book title", "imt_1")
             .InsertPara("imt")
             .InsertChapter("1")
@@ -3561,6 +3609,7 @@ public class DeltaUsxMapperTests
 
         var expectedChapter1 = Delta
             .New()
+            .InsertBook("PHM")
             .InsertText("Book title", "imt_1")
             .InsertPara("imt")
             .InsertChapter("1")
@@ -3612,6 +3661,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("s_1")
             .InsertVerse("1")
@@ -3637,10 +3687,11 @@ public class DeltaUsxMapperTests
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
-        var expected = new[]
-        {
+        Delta[] expected =
+        [
             Delta
                 .New()
+                .InsertBook("TDX", invalid: true)
                 .InsertChapter("1")
                 .InsertBlank("q_1")
                 .InsertVerse("1")
@@ -3653,7 +3704,7 @@ public class DeltaUsxMapperTests
                 .InsertVerse("1")
                 .InsertText("This verse is also valid, but in an invalid book", "verse_2_1")
                 .InsertPara("q"),
-        };
+        ];
 
         Assert.That(chapterDeltas.Count, Is.EqualTo(2));
         Assert.That(chapterDeltas[0].IsValid, Is.False);
@@ -3678,7 +3729,9 @@ public class DeltaUsxMapperTests
         var mapper = new DeltaUsxMapper(_mapperGuidService, _logger, _exceptionHandler);
         List<ChapterDelta> chapterDeltas = [.. mapper.ToChapterDeltas(usxDoc)];
 
-        var expected = new Delta()
+        var expected = Delta
+            .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("q_1")
             .InsertVerse("1")
@@ -3711,6 +3764,7 @@ public class DeltaUsxMapperTests
 
         var expected = Delta
             .New()
+            .InsertBook("PHM")
             .InsertChapter("1")
             .InsertBlank("p_1")
             .InsertVerse("1")
@@ -3995,7 +4049,7 @@ public class DeltaUsxMapperTests
         string zipFilePath = Path.Join(GetPathToTestProject(), "SampleData", $"{projectZipFilename}.zip");
         await using FileStream zipFileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
         using ZipArchive archive = new ZipArchive(zipFileStream, ZipArchiveMode.Read);
-        Assert.That(archive.Entries.Any(), "setup. unexpected input size.");
+        Assert.That(archive.Entries, Is.Not.Empty, "setup. unexpected input size.");
         bool allBooksRoundtrip = true;
         List<string> errorMessages = [];
         foreach (ZipArchiveEntry entry in archive.Entries)
@@ -4024,10 +4078,13 @@ public class DeltaUsxMapperTests
     private void AssertRoundtrips(string bookUsfm) =>
         Assert.That(DoesRoundtrip(bookUsfm, out string errorMessage), Is.True, errorMessage);
 
+    [GeneratedRegex(@"\\id\s+(\w+)", RegexOptions.Compiled)]
+    private static partial Regex BookCodeRegex();
+
     private static string ExtractBookCode(string bookUsfm)
     {
-        string firstLine = bookUsfm.Split('\n').FirstOrDefault()?.Trim();
-        string bookCode = Regex.Match(firstLine, @"\\id\s+(\w+)").Groups[1].Value;
+        string firstLine = bookUsfm.Split('\n').FirstOrDefault()?.Trim() ?? string.Empty;
+        string bookCode = BookCodeRegex().Match(firstLine).Groups[1].Value;
         return bookCode;
     }
 
@@ -4065,9 +4122,7 @@ public class DeltaUsxMapperTests
         if (!didRoundtrip)
         {
             errorMessage = $"Trouble roundtripping {bookCode}.";
-            IEnumerable<int> invalidChapters = chapterDeltas
-                .Where((ChapterDelta cd) => !cd.IsValid)
-                .Select((ChapterDelta cd) => cd.Number);
+            IEnumerable<int> invalidChapters = chapterDeltas.Where(cd => !cd.IsValid).Select(cd => cd.Number);
             if (invalidChapters.Any())
                 errorMessage += $" Note that the following chapters were invalid: {string.Join(" ", invalidChapters)}";
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
@@ -141,6 +141,18 @@ public static class DeltaUsxTestExtensions
         return delta.InsertText(text, segRef, attributes);
     }
 
+    public static Delta InsertBook(this Delta delta, string code, string style = "id", bool invalid = false)
+    {
+        var obj = new JObject(new JProperty("code", code), new JProperty("style", style));
+        if (style == "")
+            obj.Add(new JProperty("status", "unknown"));
+        JObject attrs = [];
+        if (invalid)
+            attrs = new JObject(new JProperty("invalid-block", true));
+        attrs.Add(new JProperty("book", obj));
+        return delta.InsertBlank($"{style}_1").Insert("\n", attrs);
+    }
+
     public static Delta InsertChapter(this Delta delta, string number, string style = "c", bool invalid = false)
     {
         var obj = new JObject(new JProperty("number", number), new JProperty("style", style));

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -3169,8 +3169,14 @@ public class ParatextSyncRunnerTests
 
         Assert.That(
             ops[0]["insert"].Type,
-            Is.EqualTo(JTokenType.Object),
-            "first op in list should be inserting an object, not a string like newline"
+            Is.EqualTo(JTokenType.String),
+            "first op in list should be inserting a string"
+        );
+
+        Assert.That(
+            ((JValue)ops[0]["insert"]).Value,
+            Is.EqualTo("- American Standard Version"),
+            "first op in list should be the book name"
         );
     }
 
@@ -3263,16 +3269,22 @@ public class ParatextSyncRunnerTests
 
         Assert.That(
             ops[0]["insert"].Type,
-            Is.EqualTo(JTokenType.Object),
-            "first op in list should be inserting an object, not a string like newline"
+            Is.EqualTo(JTokenType.String),
+            "first op in list should be inserting a string"
+        );
+
+        Assert.That(
+            ((JValue)ops[0]["insert"]).Value,
+            Is.EqualTo("- American Standard Version"),
+            "first op in list should be the book name"
         );
 
         // We have chapter deltas from the Paratext project USFM. We store the information in SF DB. In a future sync,
         // we would write the SF DB information back to the Paratext project (if the text was changed).
 
         // Modify the text a bit so it will need written back to Paratext.
-        string newText = "In the beginning";
-        ops[3]["insert"] = newText;
+        const string newText = "In the beginning";
+        ops[5]["insert"] = newText;
 
         // Make text docs out of the chapter deltas.
         var chapterDeltasAsSortedList = new SortedList<int, IDocument<TextData>>(
@@ -3288,27 +3300,20 @@ public class ParatextSyncRunnerTests
         );
         textInfo.Chapters =
         [
-            .. chapterDeltas.Values.Select(
-                (ChapterDelta chapterDelta) =>
-                    new Chapter()
-                    {
-                        Number = chapterDelta.Number,
-                        IsValid = chapterDelta.IsValid,
-                        LastVerse = chapterDelta.LastVerse,
-                        Permissions = [],
-                    }
-            ),
+            .. chapterDeltas.Values.Select(chapterDelta => new Chapter
+            {
+                Number = chapterDelta.Number,
+                IsValid = chapterDelta.IsValid,
+                LastVerse = chapterDelta.LastVerse,
+                Permissions = [],
+            }),
         ];
 
         env.RealtimeService.AddRepository(
             "users",
             OTType.Json0,
             new MemoryRepository<User>(
-                new[]
-                {
-                    new User { Id = "user01", ParatextId = "pt01" },
-                    new User { Id = "user02", ParatextId = "pt02" },
-                }
+                [new User { Id = "user01", ParatextId = "pt01" }, new User { Id = "user02", ParatextId = "pt02" }]
             )
         );
 


### PR DESCRIPTION
This PR updates updates the editor and delta USX mapper to store and display the `\id` USFM tag in the delta, and allow the string after the book code to be edited.