### PR TITLE
SF-3531 Allow CSV files containing unmatching quotes

### DIFF
--- a/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
@@ -32,6 +32,7 @@ public class TrainingDataService(
     public const string DirectoryName = "training-data";
     private static readonly CsvConfiguration _csvConfiguration = new CsvConfiguration(CultureInfo.InvariantCulture)
     {
+        BadDataFound = null,
         DetectColumnCountChanges = true,
         DetectDelimiter = true,
         HasHeaderRecord = false,


### PR DESCRIPTION
This PR allows CSV and TSV files that contain unmatched quote marks to be correctly processed as training data for Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3404)
<!-- Reviewable:end -->
