### PR TITLE
SF-3540 Detect when quotation denormalization is possible

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
@@ -25,4 +25,5 @@ export interface ServalBuildAdditionalInfo {
   translationScriptureRanges: ProjectScriptureRange[];
   trainingDataFileIds: string[];
   requestedByUserId?: string;
+  quotationDenormalizationPossible: boolean;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/quotation-denormalization.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/quotation-denormalization.ts
@@ -1,0 +1,4 @@
+export enum QuotationDenormalization {
+  Successful = 'successful',
+  Unsuccessful = 'unsuccessful'
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -29,7 +29,12 @@
           <div class="draft-options">
             <app-draft-download-button [build]="entry" [flat]="true" />
             @if (featureFlags.usfmFormat.enabled && isLatestBuild) {
-              <button mat-button class="format-usfm" [routerLink]="['format']">
+              <button
+                mat-button
+                class="format-usfm"
+                [routerLink]="['format']"
+                [queryParams]="{ 'quotation-denormalization': quotationsDenormalize }"
+              >
                 <mat-icon>build</mat-icon> {{ t("formatting_options") }}
               </button>
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -16,6 +16,7 @@ import { TrainingDataDoc } from '../../../../core/models/training-data-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { BuildDto } from '../../../../machine-api/build-dto';
 import { BuildStates } from '../../../../machine-api/build-states';
+import { QuotationDenormalization } from '../../../../machine-api/quotation-denormalization';
 import { RIGHT_TO_LEFT_MARK } from '../../../../shared/utils';
 import { DraftDownloadButtonComponent } from '../../draft-download-button/draft-download-button.component';
 import { DraftPreviewBooksComponent } from '../../draft-preview-books/draft-preview-books.component';
@@ -153,6 +154,8 @@ export class DraftHistoryEntryComponent {
         });
     }
 
+    this._quotationsCanDenormalize = this._entry?.additionalInfo?.quotationDenormalizationPossible ?? false;
+
     // Populate the exception details, if possible
     if (this._entry?.state === BuildStates.Faulted && this._entry.message != null) {
       this._buildFaulted = true;
@@ -251,6 +254,11 @@ export class DraftHistoryEntryComponent {
     return this._trainingDataFiles.length > 0;
   }
 
+  private _quotationsCanDenormalize: boolean = false;
+  get quotationsDenormalize(): QuotationDenormalization {
+    return this._quotationsCanDenormalize ? QuotationDenormalization.Successful : QuotationDenormalization.Unsuccessful;
+  }
+
   private _canDownloadBuild: boolean | undefined;
   @Input() set canDownloadBuild(value: boolean) {
     this._canDownloadBuild = value;
@@ -266,6 +274,7 @@ export class DraftHistoryEntryComponent {
 
   private _translationSources: string[] = [];
   get translationSource(): string {
+    ``;
     if (this._translationSources.length === 0) return '';
     return this.i18n.enumerateList(this._translationSources) + ' \u2022'; // &bull; •
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
@@ -38,10 +38,11 @@
           </mat-card-header>
           <mat-card-content class="format-options">
             {{ t("quote_style_description") }}
-
-            <!-- TODO make this notice conditional -->
-            <app-notice type="warning" mode="fill-dark"> {{ t("no_quote_convention_detected") }} </app-notice>
-
+            @if (showQuoteFormatWarning) {
+              <app-notice class="quote-format-warning" type="warning" mode="fill-dark">
+                {{ t("no_quote_convention_detected") }}
+              </app-notice>
+            }
             <mat-radio-group formControlName="quoteFormat">
               <mat-radio-button [value]="quoteStyle.Denormalized">
                 <span class="option-title">{{ t("quote_style_automatic") }}</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -9,7 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Delta } from 'quill';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
@@ -28,6 +28,7 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { QuotationDenormalization } from '../../../machine-api/quotation-denormalization';
 import { ServalAdministrationService } from '../../../serval-administration/serval-administration.service';
 import { ConfirmOnLeave } from '../../../shared/project-router.guard';
 import { SharedModule } from '../../../shared/shared.module';
@@ -62,6 +63,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
   chapterNum: number = 1;
   chapters: number[] = [];
   isInitializing: boolean = true;
+  showQuoteFormatWarning: boolean = false;
   paragraphBreakFormat = ParagraphBreakFormat;
   quoteStyle = QuoteFormat;
 
@@ -78,6 +80,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
   private lastSavedState?: DraftUsfmConfig;
 
   constructor(
+    private readonly activatedRoute: ActivatedRoute,
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly draftHandlingService: DraftHandlingService,
     private readonly projectService: SFProjectService,
@@ -90,6 +93,11 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
     private destroyRef: DestroyRef
   ) {
     super(noticeService);
+    this.activatedRoute.queryParams.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      if (params['quotation-denormalization'] === QuotationDenormalization.Unsuccessful) {
+        this.showQuoteFormatWarning = true;
+      }
+    });
   }
 
   get projectId(): string | undefined {

--- a/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
@@ -17,4 +17,5 @@ public class ServalBuildAdditionalInfo
     public HashSet<string> TrainingDataFileIds { get; init; } = [];
     public string TranslationEngineId { get; init; } = string.Empty;
     public HashSet<ProjectScriptureRange> TranslationScriptureRanges { get; init; } = [];
+    public bool QuotationDenormalizationPossible { get; set; } = false;
 }

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -597,7 +597,7 @@ public class MachineApiServiceTests
         const string corpusId2 = "corpusId2";
         const string corpusId3 = "corpusId3";
         const string corpusId4 = "corpusId4";
-        const string parallelCorpusId1 = "parallelCorpusId1";
+        const string parallelCorpusId1 = ParallelCorpusId01;
         const string parallelCorpusId2 = "parallelCorpusId2";
         const int step = 123;
 
@@ -655,6 +655,15 @@ public class MachineApiServiceTests
                 // Invalid corpus format
                 new TrainingCorpus(),
             ],
+            Analysis =
+            [
+                new ParallelCorpusAnalysis
+                {
+                    ParallelCorpusRef = parallelCorpusId1,
+                    SourceQuoteConvention = "standard_english",
+                    TargetQuoteConvention = "standard_english",
+                },
+            ],
         };
         env.ConfigureTranslationBuild(translationBuild);
 
@@ -691,6 +700,7 @@ public class MachineApiServiceTests
         Assert.AreEqual(parallelCorpusId1, actual.AdditionalInfo.ParallelCorporaIds!.ElementAt(0));
         Assert.AreEqual(parallelCorpusId2, actual.AdditionalInfo.ParallelCorporaIds.ElementAt(1));
         Assert.AreEqual(TrainingDataId01, actual.AdditionalInfo.TrainingDataFileIds.Single());
+        Assert.IsTrue(actual.AdditionalInfo.QuotationDenormalizationPossible);
     }
 
     [Test]
@@ -916,6 +926,15 @@ public class MachineApiServiceTests
         // Set up test environment
         var env = new TestEnvironment();
         TranslationBuild translationBuild = env.ConfigureTranslationBuild();
+        translationBuild.Analysis =
+        [
+            new ParallelCorpusAnalysis
+            {
+                ParallelCorpusRef = ParallelCorpusId01,
+                SourceQuoteConvention = "standard_english",
+                TargetQuoteConvention = "standard_english",
+            },
+        ];
         const string trainingScriptureRange = "GEN;EXO";
         const string translationScriptureRange = "LEV;NUM";
         env.EventMetricService.GetEventMetricsAsync(Project01, Arg.Any<EventScope[]?>(), Arg.Any<string[]>())
@@ -997,6 +1016,7 @@ public class MachineApiServiceTests
             builds[0].AdditionalInfo.TrainingScriptureRanges.Single().ScriptureRange
         );
         Assert.AreEqual(TrainingDataId01, builds[0].AdditionalInfo.TrainingDataFileIds.Single());
+        Assert.IsTrue(builds[0].AdditionalInfo!.QuotationDenormalizationPossible);
     }
 
     [Test]
@@ -1038,6 +1058,7 @@ public class MachineApiServiceTests
             trainingScriptureRange,
             builds[0].AdditionalInfo?.TrainingScriptureRanges.Single().ScriptureRange
         );
+        Assert.IsFalse(builds[0].AdditionalInfo!.QuotationDenormalizationPossible);
     }
 
     [Test]
@@ -1089,6 +1110,7 @@ public class MachineApiServiceTests
             trainingScriptureRange,
             builds[0].AdditionalInfo?.TrainingScriptureRanges.Single().ScriptureRange
         );
+        Assert.IsFalse(builds[0].AdditionalInfo!.QuotationDenormalizationPossible);
     }
 
     [Test]


### PR DESCRIPTION
This PR adds the logic to detect when the serval build is able to denormalized quotation marks. This is possible if the build analysis was able to identify the quotation convention on the target project. If unable to detect the quotation convention, then a notice is shown to the user.

Each build has an analysis section that describes the quotation convention of the parallel texts of the corpora used for translation. I added this data to the Serval build DTOs returned to the frontend.

<img width="1185" height="567" alt="image" src="https://github.com/user-attachments/assets/a122df90-e9b5-45eb-9c4a-864b7c3a0a44" />
