### PR TITLE
SF-3043 Update tab header localizations when locale updated

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/base-services/tab-factory.service.ts
@@ -1,3 +1,3 @@
 export abstract class TabFactoryService<TType, T> {
-  abstract createTab(tabType: TType, tabOptions?: Partial<T>): Promise<T>;
+  abstract createTab(tabType: TType, tabOptions?: Partial<T>): T;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.spec.ts
@@ -58,12 +58,12 @@ describe('TabGroupComponent', () => {
     expect(component.addTab).toHaveBeenCalledWith(newTabType, tabOptions);
   });
 
-  it('should add tab using TabFactory and TabStateService when addTab is called', async () => {
+  it('should add tab using TabFactory and TabStateService when addTab is called', () => {
     const newTabType = 'test';
     const tab: TabInfo<string> = {
       id: uuid(),
       type: 'test',
-      headerText: 'Tab Header',
+      headerText$: of('Tab Header'),
       closeable: false,
       movable: true
     };
@@ -71,10 +71,10 @@ describe('TabGroupComponent', () => {
     const tabFactory = TestBed.inject(TabFactoryService);
     const tabStateService = TestBed.inject(TabStateService);
 
-    spyOn(tabFactory, 'createTab').and.returnValue(Promise.resolve(tab));
+    spyOn(tabFactory, 'createTab').and.returnValue(tab);
     spyOn(tabStateService, 'addTab');
 
-    await component.addTab(newTabType);
+    component.addTab(newTabType);
 
     expect(tabFactory.createTab).toHaveBeenCalledWith(newTabType, {});
     expect(tabStateService.addTab).toHaveBeenCalledWith(component.groupId, tab);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.component.ts
@@ -72,8 +72,8 @@ export class TabGroupComponent implements OnChanges {
       });
   }
 
-  async addTab(newTabType: string, tabOptions: any = {}): Promise<void> {
-    const tab = await this.tabFactory.createTab(newTabType, tabOptions);
+  addTab(newTabType: string, tabOptions: any = {}): void {
+    const tab = this.tabFactory.createTab(newTabType, tabOptions);
     this.tabState.addTab(this.groupId, tab);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -95,7 +95,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'blank',
-                    headerText$: 'New tab',
+                    headerText$: of('New tab'),
                     closeable: true,
                     movable: true
                   };
@@ -104,7 +104,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'type-a',
-                    headerText$: 'Tab A',
+                    headerText$: of('Tab A'),
                     closeable: true,
                     movable: true
                   };
@@ -114,7 +114,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'type-b',
-                    headerText$: 'Tab B',
+                    headerText$: of('Tab B'),
                     closeable: true,
                     movable: true
                   };
@@ -137,21 +137,21 @@ const tabGroups: TabGroup<string, TabInfo<string>>[] = [
     {
       id: uuid(),
       type: 'type-a',
-      headerText$: 'Uncloseable, unmovable Tab 1 is great!',
+      headerText$: of('Uncloseable, unmovable Tab 1 is great!'),
       closeable: false,
       movable: false
     },
     {
       id: uuid(),
       type: 'type-b',
-      headerText$: 'Tab 2 <em>wow!</em>',
+      headerText$: of('Tab 2 <em>wow!</em>'),
       closeable: true,
       movable: true
     },
     {
       id: uuid(),
       type: 'type-c',
-      headerText$: 'Tab 3',
+      headerText$: of('Tab 3'),
       icon: 'book',
       closeable: true,
       movable: true
@@ -189,13 +189,13 @@ export const TabReorderAndMove: Story = {
         {
           id: uuid(),
           type: 'type-a',
-          headerText$: 'Uncloseable, unmovable Tab 1',
+          headerText$: of('Uncloseable, unmovable Tab 1'),
           closeable: false,
           movable: false
         },
-        { id: uuid(), type: 'type-b', headerText$: 'Tab 2', closeable: true, movable: true },
-        { id: uuid(), type: 'type-c', headerText$: 'Tab 3', closeable: true, movable: true },
-        { id: uuid(), type: 'type-c', headerText$: 'Tab 4', closeable: true, movable: true }
+        { id: uuid(), type: 'type-b', headerText$: of('Tab 2'), closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText$: of('Tab 3'), closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText$: of('Tab 4'), closeable: true, movable: true }
       ])
     ]
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -95,7 +95,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'blank',
-                    headerText: 'New tab',
+                    headerText$: 'New tab',
                     closeable: true,
                     movable: true
                   };
@@ -104,7 +104,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'type-a',
-                    headerText: 'Tab A',
+                    headerText$: 'Tab A',
                     closeable: true,
                     movable: true
                   };
@@ -114,7 +114,7 @@ export default {
                   tab = {
                     id: uuid(),
                     type: 'type-b',
-                    headerText: 'Tab B',
+                    headerText$: 'Tab B',
                     closeable: true,
                     movable: true
                   };
@@ -137,21 +137,21 @@ const tabGroups: TabGroup<string, TabInfo<string>>[] = [
     {
       id: uuid(),
       type: 'type-a',
-      headerText: 'Uncloseable, unmovable Tab 1 is great!',
+      headerText$: 'Uncloseable, unmovable Tab 1 is great!',
       closeable: false,
       movable: false
     },
     {
       id: uuid(),
       type: 'type-b',
-      headerText: 'Tab 2 <em>wow!</em>',
+      headerText$: 'Tab 2 <em>wow!</em>',
       closeable: true,
       movable: true
     },
     {
       id: uuid(),
       type: 'type-c',
-      headerText: 'Tab 3',
+      headerText$: 'Tab 3',
       icon: 'book',
       closeable: true,
       movable: true
@@ -189,13 +189,13 @@ export const TabReorderAndMove: Story = {
         {
           id: uuid(),
           type: 'type-a',
-          headerText: 'Uncloseable, unmovable Tab 1',
+          headerText$: 'Uncloseable, unmovable Tab 1',
           closeable: false,
           movable: false
         },
-        { id: uuid(), type: 'type-b', headerText: 'Tab 2', closeable: true, movable: true },
-        { id: uuid(), type: 'type-c', headerText: 'Tab 3', closeable: true, movable: true },
-        { id: uuid(), type: 'type-c', headerText: 'Tab 4', closeable: true, movable: true }
+        { id: uuid(), type: 'type-b', headerText$: 'Tab 2', closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText$: 'Tab 3', closeable: true, movable: true },
+        { id: uuid(), type: 'type-c', headerText$: 'Tab 4', closeable: true, movable: true }
       ])
     ]
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-group.stories.ts
@@ -36,8 +36,8 @@ import {
       >
         @for (tab of tabGroup.value.tabs; track tab.id) {
           <app-tab [closeable]="tab.closeable" [movable]="tab.movable">
-            <ng-template sf-tab-header><div [innerHTML]="tab.headerText"></div></ng-template>
-            <p><span [innerHTML]="tab.headerText"></span> in {{ tabGroup.key }}</p>
+            <ng-template sf-tab-header><div [innerHTML]="tab.headerText$ | async"></div></ng-template>
+            <p><span [innerHTML]="tab.headerText$ | async"></span> in {{ tabGroup.key }}</p>
           </app-tab>
         }
       </app-tab-group>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { take } from 'rxjs';
+import { of, take } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { TabGroup } from './tab-group';
 import { TabInfo, TabStateService } from './tab-state.service';
@@ -8,8 +8,8 @@ describe('TabStateService', () => {
   let service: TabStateService<string, TabInfo<string>>;
   const groupId = 'testGroup';
   const tabs: TabInfo<string>[] = [
-    { id: uuid(), type: 'tab1', headerText: 'Tab 1', closeable: true, movable: true },
-    { id: uuid(), type: 'tab2', headerText: 'Tab 2', closeable: false, movable: true }
+    { id: uuid(), type: 'tab1', headerText$: of('Tab 1'), closeable: true, movable: true },
+    { id: uuid(), type: 'tab2', headerText$: of('Tab 2'), closeable: false, movable: true }
   ];
 
   beforeEach(() => {
@@ -49,8 +49,8 @@ describe('TabStateService', () => {
         const groupId1: string = 'group1';
         const groupId2: string = 'group2';
         const tabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true }
         ];
         service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
         service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
@@ -72,12 +72,12 @@ describe('TabStateService', () => {
       const groupId1: string = 'group1';
       const groupId2: string = 'group2';
       const tabs1: TabInfo<string>[] = [
-        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+        { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true }
       ];
       const tabs2: TabInfo<string>[] = [
-        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true }
+        { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true },
+        { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true }
       ];
       service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs1));
       service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs2));
@@ -90,8 +90,8 @@ describe('TabStateService', () => {
       const groupId1: string = 'group1';
       const groupId2: string = 'group2';
       const tabs: TabInfo<string>[] = [
-        { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-        { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+        { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+        { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true }
       ];
       service['groups'].set(groupId1, new TabGroup<string, any>(groupId1, tabs));
       service['groups'].set(groupId2, new TabGroup<string, any>(groupId2, tabs));
@@ -107,7 +107,7 @@ describe('TabStateService', () => {
       const tab: TabInfo<string> = {
         id: uuid(),
         type: 'type-a',
-        headerText: 'Header',
+        headerText$: of('Header'),
         closeable: true,
         movable: true
       };
@@ -121,7 +121,7 @@ describe('TabStateService', () => {
       const tab: TabInfo<string> = {
         id: uuid(),
         type: 'type-a',
-        headerText: 'Header',
+        headerText$: of('Header'),
         closeable: true,
         movable: true
       };
@@ -137,14 +137,14 @@ describe('TabStateService', () => {
         {
           id: uuid(),
           type: 'type-a',
-          headerText: 'Header 1',
+          headerText$: of('Header 1'),
           closeable: true,
           movable: true
         },
         {
           id: uuid(),
           type: 'type-a',
-          headerText: 'Header 2',
+          headerText$: of('Header 2'),
           closeable: true,
           movable: true
         }
@@ -158,9 +158,9 @@ describe('TabStateService', () => {
       it('should move a tab within the same group', () => {
         const groupId: string = 'source';
         const tabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-c', headerText$: of('Header 3'), closeable: true, movable: true }
         ];
         service['groups'].set(groupId, new TabGroup<string, any>(groupId, tabs));
         service.moveTab({ groupId, index: 0 }, { groupId, index: 2 });
@@ -170,9 +170,9 @@ describe('TabStateService', () => {
       it('should update selected index when moving a tab within the same group', () => {
         const groupId: string = 'source';
         const tabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-c', headerText$: of('Header 3'), closeable: true, movable: true }
         ];
         const group = new TabGroup<string, any>(groupId, tabs);
         service['groups'].set(groupId, group);
@@ -198,12 +198,12 @@ describe('TabStateService', () => {
         const fromGroupId: string = 'source';
         const toGroupId: string = 'target';
         const fromTabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true }
         ];
         const toTabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
-          { id: uuid(), type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-c', headerText$: of('Header 3'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-d', headerText$: of('Header 4'), closeable: true, movable: true }
         ];
         service['groups'].set(fromGroupId, new TabGroup<string, any>(fromGroupId, fromTabs));
         service['groups'].set(toGroupId, new TabGroup<string, any>(toGroupId, toTabs));
@@ -216,14 +216,14 @@ describe('TabStateService', () => {
         const fromGroupId: string = 'source';
         const toGroupId: string = 'target';
         const fromTabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-a', headerText: 'Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 2', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 3', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 2'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 3'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Header 4'), closeable: true, movable: true }
         ];
         const toTabs: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-c', headerText: 'Header 3', closeable: true, movable: true },
-          { id: uuid(), type: 'type-d', headerText: 'Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-c', headerText$: of('Header 3'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-d', headerText$: of('Header 4'), closeable: true, movable: true }
         ];
         const fromGroup = new TabGroup<string, any>(fromGroupId, fromTabs);
         const toGroup = new TabGroup<string, any>(toGroupId, toTabs);
@@ -251,17 +251,17 @@ describe('TabStateService', () => {
 
       beforeEach(() => {
         sourceTabs = [
-          { id: uuid(), type: 'type-a', headerText: 'Source Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Source Header 2', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Source Header 3', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Source Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Source Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Source Header 2'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Source Header 3'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Source Header 4'), closeable: true, movable: true }
         ];
 
         targetTabs = [
-          { id: uuid(), type: 'type-a', headerText: 'Target Header 1', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Target Header 2', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Target Header 3', closeable: true, movable: true },
-          { id: uuid(), type: 'type-b', headerText: 'Target Header 4', closeable: true, movable: true }
+          { id: uuid(), type: 'type-a', headerText$: of('Target Header 1'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Target Header 2'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Target Header 3'), closeable: true, movable: true },
+          { id: uuid(), type: 'type-b', headerText$: of('Target Header 4'), closeable: true, movable: true }
         ];
 
         service['groups'].set('source', new TabGroup<string, any>('source', sourceTabs));
@@ -295,8 +295,20 @@ describe('TabStateService', () => {
 
       it('should add tabs to restore list and consolidated group when tabs are added after consolidation and before deconsolidation', () => {
         const tabsToAdd: TabInfo<string>[] = [
-          { id: uuid(), type: 'type-c', headerText: 'added source Source Header 5', closeable: true, movable: true },
-          { id: uuid(), type: 'type-c', headerText: 'added source Source Header 6', closeable: true, movable: true }
+          {
+            id: uuid(),
+            type: 'type-c',
+            headerText$: of('added source Source Header 5'),
+            closeable: true,
+            movable: true
+          },
+          {
+            id: uuid(),
+            type: 'type-c',
+            headerText$: of('added source Source Header 6'),
+            closeable: true,
+            movable: true
+          }
         ];
 
         service.consolidateTabGroups('target');
@@ -313,7 +325,7 @@ describe('TabStateService', () => {
         const tabToAdd: TabInfo<string> = {
           id: uuid(),
           type: 'type-c',
-          headerText: 'added source Source Header 5',
+          headerText$: of('added source Source Header 5'),
           closeable: true,
           movable: true
         };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -13,7 +13,7 @@ export type FlatTabInfo<TGroupId extends string, T extends TabInfo<string>> = T 
 export interface TabInfo<TType extends string> {
   id: string;
   type: TType;
-  headerText: string;
+  headerText$: Observable<string>;
 
   /** Optional text to display on hover of the tab header. */
   tooltip?: string;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -68,7 +68,7 @@
               } @else if (tab.icon) {
                 <mat-icon>{{ tab.icon }}</mat-icon>
               }
-              {{ tab.headerText }}
+              {{ tab.headerText$ | async }}
             </ng-template>
             @switch (tab.type) {
               @case ("biblical-terms") {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -3878,7 +3878,7 @@ describe('EditorComponent', () => {
         env.wait();
         expect(spyCreateTab).toHaveBeenCalledWith('project-source', {
           projectId: projectDoc.data?.translateConfig.source?.projectRef,
-          headerText: projectDoc.data?.translateConfig.source?.shortName,
+          headerText$: jasmine.any(Object),
           tooltip: projectDoc.data?.translateConfig.source?.name
         });
         discardPeriodicTasks();
@@ -3892,7 +3892,7 @@ describe('EditorComponent', () => {
         env.wait();
         expect(spyCreateTab).not.toHaveBeenCalledWith('project-source', {
           projectId: projectDoc.data?.translateConfig.source?.projectRef,
-          headerText: projectDoc.data?.translateConfig.source?.shortName,
+          headerText$: jasmine.any(Object),
           tooltip: projectDoc.data?.translateConfig.source?.name
         });
         discardPeriodicTasks();
@@ -3915,7 +3915,7 @@ describe('EditorComponent', () => {
         env.wait();
         expect(spyCreateTab).toHaveBeenCalledWith('project-target', {
           projectId: projectDoc.id,
-          headerText: projectDoc.data?.shortName,
+          headerText$: jasmine.any(Object),
           tooltip: projectDoc.data?.name
         });
         discardPeriodicTasks();
@@ -4066,11 +4066,11 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should not add draft tab if draft exists and draft tab is already present', fakeAsync(async () => {
+      it('should not add draft tab if draft exists and draft tab is already present', fakeAsync(() => {
         const env = new TestEnvironment();
         env.wait();
 
-        env.component.tabState.addTab('target', await env.tabFactory.createTab('draft'));
+        env.component.tabState.addTab('target', env.tabFactory.createTab('draft'));
         const addTab = spyOn(env.component.tabState, 'addTab');
 
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.spec.ts
@@ -50,7 +50,7 @@ describe('EditorTabAddRequestService', () => {
     when(permissionsService.isUserOnProject(anything())).thenResolve(true);
 
     service.handleTabAddRequest('project-resource').subscribe(result => {
-      expect(result).toEqual({ projectId: 'testId1', headerText: 'testName1', tooltip: 'testFullName1' });
+      expect(result).toEqual({ projectId: 'testId1', headerText$: jasmine.any(Object), tooltip: 'testFullName1' });
       done();
     });
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-request.service.ts
@@ -84,7 +84,7 @@ export class EditorTabAddRequestService implements TabAddRequestService<EditorTa
         map((projectDoc: SFProjectDoc) => {
           return {
             projectId: projectDoc.id,
-            headerText: projectDoc.data?.shortName,
+            headerText$: projectDoc.data?.shortName == null ? undefined : of(projectDoc.data.shortName),
             tooltip: projectDoc.data?.name
           };
         })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.spec.ts
@@ -19,94 +19,106 @@ describe('EditorTabFactoryService', () => {
     when(mockI18nService.translate(anything())).thenReturn(of('Test Header Text'));
   });
 
-  it('should create a "biblical terms" tab', async () => {
-    const tab = await service.createTab('biblical-terms');
+  it('should create a "biblical terms" tab', done => {
+    const tab = service.createTab('biblical-terms');
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('biblical-terms');
     expect(tab.svgIcon).toEqual('biblical_terms');
-    expect(tab.headerText).toEqual('Test Header Text');
     expect(tab.closeable).toEqual(true);
     expect(tab.movable).toEqual(true);
     expect(tab.unique).toEqual(true);
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Test Header Text');
+      done();
+    });
   });
 
-  it('should create a "history" tab', async () => {
-    const tab = await service.createTab('history');
+  it('should create a "history" tab', done => {
+    const tab = service.createTab('history');
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('history');
     expect(tab.icon).toEqual('history');
-    expect(tab.headerText).toEqual('Test Header Text');
     expect(tab.closeable).toEqual(true);
     expect(tab.movable).toEqual(true);
     expect(tab.unique).toBeFalsy();
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Test Header Text');
+      done();
+    });
   });
 
-  it('should create a "draft" tab', async () => {
-    const tab = await service.createTab('draft');
+  it('should create a "draft" tab', done => {
+    const tab = service.createTab('draft');
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.type).toEqual('draft');
     expect(tab.icon).toEqual('auto_awesome');
-    expect(tab.headerText).toEqual('Test Header Text');
     expect(tab.closeable).toEqual(true);
     expect(tab.movable).toEqual(true);
     expect(tab.unique).toEqual(true);
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Test Header Text');
+      done();
+    });
   });
 
-  it('should create a "project-target" tab', async () => {
-    const tab = await service.createTab('project-target', { projectId: 'project1', headerText: 'Project 1' });
+  it('should create a "project-target" tab', done => {
+    const tab = service.createTab('project-target', { projectId: 'project1', headerText$: of('Project 1') });
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-target');
     expect(tab.icon).toEqual('book');
-    expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(false);
     expect(tab.movable).toEqual(false);
     expect(tab.unique).toEqual(true);
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Project 1');
+      done();
+    });
   });
 
-  it('should create a "project-source" tab', async () => {
-    const tab = await service.createTab('project-source', { projectId: 'project1', headerText: 'Project 1' });
+  it('should create a "project-source" tab', done => {
+    const tab = service.createTab('project-source', { projectId: 'project1', headerText$: of('Project 1') });
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-source');
     expect(tab.icon).toEqual('book');
-    expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(false);
     expect(tab.movable).toEqual(false);
     expect(tab.unique).toEqual(true);
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Project 1');
+      done();
+    });
   });
 
-  it('should create a "project-resource" tab', async () => {
-    const tab = await service.createTab('project-resource', { projectId: 'project1', headerText: 'Project 1' });
+  it('should create a "project-resource" tab', done => {
+    const tab = service.createTab('project-resource', { projectId: 'project1', headerText$: of('Project 1') });
     expect(tab.id?.length).toBeGreaterThan(0);
     expect(tab.projectId).toEqual('project1');
     expect(tab.type).toEqual('project-resource');
     expect(tab.icon).toEqual('library_books');
-    expect(tab.headerText).toEqual('Project 1');
     expect(tab.closeable).toEqual(true);
     expect(tab.movable).toEqual(true);
     expect(tab.unique).toBeFalsy();
+    tab.headerText$.subscribe(headerText => {
+      expect(headerText).toEqual('Project 1');
+      done();
+    });
   });
 
-  it('should throw error for unknown tab type', async () => {
-    await expectAsync(service.createTab('unknown' as EditorTabType)).toBeRejectedWithError('Unknown TabType: unknown');
+  it('should throw error for unknown tab type', () => {
+    expect(() => service.createTab('unknown' as EditorTabType)).toThrowError('Unknown TabType: unknown');
   });
 
-  it('should throw error for "project-target" tab without projectId', async () => {
-    await expectAsync(service.createTab('project-target')).toBeRejectedWithError(
-      "'tabOptions' must include 'projectId'"
-    );
+  it('should throw error for "project-target" tab without projectId', () => {
+    expect(() => service.createTab('project-target')).toThrowError("'tabOptions' must include 'projectId'");
   });
 
-  it('should throw error for "project-source" tab without projectId', async () => {
-    await expectAsync(service.createTab('project-source')).toBeRejectedWithError(
-      "'tabOptions' must include 'projectId'"
-    );
+  it('should throw error for "project-source" tab without projectId', () => {
+    expect(() => service.createTab('project-source')).toThrowError("'tabOptions' must include 'projectId'");
   });
 
-  it('should throw error for "project-resource" tab without projectId', async () => {
-    await expectAsync(service.createTab('project-resource')).toBeRejectedWithError(
-      "'tabOptions' must include 'projectId'"
-    );
+  it('should throw error for "project-resource" tab without projectId', () => {
+    expect(() => service.createTab('project-resource')).toThrowError("'tabOptions' must include 'projectId'");
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { isUndefined, omitBy } from 'lodash-es';
 import { EditorTabType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
-import { firstValueFrom } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { I18nService } from 'xforge-common/i18n.service';
 import { TabFactoryService } from '../../../shared/sf-tab-group';
@@ -12,7 +11,7 @@ import { EditorTabInfo } from './editor-tabs.types';
 })
 export class EditorTabFactoryService implements TabFactoryService<EditorTabType, EditorTabInfo> {
   constructor(private readonly i18n: I18nService) {}
-  async createTab(tabType: EditorTabType, tabOptions?: Partial<EditorTabInfo>): Promise<EditorTabInfo> {
+  createTab(tabType: EditorTabType, tabOptions?: Partial<EditorTabInfo>): EditorTabInfo {
     // Remove undefined options
     tabOptions = omitBy(tabOptions, isUndefined);
 
@@ -26,9 +25,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
             id,
             type: 'biblical-terms',
             svgIcon: 'biblical_terms',
-            headerText: await firstValueFrom(
-              this.i18n.translate('editor_tab_factory.default_biblical_terms_tab_header')
-            ),
+            headerText$: this.i18n.translate('editor_tab_factory.default_biblical_terms_tab_header'),
             closeable: true,
             movable: true,
             persist: true,
@@ -42,7 +39,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
             id,
             type: 'history',
             icon: 'history',
-            headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_history_tab_header')),
+            headerText$: this.i18n.translate('editor_tab_factory.default_history_tab_header'),
             closeable: true,
             movable: true,
             persist: true
@@ -55,7 +52,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
             id,
             type: 'draft',
             icon: 'auto_awesome',
-            headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.draft_tab_header')),
+            headerText$: this.i18n.translate('editor_tab_factory.draft_tab_header'),
             closeable: true,
             movable: true,
             unique: true
@@ -73,7 +70,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
             id,
             type: tabType,
             icon: 'book',
-            headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_project_tab_header')),
+            headerText$: this.i18n.translate('editor_tab_factory.default_project_tab_header'),
             closeable: false,
             movable: false,
             unique: true
@@ -90,7 +87,7 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
             id,
             type: tabType,
             icon: 'library_books',
-            headerText: await firstValueFrom(this.i18n.translate('editor_tab_factory.default_resource_tab_header')),
+            headerText$: this.i18n.translate('editor_tab_factory.default_resource_tab_header'),
             closeable: true,
             movable: true,
             unique: false,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -40,7 +40,7 @@ describe('EditorTabMenuService', () => {
 
   it('should get "history", "draft", and "project-resource" menu items', done => {
     const env = new TestEnvironment();
-    env.setExistingTabs([{ id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true }]);
+    env.setExistingTabs([{ id: uuid(), type: 'history', headerText$: of('History'), closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
     service['canShowBiblicalTerms'] = () => false;
@@ -57,9 +57,9 @@ describe('EditorTabMenuService', () => {
   it('should get "history", "project-resource", and not "draft" (tab already exists) menu items', done => {
     const env = new TestEnvironment();
     env.setExistingTabs([
-      { id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true },
-      { id: uuid(), type: 'draft', headerText: 'Draft', closeable: true, movable: true, unique: true },
-      { id: uuid(), type: 'project-resource', headerText: 'ABC', closeable: true, movable: true }
+      { id: uuid(), type: 'history', headerText$: of('History'), closeable: true, movable: true },
+      { id: uuid(), type: 'draft', headerText$: of('Draft'), closeable: true, movable: true, unique: true },
+      { id: uuid(), type: 'project-resource', headerText$: of('ABC'), closeable: true, movable: true }
     ]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => true;
@@ -75,7 +75,7 @@ describe('EditorTabMenuService', () => {
 
   it('should get "history" (enabled), not "draft" (no draft build), and not "project-resource" menu items', done => {
     const env = new TestEnvironment(TestEnvironment.projectDocNoDraft);
-    env.setExistingTabs([{ id: uuid(), type: 'history', headerText: 'History', closeable: true, movable: true }]);
+    env.setExistingTabs([{ id: uuid(), type: 'history', headerText$: of('History'), closeable: true, movable: true }]);
     service['canShowHistory'] = () => true;
     service['canShowResource'] = () => false;
     service['canShowBiblicalTerms'] = () => false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -5,8 +5,8 @@ import {
   editorTabTypes
 } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { isParatextRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { combineLatest, forkJoin, map, Observable, of } from 'rxjs';
-import { shareReplay, switchMap, take } from 'rxjs/operators';
+import { combineLatest, map, Observable, of } from 'rxjs';
+import { shareReplay, switchMap } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -88,7 +88,7 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
           }
         }
 
-        return items.length > 0 ? forkJoin(items) : of([]);
+        return items.length > 0 ? combineLatest(items) : of([]);
       }),
       shareReplay({ bufferSize: 1, refCount: true })
     );
@@ -98,7 +98,6 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
     switch (tabType) {
       case 'biblical-terms':
         return this.i18n.translate('editor_tabs_menu.biblical_terms_menu_item').pipe(
-          take(1),
           map(localizedMenuItemText => ({
             type: 'biblical-terms',
             svgIcon: 'biblical_terms',
@@ -107,7 +106,6 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
         );
       case 'history':
         return this.i18n.translate('editor_tabs_menu.history_menu_item').pipe(
-          take(1),
           map(localizedMenuItemText => ({
             type: 'history',
             icon: 'history',
@@ -116,7 +114,6 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
         );
       case 'draft':
         return this.i18n.translate('editor_tabs_menu.draft_menu_item').pipe(
-          take(1),
           map(localizedMenuItemText => ({
             type: 'draft',
             icon: 'auto_awesome',
@@ -125,7 +122,6 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
         );
       case 'project-resource':
         return this.i18n.translate('editor_tabs_menu.project_resource_menu_item').pipe(
-          take(1),
           map(localizedMenuItemText => ({
             type: 'project-resource',
             icon: 'library_books',


### PR DESCRIPTION
This change enables the localizations for labels in the editor tabs and the add tab menu to update dynamically when the user updates the locale. To do this, I needed to update the type for the tab header text to be an observable rather than a defined string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3303)
<!-- Reviewable:end -->
