### PR TITLE
dev: enable rule warn no-floating-promises and no-misused-promises

### DIFF
--- a/src/RealtimeServer/.eslintrc.json
+++ b/src/RealtimeServer/.eslintrc.json
@@ -35,6 +35,8 @@
         ],
         "@typescript-eslint/naming-convention": ["error", { "selector": "enumMember", "format": ["PascalCase"] }],
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-floating-promises": "warn",
+        "@typescript-eslint/no-misused-promises": "warn",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",
@@ -63,6 +65,10 @@
         ],
         "no-underscore-dangle": "off"
       }
+    },
+    {
+      "files": ["*.spec.ts"],
+      "rules": { "@typescript-eslint/no-floating-promises": "off", "@typescript-eslint/no-misused-promises": "off" }
     }
   ]
 }

--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -53,7 +53,9 @@
             "format": ["PascalCase"]
           }
         ],
+        "@typescript-eslint/no-floating-promises": "warn",
         "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/no-misused-promises": "warn",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",
@@ -106,6 +108,14 @@
         ],
         "deprecation/deprecation": "warn"
       }
+    },
+    {
+      "files": ["*.spec.ts"],
+      "rules": { "@typescript-eslint/no-floating-promises": "off", "@typescript-eslint/no-misused-promises": "off" }
+    },
+    {
+      "files": ["*.stories.ts"],
+      "rules": { "@typescript-eslint/no-floating-promises": "off", "@typescript-eslint/no-misused-promises": "off" }
     }
   ]
 }


### PR DESCRIPTION
The rules are not enabled for spec and stories files. It may also be
useful to have the rules on in those files, but (1) calls to async
methods in fakeAsync do not need awaited, and (2) the IDE understands
toBe, toEqual, etc to return Promises.

Ideally the rules would mark occurrences as errors, but there are many
occurrences that first need to be cleaned up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3391)
<!-- Reviewable:end -->
