### PR TITLE
Improve link sharing wording

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -432,7 +432,7 @@
     "invite_people": "Invite people",
     "invite_people_intro": "You can invite people outside of Paratext to help contribute to your project.",
     "link_copied": "Link copied to clipboard",
-    "link_sharing": "Links can also be shared to users without an email address via social media platforms.",
+    "link_sharing": "Links can also be sent to users without an email address via messaging apps or social media platforms.",
     "not_inviting_already_member": "Not inviting: User is already a member of this project",
     "not_inviting_email_invalid": "Not inviting: Invalid email address",
     "resend": "Resend",


### PR DESCRIPTION
This string shows up at the bottom of the users page

History of this string:

Until a recent change this string said "Links can also be shared to users without an email address via social media platforms or SMS messages." In #3108, during the removal of SMS as a login option, the phrase "or SMS messages" was deleted, even though there really was no impact on the ability to us SMS to share links.

I've updated the wording to try to capture the intended meaning of "you can share these links however you would normally send people stuff."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3244)
<!-- Reviewable:end -->
