### PR TITLE
Enable no-floating-promises lint rule in ClientApp

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
+++ b/src/SIL.XForge.Scripture/ClientApp/.eslintrc.json
@@ -64,6 +64,7 @@
             }
           }
         ],
+        "@typescript-eslint/no-floating-promises": "warn",
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/no-unused-vars": [
           "error",
@@ -116,6 +117,7 @@
         ],
         "deprecation/deprecation": "warn"
       }
-    }
+    },
+    { "files": ["*.spec.ts", "*.stories.ts"], "rules": { "@typescript-eslint/no-floating-promises": "off" } }
   ]
 }


### PR DESCRIPTION
This increases the number of lint warnings from 17 to 247.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3444)
<!-- Reviewable:end -->
