### PR TITLE
SF-3479 Show previous completed drafts when opening draft tab

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -12,6 +12,7 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -37,6 +38,7 @@ const mockI18nService = mock(I18nService);
 const mockDialogService = mock(DialogService);
 const mockNoticeService = mock(NoticeService);
 const mockErrorReportingService = mock(ErrorReportingService);
+const mockFeatureFlagService = mock(FeatureFlagService);
 
 describe('EditorDraftComponent', () => {
   let fixture: ComponentFixture<EditorDraftComponent>;
@@ -63,7 +65,8 @@ describe('EditorDraftComponent', () => {
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: DialogService, useMock: mockDialogService },
       { provide: NoticeService, useMock: mockNoticeService },
-      { provide: ErrorReportingService, useMock: mockErrorReportingService }
+      { provide: ErrorReportingService, useMock: mockErrorReportingService },
+      { provide: FeatureFlagService, useMock: mockFeatureFlagService }
     ]
   }));
 
@@ -92,6 +95,7 @@ describe('EditorDraftComponent', () => {
       data: createTestProjectProfile()
     } as SFProjectProfileDoc;
 
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(false));
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
@@ -153,6 +157,7 @@ describe('EditorDraftComponent', () => {
     const testProjectDoc: SFProjectProfileDoc = {
       data: createTestProjectProfile()
     } as SFProjectProfileDoc;
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(true));
     when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
       of(draftHistory)
@@ -180,6 +185,7 @@ describe('EditorDraftComponent', () => {
     const testProjectDoc: SFProjectProfileDoc = {
       data: createTestProjectProfile()
     } as SFProjectProfileDoc;
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(true));
     when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
       of(draftHistory)
@@ -204,6 +210,51 @@ describe('EditorDraftComponent', () => {
     verify(mockDraftHandlingService.draftDataToOps(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
+  }));
+
+  it('should show previous draft when history is enabled and not timestamp is provided', fakeAsync(() => {
+    const testProjectDoc: SFProjectProfileDoc = {
+      data: createTestProjectProfile()
+    } as SFProjectProfileDoc;
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(true));
+    when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(false));
+    when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
+      of(draftHistory)
+    );
+    when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
+    spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
+    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
+    when(mockDraftHandlingService.draftDataToOps(anything(), anything())).thenReturn(draftDelta.ops!);
+    when(mockDraftHandlingService.isDraftSegmentMap(anything())).thenReturn(false);
+
+    // SUT
+    fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+
+    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.draftDataToOps(anything(), anything())).once();
+    expect(component.draftCheckState).toEqual('draft-present');
+    expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
+  }));
+
+  it('should show draft empty if earlier draft exists but history is not enabled', fakeAsync(() => {
+    const testProjectDoc: SFProjectProfileDoc = {
+      data: createTestProjectProfile()
+    } as SFProjectProfileDoc;
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(false));
+    when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(false));
+    when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
+      of(draftHistory)
+    );
+    when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
+    spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
+
+    fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+
+    verify(mockDraftHandlingService.getDraft(anything(), anything())).never();
+    verify(mockDraftHandlingService.draftDataToOps(anything(), anything())).never();
+    expect(component.draftCheckState).toEqual('draft-empty');
   }));
 
   it('should return ops and update the editor when no revision', fakeAsync(() => {
@@ -233,6 +284,7 @@ describe('EditorDraftComponent', () => {
     const testProjectDoc: SFProjectProfileDoc = {
       data: createTestProjectProfile()
     } as SFProjectProfileDoc;
+    when(mockFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(false));
     when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
       of(draftHistory)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -158,10 +158,9 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
           ])
         ),
         switchMap(([timestamp, draftExists]) => {
-          // As getGeneratedDraftHistory() will always return a draft, we should not show a draft if the user does not
-          // have a timestamp in the query string. If a query string was specified, the user was sent from the draft
-          // history component.
-          if (!draftExists && (this.timestamp == null || timestamp == null)) {
+          const initialTimestamp: Date | undefined = timestamp ?? this.timestamp;
+          // If an earlier draft exists, hide it if the draft history feature is not enabled
+          if (!draftExists && (!this.featureFlags.newDraftHistory.enabled || initialTimestamp == null)) {
             this.draftCheckState = 'draft-empty';
             return EMPTY;
           }
@@ -173,7 +172,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
               this.targetProject = projectDoc.data;
             }),
             distinctUntilChanged(),
-            map(() => timestamp)
+            map(() => initialTimestamp)
           );
         }),
         switchMap((timestamp: Date | undefined) =>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -105,6 +105,7 @@ import { PRESENCE_EDITOR_ACTIVE_TIMEOUT } from '../../shared/text/text.component
 import { XmlUtils } from '../../shared/utils';
 import { BiblicalTermsComponent } from '../biblical-terms/biblical-terms.component';
 import { DraftGenerationService } from '../draft-generation/draft-generation.service';
+import { DraftPreviewBooksComponent } from '../draft-generation/draft-preview-books/draft-preview-books.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 import { EditorDraftComponent } from './editor-draft/editor-draft.component';
 import { HistoryRevisionFormatPipe } from './editor-history/history-chooser/history-revision-format.pipe';
@@ -167,6 +168,7 @@ describe('EditorComponent', () => {
     imports: [
       BiblicalTermsComponent,
       CopyrightBannerComponent,
+      DraftPreviewBooksComponent,
       NoopAnimationsModule,
       RouterModule.forRoot(ROUTES),
       SharedModule.forRoot(),


### PR DESCRIPTION
This PR updates the behaviour when opening a draft tab. If draft history is enabled, previous drafts will be shown on books and the menu to select historical drafts will be visible. If the draft history is not enabled, the previous behaviour is expected and the page will say that no draft exist for the book.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3343)
<!-- Reviewable:end -->
