### PR TITLE
SF-3584 Fix mat badge size for unread answers on community checking page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/_checking-questions-theme.scss
@@ -6,6 +6,8 @@
   --sf-community-checking-badge-background-color: #{mat.get-theme-color($theme, tertiary, if($is-dark, 60, 20))};
   --sf-community-checking-badge-text-color: #{mat.get-theme-color($theme, primary, 98)};
   --sf-community-checking-badge-text-size: 9px;
+  --sf-community-checking-badge-container-size: 16px;
+  --sf-community-checking-badge-line-height: 16px;
   --sf-community-checking-question-list-hover-background: #{mat.get-theme-color($theme, primary, if($is-dark, 10, 95))};
   --sf-community-checking-question-list-selected-background: #{mat.get-theme-color(
       $theme,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.scss
@@ -57,7 +57,9 @@ mat-icon {
   .mat-mdc-list-item {
     --mat-badge-background-color: var(--sf-community-checking-badge-background-color);
     --mat-badge-text-color: var(--sf-community-checking-badge-text-color);
+    --mat-badge-small-size-container-size: var(--sf-community-checking-badge-container-size);
     --mat-badge-small-size-text-size: var(--sf-community-checking-badge-text-size);
+    --mat-badge-small-size-line-height: var(--sf-community-checking-badge-line-height);
 
     cursor: pointer;
     height: auto;


### PR DESCRIPTION
This PR fixes a UI bug that was tracked down to PR #3338.

Before

<img width="427" height="293" alt="mat badge before size" src="https://github.com/user-attachments/assets/27e369fe-ddd0-40e2-af65-4a38ff9ee157" />

After

<img width="543" height="312" alt="mat badge after size" src="https://github.com/user-attachments/assets/6f2dde88-5fc7-4735-8f24-172dee8c1e35" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3459)
<!-- Reviewable:end -->
