### PR TITLE
Attempt to fix Storybook avatar tests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/avatar/avatar.stories.ts
@@ -31,7 +31,7 @@ export const WithFailedImage: Story = {
   args: {
     user: createTestUserProfile({
       displayName: 'John Doe',
-      avatarUrl: 'https://example.com/non-existent.png'
+      avatarUrl: 'https://localhost/non-existent.png'
     })
   }
 };
@@ -73,7 +73,7 @@ export const WithVariedSizes: Story = {
       }),
       user3: createTestUserProfile({
         displayName: '李小龙',
-        avatarUrl: 'https://example.com/non-existent.png'
+        avatarUrl: 'https://localhost/non-existent.png'
       })
     },
     template: `


### PR DESCRIPTION
The avatar component switches to a different mode when the avatar fails to load. Up until now the tests had tried to load an avatar that doesn't exist from example.com, and then demonstrate the behavior when it fails. However, since the network request can take some time to fail, the screenshots could get taken before the avatar component changes modes. This commit switches to using localhost for the nonexistent avatar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3351)
<!-- Reviewable:end -->
