### PR TITLE
SF-3430 Fix insight loading on editor edit

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
@@ -102,13 +102,7 @@ describe('LynxInsightStateService', () => {
     );
 
     when(mockLynxWorkspaceService.rawInsightSource$).thenReturn(rawInsightSource);
-    when(mockLynxWorkspaceService.currentInsights).thenReturn(
-      new Map<string, LynxInsight[]>([
-        ['project1:MAT:1', [testInsights[0], testInsights[1]]],
-        ['project1:MAT:2', [testInsights[2]]],
-        ['project1:MRK:1', [testInsights[3]]]
-      ])
-    );
+    when(mockLynxWorkspaceService.currentInsights).thenReturn(testInsights);
     when(mockActivatedBookChapterService.activatedBookChapter$).thenReturn(activatedBookChapter);
     when(mockActivatedProjectUserConfigService.projectUserConfig$).thenReturn(projectUserConfig$);
     when(mockActivatedProjectUserConfigService.projectUserConfigDoc$).thenReturn(projectUserConfigDoc$);
@@ -174,7 +168,7 @@ describe('LynxInsightStateService', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should find insight by id from current insights map', () => {
+    it('should find insight by id', () => {
       const result = service.getInsight('test-2');
       expect(result).toBeDefined();
       expect(result?.id).toBe('test-2');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.ts
@@ -159,13 +159,7 @@ export class LynxInsightStateService {
   }
 
   getInsight(id: string): LynxInsight | undefined {
-    for (const insights of this.lynxWorkspaceService.currentInsights.values()) {
-      const insight = insights.find(i => i.id === id);
-      if (insight != null) {
-        return insight;
-      }
-    }
-    return undefined;
+    return this.lynxWorkspaceService.currentInsights.find(i => i.id === id);
   }
 
   setActiveInsights(ids: string[]): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.spec.ts
@@ -279,6 +279,91 @@ describe('LynxInsightsPanelComponent', () => {
 
       verify(mockLynxInsightStateService.restoreDismissedInsights(deepEqual(['insight-1']))).once();
     }));
+
+    it('should call processExpandedNode when onNodeExpansionChange is called with isExpanded=true', fakeAsync(() => {
+      const testEnvironment = new TestEnvironment({ insights: [testInsight1, testInsight2] });
+      const parentNode: InsightPanelNode = {
+        description: 'Parent node',
+        type: 'warning',
+        range: { index: 0, length: 5 },
+        children: [
+          {
+            description: 'Child node',
+            type: 'warning',
+            insight: testInsight1,
+            range: { index: 0, length: 5 }
+          }
+        ]
+      };
+
+      spyOn<any>(testEnvironment.component, 'processExpandedNode');
+      testEnvironment.component.onNodeExpansionChange(parentNode, true);
+
+      expect(testEnvironment.component['processExpandedNode']).toHaveBeenCalledOnceWith(parentNode);
+    }));
+
+    it('should not call processExpandedNode when onNodeExpansionChange is called with isExpanded=false', fakeAsync(() => {
+      const testEnvironment = new TestEnvironment({ insights: [testInsight1, testInsight2] });
+      const parentNode: InsightPanelNode = {
+        description: 'Parent node',
+        type: 'warning',
+        range: { index: 0, length: 5 },
+        children: [
+          {
+            description: 'Child node',
+            type: 'warning',
+            insight: testInsight1,
+            range: { index: 0, length: 5 }
+          }
+        ]
+      };
+
+      spyOn<any>(testEnvironment.component, 'processExpandedNode');
+      testEnvironment.component.onNodeExpansionChange(parentNode, false);
+
+      expect(testEnvironment.component['processExpandedNode']).not.toHaveBeenCalled();
+    }));
+
+    it('should not call processExpandedNode for nodes without children', fakeAsync(() => {
+      const testEnvironment = new TestEnvironment({ insights: [testInsight1, testInsight2] });
+      const leafNode: InsightPanelNode = {
+        description: 'Leaf node',
+        type: 'warning',
+        insight: testInsight1,
+        range: { index: 0, length: 5 }
+      };
+
+      spyOn<any>(testEnvironment.component, 'processExpandedNode');
+      testEnvironment.component.onNodeExpansionChange(leafNode, true);
+
+      expect(testEnvironment.component['processExpandedNode']).not.toHaveBeenCalled();
+    }));
+
+    it('should call processExpandedNode during restoreExpandCollapseState for expanded nodes', fakeAsync(() => {
+      const testEnvironment = new TestEnvironment({ insights: [testInsight1, testInsight2] });
+      testEnvironment.component['expandCollapseState'].set('Parent node', true);
+
+      const parentNode: InsightPanelNode = {
+        description: 'Parent node',
+        type: 'warning',
+        range: { index: 0, length: 5 },
+        children: [
+          {
+            description: 'Child node',
+            type: 'warning',
+            insight: testInsight1,
+            range: { index: 0, length: 5 }
+          }
+        ]
+      };
+
+      testEnvironment.component.treeDataSource = [parentNode];
+
+      spyOn<any>(testEnvironment.component, 'processExpandedNode');
+      testEnvironment.component['restoreExpandCollapseState']();
+
+      expect(testEnvironment.component['processExpandedNode']).toHaveBeenCalledOnceWith(parentNode);
+    }));
   });
 
   describe('Paged loading', () => {


### PR DESCRIPTION
This PR fixes the issue where editor edits were causing "Loading..." to show for expanded nodes in the lynx problems panel.
Two issue were the cause of this:
-  In `LynxWorkspaceService`, `DiagnosticsChanged` event is firing multiple times for the same URI (once for each diagnostic source), causing insight ids to change for unchanged insights.
- In `LynxInsightsPanelComponent`, the processing of child nodes was only being triggered on expansion of the parent node, so if the parent node was already expanded when the edit was made, the child node would be stuck at 'loading'.

The first issue was fixed by grouping diagnostics in the `DiagnosticsChanged` event by source to prevent insight tracking for a different diagnostic source from being cleared when processing.

The second issue was fixed by calling the code to process the expanded node when restoring expand/collapse state after a tree rebuild.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3288)
<!-- Reviewable:end -->
