### PR TITLE
Update e2e screenshot sizes to fit new draft sources page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
@@ -205,8 +205,9 @@ export async function localizedScreenshots(
     await screenshot(page, { ...context, pageName: 'configure_sources_button', locale });
   });
 
-  // Make the viewport taller to fit the "confirm languages" area
-  await page.setViewportSize({ width: 1280, height: 900 });
+  const originalViewportSize = await page.viewportSize();
+  // Increase the height of the viewport to ensure all elements are visible
+  await page.setViewportSize({ width: originalViewportSize.width, height: 1200 });
 
   await page.locator('[data-test-id="configure-button"]').click();
   await forEachLocale(async locale => {
@@ -317,6 +318,9 @@ export async function localizedScreenshots(
       { margin: 8 }
     );
   });
+
+  // Reset the viewport size to the original size full page screenshots aren't excessively tall
+  await page.setViewportSize(originalViewportSize);
 
   // Generate the draft
 


### PR DESCRIPTION
Recent changes to the configure sources page made the last step significantly taller, which resulted in some screenshots getting cut off. This increases the page size before taking those screenshots, then resets the size so full page screenshots won't be excessively tall.

The screenshots this outputs are already live at https://help.scriptureforge.org/preparing-for-ai-drafting#confirming-the-languages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3321)
<!-- Reviewable:end -->
