### PR TITLE
SF-3592 Hide option to configure draft for outdated builds

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.html
@@ -49,7 +49,7 @@
             </p>
             <div class="draft-options">
               <app-draft-download-button [build]="entry" [flat]="true" />
-              @if (featureFlags.usfmFormat.enabled && isLatestBuild) {
+              @if (featureFlags.usfmFormat.enabled && formattingOptionsPossible && isLatestBuild) {
                 <button mat-button class="format-usfm" [routerLink]="['format']">
                   <mat-icon>build</mat-icon> {{ t("formatting_options") }}
                 </button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -99,7 +99,7 @@ describe('DraftHistoryEntryComponent', () => {
     it('should handle builds with additional info', fakeAsync(() => {
       when(mockedI18nService.enumerateList(anything())).thenReturn('src');
       const user = 'user-display-name';
-      const date = 'formatted-date';
+      const date = new Date().toISOString();
       const trainingBooks = ['EXO'];
       const translateBooks = ['GEN'];
       const trainingDataFiles: Map<string, string> = new Map([['file01', 'training-data.txt']]);
@@ -142,7 +142,7 @@ describe('DraftHistoryEntryComponent', () => {
     it('should state that the model did not have training configuration', fakeAsync(() => {
       when(mockedI18nService.enumerateList(anything())).thenReturn('src');
       const user = 'user-display-name';
-      const date = 'formatted-date';
+      const date = new Date().toISOString();
       const trainingBooks = [];
       const translateBooks = ['GEN'];
       const trainingDataFiles = [];
@@ -159,7 +159,7 @@ describe('DraftHistoryEntryComponent', () => {
 
     it('should show the USFM format option when the project is the latest draft', fakeAsync(() => {
       const user = 'user-display-name';
-      const date = 'formatted-date';
+      const date = new Date().toISOString();
       const trainingBooks = ['EXO'];
       const translateBooks = ['GEN'];
       const trainingDataFiles = ['file01'];
@@ -241,6 +241,7 @@ describe('DraftHistoryEntryComponent', () => {
         additionalInfo: {
           dateGenerated: new Date().toISOString(),
           dateRequested: new Date().toISOString(),
+          dateFinished: new Date().toISOString(),
           requestedByUserId: 'sf-user-id',
           translationScriptureRanges: [{ projectId: 'project01', scriptureRange: 'GEN' }]
         }
@@ -334,11 +335,13 @@ describe('DraftHistoryEntryComponent', () => {
     });
 
     it('should show set draft format UI', fakeAsync(() => {
+      const date = new Date().toISOString();
+      when(mockedI18nService.formatDate(anything())).thenReturn('formatted-date');
       component.entry = {
         id: 'build01',
         state: BuildStates.Completed,
         message: 'Completed',
-        additionalInfo: { dateGenerated: '2025-09-01' }
+        additionalInfo: { dateGenerated: date, dateFinished: date }
       } as BuildDto;
       component.isLatestBuild = true;
       component.draftIsAvailable = true;
@@ -389,6 +392,25 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('.require-formatting-options')).toBeNull();
+    }));
+
+    it('should not show the USFM format option before a specified date', fakeAsync(() => {
+      const user = 'user-display-name';
+      const date = '2025-09-01T12:00:00.000Z';
+      const trainingBooks = ['EXO'];
+      const translateBooks = ['GEN'];
+      const trainingDataFiles = ['file01'];
+      const entry = getStandardBuildDto({ user, date, trainingBooks, translateBooks, trainingDataFiles });
+
+      // SUT
+      component.entry = entry;
+      component.isLatestBuild = true;
+      tick();
+      fixture.detectChanges();
+
+      expect(component.scriptureRange).toEqual('Genesis');
+      expect(component.draftIsAvailable).toBe(true);
+      expect(fixture.nativeElement.querySelector('.format-usfm')).toBeNull();
     }));
   });
 
@@ -451,8 +473,9 @@ describe('DraftHistoryEntryComponent', () => {
         id: 'project01'
       },
       additionalInfo: {
-        dateGenerated: new Date().toISOString(),
-        dateRequested: new Date().toISOString(),
+        dateGenerated: new Date(date).toISOString(),
+        dateFinished: new Date(date).toISOString(),
+        dateRequested: new Date(date).toISOString(),
         requestedByUserId: 'sf-user-id',
         trainingScriptureRanges:
           trainingBooks.length > 0 ? [{ projectId: 'project02', scriptureRange: trainingBooks.join(';') }] : [],

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -19,6 +19,7 @@ import { BuildStates } from '../../../../machine-api/build-states';
 import { RIGHT_TO_LEFT_MARK } from '../../../../shared/utils';
 import { DraftDownloadButtonComponent } from '../../draft-download-button/draft-download-button.component';
 import { DraftPreviewBooksComponent } from '../../draft-preview-books/draft-preview-books.component';
+import { FORMATTING_OPTIONS_RELEASE_DATE } from '../../draft-utils';
 import { TrainingDataService } from '../../training-data/training-data.service';
 
 const STATUS_INFO: Record<BuildStates, { icons: string; text: string; color: string }> = {
@@ -270,11 +271,16 @@ export class DraftHistoryEntryComponent {
   }
 
   get formattingOptionsSelected(): boolean {
-    return this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig != null;
+    return (
+      !this.formattingOptionsPossible ||
+      this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig != null
+    );
   }
 
-  get buildStateIsCompleted(): boolean {
-    return this._entry?.state === BuildStates.Completed;
+  get formattingOptionsPossible(): boolean {
+    return this.entry?.additionalInfo?.dateFinished != null
+      ? new Date(this.entry.additionalInfo.dateFinished) > FORMATTING_OPTIONS_RELEASE_DATE
+      : false;
   }
 
   @Input() isLatestBuild: boolean = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-utils.ts
@@ -3,6 +3,9 @@ import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/t
 import language_code_mapping from '../../../../../language_code_mapping.json';
 import { SelectableProjectWithLanguageCode } from '../../core/paratext.service';
 
+// Corresponds to Serval 1.11.0 release
+export const FORMATTING_OPTIONS_RELEASE_DATE: Date = new Date('2025-09-25T00:00:00Z');
+
 /** Represents draft sources as a set of two {@link TranslateSource} arrays, and one {@link SFProjectProfile} array. */
 export interface DraftSourcesAsTranslateSourceArrays {
   trainingSources: TranslateSource[];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -52,10 +52,14 @@
               </button>
             } @else {
               <span
-                [matTooltip]="t(doesLatestHaveDraft ? 'format_draft_can' : 'format_draft_cannot')"
-                [style.cursor]="doesLatestHaveDraft ? 'pointer' : 'not-allowed'"
+                [matTooltip]="formatOptionsMessage"
+                [style.cursor]="doesLatestHaveDraft && formattingOptionsPossible ? 'pointer' : 'not-allowed'"
               >
-                <button mat-button (click)="navigateToFormatting()" [disabled]="!doesLatestHaveDraft">
+                <button
+                  mat-button
+                  (click)="navigateToFormatting()"
+                  [disabled]="!formattingOptionsPossible || !doesLatestHaveDraft"
+                >
                   <mat-icon>build</mat-icon>
                   <transloco class="hide-lt-md" key="editor_draft_tab.format_draft"></transloco>
                   <transloco class="hide-gt-md" key="editor_draft_tab.formatting"></transloco>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -386,7 +386,7 @@ describe('EditorDraftComponent', () => {
       flush();
     }));
 
-    it('should guide user to select formatting options when formatting not selected', fakeAsync(() => {
+    it('should not guide user to select formatting options before specified date', fakeAsync(() => {
       const testProjectDoc: SFProjectProfileDoc = {
         data: createTestProjectProfile({
           texts: [
@@ -400,6 +400,35 @@ describe('EditorDraftComponent', () => {
       when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
       when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
         of(draftHistory)
+      );
+      when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
+      when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
+      spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
+      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
+      when(mockDraftHandlingService.draftDataToOps(anything(), anything())).thenReturn(draftDelta.ops!);
+
+      fixture.detectChanges();
+      tick(EDITOR_READY_TIMEOUT);
+
+      expect(component.mustChooseFormattingOptions).toBe(false);
+      flush();
+    }));
+
+    it('should guide user to select formatting options when formatting not selected', fakeAsync(() => {
+      const testProjectDoc: SFProjectProfileDoc = {
+        data: createTestProjectProfile({
+          texts: [
+            {
+              bookNum: 1,
+              chapters: [{ number: 1, permissions: { user01: SFProjectRole.ParatextAdministrator }, hasDraft: true }]
+            }
+          ]
+        })
+      } as SFProjectProfileDoc;
+      when(mockDraftGenerationService.draftExists(anything(), anything(), anything())).thenReturn(of(true));
+      const historyAfterFormattingOptions: Revision[] = [{ timestamp: '2025-10-01T12:00:00.000Z' }];
+      when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
+        of(historyAfterFormattingOptions)
       );
       when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
       when(mockDialogService.confirm(anything(), anything())).thenResolve(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -415,6 +415,7 @@
     "format_draft_before": "Select formatting options before adding it to your project.",
     "format_draft_can": "Customize formatting options for the draft",
     "format_draft_cannot": "You can only change formatting for books from the latest draft",
+    "format_draft_outdated_draft": "This draft is outdated and formatting options cannot be applied",
     "no_draft_notice": "{{ bookChapterName }} has no draft.",
     "offline_notice": "Generated drafts are not available offline.",
     "overwrite": "Adding the draft will overwrite the current chapter. Are you sure you want to continue?",


### PR DESCRIPTION
This PR hides the option for formatting drafts when the latest draft is finished before serval 1.11.0 was released. On the editor tabs, the options to format drafts is disabled and a message can be seen as a hint. On the draft generation page, the option for formatting is not visible on the latest draft if the draft was finished before the cutoff date.

<img width="886" height="519" alt="Formatting options outdated" src="https://github.com/user-attachments/assets/46ab32cc-47e7-4202-8f5c-8250463b369e" />
