### PR TITLE
Improve contrast of draft history cancelled indicator

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/_draft-history-entry-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/_draft-history-entry-theme.scss
@@ -5,7 +5,7 @@
 
   --draft-history-entry-red-color: #{if($is-dark, red, darkRed)};
   --draft-history-entry-green-color: #{if($is-dark, lightGreen, darkGreen)};
-  --draft-history-entry-grey-color: lightGrey;
+  --draft-history-entry-grey-color: #{if($is-dark, hsl(0 0% 60%), hsl(0 0% 45%))};
 }
 
 @mixin theme($theme) {


### PR DESCRIPTION
Before | After
-------|------
![](https://github.com/user-attachments/assets/590729ca-8d95-47dc-80dc-786a6357fe18) | ![](https://github.com/user-attachments/assets/fe711689-345c-4dc3-ac14-f624c55ff069)

This brings the contrast ratio up to the AA standard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3278)
<!-- Reviewable:end -->
