### PR TITLE
SF-2680b Send email notification on build failure

### DIFF
--- a/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineProjectService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +19,14 @@ public interface IMachineProjectService
     );
     Task<string> GetProjectZipAsync(string sfProjectId, Stream outputStream, CancellationToken cancellationToken);
     Task RemoveProjectAsync(string sfProjectId, bool preTranslate, CancellationToken cancellationToken);
+
+    Task SendBuildCompletedEmailAsync(
+        string curUserId,
+        string sfProjectId,
+        string? buildId,
+        string buildState,
+        Uri websiteUrl
+    );
 
     [Mutex]
     Task UpdateTranslationSourcesAsync(string curUserId, string sfProjectId);


### PR DESCRIPTION
This PR fixes an issue noticed in testing of SF-2680 on QA where the email wasn't sent when the build failed in the Scripture Forge side of things. This PR addresses this issue. It will need to be tested on QA.