### PR TITLE
SF-3529 Add format USFM to draft tab

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -42,6 +42,10 @@
         </mat-form-field>
       }
       <div class="apply-draft-button-container">
+        <button mat-button (click)="navigateToFormatting()">
+          <mat-icon>build</mat-icon>
+          <transloco key="editor_draft_tab.format_draft"></transloco>
+        </button>
         @if (userAppliedDraft) {
           <span class="draft-indicator">
             <mat-icon class="check-icon">check</mat-icon>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
@@ -31,6 +31,7 @@ app-notice {
   flex-grow: 1;
   display: flex;
   justify-content: flex-end;
+  column-gap: 4px;
 }
 
 .draft-indicator {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Component, DestroyRef, EventEmitter, Input, OnChanges, ViewChild } from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
+import { Router } from '@angular/router';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DeltaOperation } from 'rich-text';
@@ -92,7 +93,8 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     private readonly projectService: SFProjectService,
     readonly onlineStatusService: OnlineStatusService,
     private readonly noticeService: NoticeService,
-    private errorReportingService: ErrorReportingService
+    private errorReportingService: ErrorReportingService,
+    private readonly router: Router
   ) {}
 
   ngOnChanges(): void {
@@ -235,6 +237,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       return false;
     }
     return this.draftHandlingService.canApplyDraft(this.targetProject, this.bookNum, this.chapter, this.draftDelta.ops);
+  }
+
+  navigateToFormatting(): void {
+    this.router.navigateByUrl(`/projects/${this.projectId}/draft-generation/format`);
   }
 
   async applyDraft(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -402,6 +402,7 @@
     "draft_indicator_applied": "Added",
     "draft_legacy_warning": "We have updated our drafting functionality. You can take advantage of this by [link:generateDraftUrl]generating a new draft[/link].",
     "error_applying_draft": "Failed to add the draft to the project. Try again later.",
+    "format_draft": "Formatting options",
     "no_draft_notice": "{{ bookChapterName }} has no draft.",
     "offline_notice": "Generated drafts are not available offline.",
     "overwrite": "Adding the draft will overwrite the current chapter. Are you sure you want to continue?",


### PR DESCRIPTION
Note that this doesn't take the user to the chapter they're coming from, since the format USFM component doesn't support initializing to a book and chapter. I could theoretically add this, if desired.