### PR TITLE
SF-3411 Fix crash when a scripture range is missing

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -466,7 +466,9 @@ public class MachineApiService(
                     // We are using the TranslationBuild.Pretranslate.SourceFilters.ScriptureRange to find the
                     // books selected for drafting. Some projects may have used the now obsolete field
                     // TranslationBuild.Pretranslate.ScriptureRange and will not get checked for webhook failures.
-                    foreach (ParallelCorpusFilter source in ptc.SourceFilters ?? [])
+                    foreach (
+                        ParallelCorpusFilter source in ptc.SourceFilters?.Where(s => s.ScriptureRange is not null) ?? []
+                    )
                     {
                         foreach (
                             (string book, List<int> bookChapters) in scriptureRangeParser.GetChapters(


### PR DESCRIPTION
This PR fixes the following crash detected on QA: https://app.bugsnag.com/sil-international/scripture-forge-v2-plus/errors/6836ea5f71e48b17c509d085

As this is a simple null check, I don't think testing is required, but if you do think it should be tested, I have written the acceptance test documenting what I did to recreate this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3233)
<!-- Reviewable:end -->
