### PR TITLE
Remove unnecessary horizontal scroll in RTL UI

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -25,7 +25,11 @@ html {
 body {
   margin: 0;
   font-family: Roboto, sans-serif;
-  overflow-x: hidden;
+
+  // prevents a horizontal scroll bar in RTL mode
+  .cdk-visually-hidden {
+    inset-inline-start: 0;
+  }
 }
 
 as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -25,6 +25,7 @@ html {
 body {
   margin: 0;
   font-family: Roboto, sans-serif;
+  overflow-x: hidden;
 }
 
 as-split.is-disabled > .as-split-gutter .as-split-gutter-icon {


### PR DESCRIPTION
A horizontal scroll bar appears when the UI is changed to RTL. I think this occurred when we updated to implement material theme, but I did not go back to confirm. This change removes the unnecessary horizontal scroll bar.

![image](https://github.com/user-attachments/assets/63987576-4d78-45da-a819-86042321b8f4)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3263)
<!-- Reviewable:end -->
