### PR TITLE
SF-3562 Fix scripture chooser layout and book highlight

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.html
@@ -15,25 +15,18 @@
             <span>{{ t("choose_book") }}</span>
           </h1>
           <div mat-dialog-content>
-            <div class="upperBookSet">
-              @for (book of otBooks; track book) {
-                <button
-                  mat-button
-                  [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
-                  (click)="onClickBook(book)"
-                >
-                  {{ i18n.localizeBook(book) }}
-                </button>
+            @for (list of [otBooks, ntBooks, dcBooks]; track $index) {
+              @if (list.length > 0) {
+                <div class="book-list">
+                  @for (book of list; track book) {
+                    @if (data.input?.book === book) {
+                      <button mat-flat-button (click)="onClickBook(book)">{{ i18n.localizeBook(book) }}</button>
+                    } @else {
+                      <button mat-button (click)="onClickBook(book)">{{ i18n.localizeBook(book) }}</button>
+                    }
+                  }
+                </div>
               }
-            </div>
-            @for (book of ntBooks; track book) {
-              <button
-                mat-button
-                [ngClass]="{ 'mat-flat-button': data.input?.book === book }"
-                (click)="onClickBook(book)"
-              >
-                {{ i18n.localizeBook(book) }}
-              </button>
             }
           </div>
         </div>
@@ -49,16 +42,11 @@
           <div mat-dialog-content>
             <div class="reference">{{ getBookName(selection.book) }}</div>
             @for (chapter of chaptersOf(selection.book); track chapter) {
-              <button
-                mat-button
-                [ngClass]="{
-                  'mat-flat-button':
-                    data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter
-                }"
-                (click)="onClickChapter(chapter)"
-              >
-                {{ chapter }}
-              </button>
+              @if (data.input?.book === selection.book && getNumOrNaN(data.input?.chapterNum) === +chapter) {
+                <button mat-flat-button (click)="onClickChapter(chapter)">{{ chapter }}</button>
+              } @else {
+                <button mat-button (click)="onClickChapter(chapter)">{{ chapter }}</button>
+              }
             }
           </div>
         </div>
@@ -74,18 +62,15 @@
           <div mat-dialog-content>
             <div class="reference">{{ getBookName(selection.book) }} {{ selection.chapter }}</div>
             @for (verse of versesOf(selection.book, selection.chapter); track verse) {
-              <button
-                mat-button
-                [ngClass]="{
-                  'mat-flat-button':
-                    data.input?.book === selection.book &&
-                    data.input?.chapter === selection.chapter &&
-                    getNumOrNaN(data.input?.verseNum) === +verse
-                }"
-                (click)="onClickVerse(verse)"
-              >
-                {{ verse }}
-              </button>
+              @if (
+                data.input?.book === selection.book &&
+                data.input?.chapter === selection.chapter &&
+                getNumOrNaN(data.input?.verseNum) === +verse
+              ) {
+                <button mat-flat-button (click)="onClickVerse(verse)">{{ verse }}</button>
+              } @else {
+                <button mat-button (click)="onClickVerse(verse)">{{ verse }}</button>
+              }
             }
           </div>
         </div>
@@ -109,18 +94,15 @@
               verse of versesOf(data.rangeStart?.book, data.rangeStart?.chapter, data.rangeStart?.verseNum);
               track verse
             ) {
-              <button
-                mat-button
-                [ngClass]="{
-                  'mat-flat-button':
-                    data.input?.book === data.rangeStart?.book &&
-                    data.input?.chapter === data.rangeStart?.chapter &&
-                    getNumOrNaN(data.input?.verseNum) === +verse
-                }"
-                (click)="onClickVerse(verse)"
-              >
-                {{ verse }}
-              </button>
+              @if (
+                data.input?.book === data.rangeStart?.book &&
+                data.input?.chapter === data.rangeStart?.chapter &&
+                getNumOrNaN(data.input?.verseNum) === +verse
+              ) {
+                <button mat-flat-button (click)="onClickVerse(verse)">{{ verse }}</button>
+              } @else {
+                <button mat-button (click)="onClickVerse(verse)">{{ verse }}</button>
+              }
             }
           </div>
         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.scss
@@ -2,8 +2,10 @@
   padding: 1em;
 }
 
-.upperBookSet {
-  padding-bottom: 1em;
+[mat-dialog-content] {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
 }
 
 .dialog-container {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.spec.ts
@@ -518,7 +518,7 @@ describe('ScriptureChooserDialog', () => {
     }
 
     get highlightedButton(): DebugElement {
-      return this.fixture.debugElement.query(By.css('.mat-flat-button'));
+      return this.fixture.debugElement.query(By.css('[mat-flat-button]'));
     }
 
     click(element: DebugElement): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/scripture-chooser-dialog/scripture-chooser-dialog.component.ts
@@ -34,6 +34,7 @@ export class ScriptureChooserDialogComponent implements OnInit {
   showing: 'books' | 'chapters' | 'verses' | 'rangeEnd' = 'books';
   otBooks: string[] = [];
   ntBooks: string[] = [];
+  dcBooks: string[] = [];
   chapters: number[] = [];
   verses: number[] = [];
   closeFocuses: number = 0;
@@ -59,10 +60,13 @@ export class ScriptureChooserDialogComponent implements OnInit {
     const books = Object.keys(this.data.booksAndChaptersToShow);
     this.otBooks = books
       .filter(book => Canon.isBookOT(book))
-      .sort((a, b) => this.data.booksAndChaptersToShow[a].bookNum - this.data.booksAndChaptersToShow[b].bookNum);
+      .sort((a, b) => Canon.bookIdToNumber(a) - Canon.bookIdToNumber(b));
     this.ntBooks = books
-      .filter(book => !Canon.isBookOT(book))
-      .sort((a, b) => this.data.booksAndChaptersToShow[a].bookNum - this.data.booksAndChaptersToShow[b].bookNum);
+      .filter(book => Canon.isBookNT(book))
+      .sort((a, b) => Canon.bookIdToNumber(a) - Canon.bookIdToNumber(b));
+    this.dcBooks = books
+      .filter(book => Canon.isBookDC(book))
+      .sort((a, b) => Canon.bookIdToNumber(a) - Canon.bookIdToNumber(b));
 
     if (this.data.rangeStart != null) {
       const rangeStart = this.data.rangeStart;


### PR DESCRIPTION
- DC moved to its own section
- Highlight of active book fixed (it probably got lost during a Material upgrade)

Before | After
-------|------
<img width="560" height="827" alt="localhost_5000_projects_68ba1617261a7ce57dd1bf62_checking_GEN_1_scope=chapter (1)" src="https://github.com/user-attachments/assets/64bc55ac-ba7d-42ae-836f-3259366e4182" /> | <img width="560" height="841" alt="localhost_5000_projects_68ba1617261a7ce57dd1bf62_checking_GEN_1_scope=chapter" src="https://github.com/user-attachments/assets/affe48b4-2922-4008-b471-9ae7e0796e82" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3446)
<!-- Reviewable:end -->
