### PR TITLE
SF-3385 Hide lynx when chapter usfm is invalid

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4245,9 +4245,10 @@ describe('EditorComponent', () => {
       it('should not show lynx features when feature flag is not enabled', fakeAsync(async () => {
         const env = new TestEnvironment(() => {
           when(mockedFeatureFlagService.enableLynxInsights).thenReturn(createTestFeatureFlag(false));
-          const textDocService = TestBed.inject(TextDocService);
-          spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         });
+
+        const textDocService = TestBed.inject(TextDocService);
+        spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         env.setCurrentUser('user03');
         env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 2 });
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
@@ -4263,9 +4264,10 @@ describe('EditorComponent', () => {
       it('should not show lynx features if user has no chapter edit permissions', fakeAsync(async () => {
         const env = new TestEnvironment(() => {
           when(mockedFeatureFlagService.enableLynxInsights).thenReturn(createTestFeatureFlag(true));
-          const textDocService = TestBed.inject(TextDocService);
-          spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         });
+
+        const textDocService = TestBed.inject(TextDocService);
+        spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         env.setCurrentUser('user03');
         env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 1 });
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
@@ -4281,9 +4283,10 @@ describe('EditorComponent', () => {
       it('should not show lynx features when USFM is invalid', fakeAsync(async () => {
         const env = new TestEnvironment(() => {
           when(mockedFeatureFlagService.enableLynxInsights).thenReturn(createTestFeatureFlag(true));
-          const textDocService = TestBed.inject(TextDocService);
-          spyOn(textDocService, 'isUsfmValidForText').and.returnValue(false);
         });
+
+        const textDocService = TestBed.inject(TextDocService);
+        spyOn(textDocService, 'isUsfmValidForText').and.returnValue(false);
         env.setCurrentUser('user03');
         env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 2 });
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
@@ -4296,12 +4299,42 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
+      it('should not show lynx features when changing chapter from USFM valid to chapter USFM invalid', fakeAsync(async () => {
+        const env = new TestEnvironment(() => {
+          when(mockedFeatureFlagService.enableLynxInsights).thenReturn(createTestFeatureFlag(true));
+        });
+
+        const textDocService = TestBed.inject(TextDocService);
+        const textDocService_isUsfmValidForText_Spy = spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
+        spyOn(textDocService, 'hasChapterEditPermissionForText').and.returnValue(true); // Force edit permission true
+        env.setCurrentUser('user03');
+        env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 2 });
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });
+        env.wait();
+
+        expect(env.component.hasChapterEditPermission).toBe(true);
+        expect(env.component.isUsfmValid).toBe(true);
+        expect(env.component.showInsights).toBe(true);
+
+        // Change chapters to one with invalid USFM
+        textDocService_isUsfmValidForText_Spy.and.returnValue(false);
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        expect(env.component.hasChapterEditPermission).toBe(true);
+        expect(env.component.isUsfmValid).toBe(false);
+        expect(env.component.showInsights).toBe(false);
+
+        env.dispose();
+      }));
+
       it('should show lynx features when feature flag is enabled and user has chapter edit permissions and USFM is valid', fakeAsync(async () => {
         const env = new TestEnvironment(() => {
           when(mockedFeatureFlagService.enableLynxInsights).thenReturn(createTestFeatureFlag(true));
-          const textDocService = TestBed.inject(TextDocService);
-          spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         });
+
+        const textDocService = TestBed.inject(TextDocService);
+        spyOn(textDocService, 'isUsfmValidForText').and.returnValue(true);
         env.setCurrentUser('user03');
         env.setProjectUserConfig({ selectedBookNum: 42, selectedChapterNum: 2 });
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK' });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -67,19 +67,7 @@ import {
   Subscription,
   timer
 } from 'rxjs';
-import {
-  debounceTime,
-  distinctUntilChanged,
-  filter,
-  first,
-  map,
-  repeat,
-  retry,
-  switchMap,
-  take,
-  tap,
-  throttleTime
-} from 'rxjs/operators';
+import { debounceTime, filter, first, map, repeat, retry, switchMap, take, tap, throttleTime } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { CONSOLE, ConsoleInterface } from 'xforge-common/browser-globals';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -296,7 +284,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     this.chapter$
   ]).pipe(
     map(([_, chapterNum]) => this.textDocService.hasChapterEditPermissionForText(this.text, chapterNum)),
-    distinctUntilChanged(),
     tap(hasPermission => (this.hasChapterEditPermission = hasPermission)) // Cache for non-reactive access
   );
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -707,7 +707,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     // Show insights only if the feature flag is enabled and the user has chapter edit permissions
     combineLatest([this.featureFlagService.enableLynxInsights.enabled$, this.hasChapterEditPermission$])
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
-      .subscribe(([ffEnabled, hasEditPermission]) => (this.showInsights = ffEnabled && !!hasEditPermission));
+      .subscribe(([ffEnabled, hasEditPermission]) => {
+        this.showInsights = ffEnabled && !!hasEditPermission && this.isUsfmValid;
+        return this.showInsights;
+      });
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
This PR adds valid USFM for chapter to the conditions for showing lynx insights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3280)
<!-- Reviewable:end -->
