### PR TITLE
SF-3419 Remove Lynx problems panel quotes and improve styling

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-util.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-util.ts
@@ -1,4 +1,4 @@
-import Quill, { Delta, Range } from 'quill';
+import Quill, { Range } from 'quill';
 import { DeltaOperation, StringMap } from 'rich-text';
 
 /**
@@ -57,18 +57,4 @@ export function rangeComparer(a: { range: Range }, b: { range: Range }): number 
   }
 
   return a.range.length - b.range.length;
-}
-
-/**
- * Extracts text from a delta. If range is provided, extracts only text within that range.
- */
-export function getText(delta: Delta, range?: Range): string {
-  // Slice the delta if range is provided
-  const targetDelta: Delta = range ? delta.slice(range.index, range.index + range.length) : delta;
-
-  // Extract text from operations
-  return targetDelta
-    .filter(op => typeof op.insert === 'string')
-    .map(op => op.insert)
-    .join('');
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight.ts
@@ -66,7 +66,7 @@ export const EDITOR_INSIGHT_DEFAULTS = new InjectionToken<LynxInsightConfig>('ED
     sortOrder: 'severity',
     queryParamName: 'insight',
     actionOverlayApplyPrimaryActionChord: { altKey: true, shiftKey: true, key: 'Enter' },
-    panelLinkTextGoalLength: 30,
+    panelLinkTextGoalLength: 25,
     panelOptimizationThreshold: 100
   })
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.html
@@ -11,10 +11,24 @@
       <button matRipple [class.dismissed]="node.isDismissed" class="tree-toggle leaf" (click)="onLeafNodeClick(node)">
         <div class="level-ref">
           @if (node.isLoading) {
-            <span class="insight-loading-text">{{ node.description }}</span>
-            <mat-spinner diameter="16" class="insight-loading-spinner"></mat-spinner>
+            <div>
+              <span class="verse-ref">{{ node.insightDescription!.refString }}</span>
+              <span class="insight-desc-divider">—</span>
+              <span class="insight-loading-text">{{ t("loading") }}</span>
+              <mat-spinner diameter="16" class="insight-loading-spinner"></mat-spinner>
+            </div>
           } @else {
-            <span>{{ node.description }}</span>
+            <div>
+              <span class="verse-ref">{{ node.insightDescription!.refString }}</span>
+              <span class="insight-desc-divider">—</span>
+              <span class="sample-text"
+                >{{ node.insightDescription!.sampleTextParts.preText
+                }}<span class="lynx-insight" [class]="node.insight.type">{{
+                  node.insightDescription!.sampleTextParts.insightText
+                }}</span
+                >{{ node.insightDescription!.sampleTextParts.postText }}</span
+              >
+            </div>
             @if (node.isDismissed) {
               <mat-icon
                 [matTooltip]="t('restore')"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.scss
@@ -80,7 +80,7 @@ $restoreActionColor: #5485e7;
   align-items: center;
   gap: 1rem;
 
-  > span:first-child {
+  > div:first-child {
     display: flex;
     align-items: center;
 
@@ -89,6 +89,21 @@ $restoreActionColor: #5485e7;
       margin-right: 0.6em;
       font-size: 1.5em;
     }
+  }
+
+  .verse-ref {
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .insight-desc-divider {
+    margin: 0 0.5rem;
+    color: #999;
+    font-weight: 500;
+  }
+
+  .sample-text {
+    white-space: nowrap;
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/string-util.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/string-util.spec.ts
@@ -1,4 +1,4 @@
-import { areStringArraysEqual, stripHtml } from './string-util';
+import { areStringArraysEqual, isWhitespace, stripHtml } from './string-util';
 
 describe('areStringArraysEqual', () => {
   it('should return true if two empty arrays are compared', () => {
@@ -73,5 +73,36 @@ describe('stripHtml', () => {
     expect(stripHtml('<style>body{color:red}</style>')).toBe('body{color:red}');
     expect(stripHtml('<iframe src="evil.html">')).toBe('');
     expect(stripHtml('<object data="evil.swf">')).toBe('');
+  });
+});
+
+describe('isWhitespace', () => {
+  it('returns true for empty string', () => {
+    expect(isWhitespace('')).toBe(true);
+  });
+
+  it('returns false for null or undefined', () => {
+    expect(isWhitespace(null as any)).toBe(false);
+    expect(isWhitespace(undefined as any)).toBe(false);
+  });
+
+  it('returns true for strings with only whitespace characters', () => {
+    expect(isWhitespace(' ')).toBe(true);
+    expect(isWhitespace('\n')).toBe(true);
+    expect(isWhitespace('\t')).toBe(true);
+    expect(isWhitespace(' \n\t ')).toBe(true);
+    expect(isWhitespace('   \n\t   ')).toBe(true);
+    expect(isWhitespace(' \r\n\t ')).toBe(true);
+    expect(isWhitespace(' \f ')).toBe(true); // Form feed
+    expect(isWhitespace(' \v ')).toBe(true); // Vertical tab
+    expect(isWhitespace(' \u00A0 ')).toBe(true); // Non-breaking space
+  });
+
+  it('returns false for non-whitespace strings', () => {
+    expect(isWhitespace('hello')).toBe(false);
+    expect(isWhitespace('"')).toBe(false);
+    expect(isWhitespace(' blah')).toBe(false);
+    expect(isWhitespace('blah ')).toBe(false);
+    expect(isWhitespace('\na\n')).toBe(false);
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/string-util.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/util/string-util.ts
@@ -37,3 +37,21 @@ export function stripHtml(content: string): string {
   // Remove any remaining stray angle brackets
   return result.replace(/[<>]/g, '');
 }
+
+/**
+ * Checks if a string is whitespace or empty.
+ * @param text The string to check.
+ * @returns True if the string is empty or contains only whitespace characters, false otherwise.
+ * Nullish values are treated as false.
+ */
+export function isWhitespace(text: string): boolean {
+  if (text == null) {
+    return false;
+  }
+
+  if (text.length === 0) {
+    return true;
+  }
+
+  return /^\s*$/.test(text);
+}


### PR DESCRIPTION
This PR removes the quotes from the sample text in the lynx problems panel.  Also, the sample text is split into pre-insight/insight/post-insight parts so that they can be styled differently.  Accordingly, the insight portion of the sample text is styled with background and text decoration like the editor insights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3311)
<!-- Reviewable:end -->
