### PR TITLE
Replace Transloco translate() with i18n.selectTranslate() where possible

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -4,7 +4,6 @@ import { Component, DestroyRef, Inject, OnDestroy, OnInit } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import Bugsnag from '@bugsnag/js';
-import { translate } from '@ngneat/transloco';
 import { cloneDeep } from 'lodash-es';
 import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
@@ -356,12 +355,12 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     if (this.currentUser == null) {
       return;
     } else if (!this.isAppOnline) {
-      this.noticeService.show(translate('app.action_not_available_offline'));
+      this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
     } else {
       this.authService
         .changePassword(this.currentUser.email)
         .then(() => {
-          this.noticeService.show(translate('app.password_reset_email_sent'));
+          this.noticeService.show(this.i18n.translateStatic('app.password_reset_email_sent'));
         })
         .catch(() => {
           this.dialogService.message('app.cannot_change_password');
@@ -373,7 +372,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     if (this.isAppOnline) {
       this.userService.editDisplayName(false);
     } else {
-      this.noticeService.show(translate('app.action_not_available_offline'));
+      this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
@@ -270,14 +269,16 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   questionCountLabel(count: number): string {
-    return translate('checking_overview.question_count_label', { count: count });
+    return this.i18n.translateStatic('checking_overview.question_count_label', { count: count });
   }
 
   timeArchivedStamp(date: string | undefined): string {
     if (date == null) {
       return '';
     }
-    return translate('checking_overview.time_archived_stamp', { timeStamp: this.i18n.formatDate(new Date(date)) });
+    return this.i18n.translateStatic('checking_overview.time_archived_stamp', {
+      timeStamp: this.i18n.formatDate(new Date(date))
+    });
   }
 
   bookAnswerCount(text: TextInfo): number {
@@ -306,7 +307,9 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
 
   answerCountLabel(count?: number): string {
     return count != null && count > 0
-      ? translate('checking_overview.answer_count_label', { count: this.l10nNumberPipe.transform(count) })
+      ? this.i18n.translateStatic('checking_overview.answer_count_label', {
+          count: this.l10nNumberPipe.transform(count)
+        })
       : '';
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -10,7 +10,6 @@ import {
   ViewChildren
 } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
-import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { cloneDeep } from 'lodash-es';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -454,9 +453,9 @@ export class CheckingAnswersComponent implements OnInit {
         answer
       });
     } else if (likeAnswerResponse === LikeAnswerResponse.DeniedOwnAnswer) {
-      this.noticeService.show(translate('checking_answers.cannot_like_own_answer'));
+      this.noticeService.show(this.i18n.translateStatic('checking_answers.cannot_like_own_answer'));
     } else if (likeAnswerResponse === LikeAnswerResponse.DeniedNoPermission) {
-      this.noticeService.show(translate('checking_answers.no_permission_to_like'));
+      this.noticeService.show(this.i18n.translateStatic('checking_answers.no_permission_to_like'));
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { translate } from '@ngneat/transloco';
 import { cloneDeep, sortBy } from 'lodash-es';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { Answer } from 'realtime-server/lib/esm/scriptureforge/models/answer';
@@ -8,6 +7,7 @@ import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { debounceTime } from 'rxjs/operators';
 import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { SubscriptionDisposable } from 'xforge-common/subscription-disposable';
 import { UserService } from 'xforge-common/user.service';
 import { QuestionDoc } from '../../../../core/models/question-doc';
@@ -44,7 +44,8 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
 
   constructor(
     private readonly dialogService: DialogService,
-    private userService: UserService
+    private userService: UserService,
+    private readonly i18n: I18nService
   ) {
     super();
   }
@@ -64,9 +65,9 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
     }
 
     if (unread > 0) {
-      return translate('checking_comments.show_more_comments_and_unread', { count, unread });
+      return this.i18n.translateStatic('checking_comments.show_more_comments_and_unread', { count, unread });
     } else {
-      return translate('checking_comments.show_more_comments', { count });
+      return this.i18n.translateStatic('checking_comments.show_more_comments', { count });
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-question/checking-question.component.ts
@@ -9,7 +9,6 @@ import {
   SimpleChanges,
   ViewChild
 } from '@angular/core';
-import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { AudioTiming } from 'realtime-server/lib/esm/scriptureforge/models/audio-timing';
 import { getTextAudioId, TextAudio } from 'realtime-server/lib/esm/scriptureforge/models/text-audio';
@@ -113,7 +112,7 @@ export class CheckingQuestionComponent extends SubscriptionDisposable implements
     return this._questionDoc.data.text
       ? this._questionDoc.data.text
       : this._questionDoc.data.audioUrl != null
-        ? translate('checking_questions.listen_to_question', {
+        ? this.i18n.translateStatic('checking_questions.listen_to_question', {
             referenceForDisplay: this.referenceForDisplay
           })
         : '';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component, DestroyRef, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
-import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { cloneDeep } from 'lodash-es';
 import { Question } from 'realtime-server/lib/esm/scriptureforge/models/question';
@@ -44,8 +43,8 @@ export class QuestionDialogComponent implements OnInit {
   @ViewChild(TextAndAudioComponent) textAndAudio?: TextAndAudioComponent;
   modeLabel =
     this.data && this.data.questionDoc != null
-      ? translate('question_dialog.edit_question')
-      : translate('question_dialog.new_question');
+      ? this.i18n.translateStatic('question_dialog.edit_question')
+      : this.i18n.translateStatic('question_dialog.new_question');
   parentAndStartMatcher = new ParentAndStartErrorStateMatcher();
   versesForm: FormGroup = new FormGroup(
     {
@@ -91,19 +90,19 @@ export class QuestionDialogComponent implements OnInit {
   }
 
   get scriptureInputErrorMessages(): { startError: string; endError: string } {
-    let start: string = translate('question_dialog.required_with_asterisk');
+    let start: string = this.i18n.translateStatic('question_dialog.required_with_asterisk');
     if (this.scriptureStart.hasError('verseFormat')) {
-      start = translate('question_dialog.example_verse');
+      start = this.i18n.translateStatic('question_dialog.example_verse');
     } else if (this.scriptureStart.hasError('verseRange')) {
-      start = translate('question_dialog.must_be_inside_verse_range');
+      start = this.i18n.translateStatic('question_dialog.must_be_inside_verse_range');
     }
     let end: string = '';
     if (this.scriptureEnd.hasError('verseFormat')) {
-      end = translate('question_dialog.example_verse');
+      end = this.i18n.translateStatic('question_dialog.example_verse');
     } else if (this.scriptureEnd.hasError('verseRange')) {
-      end = translate('question_dialog.must_be_inside_verse_range');
+      end = this.i18n.translateStatic('question_dialog.must_be_inside_verse_range');
     } else if (this.versesForm.hasError('verseDifferentBookOrChapter')) {
-      end = translate('question_dialog.must_be_same_book_and_chapter');
+      end = this.i18n.translateStatic('question_dialog.must_be_same_book_and_chapter');
     }
     return { startError: start, endError: end };
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/translation-engine.service.ts
@@ -8,6 +8,7 @@ import { SFProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/mode
 import { getTextDocId } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { Observable } from 'rxjs';
 import { filter, share } from 'rxjs/operators';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OfflineData, OfflineStore } from 'xforge-common/offline-store';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -16,6 +17,7 @@ import { HttpClient } from '../machine-api/http-client';
 import { RemoteTranslationEngine } from '../machine-api/remote-translation-engine';
 import { EDITED_SEGMENTS, EditedSegmentData } from './models/edited-segment-data';
 import { SFProjectService } from './sf-project.service';
+
 /**
  * A service to access features for translation suggestions and training the translation engine
  */
@@ -38,7 +40,8 @@ export class TranslationEngineService {
     private readonly machineHttp: HttpClient,
     private readonly noticeService: NoticeService,
     private readonly router: Router,
-    private destroyRef: DestroyRef
+    private destroyRef: DestroyRef,
+    private readonly i18n: I18nService
   ) {
     this.onlineStatus$ = this.onlineStatusService.onlineStatus$.pipe(
       filter(online => online),
@@ -57,7 +60,7 @@ export class TranslationEngineService {
     if (!this.translationEngines.has(projectId)) {
       this.translationEngines.set(
         projectId,
-        new RemoteTranslationEngine(projectId, this.machineHttp, this.noticeService, this.router)
+        new RemoteTranslationEngine(projectId, this.machineHttp, this.noticeService, this.router, this.i18n)
       );
     }
     return this.translationEngines.get(projectId)!;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { TranslationSources, WordGraph } from '@sillsdev/machine';
 import { of, throwError } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { BuildDto } from './build-dto';
@@ -404,6 +405,7 @@ class TestEnvironment {
   readonly client: RemoteTranslationEngine;
   readonly mockedNoticeService: NoticeService;
   readonly mockedRouter: Router;
+  readonly mockedI18nService: I18nService;
   readonly ngZone: NgZone;
 
   constructor() {
@@ -425,11 +427,13 @@ class TestEnvironment {
     );
     this.mockedNoticeService = mock(NoticeService);
     this.mockedRouter = mock(Router);
+    this.mockedI18nService = mock(I18nService);
     this.client = new RemoteTranslationEngine(
       'project01',
       instance(this.mockedHttpClient),
       instance(this.mockedNoticeService),
-      instance(this.mockedRouter)
+      instance(this.mockedRouter),
+      instance(this.mockedI18nService)
     );
 
     this.ngZone = TestBed.inject(NgZone);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -1,5 +1,4 @@
 import { Router } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import {
   createRange,
   InteractiveTranslationEngine,
@@ -13,6 +12,7 @@ import {
 } from '@sillsdev/machine';
 import { lastValueFrom, Observable, of, throwError } from 'rxjs';
 import { catchError, expand, filter, map, mergeMap, share, startWith, takeWhile } from 'rxjs/operators';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { AlignedWordPairDto } from './aligned-word-pair-dto';
 import { BuildDto } from './build-dto';
@@ -35,7 +35,8 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
     public readonly projectId: string,
     private readonly httpClient: HttpClient,
     private readonly noticeService: NoticeService,
-    private readonly router: Router
+    private readonly router: Router,
+    private readonly i18n: I18nService
   ) {}
 
   async translate(segment: string): Promise<TranslationResult> {
@@ -97,14 +98,14 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
     } catch (err: any) {
       if (err.status === 403 || err.status === 404 || err.status === 409) {
         this.noticeService.showError(
-          translate('error_messages.suggestion_engine_requires_retrain'),
-          translate('error_messages.go_to_retrain'),
+          this.i18n.translateStatic('error_messages.suggestion_engine_requires_retrain'),
+          this.i18n.translateStatic('error_messages.go_to_retrain'),
           () => {
             this.router.navigate(['projects', this.projectId, 'translate']);
           }
         );
       } else {
-        this.noticeService.showError(translate('error_messages.failed_to_retrieve_suggestions'));
+        this.noticeService.showError(this.i18n.translateStatic('error_messages.failed_to_retrieve_suggestions'));
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -1,11 +1,10 @@
 import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import { isPTUser } from 'realtime-server/lib/esm/common/models/user';
 import { isResource } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { Observable } from 'rxjs';
-import { en } from 'xforge-common/i18n.service';
+import { en, I18nService } from 'xforge-common/i18n.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -53,6 +52,7 @@ export class MyProjectsComponent implements OnInit {
     private readonly permissions: PermissionsService,
     private readonly noticeService: NoticeService,
     private readonly router: Router,
+    private readonly i18n: I18nService,
     private destroyRef: DestroyRef
   ) {}
 
@@ -109,11 +109,11 @@ export class MyProjectsComponent implements OnInit {
     const isTranslateAccessible = this.permissions.canAccessTranslate(sfProject);
     const isCheckingAccessible = this.permissions.canAccessCommunityChecking(sfProject) ?? false;
 
-    const drafting = isTranslateAccessible ? translate('my_projects.drafting') : '';
+    const drafting = isTranslateAccessible ? this.i18n.translateStatic('my_projects.drafting') : '';
     const checking = isCheckingAccessible
       ? isTranslateAccessible
-        ? ' • ' + translate('app.community_checking')
-        : translate('app.community_checking')
+        ? ' • ' + this.i18n.translateStatic('app.community_checking')
+        : this.i18n.translateStatic('app.community_checking')
       : '';
 
     return `${drafting}${checking}`;
@@ -126,7 +126,7 @@ export class MyProjectsComponent implements OnInit {
       await this.projectService.onlineAddCurrentUser(projectId);
       this.router.navigate(['projects', projectId]);
     } catch {
-      this.noticeService.show(translate('my_projects.failed_to_join_project'));
+      this.noticeService.show(this.i18n.translateStatic('my_projects.failed_to_join_project'));
     } finally {
       this.noticeService.loadingFinished(this.constructor.name);
       this.joiningProjects.pop();
@@ -137,11 +137,11 @@ export class MyProjectsComponent implements OnInit {
     try {
       this.noticeService.loadingStarted(this.constructor.name);
       await this.projectService.onlineSyncUserRole(projectId);
-      this.noticeService.show(translate('my_projects.user_role_updated'));
+      this.noticeService.show(this.i18n.translateStatic('my_projects.user_role_updated'));
       const project = this.userParatextProjects.find(project => project.projectId === projectId);
       if (project != null) project.hasUserRoleChanged = false;
     } catch {
-      this.noticeService.showError(translate('my_projects.failed_to_update_user_role'));
+      this.noticeService.showError(this.i18n.translateStatic('my_projects.failed_to_update_user_role'));
     } finally {
       this.noticeService.loadingFinished(this.constructor.name);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -12,11 +12,12 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { translate, TranslocoModule } from '@ngneat/transloco';
+import { TranslocoModule } from '@ngneat/transloco';
 import { interval, Observable, Subscription, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { NAVIGATOR } from 'xforge-common/browser-globals';
 import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import {
   BrowserIssue,
@@ -90,7 +91,8 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
     private readonly noticeService: NoticeService,
     @Inject(NAVIGATOR) private readonly navigator: Navigator,
     private readonly dialogService: DialogService,
-    private readonly destroyRef: DestroyRef
+    private readonly destroyRef: DestroyRef,
+    private readonly i18n: I18nService
   ) {
     this.showCountdown = data?.countdown ?? false;
     this._requireSave = data?.requireSave ?? false;
@@ -232,9 +234,9 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
     this.audio = { status: 'denied' };
 
     if (error.code === DOMException.NOT_FOUND_ERR) {
-      this.noticeService.show(translate('checking_audio_recorder.mic_not_found'));
+      this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_not_found'));
     } else {
-      this.noticeService.show(translate('checking_audio_recorder.mic_access_denied'));
+      this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_access_denied'));
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/copyright-banner/copyright-banner.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { translate } from '@ngneat/transloco';
 import { of } from 'rxjs';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -23,7 +22,7 @@ export class CopyrightBannerComponent {
   ) {}
 
   get moreInfo(): string {
-    return translate('editor.more_info');
+    return this.i18n.translateStatic('editor.more_info');
   }
 
   get showMoreInfo(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -9,7 +9,6 @@ import {
   ViewChild
 } from '@angular/core';
 import { FormControl, FormGroup, FormGroupDirective, Validators } from '@angular/forms';
-import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -169,16 +168,18 @@ export class ShareControlComponent extends ShareBaseComponent {
       this.isAlreadyInvited = false;
 
       if (response === this.alreadyProjectMemberResponse) {
-        message = translate('share_control.not_inviting_already_member');
+        message = this.i18n.translateStatic('share_control.not_inviting_already_member');
       } else {
-        message = translate('share_control.invitation_sent', { email: this.sendInviteForm.value.email });
+        message = this.i18n.translateStatic('share_control.invitation_sent', {
+          email: this.sendInviteForm.value.email
+        });
         this.invited.emit();
       }
     } catch (err) {
       if (err instanceof CommandError && err.message.includes(this.invalidEmailAddress)) {
         this.isSubmitted = false;
         this.isAlreadyInvited = false;
-        message = translate('share_control.not_inviting_email_invalid');
+        message = this.i18n.translateStatic('share_control.not_inviting_email_invalid');
       } else {
         throw err;
       }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -168,7 +167,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
       return;
     }
     this.navigator.clipboard.writeText(this.shareableLink).then(async () => {
-      await this.noticeService.show(translate('share_control.link_copied'));
+      await this.noticeService.show(this.i18n.translateStatic('share_control.link_copied'));
       await this.reserveShareLink();
     });
   }
@@ -189,9 +188,9 @@ export class ShareDialogComponent extends ShareBaseComponent {
     };
     this.navigator
       .share({
-        title: translate('share_control.share_title', params),
+        title: this.i18n.translateStatic('share_control.share_title', params),
         url: this.shareableLink,
-        text: translate(
+        text: this.i18n.translateStatic(
           this.shareLinkType === ShareLinkType.Anyone
             ? 'share_control.share_text_anyone'
             : 'share_control.share_text_single',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { firstValueFrom } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
@@ -66,9 +65,11 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     }
     const dateLastSynced = this.projectDoc.data.sync.dateLastSuccessfulSync;
     if (dateLastSynced == null || dateLastSynced === '' || Date.parse(dateLastSynced) <= 0) {
-      return translate('sync.never_been_synced');
+      return this.i18n.translateStatic('sync.never_been_synced');
     } else {
-      return translate('sync.last_synced_time_stamp', { timeStamp: this.i18n.formatDate(new Date(dateLastSynced)) });
+      return this.i18n.translateStatic('sync.last_synced_time_stamp', {
+        timeStamp: this.i18n.formatDate(new Date(dateLastSynced))
+      });
     }
   }
 
@@ -106,7 +107,9 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
         )
       ) {
         if (this.projectDoc.data.sync.lastSyncSuccessful) {
-          this.noticeService.show(translate('sync.successfully_synchronized_with_paratext', { projectName }));
+          this.noticeService.show(
+            this.i18n.translateStatic('sync.successfully_synchronized_with_paratext', { projectName })
+          );
           this.previousLastSyncDate = this.lastSyncDate;
         } else if (this.showSyncUserPermissionsFailureMessage) {
           this.dialogService.message(this.i18n.translate('sync.user_permissions_failure_dialog_message'));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { translate, TranslocoModule } from '@ngneat/transloco';
+import { TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
@@ -62,10 +62,12 @@ export class DraftApplyDialogComponent implements OnInit {
     undefined
   );
   invalidMessageMapper: { [key: string]: string } = {
-    invalidProject: translate('draft_apply_dialog.please_select_valid_project'),
-    bookNotFound: translate('draft_apply_dialog.book_does_not_exist', { bookName: this.bookName }),
-    noWritePermissions: translate('draft_apply_dialog.no_write_permissions'),
-    missingChapters: translate('draft_apply_dialog.project_has_chapters_missing', { bookName: this.bookName })
+    invalidProject: this.i18n.translateStatic('draft_apply_dialog.please_select_valid_project'),
+    bookNotFound: this.i18n.translateStatic('draft_apply_dialog.book_does_not_exist', { bookName: this.bookName }),
+    noWritePermissions: this.i18n.translateStatic('draft_apply_dialog.no_write_permissions'),
+    missingChapters: this.i18n.translateStatic('draft_apply_dialog.project_has_chapters_missing', {
+      bookName: this.bookName
+    })
   };
 
   // the project id to add the draft to

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, EventEmitter, OnInit, Output, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
-import { translate, TranslocoModule } from '@ngneat/transloco';
+import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
@@ -439,7 +439,7 @@ export class DraftGenerationStepsComponent implements OnInit {
       this.stepper.next();
     } else {
       if (!this.onlineStatusService.isOnline) {
-        this.noticeService.show(translate('draft_generation.offline_message'));
+        this.noticeService.show(this.i18n.translateStatic('draft_generation.offline_message'));
         return;
       }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@angular/core';
-import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
@@ -8,6 +7,8 @@ import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/t
 import { DeltaOperation } from 'rich-text';
 import { EMPTY, firstValueFrom, Observable, of, throwError, timer } from 'rxjs';
 import { catchError, distinct, map, shareReplay, switchMap, takeWhile } from 'rxjs/operators';
+
+import { I18nService } from 'xforge-common/i18n.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -35,7 +36,8 @@ export class DraftGenerationService {
     private readonly httpClient: HttpClient,
     private readonly noticeService: NoticeService,
     private readonly onlineStatusService: OnlineStatusService,
-    @Inject(DRAFT_GENERATION_SERVICE_OPTIONS) private readonly options: DraftGenerationServiceOptions
+    @Inject(DRAFT_GENERATION_SERVICE_OPTIONS) private readonly options: DraftGenerationServiceOptions,
+    private readonly i18n: I18nService
   ) {}
 
   /**
@@ -73,7 +75,7 @@ export class DraftGenerationService {
           return of(undefined);
         }
 
-        this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of(undefined);
       })
     );
@@ -97,7 +99,7 @@ export class DraftGenerationService {
           return of(undefined);
         }
 
-        this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of(undefined);
       })
     );
@@ -123,7 +125,7 @@ export class DraftGenerationService {
             return of(undefined);
           }
 
-          this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of(undefined);
         })
       );
@@ -190,7 +192,7 @@ export class DraftGenerationService {
             return of({});
           }
 
-          this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of({});
         })
       );
@@ -237,7 +239,7 @@ export class DraftGenerationService {
           return throwError(() => err);
         }
 
-        this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of([]);
       })
     );
@@ -266,7 +268,7 @@ export class DraftGenerationService {
             return of(undefined);
           }
 
-          this.noticeService.showError(translate('draft_generation.temporarily_unavailable'));
+          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of(undefined);
         })
       );
@@ -316,7 +318,7 @@ export class DraftGenerationService {
   ): Observable<DraftZipProgress> {
     return new Observable<DraftZipProgress>(observer => {
       if (projectDoc?.data == null) {
-        observer.error(translate('draft_generation.info_alert_download_error'));
+        observer.error(this.i18n.translateStatic('draft_generation.info_alert_download_error'));
         return;
       }
 
@@ -366,7 +368,7 @@ export class DraftGenerationService {
       Promise.all(usfmFiles).then(() => {
         if (Object.keys(zip.files).length === 0) {
           observer.next({ current: 0, total: 0 });
-          observer.error(translate('draft_generation.info_alert_download_error'));
+          observer.error(this.i18n.translateStatic('draft_generation.info_alert_download_error'));
           return;
         }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, OnChanges, ViewChild } from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
-import { translate } from '@ngneat/transloco';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DeltaOperation } from 'rich-text';
@@ -241,7 +240,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       this.isDraftApplied = true;
       this.userAppliedDraft = true;
     } catch (err) {
-      this.noticeService.showError(translate('editor_draft_tab.error_applying_draft'));
+      this.noticeService.showError(this.i18n.translateStatic('editor_draft_tab.error_applying_draft'));
       if (!isNetworkError(err)) {
         this.errorReportingService.silentError(
           'Error applying a draft to a chapter',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
-import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { Delta } from 'quill';
 import { TextData } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
@@ -18,6 +17,7 @@ import {
 import { isNetworkError } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { TextSnapshot } from 'xforge-common/models/textsnapshot';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -70,7 +70,8 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
     private readonly paratextService: ParatextService,
     private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
-    private readonly errorReportingService: ErrorReportingService
+    private readonly errorReportingService: ErrorReportingService,
+    private readonly i18n: I18nService
   ) {}
 
   get canRestoreSnapshot(): boolean {
@@ -140,7 +141,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
 
   async revertToSnapshot(): Promise<void> {
     if (!this.onlineStatusService.isOnline) {
-      this.noticeService.show(translate('history_chooser.please_connect'));
+      this.noticeService.show(this.i18n.translateStatic('history_chooser.please_connect'));
       return;
     }
     // Ensure the user wants to proceed
@@ -160,7 +161,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       this.chapter == null ||
       !this.canRestoreSnapshot
     ) {
-      this.noticeService.showError(translate('history_chooser.error'));
+      this.noticeService.showError(this.i18n.translateStatic('history_chooser.error'));
       return;
     }
 
@@ -181,11 +182,11 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       }
       await this.textDocService.overwrite(textDocId, delta, 'History');
 
-      this.noticeService.show(translate('history_chooser.revert_successful'));
+      this.noticeService.show(this.i18n.translateStatic('history_chooser.revert_successful'));
       // Force the history editor to reload
       this.revisionSelect.emit({ revision: this.selectedRevision, snapshot: this.selectedSnapshot });
     } catch (err) {
-      this.noticeService.showError(translate('history_chooser.revert_error'));
+      this.noticeService.showError(this.i18n.translateStatic('history_chooser.revert_error'));
       if (!isNetworkError(err)) {
         this.errorReportingService.silentError(
           'Error occurred restoring a snapshot',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -18,7 +18,6 @@ import { UntypedFormControl, Validators } from '@angular/forms';
 import { MatBottomSheet, MatBottomSheetRef } from '@angular/material/bottom-sheet';
 import { MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import {
   InteractiveTranslator,
   InteractiveTranslatorFactory,
@@ -547,7 +546,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   }
 
   get writingSystemWarningMessage(): string {
-    return translate('editor.browser_warning_banner', {
+    return this.i18n.translateStatic('editor.browser_warning_banner', {
       firefoxLink: browserLinks().firefoxLink,
       safari: browserLinks().safariLink
     });
@@ -1168,7 +1167,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     if (!this.target.contentShowing) {
-      this.noticeService.show(translate('editor.navigate_to_a_valid_text'));
+      this.noticeService.show(this.i18n.translateStatic('editor.navigate_to_a_valid_text'));
       return;
     }
     let verseRef: VerseRef | undefined = this.commenterSelectedVerseRef;
@@ -1781,7 +1780,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     } else if (!translator.isSegmentValid) {
       this.translator = undefined;
       if (this.translationSuggestionsEnabled) {
-        this.noticeService.show(translate('editor.verse_too_long_for_suggestions'));
+        this.noticeService.show(this.i18n.translateStatic('editor.verse_too_long_for_suggestions'));
       }
       return;
     }
@@ -2072,7 +2071,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     const notes: Note[] = threadDoc.notesInOrderClone(threadDoc.data!.notes);
     let preview: string = notes[0].content != null ? stripHtml(notes[0].content.trim()) : '';
     if (notes.length > 1) {
-      preview += '\n' + translate('editor.more_notes', { count: notes.length - 1 });
+      preview += '\n' + this.i18n.translateStatic('editor.more_notes', { count: notes.length - 1 });
     }
     const verseRef: VerseRef | undefined = threadDoc.currentVerseRef();
     if (threadDoc.data == null || verseRef == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { translate } from '@ngneat/transloco';
 import { VerseRef } from '@sillsdev/scripture';
 import { sortBy } from 'lodash-es';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
@@ -166,7 +165,7 @@ export class NoteDialogComponent implements OnInit {
   }
 
   get verseRefDisplay(): string {
-    if (this.isBiblicalTermNote) return translate('note_dialog.biblical_term');
+    if (this.isBiblicalTermNote) return this.i18n.translateStatic('note_dialog.biblical_term');
     const verseRef: VerseRef | undefined = this.verseRef;
     return verseRef == null ? '' : this.i18n.localizeReference(verseRef);
   }
@@ -317,14 +316,14 @@ export class NoteDialogComponent implements OnInit {
     if (assignedNoteUserRef == null) return undefined;
     switch (assignedNoteUserRef) {
       case AssignedUsers.TeamUser:
-        return translate('note_dialog.team');
+        return this.i18n.translateStatic('note_dialog.team');
       case AssignedUsers.Unspecified:
-        return translate('note_dialog.unassigned');
+        return this.i18n.translateStatic('note_dialog.unassigned');
     }
     const paratextUser: ParatextUserProfile | undefined = this.paratextProjectUsers?.find(
       u => u.opaqueUserId === assignedNoteUserRef
     );
-    return paratextUser?.username ?? translate('note_dialog.paratext_user');
+    return paratextUser?.username ?? this.i18n.translateStatic('note_dialog.paratext_user');
   }
 
   close(): void {
@@ -421,12 +420,12 @@ export class NoteDialogComponent implements OnInit {
   private noteTitle(note: Note): string {
     switch (note.status) {
       case NoteStatus.Todo:
-        return translate('note_dialog.status_to_do');
+        return this.i18n.translateStatic('note_dialog.status_to_do');
       case NoteStatus.Done:
       case NoteStatus.Resolved:
-        return translate('note_dialog.status_resolved');
+        return this.i18n.translateStatic('note_dialog.status_resolved');
     }
-    return note.reattached != null ? translate('note_dialog.note_reattached') : '';
+    return note.reattached != null ? this.i18n.translateStatic('note_dialog.note_reattached') : '';
   }
 
   /**
@@ -460,17 +459,17 @@ export class NoteDialogComponent implements OnInit {
       syncUser.sfUserId === ownerDoc.id // The note is not editable, but the sync user is the owner, so use the SF owner
     ) {
       return this.userService.currentUserId === ownerDoc.id
-        ? translate('checking.me') // "Me", i.e. the current user
+        ? this.i18n.translateStatic('checking.me') // "Me", i.e. the current user
         : (ownerDoc.data?.displayName ?? // Another user
             syncUser?.username ?? // Fallback to the sync user
-            translate('checking.unknown_author')); // An "unknown author" (there is no sync user)
+            this.i18n.translateStatic('checking.unknown_author')); // An "unknown author" (there is no sync user)
     }
 
     // The note was created in Paratext, so see if we have a profile for the sync user
     const syncUserProfile: UserProfileDoc | undefined =
       syncUser.sfUserId == null ? undefined : await this.userService.getProfile(syncUser.sfUserId);
     return this.userService.currentUserId === syncUserProfile?.id
-      ? translate('checking.me') // "Me", i.e. the current user
+      ? this.i18n.translateStatic('checking.me') // "Me", i.e. the current user
       : (syncUserProfile?.data?.displayName ?? syncUser.username); // Another user, or fallback to the sync user
   }
 
@@ -507,7 +506,7 @@ export class NoteDialogComponent implements OnInit {
       const verseStr: string = reattachedParts[0];
       const vref: VerseRef = new VerseRef(verseStr);
       const verseRef: string = this.i18n.localizeReference(vref);
-      const reattached: string = translate('note_dialog.reattached');
+      const reattached: string = this.i18n.translateStatic('note_dialog.reattached');
       return `${verseRef} ${reattached}`;
     } catch {
       // Ignore any errors parsing the re-attached verse

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -1,5 +1,4 @@
 import { Component, DestroyRef, Input, OnDestroy, OnInit } from '@angular/core';
-import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { BehaviorSubject, Subscription, timer } from 'rxjs';
@@ -8,6 +7,8 @@ import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
+
+import { I18nService } from 'xforge-common/i18n.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
@@ -35,7 +36,8 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
     private readonly projectService: SFProjectService,
     private readonly translationEngineService: TranslationEngineService,
     private readonly userService: UserService,
-    private destroyRef: DestroyRef
+    private destroyRef: DestroyRef,
+    private readonly i18n: I18nService
   ) {
     super(noticeService);
   }
@@ -138,10 +140,10 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
           complete: () => {
             // training completed successfully
             if (this.trainingProgressClosed) {
-              this.noticeService.show(translate('training_progress.training_completed_successfully'));
+              this.noticeService.show(this.i18n.translateStatic('training_progress.training_completed_successfully'));
               this.trainingProgressClosed = false;
             } else {
-              this.trainingMessage = translate('training_progress.completed_successfully');
+              this.trainingMessage = this.i18n.translateStatic('training_progress.completed_successfully');
               this.trainingCompletedTimeout = setTimeout(() => {
                 this.showTrainingProgress = false;
                 this.trainingCompletedTimeout = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, DestroyRef, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { ANY_INDEX, obj } from 'realtime-server/lib/esm/common/utils/obj-path';
@@ -159,7 +158,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
         if (error instanceof HttpErrorResponse && error.status === 401) {
           this.authService.requestParatextCredentialUpdate();
         } else {
-          this.noticeService.showError(translate('translate_overview.training_unavailable'));
+          this.noticeService.showError(this.i18n.translateStatic('translate_overview.training_unavailable'));
         }
       })
       .then(() => this.listenForStatus());

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, ChangeDetectorRef, Component, DestroyRef, OnInit } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { translate } from '@ngneat/transloco';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
@@ -272,7 +271,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       );
       this._userRows = userRows.concat(invitees);
     } catch {
-      this.noticeService.show(translate('collaborators.problem_loading_invited_users'));
+      this.noticeService.show(this.i18n.translateStatic('collaborators.problem_loading_invited_users'));
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -132,9 +132,9 @@ export class I18nService {
     private readonly transloco: TranslocoService,
     private readonly cookieService: CookieService,
     private readonly reportingService: ErrorReportingService,
-    private readonly featureFlags: FeatureFlagService,
     @Inject(DOCUMENT) private readonly document: Document,
-    @Optional() @Inject(IGNORE_COOKIE_LOCALE) ignoreCookieLocale: boolean = false
+    @Optional() @Inject(IGNORE_COOKIE_LOCALE) ignoreCookieLocale: boolean = false,
+    @Optional() private readonly featureFlags?: FeatureFlagService
   ) {
     // This will set the locale to what is specified in the URL first, or fallback to the cookie
     const urlLocale = new URLSearchParams(locationService.search).get('locale');
@@ -178,7 +178,7 @@ export class I18nService {
 
   get locales(): Locale[] {
     return I18nService.locales.filter(
-      locale => locale.production || this.featureFlags.showNonPublishedLocalizations.enabled
+      locale => locale.production || this.featureFlags?.showNonPublishedLocalizations.enabled === true
     );
   }
 
@@ -301,9 +301,11 @@ export class I18nService {
     return this.transloco.selectTranslate<string>(key, params);
   }
 
-  /** Returns a translation for the given I18nKey. A string is returned, so this cannot be used to keep a localization
+  /**
+   * Returns a translation for the given I18nKey. A string is returned, so this cannot be used to keep a localization
    * updated without re-calling this whenever the locale changes. Avoid using this when observing a localization is
-   * possible. */
+   * possible.
+   */
   translateStatic(key: I18nKey, params: object = {}): string {
     return this.transloco.translate(key, params);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/supported-browsers-dialog/supported-browsers-dialog.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { translate } from '@ngneat/transloco';
 import { I18nService } from 'xforge-common/i18n.service';
 import { browserLinks, isIosDevice } from 'xforge-common/utils';
 
@@ -26,10 +25,13 @@ export class SupportedBrowsersDialogComponent {
   get dialogMessage(): string {
     if (this.data === BrowserIssue.AudioRecording) {
       return isIosDevice()
-        ? translate('supported_browsers_dialog.safari_for_audio_on_ios') + this.recommendedBrowserText
-        : translate('supported_browsers_dialog.audio_recording_not_supported') + this.recommendedBrowserText;
+        ? this.i18n.translateStatic('supported_browsers_dialog.safari_for_audio_on_ios') + this.recommendedBrowserText
+        : this.i18n.translateStatic('supported_browsers_dialog.audio_recording_not_supported') +
+            this.recommendedBrowserText;
     }
-    return translate('supported_browsers_dialog.some_features_may_not_work') + this.recommendedBrowserText;
+    return (
+      this.i18n.translateStatic('supported_browsers_dialog.some_features_may_not_work') + this.recommendedBrowserText
+    );
   }
 
   get recommendedBrowserText(): string {


### PR DESCRIPTION
I've replaced uses of `translate()` with `i18n.translateStatic()` as much as possible, for greater type safety. We should favor this whenever possible. (I was motivated to do this after catching a incorrect localization key in code review recently).

I left lots of places untouched because updating tests wasn't trivial.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3319)
<!-- Reviewable:end -->
