### PR TITLE
SF-3451 Fix Lynx overlay RTL styles

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.spec.ts
@@ -3,6 +3,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { I18nService } from 'xforge-common/i18n.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { LynxEditor, LynxTextModelConverter } from './lynx-editor';
 import { LynxInsight } from './lynx-insight';
@@ -11,13 +12,15 @@ import { LynxInsightOverlayComponent } from './lynx-insight-overlay/lynx-insight
 
 const mockOverlay = mock(Overlay);
 const mockScrollDispatcher = mock(ScrollDispatcher);
+const mockedI18nService = mock(I18nService);
 
 describe('LynxInsightOverlayService', () => {
   configureTestingModule(() => ({
     providers: [
       LynxInsightOverlayService,
       { provide: Overlay, useMock: mockOverlay },
-      { provide: ScrollDispatcher, useMock: mockScrollDispatcher }
+      { provide: ScrollDispatcher, useMock: mockScrollDispatcher },
+      { provide: I18nService, useMock: mockedI18nService }
     ]
   }));
 
@@ -155,6 +158,28 @@ describe('LynxInsightOverlayService', () => {
       env.simulateClick('.lynx-insight-action-menu');
 
       expect(env.service.close).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('direction handling', () => {
+    it('should use rtl i18n direction when creating overlay config', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockedI18nService.direction).thenReturn('rtl');
+
+      env.openOverlay();
+
+      const capturedConfig = env.captureOverlayConfig();
+      expect(capturedConfig.direction).toBe('rtl');
+    }));
+
+    it('should use ltr i18n direction when creating overlay config', fakeAsync(() => {
+      const env = new TestEnvironment();
+      when(mockedI18nService.direction).thenReturn('ltr');
+
+      env.openOverlay();
+
+      const capturedConfig = env.captureOverlayConfig();
+      expect(capturedConfig.direction).toBe('ltr');
     }));
   });
 });
@@ -343,6 +368,11 @@ class TestEnvironment {
   captureAttachedPortal(): ComponentPortal<LynxInsightOverlayComponent> {
     const portalCaptor = capture<ComponentPortal<LynxInsightOverlayComponent>>(this.overlayRefs[0].mock.attach);
     return portalCaptor.last()[0];
+  }
+
+  captureOverlayConfig(): any {
+    const configCaptor = capture(mockOverlay.create);
+    return configCaptor.last()[0];
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay.service.ts
@@ -3,6 +3,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { Injectable, NgZone } from '@angular/core';
 import { asyncScheduler, observeOn, Subject, take, takeUntil } from 'rxjs';
+import { I18nService } from 'xforge-common/i18n.service';
 import { LynxEditor, LynxTextModelConverter } from './lynx-editor';
 import { LynxInsight } from './lynx-insight';
 import { LynxInsightOverlayComponent } from './lynx-insight-overlay/lynx-insight-overlay.component';
@@ -23,7 +24,8 @@ export class LynxInsightOverlayService {
   constructor(
     private overlay: Overlay,
     private scrollDispatcher: ScrollDispatcher,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private i18n: I18nService
   ) {}
 
   get isOpen(): boolean {
@@ -125,7 +127,8 @@ export class LynxInsightOverlayService {
     return {
       positionStrategy: this.getPositionStrategy(origin),
       panelClass: 'lynx-insight-overlay-panel',
-      scrollStrategy: this.overlay.scrollStrategies.reposition()
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      direction: this.i18n.direction
     };
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.html
@@ -25,7 +25,12 @@
       }
       <div class="secondary-actions">
         @if (menuActions.length > 0) {
-          <mat-icon [matTooltip]="t('tooltip_actions')" [matMenuTriggerFor]="actionMenu" class="action-menu-trigger">
+          <mat-icon
+            [matTooltip]="t('tooltip_actions')"
+            [matMenuTriggerFor]="actionMenu"
+            [dir]="i18n.direction"
+            class="action-menu-trigger"
+          >
             more_horiz
           </mat-icon>
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.scss
@@ -18,6 +18,10 @@ $borderRadius: 0.3em;
   overflow: hidden;
 }
 
+:host-context([dir='rtl']) ::ng-deep .cdk-overlay-container {
+  direction: rtl;
+}
+
 mat-icon {
   width: auto;
   height: auto;
@@ -31,6 +35,7 @@ mat-icon {
 
 .main-section {
   background-color: $mainSectionBGColor;
+  position: relative;
 
   // When prompt is for single insight, or insight is selected from multi-picker
   &.focused {
@@ -79,6 +84,8 @@ mat-icon {
 
       h1 {
         font-size: 0.8em;
+        padding-inline-end: 1em;
+        margin-inline-end: auto;
       }
 
       &:not(:last-child) {
@@ -102,8 +109,6 @@ mat-icon {
 
       .ellipsis-icon {
         color: $secondaryTextColor;
-        margin-inline-start: auto;
-        padding-inline-start: 1em;
         flex-shrink: 0;
       }
     }
@@ -162,6 +167,7 @@ h1 {
       position: absolute;
       inset-inline-start: 0;
       font-size: 1.7em;
+      direction: inherit;
     }
 
     &:hover {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.scss
@@ -18,10 +18,6 @@ $borderRadius: 0.3em;
   overflow: hidden;
 }
 
-:host-context([dir='rtl']) ::ng-deep .cdk-overlay-container {
-  direction: rtl;
-}
-
 mat-icon {
   width: auto;
   height: auto;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.ts
@@ -3,6 +3,7 @@ import { Component, DestroyRef, ElementRef, EventEmitter, Inject, Input, OnInit,
 import { MAT_TOOLTIP_DEFAULT_OPTIONS } from '@angular/material/tooltip';
 import { Delta } from 'quill';
 import { fromEvent } from 'rxjs';
+import { I18nService } from 'xforge-common/i18n.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { LynxEditor, LynxTextModelConverter } from '../lynx-editor';
 import { EDITOR_INSIGHT_DEFAULTS, LynxInsight, LynxInsightAction, LynxInsightConfig } from '../lynx-insight';
@@ -58,6 +59,7 @@ export class LynxInsightOverlayComponent implements OnInit {
     private readonly insightState: LynxInsightStateService,
     private readonly overlayService: LynxInsightOverlayService,
     private readonly lynxWorkspaceService: LynxWorkspaceService,
+    readonly i18n: I18nService,
     @Inject(DOCUMENT) private readonly document: Document,
     @Inject(EDITOR_INSIGHT_DEFAULTS) private readonly config: LynxInsightConfig
   ) {}


### PR DESCRIPTION
This PR adds styling fixes to better display the lynx dialog overlay (viewed by clicking a lynx warning lightbulb or error icon in the editor) in RTL direction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3367)
<!-- Reviewable:end -->
