### PR TITLE
SF-3563 Fix offline support for community checking users

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -108,6 +108,15 @@ describe('PermissionsService', () => {
     expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(true);
   }));
 
+  it('allows access to text if user is on project and does not have chapter permission', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    env.setupProjectData(undefined);
+
+    const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
+
+    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(true);
+  }));
+
   it('does not allow access to text if user is not on project', fakeAsync(async () => {
     const env = new TestEnvironment();
     env.setCurrentUser('other');
@@ -122,6 +131,15 @@ describe('PermissionsService', () => {
     env.setupProjectData(TextInfoPermission.None);
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
+
+    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(false);
+  }));
+
+  it('does not allow access to text if the chapter does not exist', fakeAsync(async () => {
+    const env = new TestEnvironment();
+    env.setupProjectData(TextInfoPermission.Read);
+
+    const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 2 };
 
     expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(false);
   }));
@@ -246,7 +264,7 @@ class TestEnvironment {
     this.setupUserData();
   }
 
-  setupProjectData(textPermission?: TextInfoPermission): void {
+  setupProjectData(textPermission?: TextInfoPermission | undefined): void {
     const projectId: string = 'project01';
     const permission: TextInfoPermission = textPermission ?? TextInfoPermission.Write;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -76,8 +76,10 @@ export class PermissionsService {
         .find(t => t.bookNum === textDocId.bookNum)
         ?.chapters.find(c => c.number === textDocId.chapterNum);
       if (chapter != null) {
-        const chapterPermission: string = chapter.permissions[this.userService.currentUserId];
-        return chapterPermission === TextInfoPermission.Write || chapterPermission === TextInfoPermission.Read;
+        const chapterPermission: string | undefined = chapter.permissions[this.userService.currentUserId];
+        // If there is no chapter permission, they will have access to the chapter as they have access to the project.
+        // We should only deny access if there is an explicit "None" permission.
+        return chapterPermission !== TextInfoPermission.None;
       }
     }
 


### PR DESCRIPTION
This PR fixes a bug where community checking users could not view all texts in a project offline because they did not have a chapter permission record.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3436)
<!-- Reviewable:end -->
