### PR TITLE
SF-3343 Fix error when use refreshes configure source page while offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -14,7 +14,7 @@
         <p>{{ t("select_project_to_translate") }}</p>
         @for (source of draftingSources; track $index) {
           <app-project-select
-            [isDisabled]="loading"
+            [isDisabled]="loading || !appOnline"
             [projects]="projects"
             [resources]="resources"
             [nonSelectableProjects]="nonSelectableProjects"
@@ -55,7 +55,7 @@
         </p>
         @for (source of trainingSources; track $index) {
           <app-project-select
-            [isDisabled]="loading"
+            [isDisabled]="loading || !appOnline"
             [projects]="projects"
             [resources]="resources"
             [nonSelectableProjects]="nonSelectableProjects"


### PR DESCRIPTION
An error appears when a user attempts to refresh the page on the configure sources page while offline. This fix updates the behaviour on the page so that it only makes network requests while online. Additionally, if we get offline errors on this page, the errors are suppressed. If the error is not network related, they get silently reported.

This error is hard to reproduce locally. The best way to test this is by merging it to master and testing on QA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3266)
<!-- Reviewable:end -->
