### PR TITLE
Use production help URL in development environment

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/environments/environment.ts
@@ -16,7 +16,7 @@ export const environment = {
   scope: 'sf_data',
   siteId: 'sf',
   assets: '/assets/',
-  helps: 'https://github-action-preview--scriptureforgehelp.netlify.app',
+  helps: 'https://help.scriptureforge.org',
   bugsnagApiKey: 'b72a46a8924a3cd161d4c5534287923c',
   realtimePort: 5003,
   realtimeSecurePort: 5005,

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/external-url.service.spec.ts
@@ -7,11 +7,11 @@ function stubbedI18nService(helpUrlPortion: string): any {
 describe('ExternalUrlService', () => {
   it('should provide the help URL for English', () => {
     const service = new ExternalUrlService(stubbedI18nService(''));
-    expect(service.helps).toEqual('https://github-action-preview--scriptureforgehelp.netlify.app');
+    expect(service.helps).toEqual('https://help.scriptureforge.org');
   });
 
   it('should provide the localized help URL', () => {
     const service = new ExternalUrlService(stubbedI18nService('es'));
-    expect(service.helps).toEqual('https://github-action-preview--scriptureforgehelp.netlify.app/es');
+    expect(service.helps).toEqual('https://help.scriptureforge.org/es');
   });
 });


### PR DESCRIPTION
The github-action-preview subdomain is not consistently updated, and expires after something like 30 or 90 days from its most recent deploy. There isn't a compelling reason to link localhost to it, and if for some reason that's helpful for testing, a developer can easily edit the environment file locally to make sure links work. Also, `./scripts/check_external_urls.mts` is our main way of making sure the app and new help site don't have broken links.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3410)
<!-- Reviewable:end -->
