### PR TITLE
SF-3574 Show guide to formatting options only on completed builds

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -21,7 +21,7 @@
         </mat-panel-description>
       </mat-expansion-panel-header>
       <div class="draft-entry-body">
-        @if (this.featureFlags.usfmFormat.enabled && !formattingOptionsSelected && isLatestBuild) {
+        @if (this.featureFlags.usfmFormat.enabled && !formattingOptionsSelected && isLatestBuild && draftIsAvailable) {
           <p class="require-formatting-options">
             {{ t("select_formatting_options") }}
           </p>
@@ -42,7 +42,7 @@
             }
           </div>
         } @else {
-          @if (canDownloadBuild) {
+          @if (draftIsAvailable) {
             <p>{{ t("click_book_to_preview") }}</p>
             <p class="book-buttons">
               <app-draft-preview-books [build]="entry" />
@@ -85,7 +85,7 @@
             </p>
           }
           @if (hasTrainingConfiguration || hasTrainingDataFiles) {
-            @if (canDownloadBuild) {
+            @if (draftIsAvailable) {
               <p>
                 <a
                   href="javascript:;"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -64,8 +64,8 @@ export class DraftHistoryEntryComponent {
     this._entry = value;
 
     // Only set if a draft can be downloaded if it is not set externally
-    if (this._canDownloadBuild == null) {
-      this.canDownloadBuild = this._entry?.additionalInfo?.dateGenerated != null;
+    if (this._draftIsAvailable == null) {
+      this.draftIsAvailable = this._entry?.additionalInfo?.dateGenerated != null;
     }
 
     // Get the user who requested the build
@@ -114,7 +114,7 @@ export class DraftHistoryEntryComponent {
       this._trainingConfiguration = trainingConfiguration;
 
       // If we can only show training data, expand the training configuration
-      if (!this.canDownloadBuild && this.hasTrainingConfiguration) {
+      if (!this.draftIsAvailable && this.hasTrainingConfiguration) {
         this.trainingConfigurationOpen = true;
       }
     });
@@ -219,7 +219,7 @@ export class DraftHistoryEntryComponent {
   }
 
   get hasDetails(): boolean {
-    return this.hasTrainingConfiguration || this.canDownloadBuild || this.buildFaulted;
+    return this.hasTrainingConfiguration || this.draftIsAvailable || this.buildFaulted;
   }
 
   get hasTrainingConfiguration(): boolean {
@@ -250,12 +250,12 @@ export class DraftHistoryEntryComponent {
     return this._trainingDataFiles.length > 0;
   }
 
-  private _canDownloadBuild: boolean | undefined;
-  @Input() set canDownloadBuild(value: boolean) {
-    this._canDownloadBuild = value;
+  private _draftIsAvailable: boolean | undefined;
+  @Input() set draftIsAvailable(value: boolean) {
+    this._draftIsAvailable = value;
   }
-  get canDownloadBuild(): boolean {
-    return this._canDownloadBuild ?? false;
+  get draftIsAvailable(): boolean {
+    return this._draftIsAvailable ?? false;
   }
 
   private _scriptureRange?: string = undefined;
@@ -271,6 +271,10 @@ export class DraftHistoryEntryComponent {
 
   get formattingOptionsSelected(): boolean {
     return this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig != null;
+  }
+
+  get buildStateIsCompleted(): boolean {
+    return this._entry?.state === BuildStates.Completed;
   }
 
   @Input() isLatestBuild: boolean = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.html
@@ -4,7 +4,7 @@
     <app-draft-history-entry
       [entry]="latestBuild"
       [isLatestBuild]="true"
-      [canDownloadBuild]="latestBuildHasCompleted"
+      [draftIsAvailable]="latestBuildHasCompleted"
     />
   }
 


### PR DESCRIPTION
The PR guides the user to format their draft if the project does not have formatting selected, but only in cases where the draft is completed and is available. If the draft was cancelled or faulted, then the default behaviour is used to show the details of the draft.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3460)
<!-- Reviewable:end -->
