### PR TITLE
SF-3476 Add error reporting when applying draft fails

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.html
@@ -14,9 +14,10 @@
                 <mat-icon>warning</mat-icon>
                 <span>{{ t("some_chapters_not_applied", { bookName }) }}</span>
               </h2>
-              <p>{{ t("go_to_chapter") }}</p>
               <span>{{ t("failed_to_apply_chapters") }}</span>
-              <span class="failed-chapters">{{ failedToApplyChapters }}</span>
+              @for (message of draftApplyProgress?.errorMessages; track $index) {
+                <span class="failed-chapters">{{ message }}</span>
+              }
             </div>
           } @else {
             <h2>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'draft_apply_progress-dialog'">
-  <mat-dialog-content>
+  <mat-dialog-content class="hide-scroll">
     <div class="progress-content">
       @if (draftApplyProgress?.completed !== true) {
         <div class="progress-container">
@@ -14,10 +14,12 @@
                 <mat-icon>warning</mat-icon>
                 <span>{{ t("some_chapters_not_applied", { bookName }) }}</span>
               </h2>
-              <span>{{ t("failed_to_apply_chapters") }}</span>
-              @for (message of draftApplyProgress?.errorMessages; track $index) {
-                <span class="failed-chapters">{{ message }}</span>
-              }
+              <div class="error-content">
+                <span>{{ t("failed_to_apply_chapters") }}</span>
+                @for (message of draftApplyProgress?.errorMessages; track $index) {
+                  <span class="failed-chapters">{{ message }}</span>
+                }
+              </div>
             </div>
           } @else {
             <h2>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  overflow: auto;
 
   .progress-container {
     width: 100%;
@@ -27,8 +28,6 @@
 
     .failed-chapters {
       text-indent: 1em;
-      font-weight: bold;
-      font-size: 2em;
       margin-top: 0.5em;
       line-height: 1em;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.scss
@@ -3,13 +3,10 @@
   max-width: 500px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  overflow: auto;
+  min-height: 0;
 
   .progress-container {
     width: 100%;
-    display: flex;
     flex-direction: column;
     align-items: center;
 
@@ -18,9 +15,16 @@
     }
   }
 
+  .result-container {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
   .error-result {
     display: flex;
     flex-direction: column;
+    min-height: 0;
 
     .mat-icon {
       flex-shrink: 0;
@@ -29,7 +33,13 @@
     .failed-chapters {
       text-indent: 1em;
       margin-top: 0.5em;
-      line-height: 1em;
+      line-height: 1.2em;
+    }
+
+    .error-content {
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
     }
   }
 
@@ -38,6 +48,12 @@
     column-gap: 8px;
     align-items: center;
   }
+}
+
+.hide-scroll {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .mat-mdc-dialog-actions {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.spec.ts
@@ -16,7 +16,8 @@ describe('DraftApplyProgressDialogComponent', () => {
     bookNum: 1,
     completed: false,
     chapters: [1, 2, 3],
-    chaptersApplied: []
+    chaptersApplied: [],
+    errorMessages: []
   });
 
   configureTestingModule(() => ({
@@ -33,7 +34,7 @@ describe('DraftApplyProgressDialogComponent', () => {
   });
 
   it('shows progress', () => {
-    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1], completed: false });
+    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1], completed: false, errorMessages: [] });
     env.fixture.detectChanges();
     expect(env.progressContainer).not.toBeNull();
     expect(env.resultContainer).toBeNull();
@@ -41,7 +42,7 @@ describe('DraftApplyProgressDialogComponent', () => {
   });
 
   it('shows apply draft completed', () => {
-    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1, 2], completed: true });
+    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1, 2], completed: true, errorMessages: [] });
     env.fixture.detectChanges();
     expect(env.progressContainer).toBeNull();
     expect(env.resultContainer).not.toBeNull();
@@ -50,12 +51,13 @@ describe('DraftApplyProgressDialogComponent', () => {
   });
 
   it('shows chapters that failed to be applied', () => {
-    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1], completed: true });
+    progress$.next({ bookNum: 1, chapters: [1, 2], chaptersApplied: [1], completed: true, errorMessages: ['error'] });
     env.fixture.detectChanges();
     expect(env.progressContainer).toBeNull();
     expect(env.resultContainer).not.toBeNull();
     expect(env.component.failedToApplyChapters).toEqual('2');
     expect(env.resultContainer.textContent).toContain('warning');
+    expect(env.component.draftApplyProgress?.errorMessages).toContain('error');
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-progress-dialog/draft-apply-progress-dialog.component.ts
@@ -11,6 +11,7 @@ export interface DraftApplyProgress {
   chapters: number[];
   chaptersApplied: number[];
   completed: boolean;
+  errorMessages: string[];
 }
 
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -5,6 +5,7 @@ import { DeltaOperation } from 'rich-text';
 import { of, throwError } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
@@ -19,6 +20,7 @@ const mockedTextDocService = mock(TextDocService);
 const mockedDraftGenerationService = mock(DraftGenerationService);
 const mockedSFProject = mock(SFProjectProfileDoc);
 const mockedErrorReportingService = mock(ErrorReportingService);
+const mockedI18nService = mock(I18nService);
 
 describe('DraftHandlingService', () => {
   let service: DraftHandlingService;
@@ -28,7 +30,8 @@ describe('DraftHandlingService', () => {
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: TextDocService, useMock: mockedTextDocService },
       { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
-      { provide: ErrorReportingService, useMock: mockedErrorReportingService }
+      { provide: ErrorReportingService, useMock: mockedErrorReportingService },
+      { provide: I18nService, useMock: mockedI18nService }
     ]
   }));
 
@@ -417,13 +420,13 @@ describe('DraftHandlingService', () => {
         )
       ).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
-      const result: boolean = await service.getAndApplyDraftAsync(
+      const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
         textDocId,
         undefined
       );
-      expect(result).toBe(true);
+      expect(result).toBe(undefined);
       verify(
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
       ).once();
@@ -449,13 +452,13 @@ describe('DraftHandlingService', () => {
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations(anything(), anything(), anything(), anything())
       ).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(false);
-      const result: boolean = await service.getAndApplyDraftAsync(
+      const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
         textDocId,
         undefined
       );
-      expect(result).toBe(false);
+      expect(result).not.toBe(undefined);
       verify(mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined)).never();
       verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).never();
     });
@@ -474,13 +477,13 @@ describe('DraftHandlingService', () => {
       ).thenReturn(throwError(() => ({ status: 405 })));
       when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(of(draft));
       when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
-      const result: boolean = await service.getAndApplyDraftAsync(
+      const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
         textDocId,
         undefined
       );
-      expect(result).toBe(false);
+      expect(result).not.toBe(undefined);
       verify(
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
       ).once();
@@ -507,13 +510,13 @@ describe('DraftHandlingService', () => {
       when(
         mockedProjectService.onlineSetDraftApplied(anything(), anything(), anything(), anything(), anything())
       ).thenReturn(Promise.reject(new Error('Failed')));
-      const result: boolean = await service.getAndApplyDraftAsync(
+      const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
         textDocId,
         undefined
       );
-      expect(result).toBe(false);
+      expect(result).not.toBe(undefined);
       verify(
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
       ).once();
@@ -542,13 +545,13 @@ describe('DraftHandlingService', () => {
           anything()
         )
       ).thenReturn(throwError(() => ({ message: 'Getting draft failed', status: 404 })));
-      const result: boolean = await service.getAndApplyDraftAsync(
+      const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
         textDocId,
         undefined
       );
-      expect(result).toBe(false);
+      expect(result).not.toBe(undefined);
       verify(
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
       ).once();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -387,7 +387,7 @@ describe('DraftHandlingService', () => {
         { insert: { verse: { number: 1 } } },
         { insert: 'In the beginning', attributes: { segment: 'verse_1_1' } }
       ];
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
       await service.applyChapterDraftAsync(textDocId, new Delta(draftOps));
       verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).once();
       verify(
@@ -419,7 +419,7 @@ describe('DraftHandlingService', () => {
           anything()
         )
       ).thenReturn(of(draft));
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
       const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
@@ -449,9 +449,15 @@ describe('DraftHandlingService', () => {
       const textDocId = new TextDocId('project01', 1, 1);
       const draft: DeltaOperation[] = [{ insert: 'In the beginning', attributes: { segment: 'verse_1_1' } }];
       when(
-        mockedDraftGenerationService.getGeneratedDraftDeltaOperations(anything(), anything(), anything(), anything())
+        mockedDraftGenerationService.getGeneratedDraftDeltaOperations(
+          anything(),
+          anything(),
+          anything(),
+          anything(),
+          anything()
+        )
       ).thenReturn(of(draft));
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(false);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(false);
       const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
@@ -459,7 +465,9 @@ describe('DraftHandlingService', () => {
         undefined
       );
       expect(result).not.toBe(undefined);
-      verify(mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined)).never();
+      verify(
+        mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
+      ).never();
       verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).never();
     });
 
@@ -476,7 +484,7 @@ describe('DraftHandlingService', () => {
         )
       ).thenReturn(throwError(() => ({ status: 405 })));
       when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(of(draft));
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
       const result: string | undefined = await service.getAndApplyDraftAsync(
         mockedSFProject.data!,
         textDocId,
@@ -506,7 +514,7 @@ describe('DraftHandlingService', () => {
           anything()
         )
       ).thenReturn(of(draft));
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
       when(
         mockedProjectService.onlineSetDraftApplied(anything(), anything(), anything(), anything(), anything())
       ).thenReturn(Promise.reject(new Error('Failed')));
@@ -535,7 +543,7 @@ describe('DraftHandlingService', () => {
 
     it('should return false if applying a draft fails at getting the draft', async () => {
       const textDocId = new TextDocId('project01', 1, 1);
-      when(mockedTextDocService.canEdit(anything(), 1, 1)).thenReturn(true);
+      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
       when(
         mockedDraftGenerationService.getGeneratedDraftDeltaOperations(
           anything(),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -6,6 +6,7 @@ import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/t
 import { DeltaOperation } from 'rich-text';
 import { catchError, Observable, throwError } from 'rxjs';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { isString } from '../../../type-utils';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -31,7 +32,8 @@ export class DraftHandlingService {
     private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
     private readonly draftGenerationService: DraftGenerationService,
-    private readonly errorReportingService: ErrorReportingService
+    private readonly errorReportingService: ErrorReportingService,
+    private readonly i18n: I18nService
   ) {}
 
   /**
@@ -227,19 +229,19 @@ export class DraftHandlingService {
     draftTextDocId: TextDocId,
     targetTextDocId: TextDocId,
     timestamp?: Date
-  ): Promise<boolean> {
+  ): Promise<string | undefined> {
     if (!this.textDocService.canEdit(project, draftTextDocId.bookNum, draftTextDocId.chapterNum)) {
-      return false;
+      return this.i18n.translateStatic('draft_apply_progress-dialog.fail_cannot_edit');
     }
 
-    return await new Promise<boolean>(resolve => {
+    return await new Promise<string | undefined>(resolve => {
       this.getDraft(draftTextDocId, { isDraftLegacy: false, timestamp }).subscribe({
         next: async draft => {
           let ops: DeltaOperation[] = [];
           if (this.isDraftSegmentMap(draft)) {
             // Do not support applying drafts for the legacy segment map format.
             // This can be applied chapter by chapter.
-            resolve(false);
+            resolve(this.i18n.translateStatic('draft_apply_progress-dialog.fail_legacy_format'));
             return;
           } else {
             ops = draft;
@@ -248,14 +250,14 @@ export class DraftHandlingService {
           await this.applyChapterDraftAsync(targetTextDocId, draftDelta).catch(err => {
             // report the error to bugsnag
             this.errorReportingService.silentError('Error applying a draft', ErrorReportingService.normalizeError(err));
-            resolve(false);
+            resolve(this.i18n.translateStatic('draft_apply_progress-dialog.fail_unknown'));
           });
-          resolve(true);
+          resolve(undefined);
         },
         error: err => {
           // report the error to bugsnag
           this.errorReportingService.silentError('Error applying a draft', ErrorReportingService.normalizeError(err));
-          resolve(false);
+          resolve(this.i18n.translateStatic('draft_apply_progress-dialog.fail_unknown'));
         }
       });
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -218,19 +218,19 @@ export class DraftHandlingService {
 
   /**
    * Retrieves and applies the draft to the text document.
-   * @param project The project profile.
+   * @param targetProject The project profile.
    * @param draftTextDocId The text doc identifier of the draft of a chapter.
    * @param targetTextDocId The text doc identifier to apply the draft to.
    * @returns True if the draft was successfully applied, false if the draft was not applied i.e. the draft
    * was in the legacy USFM format.
    */
   async getAndApplyDraftAsync(
-    project: SFProjectProfile,
+    targetProject: SFProjectProfile,
     draftTextDocId: TextDocId,
     targetTextDocId: TextDocId,
     timestamp?: Date
   ): Promise<string | undefined> {
-    if (!this.textDocService.canEdit(project, draftTextDocId.bookNum, draftTextDocId.chapterNum)) {
+    if (!this.textDocService.canRestore(targetProject, targetTextDocId.bookNum, targetTextDocId.chapterNum)) {
       return this.i18n.translateStatic('draft_apply_progress-dialog.fail_cannot_edit');
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -111,8 +111,8 @@ describe('DraftPreviewBooks', () => {
     setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything()))
       .thenReject(new Error('Draft error'))
-      .thenResolve(true)
-      .thenResolve(false);
+      .thenResolve(undefined)
+      .thenResolve('error');
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);
     tick();
@@ -129,7 +129,7 @@ describe('DraftPreviewBooks', () => {
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
     setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything())).thenResolve(
-      true
+      undefined
     );
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);
@@ -146,7 +146,7 @@ describe('DraftPreviewBooks', () => {
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[1];
     setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything())).thenResolve(
-      true
+      undefined
     );
     expect(env.getBookButtonAtIndex(1).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);
@@ -166,7 +166,7 @@ describe('DraftPreviewBooks', () => {
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[1];
     setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything())).thenResolve(
-      true
+      undefined
     );
     expect(env.getBookButtonAtIndex(1).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);
@@ -276,7 +276,7 @@ describe('DraftPreviewBooks', () => {
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
     setupDialog('project01');
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything())).thenResolve(
-      false
+      'error: legacy format'
     );
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);
@@ -291,11 +291,11 @@ describe('DraftPreviewBooks', () => {
     const bookWithDraft: BookWithDraft = env.booksWithDrafts[0];
     setupDialog('project01');
     const resolveSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-    const promise: Promise<boolean> = new Promise<boolean>(resolve => {
-      resolveSubject$.pipe(filter(value => value)).subscribe(() => resolve(true));
+    const promise: Promise<string | undefined> = new Promise<string | undefined>(resolve => {
+      resolveSubject$.pipe(filter(value => value)).subscribe(() => resolve(undefined));
     });
     when(mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything()))
-      .thenReturn(Promise.resolve(true))
+      .thenResolve(undefined)
       .thenReturn(promise);
     expect(env.getBookButtonAtIndex(0).querySelector('.book-more')).toBeTruthy();
     env.component.chooseProjectToAddDraft(bookWithDraft);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -51,7 +51,7 @@ describe('DraftPreviewBooks', () => {
   }));
 
   afterEach(() => {
-    env.progressSubscription?.unsubscribe();
+    env?.progressSubscription?.unsubscribe();
   });
 
   it('should show books for a build', fakeAsync(() => {
@@ -310,6 +310,82 @@ describe('DraftPreviewBooks', () => {
     env.fixture.detectChanges();
     expect(env.component.numChaptersApplied).toEqual(3);
   }));
+
+  describe('combineErrorMessages', () => {
+    it('should return an empty array if there are no error messages', () => {
+      const errorMessages: { chapter: number; message: string }[] = [];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual([]);
+    });
+
+    it('should format a single error message', () => {
+      const errorMessages = [{ chapter: 1, message: 'Error message' }];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1: Error message']);
+    });
+
+    it('should format multiple error messages for non-consecutive chapters', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message' },
+        { chapter: 3, message: 'Another error message' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1: Error message', '3: Another error message']);
+    });
+
+    it('should group consecutive chapters with the same error message', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message' },
+        { chapter: 2, message: 'Error message' },
+        { chapter: 3, message: 'Error message' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1-3: Error message']);
+    });
+
+    it('should handle a mix of single and ranged error messages', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message' },
+        { chapter: 2, message: 'Error message' },
+        { chapter: 4, message: 'Another error message' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1-2: Error message', '4: Another error message']);
+    });
+
+    it('should handle multiple ranges', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message' },
+        { chapter: 2, message: 'Error message' },
+        { chapter: 4, message: 'Another error message' },
+        { chapter: 5, message: 'Another error message' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1-2: Error message', '4-5: Another error message']);
+    });
+
+    it('should handle ranges and singletons with different messages', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message 1' },
+        { chapter: 2, message: 'Error message 1' },
+        { chapter: 3, message: 'Error message 2' },
+        { chapter: 4, message: 'Error message 1' },
+        { chapter: 5, message: 'Error message 1' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1-2: Error message 1', '3: Error message 2', '4-5: Error message 1']);
+    });
+
+    it('should handle a single error at the end of a range', () => {
+      const errorMessages = [
+        { chapter: 1, message: 'Error message 1' },
+        { chapter: 2, message: 'Error message 1' },
+        { chapter: 3, message: 'Error message 2' }
+      ];
+      const result = DraftPreviewBooksComponent['combineErrorMessages'](errorMessages);
+      expect(result).toEqual(['1-2: Error message 1', '3: Error message 2']);
+    });
+  });
 
   function setupDialog(projectId?: string): void {
     const mockedDialogRef: MatDialogRef<DraftApplyDialogComponent> = mock(MatDialogRef<DraftApplyDialogComponent>);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -99,6 +99,7 @@ export class DraftPreviewBooksComponent {
   private applyChapters: number[] = [];
   private draftApplyBookNum: number = 0;
   private chaptersApplied: number[] = [];
+  private errorMessages: string[] = [];
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
@@ -155,9 +156,10 @@ export class DraftPreviewBooksComponent {
     this.applyChapters = bookWithDraft.chaptersWithDrafts;
     this.draftApplyBookNum = bookWithDraft.bookNumber;
     this.chaptersApplied = [];
+    this.errorMessages = [];
     this.updateProgress();
 
-    const promises: Promise<boolean>[] = [];
+    const promises: Promise<string | undefined>[] = [];
     const project: SFProjectProfile = this.activatedProjectService.projectDoc!.data!;
     for (const chapter of bookWithDraft.chaptersWithDrafts) {
       const draftTextDocId = new TextDocId(this.activatedProjectService.projectId!, bookWithDraft.bookNumber, chapter);
@@ -167,8 +169,8 @@ export class DraftPreviewBooksComponent {
 
     try {
       this.openProgressDialog();
-      const results: boolean[] = await Promise.all(promises);
-      if (results.some(result => !result)) {
+      const results: (string | undefined)[] = await Promise.all(promises);
+      if (results.some(result => result !== undefined)) {
         this.updateProgress(undefined, true);
         // The draft is in the legacy format. This can only be applied chapter by chapter.
         return;
@@ -200,7 +202,7 @@ export class DraftPreviewBooksComponent {
     project: SFProjectProfile,
     draftTextDocId: TextDocId,
     targetTextDocId: TextDocId
-  ): Promise<boolean> {
+  ): Promise<string | undefined> {
     let timestamp: Date | undefined = undefined;
     if (this.build?.additionalInfo?.dateGenerated != null) {
       timestamp = new Date(this.build.additionalInfo.dateGenerated);
@@ -208,20 +210,25 @@ export class DraftPreviewBooksComponent {
     return await this.draftHandlingService
       .getAndApplyDraftAsync(project, draftTextDocId, targetTextDocId, timestamp)
       .then(result => {
-        this.updateProgress(result ? targetTextDocId.chapterNum : undefined);
+        const errorMessage = result !== undefined ? targetTextDocId.chapterNum + ': ' + result : undefined;
+        this.updateProgress(result === undefined ? targetTextDocId.chapterNum : undefined, undefined, errorMessage);
         return result;
       });
   }
 
-  private updateProgress(bookCompleted?: number, completed?: boolean): void {
+  private updateProgress(bookCompleted?: number, completed?: boolean, errorMessage?: string): void {
     if (bookCompleted != null) {
       this.chaptersApplied.push(bookCompleted);
+    }
+    if (errorMessage != null) {
+      this.errorMessages.push(errorMessage);
     }
     this.draftApplyProgress$.next({
       bookNum: this.draftApplyBookNum,
       chapters: this.applyChapters,
       chaptersApplied: this.chaptersApplied,
-      completed: !!completed ? completed : this.chaptersApplied.length === this.applyChapters.length
+      completed: !!completed ? completed : this.chaptersApplied.length === this.applyChapters.length,
+      errorMessages: this.errorMessages
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -152,7 +152,7 @@ export class DraftPreviewBooksComponent {
     await this.applyBookDraftAsync(bookWithDraft, result.projectId);
   }
 
-  private async applyBookDraftAsync(bookWithDraft: BookWithDraft, projectId: string): Promise<void> {
+  private async applyBookDraftAsync(bookWithDraft: BookWithDraft, targetProjectId: string): Promise<void> {
     this.applyChapters = bookWithDraft.chaptersWithDrafts;
     this.draftApplyBookNum = bookWithDraft.bookNumber;
     this.chaptersApplied = [];
@@ -160,11 +160,11 @@ export class DraftPreviewBooksComponent {
     this.updateProgress();
 
     const promises: Promise<string | undefined>[] = [];
-    const project: SFProjectProfile = this.activatedProjectService.projectDoc!.data!;
+    const targetProject = (await this.projectService.getProfile(targetProjectId)).data!;
     for (const chapter of bookWithDraft.chaptersWithDrafts) {
       const draftTextDocId = new TextDocId(this.activatedProjectService.projectId!, bookWithDraft.bookNumber, chapter);
-      const targetTextDocId = new TextDocId(projectId, bookWithDraft.bookNumber, chapter);
-      promises.push(this.applyAndReportChapter(project, draftTextDocId, targetTextDocId));
+      const targetTextDocId = new TextDocId(targetProjectId, bookWithDraft.bookNumber, chapter);
+      promises.push(this.applyAndReportChapter(targetProject, draftTextDocId, targetTextDocId));
     }
 
     try {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -99,7 +99,7 @@ export class DraftPreviewBooksComponent {
   private applyChapters: number[] = [];
   private draftApplyBookNum: number = 0;
   private chaptersApplied: number[] = [];
-  private errorMessages: string[] = [];
+  private errorMessages: { chapter: number; message: string }[] = [];
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
@@ -210,25 +210,67 @@ export class DraftPreviewBooksComponent {
     return await this.draftHandlingService
       .getAndApplyDraftAsync(project, draftTextDocId, targetTextDocId, timestamp)
       .then(result => {
-        const errorMessage = result !== undefined ? targetTextDocId.chapterNum + ': ' + result : undefined;
-        this.updateProgress(result === undefined ? targetTextDocId.chapterNum : undefined, undefined, errorMessage);
+        this.updateProgress(
+          result === undefined ? targetTextDocId.chapterNum : undefined,
+          undefined,
+          result === undefined ? undefined : { chapter: targetTextDocId.chapterNum, message: result }
+        );
         return result;
       });
   }
 
-  private updateProgress(bookCompleted?: number, completed?: boolean, errorMessage?: string): void {
+  private updateProgress(
+    bookCompleted?: number,
+    completed?: boolean,
+    error?: { chapter: number; message: string }
+  ): void {
     if (bookCompleted != null) {
       this.chaptersApplied.push(bookCompleted);
     }
-    if (errorMessage != null) {
-      this.errorMessages.push(errorMessage);
+    if (error != null) {
+      this.errorMessages.push(error);
+      this.errorMessages.sort((a, b) => a.chapter - b.chapter);
     }
+
     this.draftApplyProgress$.next({
       bookNum: this.draftApplyBookNum,
       chapters: this.applyChapters,
       chaptersApplied: this.chaptersApplied,
       completed: !!completed ? completed : this.chaptersApplied.length === this.applyChapters.length,
-      errorMessages: this.errorMessages
+      errorMessages: DraftPreviewBooksComponent.combineErrorMessages(this.errorMessages)
     });
+  }
+
+  private static combineErrorMessages(errorMessages: { chapter: number; message: string }[]): string[] {
+    const formattedErrors: string[] = [];
+    if (errorMessages.length > 0) {
+      let rangeStart = errorMessages[0].chapter;
+      let currentMessage = errorMessages[0].message;
+
+      for (let i = 1; i < errorMessages.length; i++) {
+        const prevChapter = errorMessages[i - 1].chapter;
+        const currentChapter = errorMessages[i].chapter;
+        const message = errorMessages[i].message;
+
+        if (message !== currentMessage || currentChapter !== prevChapter + 1) {
+          const rangeEnd = errorMessages[i - 1].chapter;
+          if (rangeStart === rangeEnd) {
+            formattedErrors.push(`${rangeStart}: ${currentMessage}`);
+          } else {
+            formattedErrors.push(`${rangeStart}-${rangeEnd}: ${currentMessage}`);
+          }
+          rangeStart = currentChapter;
+          currentMessage = message;
+        }
+      }
+
+      const lastError = errorMessages[errorMessages.length - 1];
+      if (rangeStart === lastError.chapter) {
+        formattedErrors.push(`${rangeStart}: ${currentMessage}`);
+      } else {
+        formattedErrors.push(`${rangeStart}-${lastError.chapter}: ${currentMessage}`);
+      }
+    }
+    return formattedErrors;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -160,8 +160,10 @@
   "draft_apply_progress-dialog": {
     "add_draft_to_book": "Adding draft to {{ bookName }}",
     "close": "Close",
-    "failed_to_apply_chapters": "Failed to apply chapters",
-    "go_to_chapter": "Go to the chapter to try again.",
+    "failed_to_apply_chapters": "Failed to apply these chapters:",
+    "fail_cannot_edit": "The target chapter is not editable. View that chapter for more information.",
+    "fail_legacy_format": "Legacy draft format detected. Please apply chapter by chapter.",
+    "fail_unknown": "Unknown error. Please try again later. If the error persists, please report an issue.",
     "some_chapters_not_applied": "Drafts of one or more chapters could not be applied to {{ bookName }}",
     "successfully_applied_all_chapters": "Successfully applied all chapters to {{ bookName }}"
   },


### PR DESCRIPTION
This change adds an errorMessages property to the draft apply progress. We attempt to infer some information from any failures, based on where they occurred, and report that to the users via the new property. Sometimes exceptions can include an error code, but the error codes don't seem to be very valuable to the user.

Obviously we'll need to refine the error text content I used here.

This also, notably, makes the app no longer prevent applying when the target chapter has invalid/unsupported USFM. We now check whether the target is editable, less when it's invalid/unsupported.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3357)
<!-- Reviewable:end -->
