### PR TITLE
SF-3569 Fix Draft Format alignment when the user cannot edit the chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -83,12 +83,13 @@
                 }
               </button>
             </span>
-          } @else {
-            <app-notice icon="warning" type="warning" mode="fill-dark">
-              {{ "editor_draft_tab.cannot_import" | transloco }}
-            </app-notice>
           }
         </div>
+        @if (!canApplyDraft) {
+          <app-notice icon="warning" type="warning" mode="fill-dark">
+            {{ "editor_draft_tab.cannot_import" | transloco }}
+          </app-notice>
+        }
       </div>
     }
   } @else {


### PR DESCRIPTION
Putting the notice banner on its own line is the sensible solution here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3468)
<!-- Reviewable:end -->
