### PR TITLE
Improve draft history configuration heading

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -278,7 +278,7 @@
     "hide_model_training_configuration": "Hide model training configuration",
     "show_model_training_configuration": "Show model training configuration",
     "training_books": "Training books",
-    "training_model_description": "The language model was trained on this configuration"
+    "training_model_description": "The language model was trained on this configuration:"
   },
   "draft_history_list": {
     "draft_canceled": "The draft was canceled",


### PR DESCRIPTION
Every time I look at this statement it feels disjointed from what follows.

### Before
<img width="997" height="244" alt="draft_history_title_before" src="https://github.com/user-attachments/assets/c05fa2ac-0642-4073-a212-07f42548fd17" />

### After
<img width="997" height="244" alt="draft_history_title_after" src="https://github.com/user-attachments/assets/63f52e08-6bf0-4a71-a879-5fed77a2bf95" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3353)
<!-- Reviewable:end -->
