### PR TITLE
dev: fix RealtimeServer source path for debugging

### DIFF
--- a/src/RealtimeServer/tsconfig.json
+++ b/src/RealtimeServer/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "sourceMap": true,
-    "sourceRoot": "../../../../../../../../../../src/RealtimeServer/common/",
+    // This long path points up from `.../bin/Debug/net8.0/...` to the RealtimeServer source code.
+    "sourceRoot": "../../../../../../../../../src/RealtimeServer/common/",
     "declaration": true,
     "target": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
To get breakpoints to work again when attaching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3243)
<!-- Reviewable:end -->
