### PR TITLE
Fix word wrap of status text in draft history

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
@@ -36,6 +36,7 @@ mat-panel-description {
   display: flex;
   align-items: center;
   gap: 4px;
+  white-space: nowrap;
 }
 
 .expand-icon {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.spec.ts
@@ -1,8 +1,19 @@
 import { PseudoLocalization } from './pseudo-localization';
 
 describe('pseudo-localization', () => {
-  it('should localize', () => {
+  it('should not localize variables', () => {
     expect(PseudoLocalization.localize({ key: 'ABC {{ var }} xyz' })).toEqual({ key: 'BCD {{ var }} yza' });
-    expect(PseudoLocalization.localize({ a: { x: 'a' }, b: { y: 'b' } })).toEqual({ a: { x: 'b' }, b: { y: 'c' } });
+  });
+
+  it('should add spaces to single words', () => {
+    expect(
+      PseudoLocalization.localize({
+        a: { x: 'abcd' },
+        b: { y: 'bcde' }
+      })
+    ).toEqual({
+      a: { x: 'bc de' },
+      b: { y: 'cd ef' }
+    });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pseudo-localization.ts
@@ -26,6 +26,13 @@ function pseudoLocalizeString(input: string): string {
     if (bracketDepth === 0) output += pseudoLocalizeCharacter(char);
     else output += char;
   }
+
+  // If output contains a single word, add a space in the middle so word wrapping can be properly tested
+  if (/^[a-z]+$/i.test(output)) {
+    const insertIndex = Math.floor(output.length / 2);
+    output = output.slice(0, insertIndex) + ' ' + output.slice(insertIndex);
+  }
+
   return output;
 }
 


### PR DESCRIPTION
Also updated pseudolocalization to show word wrap problems better

### Original

Pseudolocalization shows no problem, because there's no space in the status text for English. However, some translated strings will show a word wrap problem, because they contain spaces.
<img width="657" height="230" alt="localhost_5000_projects_68a4bbb756791bc03fa08593_draft-generation (2)" src="https://github.com/user-attachments/assets/5052cb6d-ac98-4f7e-b8b4-913965507336" />

### Pseudolocalization updated

I updated the logic to add a space in the middle of any strings that consist of a single word. This allows pseudolocalization to show white space problems before any translations have been completed.
<img width="657" height="230" alt="localhost_5000_projects_68a4bbb756791bc03fa08593_draft-generation" src="https://github.com/user-attachments/assets/f9dc80f8-c541-4d0a-ba63-0cf89f650cef" />

### Final version

White space issue is fixed.
<img width="657" height="230" alt="localhost_5000_projects_68a4bbb756791bc03fa08593_draft-generation (1)" src="https://github.com/user-attachments/assets/509ad367-e908-47e7-9ea0-435384bbfbf6" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3386)
<!-- Reviewable:end -->
