### PR TITLE
Add notice for upcoming DBL maintenance

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
@@ -1,17 +1,12 @@
 <ng-container *transloco="let t; read: 'global_notices'">
-  @if (showDowntimeNotice) {
+  @if (showNotice) {
     <app-notice class="downtime-notice" type="warning" mode="fill-dark" icon="construction">
       <div class="downtime-notice-content-wrapper">
         <div>
-          {{
-            t("upcoming_maintenance", {
-              duration,
-              startTime: i18n.formatDate(upcomingDowntime.start, { showTimeZone: true })
-            })
-          }}
+          {{ t(messageKey, { duration, startTime: i18n.formatDate(upcomingDowntime.start, { showTimeZone: true }) }) }}
           <a [href]="upcomingDowntime.detailsUrl" target="_blank">{{ t("learn_more") }}</a>
         </div>
-        <button mat-icon-button (click)="showDowntimeNotice = false" [matTooltip]="t('close')">
+        <button mat-icon-button (click)="hideNotice = true" [matTooltip]="t('close')">
           <mat-icon>close</mat-icon>
         </button>
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.ts
@@ -4,7 +4,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslocoModule } from '@ngneat/transloco';
-import { I18nService } from 'xforge-common/i18n.service';
+import { AuthService } from 'xforge-common/auth.service';
+import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { NoticeComponent } from '../notice/notice.component';
 
 @Component({
@@ -15,18 +16,32 @@ import { NoticeComponent } from '../notice/notice.component';
   styleUrl: './global-notices.component.scss'
 })
 export class GlobalNoticesComponent {
-  // This is only an input so that the Storybook can turn this on even when it's off in the app
-  @Input() showDowntimeNotice = false;
+  // This is only an input so that the Storybook show the notice even when it's hidden in the app
+  @Input() hideNotice = false;
+
+  get showNotice(): boolean {
+    // Hide the notice for users that are not logged in since it mentions DBL and shouldn't be shown on whitelabled site
+    return !this.hideNotice && this.userLoggedIn === true;
+  }
+
+  messageKey: I18nKeyForComponent<'global_notices'> = 'dbl_maintenance';
 
   upcomingDowntime = {
-    start: new Date('2024-12-04 16:30 UTC'),
-    durationMin: 2,
-    durationMax: 6,
+    start: new Date('2025-07-13 12:00:00 UTC'),
+    durationMin: 24,
+    durationMax: 48,
     durationUnit: 'hour',
-    detailsUrl: 'https://software.sil.org/scriptureforge/scripture-forge-will-be-unavailable-for-scheduled-maintenance/'
+    detailsUrl: 'https://paratext.org/2025/07/09/dbl-down-two-days-in-july/'
   } as const;
 
-  constructor(readonly i18n: I18nService) {}
+  userLoggedIn?: boolean;
+
+  constructor(
+    readonly i18n: I18nService,
+    private readonly authService: AuthService
+  ) {
+    this.authService.isLoggedIn.then(isLoggedIn => (this.userLoggedIn = isLoggedIn));
+  }
 
   get duration(): string {
     return this.i18n.translateStatic(`global_notices.${this.upcomingDowntime.durationUnit}_range`, {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.stories.ts
@@ -1,14 +1,25 @@
-import { Meta, StoryObj } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { instance, mock, when } from 'ts-mockito';
+import { AuthService } from 'xforge-common/auth.service';
 import { GlobalNoticesComponent } from './global-notices.component';
+
+const mockedAuthService = mock(AuthService);
+when(mockedAuthService.isLoggedIn).thenResolve(true);
 
 const meta: Meta<GlobalNoticesComponent> = {
   title: 'Shared/Global Notices',
-  component: GlobalNoticesComponent
+  component: GlobalNoticesComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GlobalNoticesComponent],
+      providers: [{ provide: AuthService, useValue: instance(mockedAuthService) }]
+    })
+  ]
 };
 
 export default meta;
 type Story = StoryObj<GlobalNoticesComponent>;
 
 export const Default: Story = {
-  args: { showDowntimeNotice: true }
+  args: { hideNotice: false }
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_de.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_de.json
@@ -353,7 +353,8 @@
     "hour_range": "{{ min }} bis {{ max }} Stunden",
     "learn_more": "Mehr erfahren",
     "minute_range": "{{ min }} bis {{ max }} Minuten",
-    "upcoming_maintenance": "Scripture Forge wird wegen Wartungsarbeiten für etwa {{ duration }} ab {{ startTime }} nicht zur Verfügung stehen."
+    "upcoming_maintenance": "Scripture Forge wird wegen Wartungsarbeiten für etwa {{ duration }} ab {{ startTime }} nicht zur Verfügung stehen.",
+    "dbl_maintenance": "Die Digitale Bibelbibliothek wird wegen Wartungsarbeiten für etwa {{ duration }} ab {{ startTime }} nicht verfügbar sein. Während dieser Zeit kanns Du keine Ressourcen der Digitalen Bibelbibliothek mit Deinem Projekt verbinden."
   },
   "issue_email": {
     "heading": "Bitte beschreibe das Problem.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -353,7 +353,8 @@
     "hour_range": "{{ min }} to {{ max }} hours",
     "learn_more": "Learn more",
     "minute_range": "{{ min }} to {{ max }} minutes",
-    "upcoming_maintenance": "Scripture Forge will be down for maintenance for about {{ duration }} starting at {{ startTime }}."
+    "upcoming_maintenance": "Scripture Forge will be down for maintenance for about {{ duration }} starting {{ startTime }}.",
+    "dbl_maintenance": "The Digital Bible Library will be down for maintenance for about {{ duration }} starting {{ startTime }}. You will not be able to connect Digital Bible Library resources to your project during this time."
   },
   "issue_email": {
     "heading": "Please explain the problem.",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_es.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_es.json
@@ -353,7 +353,8 @@
     "hour_range": "{{ min }} a {{ max }} horas",
     "learn_more": "Más información",
     "minute_range": "{{ min }} a {{ max }} minutos",
-    "upcoming_maintenance": "Scripture Forge estará inactiva por mantenimiento durante aproximadamente {{ duration }} a partir de {{ startTime }}."
+    "upcoming_maintenance": "Scripture Forge estará inactiva por mantenimiento durante aproximadamente {{ duration }} a partir de {{ startTime }}.",
+    "dbl_maintenance": "La Biblioteca Digital de la Biblia estará inactiva por mantenimiento durante aproximadamente {{ duration }} a partir de {{ startTime }}. Durante este tiempo no podrá conectar los recursos de la Biblioteca Digital de la Biblia a su proyecto."
   },
   "issue_email": {
     "heading": "Por favor, explíquenos el problema.",


### PR DESCRIPTION
This is a PR against master that is intended to afterwards become a hotfix against live. I've added a new notice about DBL downtime, and updated the global notice component to be a little more general in being able to handle different kinds of notices.

I've also pulled in the localizations for the new string, where available, since it's likely to become a hotfix and not go through our normal release cycle and get the updated localizations that way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3307)
<!-- Reviewable:end -->
