### PR TITLE
SF-3506 Allow e2e tests to be run for PRs with the e2e label

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,8 @@ on:
     # Run an hour before release-qa.yml
     # For now this is just to determine how reliable this workflow is.
     - cron: "30 0 * * 0-1,3-6"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   prepare-realtimeserver-backend:
@@ -18,6 +20,10 @@ jobs:
         dotnet_version: ["8.0.x"]
         node_version: ["22.13.0"]
         npm_version: ["10.9.2"]
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'e2e')
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
@@ -222,6 +228,7 @@ jobs:
 
   prepare-e2e:
     name: "Prepare E2E"
+    needs: [prepare-realtimeserver-backend]
     strategy:
       matrix:
         os: ["ubuntu-22.04"]


### PR DESCRIPTION
This PR allows PRs with the e2e label to run the e2e tests. This also includes adding the e2e label after the fact.

Note: Every PR will have the 5 skipped checks listed in the review section at the bottom, after this PR is merged.

To test: Add the e2e label to this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3400)
<!-- Reviewable:end -->
