### PR TITLE
Fix screenshot name in localized_screenshots e2e test

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
@@ -242,7 +242,7 @@ export async function localizedScreenshots(
     await screenshotElements(
       page,
       [page.locator('app-draft-sources > .draft-sources-stepper'), page.locator('app-draft-sources > .overview')],
-      { ...context, pageName: 'configure_sources_draft_reference', locale },
+      { ...context, pageName: 'configure_sources_draft_source', locale },
       { margin: 8 }
     );
   });


### PR DESCRIPTION
The mistake in this file became evident when I ran `./update-help-site-screenshots.sh` and the screenshots in the help didn't match their context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3411)
<!-- Reviewable:end -->
