### PR TITLE
Add short name to confirm sources component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -12,7 +12,7 @@
     <div class="sources">
       @for (project of trainingSources; track project.paratextId) {
         <div class="project">
-          <span class="project-name">{{ project.name }}</span>
+          <span class="project-name">{{ projectLabel(project) }}</span>
           <span class="language-code">
             {{ t("language_code") }} <strong>{{ project.languageTag }}</strong>
           </span>
@@ -23,7 +23,7 @@
     <div class="targets">
       @for (project of trainingTargets; track project.paratextId) {
         <div class="project">
-          <span class="project-name">{{ project.name }}</span>
+          <span class="project-name">{{ projectLabel(project) }}</span>
           <span class="language-code">
             {{ t("language_code") }} <strong>{{ project.languageTag }}</strong>
           </span>
@@ -36,7 +36,7 @@
   <div class="translation-data">
     @for (project of draftingSources; track project.paratextId) {
       <div class="project">
-        <span class="project-name">{{ project.name }}</span>
+        <span class="project-name">{{ projectLabel(project) }}</span>
         <span class="language-code">
           {{ t("language_code") }} <strong>{{ project.languageTag }}</strong>
         </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -6,6 +6,7 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { I18nService } from 'xforge-common/i18n.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SelectableProjectWithLanguageCode } from '../../../core/paratext.service';
+import { projectLabel } from '../../../shared/utils';
 import {
   DraftSourcesAsSelectableProjectArrays,
   draftSourcesAsTranslateSourceArraysToDraftSourcesAsSelectableProjectArrays,
@@ -38,6 +39,10 @@ export class ConfirmSourcesComponent {
         );
       }
     });
+  }
+
+  projectLabel(project: SelectableProjectWithLanguageCode): string {
+    return projectLabel(project);
   }
 
   get trainingSources(): SelectableProjectWithLanguageCode[] {


### PR DESCRIPTION
This brings the display of the projects more inline with how we show projects elsewhere in the application.

![](https://github.com/user-attachments/assets/f0c343f4-764c-4cfd-8fe1-594672360a5a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3285)
<!-- Reviewable:end -->
