### PR TITLE
Use DialogService to launch dialog in Storybook tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/.storybook/util/mat-dialog-launch.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { Component, Inject, InjectionToken, Injector, OnInit, Provider } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TranslocoModule } from '@ngneat/transloco';
 import { StoryFn } from '@storybook/angular';
 import { UICommonModule } from 'xforge-common/ui-common.module';
 import { hasProp } from '../../src/type-utils';
+import { DialogService } from '../../src/xforge-common/dialog.service';
 
 export function getOverlays(element: HTMLElement): HTMLElement[] {
   return Array.from(element.ownerDocument.querySelectorAll('.cdk-overlay-container .cdk-overlay-pane'));
@@ -31,7 +32,6 @@ export interface MatDialogStoryConfig {
 @Component({ template: '' })
 export class MatDialogLaunchComponent implements OnInit {
   constructor(
-    private dialog: MatDialog,
     @Inject(MAT_DIALOG_DATA) public data: any,
     @Inject(COMPONENT_UNDER_TEST) private component: any,
     @Inject(COMPONENT_PROPS) private props: any,
@@ -39,7 +39,8 @@ export class MatDialogLaunchComponent implements OnInit {
   ) {}
 
   public ngOnInit(): void {
-    const dialogRef = this.dialog.open(this.component, {
+    const dialogService = this.injector.get(DialogService);
+    const dialogRef = dialogService.openMatDialog(this.component, {
       data: this.data,
       injector: Injector.create({ providers: [], parent: this.injector })
     });


### PR DESCRIPTION
This changes how storybook launches dialogs to use the same service we use in the application itself, meaning the dialog may actually get launched with slightly different (more realistic) options.

(I ran into this discrepancy, and then ended up going with an approach where it didn't end up mattering, but still wanted to submit this change as an improvement)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3342)
<!-- Reviewable:end -->
