### PR TITLE
SF-3561 Fix lynx autocomplete error when nav to book with no first chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
@@ -401,6 +401,12 @@ export class LynxWorkspaceService {
             bookChapter?.chapter
           );
 
+    // 'textDocId' will be undefined if bookChapter has no chapter specified.
+    // This can happen when navigating to a book that doesn't have a first chapter.
+    if (textDocId == null) {
+      return;
+    }
+
     const { assessmentsEnabled, autoCorrectionsEnabled } = this.getLynxSettings(
       this.activatedProjectService.projectDoc
     );


### PR DESCRIPTION
This PR adds a null check to the `LynxWorkspaceService` to handle cases where a book/chapter may not have a defined chapter, which can happen when navigating to a book with no first chapter.

Also added a test case to for the fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3457)
<!-- Reviewable:end -->
