### PR TITLE
SF-3490 Show who created a draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -89,6 +89,20 @@
               <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
               <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
             </table>
+            @if (buildRequestedAtDate != null && buildRequestedByUserName != null) {
+              <p>
+                {{
+                  t("requested_by", {
+                    requestedAtDate: buildRequestedAtDate,
+                    requestedByUserName: buildRequestedByUserName
+                  })
+                }}
+              </p>
+            } @else if (buildRequestedAtDate != null) {
+              <p>
+                {{ t("requested_at", { requestedAtDate: buildRequestedAtDate }) }}
+              </p>
+            }
           }
         }
       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -60,7 +60,7 @@ describe('DraftHistoryEntryComponent', () => {
       component.entry = undefined;
       expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(component.hasDetails).toBe(false);
       expect(component.entry).toBeUndefined();
@@ -80,7 +80,7 @@ describe('DraftHistoryEntryComponent', () => {
 
       expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBe(user);
-      expect(component.buildRequestedByDate).toBe(date);
+      expect(component.buildRequestedAtDate).toBe(date);
       expect(component.canDownloadBuild).toBe(true);
       expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
       expect(component.columnsToDisplay).toEqual(['scriptureRange', 'source', 'target']);
@@ -146,7 +146,7 @@ describe('DraftHistoryEntryComponent', () => {
 
       expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
       expect(component.columnsToDisplay).toEqual(['scriptureRange', 'source', 'target']);
@@ -187,7 +187,7 @@ describe('DraftHistoryEntryComponent', () => {
 
       expect(component.scriptureRange).toEqual('Genesis');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('formatted-date');
+      expect(component.buildRequestedAtDate).toBe('formatted-date');
       expect(component.canDownloadBuild).toBe(true);
       expect(fixture.nativeElement.querySelector('.format-usfm')).not.toBeNull();
       expect(component.hasDetails).toBe(true);
@@ -200,7 +200,7 @@ describe('DraftHistoryEntryComponent', () => {
       component.isLatestBuild = true;
       expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
       expect(component.hasDetails).toBe(false);
@@ -212,7 +212,7 @@ describe('DraftHistoryEntryComponent', () => {
       component.entry = entry;
       expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(component.hasDetails).toBe(false);
       expect(component.entry).toBe(entry);
@@ -233,7 +233,7 @@ describe('DraftHistoryEntryComponent', () => {
       component.entry = entry;
       expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(component.hasDetails).toBe(true);
       expect(component.entry).toBe(entry);
@@ -250,7 +250,7 @@ describe('DraftHistoryEntryComponent', () => {
       component.entry = entry;
       expect(component.scriptureRange).toEqual('');
       expect(component.buildRequestedByUserName).toBeUndefined();
-      expect(component.buildRequestedByDate).toBe('');
+      expect(component.buildRequestedAtDate).toBe('');
       expect(component.canDownloadBuild).toBe(false);
       expect(component.hasDetails).toBe(true);
       expect(component.entry).toBe(entry);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -176,7 +176,7 @@ export class DraftHistoryEntryComponent {
     return this._buildRequestedByUserName;
   }
 
-  get buildRequestedByDate(): string {
+  get buildRequestedAtDate(): string {
     if (this._entry?.additionalInfo?.dateRequested == null) return '';
     return this.i18n.formatDate(new Date(this._entry?.additionalInfo?.dateRequested));
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -276,6 +276,8 @@
     "error_details": "Please include these details when contacting support for assistance",
     "format_draft": "Format draft",
     "hide_model_training_configuration": "Hide model training configuration",
+    "requested_at": "Requested at {{ requestedAtDate }}.",
+    "requested_by": "Requested by {{ requestedByUserName }} at {{ requestedAtDate }}.",
     "show_model_training_configuration": "Show model training configuration",
     "training_books": "Training books",
     "training_model_description": "The language model was trained on this configuration"


### PR DESCRIPTION
This PR adds a line to the bottom of the build details showing who started the build and when (when this data is available).

<img width="1053" height="424" alt="image" src="https://github.com/user-attachments/assets/a03937a9-4306-4b3c-900b-7993e14d9ac5" />

@Nateowami Was this what you were expecting for this change? I didn't add it to the date subtitle, as saying "Build completed by User 123 at Aug 6 2025, 12:01 AM" didn't really make sense to me (unless you can think of better wording?)
