### PR TITLE
Adjust color of text on checking overview page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_variables.scss
@@ -24,8 +24,6 @@ $disabled-text-color: $greyLight;
  * how mat-hint looks on a white background.
  */
 $lighterTextColor: #666666;
-// Not recommended to use; copied from --mdc-theme-text-hint-on-background
-$text-hint-on-background: rgba(0, 0, 0, 0.38);
 
 $pt-button-green: $greenDark;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.scss
@@ -117,7 +117,7 @@ app-donut-chart {
 #loading-archived-questions-message {
   text-align: center;
   justify-content: center;
-  color: variables.$text-hint-on-background;
+  color: #666;
 }
 
 .reviewer-panels {


### PR DESCRIPTION
This makes the text color on this page slightly darker from a contrast ratio of 2.67 to 5.74 (4.5 is the minimum for AA accessibility standards). However, since it's no longer transparent, it's also _lighter_ than before in dark mode, which was the impetus for working on this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3369)
<!-- Reviewable:end -->
