### PR TITLE
Localize training files label in draft generation stepper

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.html
@@ -32,7 +32,7 @@
     </div>
     @if (this.trainingDataFiles.length > 0) {
       <div class="training-files">
-        <h3>Training files</h3>
+        <h3>{{ t("training_files") }}</h3>
         <div class="files-list">
           @for (file of trainingDataFiles; track file) {
             <span class="project-name">{{ file.title }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -256,7 +256,7 @@
           @if (this.trainingDataFiles.length > 0) {
             <table mat-table [dataSource]="this.trainingDataFiles">
               <ng-container matColumnDef="file">
-                <th mat-header-cell *matHeaderCellDef>Training files</th>
+                <th mat-header-cell *matHeaderCellDef>{{ t("training_files") }}</th>
                 <td mat-cell class="filename-cell" *matCellDef="let element">
                   <div class="filename">{{ element.title }}</div>
                 </td>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -111,6 +111,7 @@
     "references_heading": "References ({{ referenceLanguage }})",
     "review_draft_setup": "Review draft setup",
     "targets_heading": "Translation project ({{ targetLanguage }})",
+    "training_files": "Training files",
     "training_language_model": "Training the language model"
   },
   "connect_project": {
@@ -257,6 +258,7 @@
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
     "training_books_will_appear": "Training books will appear as you select books under translated books",
     "training_books": "Training books",
+    "training_files": "Training files",
     "translated_book_selected_no_training_pair": "Some of the training books you selected have no matching reference books selected. Please select matching reference books.",
     "translated_books": "Translated books",
     "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project.",


### PR DESCRIPTION
This PR fixes the issue where "training files" was not being localized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3325)
<!-- Reviewable:end -->
