### PR TITLE
SF-3524 Fix bug where notes in headings cannot be reopened after editing

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -2070,8 +2070,9 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private getFeaturedVerseRefInfo(threadDoc: NoteThreadDoc): FeaturedVerseRefInfo | undefined {
     const notes: Note[] = threadDoc.notesInOrderClone(threadDoc.data!.notes);
     let preview: string = notes[0].content != null ? stripHtml(notes[0].content.trim()) : '';
-    if (notes.length > 1) {
-      preview += '\n' + this.i18n.translateStatic('editor.more_notes', { count: notes.length - 1 });
+    const numberOfNotes: number = notes.filter(n => !n.deleted).length;
+    if (numberOfNotes > 1) {
+      preview += '\n' + this.i18n.translateStatic('editor.more_notes', { count: numberOfNotes - 1 });
     }
     const verseRef: VerseRef | undefined = threadDoc.currentVerseRef();
     if (threadDoc.data == null || verseRef == null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1913,7 +1913,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     for (const segment of segments) {
-      const elements = this.target.getSegmentElement(segment)?.querySelectorAll('display-note');
+      // If a note is in the middle of a segment, the editor may have two segments with the same data-segment.
+      // This will not affect the text in the Realtime Server, as ShareDB will combine the segments together again.
+      const elements = this.target.editor?.container.querySelectorAll(
+        `usx-segment[data-segment="${segment}"] display-note`
+      );
       if (elements == null) {
         continue;
       }


### PR DESCRIPTION
This PR fixes a bug where notes cannot be reopened after editing when they are in `s_` section heading segments. This bug occurs because the editor will sometimes break the segment into two in the view (the data model is unaffected as ShareDB will recombine these segments into the same Delta).

While investigating, I also noticed a bug where the tooltip showed the wrong note count when a note thread contained deleted notes, which I have included a fix for.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3413)
<!-- Reviewable:end -->
