### PR TITLE
SF-3470 Use the rights by role permissions for the machine API backend

### DIFF
--- a/src/RealtimeServer/scriptureforge/rightsByRole.json
+++ b/src/RealtimeServer/scriptureforge/rightsByRole.json
@@ -73,7 +73,8 @@
     "notes": ["view", "create", "edit_own", "delete_own"],
     "text_audio": ["view"],
     "text_documents": ["view", "edit"],
-    "drafts": ["view"]
+    "training_data": ["view"],
+    "drafts": ["view", "create"]
   },
   "pt_administrator": {
     "project_user_configs": ["view_own", "edit_own"],
@@ -91,7 +92,7 @@
     "text_audio": ["view", "edit", "create", "delete"],
     "text_documents": ["view", "edit"],
     "training_data": ["view", "create", "edit", "delete"],
-    "drafts": ["view"],
+    "drafts": ["view", "create"],
     "user_invites": ["create"]
   },
   "none": {}

--- a/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
@@ -13,14 +13,14 @@ import { getTrainingDataId, TRAINING_DATA_COLLECTION, TrainingData } from '../mo
 import { TrainingDataService } from './training-data-service';
 
 describe('TrainingDataService', () => {
-  it('does not allow translator to view training data', async () => {
+  it('allows translator to view training data', async () => {
     const env = new TestEnvironment();
     await env.createData();
 
     const conn = clientConnect(env.server, 'translator');
     await expect(
       fetchDoc(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'))
-    ).rejects.toThrow();
+    ).resolves.not.toThrow();
   });
 
   it('allows administrator to edit training data', async () => {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -1,6 +1,3 @@
-using SIL.XForge.Models;
-using SIL.XForge.Services;
-
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>
@@ -37,23 +34,6 @@ public static class MachineApi
     public const string GetLastCompletedPreTranslationBuild =
         "translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild";
 
-    /// <summary>
-    /// Ensures that a user has permission to perform actions to the Serval/Machine API.
-    /// </summary>
-    /// <param name="userId">The user id.</param>
-    /// <param name="project">The project.</param>
-    /// <exception cref="ForbiddenException">
-    /// The user does not have permission to access the Serval/Machine API.
-    /// </exception>
-    public static void EnsureProjectPermission(string userId, Project project)
-    {
-        // Check for permission
-        if (!HasPermission(userId, project))
-        {
-            throw new ForbiddenException();
-        }
-    }
-
     public static string GetBuildHref(string sfProjectId, string buildId)
     {
         // If there is no build id, the href will end in a dot, which we must remove to have a valid URL
@@ -63,15 +43,4 @@ public static class MachineApi
 
     public static string GetEngineHref(string sfProjectId) =>
         $"{Namespace}/{GetEngine.Replace("{sfProjectId}", sfProjectId)}";
-
-    /// <summary>
-    /// Determines if a user has permission to perform actions to the Serval/Machine API.
-    /// </summary>
-    /// <param name="userId">The user id.</param>
-    /// <param name="project">The project.</param>
-    /// <returns><c>true</c> if the user has permission; otherwise, <c>false</c>.</returns>
-    private static bool HasPermission(string? userId, Project project) =>
-        !string.IsNullOrWhiteSpace(userId)
-        && project.UserRoles.TryGetValue(userId, out string role)
-        && role is SFProjectRole.Administrator or SFProjectRole.Translator;
 }

--- a/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
@@ -21,6 +21,7 @@ namespace SIL.XForge.Scripture.Services;
 public class TrainingDataService(
     IFileSystemService fileSystemService,
     IRealtimeService realtimeService,
+    ISFProjectRights projectRights,
     IOptions<SiteOptions> siteOptions
 ) : ITrainingDataService
 {
@@ -102,8 +103,11 @@ public class TrainingDataService(
             throw new DataNotFoundException("The project does not exist.");
         }
 
-        // Ensure permission to access the Machine API
-        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+        // Ensure permission to delete training data
+        if (!projectRights.HasRight(projectDoc.Data, userId, SFProjectDomain.TrainingData, Operation.Delete))
+        {
+            throw new ForbiddenException();
+        }
 
         // Ensure the user is the owner of the file, or an administrator
         if (
@@ -146,7 +150,11 @@ public class TrainingDataService(
             throw new DataNotFoundException("The project does not exist.");
         }
 
-        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+        // Ensure permission to view training data
+        if (!projectRights.HasRight(projectDoc.Data, userId, SFProjectDomain.TrainingData, Operation.View))
+        {
+            throw new ForbiddenException();
+        }
 
         // Ensure that the training data directory exists
         string trainingDataDir = Path.Join(siteOptions.Value.SiteDir, DirectoryName, projectId);
@@ -244,7 +252,11 @@ public class TrainingDataService(
             throw new DataNotFoundException("The project does not exist.");
         }
 
-        MachineApi.EnsureProjectPermission(userId, projectDoc.Data);
+        // Ensure permission to create training data
+        if (!projectRights.HasRight(projectDoc.Data, userId, SFProjectDomain.TrainingData, Operation.Create))
+        {
+            throw new ForbiddenException();
+        }
 
         if (!StringUtils.ValidateId(dataId))
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -3879,6 +3879,20 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void UpdatePreTranslationTextDocumentsAsync_UserCannotCreateDrafts()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.ProjectRights.HasRight(Arg.Any<SFProject>(), User01, SFProjectDomain.Drafts, Operation.Create)
+            .Returns(false);
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() =>
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+        );
+    }
+
+    [Test]
     public async Task UpdatePreTranslationTextDocumentsAsync_UpdatesExistingDocument()
     {
         // Set up test environment
@@ -3989,6 +4003,10 @@ public class MachineApiServiceTests
                 ]
             );
             TextDocuments = new MemoryRepository<TextDocument>();
+            ProjectRights = Substitute.For<ISFProjectRights>();
+            ProjectRights
+                .HasRight(Arg.Any<SFProject>(), User01, SFProjectDomain.Drafts, Operation.Create)
+                .Returns(true);
             ProjectService = Substitute.For<ISFProjectService>();
             ProjectService.SyncAsync(User01, Arg.Any<string>()).Returns(Task.FromResult(JobId));
             RealtimeService = new SFMemoryRealtimeService();
@@ -4031,6 +4049,7 @@ public class MachineApiServiceTests
                 ParatextService,
                 PreTranslationService,
                 ProjectSecrets,
+                ProjectRights,
                 ProjectService,
                 RealtimeService,
                 servalOptions,
@@ -4051,6 +4070,7 @@ public class MachineApiServiceTests
         public MemoryRepository<SFProject> Projects { get; }
         public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
         public MemoryRepository<TextDocument> TextDocuments { get; }
+        public ISFProjectRights ProjectRights { get; }
         public ISFProjectService ProjectService { get; }
         public SFMemoryRealtimeService RealtimeService { get; }
         public MachineApiService Service { get; }

--- a/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/TrainingDataServiceTests.cs
@@ -81,12 +81,12 @@ public class TrainingDataServiceTests
     public async Task GetTextsAsync_DoesNotGenerateTextsIfTooFewColumns()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { Data01 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // Set up the training data files
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Line1\nLine2"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Line1\nLine2"));
         env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data01)), FileMode.Open).Returns(fileStream);
 
         // SUT
@@ -99,16 +99,16 @@ public class TrainingDataServiceTests
     public async Task GetTextsAsync_GeneratesSourceAndTargetTexts()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { Data01, Data02 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01, Data02];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // Set up the training data files
-        await using MemoryStream fileStream1 = new MemoryStream(
+        await using var fileStream1 = new MemoryStream(
             Encoding.UTF8.GetBytes("D1Source1,D1Target1\nD1Source2,D1Target2")
         );
         env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data01)), FileMode.Open).Returns(fileStream1);
-        await using MemoryStream fileStream2 = new MemoryStream(
+        await using var fileStream2 = new MemoryStream(
             Encoding.UTF8.GetBytes("Source_Heading\tTarget_Heading\n\"D2 Source 1\"\t\"D2 Target 1\"")
         );
         env.FileSystemService.OpenFile(Arg.Is<string>(p => p.Contains(Data02)), FileMode.Open).Returns(fileStream2);
@@ -139,9 +139,9 @@ public class TrainingDataServiceTests
     public void GetTextsAsync_MissingProject()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { Data01 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
@@ -153,9 +153,9 @@ public class TrainingDataServiceTests
     public void GetTextsAsync_MissingTrainingDataDirectory()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { Data01 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
         env.FileSystemService.DirectoryExists(Arg.Any<string>()).Returns(false);
 
         // SUT
@@ -168,9 +168,9 @@ public class TrainingDataServiceTests
     public void GetTextsAsync_NoPermission()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { Data01 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(() =>
@@ -182,9 +182,9 @@ public class TrainingDataServiceTests
     public async Task GetTextsAsync_SkipsMissingDataId()
     {
         var env = new TestEnvironment();
-        var dataIds = new string[] { "missing_data_id" };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = ["missing_data_id"];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // SUT
         await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
@@ -197,9 +197,9 @@ public class TrainingDataServiceTests
     {
         var env = new TestEnvironment();
         env.FileSystemService.FileExists(Arg.Any<string>()).Returns(false);
-        var dataIds = new string[] { Data01, Data02 };
-        var sourceTexts = new List<ISFText>();
-        var targetTexts = new List<ISFText>();
+        string[] dataIds = [Data01, Data02];
+        List<ISFText> sourceTexts = [];
+        List<ISFText> targetTexts = [];
 
         // SUT
         await env.Service.GetTextsAsync(User01, Project01, dataIds, sourceTexts, targetTexts);
@@ -213,8 +213,8 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Create the input file
-        await using MemoryStream fileStream = new MemoryStream();
-        using IWorkbook workbook = new HSSFWorkbook();
+        await using var fileStream = new MemoryStream();
+        using var workbook = new HSSFWorkbook();
         workbook.Write(fileStream, leaveOpen: true);
         fileStream.Seek(0, SeekOrigin.Begin);
         env.FileSystemService.OpenFile(FileExcel2003, FileMode.Open).Returns(fileStream);
@@ -231,8 +231,8 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Create the input file
-        await using MemoryStream fileStream = new MemoryStream();
-        using IWorkbook workbook = new HSSFWorkbook();
+        await using var fileStream = new MemoryStream();
+        using var workbook = new HSSFWorkbook();
         workbook.CreateSheet("Sheet1");
         workbook.Write(fileStream, leaveOpen: true);
         fileStream.Seek(0, SeekOrigin.Begin);
@@ -294,7 +294,7 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Set up the input file
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test"));
         env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
 
         // SUT
@@ -308,7 +308,7 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Set up the input file
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data"));
         env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
 
         // We will also check that the directory is created
@@ -335,7 +335,7 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Set up the input file
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test\tData"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test\tData"));
         env.FileSystemService.OpenFile(FileTsv, FileMode.Open).Returns(fileStream);
 
         // SUT
@@ -357,7 +357,7 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Set up the input file
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test;Data"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test;Data"));
         env.FileSystemService.OpenFile(FileTxt, FileMode.Open).Returns(fileStream);
 
         // SUT
@@ -378,8 +378,8 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Create the input file
-        await using MemoryStream fileStream = new MemoryStream();
-        using IWorkbook workbook = new HSSFWorkbook();
+        await using var fileStream = new MemoryStream();
+        using var workbook = new HSSFWorkbook();
         ISheet sheet = workbook.CreateSheet("Sheet1");
         IRow row = sheet.CreateRow(0);
         row.CreateCell(0).SetCellValue("Test"); // A1
@@ -395,7 +395,7 @@ public class TrainingDataServiceTests
             Project01,
             $"{User01}_{Data01}.csv"
         );
-        await using NonDisposingMemoryStream outputStream = new NonDisposingMemoryStream();
+        await using var outputStream = new NonDisposingMemoryStream();
         env.FileSystemService.CreateFile(path).Returns(outputStream);
 
         // SUT
@@ -407,7 +407,7 @@ public class TrainingDataServiceTests
             Is.True
         );
 
-        using StreamReader reader = new StreamReader(outputStream);
+        using var reader = new StreamReader(outputStream);
         string text = await reader.ReadToEndAsync();
         text = text.TrimEnd(); // Remove trailing new lines
         Assert.AreEqual("Test,Data", text);
@@ -420,8 +420,8 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Create the input file
-        await using MemoryStream fileStream = new MemoryStream();
-        using IWorkbook workbook = new XSSFWorkbook();
+        await using var fileStream = new MemoryStream();
+        using var workbook = new XSSFWorkbook();
         ISheet sheet = workbook.CreateSheet("Output");
         IRow row = sheet.CreateRow(1);
         row.CreateCell(1).SetCellValue("Test"); // B2
@@ -437,7 +437,7 @@ public class TrainingDataServiceTests
             Project01,
             $"{User01}_{Data01}.csv"
         );
-        await using NonDisposingMemoryStream outputStream = new NonDisposingMemoryStream();
+        await using var outputStream = new NonDisposingMemoryStream();
         env.FileSystemService.CreateFile(path).Returns(outputStream);
 
         // SUT
@@ -449,7 +449,7 @@ public class TrainingDataServiceTests
             Is.True
         );
 
-        using StreamReader reader = new StreamReader(outputStream);
+        using var reader = new StreamReader(outputStream);
         string text = await reader.ReadToEndAsync();
         text = text.TrimEnd(); // Remove trailing new lines
         Assert.AreEqual("Test,Data", text);
@@ -462,7 +462,7 @@ public class TrainingDataServiceTests
         var env = new TestEnvironment();
 
         // Set up the input file
-        await using MemoryStream fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data,More"));
+        await using var fileStream = new MemoryStream(Encoding.UTF8.GetBytes("Test,Data,More"));
         env.FileSystemService.OpenFile(FileCsv, FileMode.Open).Returns(fileStream);
 
         // SUT
@@ -548,7 +548,11 @@ public class TrainingDataServiceTests
             var realtimeService = new SFMemoryRealtimeService();
             realtimeService.AddRepository("sf_projects", OTType.Json0, projects);
             realtimeService.AddRepository("training_data", OTType.Json0, trainingData);
-            Service = new TrainingDataService(FileSystemService, realtimeService, SiteOptions);
+            var projectRights = Substitute.For<ISFProjectRights>();
+            projectRights
+                .HasRight(Arg.Any<SFProject>(), User01, SFProjectDomain.TrainingData, Arg.Any<string>())
+                .Returns(true);
+            Service = new TrainingDataService(FileSystemService, realtimeService, projectRights, SiteOptions);
         }
 
         public IFileSystemService FileSystemService { get; }


### PR DESCRIPTION
This PR updates the machine-api backend to use the `rightsByRole.json` permissions rather than hardcoding an "is administrator or translator" check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3312)
<!-- Reviewable:end -->
