### PR TITLE
SF-3552 Fix editor error on remote browser lynx enable

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
@@ -222,6 +222,10 @@ export class LynxWorkspaceService {
     // Create a new workspace with the updated settings
     this.workspace = this.workspaceFactory.createWorkspace(this.documentManager, lynxSettings);
 
+    // Workspace init causes localizer init.  Important that this is done before emitting the new insight source.
+    await this.workspace.init();
+    await this.workspace.changeLanguage(this.i18n.localeCode);
+
     const newInsightSource$ = this.workspace.diagnosticsChanged$.pipe(
       // Group events by event URI, then switchMap within each group to handle the cancellation and processing
       // of only the latest event for that URI.
@@ -231,9 +235,6 @@ export class LynxWorkspaceService {
     );
 
     this.rawInsightSourceSubject$.next(newInsightSource$);
-
-    await this.workspace.init();
-    await this.workspace.changeLanguage(this.i18n.localeCode);
   }
 
   private async onDiagnosticsChanged(event: DiagnosticsChanged): Promise<LynxInsight[]> {


### PR DESCRIPTION
This PR fixes a `Diagnostic message was not initialized` error that occurred in the editor of browser 1 when a lynx was enabled browser 2.  The error occurred because the lynx lib localizer was not yet initialized before trying to get a message string, resulting in an `undefined` message.

The fix ensures that the `Workspace.init()` is called (thus calling `Localizer.init()`) before emitting the new insight source.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3434)
<!-- Reviewable:end -->
