### PR TITLE
Add index to improve question querying performance

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/question.ts
+++ b/src/RealtimeServer/scriptureforge/models/question.ts
@@ -1,9 +1,19 @@
 import { PROJECT_DATA_INDEX_PATHS, ProjectData } from '../../common/models/project-data';
+import { obj } from '../../common/utils/obj-path';
 import { Answer } from './answer';
 import { VerseRefData } from './verse-ref-data';
 
 export const QUESTIONS_COLLECTION = 'questions';
-export const QUESTION_INDEX_PATHS: string[] = PROJECT_DATA_INDEX_PATHS;
+export const QUESTION_INDEX_PATHS = [
+  ...PROJECT_DATA_INDEX_PATHS,
+  // Index for CheckingQuestionsService.queryQuestions() and CheckingQuestionsService.queryAdjacentQuestions()
+  {
+    [obj<Question>().pathStr(n => n.projectRef)]: 1,
+    [obj<Question>().pathStr(n => n.isArchived)]: 1,
+    [obj<Question>().pathStr(n => n.verseRef.bookNum)]: 1,
+    [obj<Question>().pathStr(n => n.verseRef.chapterNum)]: 1
+  }
+];
 
 export function getQuestionDocId(projectId: string, questionId: string): string {
   return `${projectId}:${questionId}`;


### PR DESCRIPTION
In my code review of #3262, I noticed that there were no indexes for the queries in the CheckingQuestionsService.

This PR adds a query that is used by `CheckingQuestionsService.queryQuestions()` and `CheckingQuestionsService.queryAdjacentQuestions()`.

The index when created looks like:
![image](https://github.com/user-attachments/assets/19245b09-f6e2-45bc-ba52-93e6a86ba9ef)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3275)
<!-- Reviewable:end -->
