### PR TITLE
SF-3518 Exclude id segment from segment counts

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -59,8 +59,8 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, Range> {
         const op = this.data.ops[i];
         const nextOp = i < this.data.ops.length - 1 ? this.data.ops[i + 1] : undefined;
         if (op.attributes != null && op.attributes.segment != null) {
+          const segRef: string = op.attributes.segment as string;
           if ((op.insert as any).blank != null) {
-            const segRef: string = op.attributes.segment as string;
             if (
               nextOp == null ||
               nextOp.insert == null ||
@@ -69,7 +69,8 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, Range> {
             ) {
               blank++;
             }
-          } else {
+          } else if (!segRef.startsWith('id_')) {
+            // Exclude the id segment from the translated count
             translated++;
           }
         }


### PR DESCRIPTION
This PR excludes the id segment from the translated segment count, as this is a segment that is not translated, and will usually have text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3384)
<!-- Reviewable:end -->
