### PR TITLE
SF-3435 Save fast training and echo settings across draft builds

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -71,6 +71,8 @@ export interface DraftConfig {
   lastSelectedTranslationBooks: number[];
   lastSelectedTranslationScriptureRange?: string;
   lastSelectedTranslationScriptureRanges?: ProjectScriptureRange[];
+  fastTraining?: boolean;
+  useEcho?: boolean;
   servalConfig?: string;
   usfmConfig?: DraftUsfmConfig;
 }

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -302,6 +302,12 @@ export class SFProjectService extends ProjectService<SFProject> {
                   additionalProperties: false
                 }
               },
+              fastTraining: {
+                bsonType: 'bool'
+              },
+              useEcho: {
+                bsonType: 'bool'
+              },
               servalConfig: {
                 bsonType: 'string'
               },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -232,6 +232,13 @@ export class DraftGenerationStepsComponent implements OnInit {
             bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
           );
 
+          // set developer settings
+          if (this.featureFlags.showDeveloperTools.enabled) {
+            this.fastTraining =
+              this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.fastTraining ?? false;
+            this.useEcho = this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.useEcho ?? false;
+          }
+
           this.hasLoaded = true;
         }
       );

--- a/src/SIL.XForge.Scripture/Models/DraftConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftConfig.cs
@@ -17,6 +17,8 @@ public class DraftConfig
     public IList<int> LastSelectedTranslationBooks { get; set; } = [];
     public string? LastSelectedTranslationScriptureRange { get; set; }
     public IList<ProjectScriptureRange> LastSelectedTranslationScriptureRanges { get; set; } = [];
+    public bool? FastTraining { get; set; }
+    public bool? UseEcho { get; set; }
     public string? ServalConfig { get; set; }
     public DraftUsfmConfig? UsfmConfig { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1329,6 +1329,8 @@ public class MachineApiService(
                 [.. buildConfig.TranslationScriptureRanges],
                 _listProjectScriptureRangeComparer
             );
+            op.Set(p => p.TranslateConfig.DraftConfig.FastTraining, buildConfig.FastTraining);
+            op.Set(p => p.TranslateConfig.DraftConfig.UseEcho, buildConfig.UseEcho);
             if (!projectDoc.Data.TranslateConfig.PreTranslate)
             {
                 op.Set(p => p.TranslateConfig.PreTranslate, true);


### PR DESCRIPTION
This PR stores the developer only settings of fast training and echo translation engine on a project. The result of this is that future pretranslation builds will automatically have the fast training and echo translation checkboxes selected if the most recent build used those features.
However, if a user does not have the developer tools feature flag enabled, these settings will not be used on the build and will be reset to false on the project. It may be possible to avoid updating the settings when the feature flag is not enabled, but it seems more intuitive to keep the state of the draft config consistent with what was used on the most recent pretranslation build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3326)
<!-- Reviewable:end -->
