### PR TITLE
SF-3579 Fix lynx autocorrect not working after note embed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -594,6 +594,10 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
     return this.addEmbeddedElementsToDelta(dataDelta);
   }
 
+  getEmbedCountsToOffsetFunc(): (offset: number) => number {
+    return (offset: number) => this.getEmbedsInEditorRange(0, offset);
+  }
+
   private countSequentialEmbedsStartingAt(startEditorPosition: number): number {
     const embedEditorPositions = this.embedPositions;
     // add up the leading embeds

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-editor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-editor.ts
@@ -3,6 +3,7 @@ import Quill, { Delta, Op, Range } from 'quill';
 import { QuillLynxEditorAdapter } from './quill-services/quill-lynx-editor-adapter';
 
 export type LynxableEditor = Quill; // Add future editor as union type
+export type LynxCountToOffsetFunc = (offset: number) => number;
 
 export interface LynxEditor {
   getEditor(): LynxableEditor;
@@ -36,6 +37,13 @@ export interface LynxTextModelConverter {
    * @returns The corresponding editor model delta.
    */
   dataDeltaToEditorDelta(dataDelta: Delta): Delta;
+
+  /**
+   * Gets a function that takes an offset in the data model and returns
+   * the number of embeds preceding that offset in the editor model.
+   * Useful when embeds that are present only in the editor model may affect position offsets from Lynx.
+   */
+  getEmbedCountsToOffsetFunc(): LynxCountToOffsetFunc;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
@@ -262,7 +262,7 @@ describe('LynxInsightEditorObjectsComponent', () => {
       const delta = new Delta([{ insert: 'test' }]);
       const editDelta = new Delta([{ insert: 'edited' }]);
 
-      when(mockLynxWorkspaceService.getOnTypeEdits(anything())).thenResolve([editDelta]);
+      when(mockLynxWorkspaceService.getOnTypeEdits(anything(), anything())).thenResolve([editDelta]);
       when(mockTextModelConverter.dataDeltaToEditorDelta(anything())).thenReturn(editDelta);
 
       env.setEditorReady(true);
@@ -272,7 +272,7 @@ describe('LynxInsightEditorObjectsComponent', () => {
       tick(); // Process text change event
       flush();
 
-      verify(mockLynxWorkspaceService.getOnTypeEdits(delta)).once();
+      verify(mockLynxWorkspaceService.getOnTypeEdits(delta, anything())).once();
       expect(env.hostComponent.editor!.updateContents).toHaveBeenCalledWith(editDelta, 'user');
     }));
   });
@@ -434,7 +434,7 @@ class TestEnvironment {
     when(mockInsightRenderService.removeAllInsightFormatting(anything())).thenResolve();
     when(mockOverlayService.close()).thenResolve();
     when(mockOverlayService.isOpen).thenReturn(false);
-    when(mockLynxWorkspaceService.getOnTypeEdits(anything())).thenResolve([]);
+    when(mockLynxWorkspaceService.getOnTypeEdits(anything(), anything())).thenResolve([]);
     when(mockTextModelConverter.dataDeltaToEditorDelta(anything())).thenCall((delta: Delta) => delta);
 
     // Setup text model converter to return ranges as-is (prevents null range issues)

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
@@ -86,7 +86,7 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
       )
       .subscribe(([delta]) => {
         if (this.autoCorrectionsEnabled) {
-          this.handleTextChange(delta);
+          void this.handleTextChange(delta);
         }
       });
 
@@ -287,7 +287,10 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
       return;
     }
 
-    const edits = await this.lynxWorkspaceService.getOnTypeEdits(delta);
+    const edits: Delta[] = await this.lynxWorkspaceService.getOnTypeEdits(
+      delta,
+      this.lynxTextModelConverter.getEmbedCountsToOffsetFunc()
+    );
     for (const edit of edits) {
       this.editor.updateContents(this.lynxTextModelConverter.dataDeltaToEditorDelta(edit), 'user');
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
@@ -56,6 +56,8 @@ export class LynxWorkspaceService {
   private projectDocChangeSubscription?: Subscription;
   private readonly curInsightsByEventUriAndSource = new Map<string, Map<string, LynxInsight[]>>();
   private curInsightsFlattened: LynxInsight[] = [];
+  private onTypeEditsSequence = 0;
+  private onTypeEditsActiveDelta?: Delta;
 
   // Emits when workspace is recreated when project settings change
   private rawInsightSourceSubject$ = new BehaviorSubject<Observable<LynxInsight[]> | null>(null);
@@ -174,42 +176,75 @@ export class LynxWorkspaceService {
     if (curDocUri == null) {
       return [];
     }
-    const ops: Op[] = delta.ops;
-    let offset: number;
-    let text: string;
-    if (ops.length === 1 && typeof ops[0].insert === 'string') {
-      offset = 0;
-      text = ops[0].insert;
-    } else if (ops.length === 2 && typeof ops[0].retain === 'number' && typeof ops[1].insert === 'string') {
-      offset = ops[0].retain;
-      text = ops[1].insert;
-    } else {
-      return [];
-    }
 
-    const doc: ScriptureDeltaDocument | undefined = await this.documentManager.get(curDocUri);
-    if (doc == null) {
-      return [];
-    }
-    const edits: Delta[] = [];
-    for (const ch of this.workspace.getOnTypeTriggerCharacters()) {
-      let startIndex: number = 0;
-      while (startIndex < text.length) {
-        const chIndex: number = text.indexOf(ch, startIndex);
-        if (chIndex >= 0) {
-          const position = doc.positionAt(offset + chIndex + 1);
-          const chEdits: Op[] | undefined = await this.workspace.getOnTypeEdits(curDocUri, position, ch);
+    // Increment sequence number for this call
+    const currentSequence = ++this.onTypeEditsSequence;
+    let isAborted = false;
 
-          if (chEdits != null && chEdits.length > 0) {
-            edits.push(new Delta(chEdits));
-          }
-          startIndex = chIndex + ch.length;
-        } else {
+    // Compose with any existing active delta
+    this.onTypeEditsActiveDelta = this.onTypeEditsActiveDelta?.compose(delta) ?? delta;
+
+    try {
+      const ops: Op[] = this.onTypeEditsActiveDelta.ops;
+      let offset: number = 0;
+      let text: string = '';
+
+      for (let i = 0; i < ops.length; i++) {
+        if (typeof ops[i].insert === 'string') {
+          text = ops[i].insert as string;
           break;
+        } else if (typeof ops[i].retain === 'number') {
+          offset += ops[i].retain as number;
+          continue;
+        } else {
+          return [];
         }
       }
+
+      const doc: ScriptureDeltaDocument | undefined = await this.documentManager.get(curDocUri);
+
+      // 'offset' may be stale here. For example, a blank embed may have been auto-deleted while awaiting the doc.
+      // Check if a newer call has superseded this one while we were awaiting the document.
+      if (currentSequence !== this.onTypeEditsSequence) {
+        isAborted = true;
+        return []; // Abort - a newer call is handling this
+      }
+
+      if (doc == null) {
+        return [];
+      }
+
+      const edits: Delta[] = [];
+      for (const ch of this.workspace.getOnTypeTriggerCharacters()) {
+        let startIndex: number = 0;
+        while (startIndex < text.length) {
+          const chIndex: number = text.indexOf(ch, startIndex);
+          if (chIndex >= 0) {
+            const position = doc.positionAt(offset + chIndex + 1);
+            const chEdits: Op[] | undefined = await this.workspace.getOnTypeEdits(curDocUri, position, ch);
+
+            // Check sequence number again after each async operation
+            if (currentSequence !== this.onTypeEditsSequence) {
+              isAborted = true;
+              return []; // Abort - a newer call is handling this
+            }
+
+            if (chEdits != null && chEdits.length > 0) {
+              edits.push(new Delta(chEdits));
+            }
+            startIndex = chIndex + ch.length;
+          } else {
+            break;
+          }
+        }
+      }
+      return edits;
+    } finally {
+      // Clear active delta if this call finished without aborting
+      if (!isAborted) {
+        this.onTypeEditsActiveDelta = undefined;
+      }
     }
-    return edits;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-workspace.service.ts
@@ -6,6 +6,7 @@ import {
   DocumentData,
   DocumentManager,
   DocumentReader,
+  Position,
   Workspace
 } from '@sillsdev/lynx';
 import { ScriptureDeltaDocument } from '@sillsdev/lynx-delta';
@@ -40,6 +41,7 @@ import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../../../core/models/text-doc';
 import { SFProjectService } from '../../../../core/sf-project.service';
+import { LynxCountToOffsetFunc } from './lynx-editor';
 import { LynxInsight, LynxInsightAction } from './lynx-insight';
 import { LynxWorkspaceFactory } from './lynx-workspace-factory.service';
 
@@ -160,7 +162,7 @@ export class LynxWorkspaceService {
     }));
   }
 
-  async getOnTypeEdits(delta: Delta): Promise<Delta[]> {
+  async getOnTypeEdits(delta: Delta, embedCountsToOffset: LynxCountToOffsetFunc): Promise<Delta[]> {
     if (this.workspace == null) {
       return [];
     }
@@ -220,7 +222,8 @@ export class LynxWorkspaceService {
         while (startIndex < text.length) {
           const chIndex: number = text.indexOf(ch, startIndex);
           if (chIndex >= 0) {
-            const position = doc.positionAt(offset + chIndex + 1);
+            const adjustedOffset: number = offset + chIndex + 1 - embedCountsToOffset(offset);
+            const position: Position = doc.positionAt(adjustedOffset);
             const chEdits: Op[] | undefined = await this.workspace.getOnTypeEdits(curDocUri, position, ch);
 
             // Check sequence number again after each async operation


### PR DESCRIPTION
This PR fixes an issue where note embeds were causing lynx lib position calculations to be incorrect, as lynx lib uses the delta from the DB doc, not the editor delta which may contain note embeds.

The fix involves adjusting the offset used by lynx lib, subtracting the number of preceding note embeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3470)
<!-- Reviewable:end -->
