### PR TITLE
SF-3526 Fix up Serval draft jobs component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -343,10 +343,19 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     return await this.onlineInvoke<QueryResults<EventMetric>>('eventMetrics', { projectId, pageIndex, pageSize });
   }
 
-  async onlineAllEventMetrics(projectId?: string, daysBack?: number): Promise<QueryResults<EventMetric> | undefined> {
+  async onlineAllEventMetricsForConstructionDraftJobs(
+    projectId?: string,
+    daysBack?: number
+  ): Promise<QueryResults<EventMetric> | undefined> {
     const params: any = {
       projectId: projectId ?? null,
-      scopes: [3] // Drafting scope
+      scopes: [3], // Drafting scope
+      eventTypes: [
+        'StartPreTranslationBuildAsync',
+        'BuildProjectAsync',
+        'RetrievePreTranslationStatusAsync',
+        'CancelPreTranslationBuildAsync'
+      ]
     };
 
     if (daysBack != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
@@ -13,129 +13,155 @@
 
     @if (currentProjectFilter) {
       <app-notice icon="filter_alt" mode="fill-dark">
-        Showing draft jobs for project <strong>{{ filteredProjectName || currentProjectFilter }}</strong
-        >.
+        <div class="filter-notice-content">
+          <span>
+            Showing draft jobs for project <strong>{{ filteredProjectName || currentProjectFilter }}</strong>
+          </span>
+          <button mat-icon-button class="clear-filter-btn" (click)="clearProjectFilter()">
+            <mat-icon>clear</mat-icon>
+          </button>
+        </div>
       </app-notice>
     }
 
-    @if (rows.length > 0) {
-      <div class="table-wrapper">
-        <table mat-table id="draft-jobs-table" [dataSource]="rows">
-          <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-          <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
-          <ng-container matColumnDef="status">
-            <th mat-header-cell *matHeaderCellDef>Status</th>
-            <td mat-cell *matCellDef="let row">
-              <div
-                class="status-cell"
-                matTooltip="Broken does not indicate failure, but that the sequence of events is not creating a coherent picture."
-                [matTooltipDisabled]="row.job.status !== 'broken'"
+    <div class="table-wrapper">
+      <table mat-table id="draft-jobs-table" [dataSource]="rows">
+        <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+        <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="status-cell">
+              <mat-icon
+                class="status-icon"
+                [class.successful]="row.job.status === 'success'"
+                [class.failed]="row.job.status === 'failed'"
+                [class.running]="row.job.status === 'running'"
+                [class.cancelled]="row.job.status === 'cancelled'"
+                [class.incomplete]="row.job.status === 'incomplete'"
               >
-                <mat-icon
-                  class="status-icon"
-                  [class.successful]="row.job.status === 'success'"
-                  [class.failed]="row.job.status === 'failed'"
-                  [class.running]="row.job.status === 'running'"
-                  [class.cancelled]="row.job.status === 'cancelled'"
-                  [class.broken]="row.job.status === 'broken'"
-                >
-                  @if (row.job.status === "success") {
-                    check_circle
-                  } @else if (row.job.status === "failed") {
-                    error
-                  } @else if (row.job.status === "running") {
-                    schedule
-                  } @else if (row.job.status === "cancelled") {
-                    cancel
-                  } @else if (row.job.status === "broken") {
-                    warning
-                  }
-                </mat-icon>
-                <span>{{ row.status }}</span>
+                @if (row.job.status === "success") {
+                  check_circle
+                } @else if (row.job.status === "failed") {
+                  error
+                } @else if (row.job.status === "running") {
+                  schedule
+                } @else if (row.job.status === "cancelled") {
+                  cancel
+                } @else if (row.job.status === "incomplete") {
+                  warning
+                }
+              </mat-icon>
+              <span>{{ row.status }}</span>
+            </div>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="projectId">
+          <th mat-header-cell *matHeaderCellDef>Project</th>
+          <td mat-cell *matCellDef="let row">
+            @if (!row.projectDeleted) {
+              <a [routerLink]="['/serval-administration', row.projectId]">{{ row.projectName || "Unknown" }}</a>
+            } @else {
+              <div class="deleted-project">
+                <mat-icon class="deleted-project-icon" matTooltip="Project has been deleted">delete</mat-icon>
+                <span>{{ row.projectId }}</span>
               </div>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="projectId">
-            <th mat-header-cell *matHeaderCellDef>Project</th>
-            <td mat-cell *matCellDef="let row">
-              @if (!row.projectDeleted) {
-                <a [routerLink]="['/serval-administration', row.projectId]">{{ row.projectName || "Unknown" }}</a>
-              } @else {
-                <div class="deleted-project">
-                  <mat-icon class="deleted-project-icon" matTooltip="Project has been deleted">delete</mat-icon>
-                  <span>{{ row.projectId }}</span>
-                </div>
-              }
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="trainingBooks">
-            <th mat-header-cell *matHeaderCellDef>Training Books</th>
-            <td mat-cell *matCellDef="let row">
-              @if (row.trainingBooksTooltip) {
-                <span [matTooltip]="row.trainingBooksTooltip">{{ row.trainingBooks }}</span>
-              } @else {
-                {{ row.trainingBooks }}
-              }
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="translationBooks">
-            <th mat-header-cell *matHeaderCellDef>Translation Books</th>
-            <td mat-cell *matCellDef="let row">
-              @if (row.translationBooksTooltip) {
-                <span [matTooltip]="row.translationBooksTooltip">{{ row.translationBooks }}</span>
-              } @else {
-                {{ row.translationBooks }}
-              }
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="startTime">
-            <th mat-header-cell *matHeaderCellDef>Start Time</th>
-            <td mat-cell *matCellDef="let row">
-              {{ row.startTimeStamp }}
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="duration">
-            <th mat-header-cell *matHeaderCellDef>Duration</th>
-            <td mat-cell *matCellDef="let row">
-              @if (row.job.status === "running") {
-                <span class="running-text">In progress</span>
-              } @else if (row.durationTooltip) {
-                <span [matTooltip]="row.durationTooltip">{{ row.duration || "Not available" }}</span>
-              } @else {
-                {{ row.duration || "Not available" }}
-              }
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="author">
-            <th mat-header-cell *matHeaderCellDef>Author</th>
-            <td mat-cell *matCellDef="let row">
-              <app-owner
-                [ownerRef]="row.userId"
-                [includeAvatar]="true"
-                [dateTime]="row.startTimeStamp"
-                [showTimeZone]="true"
-              ></app-owner>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="buildId">
-            <th mat-header-cell *matHeaderCellDef>Build ID & ClearML link</th>
-            <td mat-cell *matCellDef="let row">
-              <a [href]="row.clearmlUrl" target="_blank" rel="noopener noreferrer" matTooltip="Open in ClearML">
-                {{ row.job.buildId }}
-              </a>
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="details">
-            <th mat-header-cell *matHeaderCellDef>Events</th>
-            <td mat-cell *matCellDef="let row">
-              <button mat-stroked-button (click)="openDetailsDialog(row.job)" color="primary" class="details-button">
-                <mat-icon class="mirror-rtl">list</mat-icon> Events
-              </button>
-            </td>
-          </ng-container>
-        </table>
-      </div>
-    } @else if (rows.length === 0) {
+            }
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="trainingBooks">
+          <th mat-header-cell *matHeaderCellDef>Training Books</th>
+          <td mat-cell *matCellDef="let row">
+            @for (projectBook of row.trainingBooks; track projectBook.projectId) {
+              <div class="project-books-line">
+                <a [routerLink]="['/serval-administration', projectBook.projectId]" class="project-link">{{
+                  getProjectShortName(projectBook.projectId)
+                }}</a
+                >:
+                @if (projectBook.books.length <= 2) {
+                  {{ projectBook.books.join(", ") }}
+                } @else {
+                  <span [matTooltip]="projectBook.books.join(', ')" class="book-count">
+                    {{ projectBook.books.length }} books
+                  </span>
+                }
+              </div>
+            } @empty {
+              None
+            }
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="translationBooks">
+          <th mat-header-cell *matHeaderCellDef>Translation Books</th>
+          <td mat-cell *matCellDef="let row">
+            @for (projectBook of row.translationBooks; track projectBook.projectId) {
+              <div class="project-books-line">
+                <a [routerLink]="['/serval-administration', projectBook.projectId]" class="project-link">{{
+                  getProjectShortName(projectBook.projectId)
+                }}</a
+                >:
+                @if (projectBook.books.length <= 2) {
+                  {{ projectBook.books.join(", ") }}
+                } @else {
+                  <span [matTooltip]="projectBook.books.join(', ')" class="book-count">
+                    {{ projectBook.books.length }} books
+                  </span>
+                }
+              </div>
+            } @empty {
+              None
+            }
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="startTime">
+          <th mat-header-cell *matHeaderCellDef>Start Time</th>
+          <td mat-cell *matCellDef="let row">
+            {{ row.startTimeStamp }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="duration">
+          <th mat-header-cell *matHeaderCellDef>Duration</th>
+          <td mat-cell *matCellDef="let row">
+            @if (row.job.status === "running") {
+              <span class="running-text">In progress</span>
+            } @else if (row.durationTooltip) {
+              <span [matTooltip]="row.durationTooltip">{{ row.duration || "Not available" }}</span>
+            } @else {
+              {{ row.duration || "Not available" }}
+            }
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="author">
+          <th mat-header-cell *matHeaderCellDef>Author</th>
+          <td mat-cell *matCellDef="let row">
+            <app-owner
+              [ownerRef]="row.userId"
+              [includeAvatar]="true"
+              [dateTime]="row.startTimeStamp"
+              [showTimeZone]="true"
+            ></app-owner>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="buildId">
+          <th mat-header-cell *matHeaderCellDef>Build ID & ClearML link</th>
+          <td mat-cell *matCellDef="let row">
+            <a [href]="row.clearmlUrl" target="_blank" rel="noopener noreferrer" matTooltip="Open in ClearML">
+              {{ row.job.buildId }}
+            </a>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="details">
+          <th mat-header-cell *matHeaderCellDef>Events</th>
+          <td mat-cell *matCellDef="let row">
+            <button mat-stroked-button (click)="openDetailsDialog(row.job)" color="primary" class="details-button">
+              <mat-icon class="mirror-rtl">list</mat-icon> Events
+            </button>
+          </td>
+        </ng-container>
+      </table>
+    </div>
+
+    @if (rows.length === 0) {
       <p>No draft jobs found for the selected time period.</p>
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.scss
@@ -5,6 +5,10 @@
   display: block;
 }
 
+#draft-jobs-table tr:nth-child(odd) {
+  background-color: white;
+}
+
 app-owner,
 .details-button {
   white-space: nowrap;
@@ -38,7 +42,7 @@ app-owner,
   color: sfColors.$greyLight;
 }
 
-.status-icon.broken {
+.status-icon.incomplete {
   color: sfColors.$orange;
 }
 
@@ -68,5 +72,44 @@ app-owner,
 
   mat-form-field {
     min-width: 150px;
+  }
+}
+
+.project-link {
+  color: #1976d2;
+  text-decoration: none;
+  font-weight: 500;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.book-count {
+  cursor: help;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  color: #666;
+}
+
+.filter-notice-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.clear-filter-btn {
+  margin-left: 8px;
+  opacity: 0.8;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { MatDialogConfig } from '@angular/material/dialog';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { BehaviorSubject, combineLatest, map, Observable, switchMap } from 'rxjs';
 import { AuthService } from 'xforge-common/auth.service';
@@ -23,21 +23,27 @@ import { ServalAdministrationService } from './serval-administration.service';
  * Draft jobs component for the serval administration page.
  * Shows draft jobs derived from event metrics across all projects for system administrators.
  */
-interface DraftJob {
+interface ProjectBooks {
   projectId: string;
-  startTime: Date;
-  finishTime?: Date;
-  duration?: number; // in milliseconds
-  status: 'running' | 'success' | 'failed' | 'cancelled' | 'broken';
-  userId?: string;
-  startEvent: EventMetric;
+  books: string[];
+}
+
+interface DraftJob {
+  buildId: string | null;
+  projectId: string;
+  startEvent?: EventMetric; // Made optional since incomplete jobs might not have a start event
   buildEvent?: EventMetric;
   finishEvent?: EventMetric;
   cancelEvent?: EventMetric;
+  events: EventMetric[];
+  status: 'running' | 'success' | 'failed' | 'cancelled' | 'incomplete';
+  startTime: Date | null;
+  finishTime: Date | null;
+  duration: number | null;
   errorMessage?: string;
-  trainingBooks: string[];
-  translationBooks: string[];
-  buildId?: string;
+  userId?: string;
+  trainingBooks?: ProjectBooks[];
+  translationBooks?: ProjectBooks[];
 }
 
 interface Row {
@@ -50,10 +56,8 @@ interface Row {
   durationTooltip?: string;
   status: string;
   userId?: string;
-  trainingBooks: string;
-  translationBooks: string;
-  trainingBooksTooltip?: string;
-  translationBooksTooltip?: string;
+  trainingBooks: ProjectBooks[];
+  translationBooks: ProjectBooks[];
   clearmlUrl?: string;
 }
 
@@ -102,6 +106,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
   private eventMetrics?: EventMetric[];
   private draftJobs: DraftJob[] = [];
   private projectNames = new Map<string, string | null>(); // Cache for project names
+  private projectShortNames = new Map<string, string | null>(); // Cache for project short names
   filteredProjectName = '';
 
   constructor(
@@ -113,7 +118,8 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     private readonly projectService: SFProjectService,
     private readonly servalAdministrationService: ServalAdministrationService,
     private destroyRef: DestroyRef,
-    private readonly route: ActivatedRoute
+    private readonly route: ActivatedRoute,
+    private readonly router: Router
   ) {
     super(noticeService);
   }
@@ -154,7 +160,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
           }
 
           if (isOnline) {
-            const queryResults = await this.projectService.onlineAllEventMetrics(
+            const queryResults = await this.projectService.onlineAllEventMetricsForConstructionDraftJobs(
               projectFilterId ?? undefined,
               daysBack === 'all_time' ? undefined : daysBack
             );
@@ -175,12 +181,9 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
 
   openDetailsDialog(job: DraftJob): void {
     // Collect all events that were used to create this job
-    const events = [
-      job.startEvent,
-      ...(job.buildEvent ? [job.buildEvent] : []),
-      ...(job.finishEvent ? [job.finishEvent] : []),
-      ...(job.cancelEvent ? [job.cancelEvent] : [])
-    ].sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
+    const events = [job.startEvent, job.buildEvent, job.finishEvent, job.cancelEvent]
+      .filter((event): event is EventMetric => event != null)
+      .sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
 
     const dialogData = {
       projectId: job.projectId,
@@ -190,6 +193,14 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
 
     const dialogConfig: MatDialogConfig<any> = { data: dialogData, width: '800px', maxHeight: '80vh' };
     this.dialogService.openMatDialog(JobEventsDialogComponent, dialogConfig);
+  }
+
+  clearProjectFilter(): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { projectId: null },
+      queryParamsHandling: 'merge'
+    });
   }
 
   private processDraftJobs(): void {
@@ -208,111 +219,405 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
         event.eventType === 'CancelPreTranslationBuildAsync'
     );
 
-    // Group events by project ID and create jobs
-    const jobs: DraftJob[] = [];
-    const startEvents = draftEvents
-      .filter(e => e.eventType === 'StartPreTranslationBuildAsync')
-      .sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
+    // Step 1: Group events by build ID where available
+    const jobsByBuildId = new Map<string, EventMetric[]>();
+    const eventsWithoutBuildId: EventMetric[] = [];
 
-    for (let i = 0; i < startEvents.length; i++) {
-      const startEvent = startEvents[i];
+    for (const event of draftEvents) {
+      const buildId = this.extractBuildIdFromEvent(event);
+      if (buildId != null) {
+        if (!jobsByBuildId.has(buildId)) {
+          jobsByBuildId.set(buildId, []);
+        }
+        jobsByBuildId.get(buildId)!.push(event);
+      } else {
+        eventsWithoutBuildId.push(event);
+      }
+    }
+
+    // Step 2: Create jobs from events grouped by build ID
+    const jobs: DraftJob[] = [];
+    for (const [buildId, events] of jobsByBuildId) {
+      const job = this.createJobFromEvents(events, buildId);
+      if (job != null) {
+        jobs.push(job);
+      }
+    }
+
+    // Step 3: Match remaining events to existing jobs or create new jobs
+    const remainingEvents = [...eventsWithoutBuildId];
+
+    // Sort remaining events by timestamp for temporal matching
+    remainingEvents.sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
+
+    // Process StartPreTranslationBuildAsync events that don't have build IDs
+    const unmatchedStartEvents = remainingEvents.filter(e => e.eventType === 'StartPreTranslationBuildAsync');
+
+    for (const startEvent of unmatchedStartEvents) {
       if (startEvent.projectId == null) continue;
 
-      const startTime = new Date(startEvent.timeStamp);
+      // Try to find a matching job for this start event
+      const matchingJob = this.findMatchingJobForStartEvent(startEvent, jobs);
 
-      // Find the next start event for this project to determine the boundary
-      const nextStartEvent = startEvents.slice(i + 1).find(e => e.projectId === startEvent.projectId);
-      const nextStartTime = nextStartEvent ? new Date(nextStartEvent.timeStamp) : null;
+      if (matchingJob != null) {
+        // Update the matching job with this start event
+        matchingJob.startEvent = startEvent;
+        matchingJob.startTime = new Date(startEvent.timeStamp);
+        matchingJob.userId = startEvent.userId;
 
-      // Get all events for this project between this start and the next start (if any)
-      const projectEvents = draftEvents
-        .filter(
-          e =>
-            e.projectId === startEvent.projectId &&
-            new Date(e.timeStamp) >= startTime &&
-            (nextStartTime == null || new Date(e.timeStamp) < nextStartTime)
-        )
-        .sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
+        // Update books information from start event
+        const { trainingBooks, translationBooks } = this.extractBooksFromEvent(startEvent);
+        matchingJob.trainingBooks = trainingBooks;
+        matchingJob.translationBooks = translationBooks;
 
-      // Find specific event types within this job's timeframe
-      const buildEvent = projectEvents.find(e => e.eventType === 'BuildProjectAsync');
-      const finishEvent = projectEvents.find(e => e.eventType === 'RetrievePreTranslationStatusAsync');
-      const cancelEvent = projectEvents.find(e => e.eventType === 'CancelPreTranslationBuildAsync');
-
-      // Determine job status and timing
-      let status: 'running' | 'success' | 'failed' | 'cancelled' | 'broken';
-      let finishTime: Date | undefined;
-      let duration: number | undefined;
-      let errorMessage: string | undefined;
-
-      // Extract training and translation books from the start event
-      const { trainingBooks, translationBooks } = this.extractBooksFromEvent(startEvent);
-
-      // Extract build ID from the build event result (if build event exists)
-      const buildId = buildEvent?.result != null ? String(buildEvent.result) : undefined;
-
-      if (startEvent.exception != null) {
-        // Job failed at start
-        status = 'failed';
-        errorMessage = startEvent.exception;
-        finishTime = startTime;
-        duration = 0;
-      } else if (cancelEvent != null) {
-        // Job was cancelled
-        status = 'cancelled';
-        finishTime = new Date(cancelEvent.timeStamp);
-        duration = finishTime.getTime() - startTime.getTime();
-      } else if (buildEvent != null && buildEvent.exception != null) {
-        // Job failed during build
-        status = 'failed';
-        errorMessage = buildEvent.exception;
-        finishTime = new Date(buildEvent.timeStamp);
-        duration = finishTime.getTime() - startTime.getTime();
-      } else if (finishEvent != null) {
-        // Job completed (successfully or with error)
-        finishTime = new Date(finishEvent.timeStamp);
-        duration = finishTime.getTime() - startTime.getTime();
-
-        if (finishEvent.exception != null) {
-          status = 'failed';
-          errorMessage = finishEvent.exception;
-        } else {
-          status = 'success';
+        // Remove this event from remaining events
+        const index = remainingEvents.indexOf(startEvent);
+        if (index > -1) {
+          remainingEvents.splice(index, 1);
         }
-      } else if (nextStartEvent != null) {
-        // Another job started before this one was marked as finished - mark as broken
-        status = 'broken';
-        finishTime = new Date(nextStartEvent.timeStamp);
-        duration = finishTime.getTime() - startTime.getTime();
-        errorMessage = 'Job was interrupted by another start event without proper completion';
       } else {
-        // Job is still running
-        status = 'running';
+        // Create a new job for this start event
+        const newJob = this.createJobFromStartEvent(startEvent);
+        if (newJob != null) {
+          jobs.push(newJob);
+          // Remove this event from remaining events
+          const index = remainingEvents.indexOf(startEvent);
+          if (index > -1) {
+            remainingEvents.splice(index, 1);
+          }
+        }
+      }
+    }
+
+    // Step 4: Try to match remaining events to existing jobs
+    const unprocessedEvents: EventMetric[] = [];
+
+    for (const event of remainingEvents) {
+      const eventBuildId = this.extractBuildIdFromEvent(event);
+      let eventWasProcessed = false;
+
+      // If this event has a build ID but wasn't grouped earlier, it might be from a different job
+      if (eventBuildId != null) {
+        // Check if we already have a job with this build ID
+        const existingJobWithBuildId = jobs.find(job => job.buildId === eventBuildId);
+        if (existingJobWithBuildId != null) {
+          this.addEventToJob(existingJobWithBuildId, event);
+          eventWasProcessed = true;
+        } else {
+          // Create a new job for this orphaned event with build ID
+          const newJob = this.createJobFromOrphanedEvent(event, eventBuildId);
+          if (newJob != null) {
+            jobs.push(newJob);
+            eventWasProcessed = true;
+          }
+        }
+      } else {
+        // Event has no build ID, try temporal matching
+        const matchingJob = this.findMatchingJobForEvent(event, jobs);
+        if (matchingJob != null) {
+          this.addEventToJob(matchingJob, event);
+          eventWasProcessed = true;
+        }
       }
 
-      jobs.push({
-        projectId: startEvent.projectId,
-        startTime,
-        finishTime,
-        duration,
-        status,
-        userId: startEvent.userId,
-        startEvent,
-        buildEvent,
-        finishEvent,
-        cancelEvent,
-        errorMessage,
-        trainingBooks,
-        translationBooks,
-        buildId
-      });
+      if (!eventWasProcessed) {
+        unprocessedEvents.push(event);
+      }
+    }
+
+    // Log any events that couldn't be processed
+    if (unprocessedEvents.length > 0) {
+      console.warn(`${unprocessedEvents.length} events could not be processed:`);
+      for (const event of unprocessedEvents) {
+        console.warn(
+          `- ${event.eventType} (project: ${event.projectId}, time: ${event.timeStamp}, buildId: ${this.extractBuildIdFromEvent(event) || 'none'})`
+        );
+      }
+    }
+
+    // Step 5: Finalize job statuses and mark incomplete jobs as broken
+    for (const job of jobs) {
+      this.finalizeJobStatus(job);
     }
 
     // Sort by start time (most recent first)
-    this.draftJobs = jobs.sort((a, b) => b.startTime.getTime() - a.startTime.getTime());
+    this.draftJobs = jobs.sort((a, b) => {
+      const aTime = a.startTime?.getTime() ?? 0;
+      const bTime = b.startTime?.getTime() ?? 0;
+      return bTime - aTime;
+    });
 
     // Generate rows with fallback project names (just IDs for now)
     this.generateRows();
+  }
+
+  private extractBuildIdFromEvent(event: EventMetric): string | null {
+    // First try the result field (common for many event types)
+    if (event.result != null) {
+      return String(event.result);
+    }
+
+    // Then try the payload buildId field (alternative location)
+    if (event.payload?.buildId != null) {
+      return String(event.payload.buildId);
+    }
+
+    return null;
+  }
+
+  private createJobFromEvents(events: EventMetric[], buildId: string): DraftJob | null {
+    if (events.length === 0) return null;
+
+    // Sort events by timestamp
+    events.sort((a, b) => new Date(a.timeStamp).getTime() - new Date(b.timeStamp).getTime());
+
+    const startEvent = events.find(e => e.eventType === 'StartPreTranslationBuildAsync');
+    const buildEvent = events.find(e => e.eventType === 'BuildProjectAsync');
+    const cancelEvent = events.find(e => e.eventType === 'CancelPreTranslationBuildAsync');
+
+    // For finish events, take the latest one (they can occur multiple times)
+    const finishEvents = events.filter(e => e.eventType === 'RetrievePreTranslationStatusAsync');
+    const finishEvent = finishEvents.length > 0 ? finishEvents[finishEvents.length - 1] : undefined;
+
+    // Determine project ID (prefer from start event, fallback to any event)
+    const projectId = startEvent?.projectId ?? events.find(e => e.projectId != null)?.projectId;
+    if (projectId == null) return null;
+
+    // Determine start time and user
+    const startTime = startEvent ? new Date(startEvent.timeStamp) : new Date(events[0].timeStamp);
+    const userId = startEvent?.userId;
+
+    // Extract books from start event if available
+    const booksInfo = startEvent ? this.extractBooksFromEvent(startEvent) : { trainingBooks: [], translationBooks: [] };
+    const { trainingBooks, translationBooks } = booksInfo;
+
+    return {
+      projectId,
+      startTime,
+      events: [],
+      userId,
+      startEvent: startEvent,
+      buildEvent,
+      finishEvent,
+      cancelEvent,
+      trainingBooks,
+      translationBooks,
+      buildId,
+      status: 'running', // Will be finalized later
+      errorMessage: undefined,
+      finishTime: null,
+      duration: null
+    };
+  }
+
+  private findMatchingJobForStartEvent(startEvent: EventMetric, jobs: DraftJob[]): DraftJob | null {
+    if (startEvent.projectId == null) return null;
+
+    const startTime = new Date(startEvent.timeStamp);
+
+    // Look for jobs in the same project that don't have a start event yet
+    const candidateJobs = jobs.filter(job => job.projectId === startEvent.projectId && job.startEvent == null);
+
+    if (candidateJobs.length === 0) return null;
+
+    // Find the job with build event closest after this start event
+    let bestMatch: DraftJob | null = null;
+    let bestTimeDiff = Infinity;
+
+    for (const job of candidateJobs) {
+      if (job.buildEvent != null) {
+        const buildTime = new Date(job.buildEvent.timeStamp);
+        const timeDiff = buildTime.getTime() - startTime.getTime();
+
+        // Build event should be after start event
+        if (timeDiff > 0 && timeDiff < bestTimeDiff) {
+          bestMatch = job;
+          bestTimeDiff = timeDiff;
+        }
+      }
+    }
+
+    return bestMatch;
+  }
+
+  private createJobFromStartEvent(startEvent: EventMetric): DraftJob | null {
+    if (startEvent.projectId == null) return null;
+
+    const { trainingBooks, translationBooks } = this.extractBooksFromEvent(startEvent);
+
+    return {
+      projectId: startEvent.projectId,
+      startTime: new Date(startEvent.timeStamp),
+      events: [],
+      userId: startEvent.userId,
+      startEvent,
+      buildEvent: undefined,
+      finishEvent: undefined,
+      cancelEvent: undefined,
+      trainingBooks,
+      translationBooks,
+      buildId: null,
+      status: 'running', // Will be finalized later
+      errorMessage: undefined,
+      finishTime: null,
+      duration: null
+    };
+  }
+
+  private createJobFromOrphanedEvent(event: EventMetric, buildId: string | null): DraftJob | null {
+    if (event.projectId == null) return null;
+
+    // Create a minimal job from this orphaned event
+    const job: DraftJob = {
+      projectId: event.projectId,
+      startTime: new Date(event.timeStamp), // Use event time as fallback start time
+      events: [],
+      userId: event.userId,
+      startEvent: undefined,
+      buildEvent: undefined,
+      finishEvent: undefined,
+      cancelEvent: undefined,
+      trainingBooks: [],
+      translationBooks: [],
+      buildId: buildId ?? null,
+      status: 'running', // Will be finalized later
+      errorMessage: undefined,
+      finishTime: null,
+      duration: null
+    };
+
+    // Add the event to the appropriate slot
+    this.addEventToJob(job, event);
+
+    return job;
+  }
+
+  private findMatchingJobForEvent(event: EventMetric, jobs: DraftJob[]): DraftJob | null {
+    if (event.projectId == null) return null;
+
+    const eventTime = new Date(event.timeStamp);
+    const eventBuildId = this.extractBuildIdFromEvent(event);
+
+    // Find jobs in the same project
+    const projectJobs = jobs.filter(job => job.projectId === event.projectId);
+
+    if (event.eventType === 'BuildProjectAsync') {
+      // Find job with start event that most closely precedes this build event
+      const candidateJobs = projectJobs.filter(
+        job =>
+          job.buildEvent == null &&
+          job.startEvent != null &&
+          new Date(job.startEvent.timeStamp) <= eventTime &&
+          // Only match if build IDs are compatible (job has no build ID or they match)
+          (job.buildId == null || eventBuildId == null || job.buildId === eventBuildId)
+      );
+
+      if (candidateJobs.length === 0) return null;
+
+      return candidateJobs.reduce((closest, job) => {
+        const currentDiff = eventTime.getTime() - new Date(job.startEvent!.timeStamp).getTime();
+        const closestDiff = eventTime.getTime() - new Date(closest.startEvent!.timeStamp).getTime();
+        return currentDiff < closestDiff ? job : closest;
+      });
+    }
+
+    if (
+      event.eventType === 'RetrievePreTranslationStatusAsync' ||
+      event.eventType === 'CancelPreTranslationBuildAsync'
+    ) {
+      // Find job with build event that precedes this event
+      const candidateJobs = projectJobs.filter(
+        job =>
+          job.buildEvent != null &&
+          new Date(job.buildEvent.timeStamp) <= eventTime &&
+          // Only match if build IDs are compatible
+          (job.buildId == null || eventBuildId == null || job.buildId === eventBuildId)
+      );
+
+      if (candidateJobs.length === 0) return null;
+
+      return candidateJobs.reduce((closest, job) => {
+        const currentDiff = eventTime.getTime() - new Date(job.buildEvent!.timeStamp).getTime();
+        const closestDiff = eventTime.getTime() - new Date(closest.buildEvent!.timeStamp).getTime();
+        return currentDiff < closestDiff ? job : closest;
+      });
+    }
+
+    return null;
+  }
+
+  private addEventToJob(job: DraftJob, event: EventMetric): void {
+    // Check for build ID conflicts
+    const eventBuildId = this.extractBuildIdFromEvent(event);
+    if (eventBuildId != null && job.buildId != null && eventBuildId !== job.buildId) {
+      // This event has a different build ID than the job - don't add it
+      console.warn(
+        `BUILD ID CONFLICT: Event ${event.eventType} with build ID ${eventBuildId} cannot be added to job with build ID ${job.buildId}. Project: ${event.projectId}, Event time: ${event.timeStamp}`
+      );
+      return;
+    }
+
+    if (event.eventType === 'BuildProjectAsync' && job.buildEvent == null) {
+      job.buildEvent = event;
+      // Update build ID if we get it from the build event
+      if (event.result != null) {
+        job.buildId = String(event.result);
+      }
+    } else if (event.eventType === 'RetrievePreTranslationStatusAsync') {
+      // For finish events, take the latest one (but only if build ID matches or is null)
+      if (job.finishEvent == null || new Date(event.timeStamp) > new Date(job.finishEvent.timeStamp)) {
+        job.finishEvent = event;
+      }
+    } else if (event.eventType === 'CancelPreTranslationBuildAsync' && job.cancelEvent == null) {
+      job.cancelEvent = event;
+    }
+  }
+
+  private finalizeJobStatus(job: DraftJob): void {
+    let status: 'running' | 'success' | 'failed' | 'cancelled' | 'incomplete';
+    let finishTime: Date | null = null;
+    let duration: number | null = null;
+    let errorMessage: string | undefined;
+
+    // Check for early failures or cancellations
+    if (job.startEvent?.exception != null) {
+      status = 'failed';
+      errorMessage = job.startEvent.exception;
+      finishTime = job.startTime;
+      duration = 0;
+    } else if (job.cancelEvent != null) {
+      status = 'cancelled';
+      finishTime = new Date(job.cancelEvent.timeStamp);
+      duration = job.startTime ? finishTime.getTime() - job.startTime.getTime() : null;
+    } else if (job.buildEvent?.exception != null) {
+      status = 'failed';
+      errorMessage = job.buildEvent.exception;
+      finishTime = new Date(job.buildEvent.timeStamp);
+      duration = job.startTime ? finishTime.getTime() - job.startTime.getTime() : null;
+    } else if (job.finishEvent != null) {
+      finishTime = new Date(job.finishEvent.timeStamp);
+      duration = job.startTime ? finishTime.getTime() - job.startTime.getTime() : null;
+
+      if (job.finishEvent.exception != null) {
+        status = 'failed';
+        errorMessage = job.finishEvent.exception;
+      } else {
+        status = 'success';
+      }
+    } else {
+      // Job doesn't have a clear completion - check if it's incomplete or still running
+      if (job.startEvent == null || job.buildEvent == null) {
+        status = 'incomplete';
+        errorMessage = 'Job has incomplete event correlation';
+      } else {
+        status = 'running';
+      }
+    }
+
+    job.status = status;
+    job.finishTime = finishTime;
+    job.duration = duration;
+    job.errorMessage = errorMessage;
   }
 
   private generateRows(): void {
@@ -326,12 +631,6 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
         ? `https://app.sil.hosted.allegro.ai/projects?gq=${job.buildId}&tab=tasks`
         : undefined;
 
-      const { displayText: trainingBooksDisplay, tooltipText: trainingBooksTooltip } = this.formatBooksWithTooltip(
-        job.trainingBooks
-      );
-      const { displayText: translationBooksDisplay, tooltipText: translationBooksTooltip } =
-        this.formatBooksWithTooltip(job.translationBooks);
-
       const duration = job.duration ? this.formatDuration(job.duration) : undefined;
       const durationTooltip = job.finishTime
         ? `Finished: ${this.i18n.formatDate(job.finishTime, { showTimeZone: true })}`
@@ -342,15 +641,13 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
         projectId: job.projectId,
         projectName: projectDeleted ? `${job.projectId} [deleted]` : (projectName ?? job.projectId),
         projectDeleted,
-        startTimeStamp: this.i18n.formatDate(job.startTime, { showTimeZone: true }),
+        startTimeStamp: job.startTime ? this.i18n.formatDate(job.startTime, { showTimeZone: true }) : 'N/A',
         duration,
         durationTooltip,
         status: this.getStatusDisplay(job.status),
         userId: job.userId,
-        trainingBooks: trainingBooksDisplay,
-        translationBooks: translationBooksDisplay,
-        trainingBooksTooltip,
-        translationBooksTooltip,
+        trainingBooks: job.trainingBooks || [],
+        translationBooks: job.translationBooks || [],
         clearmlUrl
       });
     }
@@ -379,16 +676,33 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     // Get unique project IDs from draft jobs
     const projectIds = new Set(this.draftJobs.map(job => job.projectId));
 
-    // Clear existing cache
+    // Also collect project IDs from training and translation book ranges
+    for (const job of this.draftJobs) {
+      if (job.trainingBooks) {
+        for (const projectBook of job.trainingBooks) {
+          projectIds.add(projectBook.projectId);
+        }
+      }
+      if (job.translationBooks) {
+        for (const projectBook of job.translationBooks) {
+          projectIds.add(projectBook.projectId);
+        }
+      }
+    }
+
+    // Clear existing caches
     this.projectNames.clear();
+    this.projectShortNames.clear();
 
     // Fetch project data for each unique project ID
     for (const projectId of projectIds) {
       const projectDoc = await this.servalAdministrationService.get(projectId);
       if (projectDoc?.data != null) {
         this.projectNames.set(projectId, projectLabel(projectDoc.data));
+        this.projectShortNames.set(projectId, projectDoc.data.shortName || null);
       } else {
         this.projectNames.set(projectId, null);
+        this.projectShortNames.set(projectId, null);
       }
     }
 
@@ -396,9 +710,12 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     this.generateRows();
   }
 
-  private extractBooksFromEvent(event: EventMetric): { trainingBooks: string[]; translationBooks: string[] } {
-    const trainingBooks: string[] = [];
-    const translationBooks: string[] = [];
+  private extractBooksFromEvent(event: EventMetric): {
+    trainingBooks: ProjectBooks[];
+    translationBooks: ProjectBooks[];
+  } {
+    const trainingProjects = new Map<string, string[]>();
+    const translationProjects = new Map<string, string[]>();
 
     try {
       if (event.payload != null) {
@@ -408,9 +725,16 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
           if (Array.isArray(buildConfig.TrainingScriptureRanges)) {
             for (const range of buildConfig.TrainingScriptureRanges) {
               if (range.ScriptureRange != null) {
-                // Split semicolon-separated books and add them to the array
-                const books = range.ScriptureRange.split(';').filter((book: string) => book.trim().length > 0);
-                trainingBooks.push(...books);
+                // Use the project ID from the range if available, otherwise use the event's project ID
+                const projectId = range.ProjectId || event.projectId;
+                if (projectId) {
+                  // Split semicolon-separated books and add them to the project's books
+                  const books = range.ScriptureRange.split(';').filter((book: string) => book.trim().length > 0);
+                  if (!trainingProjects.has(projectId)) {
+                    trainingProjects.set(projectId, []);
+                  }
+                  trainingProjects.get(projectId)!.push(...books);
+                }
               }
             }
           }
@@ -419,9 +743,16 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
           if (Array.isArray(buildConfig.TranslationScriptureRanges)) {
             for (const range of buildConfig.TranslationScriptureRanges) {
               if (range.ScriptureRange != null) {
-                // Split semicolon-separated books and add them to the array
-                const books = range.ScriptureRange.split(';').filter((book: string) => book.trim().length > 0);
-                translationBooks.push(...books);
+                // Use the project ID from the range if available, otherwise use the event's project ID
+                const projectId = range.ProjectId || event.projectId;
+                if (projectId) {
+                  // Split semicolon-separated books and add them to the project's books
+                  const books = range.ScriptureRange.split(';').filter((book: string) => book.trim().length > 0);
+                  if (!translationProjects.has(projectId)) {
+                    translationProjects.set(projectId, []);
+                  }
+                  translationProjects.get(projectId)!.push(...books);
+                }
               }
             }
           }
@@ -431,21 +762,21 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
       // If there's an error parsing the data, return empty arrays
     }
 
+    // Convert maps to ProjectBooks arrays
+    const trainingBooks: ProjectBooks[] = Array.from(trainingProjects.entries()).map(([projectId, books]) => ({
+      projectId,
+      books
+    }));
+
+    const translationBooks: ProjectBooks[] = Array.from(translationProjects.entries()).map(([projectId, books]) => ({
+      projectId,
+      books
+    }));
+
     return { trainingBooks, translationBooks };
   }
 
-  private formatBooksWithTooltip(books: string[]): { displayText: string; tooltipText?: string } {
-    if (books.length === 0) {
-      return { displayText: 'None' };
-    }
-
-    if (books.length <= 3) {
-      const displayText = books.join(', ');
-      return { displayText };
-    } else {
-      const displayText = books.slice(0, 3).join(', ') + '…';
-      const tooltipText = books.join(', ');
-      return { displayText, tooltipText };
-    }
+  getProjectShortName(projectId: string): string {
+    return this.projectShortNames.get(projectId) || this.projectNames.get(projectId) || projectId;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
@@ -4,10 +4,14 @@
 
   <mat-tab-group [selectedIndex]="selectedTabIndex" (selectedIndexChange)="onTabChange($event)">
     <mat-tab label="Projects">
-      <app-serval-projects></app-serval-projects>
+      <ng-template matTabContent>
+        <app-serval-projects></app-serval-projects>
+      </ng-template>
     </mat-tab>
     <mat-tab label="Draft Jobs">
-      <app-draft-jobs></app-draft-jobs>
+      <ng-template matTabContent>
+        <app-draft-jobs></app-draft-jobs>
+      </ng-template>
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
@@ -40,7 +40,7 @@ export class ServalAdministrationComponent implements OnInit {
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { tab: this.availableTabs[index] },
-      queryParamsHandling: ''
+      queryParamsHandling: 'preserve'
     });
   }
 }


### PR DESCRIPTION
There is a linked issue, but most of the changes do not actually pertain to it.

Main changes:
- Clicking on the "Draft jobs" button on the Serval projects page now properly opens the jobs list filtered to just that project (That's what the linked issue is about).
- The jobs list isn't loaded until the tab is active, which means it doesn't load if the user is just looking at the projects tab
- We only fetch relevant events in the Drafting category (my testing shows about a 90% reduction in the number of events that end up loaded)
- Logic for correlating events is greatly improved. I used data from live in local testing to make sure it was working correctly.
- Projects used for training/translating data are now listed, along with which books are used

Given the current component on live is so thoroughly broken, the risk of unknown bugs in this change is fall smaller than the known bugs already on live, so the standard for testing this is extremely low. The main reason the first implementation of correlating events was unreliable was because reasonable assumptions about the events were incorrect in the real world. Testing with real data makes me much more confident in this version, though I'm fairly certain it's not bulletproof either.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3394)
<!-- Reviewable:end -->
