### PR TITLE
SF-3444 Prevent error when rapidly clicking Lynx panel insights

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.ts
@@ -88,10 +88,10 @@ export class LynxInsightOverlayService {
         }
       });
 
-    // When initially displayed, scroll editor if necessary to ensure overlay is displayed within editor bounds
-    setTimeout(() => this.ensureOverlayWithinEditorBounds(overlayRef.ref));
-
     this.openRef = overlayRef;
+
+    // When initially displayed, scroll editor if necessary to ensure overlay is displayed within editor bounds
+    setTimeout(() => this.ensureOverlayWithinEditorBounds());
 
     return overlayRef;
   }
@@ -174,8 +174,10 @@ export class LynxInsightOverlayService {
   /**
    * Ensures the overlay is fully within the editor bounds.
    */
-  private ensureOverlayWithinEditorBounds(overlayRef: OverlayRef): void {
-    if (this.scrollableContainer == null) {
+  private ensureOverlayWithinEditorBounds(): void {
+    const overlayRef: OverlayRef | undefined = this.openRef?.ref;
+
+    if (this.scrollableContainer == null || overlayRef?.overlayElement == null) {
       return;
     }
 


### PR DESCRIPTION
This PR fixes a timing issue that caused a null reference error due to the 'setTimeout' used when calling `ensureOverlayWithinEditorBounds()`.
- Changed `ensureOverlayWithinEditorBounds()` to use the instance variable `openRef` instead of passing in overlay ref.
- Added null check for `overlayElement` inside `ensureOverlayWithinEditorBounds()` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3290)
<!-- Reviewable:end -->
