### PR TITLE
Increase interaction speed of default e2e preset

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/presets.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/presets.ts
@@ -39,7 +39,7 @@ const defaultPreset: TestPreset = {
   locales: ['en'],
   browsers: ['chromium'],
   skipScreenshots: false,
-  defaultUserDelay: 500,
+  defaultUserDelay: 0,
   showArrow: true,
   trace: true,
   outputDir: `test_output/${Utils.formatDate(new Date())}`,
@@ -48,14 +48,15 @@ const defaultPreset: TestPreset = {
 } as const;
 
 export const presets = {
-  default: defaultPreset,
-  fast: {
+  default: {
+    ...defaultPreset
+  },
+  user_speed: {
     ...defaultPreset,
-    defaultUserDelay: 0
+    defaultUserDelay: 500
   },
   localization: {
     ...defaultPreset,
-    defaultUserDelay: 0,
     locales: helpLocales,
     showArrow: true,
     outputDir: 'test_output/localized_screenshots'


### PR DESCRIPTION
I designed the e2e tests to interact at similar speed as a user, to be able to actually watch what is going on, and optionally record them for debugging purposes. However, going slow doesn't need to be the default, and makes running them locally take longer unless you explicitly choose to use the fast option.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3387)
<!-- Reviewable:end -->
