### PR TITLE
SF-3397 Synchronize drafting sources if needed when configured

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.html
@@ -213,7 +213,7 @@
           } @else if (getControlState("projectSettings") === ElementState.Submitted) {
             <mat-icon class="success">checkmark</mat-icon> {{ t("all_changes_saved") }}
           } @else {
-            <mat-icon class="failure">error</mat-icon> Failed to save changes
+            <mat-icon class="failure">error</mat-icon> {{ t("failed_to_save_changes") }}
           }
         </div>
         @for (entry of syncStatus | keyvalue; track entry.key) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -301,6 +301,7 @@
     "confirm_language_codes": "Please confirm that the language codes are correct before saving.",
     "discard_changes_confirmation": "Are you sure you want to leave the page with unsaved changes?",
     "draft_source": "Draft source",
+    "failed_to_save_changes": "Failed to save changes.",
     "generate_draft_from_language_model": "Generate draft from language model",
     "language_code": "Language code: ",
     "leave_and_discard": "Leave & discard changes",
@@ -334,7 +335,6 @@
     "unknown_language_code": "unknown"
   },
   "draft_usfm_format": {
-    "changes_have_been_saved": "Changes have been saved",
     "cancel": "Cancel",
     "connect_to_the_internet": "Please connect to the internet to change the USFM format for your draft",
     "draft_format_description": "The draft has been created. Here are some formatting options for the text. You can try each option to see the difference it makes.",


### PR DESCRIPTION
When a source project has failed its most recent sync attempt, it shows on the configure sources page as having failed to sync when the user saves their changes. This was not completely accurate because the page only reports the last sync state without actually attempting to synchronize the project.
This change updates the backend logic so that when a source project's most recent sync attempt has failed, saving the project as a source on the configure sources page will kick off a sync of the source project.

The steps to reproduce the issue require manually updating the DB. Developer testing should be sufficient to reproduce the issue and confirm this change works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3320)
<!-- Reviewable:end -->
