### PR TITLE
SF-3557 Improve book progress accuracy for incomplete books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
@@ -44,7 +44,7 @@ describe('progress service', () => {
     expect(env.service.texts.length).toBeGreaterThan(0);
     let i = 0;
     for (const book of env.service.texts) {
-      expect(book.text.bookNum).toEqual(i++);
+      expect(book.text.bookNum).toEqual(++i);
       expect(book.text.chapters.length).toBeGreaterThan(0);
       let j = 0;
       for (const chapter of book.text.chapters) {
@@ -73,7 +73,7 @@ describe('progress service', () => {
   it('updates total progress when chapter content changes', fakeAsync(async () => {
     const env = new TestEnvironment();
     const changeEvent = new BehaviorSubject({});
-    when(mockSFProjectService.getText(deepEqual(new TextDocId('project01', 0, 2, 'target')))).thenCall(() => {
+    when(mockSFProjectService.getText(deepEqual(new TextDocId('project01', 1, 2, 'target')))).thenCall(() => {
       return {
         getSegmentCount: () => {
           return { translated: 12, blank: 2 };
@@ -86,7 +86,7 @@ describe('progress service', () => {
     tick();
 
     // mock a change
-    when(mockSFProjectService.getText(deepEqual(new TextDocId('project01', 0, 2, 'target')))).thenCall(() => {
+    when(mockSFProjectService.getText(deepEqual(new TextDocId('project01', 1, 2, 'target')))).thenCall(() => {
       return {
         getSegmentCount: () => {
           return { translated: 13, blank: 1 };
@@ -196,7 +196,7 @@ class TestEnvironment {
   }
 
   setUpGetText(projectId: string, translatedSegments: number, blankSegments: number): void {
-    for (let book = 0; book < this.numBooks; book++) {
+    for (let book = 1; book <= this.numBooks; book++) {
       for (let chapter = 0; chapter < this.numChapters; chapter++) {
         const translated = translatedSegments >= 9 ? 9 : translatedSegments;
         translatedSegments -= translated;
@@ -225,7 +225,7 @@ class TestEnvironment {
 
   createTexts(): TextInfo[] {
     const texts: TextInfo[] = [];
-    for (let book = 0; book < this.numBooks; book++) {
+    for (let book = 1; book <= this.numBooks; book++) {
       const chapters: Chapter[] = [];
       for (let chapter = 0; chapter < this.numChapters; chapter++) {
         chapters.push({ isValid: true, lastVerse: 1, number: chapter, permissions: {}, hasAudio: false });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
@@ -34,7 +34,7 @@ describe('progress service', () => {
   it('populates progress and texts on construction', fakeAsync(() => {
     // Create segments for 20 chapters multiplied by 20 books
     const env = new TestEnvironment(3600, 2000);
-    // Override the verse counts to be less half the number created for each book
+    // Override the verse counts to be less than half of the number created for each book
     spyOn(TextProgress.prototype as any, 'getVerseCount').and.callFake(() => 200);
     const calculate = spyOn<any>(env.service, 'calculateProgress').and.callThrough();
 
@@ -49,8 +49,8 @@ describe('progress service', () => {
     let i = 0;
     for (const book of env.service.texts) {
       expect(book.text.bookNum).toEqual(++i);
-      expect(book.numberOfVerses).toEqual(200);
-      expect(book.useNumberOfVerses).toEqual(false);
+      expect(book.expectedNumberOfVerses).toEqual(200);
+      expect(book.useExpectedNumberOfVerses).toEqual(false);
       expect(book.blank).toEqual(100);
       expect(book.translated).toEqual(180);
       expect(book.total).toEqual(280);
@@ -115,20 +115,22 @@ describe('progress service', () => {
   }));
 
   it('uses the verse counts when there are too few segments', fakeAsync(() => {
-    const env = new TestEnvironment(5, 1);
+    const notTranslatedVerses = 17380;
+    const translatedVerses = 5;
+    const env = new TestEnvironment(translatedVerses, 1);
     tick();
 
-    expect(env.service.overallProgress.translated).toEqual(5);
-    expect(env.service.overallProgress.notTranslated).toEqual(17380);
-    expect(env.service.overallProgress.blank).toEqual(17380);
-    expect(env.service.overallProgress.total).toEqual(17385);
+    expect(env.service.overallProgress.translated).toEqual(translatedVerses);
+    expect(env.service.overallProgress.notTranslated).toEqual(notTranslatedVerses);
+    expect(env.service.overallProgress.blank).toEqual(notTranslatedVerses);
+    expect(env.service.overallProgress.total).toEqual(notTranslatedVerses + translatedVerses);
     expect(env.service.overallProgress.percentage).toEqual(0);
     expect(env.service.texts.length).toBeGreaterThan(0);
     let i = 0;
     for (const book of env.service.texts) {
       expect(book.text.bookNum).toEqual(++i);
-      expect(book.useNumberOfVerses).toEqual(true);
-      expect(book.total).toEqual(book.numberOfVerses);
+      expect(book.useExpectedNumberOfVerses).toEqual(true);
+      expect(book.total).toEqual(book.expectedNumberOfVerses);
       expect(book.text.chapters.length).toBeGreaterThan(0);
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -13,7 +13,7 @@ import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 
 /**
- * The number of verses per book, calculated from the libpalaso versification files.
+ * The expected number of verses per book, calculated from the libpalaso versification files.
  */
 const verseCounts: Record<string, number> = {
   GEN: 1533,
@@ -153,25 +153,25 @@ export class Progress {
 }
 
 export class TextProgress extends Progress {
-  numberOfVerses: number = 0;
+  expectedNumberOfVerses: number = 0;
 
   constructor(public readonly text: TextInfo) {
     super();
-    this.numberOfVerses = this.getVerseCount(text.bookNum);
+    this.expectedNumberOfVerses = this.getVerseCount(text.bookNum);
   }
 
   get notTranslated(): number {
-    // This value will be the number of blanks unless useNumberOfVerses is true.
+    // This value will be the number of blanks unless useExpectedNumberOfVerses is true.
     return this.total - this.translated;
   }
 
   get total(): number {
-    return this.useNumberOfVerses ? this.numberOfVerses : super.total;
+    return this.useExpectedNumberOfVerses ? this.expectedNumberOfVerses : super.total;
   }
 
-  get useNumberOfVerses(): boolean {
-    // If the total calculated from segments is at least 2/3 of the number of verses possible, use the total.
-    return this.numberOfVerses > 0 && super.total < this.numberOfVerses * 0.66;
+  get useExpectedNumberOfVerses(): boolean {
+    // If the total calculated from segments is at least 2/3 of the expected number of verses possible, use the total.
+    return this.expectedNumberOfVerses > 0 && super.total < this.expectedNumberOfVerses * 0.66;
   }
 
   getVerseCount(bookNum: number): number {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -1,4 +1,5 @@
 import { DestroyRef, Injectable, OnDestroy } from '@angular/core';
+import { Canon } from '@sillsdev/scripture';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { asyncScheduler, merge, startWith, Subscription, tap, throttleTime } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
@@ -10,6 +11,121 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDoc, TextDocId } from '../../core/models/text-doc';
 import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
+
+/**
+ * The number of verses per book, calculated from the libpalaso versification files.
+ */
+const verseCounts: Record<string, number> = {
+  GEN: 1533,
+  EXO: 1213,
+  LEV: 859,
+  NUM: 1289,
+  DEU: 959,
+  JOS: 658,
+  JDG: 618,
+  RUT: 85,
+  '1SA': 811,
+  '2SA': 695,
+  '1KI': 817,
+  '2KI': 719,
+  '1CH': 943,
+  '2CH': 822,
+  EZR: 280,
+  NEH: 405,
+  EST: 167,
+  JOB: 1070,
+  PSA: 2527,
+  PRO: 915,
+  ECC: 222,
+  SNG: 117,
+  ISA: 1291,
+  JER: 1364,
+  LAM: 154,
+  EZK: 1273,
+  DAN: 357,
+  HOS: 197,
+  JOL: 73,
+  AMO: 146,
+  OBA: 21,
+  JON: 48,
+  MIC: 105,
+  NAM: 47,
+  HAB: 56,
+  ZEP: 53,
+  HAG: 38,
+  ZEC: 211,
+  MAL: 55,
+  MAT: 1071,
+  MRK: 678,
+  LUK: 1151,
+  JHN: 879,
+  ACT: 1006,
+  ROM: 433,
+  '1CO': 437,
+  '2CO': 256,
+  GAL: 149,
+  EPH: 155,
+  PHP: 104,
+  COL: 95,
+  '1TH': 89,
+  '2TH': 47,
+  '1TI': 113,
+  '2TI': 83,
+  TIT: 46,
+  PHM: 25,
+  HEB: 303,
+  JAS: 108,
+  '1PE': 105,
+  '2PE': 61,
+  '1JN': 105,
+  '2JN': 13,
+  '3JN': 15,
+  JUD: 25,
+  REV: 405,
+  TOB: 248,
+  JDT: 340,
+  ESG: 267,
+  WIS: 435,
+  SIR: 1401,
+  BAR: 141,
+  LJE: 72,
+  S3Y: 67,
+  SUS: 64,
+  BEL: 42,
+  '1MA': 924,
+  '2MA': 555,
+  '3MA': 228,
+  '4MA': 482,
+  '1ES': 434,
+  '2ES': 944,
+  MAN: 15,
+  PS2: 7,
+  ODA: 275,
+  PSS: 293,
+  JSA: 658,
+  JDB: 618,
+  TBS: 248,
+  SST: 64,
+  DNT: 424,
+  BLT: 42,
+  '3ES': 944,
+  EZA: 715,
+  '5EZ': 88,
+  '6EZ': 141,
+  DAG: 424,
+  PS3: 49,
+  '2BA': 613,
+  LBA: 82,
+  JUB: 1217,
+  ENO: 1563,
+  '1MQ': 756,
+  '2MQ': 396,
+  '3MQ': 208,
+  REP: 160,
+  '4BA': 184,
+  LAO: 20
+};
+
 export class Progress {
   translated: number = 0;
   blank: number = 0;
@@ -22,6 +138,14 @@ export class Progress {
     return Math.round((this.translated / this.total) * 100);
   }
 
+  get notTranslated(): number {
+    return this.blank;
+  }
+
+  set notTranslated(value: number) {
+    this.blank = value;
+  }
+
   reset(): void {
     this.translated = 0;
     this.blank = 0;
@@ -29,8 +153,29 @@ export class Progress {
 }
 
 export class TextProgress extends Progress {
+  numberOfVerses: number = 0;
+
   constructor(public readonly text: TextInfo) {
     super();
+    this.numberOfVerses = this.getVerseCount(text.bookNum);
+  }
+
+  get notTranslated(): number {
+    // This value will be the number of blanks unless useNumberOfVerses is true.
+    return this.total - this.translated;
+  }
+
+  get total(): number {
+    return this.useNumberOfVerses ? this.numberOfVerses : super.total;
+  }
+
+  get useNumberOfVerses(): boolean {
+    // If the total calculated from segments is at least 2/3 of the number of verses possible, use the total.
+    return this.numberOfVerses > 0 && super.total < this.numberOfVerses * 0.66;
+  }
+
+  getVerseCount(bookNum: number): number {
+    return verseCounts[Canon.bookNumberToId(bookNum)] ?? 0;
   }
 }
 
@@ -141,8 +286,6 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
       const { translated, blank } = chapterText.getSegmentCount();
       book.translated += translated;
       book.blank += blank;
-      this.overallProgress.translated += translated;
-      this.overallProgress.blank += blank;
 
       // If translation suggestions are enabled, collect the number of segment pairs up to the minimum required
       // We don't go any further so we don't load all of the source texts while this is running
@@ -172,5 +315,9 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
         }
       }
     }
+
+    // Add the book to the overall progress
+    this.overallProgress.translated += book.translated;
+    this.overallProgress.notTranslated += book.notTranslated;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -601,13 +601,13 @@ describe('DraftGenerationStepsComponent', () => {
         source2: [
           { number: 2, selected: true },
           { number: 3, selected: false },
-          { number: 6, selected: true }
+          { number: 6, selected: false }
         ],
         project01: [
           { number: 1, selected: true },
           { number: 2, selected: true },
           { number: 3, selected: false },
-          { number: 6, selected: true }
+          { number: 6, selected: false }
         ]
       });
     }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -260,7 +260,7 @@ export class DraftGenerationStepsComponent implements OnInit {
               !hasPreviousTrainingRange &&
               textProgress != null &&
               textProgress.translated > minimumTranslatedSegments &&
-              (textProgress.percentage >= 99 || textProgress.blank <= 3);
+              (textProgress.percentage >= 99 || textProgress.notTranslated <= 3);
 
             // If books were automatically selected, reflect this in the UI via a notice
             this.trainingBooksWereAutoSelected ||= selected;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -13,7 +13,7 @@
           <div class="progress" [title]="progressService.overallProgress.percentage">
             <app-donut-chart
               [colors]="['#b8d332', 'transparent']"
-              [data]="[progressService.overallProgress.translated, progressService.overallProgress.blank]"
+              [data]="[progressService.overallProgress.translated, progressService.overallProgress.notTranslated]"
               backgroundColor="#ececec"
               [innerThicknessDelta]="0"
               [thickness]="22"
@@ -37,7 +37,7 @@
               <div class="progress" matListItemMeta [title]="textProgress.percentage + '%'">
                 <app-donut-chart
                   [colors]="['#b8d332', 'transparent']"
-                  [data]="[textProgress.translated, textProgress.blank]"
+                  [data]="[textProgress.translated, textProgress.notTranslated]"
                   backgroundColor="#ececec"
                   [innerThicknessDelta]="0"
                   [thickness]="22"


### PR DESCRIPTION
This PR fixes a bug where books with many missing verse numbers showed incorrect progress. This is fixed by using the known number of verses in a book when that book has less than two third of the known verse segments present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3437)
<!-- Reviewable:end -->
