### PR TITLE
SF-2904 Store Paratext project visibility in the project document

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/sf-project.ts
+++ b/src/RealtimeServer/scriptureforge/models/sf-project.ts
@@ -48,6 +48,7 @@ export interface SFProjectProfile extends Project {
   biblicalTermsConfig: BiblicalTermsConfig;
   copyrightBanner?: string;
   copyrightNotice?: string;
+  visibility?: string;
 }
 
 export interface SFProject extends SFProjectProfile {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -36,7 +36,8 @@ const SF_PROJECT_PROFILE_FIELDS: ShareDB.ProjectionFields = {
   sync: true,
   noteTags: true,
   copyrightBanner: true,
-  copyrightNotice: true
+  copyrightNotice: true,
+  visibility: true
 };
 
 /**
@@ -543,6 +544,9 @@ export class SFProjectService extends ProjectService<SFProject> {
       copyrightNotice: {
         bsonType: 'string'
       },
+      visibility: {
+        bsonType: 'string'
+      },
       paratextUsers: {
         bsonType: 'array',
         items: {
@@ -579,7 +583,8 @@ export class SFProjectService extends ProjectService<SFProject> {
       this.pathTemplate(p => p.shortName),
       this.pathTemplate(p => p.writingSystem),
       this.pathTemplate(p => p.copyrightBanner),
-      this.pathTemplate(p => p.copyrightNotice)
+      this.pathTemplate(p => p.copyrightNotice),
+      this.pathTemplate(p => p.visibility)
     ];
     this.immutableProps.push(...immutableProps);
   }

--- a/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextSettings.cs
@@ -39,4 +39,5 @@ public class ParatextSettings
     public string? CopyrightBanner { get; init; }
     public string? CopyrightNotice { get; init; }
     public ScrVers? Versification { get; init; }
+    public string Visibility { get; init; } = string.Empty;
 }

--- a/src/SIL.XForge.Scripture/Models/SFProject.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProject.cs
@@ -45,4 +45,11 @@ public class SFProject : Project
     /// <value>The copyright notice.</value>
     /// <remarks>This is may be plain text or HTML formatted.</remarks>
     public string? CopyrightNotice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the project visibility
+    /// </summary>
+    /// <value>The project visibility.</value>
+    /// <remarks>This will be one of the following: "Public", "Test", or "Confidential".</remarks>
+    public string? Visibility { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1005,6 +1005,7 @@ public class ParatextService : DisposableBase, IParatextService
             CopyrightBanner = copyrightBanner,
             CopyrightNotice = copyrightNotice,
             Versification = scrText.Settings.Versification,
+            Visibility = scrText.Settings.Visibility.ToString(),
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1831,6 +1831,8 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     // There is no longer a copyright notice, so remove it
                     op.Unset(pd => pd.CopyrightNotice);
                 }
+
+                op.Set(pd => pd.Visibility, settings.Visibility);
             }
 
             // The source can be null if there was an error getting a resource from the DBL

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -866,6 +866,7 @@ public class ParatextSyncRunnerTests
         Assert.IsNull(project.WritingSystem.Tag);
         Assert.IsNull(project.CopyrightBanner);
         Assert.IsNull(project.CopyrightNotice);
+        Assert.IsNull(project.Visibility);
         Assert.That(project.TranslateConfig.Source.WritingSystem.Tag, Is.EqualTo(sourceWritingSystemTag));
         const int newFontSize = 16;
         const string newFont = "Doulos SIL";
@@ -887,6 +888,7 @@ public class ParatextSyncRunnerTests
         string newBaseProjectShortName = "BPT";
         const string newCopyrightBanner = "Copyright Banner Goes Here";
         const string newCopyrightNotice = $"<p>Notification: {newCopyrightBanner}</p><p>Copyright Notice Goes Here</p>";
+        const string newVisibility = "Confidential";
         env.ParatextService.GetParatextSettings(Arg.Any<UserSecret>(), Arg.Any<string>())
             .Returns(
                 new ParatextSettings
@@ -902,6 +904,7 @@ public class ParatextSyncRunnerTests
                     BaseProjectShortName = newBaseProjectShortName,
                     CopyrightBanner = newCopyrightBanner,
                     CopyrightNotice = newCopyrightNotice,
+                    Visibility = newVisibility,
                 }
             );
 
@@ -920,6 +923,7 @@ public class ParatextSyncRunnerTests
         Assert.That(project.TranslateConfig.BaseProject.ShortName, Is.EqualTo(newBaseProjectShortName));
         Assert.That(project.CopyrightBanner, Is.EqualTo(newCopyrightBanner));
         Assert.That(project.CopyrightNotice, Is.EqualTo(newCopyrightNotice));
+        Assert.That(project.Visibility, Is.EqualTo(newVisibility));
 
         // Change the base project configuration and remove copyright banner & message
         newProjectType = ProjectType.Daughter.ToString();


### PR DESCRIPTION
This PR adds a "Visibility" property to `sf_project` that will be set on the next sync of the project.

This should be tested by a developer, as this property is not yet displayed on the frontend in any way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3346)
<!-- Reviewable:end -->
