### PR TITLE
SF-3556 Wait for finishing build to complete before showing draft

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -273,10 +273,6 @@ export class DraftHistoryEntryComponent {
     return this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig != null;
   }
 
-  get buildStateIsCompleted(): boolean {
-    return this._entry?.state === BuildStates.Completed;
-  }
-
   @Input() isLatestBuild: boolean = false;
   trainingConfigurationOpen = false;
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -38,6 +38,7 @@ import { isString } from '../../../../type-utils';
 import { TextDocId } from '../../../core/models/text-doc';
 import { Revision } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { BuildStates } from '../../../machine-api/build-states';
 import { TextComponent } from '../../../shared/text/text.component';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { DraftHandlingService } from '../../draft-generation/draft-handling.service';
@@ -144,12 +145,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   populateDraftTextInit(): void {
     combineLatest([
       this.onlineStatusService.onlineStatus$,
+      this.draftGenerationService.pollBuildProgress(this.textDocId!.projectId),
       this.draftText.editorCreated as EventEmitter<any>,
       this.inputChanged$.pipe(startWith(undefined))
     ])
       .pipe(
         quietTakeUntilDestroyed(this.destroyRef),
-        filter(([isOnline]) => isOnline),
+        filter(([isOnline, build]) => isOnline && build != null && build.state !== BuildStates.Finishing),
         tap(() => this.setInitialState()),
         switchMap(() =>
           combineLatest([

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -95,6 +95,8 @@ import { PermissionsService } from '../../core/permissions.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
+import { BuildDto } from '../../machine-api/build-dto';
+import { BuildStates } from '../../machine-api/build-states';
 import { HttpClient } from '../../machine-api/http-client';
 import { RemoteTranslationEngine } from '../../machine-api/remote-translation-engine';
 import { CopyrightBannerComponent } from '../../shared/copyright-banner/copyright-banner.component';
@@ -4864,6 +4866,9 @@ class TestEnvironment {
     });
     when(mockedDraftGenerationService.getLastCompletedBuild(anything())).thenReturn(of({} as any));
     when(mockedDraftGenerationService.getGeneratedDraft(anything(), anything(), anything())).thenReturn(of({}));
+    when(mockedDraftGenerationService.pollBuildProgress(anything())).thenReturn(
+      of({ state: BuildStates.Completed } as BuildDto)
+    );
     when(
       mockedDraftGenerationService.getGeneratedDraftDeltaOperations(
         anything(),

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -2298,12 +2298,12 @@ public class MachineApiService(
             .FirstOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime > timestamp)
             ?.AdditionalInfo?.DateRequested;
 
-        // If not, then if there is a build that was requested before the timestamp
-        time ??= builds
-            .LastOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime < timestamp)
-            ?.AdditionalInfo?.DateRequested;
+        // If not, search for a build that comes before the timestamp and use the current time if the build exists
+        time ??= builds.LastOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime < timestamp) is not null
+            ? DateTime.UtcNow
+            : null;
 
-        // Return the timestamp, or the time of the draft that immediate follows the intended draft.
+        // Return the latest time to access a draft, or the original timestamp is none is found
         return time?.UtcDateTime ?? timestamp;
     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1423,9 +1423,6 @@ public class MachineApiService(
         CancellationToken cancellationToken
     )
     {
-        // Set up the list of revisions to be returned
-        List<DocumentRevision> revisions = [];
-
         // Ensure that the user has permission
         await EnsureProjectPermissionAsync(curUserId, sfProjectId, isServalAdmin, cancellationToken);
 
@@ -1436,32 +1433,19 @@ public class MachineApiService(
             isServalAdmin,
             cancellationToken
         );
-        ServalBuildDto[] buildsForBook =
+        builds = FilterBuildsByBook(builds, bookNum);
+
+        // Set up the list of revisions to be returned
+        List<DocumentRevision> revisions =
         [
-            .. builds.Where(b =>
-                b.State == BuildStateCompleted
-                && (
-                    b.AdditionalInfo?.TranslationScriptureRanges.Any(r =>
-                        r.ScriptureRange.Contains(Canon.BookNumberToId(bookNum))
-                    ) ?? false
-                )
-            ),
-        ];
-
-        foreach (ServalBuildDto build in buildsForBook)
-        {
-            DateTimeOffset? date = build.AdditionalInfo.DateFinished;
-            if (date is null)
-                continue;
-
-            revisions.Add(
-                new DocumentRevision
+            .. builds
+                .Where(b => b.AdditionalInfo?.DateFinished is not null)
+                .Select(build => new DocumentRevision
                 {
                     Source = OpSource.Draft,
-                    Timestamp = build.AdditionalInfo.DateFinished?.UtcDateTime ?? DateTime.UtcNow,
-                }
-            );
-        }
+                    Timestamp = build.AdditionalInfo?.DateFinished?.UtcDateTime ?? DateTime.UtcNow,
+                }),
+        ];
 
         // Display the revisions in descending order to match the history API endpoint
         revisions.Reverse();
@@ -2286,29 +2270,40 @@ public class MachineApiService(
             isServalAdmin,
             cancellationToken
         );
+        builds = FilterBuildsByBook(builds, bookNum);
 
-        // TODO: What if the TranslationScriptureRange is in the form EXO-DEU?
-        ServalBuildDto[] buildsWithBook =
+        DateTimeOffset? time = builds
+            .FirstOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime > timestamp)
+            ?.AdditionalInfo?.DateRequested;
+
+        time ??= builds
+            .LastOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime < timestamp)
+            ?.AdditionalInfo?.DateRequested;
+        // Return the timestamp, or the time of the draft that immediate follows the intended draft.
+        return time?.UtcDateTime ?? timestamp;
+    }
+
+    /// <summary>
+    /// Filters a list of builds to only those that contain the specified book number in their translation scripture ranges.
+    /// </summary>
+    /// <param name="builds">The builds.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <returns>The builds containing the specified book.</returns>
+    private static IReadOnlyList<ServalBuildDto> FilterBuildsByBook(IReadOnlyList<ServalBuildDto> builds, int bookNum)
+    {
+        // As we are only parsing books, we do not need to set the versification
+        ScriptureRangeParser scriptureRangeParser = new ScriptureRangeParser();
+        return
         [
             .. builds.Where(b =>
                 b.State == BuildStateCompleted
                 && (
                     b.AdditionalInfo?.TranslationScriptureRanges.Any(r =>
-                        r.ScriptureRange.Contains(Canon.BookNumberToId(bookNum))
+                        scriptureRangeParser.GetChapters(r.ScriptureRange).ContainsKey(Canon.BookNumberToId(bookNum))
                     ) ?? false
                 )
             ),
         ];
-
-        DateTimeOffset? time = buildsWithBook
-            .FirstOrDefault(b => b.AdditionalInfo?.DateRequested > timestamp)
-            ?.AdditionalInfo?.DateRequested;
-
-        time ??= buildsWithBook
-            .LastOrDefault(b => b.AdditionalInfo?.DateRequested < timestamp)
-            ?.AdditionalInfo?.DateRequested;
-        // Return the timestamp, or the time of the draft that immediate follows the intended draft.
-        return time is not null ? time.Value.UtcDateTime : timestamp;
     }
 
     /// <summary>

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -88,7 +88,7 @@ public class MachineApiService(
     /// The Completed build state.
     /// </summary>
     /// <remarks>
-    /// SF returns this state when the build is completed.
+    /// Serval returns this state when the build is completed.
     /// </remarks>
     internal const string BuildStateCompleted = "COMPLETED";
 
@@ -844,7 +844,17 @@ public class MachineApiService(
         return buildDto;
     }
 
-    public async Task<IReadOnlyList<ServalBuildDto>> GetBuildsAsync(
+    /// <summary>
+    /// Gets the builds for the specified project.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="preTranslate">If <c>true</c>, return NMT builds only; otherwise, return SMT builds.</param>
+    /// <param name="isServalAdmin">If <c>true</c>, the current user is a Serval Administrator.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The builds.</returns>
+    /// <remarks>This function is virtual to allow mocking in unit tests.</remarks>
+    public virtual async Task<IReadOnlyList<ServalBuildDto>> GetBuildsAsync(
         string curUserId,
         string sfProjectId,
         bool preTranslate,
@@ -1526,7 +1536,7 @@ public class MachineApiService(
         await using IConnection connection = await realtimeService.ConnectAsync(userId);
         string id = TextDocument.GetDocId(sfProjectId, bookNum, chapterNum, TextDocument.Draft);
 
-        DateTime latestTimestampForRevision = await LatestTimestampForRevision(
+        DateTime latestTimestampForRevision = await LatestTimestampForRevisionAsync(
             curUserId,
             sfProjectId,
             bookNum,
@@ -2254,7 +2264,18 @@ public class MachineApiService(
         return translationEngineId;
     }
 
-    private async Task<DateTime> LatestTimestampForRevision(
+    /// <summary>
+    /// Retrieves the latest timestamp for the revision corresponding to the specified timestamp.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="isServalAdmin">If <c>true</c>, the current user is a Serval Administrator.</param>
+    /// <param name="timestamp">The timestamp to retrieve the timestamp of the closest revision for.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The timestamp of the draft that immediate follows the intended draft revision.</returns>
+    /// <remarks>This function is internal so it can be unit tests.</remarks>
+    internal async Task<DateTime> LatestTimestampForRevisionAsync(
         string curUserId,
         string sfProjectId,
         int bookNum,
@@ -2272,13 +2293,16 @@ public class MachineApiService(
         );
         builds = FilterBuildsByBook(builds, bookNum);
 
+        // See if there is a build that was requested after the timestamp
         DateTimeOffset? time = builds
             .FirstOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime > timestamp)
             ?.AdditionalInfo?.DateRequested;
 
+        // If not, then if there is a build that was requested before the timestamp
         time ??= builds
             .LastOrDefault(b => b.AdditionalInfo?.DateRequested?.UtcDateTime < timestamp)
             ?.AdditionalInfo?.DateRequested;
+
         // Return the timestamp, or the time of the draft that immediate follows the intended draft.
         return time?.UtcDateTime ?? timestamp;
     }
@@ -2455,9 +2479,9 @@ public class MachineApiService(
     /// Ensures that the user has permission to access Serval and the project.
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
-    /// <param name="sfProjectId"></param>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <param name="isServalAdmin">If <c>true</c>, the current user is a Serval Administrator.</param>
-    /// <param name="cancellationToken">The cancellatioon token.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The project.</returns>
     /// <exception cref="DataNotFoundException">The project does not exist.</exception>
     /// <exception cref="ForbiddenException">

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -3619,7 +3619,7 @@ public class MachineApiServiceTests
             timestamp,
             CancellationToken.None
         );
-        Assert.AreEqual(actual, buildRequested);
+        Assert.GreaterOrEqual(actual, timestamp);
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -2399,7 +2399,6 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        string textDocumentId = TextDocument.GetDocId(Project01, 2, 1, TextDocument.Draft);
         env.SetupEventMetrics("EXO", "GEN", DateTime.UtcNow.AddMinutes(-30));
         string[] buildIds = [Build01, Build02];
         env.TranslationEnginesClient.GetAllBuildsAsync(Arg.Any<string>(), CancellationToken.None)
@@ -2453,7 +2452,6 @@ public class MachineApiServiceTests
     {
         // Set up test environment
         var env = new TestEnvironment();
-        string textDocumentId = TextDocument.GetDocId(Project01, 2, 1, TextDocument.Draft);
         env.SetupEventMetrics("EXO", "GEN", DateTime.UtcNow.AddMinutes(-30));
         string[] buildIds = [Build01, Build02];
         env.TranslationEnginesClient.GetAllBuildsAsync(Arg.Any<string>(), CancellationToken.None)


### PR DESCRIPTION
This PR updates the revision system. TextDocuments are saved that correspond to the most recent version of a draft. However, anytime a new format is introduced, a new version of the document is saved. So we cannot depend on the timestamp to help get the correct version. I introduced logic to use the most recent version of a document that comes before the next build. That ensures we get the right version of the document for an earlier draft.

There is still some clean up (like chapter number not being used). There are probably more tests that can be written too. But it is ready for review.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3479)
<!-- Reviewable:end -->
