### PR TITLE
SF-3564 Fix draft history on very small screens

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.scss
@@ -24,7 +24,8 @@ mat-panel-description {
 
 .draft-options {
   display: flex;
-  column-gap: 8px;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .subtitle,


### PR DESCRIPTION
This isn't very important for English, since it's only barely broken, the the screen size is quote small (and not our target size), but if it breaks for English it's likely to be worse for some other languages.

Before | After
-------|------
<img width="712" height="796" alt="localhost_5000_projects_68ba1617261a7ce57dd1bf62_draft-generation (3)" src="https://github.com/user-attachments/assets/ad35345c-dd7c-4188-bbc8-e7e8a7971ba3" /> | <img width="712" height="892" alt="localhost_5000_projects_68ba1617261a7ce57dd1bf62_draft-generation (2)" src="https://github.com/user-attachments/assets/b382318e-a3a2-4a3f-8e16-ef2c939074bd" />
