### PR TITLE
Remove unneeded wait from e2e tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/e2e-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/e2e-utils.ts
@@ -124,11 +124,6 @@ export async function connectProject(page: Page, shortName: string, source?: str
 
   if (source != null) {
     await page.getByRole('combobox', { name: 'Source text (optional)' }).click();
-    // FIXME(application-bug) The source text combobox is not always ready to be used immediately after opening the
-    // connect project page because resources are still loading, and if they load after the user types, the filtering
-    // doesn't happen until further input.
-    await page.waitForTimeout(5000);
-    await page.getByRole('combobox', { name: 'Source text (optional)' }).click();
     await page.keyboard.type(source);
     await page.getByRole('option', { name: `${source} - ` }).click();
   }


### PR DESCRIPTION
The underlying issue was fixed in #3246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3318)
<!-- Reviewable:end -->
