### PR TITLE
Update Serval.Client to 1.12.1

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
@@ -40,8 +40,8 @@
     <PackageReference Include="ParatextData" Version="9.5.0.19" />
     <!-- When updating Serval.Client consider that API changes must be released to Serval Prod
         prior to testing on SF QA -->
-    <PackageReference Include="Serval.Client" Version="1.10.1" />
-    <PackageReference Include="SIL.Machine" Version="3.7.7" />
+    <PackageReference Include="Serval.Client" Version="1.12.1" />
+    <PackageReference Include="SIL.Machine" Version="3.7.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.6" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1455,15 +1455,17 @@ public class MachineProjectService(
                 .ToArray() ?? [];
         foreach (string corpusId in corpusIds)
         {
-            // Delete the corpus
+            // Delete the legacy corpus
             try
             {
+#pragma warning disable CS0612 // Type or member is obsolete
                 await translationEnginesClient.DeleteCorpusAsync(
                     translationEngineId,
                     corpusId,
                     deleteFiles: true,
                     cancellationToken
                 );
+#pragma warning restore CS0612 // Type or member is obsolete
             }
             catch (ServalApiException e)
             {

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -107,9 +107,9 @@
       },
       "Serval.Client": {
         "type": "Direct",
-        "requested": "[1.10.1, )",
-        "resolved": "1.10.1",
-        "contentHash": "Fa05THT6PqRKAo+ZpYNf5/endZRBfF/i007+haGfbubxZTJ0NwR+E87+QqcQr7l9zdWTrk5kc4DyjwceJGFFDA==",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "qRySQeyCJkFGMgotwzQac9HTasYqVGUjpgI1sMG1QyLT7oqEEpNMc0C33UEoXNBrSJJQFBs37AOQZaJxkO3oNA==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
           "System.ComponentModel.Annotations": "5.0.0"
@@ -117,9 +117,9 @@
       },
       "SIL.Machine": {
         "type": "Direct",
-        "requested": "[3.7.7, )",
-        "resolved": "3.7.7",
-        "contentHash": "ElGEz0nQqiMfHNxy49A05E1trMVvFsy2cCp7qWokEerYkt6jX9O3KXWrrztgupP9M9j+uPhnyI0N9rD7sFS0JQ==",
+        "requested": "[3.7.9, )",
+        "resolved": "3.7.9",
+        "contentHash": "nXfj5MERE/gVWHYpAkUUrtQ58jMeDi+YwzZlWyoLppbL0odTJFsoBkjrhhmD7GZt9MPkxWI8Gv02kmbNhVhrVQ==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.2",

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -2222,6 +2222,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpora")]
     public async Task RemoveLegacyServalDataAsync_DoesNotCallServalIfNoTranslationEngineId()
     {
         // Set up test environment
@@ -2237,6 +2238,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpora")]
     public async Task RemoveLegacyServalDataAsync_LogsAnErrorWhenAServalErrorOccurs()
     {
         // Set up test environment
@@ -2259,6 +2261,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpora")]
     public async Task RemoveLegacyServalDataAsync_LogsAnEventWhenTheFileIsNotFound()
     {
         // Set up test environment
@@ -2283,6 +2286,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpora")]
     public async Task RemoveLegacyServalDataAsync_OnlyRemovesRelevantCorpora()
     {
         // Set up test environment
@@ -2304,6 +2308,7 @@ public class MachineProjectServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpora")]
     public async Task RemoveLegacyServalDataAsync_RemovesCorporaPropertyIfNoMoreCorpora()
     {
         // Set up test environment

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -47,10 +48,11 @@ public class PreTranslationServiceTests
         );
 
         // SUT
-        (string translationEngineId, string corpusId, bool useParatextVerseRef) =
+        (string translationEngineId, string corpusId, string parallelCorpusId, bool useParatextVerseRef) =
             await env.Service.GetPreTranslationParametersAsync(Project01);
         Assert.AreEqual(TranslationEngine01, translationEngineId);
         Assert.AreEqual(Corpus01, corpusId);
+        Assert.IsNull(parallelCorpusId);
         Assert.AreEqual(uploadParatextZipFile, useParatextVerseRef);
     }
 
@@ -68,10 +70,11 @@ public class PreTranslationServiceTests
         );
 
         // SUT
-        (string translationEngineId, string corpusId, bool useParatextVerseRef) =
+        (string translationEngineId, string corpusId, string parallelCorpusId, bool useParatextVerseRef) =
             await env.Service.GetPreTranslationParametersAsync(Project01);
         Assert.AreEqual(TranslationEngine01, translationEngineId);
-        Assert.AreEqual(ParallelCorpus01, corpusId);
+        Assert.IsNull(corpusId);
+        Assert.AreEqual(ParallelCorpus01, parallelCorpusId);
         Assert.IsTrue(useParatextVerseRef);
     }
 
@@ -129,6 +132,67 @@ public class PreTranslationServiceTests
         const int chapterNum = 1;
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
+                TranslationEngine01,
+                ParallelCorpus01,
+                textId,
+                CancellationToken.None
+            )
+            .Returns(
+                Task.FromResult<IList<Pretranslation>>(
+                    [
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:mt1_001" },
+                            Translation = "3 John",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001" },
+                            Translation = "By the old man,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_001" },
+                            Translation = "To my dear friend Gaius,",
+                        },
+                        new Pretranslation
+                        {
+                            TextId = "64_1",
+                            Refs = { "64_1:verse_001_001_002" },
+                            Translation = "whom I love in the truth:",
+                        },
+                    ]
+                )
+            );
+
+        // SUT
+        PreTranslation[] actual = await env.Service.GetPreTranslationsAsync(
+            Project01,
+            bookNum,
+            chapterNum,
+            CancellationToken.None
+        );
+        Assert.AreEqual(1, actual.Length);
+        Assert.AreEqual("verse_1_1", actual.First().Reference);
+        Assert.AreEqual(
+            "By the old man, To my dear friend Gaius, whom I love in the truth: ",
+            actual.First().Translation
+        );
+    }
+
+    [Test]
+    [Obsolete("Tests legacy corpus")]
+    public async Task GetPreTranslationsAsync_LegacyCorpus()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true });
+        const int bookNum = 64;
+        const int chapterNum = 1;
+        string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
+        env.TranslationEnginesClient.GetAllCorpusPretranslationsAsync(
                 TranslationEngine01,
                 Corpus01,
                 textId,
@@ -192,7 +256,7 @@ public class PreTranslationServiceTests
         string textId = PreTranslationService.GetTextId(bookNum);
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
                 TranslationEngine01,
-                Corpus01,
+                ParallelCorpus01,
                 textId,
                 CancellationToken.None
             )
@@ -208,7 +272,7 @@ public class PreTranslationServiceTests
         Assert.Zero(actual.Length);
         await env
             .TranslationEnginesClient.Received()
-            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None);
+            .GetAllPretranslationsAsync(TranslationEngine01, ParallelCorpus01, textId, CancellationToken.None);
     }
 
     [Test]
@@ -221,7 +285,7 @@ public class PreTranslationServiceTests
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
                 TranslationEngine01,
-                Corpus01,
+                ParallelCorpus01,
                 textId,
                 CancellationToken.None
             )
@@ -237,7 +301,7 @@ public class PreTranslationServiceTests
         Assert.Zero(actual.Length);
         await env
             .TranslationEnginesClient.Received()
-            .GetAllPretranslationsAsync(TranslationEngine01, Corpus01, textId, CancellationToken.None);
+            .GetAllPretranslationsAsync(TranslationEngine01, ParallelCorpus01, textId, CancellationToken.None);
     }
 
     [Test]
@@ -252,7 +316,7 @@ public class PreTranslationServiceTests
         string textId = PreTranslationService.GetTextId(bookNum);
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
                 TranslationEngine01,
-                Corpus01,
+                ParallelCorpus01,
                 textId,
                 CancellationToken.None
             )
@@ -332,7 +396,7 @@ public class PreTranslationServiceTests
         string textId = PreTranslationService.GetTextId(bookNum, chapterNum);
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
                 TranslationEngine01,
-                Corpus01,
+                ParallelCorpus01,
                 textId,
                 CancellationToken.None
             )
@@ -400,6 +464,39 @@ public class PreTranslationServiceTests
             "Abraham was the father of Isaac, Isaac was the father of James, and James was the father of Jude and his brethren. ",
             actual.Last().Translation
         );
+    }
+
+    [Test]
+    [Obsolete("Uses legacy corpus")]
+    public async Task GetPreTranslationUsfmAsync_LegacyCorpus()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(
+            new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true, UseParatextZipFile = true }
+        );
+        env.TranslationEnginesClient.GetCorpusPretranslatedUsfmAsync(
+                id: Arg.Any<string>(),
+                corpusId: Arg.Any<string>(),
+                textId: "MAT",
+                textOrigin: PretranslationUsfmTextOrigin.OnlyPretranslated,
+                template: PretranslationUsfmTemplate.Source,
+                paragraphMarkerBehavior: Arg.Any<PretranslationUsfmMarkerBehavior>(),
+                embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: Arg.Any<PretranslationNormalizationBehavior>(),
+                cancellationToken: CancellationToken.None
+            )
+            .Returns(TestEnvironment.MatthewBookUsfm);
+
+        // SUT
+        string usfm = await env.Service.GetPreTranslationUsfmAsync(
+            Project01,
+            40,
+            0,
+            new DraftUsfmConfig(),
+            CancellationToken.None
+        );
+        Assert.AreEqual(TestEnvironment.MatthewBookUsfm, usfm);
     }
 
     [Test]
@@ -484,9 +581,9 @@ public class PreTranslationServiceTests
                 Arg.Any<PretranslationUsfmTextOrigin>(),
                 Arg.Any<PretranslationUsfmTemplate>(),
                 paragraphMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
-                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                 styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 cancellationToken: CancellationToken.None
             );
 
@@ -507,9 +604,9 @@ public class PreTranslationServiceTests
                 Arg.Any<PretranslationUsfmTextOrigin>(),
                 Arg.Any<PretranslationUsfmTemplate>(),
                 paragraphMarkerBehavior: PretranslationUsfmMarkerBehavior.PreservePosition,
-                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                 styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 cancellationToken: CancellationToken.None
             );
 
@@ -530,9 +627,9 @@ public class PreTranslationServiceTests
                 Arg.Any<PretranslationUsfmTextOrigin>(),
                 Arg.Any<PretranslationUsfmTemplate>(),
                 paragraphMarkerBehavior: PretranslationUsfmMarkerBehavior.Preserve,
-                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                 styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 cancellationToken: CancellationToken.None
             );
     }
@@ -562,9 +659,9 @@ public class PreTranslationServiceTests
                 Arg.Any<PretranslationUsfmTextOrigin>(),
                 Arg.Any<PretranslationUsfmTemplate>(),
                 paragraphMarkerBehavior: PretranslationUsfmMarkerBehavior.PreservePosition,
-                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Normalized,
                 embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                 styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Normalized,
                 cancellationToken: CancellationToken.None
             );
 
@@ -585,9 +682,9 @@ public class PreTranslationServiceTests
                 Arg.Any<PretranslationUsfmTextOrigin>(),
                 Arg.Any<PretranslationUsfmTemplate>(),
                 paragraphMarkerBehavior: PretranslationUsfmMarkerBehavior.PreservePosition,
-                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                 styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                quoteNormalizationBehavior: PretranslationNormalizationBehavior.Denormalized,
                 cancellationToken: CancellationToken.None
             );
     }
@@ -670,7 +767,7 @@ public class PreTranslationServiceTests
 
         env.TranslationEnginesClient.GetAllPretranslationsAsync(
                 TranslationEngine01,
-                Corpus01,
+                ParallelCorpus01,
                 textId: null,
                 CancellationToken.None
             )
@@ -709,12 +806,13 @@ public class PreTranslationServiceTests
     }
 
     [Test]
+    [Obsolete("Tests legacy corpus")]
     public async Task UpdatePreTranslationStatusAsync_Text()
     {
         // Set up test environment
-        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true });
 
-        env.TranslationEnginesClient.GetAllPretranslationsAsync(
+        env.TranslationEnginesClient.GetAllCorpusPretranslationsAsync(
                 TranslationEngine01,
                 Corpus01,
                 textId: null,
@@ -756,6 +854,7 @@ public class PreTranslationServiceTests
 
     private class TestEnvironmentOptions
     {
+        public bool MockLegacyPreTranslationParameters { get; init; }
         public bool MockPreTranslationParameters { get; init; }
         public bool UseParatextZipFile { get; init; }
     }
@@ -808,14 +907,14 @@ public class PreTranslationServiceTests
             TranslationEnginesClient
                 .GetPretranslatedUsfmAsync(
                     id: Arg.Any<string>(),
-                    corpusId: Arg.Any<string>(),
+                    parallelCorpusId: Arg.Any<string>(),
                     textId: "MAT",
                     textOrigin: PretranslationUsfmTextOrigin.OnlyPretranslated,
                     template: PretranslationUsfmTemplate.Source,
                     paragraphMarkerBehavior: Arg.Any<PretranslationUsfmMarkerBehavior>(),
-                    quoteNormalizationBehavior: Arg.Any<PretranslationNormalizationBehavior>(),
                     embedBehavior: PretranslationUsfmMarkerBehavior.Strip,
                     styleMarkerBehavior: PretranslationUsfmMarkerBehavior.Strip,
+                    quoteNormalizationBehavior: Arg.Any<PretranslationNormalizationBehavior>(),
                     cancellationToken: CancellationToken.None
                 )
                 .Returns(MatthewBookUsfm);
@@ -824,14 +923,25 @@ public class PreTranslationServiceTests
                 RealtimeService,
                 TranslationEnginesClient
             );
-            if (options.MockPreTranslationParameters)
+            if (options.MockLegacyPreTranslationParameters)
             {
                 Service
                     .Configure()
                     .GetPreTranslationParametersAsync(Project01)
                     .Returns(
-                        Task.FromResult<(string, string, bool)>(
-                            (TranslationEngine01, Corpus01, options.UseParatextZipFile)
+                        Task.FromResult<(string, string, string, bool)>(
+                            (TranslationEngine01, Corpus01, null, options.UseParatextZipFile)
+                        )
+                    );
+            }
+            else if (options.MockPreTranslationParameters)
+            {
+                Service
+                    .Configure()
+                    .GetPreTranslationParametersAsync(Project01)
+                    .Returns(
+                        Task.FromResult<(string, string, string, bool)>(
+                            (TranslationEngine01, null, ParallelCorpus01, options.UseParatextZipFile)
                         )
                     );
             }

--- a/tools/ServalBuildReport/ServalBuildReport.csproj
+++ b/tools/ServalBuildReport/ServalBuildReport.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="NPOI" Version="2.7.5" />
-    <PackageReference Include="Serval.Client" Version="1.9.1" />
+    <PackageReference Include="Serval.Client" Version="1.12.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Serval.Client" Version="1.9.1" />
+    <PackageReference Include="Serval.Client" Version="1.12.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the Serval Client to version 1.12.1 (the version currently on QA).

This update to Serval.Client marks several the older corpus API endpoints as deprecated, so the code now clearly needs to demarcate whether a parallel corpus or a legacy corpus is being used to retrieve pre-translations.

This PR should only be merged when Serval 1.12.1 is deployed to production (likely later this week).

The current version of Serval.Client (1.10.1) will continue to work as per normal when Serval production is updated, so this PR is not a blocker in any way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3495)
<!-- Reviewable:end -->
