### PR TITLE
Hotfix: Revert "Switch to new DBL server in prod environment (#3385)"

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -68,9 +68,9 @@ public class ParatextService : DisposableBase, IParatextService
     private readonly IJwtTokenHelper _jwtTokenHelper;
     private readonly IParatextDataHelper _paratextDataHelper;
     private readonly IGuidService _guidService;
-    private readonly string _dblServerUri = "https://pt-resources-adapter.library.bible/";
-    private readonly string _registryServerUri = "https://registry.paratext.org";
-    private readonly string _sendReceiveServerUri = InternetAccess.uriProduction;
+    private string _dblServerUri = "https://paratext.thedigitalbiblelibrary.org/";
+    private string _registryServerUri = "https://registry.paratext.org";
+    private string _sendReceiveServerUri = InternetAccess.uriProduction;
     private readonly IInternetSharedRepositorySourceProvider _internetSharedRepositorySourceProvider;
     private readonly ISFRestClientFactory _restClientFactory;
 


### PR DESCRIPTION
This reverts commit 254f660436dc0f3b98ac704a7cb8dd3670c38898.

This will revert Scripture Forge to use the same URL for the DBL as Paratext.

Users are encountering issues where resources they see in Paratext (i.e. the NIV84) are no longer visible in Scripture Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3421)
<!-- Reviewable:end -->
