### PR TITLE
SF-3514 Show requested by user label above training configuration

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -49,6 +49,20 @@
             <tr mat-row *matRowDef="let row; columns: ['heading', 'details']"></tr>
           </table>
         }
+        @if (buildRequestedAtDate != null && buildRequestedByUserName != null) {
+          <p class="requested-label">
+            {{
+              t("requested_by", {
+                requestedAtTime: buildRequestedAtDate,
+                requestedByUserName: buildRequestedByUserName
+              })
+            }}
+          </p>
+        } @else if (buildRequestedAtDate != null) {
+          <p class="requested-label">
+            {{ t("requested_at", { requestedAtTime: buildRequestedAtDate }) }}
+          </p>
+        }
         @if (hasTrainingConfiguration) {
           @if (canDownloadBuild) {
             <p>
@@ -92,21 +106,11 @@
               <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
               <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
             </table>
-            @if (buildRequestedAtDate != null && buildRequestedByUserName != null) {
-              <p>
-                {{
-                  t("requested_by", {
-                    requestedAtTime: buildRequestedAtDate,
-                    requestedByUserName: buildRequestedByUserName
-                  })
-                }}
-              </p>
-            } @else if (buildRequestedAtDate != null) {
-              <p>
-                {{ t("requested_at", { requestedAtTime: buildRequestedAtDate }) }}
-              </p>
-            }
           }
+        } @else {
+          <p class="no-training-configuration">
+            {{ t("training_data_not_configured") }}
+          </p>
         }
       </div>
     </mat-expansion-panel>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -98,6 +98,24 @@ describe('DraftHistoryEntryComponent', () => {
         }
       ]);
       expect(component.trainingConfigurationOpen).toBe(false);
+      expect(fixture.nativeElement.querySelector('.requested-label')).not.toBeNull();
+    }));
+
+    it('should state that the model did not have training configuration', fakeAsync(() => {
+      when(mockedI18nService.enumerateList(anything())).thenReturn('src');
+      const user = 'user-display-name';
+      const date = 'formatted-date';
+      const trainingBooks = [];
+      const translateBooks = ['GEN'];
+      const entry = getStandardBuildDto({ user, date, trainingBooks, translateBooks });
+
+      // SUT
+      component.entry = entry;
+      tick();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('.no-training-configuration')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('.requested-label')).not.toBeNull();
     }));
 
     it('should show the USFM format option when the project is the latest draft', fakeAsync(() => {
@@ -321,7 +339,8 @@ describe('DraftHistoryEntryComponent', () => {
         dateGenerated: new Date().toISOString(),
         dateRequested: new Date().toISOString(),
         requestedByUserId: 'sf-user-id',
-        trainingScriptureRanges: [{ projectId: 'project02', scriptureRange: trainingBooks.join(';') }],
+        trainingScriptureRanges:
+          trainingBooks.length > 0 ? [{ projectId: 'project02', scriptureRange: trainingBooks.join(';') }] : [],
         translationScriptureRanges: [{ projectId: 'project02', scriptureRange: translateBooks.join(';') }]
       }
     } as BuildDto;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -283,6 +283,7 @@
     "requested_by": "Requested by {{ requestedByUserName }} at {{ requestedAtTime }}.",
     "show_model_training_configuration": "Show model training configuration",
     "training_books": "Training books",
+    "training_data_not_configured": "No training data was configured on this draft.",
     "training_model_description": "The language model was trained on this configuration:"
   },
   "draft_history_list": {


### PR DESCRIPTION
This PR takes the requested by user label and places it above the model training configuration details. If training data was not configured for the build, then a label is shown indicating that training data was not configured.

<img width="1387" height="350" alt="image" src="https://github.com/user-attachments/assets/67c1546a-6abd-4dc6-a267-20089ec6cd11" />
