### PR TITLE
Add phase 8 percent localization string

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -736,6 +736,7 @@
     "phase_7": "Finalizing send/receive with Paratext",
     "phase_7_percent": "Updating biblical terms from Paratext {{progressPercent}}%",
     "phase_8": "Finalizing project sync...",
+    "phase_8_percent": "Finalizing project sync {{progressPercent}}%",
     "something_went_wrong_synchronizing_this_project": "Something went wrong while synchronizing {{ projectName }} with Paratext. Please try again.",
     "successfully_synchronized_with_paratext": "Successfully synchronized {{ projectName }} with Paratext.",
     "synchronize": "Sync with Paratext",


### PR DESCRIPTION
This PR adds a missing resource string for the final phase of a string when a percentage is reported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3363)
<!-- Reviewable:end -->
