### PR TITLE
Update e2e tests to work with Angular 19

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/e2e-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/e2e-utils.ts
@@ -256,8 +256,9 @@ export async function deleteProject(page: Page, shortName: string): Promise<void
   const paragraph = await page.getByText('This action cannot be undone');
   const projectName = (await paragraph.textContent())?.match(/delete the (.*) project/)?.[1];
   if (projectName == null) throw new Error('Project name not found');
-  await page.getByRole('textbox', { name: 'Project name' }).fill(projectName);
-  await page.getByRole('button', { name: 'Delete this project' }).click();
+  const dialogContainer = await page.locator('mat-dialog-container');
+  await dialogContainer.getByRole('textbox', { name: 'Project name' }).fill(projectName);
+  await dialogContainer.getByRole('button', { name: 'Delete this project' }).click();
 
   // Wait for the project to be fully deleted and user redirected to my projects page
   await page.waitForURL(url => /\/projects\/?$/.test(url.pathname));

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/community-checking.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/community-checking.ts
@@ -87,7 +87,7 @@ export async function communityChecking(
   await expect(
     page.getByRole('heading', { name: 'Are you sure you want to archive all the questions in John?' })
   ).toBeVisible();
-  await user.click(page.getByRole('button', { name: 'Archive' }));
+  await user.click(page.locator('mat-dialog-container').getByRole('button', { name: 'Archive' }));
 
   await user.click(page.getByRole('button', { name: 'Import' }));
   const fileChooserPromise = page.waitForEvent('filechooser');

--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/edit-translation.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/edit-translation.ts
@@ -79,7 +79,7 @@ export async function editTranslation(
   await expect(deletedSegments[0]).toBe(initialSegmentText);
 
   await user.click(page.getByRole('button', { name: 'Restore this version' }));
-  await user.click(page.getByRole('button', { name: 'Restore' }));
+  await user.click(page.getByRole('button', { name: 'Restore', exact: true }));
 
   // Go back to the editor tab
   await goToProjectTab(page, user, 'target', DEFAULT_PROJECT_SHORTNAME);


### PR DESCRIPTION
I'm not clear exactly why, but when running on the Angular 19 upgrade branch, some of the Playwright locators find elements behind the dialog, leading a locator to match multiple elements. This updates the locators to be more precise, and continue to work post upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3380)
<!-- Reviewable:end -->
