### PR TITLE
SF-3486 Hide completed drafts when content is not available

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
@@ -14,9 +14,9 @@
       <app-draft-history-entry [entry]="entry" />
     }
   }
-  @if (nonActiveBuilds.length > 0) {
+  @if (showOlderDraftsNotSupportedWarning && nonActiveBuilds.length > 0) {
     <app-notice [icon]="'summarize'" class="older-drafts">{{
-      t("older_drafts_not_available", { date: draftHistoryCutoffDate })
+      t("older_drafts_not_available", { date: draftHistoryCutOffDateFormatted })
     }}</app-notice>
   }
 </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -294,7 +294,7 @@
     "draft_canceled": "The draft was canceled",
     "draft_completed": "The draft is ready",
     "draft_faulted": "The draft failed",
-    "older_drafts_not_available": "Older drafts generated before {{ date }} are not available.",
+    "older_drafts_not_available": "Older drafts requested before {{ date }} are not available.",
     "previously_generated_drafts": "Previously generated drafts"
   },
   "draft_preview_books": {


### PR DESCRIPTION
Some drafts appear in the history without a way to use them. This is because they were generated before the draft history feature was introduced. This change hides drafts that were generated but cannot be downloaded or applied because they are not stored in our database. As per the [balsamiq](https://balsamiq.cloud/sghq53/pejrlz8/rB051) I added a notice to inform the user that drafts older than Dec 3 are not available in the history.

Another requirement on the Jira issue is that the notice would not show for projects older newer than Dec. 3, but I am not sure how to implement that since the project docs do not explicitly have a date created property.

<img width="1025" height="669" alt="image" src="https://github.com/user-attachments/assets/9fca78a2-abca-43ac-9e59-a65dcad8a8d2" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3348)
<!-- Reviewable:end -->
