### PR TITLE
SF-3422 Allow source projects with observer permission to sync

### DIFF
--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -22,13 +22,47 @@ public record SyncMetrics : IIdentifiable
     public string UserRef { get; set; }
 
     // Sync Statistics
+
+    /// <summary>
+    /// Gets or sets the info for changes to biblical terms incoming from Paratext.
+    /// </summary>
     public SyncMetricInfo BiblicalTerms { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to books incoming from Paratext.
+    /// </summary>
     public SyncMetricInfo Books { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to notes incoming from Paratext.
+    /// </summary>
     public NoteSyncMetricInfo Notes { get; set; } = new NoteSyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to note threads incoming from Paratext.
+    /// </summary>
     public SyncMetricInfo NoteThreads { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to biblical terms outgoing to Paratext.
+    /// </summary>
+    public SyncMetricInfo ParatextBiblicalTerms { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to books outgoing to Paratext.
+    /// </summary>
     public SyncMetricInfo ParatextBooks { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to notes outgoing to Paratext.
+    /// </summary>
     public SyncMetricInfo ParatextNotes { get; set; } = new SyncMetricInfo();
+
+    /// <summary>
+    /// Gets or sets the info for changes to questions incoming from Paratext.
+    /// </summary>
     public SyncMetricInfo Questions { get; set; } = new SyncMetricInfo();
+
     public bool RepositoryBackupCreated { get; set; }
     public bool RepositoryRestoredFromBackup { get; set; }
     public SyncMetricInfo ResourceUsers { get; set; } = new SyncMetricInfo();

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -72,7 +72,11 @@ public interface IParatextService
     );
     int UpdateCommentTag(UserSecret userSecret, string paratextId, NoteTag noteTag);
     Task<BiblicalTermsChanges> GetBiblicalTermsAsync(UserSecret userSecret, string paratextId, IEnumerable<int> books);
-    void UpdateBiblicalTerms(UserSecret userSecret, string paratextId, IReadOnlyList<BiblicalTerm> biblicalTerms);
+    SyncMetricInfo UpdateBiblicalTerms(
+        UserSecret userSecret,
+        string paratextId,
+        IReadOnlyList<BiblicalTerm> biblicalTerms
+    );
     string? GetLatestSharedVersion(UserSecret userSecret, string paratextId);
     string GetRepoRevision(UserSecret userSecret, string paratextId);
     void SetRepoToRevision(UserSecret userSecret, string paratextId, string desiredRevision);

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -308,8 +308,6 @@ public class ParatextService : DisposableBase, IParatextService
                     sharedProj.Permissions = new ParatextRegistryPermissionManager(username, permissionManager);
                 }
 
-                List<SharedProject> sharedPtProjectsToSr = [sharedProj];
-
                 // If we are in development, unlock the repo before we begin,
                 // just in case the repo is locked.
                 if (_env.IsDevelopment())
@@ -323,11 +321,13 @@ public class ParatextService : DisposableBase, IParatextService
                         // A 403 error will be thrown if the repo is not locked
                     }
                 }
+
                 // ShareChanges() will fail silently if the user is an Observer,
                 // so throw an error if the user is an Observer in the Registry
                 // and there are outgoing changes to share.
+                bool userIsAnObserver = !sharedProj.Permissions.HaveRoleNotObserver;
                 if (
-                    !sharedPtProjectsToSr.All(s => s.Permissions.HaveRoleNotObserver)
+                    userIsAnObserver
                     && (
                         syncMetrics.ParatextBooks != new SyncMetricInfo()
                         || syncMetrics.ParatextNotes != new SyncMetricInfo()
@@ -339,6 +339,7 @@ public class ParatextService : DisposableBase, IParatextService
                 }
 
                 // TODO report results
+                List<SharedProject> sharedPtProjectsToSr = [sharedProj];
                 List<SendReceiveResult> results = Enumerable.Empty<SendReceiveResult>().ToList();
                 bool success = false;
                 bool noErrors = SharingLogicWrapper.HandleErrors(() =>

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -692,7 +692,11 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
         LogMetric("Saving Paratext biblical terms");
         await NotifySyncProgress(syncPhase, 75);
-        _paratextService.UpdateBiblicalTerms(_userSecret, paratextId, biblicalTermsToUpdate);
+        _syncMetrics.ParatextBiblicalTerms += _paratextService.UpdateBiblicalTerms(
+            _userSecret,
+            paratextId,
+            biblicalTermsToUpdate
+        );
         return biblicalTermDocs;
     }
 

--- a/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/SharingLogicWrapper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
 
@@ -16,17 +15,7 @@ public class SharingLogicWrapper : ISharingLogicWrapper
         SharedRepositorySource source,
         out List<SendReceiveResult> results,
         IList<SharedProject> reviewProjects
-    )
-    {
-        // ShareChanges() will fail silently if the user is an Observer,
-        // so throw an error if the user is an Observer in the Registry.
-        if (!sharedProjects.All(s => s.Permissions.HaveRoleNotObserver))
-        {
-            throw new InvalidOperationException("User does not have permission to share changes.");
-        }
-
-        return SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
-    }
+    ) => SharingLogic.ShareChanges(sharedProjects, source, out results, reviewProjects);
 
     public bool HandleErrors(Action action, bool throwExceptions = false) =>
         SharingLogic.HandleErrors(action, throwExceptions);

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -4098,6 +4098,30 @@ public class ParatextServiceTests
     }
 
     [Test]
+    public void SendReceiveAsync_ThrowsExceptionIfObserver()
+    {
+        // Setup
+        var env = new TestEnvironment();
+
+        // Create a project with a user that is an observer
+        var associatedPtUser = new SFParatextUser(env.Username01);
+        string ptProjectId = env.SetupProject(env.Project01, associatedPtUser);
+        UserSecret user01Secret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetSharedRepositorySource(user01Secret, UserRoles.Observer);
+
+        // SUT
+        Assert.ThrowsAsync<InvalidOperationException>(() =>
+            env.Service.SendReceiveAsync(
+                user01Secret,
+                ptProjectId,
+                null,
+                CancellationToken.None,
+                new SyncMetrics { ParatextBooks = new SyncMetricInfo(0, 0, 1) }
+            )
+        );
+    }
+
+    [Test]
     public async Task SendReceiveAsync_UserIsAdministrator_Succeeds()
     {
         var env = new TestEnvironment();
@@ -6302,8 +6326,13 @@ public class ParatextServiceTests
         IReadOnlyList<BiblicalTerm> biblicalTerms = [new BiblicalTerm()];
 
         // SUT
-        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        SyncMetricInfo actual = env.Service.UpdateBiblicalTerms(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            biblicalTerms
+        );
         env.MockScrTextCollection.Received(1).FindById(Arg.Any<string>(), Arg.Any<string>());
+        Assert.That(actual, Is.EqualTo(new SyncMetricInfo()));
     }
 
     [Test]
@@ -6314,8 +6343,68 @@ public class ParatextServiceTests
         IReadOnlyList<BiblicalTerm> biblicalTerms = [];
 
         // SUT
-        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        SyncMetricInfo actual = env.Service.UpdateBiblicalTerms(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            biblicalTerms
+        );
         env.MockScrTextCollection.DidNotReceive().FindById(Arg.Any<string>(), Arg.Any<string>());
+        Assert.That(actual, Is.EqualTo(new SyncMetricInfo()));
+    }
+
+    [Test]
+    public void UpdateBiblicalTerms_NoChange()
+    {
+        var env = new TestEnvironment();
+        UserSecret userSecret = TestEnvironment.MakeUserSecret(env.User01, env.Username01, env.ParatextUserId01);
+        env.SetupProject(env.Project01, new SFParatextUser(env.Username01));
+
+        // Setup term rendering
+        const string termId = "Ἀβιά-1";
+        const string rendering = "Abijah";
+        const string notes = "Notes";
+        env.ProjectFileManager.GetXml<TermRenderingsList>(Arg.Any<string>())
+            .Returns(
+                new TermRenderingsList
+                {
+                    RenderingsInternal =
+                    [
+                        new TermRendering
+                        {
+                            Id = termId,
+                            RenderingsInternal = rendering,
+                            Notes = notes,
+                        },
+                    ],
+                }
+            );
+
+        IReadOnlyList<BiblicalTerm> biblicalTerms =
+        [
+            new BiblicalTerm
+            {
+                TermId = termId,
+                Renderings = [rendering],
+                Description = notes,
+            },
+        ];
+
+        // SUT
+        SyncMetricInfo actual = env.Service.UpdateBiblicalTerms(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            biblicalTerms
+        );
+        env.ProjectFileManager.Received(1)
+            .SetXml(
+                Arg.Is<TermRenderingsList>(r =>
+                    r.Renderings.Single().Id == termId
+                    && r.Renderings.Single().RenderingsEntries.Single() == rendering
+                    && r.Renderings.Single().Notes == notes
+                ),
+                "TermRenderings.xml"
+            );
+        Assert.That(actual, Is.EqualTo(new SyncMetricInfo()));
     }
 
     [Test]
@@ -6356,7 +6445,11 @@ public class ParatextServiceTests
         ];
 
         // SUT
-        env.Service.UpdateBiblicalTerms(userSecret, env.PTProjectIds[env.Project01].Id, biblicalTerms);
+        SyncMetricInfo actual = env.Service.UpdateBiblicalTerms(
+            userSecret,
+            env.PTProjectIds[env.Project01].Id,
+            biblicalTerms
+        );
         env.ProjectFileManager.Received(1)
             .SetXml(
                 Arg.Is<TermRenderingsList>(r =>
@@ -6366,6 +6459,7 @@ public class ParatextServiceTests
                 ),
                 "TermRenderings.xml"
             );
+        Assert.That(actual, Is.EqualTo(new SyncMetricInfo(0, 0, 1)));
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -2611,6 +2611,13 @@ public class ParatextSyncRunnerTests
         env.SetupSFData(true, true, true, false, books);
         env.SetupPTData(books);
 
+        env.ParatextService.UpdateBiblicalTerms(
+                Arg.Any<UserSecret>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<BiblicalTerm>>()
+            )
+            .Returns(new SyncMetricInfo(0, 0, 1));
+
         // This Biblical Term will be updated
         env.RealtimeService.GetRepository<BiblicalTerm>()
             .Add(
@@ -2761,6 +2768,10 @@ public class ParatextSyncRunnerTests
         Assert.AreEqual("domain03_en", biblicalTerm.Definitions["en"].Domains.Last());
         Assert.AreEqual("gloss02_en", biblicalTerm.Definitions["en"].Gloss);
         Assert.AreEqual("notes02_en", biblicalTerm.Definitions["en"].Notes);
+
+        // Check that the resource users metrics have been updated
+        SyncMetrics syncMetrics = env.GetSyncMetrics("project01");
+        Assert.That(syncMetrics.ParatextBiblicalTerms, Is.EqualTo(new SyncMetricInfo(0, 0, 1)));
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/SharingLogicWrapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SharingLogicWrapperTests.cs
@@ -1,18 +1,14 @@
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Paratext.Data;
 using Paratext.Data.Repository;
 using Paratext.Data.Users;
-using SIL.XForge.Scripture.Models;
 
 namespace SIL.XForge.Scripture.Services;
 
 [TestFixture]
 public class SharingLogicWrapperTests
 {
-    private const string ParatextUser01 = "ParatextUser01";
-
     [Test]
     public void HandleErrors_DoesNotThrowByDefault()
     {
@@ -64,27 +60,6 @@ public class SharingLogicWrapperTests
         );
         Assert.That(actual, Is.True);
         Assert.That(results, Is.Empty);
-    }
-
-    [Test]
-    public void ShareChanges_ThrowsExceptionIfObserver()
-    {
-        // Setup
-        var env = new TestEnvironment();
-
-        // Create a shared project with a user that is an observer
-        var sharedProject = new SharedProject { Permissions = new ParatextRegistryPermissionManager(ParatextUser01) };
-        sharedProject.Permissions.CreateUser(ParatextUser01);
-
-        // SUT
-        Assert.Throws<InvalidOperationException>(() =>
-            env.Service.ShareChanges(
-                sharedProjects: [sharedProject],
-                new SharedRepositorySource(),
-                out List<SendReceiveResult> _,
-                reviewProjects: []
-            )
-        );
     }
 
     private class TestEnvironment


### PR DESCRIPTION
This PR resolves SF-3422 (a bug introduced by SF-3241 / #3061) by allowing Observers to sync projects if there are no outgoing changes to Paratext.

This scenario occurs if a project only has users who are observers in Scripture Forge, and this project is a source project for translation suggestions or drafting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3277)
<!-- Reviewable:end -->
