### PR TITLE
Update capitalization of pt-BR help URL to match Docusaurus

### DIFF
--- a/src/SIL.XForge.Scripture/locales.json
+++ b/src/SIL.XForge.Scripture/locales.json
@@ -45,7 +45,7 @@
     "englishName": "Portuguese",
     "tags": ["pt-BR"],
     "production": true,
-    "helps": "pt-br"
+    "helps": "pt-BR"
   },
   {
     "localName": "简体中文",


### PR DESCRIPTION
Various systems are picky about the exact format of locale codes (e.g. Docusaurus and Crowdin might not expect the same format). I *think* Docusaurus is less picky than it used to be.

There isn't a real user-facing problem at the moment, and the server for the help site appears to be case-insensitive, but locally the capitalization sometimes becomes an issue when running the development server, which is case-sensitive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3352)
<!-- Reviewable:end -->
