### PR TITLE
SF-3443 SF-3494 Filter out Lynx insights for chapters that cannot be edited

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-filter.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-filter.service.ts
@@ -1,20 +1,23 @@
 import { Injectable } from '@angular/core';
 import { Canon } from '@sillsdev/scripture';
 import { LynxInsightFilter, LynxInsightFilterScope } from 'realtime-server/lib/esm/scriptureforge/models/lynx-insight';
+import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { RouteBookChapter } from 'xforge-common/activated-book-chapter.service';
+import { TextDocService } from '../../../../core/text-doc.service';
 import { LynxInsight } from './lynx-insight';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LynxInsightFilterService {
-  constructor() {}
+  constructor(private readonly textDocService: TextDocService) {}
 
   matchesFilter(
     insight: LynxInsight,
     filter: LynxInsightFilter,
     bookChapter: RouteBookChapter,
-    dismissedIds: string[]
+    dismissedIds: string[],
+    projectTexts?: TextInfo[]
   ): boolean {
     const routeBookNum: number | undefined = bookChapter.bookId ? Canon.bookIdToNumber(bookChapter.bookId) : undefined;
     const routeChapter = bookChapter.chapter;
@@ -25,6 +28,11 @@ export class LynxInsightFilterService {
     }
 
     if (!filter.types.includes(insight.type)) {
+      return false;
+    }
+
+    // Check edit permissions and USFM validity if project texts are provided
+    if (projectTexts != null && !this.hasDisplayPermission(insight, projectTexts)) {
       return false;
     }
 
@@ -57,5 +65,36 @@ export class LynxInsightFilterService {
     } else {
       return 'project';
     }
+  }
+
+  /**
+   * Check if an insight has display permission (edit permission and USFM validity).
+   * @param insight The insight to check.
+   * @param projectTexts The project texts to check permissions against.
+   * @returns True if the insight should be displayed, false otherwise.
+   */
+  hasDisplayPermission(insight: LynxInsight, projectTexts: TextInfo[]): boolean {
+    // Find the text info for this book
+    const text: TextInfo | undefined = projectTexts.find(t => t.bookNum === insight.textDocId.bookNum);
+    if (text == null) {
+      return false;
+    }
+
+    // Check chapter edit permission
+    const hasEditPermission: boolean | undefined = this.textDocService.hasChapterEditPermissionForText(
+      text,
+      insight.textDocId.chapterNum
+    );
+    if (!hasEditPermission) {
+      return false;
+    }
+
+    // Check USFM validity
+    const isUsfmValid: boolean = this.textDocService.isUsfmValidForText(text, insight.textDocId.chapterNum);
+    if (!isUsfmValid) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { LynxInsightFilter, LynxInsightType } from 'realtime-server/lib/esm/scriptureforge/models/lynx-insight';
+import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { createTestProjectUserConfig } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-user-config-test-data';
 import { TextInfo } from 'realtime-server/scriptureforge/models/text-info';
 import { BehaviorSubject, firstValueFrom, Subject } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -7,8 +9,6 @@ import { ActivatedBookChapterService, RouteBookChapter } from 'xforge-common/act
 import { ActivatedProjectUserConfigService } from 'xforge-common/activated-project-user-config.service';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
-import { createTestProject } from '../../../../../../../../RealtimeServer/scriptureforge/models/sf-project-test-data';
-import { createTestProjectUserConfig } from '../../../../../../../../RealtimeServer/scriptureforge/models/sf-project-user-config-test-data';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
 import { TextDocId } from '../../../../core/models/text-doc';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.spec.ts
@@ -1,11 +1,15 @@
 import { TestBed } from '@angular/core/testing';
-import { LynxInsightType } from 'realtime-server/lib/esm/scriptureforge/models/lynx-insight';
+import { LynxInsightFilter, LynxInsightType } from 'realtime-server/lib/esm/scriptureforge/models/lynx-insight';
+import { TextInfo } from 'realtime-server/scriptureforge/models/text-info';
 import { BehaviorSubject, firstValueFrom, Subject } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { ActivatedBookChapterService, RouteBookChapter } from 'xforge-common/activated-book-chapter.service';
 import { ActivatedProjectUserConfigService } from 'xforge-common/activated-project-user-config.service';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { createTestProject } from '../../../../../../../../RealtimeServer/scriptureforge/models/sf-project-test-data';
 import { createTestProjectUserConfig } from '../../../../../../../../RealtimeServer/scriptureforge/models/sf-project-user-config-test-data';
+import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { SFProjectUserConfigDoc } from '../../../../core/models/sf-project-user-config-doc';
 import { TextDocId } from '../../../../core/models/text-doc';
 import { LynxInsight } from './lynx-insight';
@@ -33,6 +37,7 @@ describe('LynxInsightStateService', () => {
 
   const mockInsightFilterService = mock<LynxInsightFilterService>();
   const mockActivatedBookChapterService = mock<ActivatedBookChapterService>();
+  const mockActivatedProjectService = mock<ActivatedProjectService>();
   const mockActivatedProjectUserConfigService = mock<ActivatedProjectUserConfigService>();
   const mockLynxWorkspaceService = mock<LynxWorkspaceService>();
   const mockProjectUserConfigDoc = mock(SFProjectUserConfigDoc);
@@ -72,6 +77,7 @@ describe('LynxInsightStateService', () => {
       LynxInsightStateService,
       { provide: LynxInsightFilterService, useMock: mockInsightFilterService },
       { provide: ActivatedBookChapterService, useMock: mockActivatedBookChapterService },
+      { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: ActivatedProjectUserConfigService, useMock: mockActivatedProjectUserConfigService },
       { provide: LynxWorkspaceService, useMock: mockLynxWorkspaceService }
     ]
@@ -101,14 +107,27 @@ describe('LynxInsightStateService', () => {
       instance(mockProjectUserConfigDoc)
     );
 
+    const projectDoc$ = new BehaviorSubject<SFProjectDoc | undefined>({
+      id: 'project1',
+      data: createTestProject()
+    } as SFProjectDoc);
+
     when(mockLynxWorkspaceService.rawInsightSource$).thenReturn(rawInsightSource);
     when(mockLynxWorkspaceService.currentInsights).thenReturn(testInsights);
     when(mockActivatedBookChapterService.activatedBookChapter$).thenReturn(activatedBookChapter);
+    when(mockActivatedProjectService.projectDoc$).thenReturn(projectDoc$);
     when(mockActivatedProjectUserConfigService.projectUserConfig$).thenReturn(projectUserConfig$);
     when(mockActivatedProjectUserConfigService.projectUserConfigDoc$).thenReturn(projectUserConfigDoc$);
 
-    when(mockInsightFilterService.matchesFilter(anything(), anything(), anything(), anything())).thenCall(
-      (insight: LynxInsight, filter: any, _bookChapter: RouteBookChapter, dismissedIds: string[]) => {
+    when(mockInsightFilterService.hasDisplayPermission(anything(), anything())).thenReturn(true);
+    when(mockInsightFilterService.matchesFilter(anything(), anything(), anything(), anything(), anything())).thenCall(
+      (
+        insight: LynxInsight,
+        filter: LynxInsightFilter,
+        _bookChapter: RouteBookChapter,
+        dismissedIds: string[],
+        _projectTexts?: TextInfo[]
+      ) => {
         if (!filter.types.includes(insight.type)) {
           return false;
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.ts
@@ -166,15 +166,14 @@ export class LynxInsightsPanelComponent implements AfterViewInit {
       });
   }
 
-  // Passed to mat-tree in the template.
+  // Passed to mat-tree in the template
   getChildrenAccessor = (node: InsightPanelNode): InsightPanelNode[] => {
-    // If paged loading is needed, only return a subset of children
-    if (this.needsPagedLoading(node)) {
-      const visibleChildren = this.getVisibleChildren(node);
-      return visibleChildren;
+    if (node.children == null) {
+      return [];
     }
 
-    return node.children ?? [];
+    // If paged loading is needed, only return a subset of children
+    return this.needsPagedLoading(node) ? this.getVisibleChildren(node) : node.children;
   };
 
   // 'when' predicate to determine if the group template should be used
@@ -235,7 +234,7 @@ export class LynxInsightsPanelComponent implements AfterViewInit {
    */
   needsPagedLoading(node: InsightPanelNode): boolean {
     // If node has no description or no children, it doesn't need paged loading
-    if (!node.description || !node.children) {
+    if (node.description == null || node.children == null) {
       return false;
     }
 


### PR DESCRIPTION
This PR fixes both:
- SF-3443 Error when lynx nav to unsupported USFM chapter
- SF-3494 Lynx problems panel shows insights with no chapter permissions

Both issues are fixed by filtering out lynx insights for chapters that cannot be edited (no permission or invalid USFM).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3355)
<!-- Reviewable:end -->
