### PR TITLE
SF-3549 Position notes correctly in introductory paragraphs

### DIFF
--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -67,6 +67,62 @@ public class DeltaUsxMapper(
         "id",
     ];
 
+    /// <summary>
+    /// All paragraph styles that are used in introductory material and outside of verses.
+    /// </summary>
+    private static readonly HashSet<string> TitleIntroductionStyles =
+    [
+        // Titles and sections
+        "mt",
+        "mte",
+        "cl",
+        "cd",
+        "ms",
+        "mr",
+        "s",
+        "sr",
+        "r",
+        "d",
+        "sp",
+        "sd",
+        // Introductory material
+        "imt",
+        "is",
+        "ip",
+        "ipi",
+        "im",
+        "imi",
+        "ipq",
+        "ipr",
+        "ipc",
+        "iq",
+        "ili",
+        "iot",
+        "io",
+        "iex",
+        "imte",
+        "ie",
+        // Identification
+        "ide",
+        "sts",
+        "rem",
+        "h",
+        "toc",
+        "toca",
+        // Should not contain verse text, but sometimes do
+        "ib",
+        // NOTE: When table support is added, add table USFM tags here
+    ];
+
+    /// <summary>
+    /// All paragraph styles that can contain text.
+    /// </summary>
+    private static readonly HashSet<string> AllParaTextStyles =
+    [
+        .. ParagraphPoetryListStyles,
+        .. TitleIntroductionStyles,
+    ];
+
     private class ParseState
     {
         public string? CurRef { get; set; }
@@ -93,7 +149,18 @@ public class DeltaUsxMapper(
         }
     }
 
-    public static bool CanParaContainVerseText(string? style)
+    public static bool CanParaContainText(string? style)
+    {
+        // an empty style indicates an improperly formatted paragraph which could contain verse text
+        if (string.IsNullOrEmpty(style))
+            return true;
+        if (char.IsDigit(style[^1]))
+            style = style[..^1];
+        // paragraph, poetry, and list styles are the only types of valid paras that can contain verse text
+        return AllParaTextStyles.Contains(style);
+    }
+
+    private static bool CanParaContainVerseText(string? style)
     {
         // an empty style indicates an improperly formatted paragraph which could contain verse text
         if (string.IsNullOrEmpty(style))

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -3478,7 +3478,7 @@ public class ParatextService : DisposableBase, IParatextService
     private static string GetVerseText(Delta delta, VerseRef verseRef)
     {
         string vref = string.IsNullOrEmpty(verseRef.Verse) ? verseRef.VerseNum.ToString() : verseRef.Verse;
-        return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainVerseText)
+        return delta.TryConcatenateInserts(out string verseText, vref, DeltaUsxMapper.CanParaContainText)
             ? verseText
             : string.Empty;
     }

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -4044,6 +4044,19 @@ public partial class DeltaUsxMapperTests
         Assert.IsFalse(result);
     }
 
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("mt1")]
+    [TestCase("q1")]
+    [TestCase("p")]
+    [TestCase("id")]
+    public void CanParaContainText_True(string? style) => Assert.IsTrue(DeltaUsxMapper.CanParaContainText(style));
+
+    [TestCase("nd")]
+    [TestCase("tr")]
+    [TestCase("zimagecopyrights")]
+    public void CanParaContainText_False(string? style) => Assert.IsFalse(DeltaUsxMapper.CanParaContainText(style));
+
     private async Task RoundTripTestHelper(string projectZipFilename, string projectShortName)
     {
         string zipFilePath = Path.Join(GetPathToTestProject(), "SampleData", $"{projectZipFilename}.zip");


### PR DESCRIPTION
This PR fixes a bug where notes were incorrectly positioned in introductory paragraphs. This issues occured because the USFM segments in the introductory material were not being as paragraphs, and so the notes were being offset by the number of preceding introductory paragraphs, headings, identificatory tags, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3438)
<!-- Reviewable:end -->
