### PR TITLE
SF-3454 Fix remaining issues with the new draft user interface

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -146,7 +146,9 @@
                     ><transloco
                       key="draft_generation.warning_generation_faulted"
                       [params]="{
-                        generateButtonText: t('generate_draft_button')
+                        generateButtonText: featureFlags.newDraftHistory.enabled
+                          ? t('generate_new_draft')
+                          : t('generate_draft_button')
                       }"
                     ></transloco
                   ></span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -346,7 +346,12 @@
         hasAnyCompletedBuild &&
         isSourcesConfigurationComplete
       ) {
-        <button mat-flat-button color="primary" type="button" (click)="generateDraft({ withConfirm: true })">
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          (click)="generateDraft({ withConfirm: !featureFlags.newDraftHistory.enabled })"
+        >
           <mat-icon>add</mat-icon>
           {{ t("generate_new_draft") }}
         </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -157,27 +157,29 @@
                   </a>
                 </div>
               </app-notice>
-              <section data-test-id="technical-details">
-                <div>
-                  <p class="error-text">Technical details:</p>
+              @if (!featureFlags.newDraftHistory.enabled) {
+                <section data-test-id="technical-details">
                   <div>
-                    <div><strong>Message:</strong> {{ draftJob?.message ?? "unknown" }}</div>
+                    <p class="error-text">Technical details:</p>
                     <div>
-                      <strong>Translation Engine Id:</strong>
-                      {{ draftJob?.additionalInfo?.translationEngineId ?? "unknown" }}
-                    </div>
-                    <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId ?? "unknown" }}</div>
-                    <div>
-                      <strong>Corpora Ids:</strong>
-                      {{ draftJob?.additionalInfo?.corporaIds?.join(", ") ?? "unknown" }}
-                    </div>
-                    <div>
-                      <strong>Parallel Corpora Ids:</strong>
-                      {{ draftJob?.additionalInfo?.parallelCorporaIds?.join(", ") ?? "unknown" }}
+                      <div><strong>Message:</strong> {{ draftJob?.message ?? "unknown" }}</div>
+                      <div>
+                        <strong>Translation Engine Id:</strong>
+                        {{ draftJob?.additionalInfo?.translationEngineId ?? "unknown" }}
+                      </div>
+                      <div><strong>Build Id:</strong> {{ draftJob?.additionalInfo?.buildId ?? "unknown" }}</div>
+                      <div>
+                        <strong>Corpora Ids:</strong>
+                        {{ draftJob?.additionalInfo?.corporaIds?.join(", ") ?? "unknown" }}
+                      </div>
+                      <div>
+                        <strong>Parallel Corpora Ids:</strong>
+                        {{ draftJob?.additionalInfo?.parallelCorporaIds?.join(", ") ?? "unknown" }}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </section>
+                </section>
+              }
             }
             @if (!isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {
               <section class="action-button-strip">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -218,4 +218,9 @@ mat-panel-description {
   display: flex;
   align-items: center;
   gap: 24px;
+
+  /* Do not allow the cancel button text to split onto two lines */
+  button {
+    white-space: nowrap;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -32,6 +32,20 @@
             }
           </div>
         }
+        @if (buildFaulted) {
+          <p>
+            <strong>{{ t("error_details") }}</strong>
+          </p>
+          <table mat-table [dataSource]="buildFaultDetails">
+            <ng-container matColumnDef="heading">
+              <td mat-cell *matCellDef="let element">{{ element.heading }}</td>
+            </ng-container>
+            <ng-container matColumnDef="details">
+              <td mat-cell *matCellDef="let element">{{ element.details }}</td>
+            </ng-container>
+            <tr mat-row *matRowDef="let row; columns: ['heading', 'details']"></tr>
+          </table>
+        }
         @if (hasTrainingConfiguration) {
           @if (canDownloadBuild) {
             <p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
@@ -67,3 +67,8 @@ strong {
 .red {
   color: var(--draft-history-entry-red-color);
 }
+
+/* Styling for the error details table */
+.mat-column-heading {
+  font-weight: bolder;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
@@ -1,5 +1,5 @@
 mat-expansion-panel-header {
-  padding: 8px 16px;
+  padding: 8px 24px;
 }
 
 mat-panel-title {
@@ -7,6 +7,7 @@ mat-panel-title {
   align-items: flex-start;
   flex-direction: column;
   flex-grow: 1;
+  flex: 0 1 50;
 }
 
 mat-panel-description {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -217,6 +217,46 @@ describe('DraftHistoryEntryComponent', () => {
       expect(component.hasDetails).toBe(false);
       expect(component.entry).toBe(entry);
     });
+
+    it('should handle faulted builds with additional info', () => {
+      const entry = {
+        state: BuildStates.Faulted,
+        message: 'An error occurred',
+        engine: { id: 'project01' },
+        additionalInfo: {
+          translationEngineId: 'translationEngine01',
+          buildId: 'build01',
+          corporaIds: ['corpora01'],
+          parallelCorporaIds: ['parallelCorpora01']
+        }
+      } as BuildDto;
+      component.entry = entry;
+      expect(component.scriptureRange).toEqual('');
+      expect(component.buildRequestedByUserName).toBeUndefined();
+      expect(component.buildRequestedByDate).toBe('');
+      expect(component.canDownloadBuild).toBe(false);
+      expect(component.hasDetails).toBe(true);
+      expect(component.entry).toBe(entry);
+      expect(component.buildFaulted).toBe(true);
+      expect(component.buildFaultDetails.length).toBe(6);
+    });
+
+    it('should handle faulted builds without additional info', () => {
+      const entry = {
+        state: BuildStates.Faulted,
+        message: 'An error occurred',
+        engine: { id: 'project01' }
+      } as BuildDto;
+      component.entry = entry;
+      expect(component.scriptureRange).toEqual('');
+      expect(component.buildRequestedByUserName).toBeUndefined();
+      expect(component.buildRequestedByDate).toBe('');
+      expect(component.canDownloadBuild).toBe(false);
+      expect(component.hasDetails).toBe(true);
+      expect(component.entry).toBe(entry);
+      expect(component.buildFaulted).toBe(true);
+      expect(component.buildFaultDetails.length).toBe(2);
+    });
   });
 
   describe('formatDate', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -54,8 +54,10 @@ export class DraftHistoryEntryComponent {
   @Input() set entry(value: BuildDto | undefined) {
     this._entry = value;
 
-    // See if a draft can be downloaded
-    this.canDownloadBuild = this._entry?.additionalInfo?.dateGenerated != null;
+    // Only set if a draft can be downloaded if it is not set externally
+    if (this._canDownloadBuild == null) {
+      this.canDownloadBuild = this._entry?.additionalInfo?.dateGenerated != null;
+    }
 
     // Get the user who requested the build
     this._buildRequestedByUserName = undefined;
@@ -145,7 +147,14 @@ export class DraftHistoryEntryComponent {
     return this._trainingConfiguration;
   }
 
-  @Input() canDownloadBuild = false;
+  private _canDownloadBuild: boolean | undefined;
+  @Input() set canDownloadBuild(value: boolean) {
+    this._canDownloadBuild = value;
+  }
+  get canDownloadBuild(): boolean {
+    return this._canDownloadBuild ?? false;
+  }
+
   @Input() isLatestBuild = false;
 
   trainingConfigurationOpen = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -272,6 +272,7 @@
     "draft_faulted": "Failed",
     "draft_pending": "Pending",
     "draft_unknown": "Unknown",
+    "error_details": "Please include these details when contacting support for assistance",
     "format_draft": "Format draft",
     "hide_model_training_configuration": "Hide model training configuration",
     "show_model_training_configuration": "Show model training configuration",

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -524,7 +524,9 @@ public class MachineApiService(
                 if (hasDraftIsFalseOrNullInScriptureRange)
                 {
                     // Chapters HasDraft is missing or false but should be true, retrieve the pre-translation status to update them.
-                    await RetrievePreTranslationStatusAsync(sfProjectId, cancellationToken);
+                    backgroundJobClient.Enqueue<IMachineApiService>(r =>
+                        r.RetrievePreTranslationStatusAsync(sfProjectId, CancellationToken.None)
+                    );
                 }
 
                 buildDto = CreateDto(translationBuild);

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -584,6 +584,14 @@ public class MachineApiService(
                     ) ?? throw new DataNotFoundException("Entity Deleted");
             }
 
+            // Notify any SignalR clients subscribed to the project of the current build's state
+            string buildId = translationBuild.Id;
+            string buildState = translationBuild.State.ToString();
+            await hubContext.NotifyBuildProgress(
+                sfProjectId,
+                new ServalBuildState { BuildId = buildId, State = buildState }
+            );
+
             buildDto = CreateDto(translationBuild);
             buildDto = UpdateDto(buildDto, project.TranslateConfig.DraftConfig);
             buildDto = UpdateDto(buildDto, sfProjectId);

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -758,8 +758,9 @@ public class MachineApiService(
             }
             else
             {
-                // If the webhook is running, display that as a build state to the user
-                if (preTranslate && projectSecret.ServalData.PreTranslationsRetrieved == false)
+                // If the webhook is running, and no build is queued, display that as a build state to the user
+                // We don't show this if a build is queued, as we will want that build's state to be displayed
+                if (preTranslate && queuedAt is null && projectSecret.ServalData.PreTranslationsRetrieved == false)
                 {
                     buildDto = new ServalBuildDto
                     {

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -161,7 +161,7 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         await env.ProjectSecrets.UpdateAsync(Project01, op => op.Unset(p => p.ServalData.PreTranslationEngineId));
-        await env.QueueBuildAsync(Project01, preTranslate: true);
+        await env.QueueBuildAsync(Project01, preTranslate: true, dateTime: DateTime.UtcNow);
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
@@ -178,7 +178,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        await env.QueueBuildAsync(Project01, preTranslate: true);
+        await env.QueueBuildAsync(Project01, preTranslate: true, dateTime: DateTime.UtcNow);
         env.ConfigureTranslationBuild();
 
         // SUT
@@ -597,7 +597,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        await env.QueueBuildAsync(Project01, preTranslate: true);
+        await env.QueueBuildAsync(Project01, preTranslate: true, dateTime: DateTime.UtcNow);
         env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult<IList<TranslationBuild>>([]));
         env.EventMetricService.GetEventMetricsAsync(Project01, Arg.Any<EventScope[]?>(), Arg.Any<string[]>())
@@ -625,7 +625,7 @@ public class MachineApiServiceTests
         const string trainingScriptureRange = "GEN;EXO";
         const string translationScriptureRange = "LEV;NUM";
         DateTime requestedDateTime = DateTime.UtcNow;
-        await env.QueueBuildAsync(Project01, preTranslate: true);
+        await env.QueueBuildAsync(Project01, preTranslate: true, dateTime: DateTime.UtcNow);
         env.TranslationEnginesClient.GetAllBuildsAsync(TranslationEngine01, CancellationToken.None)
             .Returns(Task.FromResult<IList<TranslationBuild>>([]));
         env.EventMetricService.GetEventMetricsAsync(Project01, Arg.Any<EventScope[]?>(), Arg.Any<string[]>())
@@ -2634,7 +2634,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        await env.QueueBuildAsync(Project01, preTranslate: false);
+        await env.QueueBuildAsync(Project01, preTranslate: false, dateTime: DateTime.UtcNow);
 
         // SUT
         ServalBuildDto? actual = await env.Service.GetQueuedStateAsync(
@@ -2709,7 +2709,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        await env.QueueBuildAsync(Project01, preTranslate: true);
+        await env.QueueBuildAsync(Project01, preTranslate: true, dateTime: DateTime.UtcNow);
 
         // SUT
         ServalBuildDto? actual = await env.Service.GetQueuedStateAsync(
@@ -2736,7 +2736,7 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        await env.QueueBuildAsync(Project02, preTranslate: true);
+        await env.QueueBuildAsync(Project02, preTranslate: true, dateTime: DateTime.UtcNow);
 
         // SUT
         ServalBuildDto? actual = await env.Service.GetQueuedStateAsync(
@@ -4113,7 +4113,7 @@ public class MachineApiServiceTests
         public async Task QueueBuildAsync(
             string sfProjectId,
             bool preTranslate,
-            DateTime? dateTime = null,
+            DateTime? dateTime,
             string? errorMessage = null,
             bool? preTranslationsRetrieved = null
         ) =>
@@ -4124,7 +4124,7 @@ public class MachineApiServiceTests
                     if (preTranslate)
                     {
                         u.Set(p => p.ServalData.PreTranslationJobId, JobId);
-                        u.Set(p => p.ServalData.PreTranslationQueuedAt, dateTime ?? DateTime.UtcNow);
+                        u.Set(p => p.ServalData.PreTranslationQueuedAt, dateTime);
                         u.Set(p => p.ServalData.PreTranslationsRetrieved, preTranslationsRetrieved);
                         if (string.IsNullOrWhiteSpace(errorMessage))
                         {
@@ -4138,7 +4138,7 @@ public class MachineApiServiceTests
                     else
                     {
                         u.Set(p => p.ServalData.TranslationJobId, JobId);
-                        u.Set(p => p.ServalData.TranslationQueuedAt, dateTime ?? DateTime.UtcNow);
+                        u.Set(p => p.ServalData.TranslationQueuedAt, dateTime);
                         if (string.IsNullOrWhiteSpace(errorMessage))
                         {
                             u.Unset(p => p.ServalData.TranslationErrorMessage);


### PR DESCRIPTION
This PR fixed the remaining issues with the new draft user interface. I have fixed each bug in a separate commit.

@Nateowami I am marking as a draft so you see if this fixes the issues you have been encountering, and if there are any additional bugs you are aware of to add to the  the ticket (https://jira.sil.org/browse/SF-3454)

Also, here is the interface for showing error details in a history item (the items will expand as data is available - this crash occurred before the build reached Serval):

![image](https://github.com/user-attachments/assets/112f961b-fa2b-4710-9d79-3026a97b4d3e)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3297)
<!-- Reviewable:end -->
