### PR TITLE
SF-3511 Show training files used on draft builds

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
@@ -23,5 +23,6 @@ export interface ServalBuildAdditionalInfo {
   trainingScriptureRanges: ProjectScriptureRange[];
   translationEngineId: string;
   translationScriptureRanges: ProjectScriptureRange[];
+  trainingDataFileIds: string[];
   requestedByUserId?: string;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -92,6 +92,15 @@
               <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
               <tr mat-row *matRowDef="let row; columns: columnsToDisplay"></tr>
             </table>
+            @if (trainingDataFiles.length > 0) {
+              <p>
+                <span>{{ t("training_data_files_used") }}</span>
+                <br />
+                <span
+                  ><small>{{ trainingFilesString(trainingDataFiles) }}</small></span
+                >
+              </p>
+            }
             @if (buildRequestedAtDate != null && buildRequestedByUserName != null) {
               <p>
                 {{

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -3,25 +3,32 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
 import { createTestUserProfile } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
-import { anything, mock, when } from 'ts-mockito';
+import { of } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
+import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { TestRealtimeModule } from 'xforge-common/test-realtime.module';
 import { configureTestingModule, TestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../../../core/models/sf-type-registry';
+import { TrainingDataDoc } from '../../../../core/models/training-data-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { BuildDto } from '../../../../machine-api/build-dto';
 import { BuildStates } from '../../../../machine-api/build-states';
 import { DraftGenerationService } from '../../draft-generation.service';
+import { TrainingDataService } from '../../training-data/training-data.service';
 import { DraftHistoryEntryComponent } from './draft-history-entry.component';
 
 const mockedDraftGenerationService = mock(DraftGenerationService);
 const mockedI18nService = mock(I18nService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
+const mockedTrainingDataService = mock(TrainingDataService);
+const mockedActivatedProjectService = mock(ActivatedProjectService);
 const mockedFeatureFlagsService = mock(FeatureFlagService);
 
 describe('DraftHistoryEntryComponent', () => {
@@ -40,12 +47,22 @@ describe('DraftHistoryEntryComponent', () => {
       { provide: I18nService, useMock: mockedI18nService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
       { provide: UserService, useMock: mockedUserService },
+      { provide: TrainingDataService, useMock: mockedTrainingDataService },
+      { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
       { provide: FeatureFlagService, useMock: mockedFeatureFlagsService }
     ]
   }));
 
   beforeEach(() => {
     when(mockedFeatureFlagsService.usfmFormat).thenReturn(createTestFeatureFlag(true));
+    when(mockedActivatedProjectService.projectId).thenReturn('project01');
+    const trainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery<TrainingDataDoc>);
+    when(trainingDataQuery.docs).thenReturn([
+      { id: 'doc01', data: { dataId: 'file01', title: 'training-data.txt' } } as TrainingDataDoc
+    ]);
+    when(mockedTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
+      instance(trainingDataQuery)
+    );
     fixture = TestBed.createComponent(DraftHistoryEntryComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -72,7 +89,14 @@ describe('DraftHistoryEntryComponent', () => {
       const date = 'formatted-date';
       const trainingBooks = ['EXO'];
       const translateBooks = ['GEN'];
-      const entry = getStandardBuildDto({ user, date, trainingBooks, translateBooks });
+      const trainingDataFiles: Map<string, string> = new Map([['file01', 'training-data.txt']]);
+      const entry = getStandardBuildDto({
+        user,
+        date,
+        trainingBooks,
+        translateBooks,
+        trainingDataFiles: Array.from(trainingDataFiles.keys())
+      });
 
       // SUT
       component.entry = entry;
@@ -97,6 +121,7 @@ describe('DraftHistoryEntryComponent', () => {
           target: 'tar'
         }
       ]);
+      expect(component.trainingDataFiles).toEqual(Array.from(trainingDataFiles.values()));
       expect(component.trainingConfigurationOpen).toBe(false);
     }));
 
@@ -105,7 +130,8 @@ describe('DraftHistoryEntryComponent', () => {
       const date = 'formatted-date';
       const trainingBooks = ['EXO'];
       const translateBooks = ['GEN'];
-      const entry = getStandardBuildDto({ user, date, trainingBooks, translateBooks });
+      const trainingDataFiles = ['file01'];
+      const entry = getStandardBuildDto({ user, date, trainingBooks, translateBooks, trainingDataFiles });
 
       // SUT
       component.entry = entry;
@@ -173,6 +199,12 @@ describe('DraftHistoryEntryComponent', () => {
       when(mockedI18nService.formatAndLocalizeScriptureRange('EXO')).thenReturn('Exodus');
       const userDoc = { id: 'sf-user-id', data: undefined } as UserProfileDoc;
       when(mockedUserService.getProfile(anything())).thenResolve(userDoc);
+      const targetProjectDoc = {
+        id: 'project01',
+        data: createTestProjectProfile({ shortName: 'tar', writingSystem: { tag: 'en' } })
+      } as SFProjectProfileDoc;
+      when(mockedSFProjectService.getProfile('project01')).thenResolve(targetProjectDoc);
+      when(mockedActivatedProjectService.changes$).thenReturn(of(targetProjectDoc));
       const entry = {
         additionalInfo: {
           dateGenerated: new Date().toISOString(),
@@ -288,12 +320,14 @@ describe('DraftHistoryEntryComponent', () => {
     user,
     date,
     trainingBooks,
-    translateBooks
+    translateBooks,
+    trainingDataFiles
   }: {
     user: string;
     date: string;
     trainingBooks: string[];
     translateBooks: string[];
+    trainingDataFiles: string[];
   }): BuildDto {
     when(mockedI18nService.formatDate(anything())).thenReturn(date);
     when(mockedI18nService.formatAndLocalizeScriptureRange('GEN')).thenReturn('Genesis');
@@ -308,6 +342,7 @@ describe('DraftHistoryEntryComponent', () => {
       data: createTestProjectProfile({ shortName: 'tar', writingSystem: { tag: 'en' } })
     } as SFProjectProfileDoc;
     when(mockedSFProjectService.getProfile('project01')).thenResolve(targetProjectDoc);
+    when(mockedActivatedProjectService.changes$).thenReturn(of(targetProjectDoc));
     const sourceProjectDoc = {
       id: 'project02',
       data: createTestProjectProfile({ shortName: 'src', writingSystem: { tag: 'fr' } })
@@ -322,7 +357,8 @@ describe('DraftHistoryEntryComponent', () => {
         dateRequested: new Date().toISOString(),
         requestedByUserId: 'sf-user-id',
         trainingScriptureRanges: [{ projectId: 'project02', scriptureRange: trainingBooks.join(';') }],
-        translationScriptureRanges: [{ projectId: 'project02', scriptureRange: translateBooks.join(';') }]
+        translationScriptureRanges: [{ projectId: 'project02', scriptureRange: translateBooks.join(';') }],
+        trainingDataFileIds: trainingDataFiles
       }
     } as BuildDto;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -288,6 +288,7 @@
     "requested_by": "Requested by {{ requestedByUserName }} at {{ requestedAtTime }}.",
     "show_model_training_configuration": "Show model training configuration",
     "training_books": "Training books",
+    "training_data_files_used": "Data files were used to train the model.",
     "training_model_description": "The language model was trained on this configuration:"
   },
   "draft_history_list": {

--- a/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
@@ -14,6 +14,7 @@ public class ServalBuildAdditionalInfo
     public string? RequestedByUserId { get; set; }
     public int Step { get; init; }
     public HashSet<ProjectScriptureRange> TrainingScriptureRanges { get; init; } = [];
+    public HashSet<string> TrainingDataFileIds { get; init; } = [];
     public string TranslationEngineId { get; init; } = string.Empty;
     public HashSet<ProjectScriptureRange> TranslationScriptureRanges { get; init; } = [];
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1970,6 +1970,14 @@ public class MachineApiService(
                 new ProjectScriptureRange { ScriptureRange = draftConfig.LastSelectedTranslationScriptureRange }
             );
         }
+
+        // Add training data files
+        buildDto.AdditionalInfo.TrainingDataFileIds.Clear();
+        foreach (string trainingFileDataId in draftConfig.LastSelectedTrainingDataFiles)
+        {
+            buildDto.AdditionalInfo.TrainingDataFileIds.Add(trainingFileDataId);
+        }
+
         return buildDto;
     }
 
@@ -2018,6 +2026,13 @@ public class MachineApiService(
             buildDto.AdditionalInfo.TranslationScriptureRanges.Add(
                 new ProjectScriptureRange { ScriptureRange = buildConfig.TranslationScriptureRange }
             );
+        }
+
+        // Add training data files
+        buildDto.AdditionalInfo.TrainingDataFileIds.Clear();
+        foreach (string trainingFileDataId in buildConfig.TrainingDataFiles)
+        {
+            buildDto.AdditionalInfo.TrainingDataFileIds.Add(trainingFileDataId);
         }
 
         return buildDto;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -47,6 +47,7 @@ public class MachineApiServiceTests
     private const string Build01 = "build01";
     private const string ParallelCorpusId01 = "parallelCorpusId01";
     private const string TranslationEngine01 = "translationEngine01";
+    private const string TrainingDataId01 = "trainingDataId01";
     private const string User01 = "user01";
     private const string User02 = "user02";
     private const string Paratext01 = "paratext01";
@@ -735,6 +736,7 @@ public class MachineApiServiceTests
         Assert.IsNotNull(actual.AdditionalInfo.ParallelCorporaIds);
         Assert.AreEqual(parallelCorpusId1, actual.AdditionalInfo.ParallelCorporaIds!.ElementAt(0));
         Assert.AreEqual(parallelCorpusId2, actual.AdditionalInfo.ParallelCorporaIds.ElementAt(1));
+        Assert.AreEqual(TrainingDataId01, actual.AdditionalInfo.TrainingDataFileIds.Single());
     }
 
     [Test]
@@ -996,6 +998,7 @@ public class MachineApiServiceTests
                                                             ScriptureRange = translationScriptureRange,
                                                         },
                                                     ],
+                                                    TrainingDataFiles = [TrainingDataId01],
                                                 }
                                             )
                                         )
@@ -1031,6 +1034,15 @@ public class MachineApiServiceTests
         Assert.AreEqual(1, builds.Count);
         TestEnvironment.AssertCoreBuildProperties(translationBuild, builds[0]);
         Assert.NotNull(builds[0].AdditionalInfo);
+        Assert.AreEqual(
+            translationScriptureRange,
+            builds[0].AdditionalInfo.TranslationScriptureRanges.Single().ScriptureRange
+        );
+        Assert.AreEqual(
+            trainingScriptureRange,
+            builds[0].AdditionalInfo.TrainingScriptureRanges.Single().ScriptureRange
+        );
+        Assert.AreEqual(TrainingDataId01, builds[0].AdditionalInfo.TrainingDataFileIds.Single());
     }
 
     [Test]
@@ -4219,6 +4231,7 @@ public class MachineApiServiceTests
                                 LastSelectedTranslationScriptureRange = "GEN",
                                 LastSelectedTrainingScriptureRange = "EXO",
                                 UsfmConfig = new DraftUsfmConfig { ParagraphFormat = ParagraphBreakFormat.MoveToEnd },
+                                LastSelectedTrainingDataFiles = [TrainingDataId01],
                             },
                         },
                         ParatextId = Paratext01,


### PR DESCRIPTION
This PR adds a label to show the training data files used to training a model. If no training data files were used, nothing is shown.

<img width="1235" height="627" alt="Data files training model" src="https://github.com/user-attachments/assets/27f6bcc3-d2ba-46f4-95fd-d9fad3ec0893" />
