### PR TITLE
SF-3560 Fix permissions check for lynx to include role

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1370,6 +1370,7 @@ describe('EditorComponent', () => {
       expect(element.classList).not.toContain('highlight-segment');
 
       env.setCurrentUser('user01');
+      env.component['targetEditorLoaded$'].next(); // Trigger 'canEdit' check
       env.wait();
       element = env.targetTextEditor.querySelector('usx-segment[data-segment="verse_1_1"]')!;
       expect(element.classList).toContain('highlight-segment');


### PR DESCRIPTION
This PR fixes an issue where changing a user role to observer was not disabling lynx in the editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3453)
<!-- Reviewable:end -->
