### PR TITLE
SF-3512 Do not allow unpaired parentheses in BT renderings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.spec.ts
@@ -1,0 +1,34 @@
+import { fakeAsync } from '@angular/core/testing';
+import { FormControl } from '@angular/forms';
+import { SFValidators } from './sfvalidators';
+
+describe('SFValidators', () => {
+  describe('balanced parentheses', () => {
+    it('no error on null control', fakeAsync(() => {
+      expect(SFValidators.balancedParentheses(null)).toBeNull();
+    }));
+
+    it('no error on null or empty value', fakeAsync(() => {
+      expect(SFValidators.balancedParentheses(new FormControl(null))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl(''))).toBeNull();
+    }));
+
+    it('no error if brackets match or are missing', fakeAsync(() => {
+      expect(SFValidators.balancedParentheses(new FormControl('a'))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl('a()'))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl('(a)'))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl('((a))'))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl('(())\n()'))).toBeNull();
+      expect(SFValidators.balancedParentheses(new FormControl('(())\n(())\n(())\n'))).toBeNull();
+    }));
+
+    it('error when brackets are not closed', fakeAsync(() => {
+      expect(SFValidators.balancedParentheses(new FormControl('('))).toEqual({ unbalancedParentheses: true });
+      expect(SFValidators.balancedParentheses(new FormControl(')'))).toEqual({ unbalancedParentheses: true });
+      expect(SFValidators.balancedParentheses(new FormControl('(()'))).toEqual({ unbalancedParentheses: true });
+      expect(SFValidators.balancedParentheses(new FormControl('()))'))).toEqual({ unbalancedParentheses: true });
+      expect(SFValidators.balancedParentheses(new FormControl('(\n)'))).toEqual({ unbalancedParentheses: true });
+      expect(SFValidators.balancedParentheses(new FormControl('(()\n)'))).toEqual({ unbalancedParentheses: true });
+    }));
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sfvalidators.ts
@@ -124,6 +124,34 @@ export class SFValidators {
       ? { startReferenceRequired: true }
       : null;
   }
+
+  /**
+   *
+   * @param control The control.
+   * @returns null when the parentheses are balanced, an object with unbalancedParentheses as true when not.
+   */
+  static balancedParentheses(control: AbstractControl | null): ValidationErrors | null {
+    const error = { unbalancedParentheses: true };
+    if (control?.value == null || control.value.length === 0) {
+      return null;
+    }
+
+    for (const line of control.value.split(/\r?\n/)) {
+      let depth = 0;
+      for (const char of line) {
+        if (char === '(') {
+          depth++;
+        } else if (char === ')') {
+          depth--;
+          if (depth < 0) return error;
+        }
+      }
+      if (depth !== 0) return error;
+    }
+
+    // All lines are balanced
+    return null;
+  }
 }
 
 /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
@@ -13,6 +13,11 @@
         [readonly]="!canEdit()"
       ></textarea>
       <mat-hint>{{ t("renderings_hint") }}</mat-hint>
+      @if (renderings.hasError("unbalancedParentheses")) {
+        <mat-error>
+          {{ t("renderings_error") }}
+        </mat-error>
+      }
     </mat-form-field>
     <mat-form-field [formGroup]="form" appearance="outline">
       <mat-label>{{ t("description") }}</mat-label>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.spec.ts
@@ -144,6 +144,33 @@ describe('BiblicalTermDialogComponent', () => {
     expect(biblicalTerm.data?.description).toBe('');
   }));
 
+  it('should not save renderings with unbalanced parentheses', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData('en');
+    env.wait();
+
+    env.openDialog('id01');
+    env.setTextFieldValue(env.renderings, '(');
+    env.click(env.submitButton);
+    env.wait();
+    const biblicalTerm = env.getBiblicalTermDoc('id01');
+    expect(biblicalTerm.data?.renderings).toEqual(['rendering01']);
+    env.closeDialog();
+  }));
+
+  it('should save renderings with balanced parentheses', fakeAsync(() => {
+    const env = new TestEnvironment();
+    env.setupProjectData('en');
+    env.wait();
+
+    env.openDialog('id01');
+    env.setTextFieldValue(env.renderings, '()');
+    env.click(env.submitButton);
+    env.wait();
+    const biblicalTerm = env.getBiblicalTermDoc('id01');
+    expect(biblicalTerm.data?.renderings).toEqual(['()']);
+  }));
+
   it('should be read only for users without write access', fakeAsync(() => {
     const env = new TestEnvironment();
     env.setProjectUserConfig({ transliterateBiblicalTerms: true, ownerRef: 'user02' });

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -18,6 +18,7 @@
     "description": "Description",
     "edit_renderings": "Edit Renderings",
     "renderings": "Renderings",
+    "renderings_error": "Parentheses must have a match.",
     "renderings_hint": "If there is more than one rendering, type each one on a separate line.",
     "save": "Save",
     "term": "Term/Definition",


### PR DESCRIPTION
This PR prevents unpaired parentheses from being written to the database for Biblical Term Renderings. If not stopped, these will cause ParatextData to throw an exception and the sync will fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3378)
<!-- Reviewable:end -->
