### PR TITLE
SF-3448 Add resource usage monitoring to RealtimeServer

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -10,6 +10,7 @@ import './diagnostics';
 import { ExceptionReporter } from './exception-reporter';
 import { MetadataDB } from './metadata-db';
 import { RealtimeServer, RealtimeServerConstructor } from './realtime-server';
+import { ResourceMonitor } from './resource-monitor';
 import { SchemaVersionRepository } from './schema-version-repository';
 import { WebSocketStreamListener } from './web-socket-stream-listener';
 
@@ -186,6 +187,7 @@ export = {
     connection.on('error', err => console.log(err));
     const index = connectionIndex++;
     connections.set(index, connection);
+    ResourceMonitor.instance.startMonitoringConnection(connection);
     callback(undefined, index);
   },
 
@@ -193,6 +195,10 @@ export = {
     if (server == null) {
       callback(new Error('Server not started.'));
       return;
+    }
+    const conn = connections.get(handle);
+    if (conn != null) {
+      ResourceMonitor.instance.stopMonitoringConnection(conn);
     }
     connections.delete(handle);
     callback(undefined, {});

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -7,6 +7,7 @@ import { Connection, Doc, Op, RawOp } from 'sharedb/lib/client';
 import { ConnectSession } from './connect-session';
 import { Project } from './models/project';
 import { SchemaProperties, ValidationSchema } from './models/validation-schema';
+import { ResourceMonitor } from './resource-monitor';
 import { SchemaVersionRepository } from './schema-version-repository';
 import { DocService } from './services/doc-service';
 import { createFetchQuery, docFetch } from './utils/sharedb-utils';
@@ -394,6 +395,14 @@ export class RealtimeServer extends ShareDB {
     });
 
     this.defaultConnection = this.connect();
+
+    // Report memory usages, but not when running a migration.
+    if (!this.dataValidationDisabled) {
+      const resourceMonitor = ResourceMonitor.instance;
+      resourceMonitor.setPubSub((this as any).pubsub);
+      resourceMonitor.startMonitoringConnection(this.defaultConnection);
+      resourceMonitor.start();
+    }
   }
 
   async addValidationSchema(db: Db): Promise<void> {
@@ -416,11 +425,14 @@ export class RealtimeServer extends ShareDB {
     if (connectionOrUserId instanceof Connection) {
       connection = connectionOrUserId;
     } else {
-      connection = new MigrationConnection({
+      // Temporary socket that is used in constructing the Connection, but quickly replaced with a new socket in ShareDB
+      // backend.js connect().
+      const tmpSocket = {
         close: () => {
           // do nothing
         }
-      } as WebSocket);
+      } as WebSocket;
+      connection = new MigrationConnection(tmpSocket);
       if (connectionOrUserId != null) {
         req = { userId: connectionOrUserId };
       }
@@ -429,7 +441,9 @@ export class RealtimeServer extends ShareDB {
   }
 
   listen(stream: any, req?: any): ShareDB.Agent {
+    // Streams of types WebSocketJSONStream and ServerStream are received by this method.
     const agent = new MigrationAgent(this, stream);
+    ResourceMonitor.instance.monitorAgent(agent, stream);
     this.trigger('connect', agent, { stream, req }, err => {
       if (err) {
         return agent.close(err);

--- a/src/RealtimeServer/common/resource-monitor.ts
+++ b/src/RealtimeServer/common/resource-monitor.ts
@@ -1,0 +1,293 @@
+import * as fs from 'fs';
+import sizeof from 'object-sizeof';
+import * as path from 'path';
+import ShareDB, { Agent, PubSub } from 'sharedb';
+import { Connection } from 'sharedb/lib/client';
+import { Duplex } from 'stream';
+import { ConnectSession } from './connect-session';
+import './sharedb-extensions';
+
+/**
+ * Defines some fields on the ShareDB Connection type in connection.js, to be used for measuring purposes.
+ */
+export interface ConnectionInternal {
+  id: string;
+  collections: Record<string, Record<string, { data: any }>>;
+  queries: Record<string, { results: any }>;
+  _presences: Record<string, unknown>;
+  _snapshotRequests: Record<string, unknown>;
+  agent: Agent | null;
+}
+
+/**
+ * Information about a connection for monitoring purposes
+ */
+export interface ConnectionInfo {
+  timestamp: string;
+  id: string;
+  collectionsDocsCount: number;
+  collectionsDocsBytes: number;
+  queriesCount: number;
+  queriesBytes: number;
+  presencesCount: number;
+  snapshotRequestsCount: number;
+}
+
+/**
+ * Defines some fields on the ShareDB Agent type in agent.js, used for measuring purposes.
+ */
+export interface AgentInternal {
+  src: string | null;
+  clientId: string;
+  connectTime: number;
+  subscribedDocs: Record<string, Record<string, unknown>>;
+  subscribedQueries: Record<string, { query: unknown | undefined; streams: unknown }>;
+  subscribedPresences: Record<string, unknown>;
+  connectSession: ConnectSession | undefined;
+}
+
+/**
+ * Information about a ShareDB Agent for monitoring purposes
+ */
+export interface AgentInfo {
+  timestamp: string;
+  src: string | null;
+  clientId: string;
+  connectTime: number;
+  connectSessionUserId: string | undefined;
+  subscribedDocsCount: number;
+  subscribedDocsBytes: number;
+  subscribedPresencesCount: number;
+  subscribedPresencesBytes: number;
+  subscribedQueriesCount: number;
+  subscribedQueriesBytes: number;
+}
+
+/**
+ * Defines some fields on the ShareDB PubSub type in pubsub/index.js, used for measuring purposes.
+ */
+export interface PubSubInternal {
+  nextStreamId: number;
+  streamsCount: number;
+  streams: Record<string, Record<string, unknown>>;
+  subscribed: Record<string, true>;
+}
+
+/**
+ * Information about ShareDB PubSub for monitoring purposes
+ */
+export interface PubSubInfo {
+  timestamp: string;
+  nextStreamId: number;
+  streamsCount: number;
+  streamsBytes: number;
+  subscribedCount: number;
+  subscribedBytes: number;
+}
+
+/**
+ * Snapshot of measured memory usage information.
+ */
+interface ResourceUsageData {
+  /**  When measured */
+  timestamp: string;
+  /** NodeJS process ID */
+  pid: number;
+  /** How long the process has been running, in seconds. */
+  runtimeS: number;
+  rssBytes: number;
+  heapTotalBytes: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+  /** Note: This is also included in the externalBytes value. */
+  arrayBuffersBytes: number;
+  /** Free memory Bytes "still available to the process". This may match `free --bytes` "available". */
+  availableMemoryBytes: number;
+}
+
+/**
+ * Monitors and reports on various memory usages.
+ */
+export class ResourceMonitor {
+  /** Singleton. */
+  public static readonly instance: ResourceMonitor = new ResourceMonitor();
+  /** How often to record resource usage. */
+  private intervalMs: number;
+  /** Agent objects being monitored. */
+  private readonly agents: Set<ShareDB.Agent> = new Set<ShareDB.Agent>();
+  private readonly connections: Set<Connection> = new Set<Connection>();
+  private pubSub: PubSub | undefined;
+  private readonly heapInfoPath: string;
+  private readonly connectionInfoPath: string;
+  private readonly agentInfoPath: string;
+  private readonly pubSubInfoPath: string;
+
+  private constructor() {
+    this.heapInfoPath = path.join(process.cwd(), 'heap-info.csv');
+    this.connectionInfoPath = path.join(process.cwd(), 'connection-info.csv');
+    this.agentInfoPath = path.join(process.cwd(), 'agent-info.csv');
+    this.pubSubInfoPath = path.join(process.cwd(), 'pubsub-info.csv');
+    const minutes: number = 30;
+    this.intervalMs = minutes * 60 * 1000;
+  }
+
+  /** Begin periodic monitoring. */
+  public start(): void {
+    setInterval(() => this.record(), this.intervalMs);
+    this.record();
+  }
+
+  public startMonitoringConnection(connection: Connection): void {
+    if (this.connections.has(connection)) return;
+    this.connections.add(connection);
+  }
+
+  public stopMonitoringConnection(connection: Connection): void {
+    this.stopMonitoringAgentOnConnection(connection);
+    this.connections.delete(connection);
+  }
+
+  public monitorAgent(agent: ShareDB.Agent, stream: Duplex): void {
+    if (this.agents.has(agent)) return;
+    this.agents.add(agent);
+    // When the agent's stream closes, stop monitoring the agent.
+    stream.once('close', () => this.agents.delete(agent));
+  }
+
+  public stopMonitoringAgentOnConnection(connection: Connection): void {
+    const conn: ConnectionInternal = connection as unknown as ConnectionInternal;
+    const agent: ShareDB.Agent | null = conn.agent;
+    if (agent == null) return;
+    this.agents.delete(agent);
+  }
+
+  public setPubSub(pubSub: PubSub): void {
+    this.pubSub = pubSub;
+  }
+
+  private record(): void {
+    this.recordHeapUsage();
+    this.recordConnectionDiagnostics();
+    this.recordAgentDiagnostics();
+    this.recordPubSubDiagnostics();
+  }
+
+  private recordConnectionDiagnostics(): void {
+    const connections = Array.from(this.connections.values());
+    const report: ConnectionInfo[] = connections.map((connection: Connection) => this.reportOnConnection(connection));
+    this.saveToCsv(this.connectionInfoPath, report);
+  }
+
+  private recordAgentDiagnostics(): void {
+    const report: AgentInfo[] = Array.from(this.agents.values()).map(agent => this.reportOnAgent(agent));
+    this.saveToCsv(this.agentInfoPath, report);
+  }
+
+  private recordPubSubDiagnostics(): void {
+    if (this.pubSub === undefined) return;
+    const report = this.reportOnPubSub(this.pubSub);
+    this.saveToCsv(this.pubSubInfoPath, [report]);
+  }
+
+  private reportOnConnection(connection: Connection): ConnectionInfo {
+    const conn: ConnectionInternal = connection as unknown as ConnectionInternal;
+    const report: ConnectionInfo = {
+      timestamp: new Date().toISOString(),
+      id: conn.id,
+      collectionsDocsCount: Object.values(conn.collections).reduce(
+        (count, docs) => count + Object.keys(docs).length,
+        0
+      ),
+      // Just measure data items to avoid circular reference.
+      collectionsDocsBytes: Object.values(conn.collections).reduce(
+        (collectionsBytes, coll) =>
+          collectionsBytes + Object.values(coll).reduce((docsBytes, doc) => docsBytes + sizeof(doc.data), 0),
+        0
+      ),
+      queriesCount: Object.keys(conn.queries).length,
+      // Avoid circular reference.
+      queriesBytes: Object.values(conn.queries).reduce((totalBytes, query) => totalBytes + sizeof(query.results), 0),
+      presencesCount: Object.keys(conn._presences).length,
+      snapshotRequestsCount: Object.keys(conn._snapshotRequests).length
+    };
+    return report;
+  }
+
+  private reportOnAgent(agent: ShareDB.Agent): AgentInfo {
+    const ag: AgentInternal = agent as unknown as AgentInternal;
+    // QueryEmitter has a circular reference and so we can not use sizeof. Substitute in a sum of the interesting field
+    // sizes.
+    const subscribedQueriesBytes: number = Object.values(ag.subscribedQueries).reduce(
+      (sum, queryEmitter) => sum + sizeof(queryEmitter.query) + sizeof(queryEmitter.streams),
+      0
+    );
+    const agentInfo: AgentInfo = {
+      timestamp: new Date().toISOString(),
+      src: ag.src,
+      clientId: ag.clientId,
+      connectTime: ag.connectTime,
+      connectSessionUserId: ag.connectSession?.userId,
+      subscribedDocsCount: Object.keys(ag.subscribedDocs).length,
+      subscribedDocsBytes: sizeof(ag.subscribedDocs),
+      subscribedPresencesCount: Object.keys(ag.subscribedPresences).length,
+      subscribedPresencesBytes: sizeof(ag.subscribedPresences),
+      subscribedQueriesCount: Object.keys(ag.subscribedQueries).length,
+      subscribedQueriesBytes
+    };
+    return agentInfo;
+  }
+
+  private reportOnPubSub(pubsub: PubSub): PubSubInfo {
+    const ps: PubSubInternal = pubsub as unknown as PubSubInternal;
+    const pubsubInfo: PubSubInfo = {
+      timestamp: new Date().toISOString(),
+      nextStreamId: ps.nextStreamId,
+      streamsCount: ps.streamsCount,
+      streamsBytes: sizeof(ps.streams),
+      subscribedCount: Object.keys(ps.subscribed).length,
+      subscribedBytes: sizeof(ps.subscribed)
+    };
+    return pubsubInfo;
+  }
+
+  private recordHeapUsage(): void {
+    // Measuring memory is more meaningful if GC runs first. The NodeJS process must be started with --expose-gc for
+    // this to work..
+    if (typeof global.gc === 'function') global.gc();
+
+    const memoryUsage: NodeJS.MemoryUsage = process.memoryUsage();
+
+    const data: ResourceUsageData = {
+      timestamp: new Date().toISOString(),
+      pid: process.pid,
+      runtimeS: Math.floor(process.uptime()),
+      rssBytes: memoryUsage.rss,
+      heapTotalBytes: memoryUsage.heapTotal,
+      heapUsedBytes: memoryUsage.heapUsed,
+      externalBytes: memoryUsage.external,
+      arrayBuffersBytes: memoryUsage.arrayBuffers,
+      availableMemoryBytes: process.availableMemory()
+    };
+    this.saveToCsv(this.heapInfoPath, [data]);
+  }
+
+  /** Write data to a CSV file. If needed, create header row from the data's objects' keys. */
+  private saveToCsv<T extends object>(filePath: string, data: T[]): void {
+    if (data.length === 0) return;
+    try {
+      const fileExists: boolean = fs.existsSync(filePath);
+      const fields: (keyof T)[] = Object.keys(data[0]) as (keyof T)[];
+      const rows: string[] = data.map(item => {
+        return fields.map(field => item[field]).join(',');
+      });
+
+      if (!fileExists) {
+        const rowHeaders: string = fields.join(',');
+        fs.writeFileSync(filePath, rowHeaders + '\n');
+      }
+      fs.appendFileSync(filePath, rows.join('\n') + '\n');
+    } catch (error) {
+      console.error(`Ignoring error writing to ${filePath}:`, error);
+    }
+  }
+}

--- a/src/RealtimeServer/package-lock.json
+++ b/src/RealtimeServer/package-lock.json
@@ -21,6 +21,7 @@
         "jwks-rsa": "^2.1.2",
         "lodash-es": "^4.17.21",
         "mongodb": "^4.17.2",
+        "object-sizeof": "^2.6.5",
         "ot-json0": "^1.1.0",
         "rich-text": "^4.1.0",
         "sharedb": "^5.1.1",
@@ -7142,6 +7143,39 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-sizeof": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-2.6.5.tgz",
+      "integrity": "sha512-Mu3udRqIsKpneKjIEJ2U/s1KmEgpl+N6cEX1o+dDl2aZ+VW5piHqNgomqAk5YMsDoSkpcA8HnIKx1eqGTKzdfw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/object-sizeof/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/object.assign": {
@@ -14271,6 +14305,25 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object-sizeof": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-2.6.5.tgz",
+      "integrity": "sha512-Mu3udRqIsKpneKjIEJ2U/s1KmEgpl+N6cEX1o+dDl2aZ+VW5piHqNgomqAk5YMsDoSkpcA8HnIKx1eqGTKzdfw==",
+      "requires": {
+        "buffer": "^6.0.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
     },
     "object.assign": {
       "version": "4.1.2",

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -33,6 +33,7 @@
     "jwks-rsa": "^2.1.2",
     "lodash-es": "^4.17.21",
     "mongodb": "^4.17.2",
+    "object-sizeof": "^2.6.5",
     "ot-json0": "^1.1.0",
     "rich-text": "^4.1.0",
     "sharedb": "^5.1.1",

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -31,6 +31,7 @@
   "Realtime": {
     "Port": 5003
   },
+  "node-options": "--expose-gc",
   "Bugsnag": {
     "ApiKey": "b72a46a8924a3cd161d4c5534287923c",
     "AppType": ".NET",


### PR DESCRIPTION
With additional insight into ShareDB object types, periodically record
memory usage of active ShareDB Agent and Connection objects, and the
ShareDB PubSub, as well as NodeJS heap usage. These measurements are
stored in .csv files.

To improve usefulness of heap reporting, garbage collection is run
immediately before measuring heap usage.

Object memory measurement is approximate, done in consideration of an
object's JSON representation string length.
