### PR TITLE
SF-3573 Exclude blank line tags from segment count

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -43,7 +43,7 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, Range> {
   static readonly COLLECTION = TEXTS_COLLECTION;
   static readonly INDEX_PATHS = TEXT_INDEX_PATHS;
 
-  private readonly blank_tags = ['ie_', '/b_'];
+  private readonly blank_tags = ['ib_', 'ie_', 'imte_', '/b_'];
 
   constructor(
     protected readonly realtimeService: RealtimeService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/models/text-doc.ts
@@ -43,6 +43,8 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, Range> {
   static readonly COLLECTION = TEXTS_COLLECTION;
   static readonly INDEX_PATHS = TEXT_INDEX_PATHS;
 
+  private readonly blank_tags = ['ie_', '/b_'];
+
   constructor(
     protected readonly realtimeService: RealtimeService,
     public readonly adapter: RealtimeDocAdapter
@@ -60,7 +62,7 @@ export class TextDoc extends RealtimeDoc<TextData, TextData, Range> {
         const nextOp = i < this.data.ops.length - 1 ? this.data.ops[i + 1] : undefined;
         if (op.attributes != null && op.attributes.segment != null) {
           const segRef: string = op.attributes.segment as string;
-          if ((op.insert as any).blank != null) {
+          if ((op.insert as any).blank != null && !this.blank_tags.some(t => segRef.includes(t))) {
             if (
               nextOp == null ||
               nextOp.insert == null ||


### PR DESCRIPTION
Our segment count logic counts poetry break verse tag /b and chapter intro tag /ie as untranslated segments, which messes up the count on the Translate Overview. This should fix the issue for those tags, but there may be other tags that need to be ignored, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3451)
<!-- Reviewable:end -->
