### PR TITLE
SF-2504 Fix broken links and language picker on error page

### DIFF
--- a/src/SIL.XForge.Scripture/Pages/Shared/_Footer.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_Footer.cshtml
@@ -27,8 +27,8 @@
                         <li class="version">@Settings.GetProductVersion()</li>
                     </ul>
                     <ul class="links">
-                        <li><a asp-page="Terms">@SharedLocalizer[SharedResource.Keys.Terms]</a></li>
-                        <li><a asp-page="Privacy">@SharedLocalizer[SharedResource.Keys.Privacy]</a></li>
+                        <li><a href="/terms">@SharedLocalizer[SharedResource.Keys.Terms]</a></li>
+                        <li><a href="/privacy">@SharedLocalizer[SharedResource.Keys.Privacy]</a></li>
                         <li><a href="https://help.scriptureforge.org">@SharedLocalizer[SharedResource.Keys.LearnMore]</a></li>
                         <li><a href="@helps" target="_blank">@SharedLocalizer[SharedResource.Keys.Help]</a></li>
                         <li><a href="https://community.scripture.software.sil.org/c/scripture-forge/19"

--- a/src/SIL.XForge.Scripture/Pages/Shared/_Layout.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_Layout.cshtml
@@ -56,7 +56,7 @@
             <div class="mdl-grid">
                 <div class="mdl-cell mdl-cell--12-col flex justify-content-space-between">
                     <div class="flex align-items-center">
-                        <a asp-page="Index">
+                        <a href="/">
                             <img
                                 src="~/assets/images/@(Settings.UseScriptureForgeBranding() ? "sf_logo_with_name_black" : "sd").svg"
                                 class="@(Settings.UseScriptureForgeBranding() ? string.Empty : "square")"

--- a/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
@@ -25,7 +25,8 @@
 <div title="@SharedLocalizer[SharedResource.Keys.Language]">
     <form id="selectLanguage" asp-controller="Language" asp-action="SetLanguage" method="post" class="form-horizontal"
           role="form">
-        <input type="hidden" name="returnUrl" value="@Context.Request.Path" />
+        @* Include the query string so users return to the exact page (including errors/404) after changing language. *@
+        <input type="hidden" name="returnUrl" value="@(Context.Request.Path + Context.Request.QueryString)" />
         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
             <select name="culture" class="mdl-textfield__input" onchange="this.form.submit();"
                     asp-for="@requestCulture.RequestCulture.UICulture.Name" asp-items="cultureItems">


### PR DESCRIPTION
Some of the ASP.NET page/routing handling doesn't work on error pages, so I've updated it to use hard-coded URLs (even though this isn't completely ideal).

The language picker also was updated to work on error pages, where it's a bit of an odd situation. It's supposed to change the language and send the user back to the current page, but given the user has been routed to the error page, it can't reliably recreate an error. However, it can set the language and send the user to the error page *without* recreating the error, by sending the user to e.g. `http://localhost:5000/Status/Error?code=404`, which renders a 404 error page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3240)
<!-- Reviewable:end -->
