### PR TITLE
SF-3565 Fix error when opening a note in a Lynx insight

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-formats/quill-blots.ts
@@ -313,6 +313,12 @@ export class NoteThreadEmbed extends QuillEmbedBlot {
     };
   }
 
+  appendChild(_child: Node): void {
+    // An embed cannot have children. As such, we will just ignore this request.
+    // This function can be called by wrap() if the embed is inside an inline of block,
+    // and this embed is having a format applied to it (i.e. 'highlight' in EditorComponent).
+  }
+
   format(name: string, value: any): void {
     if (name === NoteThreadEmbed.blotName && value != null) {
       const ref = value as NoteThread;


### PR DESCRIPTION
This fixes a race condition on editor load where in some circumstances Lynx insights were inserted before the notes were added, resulting in an inability for notes to be reformatted (i.e. the removing of the highlight state) when they were enclosed by a lynx insight.

As notes are embed blots, not inline or block blots, they should not contain an inline blot. However, as the note thread may still end up being wrapped by a lynx insight's inline embed if a note is inserted within its bounds either by sync or user action, I implemented a default `appendChild` function for the note thread embed blot, which will quietly drop the event (as the embed blot cannot render an inline blot inside it anyway).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3473)
<!-- Reviewable:end -->
