### PR TITLE
Fix GHA failures caused dpkg finding no .NET packages installed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,7 +56,6 @@ jobs:
           lsb_release -a
           which dotnet
           dotnet --version
-          dpkg -l dotnet\*
           dotnet --list-sdks
           dotnet --list-runtimes
           which node
@@ -169,7 +168,6 @@ jobs:
           lsb_release -a
           which dotnet
           dotnet --version
-          dpkg -l dotnet\*
           dotnet --list-sdks
           dotnet --list-runtimes
           which node

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -217,7 +217,6 @@ jobs:
           lsb_release -a
           which dotnet
           dotnet --version
-          dpkg -l dotnet\*
           dotnet --list-sdks
           dotnet --list-runtimes
       - name: "Deps: Backend nuget"
@@ -411,7 +410,6 @@ jobs:
           lsb_release -a
           which dotnet
           dotnet --version
-          dpkg -l dotnet\*
           dotnet --list-sdks
           dotnet --list-runtimes
           which node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,6 @@ jobs:
           lsb_release -a
           which dotnet
           dotnet --version
-          dpkg -l dotnet\*
           dotnet --list-sdks
           dotnet --list-runtimes
           which node


### PR DESCRIPTION
This line has started failing because while `dotnet --version` finds .NET, `dpkg` can't find .NET installed as a package (likely the image installs it via a different method).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3465)
<!-- Reviewable:end -->
