### PR TITLE
SF-3554 Create missing chapters when adding draft to a project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-apply-dialog/draft-apply-dialog.component.spec.ts
@@ -11,6 +11,7 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { of } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { TestOnlineStatusModule } from 'xforge-common/test-online-status.module';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
@@ -22,11 +23,14 @@ import { TextDoc } from '../../../core/models/text-doc';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { TextDocService } from '../../../core/text-doc.service';
 import { CustomValidatorState } from '../../../shared/sfvalidators';
+import { DraftGenerationService } from '../draft-generation.service';
 import { DraftApplyDialogComponent } from './draft-apply-dialog.component';
 
+const mockedActivatedProjectService = mock(ActivatedProjectService);
 const mockedUserProjectsService = mock(SFUserProjectsService);
 const mockedProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
+const mockedDraftGenerationService = mock(DraftGenerationService);
 const mockedDialogRef = mock(MatDialogRef);
 const mockedTextDocService = mock(TextDocService);
 
@@ -39,7 +43,7 @@ const ROUTES: Route[] = [{ path: 'projects', component: MockComponent }];
 
 let env: TestEnvironment;
 
-describe('DraftApplyDialogComponent', () => {
+fdescribe('DraftApplyDialogComponent', () => {
   configureTestingModule(() => ({
     imports: [
       TestTranslocoModule,
@@ -48,9 +52,11 @@ describe('DraftApplyDialogComponent', () => {
       TestOnlineStatusModule.forRoot()
     ],
     providers: [
+      { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
       { provide: SFUserProjectsService, useMock: mockedUserProjectsService },
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: UserService, useMock: mockedUserService },
+      { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
       { provide: TextDocService, useMock: mockedTextDocService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
       { provide: MatDialogRef, useMock: mockedDialogRef },
@@ -343,7 +349,9 @@ class TestEnvironment {
     const mockedTextDoc = {
       getNonEmptyVerses: (): string[] => ['verse_1_1', 'verse_1_2', 'verse_1_3']
     } as TextDoc;
+    when(mockedActivatedProjectService.projectId$).thenReturn(of('project01'));
     when(mockedProjectService.getText(anything())).thenResolve(mockedTextDoc);
     when(mockedTextDocService.userHasGeneralEditRight(anything())).thenReturn(true);
+    when(mockedDraftGenerationService.getDraftChaptersForBook(anything(), anything())).thenReturn(of([1, 2]));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -402,6 +402,23 @@ export class DraftGenerationService {
   }
 
   /**
+   * Gets the number of draft chapters for a specific book.
+   * @param projectId The SF project id for the target translation.
+   * @param bookNum The book number.
+   * @returns An observable containing the number of draft chapters or undefined if not found.
+   */
+  getDraftChaptersForBook(projectId: string, bookNum: number): Observable<number[] | undefined> {
+    return this.httpClient
+      .get<number[]>(`translation/engines/project:${projectId}/actions/pretranslate/${bookNum}/chapters`)
+      .pipe(
+        map(res => res.data),
+        catchError(_ => {
+          return of(undefined);
+        })
+      );
+  }
+
+  /**
    * Calls the machine api to start a pre-translation build job.
    * This should only be called if no build is currently active.
    * @param buildConfig The build configuration.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -2,7 +2,7 @@
   @for (book of booksWithDrafts$ | async; track book.bookId) {
     <mat-button-toggle-group
       class="draft-book-option"
-      [disabled]="book.chaptersWithDrafts.length === 0"
+      [disabled]="book.existingChapters.length === 0"
       (change)="$event.source.checked = false"
     >
       <mat-button-toggle class="book-name" (click)="navigate(book)">

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -933,6 +933,48 @@ public class MachineApiController : ControllerBase
     }
 
     /// <summary>
+    /// Gets the count of chapters that have TextDocument objects.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The chapter count was retrieved successfully.</response>
+    /// <response code="403">You do not have permission to access this project.</response>
+    /// <response code="404">The project does not exist.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
+    [HttpGet(MachineApi.GetChaptersForBook)]
+    public async Task<ActionResult<int>> GetPretranslationChapterCountAsync(
+        string sfProjectId,
+        int bookNum,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            int count = await _machineApiService.GetPretranslationChapterCountAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                bookNum,
+                cancellationToken
+            );
+            return Ok(count);
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>
     /// Translates a segment of text into the top N results.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -940,10 +940,8 @@ public class MachineApiController : ControllerBase
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The chapter count was retrieved successfully.</response>
     /// <response code="403">You do not have permission to access this project.</response>
-    /// <response code="404">The project does not exist.</response>
-    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetChaptersForBook)]
-    public async Task<ActionResult<int>> GetPretranslationChapterCountAsync(
+    public async Task<ActionResult<int[]>> GetPretranslationChapterCountAsync(
         string sfProjectId,
         int bookNum,
         CancellationToken cancellationToken
@@ -951,22 +949,13 @@ public class MachineApiController : ControllerBase
     {
         try
         {
-            int count = await _machineApiService.GetPretranslationChapterCountAsync(
+            int[] chapters = await _machineApiService.GetPretranslationChapterCountAsync(
                 _userAccessor.UserId,
                 sfProjectId,
                 bookNum,
                 cancellationToken
             );
-            return Ok(count);
-        }
-        catch (BrokenCircuitException e)
-        {
-            _exceptionHandler.ReportException(e);
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
-        }
-        catch (DataNotFoundException)
-        {
-            return NotFound();
+            return Ok(chapters);
         }
         catch (ForbiddenException)
         {

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -33,6 +33,8 @@ public static class MachineApi
         "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}_{chapterNum}/usx";
     public const string GetLastCompletedPreTranslationBuild =
         "translation/engines/project:{sfProjectId}/actions/getLastCompletedPreTranslationBuild";
+    public const string GetChaptersForBook =
+        "translation/engines/project:{sfProjectId}/actions/preTranslate/{bookNum}/chapters";
 
     public static string GetBuildHref(string sfProjectId, string buildId)
     {

--- a/src/SIL.XForge.Scripture/Models/TextDocument.cs
+++ b/src/SIL.XForge.Scripture/Models/TextDocument.cs
@@ -55,4 +55,10 @@ public class TextDocument : Json0Snapshot, IUsj
     /// The USJ spec version.
     /// </summary>
     public string Version { get; set; } = Usj.UsjVersion;
+
+    public int GetChapterNumber()
+    {
+        string[] parts = Id.Split(':');
+        return parts.Length >= 3 && int.TryParse(parts[2], out int chapter) ? chapter : 0;
+    }
 }

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -49,7 +49,7 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<ServalEngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
-    Task<int> GetPretranslationChapterCountAsync(
+    Task<int[]> GetPretranslationChapterCountAsync(
         string curUserId,
         string sfProjectId,
         int bookNum,

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -49,6 +49,12 @@ public interface IMachineApiService
         CancellationToken cancellationToken
     );
     Task<ServalEngineDto> GetEngineAsync(string curUserId, string sfProjectId, CancellationToken cancellationToken);
+    Task<int> GetPretranslationChapterCountAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        CancellationToken cancellationToken
+    );
     Task<ServalBuildDto?> GetLastCompletedPreTranslationBuildAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1167,7 +1167,7 @@ public class MachineApiService(
         }
     }
 
-    public async Task<int> GetPretranslationChapterCountAsync(
+    public async Task<int[]> GetPretranslationChapterCountAsync(
         string curUserId,
         string sfProjectId,
         int bookNum,
@@ -1186,7 +1186,9 @@ public class MachineApiService(
             .QuerySnapshots<TextDocument>()
             .Where(t => t.Id.StartsWith($"{sfProjectId}:{Canon.BookNumberToId(bookNum)}"))
             .ToListAsync(cancellationToken);
-        return textDocuments.Count;
+        List<int> chapters = [.. textDocuments.Select(t => t.GetChapterNumber()).Where(c => c != 0)];
+        chapters.Sort();
+        return [.. chapters];
     }
 
     public async Task<LanguageDto> IsLanguageSupportedAsync(string languageCode, CancellationToken cancellationToken)

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1167,6 +1167,28 @@ public class MachineApiService(
         }
     }
 
+    public async Task<int> GetPretranslationChapterCountAsync(
+        string curUserId,
+        string sfProjectId,
+        int bookNum,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure that the user has permission
+        SFProject project = await EnsureProjectPermissionAsync(
+            curUserId,
+            sfProjectId,
+            isServalAdmin: false,
+            cancellationToken
+        );
+
+        IList<TextDocument> textDocuments = await realtimeService
+            .QuerySnapshots<TextDocument>()
+            .Where(t => t.Id.StartsWith($"{sfProjectId}:{Canon.BookNumberToId(bookNum)}"))
+            .ToListAsync(cancellationToken);
+        return textDocuments.Count;
+    }
+
     public async Task<LanguageDto> IsLanguageSupportedAsync(string languageCode, CancellationToken cancellationToken)
     {
         LanguageInfo languageInfo = await translationEngineTypesClient.GetLanguageInfoAsync(

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -2344,6 +2344,49 @@ public class MachineApiControllerTests
         Assert.IsInstanceOf<OkObjectResult>(actual.Result);
     }
 
+    [Test]
+    public async Task GetPretranslationChapterCountAsync_Success()
+    {
+        // Set up test environment
+        int[] chapterCount = [1, 2, 3, 4, 5, 6];
+        int bookNum = 40;
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPretranslationChapterCountAsync(User01, Project01, bookNum, CancellationToken.None)
+            .Returns(Task.FromResult(chapterCount));
+
+        // SUT
+        ActionResult<int[]> actual = await env.Controller.GetPretranslationChapterCountAsync(
+            Project01,
+            bookNum,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+        Assert.AreEqual(chapterCount, (actual.Result as OkObjectResult)?.Value);
+        await env
+            .MachineApiService.Received(1)
+            .GetPretranslationChapterCountAsync(User01, Project01, bookNum, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task GetPretranslationChapterCountAsync_NoPermission()
+    {
+        // Set up test environment
+        const int bookNum = 40;
+        var env = new TestEnvironment();
+        env.MachineApiService.GetPretranslationChapterCountAsync(User01, Project01, bookNum, CancellationToken.None)
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<int[]> actual = await env.Controller.GetPretranslationChapterCountAsync(
+            Project01,
+            bookNum,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
     private class TestEnvironment
     {
         private static readonly DateTime Timestamp = DateTime.UtcNow;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -2670,6 +2670,12 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void GetPretranslationChapterCountAsync_Success()
+    {
+        // TODO: Gets the number of documents
+    }
+
+    [Test]
     public void GetWordGraphAsync_NoPermission()
     {
         // Set up test environment


### PR DESCRIPTION
Adding a draft to a book that is empty fails to create the missing chapters. We needed a way to detect how many chapters exist in the generated draft and notify the front end so that it can create the missing chapters and update the project texts property. This PR creates a new endpoint that can be used to get the chapters that have drafts.