### PR TITLE
SF-3543 Rethrow webhook errors caused by Serval communication issues

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1282,6 +1282,13 @@ public class MachineApiService(
                 u => u.Unset(p => p.ServalData.PreTranslationsRetrieved),
                 cancellationToken: cancellationToken
             );
+
+            // Rethrow the exception so that Hangfire can run the job again,
+            // unless the exception is caused by missing data in Scripture Forge.
+            if (e is not DataNotFoundException)
+            {
+                throw;
+            }
         }
 
         return null;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1561,9 +1561,8 @@ public class MachineApiServiceTests
             CancellationToken.None
         );
 
-        // Verify RetrievePreTranslationStatusAsync was called once
-        await env.Service.Received().RetrievePreTranslationStatusAsync(Project01, CancellationToken.None);
-
+        // Verify that a job was scheduled and the correct build was returned
+        env.BackgroundJobClient.Received(1).Create(Arg.Any<Job>(), Arg.Any<IState>());
         Assert.IsNotNull(actual);
         Assert.AreEqual(message, actual.Message);
         Assert.AreEqual(percentCompleted, actual.PercentCompleted);
@@ -3037,7 +3036,7 @@ public class MachineApiServiceTests
     }
 
     [Test]
-    public async Task RetrievePreTranslationStatusAsync_ReportsErrors()
+    public void RetrievePreTranslationStatusAsync_ReportsErrors()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -3045,7 +3044,9 @@ public class MachineApiServiceTests
         env.PreTranslationService.UpdatePreTranslationStatusAsync(Project01, CancellationToken.None).Throws(ex);
 
         // SUT
-        await env.Service.RetrievePreTranslationStatusAsync(Project01, CancellationToken.None);
+        Assert.ThrowsAsync<ServalApiException>(() =>
+            env.Service.RetrievePreTranslationStatusAsync(Project01, CancellationToken.None)
+        );
 
         env.MockLogger.AssertHasEvent(logEvent => logEvent.Exception == ex);
         env.ExceptionHandler.Received().ReportException(ex);


### PR DESCRIPTION
This PR adds support for rethrowing errors that occur in communication with Serval, which will cause the Hangfire job which is scheduled by the webhook to rerun up to a maximum of 10 times (the Hangfire retry default).

This should reduce some of the problems we have been seeing from the webhook appearing to have not run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3416)
<!-- Reviewable:end -->
