### PR TITLE
SF-3527 Hide empty books from draft translate step

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -52,7 +52,7 @@
             data-test-id="draft-stepper-translate-books"
           ></app-book-multi-select>
         }
-        @if (unusableTranslateSourceBooks.length) {
+        @if (unusableTranslateSourceBooks.length > 0 || emptyTranslateSourceBooks.length > 0) {
           <app-notice icon="info" mode="basic" type="light" class="unusable-translate-books">
             <div class="notice-container">
               <span
@@ -61,15 +61,22 @@
                 [innerHtml]="
                   !expandUnusableTranslateBooks
                     ? i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_show_why', {
-                        numBooks: unusableTranslateSourceBooks.length
+                        numBooks: unusableTranslateSourceBooks.length + emptyTranslateSourceBooks.length
                       })
                     : i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_hide_explanation', {
-                        numBooks: unusableTranslateSourceBooks.length
+                        numBooks: unusableTranslateSourceBooks.length + emptyTranslateSourceBooks.length
                       })
                 "
               >
               </span>
               @if (expandUnusableTranslateBooks) {
+                <h4 class="explanation">
+                  <transloco
+                    key="draft_generation_steps.these_source_books_are_blank"
+                    [params]="{ draftingSourceProjectName }"
+                  ></transloco>
+                </h4>
+                <span class="book-names">{{ bookNames(emptyTranslateSourceBooks) }}</span>
                 <h4 class="explanation">
                   <transloco
                     key="draft_generation_steps.these_source_books_cannot_be_used_for_translating"

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -263,6 +263,7 @@
     "summary_training": "A language model will be created using the following example translations:",
     "summary_translate_title": "Drafting from [b]{{ draftingSourceProjectName }}[/b]",
     "summary_translate": "The language model will then translate these books:",
+    "these_source_books_are_blank": "The following books cannot be translated as they are blank in the drafting source text ({{ draftingSourceProjectName }}).",
     "these_source_books_cannot_be_used_for_training": "The following books cannot be used for training as they are not in the training source text ({{ firstTrainingSource }}).",
     "these_source_books_cannot_be_used_for_translating": "The following books cannot be translated as they are not in the drafting source text ({{ draftingSourceProjectName }}).",
     "training_books_will_appear": "Training books will appear as you select books under translated books",


### PR DESCRIPTION
Empty source books selected for translation will result in an empty translation from Serval. This is not necessarily a problem, but we can improve the UX by hiding the empty source books so that they will not be selected by the user. The reason the book is selected was added to the panel for unusable translation books.

<img width="1391" height="574" alt="Empty book translation step" src="https://github.com/user-attachments/assets/b8ab5c83-4a3d-48b7-9496-f386acfa6dd8" />
