### PR TITLE
Add dark theme support to permissions viewer

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/permissions-viewer/_permissions-viewer-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/permissions-viewer/_permissions-viewer-theme.scss
@@ -1,0 +1,48 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  .permissions-table {
+    tr:nth-child(even) {
+      background-color: if($is-dark, #2a2a2a, #f9f9f9);
+    }
+    th {
+      background-color: if($is-dark, #222, #f2f2f2);
+    }
+    td,
+    th {
+      border-color: if($is-dark, #444, #ddd);
+    }
+  }
+
+  .operation-tag {
+    background-color: if($is-dark, transparent, #e0e0e0);
+    color: inherit;
+    &.view,
+    &.view_own {
+      background-color: if($is-dark, #22543a, #d4edda);
+      color: if($is-dark, #d4edda, #155724);
+    }
+    &.create {
+      background-color: if($is-dark, #1e3a5c, #cce5ff);
+      color: if($is-dark, #cce5ff, #004085);
+    }
+    &.edit,
+    &.edit_own {
+      background-color: if($is-dark, #665c1e, #fff3cd);
+      color: if($is-dark, #fff3cd, #856404);
+    }
+    &.delete,
+    &.delete_own {
+      background-color: if($is-dark, #5c1e22, #f8d7da);
+      color: if($is-dark, #f8d7da, #721c24);
+    }
+  }
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/permissions-viewer/permissions-viewer.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/permissions-viewer/permissions-viewer.component.scss
@@ -1,3 +1,5 @@
+@import './_permissions-viewer-theme.scss';
+
 .permissions-viewer-container {
   padding: 20px;
   overflow-x: auto;
@@ -5,66 +7,37 @@
   h1 {
     margin-bottom: 20px;
   }
-}
 
-.permissions-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-bottom: 20px;
+  .permissions-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
 
-  th,
-  td {
-    border: 1px solid #ddd;
-    padding: 8px;
-    text-align: left;
+    th,
+    td {
+      border: 1px solid #ddd;
+      padding: 8px;
+      text-align: left;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
   }
 
-  th {
-    background-color: #f2f2f2;
-    position: sticky;
-    top: 0;
-    z-index: 1;
+  .operations-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
   }
 
-  tr:nth-child(even) {
-    background-color: #f9f9f9;
-  }
-}
-
-.operations-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.operation-tag {
-  background-color: #e0e0e0;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 12px;
-  display: inline-block;
-  margin: 2px;
-
-  &.view,
-  &.view_own {
-    background-color: #d4edda;
-    color: #155724;
-  }
-
-  &.create {
-    background-color: #cce5ff;
-    color: #004085;
-  }
-
-  &.edit,
-  &.edit_own {
-    background-color: #fff3cd;
-    color: #856404;
-  }
-
-  &.delete,
-  &.delete_own {
-    background-color: #f8d7da;
-    color: #721c24;
+  .operation-tag {
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    display: inline-block;
+    margin: 2px;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -21,6 +21,7 @@
 @use 'src/app/translate/editor/editor-draft/editor-draft-theme' as sf-editor-draft;
 @use 'src/app/translate/biblical-terms/biblical-terms-theme' as sf-biblical-terms;
 @use 'src/app/translate/translate-overview/translate-overview.component' as sf-translate-overview;
+@use 'src/app/permissions-viewer/permissions-viewer-theme' as sf-permissions-viewer;
 
 @use 'text' as sf-text;
 
@@ -51,6 +52,7 @@
   @include sf-tab-group.theme($theme);
   @include sf-text.theme($theme);
   @include sf-translate-overview.theme($theme);
+  @include sf-permissions-viewer.theme($theme);
 
   // Custom variables
   --sf-disabled-foreground: #{mat.get-theme-color($theme, neutral, 70)};


### PR DESCRIPTION
Super minor, but nice to have. (GitHub Copilot did most of the work)

<img width="1840" height="824" alt="localhost_5000_system-administration_permissions-viewer" src="https://github.com/user-attachments/assets/913039b2-f38c-48ad-804a-8cabf222e849" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3309)
<!-- Reviewable:end -->
