### PR TITLE
SF-3495 Store pending ops when Scripture Forge client starts offline

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -133,7 +133,8 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
     // update offline data when the op has been acknowledged
     this.adapter.submitOp(ops, source).then(() => this.updateOfflineData());
     // update offline data when the op is first submitted
-    await this.updateOfflineData();
+    // we force the offline update, so if the client is offline, the pending ops will be stored in IndexedDB
+    await this.updateOfflineData(true);
     await this.realtimeService.onLocalDocUpdate(this);
   }
 


### PR DESCRIPTION
This PR fixes a bug where pending ops were not saved when the Scripture Forge client starts offline.

This bug occurred because the `updateOfflineData` function was only updating the offline data in IndexedDB if a connection was open (or had been opened) in that session to the real time server. By specifying the force parameter as `true`, the document including pending ops will be updated in IndexedDB whether there is an open connection or not. Next time the client goes online, the ops will be submitted to the real time server.

This bug affects all documents, i.e., questions, answers, biblical terms, texts.