### PR TITLE
SF-3580 Update tooltip for translator settings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -34,7 +34,7 @@
               type="button"
               id="settings-btn"
               (click)="openTranslatorSettings()"
-              [matTooltip]="t('configure_translation_suggestions')"
+              [matTooltip]="t('configure_translator_settings')"
             >
               <mat-icon>settings</mat-icon>
             </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -386,7 +386,7 @@
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
     "cannot_edit_chapter_unsupported_usfm": "This chapter cannot be edited because it contains unsupported USFM. To edit, remove these tags in Paratext: {{ tags }}",
     "cannot_edit_note_paratext": "You cannot edit this note as it has been edited in Paratext.",
-    "configure_translation_suggestions": "Configure translation suggestions",
+    "configure_translator_settings": "Configure translator settings",
     "more_info": "More Info...",
     "more_notes": "--- {{ count }} more note(s) ---",
     "navigate_to_a_valid_text": "Navigate to a valid text to insert a note",


### PR DESCRIPTION
The icon for translator settings for the editor had an incorrect tooltip. This replaces the tooltip to reflect the new lynx insights.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3461)
<!-- Reviewable:end -->
