### PR TITLE
SF-3488 Force refresh when draft config changes remotely

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -179,6 +179,30 @@ describe('DraftGenerationStepsComponent', () => {
       verify(mockDialogService.message(anything(), anything(), anything())).never();
       expect(cancelFired).toBe(false);
     }));
+
+    it('should not show dialog or emit cancel if the steps are completed', fakeAsync(() => {
+      let cancelFired = false;
+      when(mockDialogService.openDialogCount).thenReturn(1);
+      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+      component = fixture.componentInstance;
+      component.cancel.subscribe(() => (cancelFired = true));
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(component['draftingSources'].length).toBe(1);
+
+      component.isStepsCompleted = true;
+
+      // Simulate a remote change
+      const newConfig = { ...initialConfig, draftingSources: [] };
+      draftSources$.next(newConfig);
+      tick();
+      fixture.detectChanges();
+
+      verify(mockDialogService.message(anything(), anything(), anything())).never();
+      expect(cancelFired).toBe(false);
+    }));
   });
 
   describe('one training source', async () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -10,8 +10,10 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { BehaviorSubject, of } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
+import { LocationService } from 'xforge-common/location.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
@@ -40,6 +42,8 @@ describe('DraftGenerationStepsComponent', () => {
   const mockNoticeService = mock(NoticeService);
   const mockParatextService = mock(ParatextService);
   const mockUserService = mock(UserService);
+  const mockDialogService = mock(DialogService);
+  const mockLocationService = mock(LocationService);
 
   when(mockActivatedProjectService.projectId).thenReturn('project01');
 
@@ -55,6 +59,8 @@ describe('DraftGenerationStepsComponent', () => {
       { provide: OnlineStatusService, useMock: mockOnlineStatusService },
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: UserService, useMock: mockUserService },
+      { provide: DialogService, useMock: mockDialogService },
+      { provide: LocationService, useMock: mockLocationService },
       provideHttpClient(withInterceptorsFromDi()),
       provideHttpClientTesting()
     ]
@@ -73,6 +79,115 @@ describe('DraftGenerationStepsComponent', () => {
     ]);
     when(mockOnlineStatusService.isOnline).thenReturn(true);
   }));
+
+  describe('ngOnInit', () => {
+    let draftSources$: BehaviorSubject<DraftSourcesAsArrays>;
+    const initialConfig: DraftSourcesAsArrays = {
+      trainingSources: [
+        {
+          projectRef: 'sourceProject',
+          paratextId: 'PT_SP',
+          name: 'Source Project',
+          shortName: 'sP',
+          writingSystem: { tag: 'eng' },
+          texts: [{ bookNum: 1 }]
+        }
+      ],
+      trainingTargets: [
+        {
+          projectRef: 'project01',
+          paratextId: 'PT_TT',
+          name: 'Target Project',
+          shortName: 'tT',
+          writingSystem: { tag: 'xyz' },
+          texts: [{ bookNum: 1 }]
+        }
+      ],
+      draftingSources: [
+        {
+          projectRef: 'sourceProject',
+          paratextId: 'PT_SP',
+          name: 'Source Project',
+          shortName: 'sP',
+          writingSystem: { tag: 'eng' },
+          texts: [{ bookNum: 1 }]
+        }
+      ]
+    };
+
+    beforeEach(() => {
+      draftSources$ = new BehaviorSubject<DraftSourcesAsArrays>(initialConfig);
+      when(mockDraftSourceService.getDraftProjectSources()).thenReturn(draftSources$);
+      when(mockDialogService.message(anything(), anything(), anything())).thenResolve();
+      when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(false);
+      when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
+      const mockTargetProjectDoc = {
+        id: 'project01',
+        data: createTestProjectProfile({
+          texts: [{ bookNum: 1 }],
+          translateConfig: {
+            source: { projectRef: 'sourceProject', shortName: 'sP', writingSystem: { tag: 'xyz' } }
+          },
+          writingSystem: { tag: 'eng' }
+        })
+      } as SFProjectProfileDoc;
+      when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
+      when(mockActivatedProjectService.projectDoc$).thenReturn(of(mockTargetProjectDoc));
+      when(mockActivatedProjectService.changes$).thenReturn(new BehaviorSubject(undefined));
+    });
+
+    it('should show dialog and reload if sources change', fakeAsync(() => {
+      when(mockDialogService.openDialogCount).thenReturn(0);
+      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      const reload = new Error('RELOAD');
+      expect(component['draftingSources'].length).toBe(1);
+      verify(mockDialogService.message(anything(), anything(), anything())).never();
+      when(mockLocationService.reload()).thenCall(() => {
+        verify(mockDialogService.message(anything(), anything(), anything())).once();
+        verify(mockLocationService.reload()).once();
+        throw reload;
+      });
+
+      // Simulate a remote change
+      const newConfig: DraftSourcesAsArrays = {
+        ...initialConfig,
+        draftingSources: [{ ...initialConfig.draftingSources[0], texts: [{ bookNum: 2 }] }]
+      };
+      draftSources$.next(newConfig);
+
+      try {
+        tick();
+        fail('tick() did not throw');
+      } catch (e: any) {
+        expect(e.rejection).toBe(reload);
+      }
+    }));
+
+    it('should not show dialog or reload if a dialog is already open', fakeAsync(() => {
+      when(mockDialogService.openDialogCount).thenReturn(1);
+      fixture = TestBed.createComponent(DraftGenerationStepsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+      fixture.detectChanges();
+
+      expect(component['draftingSources'].length).toBe(1);
+
+      // Simulate a remote change
+      const newConfig = { ...initialConfig, draftingSources: [] };
+      draftSources$.next(newConfig);
+      tick();
+      fixture.detectChanges();
+
+      verify(mockDialogService.message(anything(), anything(), anything())).never();
+      verify(mockLocationService.reload()).never();
+    }));
+  });
 
   describe('one training source', async () => {
     const availableBooks = [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -11,7 +11,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { LocationService } from 'xforge-common/location.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -132,8 +131,7 @@ export class DraftGenerationStepsComponent implements OnInit {
     private readonly progressService: ProgressService,
     private readonly trainingFileService: TrainingDataService,
     private readonly userService: UserService,
-    private readonly dialogService: DialogService,
-    private readonly locationService: LocationService
+    private readonly dialogService: DialogService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -156,7 +154,7 @@ export class DraftGenerationStepsComponent implements OnInit {
               'draft_generation_steps.remote_changes_start_over',
               true
             );
-            this.locationService.reload();
+            this.cancel.emit();
           }
 
           // The null values will have been filtered above

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -148,7 +148,7 @@ export class DraftGenerationStepsComponent implements OnInit {
         async ([{ trainingTargets, trainingSources, draftingSources }, projectId]) => {
           // Force refresh on remote changes
           if (this.draftingSources.length > 0 || this.trainingSources.length > 0 || this.trainingTargets.length > 0) {
-            if (this.dialogService.openDialogCount > 0) return;
+            if (this.dialogService.openDialogCount > 0 || this.isStepsCompleted) return;
             await this.dialogService.message(
               'draft_generation_steps.remote_changes',
               'draft_generation_steps.remote_changes_start_over',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -8,8 +8,10 @@ import { ProjectScriptureRange, TranslateSource } from 'realtime-server/lib/esm/
 import { combineLatest, merge, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { LocationService } from 'xforge-common/location.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -129,7 +131,9 @@ export class DraftGenerationStepsComponent implements OnInit {
     private readonly paratextService: ParatextService,
     private readonly progressService: ProgressService,
     private readonly trainingFileService: TrainingDataService,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    private readonly dialogService: DialogService,
+    private readonly locationService: LocationService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -144,6 +148,17 @@ export class DraftGenerationStepsComponent implements OnInit {
       .subscribe(
         // Build book lists
         async ([{ trainingTargets, trainingSources, draftingSources }, projectId]) => {
+          // Force refresh on remote changes
+          if (this.draftingSources.length > 0 || this.trainingSources.length > 0 || this.trainingTargets.length > 0) {
+            if (this.dialogService.openDialogCount > 0) return;
+            await this.dialogService.message(
+              'draft_generation_steps.remote_changes',
+              'draft_generation_steps.remote_changes_start_over',
+              true
+            );
+            this.locationService.reload();
+          }
+
           // The null values will have been filtered above
           const target = trainingTargets[0]!;
           const draftingSource = draftingSources[0]!;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -252,6 +252,8 @@
     "overview": "Overview",
     "pending_updates": "The project {{ projectName }} has pending updates from Paratext, which may affect draft generation. Please [link:syncUrl]sync {{ projectName }}[/link] before generating a draft.",
     "reference_books": "Reference books",
+    "remote_changes": "The draft generation settings for this project have been modified, either by another user or in a separate window. Please review the latest configuration and try starting the draft again.",
+    "remote_changes_start_over": "Start over",
     "source_books_missing": "The reference text is missing one or more of the translated books in your project. Consider choosing a reference text that contains a match for all the translated books",
     "summary_header": "Summary",
     "summary_notifications": "Notifications",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -252,7 +252,7 @@
     "overview": "Overview",
     "pending_updates": "The project {{ projectName }} has pending updates from Paratext, which may affect draft generation. Please [link:syncUrl]sync {{ projectName }}[/link] before generating a draft.",
     "reference_books": "Reference books",
-    "remote_changes": "The draft generation settings for this project have been modified, either by another user or in a separate window. Please review the latest configuration and try starting the draft again.",
+    "remote_changes": "The source configuration for draft generation has been modified. Please start a new draft and review the latest source configuration.",
     "remote_changes_start_over": "Start over",
     "source_books_missing": "The reference text is missing one or more of the translated books in your project. Consider choosing a reference text that contains a match for all the translated books",
     "summary_header": "Summary",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -91,6 +91,7 @@ export class DialogService {
    * key.
    * @param close (optional) May be an Observable<string>, or an I18nKey which will be used as a translation key. If not
    * provided the button will use a default label for the close button.
+   * @param disableClose (optional) When true, prevents clicking outside the dialog from closing it. Default is false.
    */
   async message(
     message: I18nKey | Observable<string>,

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -190,7 +190,7 @@ public class MachineProjectService(
                 );
             }
         }
-        catch (DataNotFoundException e)
+        catch (DataNotFoundException e) when (e.Message.Contains("project"))
         {
             // This will occur if the project is deleted while the job is running.
             // Do not send a failure email, as the project will not exist for us to do that.

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -225,7 +225,7 @@ public class MachineProjectServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        var ex = new DataNotFoundException("Not Found");
+        var ex = new DataNotFoundException("project not found");
         var buildConfig = new BuildConfig { ProjectId = Project01 };
         env.Service.Configure()
             .BuildProjectAsync(User01, buildConfig, preTranslate: true, CancellationToken.None)
@@ -241,6 +241,28 @@ public class MachineProjectServiceTests
 
         env.MockLogger.AssertHasEvent(logEvent => logEvent.Exception == ex && logEvent.LogLevel == LogLevel.Warning);
         env.ExceptionHandler.DidNotReceive().ReportException(Arg.Any<Exception>());
+    }
+
+    [Test]
+    public async Task BuildProjectForBackgroundJobAsync_MissingDirectoryDataNotFoundException()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        var ex = new DataNotFoundException("directory not found");
+        var buildConfig = new BuildConfig { ProjectId = Project01 };
+        env.Service.Configure()
+            .BuildProjectAsync(User01, buildConfig, preTranslate: true, CancellationToken.None)
+            .ThrowsAsync(ex);
+
+        // SUT
+        await env.Service.BuildProjectForBackgroundJobAsync(
+            User01,
+            buildConfig,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(ex);
     }
 
     [Test]


### PR DESCRIPTION
I also added an optional parameter to the dialog service to disallow closing by clicking outside the dialog, since for this case, we want them to explicitly click the button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3381)
<!-- Reviewable:end -->
