### PR TITLE
SF-3276 Highlight text in project select when user clicks the input

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -7,6 +7,7 @@
       [formControl]="paratextIdControl"
       [matAutocomplete]="auto"
       (click)="inputClicked($event)"
+      (blur)="inputBlurred()"
       [errorStateMatcher]="matcher"
     />
     <mat-error id="invalidSelection">{{ invalidMessage }}</mat-error>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.html
@@ -6,7 +6,7 @@
       [placeholder]="placeholder"
       [formControl]="paratextIdControl"
       [matAutocomplete]="auto"
-      (click)="inputClicked()"
+      (click)="inputClicked($event)"
       [errorStateMatcher]="matcher"
     />
     <mat-error id="invalidSelection">{{ invalidMessage }}</mat-error>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -194,9 +194,11 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
       }
     });
   }
-
-  inputClicked(): void {
+  inputClicked(event: MouseEvent): void {
     this.autocompleteTrigger.openPanel();
+    const input = event.target as HTMLInputElement;
+    // Select all the text so the user can begin typing to replace it
+    input.select();
   }
 
   nullableLength(project: SelectableProject[] | null): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project-select/project-select.component.ts
@@ -37,6 +37,7 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
   readonly paratextIdControl = new FormControl<string | SelectableProject>('', [SFValidators.selectableProject(true)]);
   private allProjects$ = new BehaviorSubject<SelectableProject[] | undefined>(undefined);
   private allResources$ = new BehaviorSubject<SelectableProject[] | undefined>(undefined);
+  private inputSelected = false;
 
   @Input()
   set projects(value: SelectableProject[] | undefined) {
@@ -159,7 +160,7 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
     this.value = value;
   }
 
-  destroyed = false;
+  private destroyed = false;
   ngOnDestroy(): void {
     this.destroyed = true;
   }
@@ -194,11 +195,19 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
       }
     });
   }
+
+  inputBlurred(): void {
+    this.inputSelected = false;
+  }
+
   inputClicked(event: MouseEvent): void {
     this.autocompleteTrigger.openPanel();
     const input = event.target as HTMLInputElement;
-    // Select all the text so the user can begin typing to replace it
-    input.select();
+    if (!this.inputSelected) {
+      // Select all the text on first click so the user can begin typing to replace it
+      input.select();
+      this.inputSelected = true;
+    }
   }
 
   nullableLength(project: SelectableProject[] | null): number {


### PR DESCRIPTION
When a user wants to edit the project in a project select, they have to manually highlight and delete the currently selected project. This change updates the project select so that when a user clicks in the input, the currently selected project text is highlighted and the user can begin typing to clear the previously selected project.

![image](https://github.com/user-attachments/assets/c9bd8aff-fd3e-404e-bc74-1d8bee8c66e0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3261)
<!-- Reviewable:end -->
