### PR TITLE
SF-3587 Fix lingering lynx action prompt when changing book/chapter

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
@@ -15,6 +15,7 @@ import {
   tap
 } from 'rxjs';
 import { distinctUntilChanged, map, observeOn, scan } from 'rxjs/operators';
+import { ActivatedBookChapterService } from 'xforge-common/activated-book-chapter.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { EditorReadyService } from '../base-services/editor-ready.service';
 import { InsightRenderService } from '../base-services/insight-render.service';
@@ -50,6 +51,7 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
     private readonly editorReadyService: EditorReadyService,
     private readonly overlayService: LynxInsightOverlayService,
     private readonly lynxWorkspaceService: LynxWorkspaceService,
+    private readonly activatedBookChapterService: ActivatedBookChapterService,
     @Inject(DOCUMENT) private readonly document: Document
   ) {}
 
@@ -108,6 +110,14 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
         if (this.insightsEnabled) {
           this.handleMouseOver(event.target as HTMLElement);
         }
+      });
+
+    this.activatedBookChapterService.activatedBookChapter$
+      .pipe(quietTakeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        // Clear display state when changing chapters.
+        // This happens before active insights are assigned from the problems panel.
+        this.insightState.clearDisplayState();
       });
 
     this.editorReadyService


### PR DESCRIPTION
This PR fixes an issue where the lynx action prompt was not clearing when changing book/chapter.  The fix is to clear the insight display state on book/chapter change.  This clearing will happen before active insights are assigned from the problems panel on insight nav.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3472)
<!-- Reviewable:end -->
