### PR TITLE
SF-3416 Fix error reading nativeElement in project select

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -173,14 +173,14 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
 
   autocompleteOpened(): void {
     setTimeout(() => {
-      if (this.autocomplete && this.autocomplete.panel && this.autocompleteTrigger) {
-        fromEvent(this.autocomplete.panel.nativeElement, 'scroll')
+      if (this.autocomplete?.panel != null && this.autocompleteTrigger != null) {
+        fromEvent<Event>(this.autocomplete.panel.nativeElement, 'scroll')
           .pipe(
-            map(() => this.autocomplete.panel.nativeElement.scrollTop),
             takeUntil(this.autocompleteTrigger.panelClosingActions.pipe(tap(() => this.resourceCountLimit$.next(25))))
           )
-          .subscribe(() => {
-            const panel = this.autocomplete.panel.nativeElement;
+          .subscribe(event => {
+            const panel = event.target as HTMLElement | null;
+            if (panel == null) return;
             // if scrolled to within 100px of bottom, display more resources
             if (this.resources != null && panel.scrollHeight <= panel.scrollTop + panel.clientHeight + 100) {
               this.resourceCountLimit$.next(Math.min(this.resourceCountLimit$.getValue() + 25, this.resources.length));


### PR DESCRIPTION
~(Jira issue coming soon, to be opened by test team)~ Issue opened as SF-3416

Steps to reproduce are:

1. Click in project select and type something, such as "english"
2. Click out of select
3. Click in select
4. Scroll a short distance
5. Select a project
6. Observe error `Cannot read properties of undefined (reading 'nativeElement')` happening on the line I deleted in this PR.

I can't get it to happen every time though.

I believe the line with the error is a noop that probably had a use while I was originally writing this component, but by the time I opened #899 it didn't have any use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3241)
<!-- Reviewable:end -->
