### PR TITLE
SF-3428 Fix error when selecting all books scope when no question selected

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.spec.ts
@@ -277,6 +277,23 @@ describe('CheckingComponent', () => {
       }));
     });
 
+    it('gets adjacent question when no actively selected question', fakeAsync(() => {
+      const env = new TestEnvironment({
+        user: ADMIN_USER,
+        questionScope: 'book',
+        projectBookRoute: 'MAT',
+        projectChapterRoute: 2 // no questions on chapter 2
+      });
+      const getAdjacentQuestionSpy = spyOn(env.component as any, 'getAdjacentQuestion').and.callThrough();
+      env.component.activeQuestionScope = 'all';
+      env.component['activeQuestionDoc$'].next(undefined);
+      env.fixture.detectChanges();
+      tick();
+      expect(getAdjacentQuestionSpy).toHaveBeenCalledWith(undefined, 'next');
+      flush();
+      discardPeriodicTasks();
+    }));
+
     it('should open question dialog', fakeAsync(() => {
       const env = new TestEnvironment({ user: ADMIN_USER });
       env.clickButton(env.addQuestionButton);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -1131,7 +1131,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       if (activeQuestionIndex >= 0) {
         adjacentQuestionInScope = this.visibleQuestions[activeQuestionIndex + (prevOrNext === 'prev' ? -1 : 1)];
       }
-    } else if (this.activeQuestionScope !== 'all') {
+    } else {
       // Get prev/next relative to current chapter if no active question.
       // This can happen if scope has no visible questions (taking question filter into account).
       relativeTo = {


### PR DESCRIPTION
This change fixes an issue where selecting the all books scope when there are no actively selected questions causes an error. The component can be in a state where there are no actively selected questions now that we can navigate to any book and chapter from any question scope. This was introduced in PR #3223

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3268)
<!-- Reviewable:end -->
