### PR TITLE
SF-3390 Show book names in summarized format in draft history

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -10,6 +10,7 @@ import { BehaviorSubject, of, throwError } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
@@ -33,6 +34,7 @@ const mockActivatedProjectService = mock(ActivatedProjectService);
 const mockActivatedRoute = mock(ActivatedRoute);
 const mockAuthService = mock(AuthService);
 const mockDraftGenerationService = mock(DraftGenerationService);
+const mockedI18nService = mock(I18nService);
 const mockNoticeService = mock(NoticeService);
 const mockSFProjectService = mock(SFProjectService);
 const mockServalAdministrationService = mock(ServalAdministrationService);
@@ -45,6 +47,7 @@ describe('ServalProjectComponent', () => {
       { provide: ActivatedRoute, useMock: mockActivatedRoute },
       { provide: AuthService, useMock: mockAuthService },
       { provide: DraftGenerationService, useMock: mockDraftGenerationService },
+      { provide: I18nService, useMock: mockedI18nService },
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: ServalAdministrationService, useMock: mockServalAdministrationService },
@@ -215,10 +218,10 @@ describe('ServalProjectComponent', () => {
       const env = new TestEnvironment();
       const trainingSources = env.trainingSources;
       expect(trainingSources.length).toEqual(1);
-      expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis, Exodus');
+      expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis - Exodus');
       const translationSources = env.translationSources;
       expect(translationSources.length).toEqual(1);
-      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus, Numbers');
+      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus - Numbers');
     }));
 
     it('shows the last draft configs multiple training sources', fakeAsync(() => {
@@ -235,11 +238,11 @@ describe('ServalProjectComponent', () => {
       });
       const trainingSources = env.trainingSources;
       expect(trainingSources.length).toEqual(2);
-      expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis, Exodus');
+      expect(env.getTrainingSourceBookNames(trainingSources[0])).toEqual('Genesis - Exodus');
       expect(env.getTrainingSourceBookNames(trainingSources[1])).toEqual('Genesis');
       const translationSources = env.translationSources;
       expect(translationSources.length).toEqual(1);
-      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus, Numbers');
+      expect(env.getTranslationBookNames(translationSources[0])).toEqual('Leviticus - Numbers');
     }));
   });
 
@@ -323,6 +326,10 @@ describe('ServalProjectComponent', () => {
       when(mockActivatedProjectService.projectId$).thenReturn(mockProjectId$);
       when(mockActivatedProjectService.projectDoc).thenReturn(mockProjectDoc);
       when(mockActivatedProjectService.projectDoc$).thenReturn(mockProjectDoc$);
+
+      when(mockedI18nService.formatAndLocalizeScriptureRange('GEN')).thenReturn('Genesis');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('GEN;EXO')).thenReturn('Genesis - Exodus');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('LEV;NUM')).thenReturn('Leviticus - Numbers');
 
       when(mockDraftGenerationService.getLastCompletedBuild(this.mockProjectId)).thenReturn(
         of(args.lastCompletedBuild)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, Input, OnInit } from '@angular/core';
-import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DraftConfig, TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { catchError, lastValueFrom, Observable, of, Subscription, switchMap, throwError } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UICommonModule } from 'xforge-common/ui-common.module';
@@ -17,7 +17,7 @@ import { BuildDto } from '../machine-api/build-dto';
 import { MobileNotSupportedComponent } from '../shared/mobile-not-supported/mobile-not-supported.component';
 import { NoticeComponent } from '../shared/notice/notice.component';
 import { SharedModule } from '../shared/shared.module';
-import { booksFromScriptureRange, projectLabel } from '../shared/utils';
+import { projectLabel } from '../shared/utils';
 import { DraftZipProgress } from '../translate/draft-generation/draft-generation';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DraftInformationComponent } from '../translate/draft-generation/draft-information/draft-information.component';
@@ -79,6 +79,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly draftGenerationService: DraftGenerationService,
+    private readonly i18n: I18nService,
     noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly projectService: SFProjectService,
@@ -159,18 +160,16 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           if (draftConfig.lastSelectedTrainingScriptureRange != null) {
             this.trainingBooksByProject.push({
               source: 'Source 1',
-              scriptureRange: booksFromScriptureRange(draftConfig.lastSelectedTrainingScriptureRange ?? '')
-                .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
-                .join(', ')
+              scriptureRange: this.i18n.formatAndLocalizeScriptureRange(
+                draftConfig.lastSelectedTrainingScriptureRange ?? ''
+              )
             });
           } else if (draftConfig.lastSelectedTrainingScriptureRanges != null) {
             let sourceCount = 1;
             for (const range of draftConfig.lastSelectedTrainingScriptureRanges) {
               this.trainingBooksByProject.push({
                 source: `Source ${sourceCount++}`,
-                scriptureRange: booksFromScriptureRange(range.scriptureRange)
-                  .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
-                  .join(', ')
+                scriptureRange: this.i18n.formatAndLocalizeScriptureRange(range.scriptureRange)
               });
             }
           }
@@ -179,18 +178,16 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
           if (draftConfig.lastSelectedTranslationScriptureRange != null) {
             this.translationBooksByProject.push({
               source: 'Source 1',
-              scriptureRange: booksFromScriptureRange(draftConfig.lastSelectedTranslationScriptureRange ?? '')
-                .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
-                .join(', ')
+              scriptureRange: this.i18n.formatAndLocalizeScriptureRange(
+                draftConfig.lastSelectedTranslationScriptureRange ?? ''
+              )
             });
           } else if (draftConfig.lastSelectedTranslationScriptureRanges != null) {
             let sourceCount = 1;
             for (const range of draftConfig.lastSelectedTranslationScriptureRanges) {
               this.translationBooksByProject.push({
                 source: `Source ${sourceCount++}`,
-                scriptureRange: booksFromScriptureRange(range.scriptureRange)
-                  .map(bookNum => Canon.bookNumberToEnglishName(bookNum))
-                  .join(', ')
+                scriptureRange: this.i18n.formatAndLocalizeScriptureRange(range.scriptureRange)
               });
             }
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -59,7 +59,7 @@
             <table mat-table [dataSource]="trainingConfiguration">
               <ng-container matColumnDef="scriptureRange">
                 <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let element">{{ scriptureRange }}</td>
+                <td mat-cell *matCellDef="let element">{{ element.scriptureRange }}</td>
               </ng-container>
               <ng-container matColumnDef="source">
                 <th mat-header-cell *matHeaderCellDef>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -7,7 +7,7 @@
     >
       <mat-expansion-panel-header [collapsedHeight]="'auto'" [expandedHeight]="'auto'">
         <mat-panel-title>
-          <span class="drafted-books">{{ i18n.enumerateList(bookNames) }}</span>
+          <span class="drafted-books">{{ scriptureRange }}</span>
           <span class="date">{{ formatDate(entry.additionalInfo?.dateFinished) }}</span>
         </mat-panel-title>
         <mat-panel-description>
@@ -57,9 +57,9 @@
               <strong>{{ t("training_model_description") }}</strong>
             </p>
             <table mat-table [dataSource]="trainingConfiguration">
-              <ng-container matColumnDef="bookNames">
+              <ng-container matColumnDef="scriptureRange">
                 <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let element">{{ i18n.enumerateList(element.bookNames) }}</td>
+                <td mat-cell *matCellDef="let element">{{ scriptureRange }}</td>
               </ng-container>
               <ng-container matColumnDef="source">
                 <th mat-header-cell *matHeaderCellDef>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -78,7 +78,7 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.scriptureRange).toEqual('formatted-scripture-range');
+      expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBe(user);
       expect(component.buildRequestedByDate).toBe(date);
       expect(component.canDownloadBuild).toBe(true);
@@ -90,7 +90,7 @@ describe('DraftHistoryEntryComponent', () => {
       expect(component.targetLanguage).toBe('en');
       expect(component.trainingConfiguration).toEqual([
         {
-          scriptureRange: 'formatted-scripture-range',
+          scriptureRange: 'Exodus',
           source: 'src',
           target: 'tar'
         }
@@ -111,13 +111,14 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.scriptureRange).toEqual('formatted-scripture-range');
+      expect(component.scriptureRange).toEqual('Genesis');
       expect(component.canDownloadBuild).toBe(true);
       expect(fixture.nativeElement.querySelector('.format-usfm')).not.toBeNull();
     }));
 
     it('should handle builds where the draft cannot be downloaded yet', fakeAsync(() => {
-      when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('GEN')).thenReturn('Genesis');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('EXO')).thenReturn('Exodus');
       when(mockedI18nService.translateStatic('draft_history_entry.draft_unknown')).thenReturn('Unknown');
       const targetProjectDoc = {
         id: 'project01'
@@ -143,7 +144,7 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.scriptureRange).toEqual('formatted-scripture-range');
+      expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
@@ -155,7 +156,7 @@ describe('DraftHistoryEntryComponent', () => {
       expect(component.targetLanguage).toBe('');
       expect(component.trainingConfiguration).toEqual([
         {
-          scriptureRange: 'formatted-scripture-range',
+          scriptureRange: 'Exodus',
           source: 'Unknown',
           target: 'Unknown'
         }
@@ -165,7 +166,8 @@ describe('DraftHistoryEntryComponent', () => {
 
     it('should handle builds with additional info referencing a deleted user', fakeAsync(() => {
       when(mockedI18nService.formatDate(anything())).thenReturn('formatted-date');
-      when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('GEN')).thenReturn('Genesis');
+      when(mockedI18nService.formatAndLocalizeScriptureRange('EXO')).thenReturn('Exodus');
       const userDoc = { id: 'sf-user-id', data: undefined } as UserProfileDoc;
       when(mockedUserService.getProfile(anything())).thenResolve(userDoc);
       const entry = {
@@ -183,7 +185,7 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.scriptureRange).toEqual('formatted-scripture-range');
+      expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('formatted-date');
       expect(component.canDownloadBuild).toBe(true);
@@ -251,7 +253,8 @@ describe('DraftHistoryEntryComponent', () => {
     translateBooks: string[];
   }): BuildDto {
     when(mockedI18nService.formatDate(anything())).thenReturn(date);
-    when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
+    when(mockedI18nService.formatAndLocalizeScriptureRange('GEN')).thenReturn('Genesis');
+    when(mockedI18nService.formatAndLocalizeScriptureRange('EXO')).thenReturn('Exodus');
     const userDoc = {
       id: 'sf-user-id',
       data: createTestUserProfile({ displayName: user })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -58,7 +58,7 @@ describe('DraftHistoryEntryComponent', () => {
   describe('entry', () => {
     it('should handle undefined values', () => {
       component.entry = undefined;
-      expect(component.bookNames).toEqual([]);
+      expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
@@ -78,19 +78,19 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.bookNames).toEqual(['Genesis']);
+      expect(component.scriptureRange).toEqual('formatted-scripture-range');
       expect(component.buildRequestedByUserName).toBe(user);
       expect(component.buildRequestedByDate).toBe(date);
       expect(component.canDownloadBuild).toBe(true);
       expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
-      expect(component.columnsToDisplay).toEqual(['bookNames', 'source', 'target']);
+      expect(component.columnsToDisplay).toEqual(['scriptureRange', 'source', 'target']);
       expect(component.hasDetails).toBe(true);
       expect(component.entry).toBe(entry);
       expect(component.sourceLanguage).toBe('fr');
       expect(component.targetLanguage).toBe('en');
       expect(component.trainingConfiguration).toEqual([
         {
-          bookNames: ['Exodus'],
+          scriptureRange: 'formatted-scripture-range',
           source: 'src',
           target: 'tar'
         }
@@ -111,14 +111,13 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.bookNames).toEqual(['Genesis']);
+      expect(component.scriptureRange).toEqual('formatted-scripture-range');
       expect(component.canDownloadBuild).toBe(true);
       expect(fixture.nativeElement.querySelector('.format-usfm')).not.toBeNull();
     }));
 
     it('should handle builds where the draft cannot be downloaded yet', fakeAsync(() => {
-      when(mockedI18nService.localizeBook('GEN')).thenReturn('Genesis');
-      when(mockedI18nService.localizeBook('EXO')).thenReturn('Exodus');
+      when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
       when(mockedI18nService.translateStatic('draft_history_entry.draft_unknown')).thenReturn('Unknown');
       const targetProjectDoc = {
         id: 'project01'
@@ -144,19 +143,19 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.bookNames).toEqual(['Genesis']);
+      expect(component.scriptureRange).toEqual('formatted-scripture-range');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
-      expect(component.columnsToDisplay).toEqual(['bookNames', 'source', 'target']);
+      expect(component.columnsToDisplay).toEqual(['scriptureRange', 'source', 'target']);
       expect(component.hasDetails).toBe(true);
       expect(component.entry).toBe(entry);
       expect(component.sourceLanguage).toBe('');
       expect(component.targetLanguage).toBe('');
       expect(component.trainingConfiguration).toEqual([
         {
-          bookNames: ['Exodus'],
+          scriptureRange: 'formatted-scripture-range',
           source: 'Unknown',
           target: 'Unknown'
         }
@@ -166,7 +165,7 @@ describe('DraftHistoryEntryComponent', () => {
 
     it('should handle builds with additional info referencing a deleted user', fakeAsync(() => {
       when(mockedI18nService.formatDate(anything())).thenReturn('formatted-date');
-      when(mockedI18nService.localizeBook('GEN')).thenReturn('localized-book');
+      when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
       const userDoc = { id: 'sf-user-id', data: undefined } as UserProfileDoc;
       when(mockedUserService.getProfile(anything())).thenResolve(userDoc);
       const entry = {
@@ -184,7 +183,7 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(component.bookNames).toEqual(['localized-book']);
+      expect(component.scriptureRange).toEqual('formatted-scripture-range');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('formatted-date');
       expect(component.canDownloadBuild).toBe(true);
@@ -197,7 +196,7 @@ describe('DraftHistoryEntryComponent', () => {
       const entry = { additionalInfo: {} } as BuildDto;
       component.entry = entry;
       component.isLatestBuild = true;
-      expect(component.bookNames).toEqual([]);
+      expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
@@ -209,7 +208,7 @@ describe('DraftHistoryEntryComponent', () => {
     it('should handle builds without additional info', () => {
       const entry = {} as BuildDto;
       component.entry = entry;
-      expect(component.bookNames).toEqual([]);
+      expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
       expect(component.buildRequestedByDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
@@ -252,8 +251,7 @@ describe('DraftHistoryEntryComponent', () => {
     translateBooks: string[];
   }): BuildDto {
     when(mockedI18nService.formatDate(anything())).thenReturn(date);
-    when(mockedI18nService.localizeBook('GEN')).thenReturn('Genesis');
-    when(mockedI18nService.localizeBook('EXO')).thenReturn('Exodus');
+    when(mockedI18nService.formatAndLocalizeScriptureRange(anything())).thenReturn('formatted-scripture-range');
     const userDoc = {
       id: 'sf-user-id',
       data: createTestUserProfile({ displayName: user })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -27,7 +27,7 @@ const STATUS_INFO: Record<BuildStates, { icons: string; text: string; color: str
 };
 
 interface TrainingConfigurationRow {
-  bookNames: string[];
+  scriptureRange: string;
   source: string;
   target: string;
 }
@@ -93,7 +93,7 @@ export class DraftHistoryEntryComponent {
 
         // Return the data for this training range
         return {
-          bookNames: r.scriptureRange.split(';').map(id => this.i18n.localizeBook(id)),
+          scriptureRange: this.i18n.formatAndLocalizeScriptureRange(r.scriptureRange),
           source: source?.data?.shortName ?? this.i18n.translateStatic('draft_history_entry.draft_unknown'),
           target: target?.data?.shortName ?? this.i18n.translateStatic('draft_history_entry.draft_unknown')
         } as TrainingConfigurationRow;
@@ -150,7 +150,7 @@ export class DraftHistoryEntryComponent {
 
   trainingConfigurationOpen = false;
 
-  readonly columnsToDisplay: string[] = ['bookNames', 'source', 'target'];
+  readonly columnsToDisplay: string[] = ['scriptureRange', 'source', 'target'];
 
   constructor(
     readonly i18n: I18nService,
@@ -159,15 +159,11 @@ export class DraftHistoryEntryComponent {
     readonly featureFlags: FeatureFlagService
   ) {}
 
-  get bookNames(): string[] {
-    if (this.entry?.additionalInfo?.translationScriptureRanges == null) return [];
-    return [
-      ...new Set(
-        this.entry.additionalInfo.translationScriptureRanges.flatMap(r =>
-          r.scriptureRange.split(';').map(id => this.i18n.localizeBook(id))
-        )
-      )
-    ];
+  get scriptureRange(): string {
+    if (this.entry?.additionalInfo?.translationScriptureRanges == null) return '';
+    return this.i18n.formatAndLocalizeScriptureRange(
+      this.entry.additionalInfo.translationScriptureRanges.map(item => item.scriptureRange).join(';')
+    );
   }
 
   formatDate(date?: string): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -246,6 +246,23 @@ describe('I18nService', () => {
       expect(service.formatAndLocalizeScriptureRange('EXO;GEN;MRK')).toBe('Genesis - Exodus, Mark');
     });
 
+    it('should localize multiple sequences of books', () => {
+      when(mockedTranslocoService.translate<string>('canon.book_names.GEN')).thenReturn('Genesis');
+      when(mockedTranslocoService.translate<string>('canon.book_names.JOB')).thenReturn('Job');
+      when(mockedTranslocoService.translate<string>('canon.book_names.PSA')).thenReturn('Psalms');
+      when(mockedTranslocoService.translate<string>('canon.book_names.MAT')).thenReturn('Matthew');
+      when(mockedTranslocoService.translate<string>('canon.book_names.MRK')).thenReturn('Mark');
+      when(mockedTranslocoService.translate<string>('canon.book_names.LUK')).thenReturn('Luke');
+      when(mockedTranslocoService.translate<string>('canon.book_names.JHN')).thenReturn('John');
+
+      const service = getI18nService();
+
+      // SUT
+      expect(service.formatAndLocalizeScriptureRange('JHN;PSA;GEN;LUK;JOB;MAT;MRK')).toBe(
+        'Genesis, Job - Psalms, Matthew - John'
+      );
+    });
+
     it('should localize one book name', () => {
       when(mockedTranslocoService.translate<string>('canon.book_names.MRK')).thenReturn('Mark');
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -233,6 +233,37 @@ describe('I18nService', () => {
       expect(service.localizeBookChapter('MRK', 3)).toBe('Mark \u200F3');
     });
   });
+
+  describe('formatAndLocalizeScriptureRange', () => {
+    it('should localize sequential and non-sequential books', () => {
+      when(mockedTranslocoService.translate<string>('canon.book_names.GEN')).thenReturn('Genesis');
+      when(mockedTranslocoService.translate<string>('canon.book_names.EXO')).thenReturn('Exodus');
+      when(mockedTranslocoService.translate<string>('canon.book_names.MRK')).thenReturn('Mark');
+
+      const service = getI18nService();
+
+      // SUT
+      expect(service.formatAndLocalizeScriptureRange('EXO;GEN;MRK')).toBe('Genesis - Exodus, Mark');
+    });
+
+    it('should localize one book name', () => {
+      when(mockedTranslocoService.translate<string>('canon.book_names.MRK')).thenReturn('Mark');
+
+      const service = getI18nService();
+
+      // SUT
+      expect(service.formatAndLocalizeScriptureRange('MRK')).toBe('Mark');
+    });
+
+    it('should ignore invalid book codes', () => {
+      when(mockedTranslocoService.translate<string>('canon.book_names.MRK')).thenReturn('Mark');
+
+      const service = getI18nService();
+
+      // SUT
+      expect(service.formatAndLocalizeScriptureRange('invalid_book_code')).toBe('');
+    });
+  });
 });
 
 function getI18nService(): I18nService {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -252,9 +252,8 @@ export class I18nService {
 
     if (bookNumbers.length === 1) return this.localizeBook(start);
 
-    for (let i = 1; i <= bookNumbers.length; i++) {
-      // At the end of the array, this will be undefined and we will execute the else block
-      const current: number | undefined = bookNumbers[i];
+    for (let i = 1; i < bookNumbers.length; i++) {
+      const current: number = bookNumbers[i];
       if (current === end + 1) {
         end = current;
       } else {
@@ -265,6 +264,11 @@ export class I18nService {
         end = current;
       }
     }
+
+    // Handle the last book in the scripture range
+    const fromBook: string = this.localizeBook(start);
+    const toBook: string = this.localizeBook(end);
+    ranges.push(start === end ? fromBook : `${fromBook} - ${toBook}`);
 
     return ranges.join(', ');
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -7,6 +7,7 @@ import { CookieService } from 'ngx-cookie-service';
 import { BehaviorSubject, Observable, of, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { booksFromScriptureRange } from '../app/shared/utils';
 import enChecking from '../assets/i18n/checking_en.json';
 import enNonChecking from '../assets/i18n/non_checking_en.json';
 import { ObjectPaths } from '../type-utils';
@@ -236,6 +237,35 @@ export class I18nService {
 
   localizeBookChapter(book: number | string, chapter: number): string {
     return `${this.localizeBook(book)} ${this.getDirectionMark()}${chapter}`;
+  }
+
+  formatAndLocalizeScriptureRange(scriptureRange: string): string {
+    const bookNumbers = booksFromScriptureRange(scriptureRange)
+      .filter(i => i > 0)
+      .sort((a, b) => a - b);
+
+    if (bookNumbers.length === 0) return '';
+
+    const ranges: string[] = [];
+    let start = bookNumbers[0];
+    let end = bookNumbers[0];
+
+    if (bookNumbers.length === 1) return this.localizeBook(start);
+
+    for (let i = 1; i <= bookNumbers.length; i++) {
+      const current = bookNumbers[i];
+      if (current === end + 1) {
+        end = current;
+      } else {
+        const fromBook = this.localizeBook(start);
+        const toBook = this.localizeBook(end);
+        ranges.push(start === end ? fromBook : `${fromBook} - ${toBook}`);
+        start = current;
+        end = current;
+      }
+    }
+
+    return ranges.join(', ');
   }
 
   localizeReference(verse: VerseRef): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -240,25 +240,26 @@ export class I18nService {
   }
 
   formatAndLocalizeScriptureRange(scriptureRange: string): string {
-    const bookNumbers = booksFromScriptureRange(scriptureRange)
+    const bookNumbers: number[] = booksFromScriptureRange(scriptureRange)
       .filter(i => i > 0)
       .sort((a, b) => a - b);
 
     if (bookNumbers.length === 0) return '';
 
     const ranges: string[] = [];
-    let start = bookNumbers[0];
-    let end = bookNumbers[0];
+    let start: number = bookNumbers[0];
+    let end: number = bookNumbers[0];
 
     if (bookNumbers.length === 1) return this.localizeBook(start);
 
     for (let i = 1; i <= bookNumbers.length; i++) {
-      const current = bookNumbers[i];
+      // At the end of the array, this will be undefined and we will execute the else block
+      const current: number | undefined = bookNumbers[i];
       if (current === end + 1) {
         end = current;
       } else {
-        const fromBook = this.localizeBook(start);
-        const toBook = this.localizeBook(end);
+        const fromBook: string = this.localizeBook(start);
+        const toBook: string = this.localizeBook(end);
         ranges.push(start === end ? fromBook : `${fromBook} - ${toBook}`);
         start = current;
         end = current;


### PR DESCRIPTION
This PR displays the book names on the new draft history interface in a summarized format, i.e. Genesis - Exodus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3248)
<!-- Reviewable:end -->
