### PR TITLE
SF-3192 Update book names in draft stepper when UI language changes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -1,12 +1,12 @@
 <ng-container *transloco="let t; read: 'draft_preview_books'">
-  @for (book of booksWithDrafts$ | async; track book.bookNumber) {
+  @for (book of booksWithDrafts$ | async; track book.bookId) {
     <mat-button-toggle-group
       class="draft-book-option"
       [disabled]="book.chaptersWithDrafts.length === 0"
       (change)="$event.source.checked = false"
     >
       <mat-button-toggle class="book-name" (click)="navigate(book)">
-        {{ bookNumberToName(book.bookNumber) }}
+        {{ "canon.book_names." + book.bookId | transloco }}
       </mat-button-toggle>
       <mat-button-toggle class="book-more" [mat-menu-trigger-for]="menu">
         <mat-icon>more_vert</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -13,7 +13,6 @@ import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
-import { I18nService } from 'xforge-common/i18n.service';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
@@ -27,7 +26,6 @@ import { BookWithDraft, DraftPreviewBooksComponent } from './draft-preview-books
 
 const mockedActivatedProjectService = mock(ActivatedProjectService);
 const mockedProjectService = mock(SFProjectService);
-const mockedI18nService = mock(I18nService);
 const mockedUserService = mock(UserService);
 const mockedDraftHandlingService = mock(DraftHandlingService);
 const mockedDialogService = mock(DialogService);
@@ -43,7 +41,6 @@ describe('DraftPreviewBooks', () => {
     providers: [
       { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
       { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: I18nService, useMock: mockedI18nService },
       { provide: UserService, useMock: mockedUserService },
       { provide: DraftHandlingService, useMock: mockedDraftHandlingService },
       { provide: DialogService, useMock: mockedDialogService },
@@ -371,15 +368,14 @@ class TestEnvironment {
   } as SFProjectProfileDoc;
 
   booksWithDrafts: BookWithDraft[] = [
-    { bookNumber: 1, canEdit: true, chaptersWithDrafts: [1, 2, 3], draftApplied: false },
-    { bookNumber: 2, canEdit: true, chaptersWithDrafts: [1], draftApplied: false },
-    { bookNumber: 3, canEdit: false, chaptersWithDrafts: [1, 2], draftApplied: false }
+    { bookNumber: 1, bookId: 'GEN', canEdit: true, chaptersWithDrafts: [1, 2, 3], draftApplied: false },
+    { bookNumber: 2, bookId: 'EXO', canEdit: true, chaptersWithDrafts: [1], draftApplied: false },
+    { bookNumber: 3, bookId: 'LEV', canEdit: false, chaptersWithDrafts: [1, 2], draftApplied: false }
   ];
 
   constructor(build: BuildDto | undefined = undefined) {
     when(mockedActivatedProjectService.changes$).thenReturn(of(this.mockProjectDoc));
     when(mockedActivatedProjectService.projectDoc).thenReturn(this.mockProjectDoc);
-    when(mockedI18nService.localizeBook(1)).thenReturn('Genesis');
     when(
       mockedDraftHandlingService.getAndApplyDraftAsync(anything(), anything(), anything(), anything())
     ).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -3,7 +3,7 @@
     <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
   } @else if (draftCheckState === "draft-empty") {
     <app-notice icon="info" type="primary" mode="outline">
-      {{ "editor_draft_tab.no_draft_notice" | transloco: { bookChapterName } }}
+      {{ "editor_draft_tab.no_draft_notice" | transloco: { bookChapterName: this.getLocalizedBookChapter() } }}
       <p>{{ "editor_draft_tab.click_book_to_preview" | transloco }}</p>
       <app-draft-preview-books></app-draft-preview-books>
     </app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -471,7 +471,7 @@ describe('EditorDraftComponent', () => {
     });
 
     it('should return a localized book and chapter if both are not null', () => {
-      when(mockI18nService.localizeBook(1)).thenReturn('Localized Book');
+      when(mockI18nService.localizeBookChapter(1, 1)).thenReturn('Localized Book 1');
       component.bookNum = 1;
       component.chapter = 1;
       expect(component['getLocalizedBookChapter']()).toEqual('Localized Book 1');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -58,7 +58,6 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   draftCheckState: 'draft-unknown' | 'draft-present' | 'draft-legacy' | 'draft-empty' = 'draft-unknown';
   draftRevisions: Revision[] = [];
   selectedRevision: Revision | undefined;
-  bookChapterName = '';
   generateDraftUrl?: string;
   targetProject?: SFProjectProfile;
   textDocId?: TextDocId;
@@ -268,7 +267,6 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
   private setInitialState(): void {
     this.draftCheckState = 'draft-unknown';
-    this.bookChapterName = this.getLocalizedBookChapter();
     this.isDraftReady = false;
     this.isDraftApplied = false;
     this.userAppliedDraft = false;
@@ -313,12 +311,12 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     return hasContent ?? false;
   }
 
-  private getLocalizedBookChapter(): string {
+  protected getLocalizedBookChapter(): string {
     if (this.bookNum == null || this.chapter == null) {
       return '';
     }
 
-    return this.i18n.localizeBook(this.bookNum) + ' ' + this.chapter;
+    return this.i18n.localizeBookChapter(this.bookNum, this.chapter);
   }
 
   private getTargetOps(): Observable<DeltaOperation[]> {


### PR DESCRIPTION
This PR fixes the translation of the book name on the auto draft page when no draft is available for a chapter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3364)
<!-- Reviewable:end -->
