### PR TITLE
Handle floating promises

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -120,7 +120,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       // Check authentication when coming back online
       // This is also run on first load when the websocket connects for the first time
       if (status && !this.isAppLoading) {
-        this.authService.checkOnlineAuth();
+        void this.authService.checkOnlineAuth();
       }
     });
 
@@ -280,7 +280,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         if (this._selectedProjectDoc == null || !this._selectedProjectDoc.isLoaded) {
           return;
         }
-        this.userService.setCurrentProjectId(this.currentUserDoc!, this._selectedProjectDoc.id);
+        void this.userService.setCurrentProjectId(this.currentUserDoc!, this._selectedProjectDoc.id);
         this.projectUserConfigDoc = await this.projectService.getUserConfig(
           this._selectedProjectDoc.id,
           this.currentUserDoc!.id
@@ -292,7 +292,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
           // handle remotely deleted project
           const userDoc = this.currentUserDoc;
           if (userDoc != null && this.userService.currentProjectId(userDoc) != null) {
-            this.showProjectDeletedDialog();
+            void this.showProjectDeletedDialog();
           }
         });
 
@@ -312,8 +312,8 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
             // See if the user was removed from the project
             if (!(this.currentUserDoc.id in this._selectedProjectDoc.data.userRoles)) {
               // The user has been removed from the project
-              this.showProjectDeletedDialog();
-              this.projectService.localDelete(this._selectedProjectDoc.id);
+              void this.showProjectDeletedDialog();
+              void this.projectService.localDelete(this._selectedProjectDoc.id);
             }
 
             if (this.projectUserConfigDoc != null) {
@@ -349,31 +349,31 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   setLocale(locale: string): void {
     this.i18n.setLocale(locale);
-    this.authService.updateInterfaceLanguage(locale);
+    void this.authService.updateInterfaceLanguage(locale);
   }
 
   changePassword(): void {
     if (this.currentUser == null) {
       return;
     } else if (!this.isAppOnline) {
-      this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
+      void this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
     } else {
-      this.authService
+      void this.authService
         .changePassword(this.currentUser.email)
         .then(() => {
-          this.noticeService.show(this.i18n.translateStatic('app.password_reset_email_sent'));
+          void this.noticeService.show(this.i18n.translateStatic('app.password_reset_email_sent'));
         })
         .catch(() => {
-          this.dialogService.message('app.cannot_change_password');
+          void this.dialogService.message('app.cannot_change_password');
         });
     }
   }
 
   editName(): void {
     if (this.isAppOnline) {
-      this.userService.editDisplayName(false);
+      void this.userService.editDisplayName(false);
     } else {
-      this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
+      void this.noticeService.show(this.i18n.translateStatic('app.action_not_available_offline'));
     }
   }
 
@@ -394,11 +394,11 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   }
 
   installOnDevice(): void {
-    this.pwaService.install();
+    void this.pwaService.install();
   }
 
   logOut(): void {
-    this.authService.logOut();
+    void this.authService.logOut();
   }
 
   collapseDrawer(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/chapter-audio-dialog/chapter-audio-dialog.component.ts
@@ -243,7 +243,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
       this.processUploadedFiles(e.dataTransfer.files);
     });
 
-    this.projectService.queryAudioText(this.data.projectId, this.destroyRef).then(query => {
+    void this.projectService.queryAudioText(this.data.projectId, this.destroyRef).then(query => {
       this.textAudioQuery = query;
       this.populateExistingData();
     });
@@ -327,7 +327,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
     // if the upload fails, we need to show an error and not close the dialog
     this._loadingAudio = false;
     if (audioUrl == null) {
-      this.dialogService.message('chapter_audio_dialog.upload_failed');
+      void this.dialogService.message('chapter_audio_dialog.upload_failed');
       return;
     }
 
@@ -517,7 +517,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
         }
         this._editState = true;
         this.timing = this.timing_processed = doc.timings;
-        this.fileService
+        void this.fileService
           .findOrUpdateCache(FileType.Audio, TextAudioDoc.COLLECTION, textAudioId, doc.audioUrl)
           .then(data => {
             if (data == null) {
@@ -530,7 +530,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
               fileName: this.i18n.localizeBook(this.data.currentBook!) + ' ' + this.data.currentChapter,
               status: 'uploaded'
             };
-            this.audioUpdate(audioAttachment);
+            void this.audioUpdate(audioAttachment);
           });
       });
   }
@@ -559,7 +559,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
       }
       const isTimingFile: boolean = TIMING_FILE_EXTENSION_REGEX.test(file.name);
       if (isTimingFile) {
-        this.prepareTimingFileUpload(file);
+        void this.prepareTimingFileUpload(file);
       } else {
         // if file is larger than 100MB, show an error
         if (file.size > 100_000_000) {
@@ -574,7 +574,7 @@ export class ChapterAudioDialogComponent implements AfterViewInit, OnDestroy {
           status: 'uploaded'
         };
 
-        this.audioUpdate(audioAttachment);
+        void this.audioUpdate(audioAttachment);
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -333,7 +333,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
   }
 
   setQuestionArchiveStatus(questionDoc: QuestionDoc, archiveStatus: boolean): void {
-    questionDoc.submitJson0Op(op => {
+    void questionDoc.submitJson0Op(op => {
       op.set(q => q.isArchived, archiveStatus);
       if (archiveStatus) {
         op.set(q => q.dateArchived!, new Date().toJSON());

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-answers.component.ts
@@ -169,14 +169,14 @@ export class CheckingAnswersComponent implements OnInit {
     if (questionDoc == null) {
       return;
     }
-    this.updateQuestionDocAudioUrls();
+    void this.updateQuestionDocAudioUrls();
     if (this.questionChangeSubscription != null) {
       this.questionChangeSubscription!.unsubscribe();
     }
     this.questionChangeSubscription = questionDoc.remoteChanges$
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(ops => {
-        this.updateQuestionDocAudioUrls();
+        void this.updateQuestionDocAudioUrls();
         // If the user hasn't added an answer yet and is able to, then
         // don't hold back any incoming answers from appearing right away
         // as soon as the user adds their answer.
@@ -367,7 +367,7 @@ export class CheckingAnswersComponent implements OnInit {
     };
     const dialogResponseDoc: QuestionDoc | undefined = await this.questionDialogService.questionDialog(data);
     if (dialogResponseDoc?.data != null) {
-      this.updateQuestionDocAudioUrls();
+      void this.updateQuestionDocAudioUrls();
       this.action.emit({ action: 'edit', questionDoc: dialogResponseDoc });
     }
   }
@@ -396,7 +396,7 @@ export class CheckingAnswersComponent implements OnInit {
         result.audio.fileName
       );
       if (urlResult != null) {
-        this.questionDoc.submitJson0Op(op => op.set(q => q.audioUrl, urlResult));
+        void this.questionDoc.submitJson0Op(op => op.set(q => q.audioUrl, urlResult));
       }
     }
   }
@@ -454,9 +454,9 @@ export class CheckingAnswersComponent implements OnInit {
         answer
       });
     } else if (likeAnswerResponse === LikeAnswerResponse.DeniedOwnAnswer) {
-      this.noticeService.show(this.i18n.translateStatic('checking_answers.cannot_like_own_answer'));
+      void this.noticeService.show(this.i18n.translateStatic('checking_answers.cannot_like_own_answer'));
     } else if (likeAnswerResponse === LikeAnswerResponse.DeniedNoPermission) {
-      this.noticeService.show(this.i18n.translateStatic('checking_answers.no_permission_to_like'));
+      void this.noticeService.show(this.i18n.translateStatic('checking_answers.no_permission_to_like'));
     }
   }
 
@@ -548,9 +548,9 @@ export class CheckingAnswersComponent implements OnInit {
     if (this.questionDoc?.data == null) {
       return;
     }
-    this.cacheFileSource(this.questionDoc, this.questionDoc.data.dataId, this.questionDoc.data.audioUrl);
+    void this.cacheFileSource(this.questionDoc, this.questionDoc.data.dataId, this.questionDoc.data.audioUrl);
     for (const answer of this.questionDoc.getAnswers()) {
-      this.cacheFileSource(this.questionDoc, answer.dataId, answer.audioUrl);
+      void this.cacheFileSource(this.questionDoc, answer.dataId, answer.audioUrl);
     }
   }
 
@@ -590,7 +590,7 @@ export class CheckingAnswersComponent implements OnInit {
         this.hideAnswerForm();
         this.submittingAnswer = false;
         this.justEditedAnswer = true;
-        this.updateQuestionDocAudioUrls();
+        void this.updateQuestionDocAudioUrls();
       }
     });
   }
@@ -599,7 +599,7 @@ export class CheckingAnswersComponent implements OnInit {
     if (this.projectId == null) {
       return;
     }
-    this.projectService.isProjectAdmin(this.projectId, this.userService.currentUserId).then(isProjectAdmin => {
+    void this.projectService.isProjectAdmin(this.projectId, this.userService.currentUserId).then(isProjectAdmin => {
       this.isProjectAdmin = isProjectAdmin;
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-answers/checking-comments/checking-comments.component.ts
@@ -169,7 +169,7 @@ export class CheckingCommentsComponent extends SubscriptionDisposable implements
           }
         }
         if (commentIdsToMarkRead.length) {
-          this.projectUserConfigDoc.submitJson0Op(op => {
+          void this.projectUserConfigDoc.submitJson0Op(op => {
             for (const commentId of commentIdsToMarkRead) {
               op.add(puc => puc.commentRefsRead, commentId);
             }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-questions/checking-questions.component.ts
@@ -86,7 +86,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
       });
     this.setProjectAdmin();
 
-    this.questionsService
+    void this.questionsService
       .queryFirstUnansweredQuestion(projectProfileDoc.id, this.userService.currentUserId, this.destroyRef)
       .then(query => {
         this._firstUnansweredQuestion = query;
@@ -325,7 +325,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
       return;
     }
 
-    this._projectUserConfigDoc
+    void this._projectUserConfigDoc
       .submitJson0Op(op => {
         if (questionDoc != null && questionDoc.data != null && !this.hasUserReadQuestion(questionDoc)) {
           op.add(puc => puc.questionRefsRead, questionDoc.data.dataId);
@@ -406,7 +406,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     this.activeQuestionDoc = questionDoc;
 
     if (verseRef != null) {
-      this.storeMostRecentQuestion().then(() => {
+      void this.storeMostRecentQuestion().then(() => {
         // Only emit if not a filter to avoid duplicate emission, as an emit from filter is called elsewhere
         if (!actionSource?.isQuestionListChange) {
           this.changed.emit({ questionDoc, actionSource, clearFilter });
@@ -459,7 +459,7 @@ export class CheckingQuestionsComponent implements OnInit, OnChanges {
     if (this.projectId == null) {
       return;
     }
-    this.projectService.isProjectAdmin(this.projectId, this.userService.currentUserId).then(isProjectAdmin => {
+    void this.projectService.isProjectAdmin(this.projectId, this.userService.currentUserId).then(isProjectAdmin => {
       this.isProjectAdmin = isProjectAdmin;
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking-scripture-audio-player/checking-scripture-audio-player.component.ts
@@ -201,7 +201,7 @@ export class CheckingScriptureAudioPlayerComponent implements AfterViewInit {
     if (this.audioPlayer == null) return;
     this._audioIsAvailable = false;
     // wait until the next microtask cycle to get the audio player with the updated source
-    Promise.resolve(this.audioPlayer).then(audioPlayer => {
+    void Promise.resolve(this.audioPlayer).then(audioPlayer => {
       this.audioSubscription?.unsubscribe();
       this.audioSubscription = audioPlayer.isAudioAvailable$
         .pipe(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -80,7 +80,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     if (newValue !== undefined) {
       // If we are automatically showing the Scripture audio player because hide-text is enabled, don't auto-play.
       if (this.hideChapterText) return;
-      Promise.resolve(null).then(() => this._scriptureAudioPlayer?.play());
+      void Promise.resolve(null).then(() => this._scriptureAudioPlayer?.play());
     }
   }
   @ViewChild('questionsPanel') questionsPanel?: ElementRef;
@@ -627,7 +627,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
             }
 
             // TODO (scripture audio) Only fetch the timing data for the currently active chapter
-            this.projectService.queryAudioText(routeProjectId, this.destroyRef).then(query => {
+            void this.projectService.queryAudioText(routeProjectId, this.destroyRef).then(query => {
               this.textAudioQuery = query;
               this.audioChangedSub = merge(this.textAudioQuery.remoteChanges$, this.textAudioQuery.localChanges$)
                 .pipe(quietTakeUntilDestroyed(this.destroyRef))
@@ -649,7 +649,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
                 }
 
                 if (this.onlineStatusService.isOnline) {
-                  qd.updateFileCache();
+                  void qd.updateFileCache();
                 }
               });
 
@@ -927,7 +927,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
         break;
       case 'show-comments':
         if (this.projectUserConfigDoc != null) {
-          this.projectUserConfigDoc.submitJson0Op(op => {
+          void this.projectUserConfigDoc.submitJson0Op(op => {
             if (commentAction.answer != null) {
               for (const comm of commentAction.answer.comments.filter(comment => !comment.deleted)) {
                 if (!this.questionsList!.hasUserReadComment(comm)) {
@@ -993,7 +993,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       this.refreshSummary();
 
       if (this.onlineStatusService.isOnline) {
-        questionDoc.updateAnswerFileCache();
+        void questionDoc.updateAnswerFileCache();
       }
       if (!this.hideChapterText && !(actionSource?.isQuestionListChange ?? false)) {
         this.toggleAudio(true);
@@ -1288,13 +1288,13 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     }
     const answerIndex = this.getAnswerIndex(answer);
     if (answerIndex >= 0) {
-      activeQuestionDoc
+      void activeQuestionDoc
         .submitJson0Op(op => {
           op.set(q => q.answers[answerIndex].deleted, true);
         })
         .then(() => {
           if (this.projectDoc != null) {
-            activeQuestionDoc.deleteFile(FileType.Audio, answer.dataId, answer.ownerRef);
+            void activeQuestionDoc.deleteFile(FileType.Audio, answer.dataId, answer.ownerRef);
           }
         });
       this.refreshSummary();
@@ -1347,14 +1347,14 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
           .set(q => q.answers[answerIndex].dateModified, newAnswer.dateModified)
       );
       if (deleteAudio) {
-        submitPromise.then(() => {
+        void submitPromise.then(() => {
           if (this.projectDoc != null) {
-            questionDoc.deleteFile(FileType.Audio, oldAnswer.dataId, oldAnswer.ownerRef);
+            void questionDoc.deleteFile(FileType.Audio, oldAnswer.dataId, oldAnswer.ownerRef);
           }
         });
       }
     } else {
-      questionDoc.submitJson0Op(op => op.insert(q => q.answers, 0, answers[0]));
+      void questionDoc.submitJson0Op(op => op.insert(q => q.answers, 0, answers[0]));
     }
 
     this.questionsList.updateElementsRead(questionDoc);
@@ -1381,10 +1381,12 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
           .set(q => q.answers[answerIndex].comments[commentIndex].dateModified, comment.dateModified)
       );
       if (deleteAudio) {
-        submitPromise.then(() => activeQuestionDoc.deleteFile(FileType.Audio, comment.dataId, comment.ownerRef));
+        void submitPromise.then(
+          () => void activeQuestionDoc.deleteFile(FileType.Audio, comment.dataId, comment.ownerRef)
+        );
       }
     } else {
-      activeQuestionDoc.submitJson0Op(op => op.insert(q => q.answers[answerIndex].comments, 0, comment));
+      void activeQuestionDoc.submitJson0Op(op => op.insert(q => q.answers[answerIndex].comments, 0, comment));
     }
   }
 
@@ -1400,9 +1402,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     const answerIndex = this.getAnswerIndex(answer);
     const commentIndex = answer.comments.findIndex(c => c.dataId === comment.dataId);
     if (commentIndex >= 0) {
-      activeQuestionDoc
+      void activeQuestionDoc
         .submitJson0Op(op => op.set(q => q.answers[answerIndex].comments[commentIndex].deleted, true))
-        .then(() => activeQuestionDoc.deleteFile(FileType.Audio, comment.dataId, comment.ownerRef));
+        .then(() => void activeQuestionDoc.deleteFile(FileType.Audio, comment.dataId, comment.ownerRef));
     }
   }
 
@@ -1420,9 +1422,9 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     const answerIndex = this.getAnswerIndex(answer);
 
     if (likeIndex >= 0) {
-      activeQuestionDoc.submitJson0Op(op => op.remove(q => q.answers[answerIndex].likes, likeIndex));
+      void activeQuestionDoc.submitJson0Op(op => op.remove(q => q.answers[answerIndex].likes, likeIndex));
     } else {
-      activeQuestionDoc.submitJson0Op(op =>
+      void activeQuestionDoc.submitJson0Op(op =>
         op.insert(q => q.answers[answerIndex].likes, 0, {
           ownerRef: currentUserId
         })
@@ -1675,7 +1677,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
       }
     }
 
-    this.router.navigate(['projects', projectId, 'checking', ...bookChapterPathTokens], {
+    void this.router.navigate(['projects', projectId, 'checking', ...bookChapterPathTokens], {
       ...navigationExtras,
       queryParams: { scope: scope },
       queryParamsHandling: 'merge'
@@ -1683,7 +1685,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
   }
 
   private navigateScope(scope: QuestionScope, navigationExtras?: NavigationBehaviorOptions | undefined): void {
-    this.router.navigate([], {
+    void this.router.navigate([], {
       ...navigationExtras,
       relativeTo: this.activatedRoute,
       queryParams: { scope },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/import-questions-dialog/import-questions-dialog.component.ts
@@ -221,7 +221,7 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.promiseForQuestionDocQuery.then(query => query.dispose());
+    void this.promiseForQuestionDocQuery.then(query => query.dispose());
   }
 
   dialogScroll(): void {
@@ -295,7 +295,7 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
   checkboxChanged(listItem: DialogListItem): void {
     this.updateSelectAllCheckbox();
     if (listItem.checked) {
-      this.confirmEditsIfNecessary([listItem]);
+      void this.confirmEditsIfNecessary([listItem]);
     }
   }
 
@@ -307,7 +307,7 @@ export class ImportQuestionsDialogComponent implements OnDestroy {
       }
       listItem.checked = selectAllChecked;
     }
-    this.confirmEditsIfNecessary(editsToConfirm);
+    void this.confirmEditsIfNecessary(editsToConfirm);
   }
 
   updateSelectAllCheckbox(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/question-dialog/question-dialog.service.ts
@@ -44,7 +44,7 @@ export class QuestionDialogService {
       return questionDoc;
     }
     if (!(await this.canCreateAndEditQuestions(config.projectId))) {
-      this.noticeService.show(this.transloco.translate('question_dialog.add_question_denied'));
+      void this.noticeService.show(this.transloco.translate('question_dialog.add_question_denied'));
       return undefined;
     }
     const questionId = questionDoc != null && questionDoc.data != null ? questionDoc.data.dataId : objectId();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -110,7 +110,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
   ngOnInit(): void {
     this.state = 'input';
     if (this.ptProjectId === '') {
-      this.router.navigate(['/projects']);
+      void this.router.navigate(['/projects']);
     }
 
     this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
@@ -159,7 +159,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       err.message = this.translocoService.translate('connect_project.problem_already_connected');
       this.errorHandler.handleError(err);
       this.state = 'input';
-      this.populateProjectList();
+      void this.populateProjectList();
       return;
     }
     this.projectDoc = await this.projectService.get(projectId);
@@ -167,7 +167,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
 
   updateStatus(inProgress: boolean): void {
     if (!inProgress && this.projectDoc != null) {
-      this.router.navigate(['/projects', this.projectDoc.id]);
+      void this.router.navigate(['/projects', this.projectDoc.id]);
     }
   }
 
@@ -179,7 +179,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
       const projects: ParatextProject[] | undefined = (await this.paratextService.getProjects()) ?? [];
       this.projectsFromParatext = projects.sort(compareProjectsForSorting);
       // do not wait for resources to load
-      this.fetchResources();
+      void this.fetchResources();
     } catch (error: any) {
       if (error instanceof HttpErrorResponse && error.status === 401) {
         this.authService.requestParatextCredentialUpdate(() => this.router.navigate(['/projects']));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -66,7 +66,7 @@ export class ParatextService {
   ) {}
 
   linkParatext(returnUrl: string): void {
-    this.authService.linkParatext(returnUrl);
+    void this.authService.linkParatext(returnUrl);
   }
 
   getParatextUsername(): Observable<string | undefined> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -79,7 +79,7 @@ export class JoinComponent extends DataLoadingComponent {
       if (this.authService.currentUserId == null) {
         this.i18nService.setLocale(joining.locale);
       }
-      this.initialize(joining.shareKey);
+      void this.initialize(joining.shareKey);
     });
     this.onlineStatusService.onlineStatus$
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
@@ -135,7 +135,7 @@ export class JoinComponent extends DataLoadingComponent {
     if (this.status !== 'input') {
       return;
     }
-    this.authService.logIn({ returnUrl: this.locationService.pathname, signUp: false });
+    void this.authService.logIn({ returnUrl: this.locationService.pathname, signUp: false });
   }
 
   private async joinWithShareKey(shareKey: string): Promise<void> {
@@ -145,10 +145,10 @@ export class JoinComponent extends DataLoadingComponent {
       // If that fails the user will be redirected to auth0 to sign up
       await this.authService.isLoggedIn;
       const projectId = await this.projectService.onlineJoinWithShareKey(shareKey);
-      this.router.navigateByUrl(`/projects/${projectId}`, { replaceUrl: true });
+      void this.router.navigateByUrl(`/projects/${projectId}`, { replaceUrl: true });
     } catch (err) {
       await this.handleJoiningError(err);
-      this.router.navigateByUrl('/projects', { replaceUrl: true });
+      void this.router.navigateByUrl('/projects', { replaceUrl: true });
     }
   }
 
@@ -176,7 +176,7 @@ export class JoinComponent extends DataLoadingComponent {
       this.status = 'input';
     } else if (!this.onlineStatusService.isOnline && (await this.authService.isLoggedIn)) {
       await this.dialogService.message('join.please_connect_to_use_link');
-      this.router.navigateByUrl('/projects', { replaceUrl: true });
+      void this.router.navigateByUrl('/projects', { replaceUrl: true });
     } else {
       this.name.disable();
       this.status = 'unavailable';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -97,15 +97,15 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
       return this.createWordGraph(response.data as WordGraphDto);
     } catch (err: any) {
       if (err.status === 403 || err.status === 404 || err.status === 409) {
-        this.noticeService.showError(
+        void this.noticeService.showError(
           this.i18n.translateStatic('error_messages.suggestion_engine_requires_retrain'),
           this.i18n.translateStatic('error_messages.go_to_retrain'),
           () => {
-            this.router.navigate(['projects', this.projectId, 'translate']);
+            void this.router.navigate(['projects', this.projectId, 'translate']);
           }
         );
       } else {
-        this.noticeService.showError(this.i18n.translateStatic('error_messages.failed_to_retrieve_suggestions'));
+        void this.noticeService.showError(this.i18n.translateStatic('error_messages.failed_to_retrieve_suggestions'));
       }
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/my-projects/my-projects.component.ts
@@ -125,9 +125,9 @@ export class MyProjectsComponent implements OnInit {
       this.noticeService.loadingStarted(this.constructor.name);
       this.joiningProjects.push(projectId);
       await this.projectService.onlineAddCurrentUser(projectId);
-      this.router.navigate(['projects', projectId]);
+      void this.router.navigate(['projects', projectId]);
     } catch {
-      this.noticeService.show(this.i18n.translateStatic('my_projects.failed_to_join_project'));
+      void this.noticeService.show(this.i18n.translateStatic('my_projects.failed_to_join_project'));
     } finally {
       this.noticeService.loadingFinished(this.constructor.name);
       this.joiningProjects.pop();
@@ -138,11 +138,11 @@ export class MyProjectsComponent implements OnInit {
     try {
       this.noticeService.loadingStarted(this.constructor.name);
       await this.projectService.onlineSyncUserRole(projectId);
-      this.noticeService.show(this.i18n.translateStatic('my_projects.user_role_updated'));
+      void this.noticeService.show(this.i18n.translateStatic('my_projects.user_role_updated'));
       const project = this.userParatextProjects.find(project => project.projectId === projectId);
       if (project != null) project.hasUserRoleChanged = false;
     } catch {
-      this.noticeService.showError(this.i18n.translateStatic('my_projects.failed_to_update_user_role'));
+      void this.noticeService.showError(this.i18n.translateStatic('my_projects.failed_to_update_user_role'));
     } finally {
       this.noticeService.loadingFinished(this.constructor.name);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -39,7 +39,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     // Redirect old sharing links
     if ((this.route.snapshot.queryParams['sharing'] as string) === 'true') {
       const shareKey = this.route.snapshot.queryParams['shareKey'] as string;
-      this.router.navigateByUrl(`/join/${shareKey}`, { replaceUrl: true });
+      void this.router.navigateByUrl(`/join/${shareKey}`, { replaceUrl: true });
       return;
     }
     const projectId$ = this.route.params.pipe(
@@ -64,7 +64,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
 
     navigateToProject$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectId => {
       if (userDoc.data?.sites[environment.siteId].projects?.includes(projectId)) {
-        this.navigateToProject(projectId);
+        void this.navigateToProject(projectId);
       }
     });
   }
@@ -130,13 +130,13 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
       }
     }
 
-    this.router.navigate(routePath, { replaceUrl: true });
+    void this.router.navigate(routePath, { replaceUrl: true });
   }
 
   private async navigateToChecking(projectId: string, task: TaskType = 'checking'): Promise<void> {
     const defaultCheckingLink: string[] = ['/projects', projectId, task];
     const link = await lastValueFrom(this.resumeCheckingService.resumeLink$.pipe(first()));
 
-    this.router.navigate(link ?? defaultCheckingLink, { replaceUrl: true });
+    void this.router.navigate(link ?? defaultCheckingLink, { replaceUrl: true });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -195,7 +195,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
   }
 
   clearProjectFilter(): void {
-    this.router.navigate([], {
+    void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { projectId: null },
       queryParamsHandling: 'merge'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
@@ -36,7 +36,7 @@ export class ServalAdministrationComponent implements OnInit {
   onTabChange(index: number): void {
     this.selectedTabIndex = index;
 
-    this.router.navigate([], {
+    void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { tab: this.availableTabs[index] },
       queryParamsHandling: 'preserve'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -229,7 +229,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
     // If the blob is undefined, display an error
     if (blob == null) {
-      this.noticeService.showError('The project was never synced successfully and does not exist on disk.');
+      void this.noticeService.showError('The project was never synced successfully and does not exist on disk.');
       return;
     }
 
@@ -249,7 +249,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   }
 
   navigateToDraftJobs(): void {
-    this.router.navigate(['/serval-administration'], {
+    void this.router.navigate(['/serval-administration'], {
       queryParams: {
         projectId: this.activatedProjectService.projectId!,
         tab: 'draft-jobs'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -126,7 +126,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
   }
 
   viewDraftJobs(projectId: string): void {
-    this.router.navigate(['/serval-administration'], {
+    void this.router.navigate(['/serval-administration'], {
       queryParams: {
         projectId,
         tab: 'draft-jobs'

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -283,7 +283,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
         await this.userService.setCurrentProjectId(user, undefined);
         if (this.projectDoc != null) {
           await this.projectService.onlineDelete(this.projectDoc.id);
-          this.router.navigateByUrl('/projects', { replaceUrl: true });
+          void this.router.navigateByUrl('/projects', { replaceUrl: true });
         }
       }
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio-recorder-dialog/audio-recorder-dialog.component.ts
@@ -116,7 +116,7 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
   ngOnDestroy(): void {
     this.destroyed = true;
     if (this.isRecording) {
-      this.stopRecording();
+      void this.stopRecording();
     }
   }
 
@@ -233,9 +233,9 @@ export class AudioRecorderDialogComponent implements ControlValueAccessor, OnIni
     this.audio = { status: 'denied' };
 
     if (error.code === DOMException.NOT_FOUND_ERR) {
-      this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_not_found'));
+      void this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_not_found'));
     } else {
-      this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_access_denied'));
+      void this.noticeService.show(this.i18n.translateStatic('checking_audio_recorder.mic_access_denied'));
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/audio/audio-player.ts
@@ -150,7 +150,7 @@ export class AudioPlayer extends SubscriptionDisposable {
       this.audio.load();
     }
 
-    this.audio.play();
+    void this.audio.play();
     AudioPlayer.lastPlayedAudio = this.audio;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-multi-select/book-multi-select.component.ts
@@ -90,7 +90,7 @@ export class BookMultiSelectComponent implements OnChanges {
       .filter(n => n.selected)
       .map(n => ({ number: n.bookNum, selected: this.bookOptions[bookIndex].selected }));
     this.bookSelect.emit(this.selectedBooks.map(b => b.number));
-    this.initBookOptions();
+    void this.initBookOptions();
   }
 
   isBookInScope(bookNum: number, scope: Scope): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/page-not-found/page-not-found.component.ts
@@ -21,8 +21,8 @@ export class PageNotFoundComponent {
   );
 
   constructor(readonly router: Router) {
-    lastValueFrom(this.progress).then(() => {
-      this.router.navigateByUrl('/projects');
+    void lastValueFrom(this.progress).then(() => {
+      void this.router.navigateByUrl('/projects');
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.ts
@@ -207,13 +207,13 @@ export class ProgressService extends DataLoadingComponent implements OnDestroy {
         startWith(this.activatedProject.projectDoc),
         filterNullish(),
         tap(async project => {
-          this.initialize(project.id);
+          void this.initialize(project.id);
         }),
         throttleTime(1000, asyncScheduler, { leading: false, trailing: true }),
         quietTakeUntilDestroyed(this.destroyRef)
       )
       .subscribe(project => {
-        this.initialize(project.id);
+        void this.initialize(project.id);
       });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -142,7 +142,7 @@ export class CheckingAuthGuard extends RouterGuard {
     if (this.permissions.canAccessCommunityChecking(projectDoc)) {
       return true;
     }
-    this.router.navigate(['/projects', projectDoc.id], { replaceUrl: true });
+    void this.router.navigate(['/projects', projectDoc.id], { replaceUrl: true });
     return false;
   }
 }
@@ -164,7 +164,7 @@ export class TranslateAuthGuard extends RouterGuard {
     if (this.permissions.canAccessTranslate(projectDoc)) {
       return true;
     }
-    this.router.navigate(['/projects', projectDoc.id], { replaceUrl: true });
+    void this.router.navigate(['/projects', projectDoc.id], { replaceUrl: true });
     return false;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-control.component.ts
@@ -186,7 +186,7 @@ export class ShareControlComponent extends ShareBaseComponent {
       }
     }
 
-    this.noticeService.show(message);
+    void this.noticeService.show(message);
 
     const roleValue = this.shareRole;
     const localeValue = this.localeControl.value;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -64,7 +64,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
   ) {
     super(userService);
     this.projectId = this.data.projectId;
-    Promise.all([
+    void Promise.all([
       this.projectService.getProfile(this.projectId),
       this.projectService.isProjectAdmin(this.projectId, this.userService.currentUserId)
     ]).then(value => {
@@ -167,7 +167,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
       this._error = 'no_language';
       return;
     }
-    this.navigator.clipboard.writeText(this.shareableLink).then(async () => {
+    void this.navigator.clipboard.writeText(this.shareableLink).then(async () => {
       await this.noticeService.show(this.i18n.translateStatic('share_control.link_copied'));
       await this.reserveShareLink();
     });
@@ -262,7 +262,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     if (!this.onlineStatusService.isOnline || this.projectId == null || this.shareRole == null) {
       return;
     }
-    this.projectService
+    void this.projectService
       .onlineGetLinkSharingKey(this.projectId, this.shareRole, this.shareLinkType, this.shareExpiration)
       .then((shareKey: string) => {
         this.linkSharingKey = shareKey;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -241,15 +241,15 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
     if (source === 'user' && editor.isEnabled()) {
       const modelDelta = this.viewToData(delta);
       if (modelDelta.ops != null && modelDelta.ops.length > 0) {
-        this.textDoc.submit(modelDelta, 'Editor');
+        void this.textDoc.submit(modelDelta, 'Editor');
       }
     }
 
     // Re-compute segment boundaries so the insertion point stays in the right place.
-    this.updateSegments(editor, isOnline);
+    void this.updateSegments(editor, isOnline);
 
     // Defer the update, since it might cause the segment ranges to be out-of-sync with the view model
-    Promise.resolve().then(() => {
+    void Promise.resolve().then(() => {
       const updateDelta = this.updateSegments(editor, isOnline);
       if (updateDelta.ops != null && updateDelta.ops.length > 0) {
         // Clean up blanks in quill editor. This may result in re-entering the update() method.
@@ -818,7 +818,7 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
         // if the segment is no longer blank, ensure that the selection is at the end of the segment.
         // Sometimes after typing in a blank segment, the selection will be at the beginning. This seems to be a bug
         // in Quill.
-        Promise.resolve().then(() => editor.setSelection(segment.index + segment.length - 1, 0, 'user'));
+        void Promise.resolve().then(() => editor.setSelection(segment.index + segment.length - 1, 0, 'user'));
       }
     } else if (segment.containsBlank && segment.length === 1 && !segment.hasInitialFormat && segment.isInitial) {
       const delta = new Delta();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -318,7 +318,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       localStorage.setItem(this.cursorColorStorageKey, localCursorColor);
     }
     this.cursorColor = localCursorColor;
-    this.userService.getCurrentUser().then((userDoc: UserDoc) => {
+    void this.userService.getCurrentUser().then((userDoc: UserDoc) => {
       this.currentUserDoc = userDoc;
       this.currentUserDoc.changes$
         .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
@@ -380,9 +380,9 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         if (this.highlightMarker != null) {
           this.highlightMarker.style.visibility = 'hidden';
         }
-        this.bindQuill(); // not awaited
+        void this.bindQuill(); // not awaited
       }
-      this.setLangFromText();
+      void this.setLangFromText();
     }
   }
 
@@ -631,7 +631,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     this.isDestroyed = true;
     this.viewModel?.unbind();
     this.loadingState = 'unloaded';
-    this.dismissPresences();
+    void this.dismissPresences();
     this.onDeleteSub?.unsubscribe();
     this.localSystemChangesSub?.unsubscribe();
   }
@@ -649,7 +649,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.setHighlightMarkerPosition());
     this.viewModel.editor = editor;
-    this.bindQuill(); // not awaited
+    void this.bindQuill(); // not awaited
     editor.container.addEventListener('beforeinput', (ev: Event) => this.onBeforeinput(ev));
     this.editorCreated.emit();
   }
@@ -934,7 +934,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       this.update();
     }
 
-    this.submitLocalPresenceDoc(range);
+    void this.submitLocalPresenceDoc(range);
   }
 
   clearHighlight(): void {
@@ -958,7 +958,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
     segmentRefs = this.filterSegments(segmentRefs, false);
     // this changes the underlying HTML, which can mess up some Quill events, so defer this call
-    Promise.resolve(segmentRefs).then(refs => {
+    void Promise.resolve(segmentRefs).then(refs => {
       this.viewModel.highlight(refs);
       if (!this.readOnlyEnabled) {
         this.viewModel.updateUsfmDescription();
@@ -1136,7 +1136,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       }
     };
     this.presenceChannel.on('receive', this.onPresenceChannelReceive);
-    this.submitLocalPresenceChannel(false);
+    void this.submitLocalPresenceChannel(false);
   }
 
   private async bindQuill(): Promise<void> {
@@ -1187,7 +1187,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     // As these are user initiated, it is OK to complete reload the editor, as the user will not be in the editor
     this.localSystemChangesSub?.unsubscribe();
     this.localSystemChangesSub = this.textDocService.getLocalSystemChanges$(this._id).subscribe(() => {
-      this.bindQuill();
+      void this.bindQuill();
     });
 
     this.loaded.emit(true);
@@ -1521,7 +1521,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         this.activePresenceSubscription = timer(PRESENCE_EDITOR_ACTIVE_TIMEOUT)
           .pipe(takeUntil(this.presenceActiveEditor$))
           .subscribe(() => {
-            this.submitLocalPresenceChannel(false);
+            void this.submitLocalPresenceChannel(false);
           });
       }
     }
@@ -1605,7 +1605,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       this.setHighlightMarkerPosition();
     }
 
-    Promise.resolve().then(() => this.adjustSelection());
+    void Promise.resolve().then(() => this.adjustSelection());
     const affectedEmbeds: EmbedsByVerse[] =
       isUserEdit === true ? this.getEmbedsAffectedByDelta(delta, preDeltaSegmentCache, preDeltaEmbedCache) : [];
     this.updated.emit({
@@ -1616,7 +1616,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       isLocalUpdate: isUserEdit
     });
     if (isUserEdit) {
-      this.submitLocalPresenceChannel(true);
+      void this.submitLocalPresenceChannel(true);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -191,7 +191,7 @@ export function checkAppAccess(
 ): void {
   if (projectDoc.data == null) return;
   // Remove the record of the selected task so 'Project Home' will not redirect there
-  projectUserConfigDoc.submitJson0Op(op => {
+  void projectUserConfigDoc.submitJson0Op(op => {
     op.unset(puc => puc.selectedTask!);
     op.unset(puc => puc.selectedQuestionRef!);
   });
@@ -199,11 +199,11 @@ export function checkAppAccess(
   const route = '/projects/' + projectDoc.id;
 
   if (pathname.includes('translate') && !roleCanAccessTranslate(projectRole)) {
-    router.navigateByUrl(route, { replaceUrl: true });
+    void router.navigateByUrl(route, { replaceUrl: true });
     return;
   }
   if (pathname.includes('checking') && !roleCanAccessCommunityChecking(projectRole)) {
-    router.navigateByUrl(route, { replaceUrl: true });
+    void router.navigateByUrl(route, { replaceUrl: true });
   }
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-progress/sync-progress.component.ts
@@ -94,7 +94,7 @@ export class SyncProgressComponent {
       return;
     }
     this._projectDoc = doc;
-    this.initialize();
+    void this.initialize();
   }
 
   async initialize(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -108,14 +108,14 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
         )
       ) {
         if (this.projectDoc.data.sync.lastSyncSuccessful) {
-          this.noticeService.show(
+          void this.noticeService.show(
             this.i18n.translateStatic('sync.successfully_synchronized_with_paratext', { projectName })
           );
           this.previousLastSyncDate = this.lastSyncDate;
         } else if (this.showSyncUserPermissionsFailureMessage) {
-          this.dialogService.message(this.i18n.translate('sync.user_permissions_failure_dialog_message'));
+          void this.dialogService.message(this.i18n.translate('sync.user_permissions_failure_dialog_message'));
         } else {
-          this.dialogService.message(
+          void this.dialogService.message(
             this.i18n.translate('sync.something_went_wrong_synchronizing_this_project', { projectName })
           );
         }
@@ -209,7 +209,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     if (this.projectDoc == null) {
       return;
     }
-    this.projectService.onlineCancelSync(this.projectDoc.id);
+    void this.projectService.onlineCancelSync(this.projectDoc.id);
     this.isSyncCancelled = true;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.ts
@@ -63,7 +63,7 @@ export class BiblicalTermDialogComponent {
       .filter((rendering: string) => rendering !== '');
     const renderingsChanged: boolean = renderings.join('\n') !== this.biblicalTermDoc?.data?.renderings.join('\n');
     const description: string = this.description.value;
-    this.biblicalTermDoc?.submitJson0Op(op => {
+    void this.biblicalTermDoc?.submitJson0Op(op => {
       op.set<string>(b => b.description, description);
       if (renderingsChanged) {
         op.set<string[]>(b => b.renderings, renderings);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
@@ -261,8 +261,8 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
     if (this.selectedCategory !== value) {
       // Store the default dropdown value of show_all as undefined in the database
       if (value === '' || value === 'show_all') value = undefined;
-      this.projectUserConfigDoc?.submitJson0Op(op => op.set(puc => puc.selectedBiblicalTermsCategory, value));
-      this.filterBiblicalTerms(this._bookNum ?? 0, this._chapter ?? 0, this._verse);
+      void this.projectUserConfigDoc?.submitJson0Op(op => op.set(puc => puc.selectedBiblicalTermsCategory, value));
+      void this.filterBiblicalTerms(this._bookNum ?? 0, this._chapter ?? 0, this._verse);
     }
   }
 
@@ -274,8 +274,8 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
     if (this.selectedRangeFilter !== value) {
       // Store the default dropdown value of submitJson0Op as undefined in the database
       if (value === '' || value === 'current_verse') value = undefined;
-      this.projectUserConfigDoc?.submitJson0Op(op => op.set(puc => puc.selectedBiblicalTermsFilter, value));
-      this.filterBiblicalTerms(this._bookNum ?? 0, this._chapter ?? 0, this._verse);
+      void this.projectUserConfigDoc?.submitJson0Op(op => op.set(puc => puc.selectedBiblicalTermsFilter, value));
+      void this.filterBiblicalTerms(this._bookNum ?? 0, this._chapter ?? 0, this._verse);
     }
   }
 
@@ -284,7 +284,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
   }
 
   set transliterateBiblicalTerms(value: boolean) {
-    this.projectUserConfigDoc?.submitJson0Op(op => op.set<boolean>(puc => puc.transliterateBiblicalTerms, value));
+    void this.projectUserConfigDoc?.submitJson0Op(op => op.set<boolean>(puc => puc.transliterateBiblicalTerms, value));
   }
 
   get selectedReferenceForCaption(): string {
@@ -614,7 +614,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
             op.set(t => t.status, noteStatus);
           });
         } else {
-          this.dialogService.message('biblical_terms.cannot_edit_note_paratext');
+          void this.dialogService.message('biblical_terms.cannot_edit_note_paratext');
         }
       } else {
         note.threadId = threadDoc.data!.threadId;
@@ -642,7 +642,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
         return;
       }
 
-      this.projectUserConfigDoc.submitJson0Op(op => {
+      void this.projectUserConfigDoc.submitJson0Op(op => {
         for (const noteId of notesRead) {
           op.add(puc => puc.noteRefsRead, noteId);
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -551,7 +551,7 @@ export class DraftGenerationStepsComponent implements OnInit {
       this.stepper.next();
     } else {
       if (!this.onlineStatusService.isOnline) {
-        this.noticeService.show(this.i18n.translateStatic('draft_generation.offline_message'));
+        void this.noticeService.show(this.i18n.translateStatic('draft_generation.offline_message'));
         return;
       }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -210,7 +210,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         const dialogRef = this.dialogService.openMatDialog(SupportedBackTranslationLanguagesDialogComponent);
 
         dialogRef.afterClosed().subscribe(() => {
-          this.router.navigate([], { fragment: undefined });
+          void this.router.navigate([], { fragment: undefined });
         });
       });
 
@@ -412,7 +412,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         if (this.isDraftInProgress(job)) {
           this.draftJob = job;
           this.currentPage = 'initial';
-          this.dialogService.message('draft_generation.draft_already_running');
+          void this.dialogService.message('draft_generation.draft_already_running');
           return;
         }
       });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -75,7 +75,7 @@ export class DraftGenerationService {
           return of(undefined);
         }
 
-        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+        void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of(undefined);
       })
     );
@@ -99,7 +99,7 @@ export class DraftGenerationService {
           return of(undefined);
         }
 
-        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+        void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of(undefined);
       })
     );
@@ -125,7 +125,7 @@ export class DraftGenerationService {
             return of(undefined);
           }
 
-          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+          void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of(undefined);
         })
       );
@@ -192,7 +192,7 @@ export class DraftGenerationService {
             return of({});
           }
 
-          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+          void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of({});
         })
       );
@@ -240,7 +240,7 @@ export class DraftGenerationService {
           return throwError(() => err);
         }
 
-        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+        void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
         return of([]);
       })
     );
@@ -269,7 +269,7 @@ export class DraftGenerationService {
             return of(undefined);
           }
 
-          this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+          void this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
           return of(undefined);
         })
       );
@@ -366,7 +366,7 @@ export class DraftGenerationService {
         usfmFiles.push(usfmFile);
       }
 
-      Promise.all(usfmFiles).then(() => {
+      void Promise.all(usfmFiles).then(() => {
         if (Object.keys(zip.files).length === 0) {
           observer.next({ current: 0, total: 0 });
           observer.error(this.i18n.translateStatic('draft_generation.info_alert_download_error'));
@@ -381,7 +381,7 @@ export class DraftGenerationService {
 
         filename += '.zip';
 
-        zip.generateAsync({ type: 'blob' }).then(blob => {
+        void zip.generateAsync({ type: 'blob' }).then(blob => {
           saveAs(blob, filename);
           observer.next({ current: 0, total: 0 });
           observer.complete();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -71,7 +71,7 @@ export class DraftHistoryEntryComponent {
     // Get the user who requested the build
     this._buildRequestedByUserName = undefined;
     if (this._entry?.additionalInfo?.requestedByUserId != null) {
-      this.userService.getProfile(this._entry.additionalInfo.requestedByUserId).then(user => {
+      void this.userService.getProfile(this._entry.additionalInfo.requestedByUserId).then(user => {
         if (user.data != null) {
           this._buildRequestedByUserName = user.data.displayName;
         }
@@ -85,7 +85,7 @@ export class DraftHistoryEntryComponent {
 
     // Get the books used in the training configuration
     const trainingScriptureRanges = this._entry?.additionalInfo?.trainingScriptureRanges ?? [];
-    Promise.all(
+    void Promise.all(
       trainingScriptureRanges.map(async r => {
         // The engine ID is the target project ID
         let target: SFProjectProfileDoc | undefined = undefined;
@@ -125,7 +125,7 @@ export class DraftHistoryEntryComponent {
       translationScriptureRanges.map(item => item.scriptureRange).join(';')
     );
     this._translationSources = [];
-    Promise.all(
+    void Promise.all(
       translationScriptureRanges.map(async r => {
         const source =
           r.projectId === '' || r.projectId === value?.engine?.id
@@ -139,7 +139,7 @@ export class DraftHistoryEntryComponent {
     const trainingDataFiles: string[] = this._entry?.additionalInfo?.trainingDataFileIds ?? [];
     if (this.activatedProjectService.projectId != null && trainingDataFiles.length > 0) {
       this.dataFileQuery?.dispose();
-      this.trainingDataService
+      void this.trainingDataService
         .queryTrainingDataAsync(this.activatedProjectService.projectId, this.destroyRef)
         .then(query => {
           this.dataFileQuery = query;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -185,7 +185,7 @@ export class DraftPreviewBooksComponent {
   }
 
   navigate(book: BookWithDraft): void {
-    this.router.navigate(this.linkForBookAndChapter(book.bookId, book.chaptersWithDrafts[0]), {
+    void this.router.navigate(this.linkForBookAndChapter(book.bookId, book.chaptersWithDrafts[0]), {
       queryParams: { 'draft-active': true, 'draft-timestamp': this.build?.additionalInfo?.dateGenerated }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -367,7 +367,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Confi
   }
 
   navigateToDrafting(): void {
-    this.router.navigate(['/projects', this.activatedProjectService.projectId, 'draft-generation']);
+    void this.router.navigate(['/projects', this.activatedProjectService.projectId, 'draft-generation']);
   }
 
   async save(): Promise<void> {
@@ -386,7 +386,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements Confi
       messageKey = this.languageCodeConfirmationMessageIfUserTriesToContinue;
     }
     if (messageKey) {
-      this.dialogService.message(this.i18n.translate(`draft_sources.${messageKey}`));
+      void this.dialogService.message(this.i18n.translate(`draft_sources.${messageKey}`));
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -218,7 +218,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
       this.close();
     } catch (err) {
       console.error('Error occurred while saving draft format', err);
-      this.noticeService.showError(this.i18n.translateStatic('draft_usfm_format.failed_to_save'));
+      void this.noticeService.showError(this.i18n.translateStatic('draft_usfm_format.failed_to_save'));
     } finally {
       this.saving = false;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-upload-dialog.component.ts
@@ -120,7 +120,7 @@ export class TrainingDataUploadDialogComponent implements AfterViewInit {
     );
     this._isUploading = false;
     if (fileUrl == null) {
-      this.dialogService.message('training_data_upload_dialog.upload_failed');
+      void this.dialogService.message('training_data_upload_dialog.upload_failed');
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -261,7 +261,9 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   }
 
   navigateToFormatting(): void {
-    this.router.navigateByUrl(`/projects/${this.projectId}/draft-generation/format/${this.bookId}/${this.chapter}`);
+    void this.router.navigateByUrl(
+      `/projects/${this.projectId}/draft-generation/format/${this.bookId}/${this.chapter}`
+    );
   }
 
   async applyDraft(): Promise<void> {
@@ -282,7 +284,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       this.isDraftApplied = true;
       this.userAppliedDraft = true;
     } catch (err) {
-      this.noticeService.showError(this.i18n.translateStatic('editor_draft_tab.error_applying_draft'));
+      void this.noticeService.showError(this.i18n.translateStatic('editor_draft_tab.error_applying_draft'));
       if (!isNetworkError(err)) {
         this.errorReportingService.silentError(
           'Error applying a draft to a chapter',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.ts
@@ -142,7 +142,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
 
   async revertToSnapshot(): Promise<void> {
     if (!this.onlineStatusService.isOnline) {
-      this.noticeService.show(this.i18n.translateStatic('history_chooser.please_connect'));
+      void this.noticeService.show(this.i18n.translateStatic('history_chooser.please_connect'));
       return;
     }
     // Ensure the user wants to proceed
@@ -162,7 +162,7 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       this.chapter == null ||
       !this.canRestoreSnapshot
     ) {
-      this.noticeService.showError(this.i18n.translateStatic('history_chooser.error'));
+      void this.noticeService.showError(this.i18n.translateStatic('history_chooser.error'));
       return;
     }
 
@@ -183,11 +183,11 @@ export class HistoryChooserComponent implements AfterViewInit, OnChanges {
       }
       await this.textDocService.overwrite(textDocId, delta, 'History');
 
-      this.noticeService.show(this.i18n.translateStatic('history_chooser.revert_successful'));
+      void this.noticeService.show(this.i18n.translateStatic('history_chooser.revert_successful'));
       // Force the history editor to reload
       this.revisionSelect.emit({ revision: this.selectedRevision, snapshot: this.selectedSnapshot });
     } catch (err) {
-      this.noticeService.showError(this.i18n.translateStatic('history_chooser.revert_error'));
+      void this.noticeService.showError(this.i18n.translateStatic('history_chooser.revert_error'));
       if (!isNetworkError(err)) {
         this.errorReportingService.silentError(
           'Error occurred restoring a snapshot',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -350,7 +350,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   set isTargetTextRight(value: boolean) {
     if (this.projectUserConfigDoc != null && this.isTargetTextRight !== value) {
-      this.projectUserConfigDoc.submitJson0Op(op => op.set(puc => puc.isTargetTextRight, value));
+      void this.projectUserConfigDoc.submitJson0Op(op => op.set(puc => puc.isTargetTextRight, value));
     }
   }
 
@@ -404,14 +404,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   set chapter(value: number | undefined) {
     if (this.chapter$.value !== value && value != null) {
       // Update url to reflect current chapter, triggering ActivatedRoute
-      this.router.navigateByUrl(
+      void this.router.navigateByUrl(
         `/projects/${this.projectId}/translate/${Canon.bookNumberToId(this.bookNum!)}/${value}`
       );
     }
   }
 
   setBook(book: number): void {
-    this.router.navigate(['projects', this.projectId, 'translate', Canon.bookNumberToId(book)]);
+    void this.router.navigate(['projects', this.projectId, 'translate', Canon.bookNumberToId(book)]);
   }
 
   get bookNum(): number | undefined {
@@ -776,7 +776,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         // If book is not in project, navigate to 'projects' route, which should send the user
         // to the book stored in SFProjectUserConfig.
         if (this.text == null) {
-          this.router.navigateByUrl('projects', { replaceUrl: true });
+          void this.router.navigateByUrl('projects', { replaceUrl: true });
           return;
         }
 
@@ -1190,7 +1190,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       return;
     }
     if (!this.target.contentShowing) {
-      this.noticeService.show(this.i18n.translateStatic('editor.navigate_to_a_valid_text'));
+      void this.noticeService.show(this.i18n.translateStatic('editor.navigate_to_a_valid_text'));
       return;
     }
     let verseRef: VerseRef | undefined = this.commenterSelectedVerseRef;
@@ -1205,7 +1205,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.setNoteFabVisibility('hidden');
       this.bottomSheetRef = this.bottomSheet.open(this.TemplateBottomSheet, { hasBackdrop: false });
     } else {
-      this.showNoteThread(undefined, verseRef);
+      void this.showNoteThread(undefined, verseRef);
     }
   }
 
@@ -1387,7 +1387,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         return tabsToPersist;
       }),
       tap((tabs: EditorTabPersistData[]) => {
-        this.editorTabPersistenceService.persistTabsOpen(tabs);
+        void this.editorTabPersistenceService.persistTabsOpen(tabs);
       })
     );
 
@@ -1457,7 +1457,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             op.set(t => t.status, noteStatus);
           });
         } else {
-          this.dialogService.message('editor.cannot_edit_note_paratext');
+          void this.dialogService.message('editor.cannot_edit_note_paratext');
         }
       } else {
         note.threadId = threadDoc.data!.threadId;
@@ -1518,7 +1518,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             take(1)
           )
           .subscribe(() => {
-            this.router.navigate([], {
+            void this.router.navigate([], {
               queryParams: { 'draft-active': null, 'draft-timestamp': null },
               queryParamsHandling: 'merge',
               replaceUrl: true
@@ -1582,7 +1582,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     );
     this.shouldNoteThreadsRespondToEdits = true;
     // Defer the subscription so that the editor has time to clean up comments on blanks verses
-    Promise.resolve().then(() => this.subscribeClickEvents(segments));
+    void Promise.resolve().then(() => this.subscribeClickEvents(segments));
   }
 
   private async showNoteThread(threadDataId?: string, verseRef?: VerseRef): Promise<void> {
@@ -1655,7 +1655,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       if (notesRead.length === 0) {
         return;
       }
-      this.projectUserConfigDoc.submitJson0Op(op => {
+      void this.projectUserConfigDoc.submitJson0Op(op => {
         for (const noteId of notesRead) {
           op.add(puc => puc.noteRefsRead, noteId);
         }
@@ -1747,8 +1747,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
 
     this.onTargetDeleteSub = textDoc.delete$.subscribe(() => {
-      this.dialogService.message(this.i18n.translate('editor.text_has_been_deleted')).then(() => {
-        this.router.navigateByUrl('/projects/' + this.projectDoc!.id + '/translate', { replaceUrl: true });
+      void this.dialogService.message(this.i18n.translate('editor.text_has_been_deleted')).then(() => {
+        void this.router.navigateByUrl('/projects/' + this.projectDoc!.id + '/translate', { replaceUrl: true });
       });
     });
 
@@ -1803,7 +1803,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     } else if (!translator.isSegmentValid) {
       this.translator = undefined;
       if (this.translationSuggestionsEnabled) {
-        this.noticeService.show(this.i18n.translateStatic('editor.verse_too_long_for_suggestions'));
+        void this.noticeService.show(this.i18n.translateStatic('editor.verse_too_long_for_suggestions'));
       }
       return;
     }
@@ -1907,7 +1907,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.projectUserConfigDoc.data.selectedBookNum != null &&
       this.projectUserConfigDoc.data.selectedChapterNum != null
     ) {
-      this.translationEngineService.storeTrainingSegment(
+      void this.translationEngineService.storeTrainingSegment(
         this.projectUserConfigDoc.data.projectRef,
         sourceProjectRef,
         this.projectUserConfigDoc.data.selectedBookNum,
@@ -1956,7 +1956,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
               }
               const threadDataId: string | undefined = threadIdFromMouseEvent(event);
               if (threadDataId != null) {
-                this.showNoteThread(threadDataId);
+                void this.showNoteThread(threadDataId);
                 this.target?.formatEmbed(threadDataId, 'note-thread-embed', {
                   ['highlight']: false
                 });
@@ -2046,10 +2046,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     }
     this.toggleNoteThreadVerses(false);
     this.chapter$.next(chapter);
-    this.changeText();
+    void this.changeText();
     this.toggleNoteThreadVerses(true);
-    this.updateAutoDraftTabVisibility();
-    this.updateBiblicalTermsTabVisibility();
+    void this.updateAutoDraftTabVisibility();
+    void this.updateBiblicalTermsTabVisibility();
   }
 
   private loadTranslateSuggesterConfidence(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-overlay/lynx-insight-overlay.component.ts
@@ -147,7 +147,7 @@ export class LynxInsightOverlayComponent implements OnInit {
       return;
     }
 
-    this.lynxWorkspaceService.getActions(insight).then(actions => {
+    void this.lynxWorkspaceService.getActions(insight).then(actions => {
       const menuActions: LynxInsightAction[] = [];
 
       for (const action of actions) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-state.service.ts
@@ -281,7 +281,7 @@ export class LynxInsightStateService {
     combineLatest([this.filter$, this.orderBy$, this.insightPanelVisible$, stateLoaded$.pipe(filter(loaded => loaded))])
       .pipe(withLatestFrom(this.activatedProjectUserConfig.projectUserConfigDoc$))
       .subscribe(([[filter, sortOrder, isOpen], pucDoc]) => {
-        pucDoc?.submitJson0Op(op =>
+        void pucDoc?.submitJson0Op(op =>
           op.set(puc => puc.lynxInsightState, {
             panelData: {
               isOpen,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insights-panel/lynx-insights-panel.component.ts
@@ -181,17 +181,16 @@ export class LynxInsightsPanelComponent implements AfterViewInit {
   isExpandableNodePredicate = (_index: number, node: InsightPanelNode): boolean => this.hasChildren(node);
 
   // Handle clicks on leaf nodes (insights) to navigate to the chapter of the insight and show the overlay
-  onLeafNodeClick(node: InsightPanelNode): void {
+  async onLeafNodeClick(node: InsightPanelNode): Promise<void> {
     if (node.insight != null) {
       const insight: LynxInsight = node.insight;
 
-      // Show action menu overlay in editor
-      this.navInsight(insight).then(() => {
-        this.editorInsightState.updateDisplayState({
-          activeInsightIds: [insight.id],
-          promptActive: false,
-          actionOverlayActive: true
-        });
+      // Nav if needed, then show action menu overlay in editor
+      await this.navInsight(insight);
+      this.editorInsightState.updateDisplayState({
+        activeInsightIds: [insight.id],
+        promptActive: false,
+        actionOverlayActive: true
       });
     }
   }
@@ -1103,7 +1102,7 @@ export class LynxInsightsPanelComponent implements AfterViewInit {
       }
 
       const { node, insight } = batch[index++];
-      this.processNodeAsync(node, insight).then(() => {
+      void this.processNodeAsync(node, insight).then(() => {
         this.updateProgressForNode(node);
 
         // Schedule the next node
@@ -1119,7 +1118,7 @@ export class LynxInsightsPanelComponent implements AfterViewInit {
    * Process nodes in parallel for better performance.
    */
   private processNodeBatchParallel(batch: Array<{ node: InsightPanelNode; insight: LynxInsight }>): void {
-    Promise.all(
+    void Promise.all(
       batch.map(item =>
         this.processNodeAsync(item.node, item.insight).then(() => {
           this.updateProgressForNode(item.node);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-add-resource-dialog/editor-tab-add-resource-dialog.component.ts
@@ -174,7 +174,7 @@ export class EditorTabAddResourceDialogComponent implements OnInit {
 
   private cancelSync(): void {
     if (this.selectedProjectDoc?.id != null && this.isSyncActive) {
-      this.projectService.onlineCancelSync(this.selectedProjectDoc.id);
+      void this.projectService.onlineCancelSync(this.selectedProjectDoc.id);
     }
 
     this.isSyncActive = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/translate-metrics-session.ts
@@ -134,7 +134,7 @@ export class TranslateMetricsSession extends SubscriptionDisposable {
     if (this.metrics != null && this.metrics.type === 'edit') {
       this.metrics.editEndEvent = 'task-exit';
     }
-    this.sendMetrics(this.target == null ? undefined : this.target.segment);
+    void this.sendMetrics(this.target == null ? undefined : this.target.segment);
   }
 
   onSuggestionShown(): void {
@@ -283,7 +283,7 @@ export class TranslateMetricsSession extends SubscriptionDisposable {
       if (activity.event.type === 'click') {
         this.decrementMetric('mouseClickCount');
       }
-      this.sendMetrics(this.target.segment);
+      void this.sendMetrics(this.target.segment);
       this.createMetrics('edit');
       if (activity.event.type === 'click') {
         this.incrementMetric('mouseClickCount');
@@ -294,7 +294,7 @@ export class TranslateMetricsSession extends SubscriptionDisposable {
   private endEditIfNecessary(editEndEvent: EditEndEvent, segment: Segment | undefined): void {
     if (this.metrics.type === 'edit') {
       this.metrics.editEndEvent = editEndEvent;
-      this.sendMetrics(segment);
+      void this.sendMetrics(segment);
       this.createMetrics('navigate');
       this.navigateSuggestionShown = false;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -141,7 +141,9 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
           complete: () => {
             // training completed successfully
             if (this.trainingProgressClosed) {
-              this.noticeService.show(this.i18n.translateStatic('training_progress.training_completed_successfully'));
+              void this.noticeService.show(
+                this.i18n.translateStatic('training_progress.training_completed_successfully')
+              );
               this.trainingProgressClosed = false;
             } else {
               this.trainingMessage = this.i18n.translateStatic('training_progress.completed_successfully');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -101,7 +101,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
         this.projectDoc = await this.projectService.getProfile(projectId);
 
         // Update the overview now if we are online, or when we are next online
-        this.onlineStatusService.online.then(async () => {
+        void this.onlineStatusService.online.then(async () => {
           this.loadingStarted();
           try {
             if (this.translationEngine == null) {
@@ -152,17 +152,17 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     }
     this.trainingPercentage = 0;
     this.isTraining = true;
-    this.translationEngine
+    void this.translationEngine
       .startTraining()
       .catch((error: any) => {
         this.isTraining = false;
         if (error instanceof HttpErrorResponse && error.status === 401) {
-          this.authService.requestParatextCredentialUpdate();
+          void this.authService.requestParatextCredentialUpdate();
         } else {
-          this.noticeService.showError(this.i18n.translateStatic('translate_overview.training_unavailable'));
+          void this.noticeService.showError(this.i18n.translateStatic('translate_overview.training_unavailable'));
         }
       })
-      .then(() => this.listenForStatus());
+      .then(() => void this.listenForStatus());
   }
 
   getBookName(text: TextInfo): string {
@@ -215,7 +215,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
           complete: () => {
             // training completed successfully
             this.isTraining = false;
-            this.updateEngineStats();
+            void this.updateEngineStats();
           }
         }),
         repeat(),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -143,7 +143,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       .subscribe(async projectId => {
         this.loadingStarted();
         this.projectDoc = await this.projectService.get(projectId);
-        this.loadUsers();
+        void this.loadUsers();
         // TODO Clean up the use of nested subscribe()
         this.projectDoc.remoteChanges$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async () => {
           this.loadingStarted();
@@ -159,7 +159,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       this.isAppOnline = isOnline;
       if (isOnline && this._userRows == null) {
         this.loadingStarted();
-        this.loadUsers();
+        void this.loadUsers();
         this.loadingFinished();
       }
     });
@@ -198,17 +198,17 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       'collaborators.remove_user'
     );
     if (confirmed) {
-      this.projectService.onlineRemoveUser(this.projectId, row.id);
+      void this.projectService.onlineRemoveUser(this.projectId, row.id);
     }
   }
 
   async uninviteProjectUser(emailToUninvite: string): Promise<void> {
     await this.projectService.onlineUninviteUser(this.projectId, emailToUninvite);
-    this.loadUsers();
+    void this.loadUsers();
   }
 
   onInvitationSent(): void {
-    this.loadUsers();
+    void this.loadUsers();
   }
 
   async openRolesDialog(row: Row): Promise<void> {
@@ -272,7 +272,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
       );
       this._userRows = userRows.concat(invitees);
     } catch {
-      this.noticeService.show(this.i18n.translateStatic('collaborators.problem_loading_invited_users'));
+      void this.noticeService.show(this.i18n.translateStatic('collaborators.problem_loading_invited_users'));
     }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/activated-project.service.ts
@@ -88,7 +88,7 @@ export class ActivatedProjectService {
     if (this.projectDoc !== projectDoc) {
       this._projectDoc$.next(projectDoc);
       if (this.projectDoc !== undefined) {
-        this.cacheService.cache(this.projectDoc);
+        void this.cacheService.cache(this.projectDoc);
       }
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.guard.ts
@@ -20,7 +20,7 @@ export class AuthGuard {
         if (!isLoggedIn) {
           const signUp = route.queryParams['sign-up'] === 'true';
           const locale: string = route.queryParams['locale'];
-          this.authService.logIn({
+          void this.authService.logIn({
             returnUrl: this.locationService.pathname + this.locationService.search,
             signUp,
             locale

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -134,7 +134,7 @@ export class AuthService {
       )
       .subscribe(() => this.locationService.go('/'));
 
-    this.tryLogIn().then(loginResult => {
+    void this.tryLogIn().then(loginResult => {
       this._loggedInState$.next(loginResult);
     });
   }
@@ -299,18 +299,20 @@ export class AuthService {
       await this.offlineStore.deleteDB();
       this.localSettings.clear();
       this.unscheduleRenewal();
-      this.auth0.logout({ logoutParams: { returnTo: this.locationService.origin + '/' } } as LogoutOptions);
+      void this.auth0.logout({ logoutParams: { returnTo: this.locationService.origin + '/' } } as LogoutOptions);
     }
   }
 
   requestParatextCredentialUpdate(cancelCallback?: () => void): void {
-    this.dialogService.confirm('warnings.paratext_credentials_expired', 'warnings.logout').then((logOut: boolean) => {
-      if (logOut) {
-        this.logOut();
-      } else if (cancelCallback != null) {
-        cancelCallback();
-      }
-    });
+    void this.dialogService
+      .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
+      .then((logOut: boolean) => {
+        if (logOut) {
+          void this.logOut();
+        } else if (cancelCallback != null) {
+          cancelCallback();
+        }
+      });
   }
 
   /**
@@ -521,7 +523,7 @@ export class AuthService {
           console.error(err);
           return false;
         }
-        this.dialogService
+        void this.dialogService
           .message(
             this.i18n.translate('connect_project.paratext_account_linked_to_another_user', {
               email: authDetails.idToken?.email
@@ -551,9 +553,9 @@ export class AuthService {
     }
     // Ensure the return URL is one we want to return the user to
     if (this.isValidReturnUrl(state.returnUrl)) {
-      this.router.navigateByUrl(state.returnUrl!, { replaceUrl: true });
+      void this.router.navigateByUrl(state.returnUrl!, { replaceUrl: true });
     } else {
-      this.router.navigateByUrl('/projects', { replaceUrl: true });
+      void this.router.navigateByUrl('/projects', { replaceUrl: true });
     }
     return true;
   }
@@ -631,7 +633,7 @@ export class AuthService {
       }
     })
       .catch(() => {
-        this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
+        void this.logIn({ returnUrl: this.locationService.pathname + this.locationService.search });
       })
       .then(() => {
         this.renewTokenPromise = undefined;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/exception-handling.service.ts
@@ -183,14 +183,17 @@ export class ExceptionHandlingService {
       error.error.target instanceof XMLHttpRequest &&
       error.error.target.status === 0
     ) {
-      ngZone.run(() =>
-        noticeService.showError(this.i18n.translateStatic('exception_handling_service.network_request_failed'))
+      ngZone.run(
+        () =>
+          void noticeService.showError(this.i18n.translateStatic('exception_handling_service.network_request_failed'))
       );
       return;
     }
 
     if (error instanceof DOMException && (error.name === 'QuotaExceededError' || error.name === 'DataError')) {
-      ngZone.run(() => noticeService.showError(this.i18n.translateStatic('exception_handling_service.out_of_space')));
+      ngZone.run(
+        () => void noticeService.showError(this.i18n.translateStatic('exception_handling_service.out_of_space'))
+      );
       return;
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/file.service.ts
@@ -66,7 +66,7 @@ export class FileService {
     this.realtimeService = realtimeService;
     this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(isOnline => {
       if (isOnline) {
-        this.syncFiles();
+        void this.syncFiles();
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/mock-console.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/mock-console.ts
@@ -204,6 +204,6 @@ export class MockConsole extends AbstractFunctionLogger {
       this.originalConsole.log('The following was logged:');
       this.logs.forEach(this.originalConsole.log);
     }
-    expect(this.logs.length).withContext(context).toEqual(0);
+    void expect(this.logs.length).withContext(context).toEqual(0);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/realtime-doc.ts
@@ -44,7 +44,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
         if (this.subscribePromise != null) {
           await this.subscribePromise;
         }
-        this.updateOfflineData();
+        void this.updateOfflineData();
       }
     );
     this.onDeleteSub = this.adapter.delete$.subscribe(() => this.onDelete());
@@ -131,7 +131,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
    */
   async submit(ops: Ops, source?: any): Promise<void> {
     // update offline data when the op has been acknowledged
-    this.adapter.submitOp(ops, source).then(() => this.updateOfflineData());
+    void this.adapter.submitOp(ops, source).then(() => this.updateOfflineData());
     // update offline data when the op is first submitted
     // we force the offline update, so if the client is offline, the pending ops will be stored in IndexedDB
     await this.updateOfflineData(true);
@@ -139,14 +139,14 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
   }
 
   async create(data: T, type?: string): Promise<void> {
-    this.adapter.create(data, type).then(() => this.updateOfflineData(true));
+    void this.adapter.create(data, type).then(() => this.updateOfflineData(true));
     this.loadOfflineDataPromise = Promise.resolve();
     await this.updateOfflineData(true);
     await this.realtimeService.onLocalDocUpdate(this);
   }
 
   async delete(): Promise<void> {
-    this.adapter.delete();
+    await this.adapter.delete();
     await this.updateOfflineData();
     await this.realtimeService.onLocalDocUpdate(this);
   }
@@ -154,15 +154,15 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
   async onAddedToSubscribeQuery(): Promise<void> {
     this.subscribeQueryCount++;
     await this.loadOfflineData();
-    this.updateOfflineData();
+    void this.updateOfflineData();
     await this.onSubscribe();
   }
 
   onRemovedFromSubscribeQuery(): void {
-    this.updateOfflineData();
+    void this.updateOfflineData();
     this.subscribeQueryCount--;
     if (this.isLoaded) {
-      this.checkExists();
+      void this.checkExists();
     }
   }
 
@@ -251,7 +251,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
     const offlineData = await this.realtimeService.offlineStore.get<RealtimeOfflineData>(this.collection, this.id);
     if (offlineData != null) {
       if (offlineData.v == null) {
-        this.adapter.create(offlineData.data, offlineData.type).then(() => this.updateOfflineData(true));
+        void this.adapter.create(offlineData.data, offlineData.type).then(() => this.updateOfflineData(true));
       } else {
         await this.adapter.ingestSnapshot(offlineData);
         this.offlineSnapshotVersion = this.adapter.version;
@@ -264,7 +264,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
     await this.loadOfflineData();
     const promise = this.adapter.subscribe().then(() => (this.subscribedState = this.adapter.subscribed));
     if (this.isLoaded) {
-      this.checkExists();
+      void this.checkExists();
     } else {
       await promise;
     }
@@ -273,7 +273,7 @@ export abstract class RealtimeDoc<T = any, Ops = any, P = any> {
 
   private async checkExists(): Promise<void> {
     if (!(await this.adapter.exists())) {
-      this.onDelete();
+      void this.onDelete();
       this.localDelete$.next();
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/notice.service.ts
@@ -85,7 +85,7 @@ export class NoticeService {
 
     this.messageOnDisplay = message;
 
-    firstValueFrom(snackBarRef.afterDismissed()).then(() => (this.messageOnDisplay = undefined));
+    void firstValueFrom(snackBarRef.afterDismissed()).then(() => (this.messageOnDisplay = undefined));
   }
 
   private setAppLoadingAsync(value: boolean): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/online-status.service.ts
@@ -66,7 +66,7 @@ export class OnlineStatusService {
    */
   get online(): Promise<void> {
     return new Promise<void>(resolve => {
-      firstValueFrom(
+      void firstValueFrom(
         this.onlineStatus$.pipe(
           filter(isOnline => isOnline),
           take(1)

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/pwa.service.ts
@@ -87,7 +87,7 @@ export class PwaService extends SubscriptionDisposable {
   }
 
   activateUpdates(): void {
-    this.updates.activateUpdate();
+    void this.updates.activateUpdate();
     this.locationService.reload();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts
@@ -229,7 +229,7 @@ export class RealtimeService {
       );
     } catch {
       // If 'onDestroy' callback registration fails (view already destroyed), dispose immediately
-      queryPromise.then(query => query.dispose());
+      void queryPromise.then(query => query.dispose());
     }
 
     return queryPromise;

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/router-link.directive.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/router-link.directive.ts
@@ -43,7 +43,7 @@ export class RouterLinkDirective {
     if (event.ctrlKey || event.metaKey) {
       this.window.open(this.url, '_blank', 'noopener');
     } else {
-      this.router.navigate(this.route, this.routerOptions);
+      void this.router.navigate(this.route, this.routerOptions);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -125,7 +125,7 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
       .afterClosed()
       .subscribe(confirmation => {
         if (confirmation) {
-          this.deleteUser(userId);
+          void this.deleteUser(userId);
         }
       });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
@@ -22,7 +22,7 @@ export class SFUserProjectsService {
     private readonly authService: AuthService,
     private destroyRef: DestroyRef
   ) {
-    this.setup();
+    void this.setup();
   }
 
   /** List of SF project docs the user is on. Or undefined if the information is not yet available. */
@@ -38,10 +38,10 @@ export class SFUserProjectsService {
           return;
         }
         const userDoc = await this.userService.getCurrentUser();
-        this.updateProjectList(userDoc);
+        void this.updateProjectList(userDoc);
         userDoc.remoteChanges$
           .pipe(quietTakeUntilDestroyed(this.destroyRef))
-          .subscribe(() => this.updateProjectList(userDoc));
+          .subscribe(() => void this.updateProjectList(userDoc));
       });
   }
 
@@ -54,7 +54,7 @@ export class SFUserProjectsService {
     for (const [id, projectDoc] of this.projectDocs) {
       if (!currentProjectIds.includes(id)) {
         removedProjectsCount++;
-        projectDoc.dispose();
+        void projectDoc.dispose();
         this.projectDocs.delete(id);
       }
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user.service.ts
@@ -124,7 +124,7 @@ export class UserService {
       try {
         await this.updateAvatarFromDisplayName();
       } catch {
-        this.noticeService.showError(translate('error_messages.failed_to_update_avatar'));
+        void this.noticeService.showError(translate('error_messages.failed_to_update_avatar'));
       }
     }
   }


### PR DESCRIPTION
This PR fixes all lint `no-floating-promises` warnings.  All files used the `void` methodology to handle the floating promises (maintaining existing fire-and-forget behavior) except for the two instances described below.


1) In the `lynx-insight-panel.component.ts` `onLeafNodeClick()` function, the promise chain is changed to async/await.  This is more of a readability change than functional, as, in both cases, the nav completes before the call to update display state.

2) In the `realtime-doc.ts` `delete()` function:
```TS
async delete(): Promise<void> {
  await this.adapter.delete();
  await this.updateOfflineData();
  await this.realtimeService.onLocalDocUpdate(this);
}
```
`await this.adapter.delete()` was chosen instead of `void this.adapter.delete()` with the idea to maintain data consistency in the case that the `adapter.delete()` call fails.  **Please review if this is the correct approach.**