### PR TITLE
Update community checking e2e test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/test_characterization.json
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/test_characterization.json
@@ -12,12 +12,12 @@
     "failure": 0
   },
   "community_checking": {
-    "success": 39,
-    "failure": 2
+    "success": 13,
+    "failure": 1
   },
   "localized_screenshots": {
-    "success": 31,
-    "failure": 0
+    "success": 43,
+    "failure": 3
   },
   "edit_translation": {
     "success": 13,


### PR DESCRIPTION
In the past the "next question" button was often disabled when on the last question in a chapter. Now that that's been fixed, this test can be updated to no longer work around that by using the "next chapter" button when "next question" is disabled.

After making this change (and a few other minor changes to the same test), I recharacterized this test, and the localized_screenshots test, since I'd recently made changes to it and forgotten to recharacterize it.