### PR TITLE
SF-3736 Use Serval data to populate builds list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -117,7 +117,7 @@
   "omnisharp.enableRoslynAnalyzers": true,
   "python.formatting.provider": "black",
   "deno.enablePaths": ["./src/SIL.XForge.Scripture/ClientApp/e2e", "./scripts/"],
-  "deno.disablePaths": ["./scripts/db_tools/"],
+  "deno.disablePaths": ["./scripts/db_tools/", "./src"],
   "typescript.tsdk": "./src/SIL.XForge.Scripture/ClientApp/node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.preferences.importModuleSpecifier": "relative",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@ The software and a backing database can be run using the [dev container](.devcon
 
 - If you run frontend tests, run them in the `src/SIL.XForge.Scripture/ClientApp` directory with a command such as `npm run test:headless -- --watch=false --include '**/text.component.spec.ts' --include '**/settings.component.spec.ts'`
 - If you need to run all frontend tests, you can run them in the `src/SIL.XForge.Scripture/ClientApp` directory with command `npm run test:headless -- --watch=false`
+- If you run backend dotnet tests, run them in the repository root directory with a command such as `dotnet test`.

--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -11,6 +11,14 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 - Component template stylesheets should be in separate .scss files, rather than specified inline in the component decorator.
 - Avoid hard-coding colors in SCSS files when styling components. Instead, use existing CSS variables or create an Angular Material theme file and import it into src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
 
+# Frontend styling
+
+- Avoid making up and using hard-coded or new color values. Where feasible, use color values from [Material Design](https://material.angular.dev/guide/theming-your-components). For example, `--mat-sys-surface` and `--mat-sys-on-primary`. If you can't get close to what you want from Material Design colors, you can use a defined color in `_variables.scss` or `material-styles.scss`. Follow patterns in existing `_foo-theme.scss` files.
+
+# Frontend user interface
+
+- Use Sentence case for user interface elements, per Material Design. Do not use Title Case for user interface elements. For example, use "Project settings" rather than "Project Settings".
+
 ## Frontend testing
 
 - Write unit tests for new components and services
@@ -64,10 +72,27 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   `const buildEvents: EventMetric[] = eventsSorted.filter(...);` and
   `const buildEvent: EventMetric | undefined = buildEvents[0];`.
 - Prefer to use `null` to express a deliberate absence of a value, and `undefined` to express a value that has not been set yet.
+- Do not use the `!` non-null assertion operator. For example, do not write `foo!.baz()`. If you need to dereference `foo`, first prove to the type system that `foo` is not null either by using a type guard or checking for null. You may use the `!` non-null assertion operator in spec test files.
+- Do not use the `as` type assertion operator. For example, do not write `const foo: SomeType = someValue as SomeType`. If you need to treat `someValue` as `SomeType`, first prove to the type system that `someValue` is of type `SomeType` such as by using a type guard. You may use the `as` type assertion operator in spec test files.
+- Do not use object property shorthand when creating objects. For example, do not write `const obj = { foo, bar };`. Instead, write `const obj = { foo: foo, bar: bar };`.
+- Do not reorder existing fields and methods to comply with this, but when creating new fields and methods in TypeScript classes, use this order:
+  1. public static fields
+  2. @Input, @Output, and @ViewChild fields
+  3. public instance fields
+  4. non-public static and instance fields
+  5. constructor
+  6. getters and setters
+  7. ngOnInit
+  8. public static and instance methods
+  9. non-public static and instance methods
 
 ## Angular templates
 
 - Use `@if {}` syntax rather than `*ngIf` syntax.
+
+# C# language
+
+- Do not use the `!` null-forgiving operator. Instead, check for null and cause a specific outcome if it is null, or make use of the `NotNullWhen` attribute. You may use the `!` null-forgiving operator in test files.
 
 ## Code
 
@@ -76,6 +101,8 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 - It is better to explicitly check for and handle problems, or prevent problems from happening, than to assume problems will not happen.
 - Corner-cases happen. They should be handled in code.
 - Please don't change existing code without good justification. Existing code largely works and changing it will cause work for code review. Leave existing code as is when possible.
+- Avoid magic numbers where not obvious. Use a named constant for the value instead, which can be defined right before usage.
+- Don't write useless comments. For example, for field `translationEngineId`, comment "The translation engine ID." adds no additional information than the name of the field already says.
 
 ## Tests
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
@@ -10,8 +10,21 @@ export interface BuildDto extends ResourceDto {
   state: BuildStates;
   queueDepth: number;
   additionalInfo?: ServalBuildAdditionalInfo;
+  /** The Serval deployment version that executed this build. */
+  deploymentVersion?: string;
+  /** Execution data from the Serval build, including training/pretranslation counts and language tags. */
+  executionData?: BuildExecutionData;
 }
 
+/** Execution data from a Serval translation build. */
+export interface BuildExecutionData {
+  trainCount: number;
+  pretranslateCount: number;
+  sourceLanguageTag?: string;
+  targetLanguageTag?: string;
+}
+
+/** Additional information about a Serval build. */
 export interface ServalBuildAdditionalInfo {
   buildId: string;
   corporaIds?: string[];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.spec.ts
@@ -86,7 +86,19 @@ describe('RemoteTranslationEngine', () => {
     env.addCreateBuild();
 
     when(env.mockedHttpClient.post<BuildDto>('translation/builds', JSON.stringify('project01'))).thenReturn(
-      of({ status: 200 })
+      of({
+        status: 200,
+        data: {
+          id: 'build01',
+          href: 'translation/builds/id:build01',
+          revision: 0,
+          engine: { id: 'engine01', href: 'translation/engines/id:engine01' },
+          percentCompleted: 0,
+          message: '',
+          state: BuildStates.Pending,
+          queueDepth: 0
+        }
+      })
     );
 
     await env.client.startTraining();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/remote-translation-engine.ts
@@ -164,15 +164,21 @@ export class RemoteTranslationEngine implements InteractiveTranslationEngine {
   }
 
   private getEngine(projectId: string): Observable<EngineDto> {
-    return this.httpClient
-      .get<EngineDto>(`translation/engines/project:${projectId}`)
-      .pipe(map(res => res.data as EngineDto));
+    return this.httpClient.get<EngineDto>(`translation/engines/project:${projectId}`).pipe(
+      map(res => {
+        if (res.data == null) throw new Error('Unexpectedly received no engine data.');
+        return res.data;
+      })
+    );
   }
 
   private createBuild(engineId: string): Observable<BuildDto> {
-    return this.httpClient
-      .post<BuildDto>('translation/builds', JSON.stringify(engineId))
-      .pipe(map(res => res.data as BuildDto));
+    return this.httpClient.post<BuildDto>('translation/builds', JSON.stringify(engineId)).pipe(
+      map(res => {
+        if (res.data == null) throw new Error('Unexpectedly received no build data.');
+        return res.data;
+      })
+    );
   }
 
   private pollBuildProgress(locator: string, minRevision: number): Observable<ProgressStatus> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -1,0 +1,63 @@
+@use 'sass:color';
+@use '@angular/material' as mat;
+@use '../../_variables' as vars;
+
+/**
+ * Theme for the Serval Builds component.
+ */
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  // Status icon colors
+  --sf-serval-builds-status-userrequested: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
+  --sf-serval-builds-status-submittedtoserval: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
+  --sf-serval-builds-status-queued: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
+  --sf-serval-builds-status-pending: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
+  --sf-serval-builds-status-active: #{if($is-dark, #4fa3ff, #007fff)};
+  --sf-serval-builds-status-finishing: #{if($is-dark, #4fa3ff, #007fff)};
+  --sf-serval-builds-status-completed: #{if($is-dark, lightGreen, darkGreen)};
+  --sf-serval-builds-status-faulted: #{mat.get-theme-color($theme, error, if($is-dark, 70, 40))};
+  --sf-serval-builds-status-canceled: #{mat.get-theme-color($theme, neutral, if($is-dark, 60, 50))};
+
+  // Problem/warning indicator
+  --sf-serval-builds-problem-color: #{if($is-dark, #dbdb00, #ffcc00)};
+  --sf-serval-builds-problem-border-color: var(--mat-table-background-color);
+
+  // Table
+  --sf-serval-builds-table-odd-row-background: #{if(
+      $is-dark,
+      var(--mat-sys-surface-container),
+      var(--mat-sys-surface-container-high)
+    )};
+  --sf-serval-builds-table-odd-row-expanded-background: #{if(
+      $is-dark,
+      var(--mat-sys-surface-container),
+      var(--mat-sys-surface-container-high)
+    )};
+  --sf-serval-builds-table-odd-row-detail-card-background: #{if(
+      $is-dark,
+      var(--mat-sys-surface-container-highest),
+      var(--mat-sys-surface-dim)
+    )};
+  --sf-serval-builds-table-even-row-detail-card-background: #{if(
+      $is-dark,
+      var(--mat-sys-surface-container-low),
+      var(--mat-sys-surface-container)
+    )};
+
+  // Links and text
+  --sf-serval-builds-project-link-color: #{mat.get-theme-color($theme, primary, if($is-dark, 70, 40))};
+  --sf-serval-builds-subdued-text: #{mat.get-theme-color($theme, neutral, if($is-dark, 70, 50))};
+  --sf-serval-builds-label-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 80, 50))};
+  --sf-serval-builds-duration-bar-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 80))};
+
+  // Deleted project indicator
+  --sf-serval-builds-deleted-project-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 60, 50))};
+  --sf-serval-builds-deleted-icon-color: #{mat.get-theme-color($theme, error, if($is-dark, 70, 40))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -13,6 +13,8 @@
   --sf-serval-builds-status-submittedtoserval: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
   --sf-serval-builds-status-queued: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
   --sf-serval-builds-status-pending: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
+  // Note that some colors are hard-coded rather than from the palette because they the palette is not broad enough to
+  // encompass the diversity of and desired colors to correspond to statuses and problems.
   --sf-serval-builds-status-active: #{if($is-dark, #4fa3ff, #007fff)};
   --sf-serval-builds-status-finishing: #{if($is-dark, #4fa3ff, #007fff)};
   --sf-serval-builds-status-completed: #{if($is-dark, lightGreen, darkGreen)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -13,7 +13,7 @@
   --sf-serval-builds-status-submittedtoserval: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
   --sf-serval-builds-status-queued: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
   --sf-serval-builds-status-pending: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
-  // Note that some colors are hard-coded rather than from the palette because they the palette is not broad enough to
+  // Note that some colors are hard-coded rather than from the palette because it is not broad enough to
   // encompass the diversity of and desired colors to correspond to statuses and problems.
   --sf-serval-builds-status-active: #{if($is-dark, #4fa3ff, #007fff)};
   --sf-serval-builds-status-finishing: #{if($is-dark, #4fa3ff, #007fff)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
@@ -4,82 +4,38 @@ import { getTestTranslocoModule } from 'xforge-common/test-utils';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 
 describe('DraftJobsExportService', () => {
-  describe('createSpreadsheetRows', () => {
-    it('should export with correct headers and data', () => {
-      const env = new TestEnvironment();
-      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).createSpreadsheetRows([
-        {
-          job: {
-            buildId: 'build-123',
-            startTime: new Date('2025-01-15T10:00:00Z'),
-            finishTime: new Date('2025-01-15T11:00:00Z'),
-            duration: 3600000 // 1 hour in milliseconds
-          },
-          projectId: 'project1',
-          projectName: 'Test Project',
-          status: 'Success',
-          userId: 'user123',
-          trainingBooks: [{ projectId: 'project1', books: ['GEN'] }],
-          translationBooks: [{ projectId: 'project1', books: ['MAT'] }]
-        }
-      ]);
-
-      expect(spreadsheetRows.length).toEqual(1);
-      expect(spreadsheetRows[0]).toEqual({
-        servalBuildId: 'build-123',
-        startTime: '2025-01-15T10:00:00.000Z',
-        endTime: '2025-01-15T11:00:00.000Z',
-        durationMinutes: '60',
-        status: 'Success',
-        sfProjectId: 'project1',
-        projectName: 'Test Project',
-        sfUserId: 'user123',
-        trainingBooks: 'project1: GEN',
-        translationBooks: 'project1: MAT'
-      });
-    });
-  });
-
-  describe('createSpreadsheetRowsWithStatistics', () => {
+  describe('addStatistics', () => {
     it('should append blank row and statistics rows with mean and max duration', () => {
       const env = new TestEnvironment();
-      const testRows = [
+      const testRows: SpreadsheetRow[] = [
         {
-          job: {
-            buildId: 'build-1',
-            startTime: new Date('2025-01-15T10:00:00Z'),
-            finishTime: new Date('2025-01-15T10:30:00Z'),
-            duration: 1800000 // 30 minutes in milliseconds
-          },
-          projectId: 'project1',
-          projectName: 'Project 1',
+          servalBuildId: 'build-1',
+          startTime: '2025-01-15T10:00:00.000Z',
+          endTime: '2025-01-15T10:30:00.000Z',
+          durationMinutes: '30',
           status: 'Success',
-          userId: 'user1',
-          trainingBooks: [],
-          translationBooks: []
+          sfProjectId: 'project1',
+          projectName: 'Project 1',
+          sfUserId: 'user1',
+          trainingBooks: '',
+          translationBooks: ''
         },
         {
-          job: {
-            buildId: 'build-2',
-            startTime: new Date('2025-01-15T11:00:00Z'),
-            finishTime: new Date('2025-01-15T12:00:00Z'),
-            duration: 3600000 // 60 minutes in milliseconds
-          },
-          projectId: 'project1',
-          projectName: 'Project 1',
+          servalBuildId: 'build-2',
+          startTime: '2025-01-15T11:00:00.000Z',
+          endTime: '2025-01-15T12:00:00.000Z',
+          durationMinutes: '60',
           status: 'Success',
-          userId: 'user2',
-          trainingBooks: [],
-          translationBooks: []
+          sfProjectId: 'project1',
+          projectName: 'Project 1',
+          sfUserId: 'user2',
+          trainingBooks: '',
+          translationBooks: ''
         }
       ];
 
       // SUT: create rows with the test data
-      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).createSpreadsheetRowsWithStatistics(
-        testRows,
-        2700000,
-        3600000
-      );
+      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).addStatistics(testRows, 2700000, 3600000);
 
       // Should have 2 data rows + 1 blank row + 2 statistics rows = 5 total
       expect(spreadsheetRows.length).toEqual(5);
@@ -102,7 +58,7 @@ describe('DraftJobsExportService', () => {
     it('should handle empty rows array', () => {
       const env = new TestEnvironment();
       // SUT
-      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).createSpreadsheetRowsWithStatistics([], 0, 0);
+      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).addStatistics([], 0, 0);
 
       // Should have only blank row + 2 statistics rows = 3 total
       expect(spreadsheetRows.length).toEqual(3);
@@ -114,6 +70,16 @@ describe('DraftJobsExportService', () => {
 
       expect(spreadsheetRows[2].servalBuildId).toMatch(/Max/);
       expect(spreadsheetRows[2].startTime).toBe('0');
+    });
+  });
+
+  describe('getExportFilename', () => {
+    it('should use the provided filename prefix', () => {
+      const env = new TestEnvironment();
+      const dateRange = { start: new Date(2025, 0, 15), end: new Date(2025, 1, 28) };
+
+      const filename: string = (env.service as any).getExportFilename(dateRange, 'csv', 'my-prefix');
+      expect(filename).toBe('my-prefix_2025-01-15_2025-02-28.csv');
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
@@ -82,6 +82,60 @@ describe('DraftJobsExportService', () => {
       expect(filename).toBe('my-prefix_2025-01-15_2025-02-28.csv');
     });
   });
+
+  describe('exportRsv', () => {
+    it('includes draftGenerationRequestId in RSV headers and rows', () => {
+      const env = new TestEnvironment();
+      const testRows: SpreadsheetRow[] = [
+        {
+          servalBuildId: 'build-1',
+          draftGenerationRequestId: 'req-123',
+          startTime: '2025-01-15T10:00:00.000Z',
+          endTime: '2025-01-15T10:30:00.000Z',
+          durationMinutes: '30',
+          status: 'Success',
+          sfProjectId: 'project1',
+          projectName: 'Project 1',
+          sfUserId: 'user1',
+          trainingBooks: '',
+          translationBooks: ''
+        }
+      ];
+
+      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).addStatistics(testRows, 1800000, 1800000);
+
+      // SUT
+      const rsvRows: (string | null)[][] = (env.service as any).createRsvRows(spreadsheetRows);
+
+      expect(rsvRows[0]).toContain('draftGenerationRequestId');
+      expect(rsvRows[1]).toContain('req-123');
+    });
+
+    it('includes blank value for draftGenerationRequestId when missing', () => {
+      const env = new TestEnvironment();
+      const testRows: SpreadsheetRow[] = [
+        {
+          servalBuildId: 'build-1',
+          startTime: '2025-01-15T10:00:00.000Z',
+          endTime: '2025-01-15T10:30:00.000Z',
+          durationMinutes: '30',
+          status: 'Success',
+          sfProjectId: 'project1',
+          projectName: 'Project 1',
+          sfUserId: 'user1',
+          trainingBooks: '',
+          translationBooks: ''
+        }
+      ];
+
+      const spreadsheetRows: SpreadsheetRow[] = (env.service as any).addStatistics(testRows, 1800000, 1800000);
+
+      // SUT
+      const rsvRows: (string | null)[][] = (env.service as any).createRsvRows(spreadsheetRows);
+
+      expect(rsvRows[1][0]).toBeNull();
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 import { NormalizedDateRange } from './date-range-picker.component';
-import { DraftJobsTableRow } from './draft-jobs.component';
 import { encodeRsv } from './rsv';
 
 /** Set of strings representing a Serval build job, to include in an exported spreadsheet. This is somewhat of a
@@ -40,14 +39,15 @@ export class DraftJobsExportService {
    * Export the draft jobs data to a CSV file.
    */
   exportCsv(
-    rows: DraftJobsTableRow[],
-    dateRange: NormalizedDateRange,
+    rows: SpreadsheetRow[],
+    dateRangeForFilename: NormalizedDateRange,
     meanDuration: number,
-    maxDuration: number
+    maxDuration: number,
+    filenamePrefix: string
   ): void {
-    const spreadsheetRows = this.createSpreadsheetRowsWithStatistics(rows, meanDuration, maxDuration);
+    const spreadsheetRows = this.addStatistics(rows, meanDuration, maxDuration);
     const csv: string = Papa.unparse(spreadsheetRows);
-    const filename: string = this.getExportFilename(dateRange, 'csv');
+    const filename: string = this.getExportFilename(dateRangeForFilename, 'csv', filenamePrefix);
     const blob: Blob = new Blob([csv], { type: 'text/csv' });
     saveAs(blob, filename);
   }
@@ -56,12 +56,13 @@ export class DraftJobsExportService {
    * Export the draft jobs data to an RSV (Rows of String Values) file.
    */
   exportRsv(
-    rows: DraftJobsTableRow[],
-    dateRange: NormalizedDateRange,
+    rows: SpreadsheetRow[],
+    dateRangeForFilename: NormalizedDateRange,
     meanDuration: number,
-    maxDuration: number
+    maxDuration: number,
+    filenamePrefix: string
   ): void {
-    const spreadsheetRows = this.createSpreadsheetRowsWithStatistics(rows, meanDuration, maxDuration);
+    const spreadsheetRows = this.addStatistics(rows, meanDuration, maxDuration);
 
     // Convert SpreadsheetRow objects to (string | null)[][] format for RSV
     // First row is headers
@@ -98,21 +99,16 @@ export class DraftJobsExportService {
     const rsvData: Uint8Array = encodeRsv(allRows);
 
     // Create filename and download
-    const filename: string = this.getExportFilename(dateRange, 'rsv');
+    const filename: string = this.getExportFilename(dateRangeForFilename, 'rsv', filenamePrefix);
     const blob: Blob = new Blob([rsvData as BlobPart], { type: 'application/octet-stream' });
     saveAs(blob, filename);
   }
 
   /**
-   * Converts table rows to spreadsheet format and appends statistics (mean and max duration).
+   * Returns a copy of the rows with appended statistics (mean and max duration).
    */
-  protected createSpreadsheetRowsWithStatistics(
-    rows: DraftJobsTableRow[],
-    meanDuration: number,
-    maxDuration: number
-  ): SpreadsheetRow[] {
-    const dataRows = this.createSpreadsheetRows(rows);
-
+  protected addStatistics(rows: SpreadsheetRow[], meanDuration: number, maxDuration: number): SpreadsheetRow[] {
+    const result: SpreadsheetRow[] = [...rows];
     // Append blank row
     const blankRow: SpreadsheetRow = {
       status: '',
@@ -120,7 +116,7 @@ export class DraftJobsExportService {
       trainingBooks: '',
       translationBooks: ''
     };
-    dataRows.push(blankRow);
+    result.push(blankRow);
 
     // Append mean duration row. This is not in a 'correct column', but puts some desired data into the output.
     const meanRow: SpreadsheetRow = {
@@ -131,7 +127,7 @@ export class DraftJobsExportService {
       trainingBooks: '',
       translationBooks: ''
     };
-    dataRows.push(meanRow);
+    result.push(meanRow);
 
     // Append max duration row
     const maxRow: SpreadsheetRow = {
@@ -142,48 +138,18 @@ export class DraftJobsExportService {
       trainingBooks: '',
       translationBooks: ''
     };
-    dataRows.push(maxRow);
+    result.push(maxRow);
 
-    return dataRows;
+    return result;
   }
 
   /**
-   * Converts table rows to spreadsheet format.
+   * Returns export filename using current date range, formatted as {prefix}_YYYY-MM-DD_YYYY-MM-DD.{ext}
    */
-  protected createSpreadsheetRows(rows: DraftJobsTableRow[]): SpreadsheetRow[] {
-    return rows.map<SpreadsheetRow>((row: DraftJobsTableRow) => {
-      const trainingBooksList = row.trainingBooks.map(pb => `${pb.projectId}: ${pb.books.join('; ')}`).join('. ');
-      const translationBooksList = row.translationBooks.map(pb => `${pb.projectId}: ${pb.books.join('; ')}`).join('. ');
-
-      let durationMinutes: string = '';
-      if (row.job.startTime != null && row.job.finishTime != null) {
-        const durationMs = row.job.finishTime.valueOf() - row.job.startTime.valueOf();
-        const minutes = this.msToMinutes(durationMs);
-        durationMinutes = minutes.toFixed(0);
-      }
-
-      return {
-        servalBuildId: row.job.buildId,
-        startTime: row.job.startTime?.toISOString(),
-        endTime: row.job.finishTime?.toISOString(),
-        durationMinutes,
-        status: row.status,
-        sfProjectId: row.projectId,
-        projectName: row.projectName,
-        sfUserId: row.userId,
-        trainingBooks: trainingBooksList,
-        translationBooks: translationBooksList
-      };
-    });
-  }
-
-  /**
-   * Returns export filename using current date range, if possible formatted as draft_jobs_YYYY-MM-DD_YYYY-MM-DD.ext
-   */
-  private getExportFilename(dateRange: NormalizedDateRange, ext: string): string {
+  private getExportFilename(dateRange: NormalizedDateRange, ext: string, filenamePrefix: string): string {
     const startStr = this.formatDateForExport(dateRange.start);
     const endStr = this.formatDateForExport(dateRange.end);
-    return `draft_jobs_${startStr}_${endStr}.${ext}`;
+    return `${filenamePrefix}_${startStr}_${endStr}.${ext}`;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
@@ -11,6 +11,7 @@ import { encodeRsv } from './rsv';
  * Some fields are of type string that one might normally expect to be another type, but that is because this is
  * preparing the data to export as strings. */
 export interface SpreadsheetRow {
+  draftGenerationRequestId?: string;
   servalBuildId?: string;
   /** To be populated with locale-less UTC timestamp. */
   startTime?: string;
@@ -63,10 +64,21 @@ export class DraftJobsExportService {
     filenamePrefix: string
   ): void {
     const spreadsheetRows = this.addStatistics(rows, meanDuration, maxDuration);
+    const allRows: (string | null)[][] = this.createRsvRows(spreadsheetRows);
 
-    // Convert SpreadsheetRow objects to (string | null)[][] format for RSV
-    // First row is headers
+    // Encode to RSV format
+    const rsvData: Uint8Array = encodeRsv(allRows);
+
+    // Create filename and download
+    const filename: string = this.getExportFilename(dateRangeForFilename, 'rsv', filenamePrefix);
+    const blob: Blob = new Blob([rsvData as BlobPart], { type: 'application/octet-stream' });
+    saveAs(blob, filename);
+  }
+
+  protected createRsvRows(spreadsheetRows: SpreadsheetRow[]): (string | null)[][] {
+    // First row is headers.
     const headers: string[] = [
+      'draftGenerationRequestId',
       'servalBuildId',
       'startTime',
       'endTime',
@@ -80,6 +92,7 @@ export class DraftJobsExportService {
     ];
 
     const dataRows: (string | null)[][] = spreadsheetRows.map(row => [
+      row.draftGenerationRequestId ?? null,
       row.servalBuildId ?? null,
       row.startTime ?? null,
       row.endTime ?? null,
@@ -92,16 +105,7 @@ export class DraftJobsExportService {
       row.translationBooks
     ]);
 
-    // Combine headers and data
-    const allRows: (string | null)[][] = [headers, ...dataRows];
-
-    // Encode to RSV format
-    const rsvData: Uint8Array = encodeRsv(allRows);
-
-    // Create filename and download
-    const filename: string = this.getExportFilename(dateRangeForFilename, 'rsv', filenamePrefix);
-    const blob: Blob = new Blob([rsvData as BlobPart], { type: 'application/octet-stream' });
-    saveAs(blob, filename);
+    return [headers, ...dataRows];
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
@@ -75,7 +75,7 @@ export class DraftJobsExportService {
     saveAs(blob, filename);
   }
 
-  protected createRsvRows(spreadsheetRows: SpreadsheetRow[]): (string | null)[][] {
+  private createRsvRows(spreadsheetRows: SpreadsheetRow[]): (string | null)[][] {
     // First row is headers.
     const headers: string[] = [
       'draftGenerationRequestId',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
@@ -117,10 +117,10 @@
         <ng-container matColumnDef="trainingBooks">
           <th mat-header-cell *matHeaderCellDef>Training Books</th>
           <td mat-cell *matCellDef="let row">
-            @for (projectBook of row.trainingBooks; track projectBook.projectId) {
+            @for (projectBook of row.trainingBooks; track projectBook.sfProjectId) {
               <div>
-                <a [routerLink]="['/serval-administration', projectBook.projectId]" class="project-link">{{
-                  getProjectShortName(projectBook.projectId)
+                <a [routerLink]="['/serval-administration', projectBook.sfProjectId]" class="project-link">{{
+                  getProjectShortName(projectBook.sfProjectId)
                 }}</a
                 >:
                 @if (projectBook.books.length <= 2) {
@@ -139,10 +139,10 @@
         <ng-container matColumnDef="translationBooks">
           <th mat-header-cell *matHeaderCellDef>Translation Books</th>
           <td mat-cell *matCellDef="let row">
-            @for (projectBook of row.translationBooks; track projectBook.projectId) {
+            @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
               <div>
-                <a [routerLink]="['/serval-administration', projectBook.projectId]" class="project-link">{{
-                  getProjectShortName(projectBook.projectId)
+                <a [routerLink]="['/serval-administration', projectBook.sfProjectId]" class="project-link">{{
+                  getProjectShortName(projectBook.sfProjectId)
                 }}</a
                 >:
                 @if (projectBook.books.length <= 2) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -36,17 +36,14 @@ import { InfoComponent } from '../shared/info/info.component';
 import { NoticeComponent } from '../shared/notice/notice.component';
 import { projectLabel } from '../shared/utils';
 import { DateRangePickerComponent, NormalizedDateRange } from './date-range-picker.component';
-import { DraftJobsExportService } from './draft-jobs-export.service';
+import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { JobDetailsDialogComponent } from './job-details-dialog.component';
 import { ServalAdministrationService } from './serval-administration.service';
+import { ProjectBooks } from './serval-build-report';
+import { ServalBuildsComponent } from './serval-builds.component';
 
 /** Outcome or in-progress situation of a draft generation request job. */
 export type DraftJobStatus = 'running' | 'success' | 'failed' | 'cancelled' | 'incomplete';
-
-interface ProjectBooks {
-  projectId: string;
-  books: string[];
-}
 
 /** Defines information about a Serval draft generation request. This is exported so it can be used in tests. */
 export interface DraftJob {
@@ -781,12 +778,12 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     for (const job of this.draftJobs) {
       if (job.trainingBooks) {
         for (const projectBook of job.trainingBooks) {
-          projectIds.add(projectBook.projectId);
+          projectIds.add(projectBook.sfProjectId);
         }
       }
       if (job.translationBooks) {
         for (const projectBook of job.translationBooks) {
-          projectIds.add(projectBook.projectId);
+          projectIds.add(projectBook.sfProjectId);
         }
       }
     }
@@ -862,13 +859,15 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
 
     // Convert maps to ProjectBooks arrays
     const trainingBooks: ProjectBooks[] = Array.from(trainingProjects.entries()).map(([projectId, books]) => ({
-      projectId,
-      books
+      sfProjectId: projectId,
+      projectDisplayName: '',
+      books: books
     }));
 
     const translationBooks: ProjectBooks[] = Array.from(translationProjects.entries()).map(([projectId, books]) => ({
-      projectId,
-      books
+      sfProjectId: projectId,
+      projectDisplayName: '',
+      books: books
     }));
 
     return { trainingBooks, translationBooks };
@@ -883,7 +882,14 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
    */
   exportCsv(): void {
     if (this.currentDateRange == null) throw new Error('Date range is not set');
-    this.exportService.exportCsv(this.rows, this.currentDateRange, this.meanDuration ?? 0, this.maxDuration ?? 0);
+    const spreadsheetRows: SpreadsheetRow[] = DraftJobsComponent.createSpreadsheetRows(this.rows);
+    this.exportService.exportCsv(
+      spreadsheetRows,
+      this.currentDateRange,
+      this.meanDuration ?? 0,
+      this.maxDuration ?? 0,
+      'draft_jobs'
+    );
   }
 
   /**
@@ -891,6 +897,40 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
    */
   exportRsv(): void {
     if (this.currentDateRange == null) throw new Error('Date range is not set');
-    this.exportService.exportRsv(this.rows, this.currentDateRange, this.meanDuration ?? 0, this.maxDuration ?? 0);
+    const spreadsheetRows: SpreadsheetRow[] = DraftJobsComponent.createSpreadsheetRows(this.rows);
+    this.exportService.exportRsv(
+      spreadsheetRows,
+      this.currentDateRange,
+      this.meanDuration ?? 0,
+      this.maxDuration ?? 0,
+      'draft_jobs'
+    );
+  }
+
+  private static createSpreadsheetRows(rows: DraftJobsTableRow[]): SpreadsheetRow[] {
+    return rows.map<SpreadsheetRow>((row: DraftJobsTableRow) => {
+      const trainingBooksList = ServalBuildsComponent.formatProjectBooks(row.trainingBooks);
+      const translationBooksList = ServalBuildsComponent.formatProjectBooks(row.translationBooks);
+
+      let durationMinutes: string = '';
+      if (row.job.startTime != null && row.job.finishTime != null) {
+        const durationMs = row.job.finishTime.valueOf() - row.job.startTime.valueOf();
+        const minutes = durationMs / 1000 / 60;
+        durationMinutes = minutes.toFixed(0);
+      }
+
+      return {
+        servalBuildId: row.job.buildId,
+        startTime: row.job.startTime?.toISOString(),
+        endTime: row.job.finishTime?.toISOString(),
+        durationMinutes,
+        status: row.status,
+        sfProjectId: row.projectId,
+        projectName: row.projectName,
+        sfUserId: row.userId,
+        trainingBooks: trainingBooksList,
+        translationBooks: translationBooksList
+      };
+    });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -923,7 +923,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
         servalBuildId: row.job.buildId,
         startTime: row.job.startTime?.toISOString(),
         endTime: row.job.finishTime?.toISOString(),
-        durationMinutes,
+        durationMinutes: durationMinutes,
         status: row.status,
         sfProjectId: row.projectId,
         projectName: row.projectName,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.html
@@ -13,6 +13,11 @@
         <app-draft-jobs></app-draft-jobs>
       </ng-template>
     </mat-tab>
+    <mat-tab label="Serval Builds">
+      <ng-template matTabContent>
+        <app-serval-builds></app-serval-builds>
+      </ng-template>
+    </mat-tab>
     <mat-tab label="Onboarding Requests">
       <ng-template matTabContent>
         <app-onboarding-requests></app-onboarding-requests>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MobileNotSupportedComponent } from '../shared/mobile-not-supported/mobile-not-supported.component';
 import { DraftJobsComponent } from './draft-jobs.component';
 import { OnboardingRequestsComponent } from './onboarding-requests/onboarding-requests.component';
+import { ServalBuildsComponent } from './serval-builds.component';
 import { ServalProjectsComponent } from './serval-projects.component';
 
 /**
@@ -19,6 +20,7 @@ import { ServalProjectsComponent } from './serval-projects.component';
     MobileNotSupportedComponent,
     DraftJobsComponent,
     OnboardingRequestsComponent,
+    ServalBuildsComponent,
     MatTabGroup,
     MatTab,
     MatTabContent
@@ -32,7 +34,7 @@ export class ServalAdministrationComponent implements OnInit {
     private readonly router: Router
   ) {}
 
-  private readonly availableTabs = ['projects', 'draft-jobs', 'onboarding-requests'];
+  private readonly availableTabs = ['projects', 'draft-jobs', 'serval-builds', 'onboarding-requests'];
 
   ngOnInit(): void {
     this.route.queryParams.subscribe(params => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
@@ -1,0 +1,139 @@
+import {
+  buildProjectDisplayName,
+  BuildReportProjectScriptureRange,
+  ProjectBooks,
+  toProjectBooks
+} from './serval-build-report';
+
+describe('toProjectBooks', () => {
+  it('parses semicolon-delimited scripture ranges into book arrays', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN;EXO', shortName: 'ABC', name: 'Project ABC' }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result.length).toBe(1);
+    expect(result[0].sfProjectId).toBe('p1');
+    expect(result[0].projectDisplayName).toBe('ABC - Project ABC');
+    expect(result[0].books).toEqual(['GEN', 'EXO']);
+  });
+
+  it('handles a single-book range', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'MAT', shortName: 'DEF', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result.length).toBe(1);
+    expect(result[0].books).toEqual(['MAT']);
+  });
+
+  it('handles multiple project ranges with different projects', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN;EXO', shortName: 'SRC', name: 'Source' },
+      { sfProjectId: 'p2', scriptureRange: 'MAT;MRK;LUK', shortName: 'TRN', name: 'Training' }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result.length).toBe(2);
+    expect(result[0].sfProjectId).toBe('p1');
+    expect(result[0].projectDisplayName).toBe('SRC - Source');
+    expect(result[0].books).toEqual(['GEN', 'EXO']);
+    expect(result[1].sfProjectId).toBe('p2');
+    expect(result[1].projectDisplayName).toBe('TRN - Training');
+    expect(result[1].books).toEqual(['MAT', 'MRK', 'LUK']);
+  });
+
+  it('returns empty array for undefined ranges', () => {
+    const result: ProjectBooks[] = toProjectBooks(undefined);
+
+    expect(result).toEqual([]);
+  });
+
+  it('skips null entries in the ranges array', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      null as any,
+      { sfProjectId: 'p1', scriptureRange: 'GEN', shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result.length).toBe(1);
+    expect(result[0].sfProjectId).toBe('p1');
+  });
+
+  it('skips entries with undefined sfProjectId', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: undefined as any, scriptureRange: 'GEN', shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result).toEqual([]);
+  });
+
+  it('skips entries with undefined scriptureRange', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: undefined as any, shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to sfProjectId when shortName and name are both undefined', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN', shortName: undefined, name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].projectDisplayName).toBe('p1');
+  });
+
+  it('trims whitespace from book identifiers', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: ' GEN ; EXO ', shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].books).toEqual(['GEN', 'EXO']);
+  });
+
+  it('filters out empty tokens from trailing semicolons', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN;EXO;', shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].books).toEqual(['GEN', 'EXO']);
+  });
+});
+
+describe('buildProjectDisplayName', () => {
+  it('shows shortName - name when both are available', () => {
+    expect(buildProjectDisplayName('ABC', 'My Project', 'p1')).toBe('ABC - My Project');
+  });
+
+  it('shows just shortName when name is undefined', () => {
+    expect(buildProjectDisplayName('ABC', undefined, 'p1')).toBe('ABC');
+  });
+
+  it('shows just name when shortName is undefined', () => {
+    expect(buildProjectDisplayName(undefined, 'My Project', 'p1')).toBe('My Project');
+  });
+
+  it('falls back to projectId when both shortName and name are undefined', () => {
+    expect(buildProjectDisplayName(undefined, undefined, 'p1')).toBe('p1');
+  });
+
+  it('falls back to Unknown when everything is undefined', () => {
+    expect(buildProjectDisplayName(undefined, undefined, undefined)).toBe('Unknown project');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
@@ -95,9 +95,9 @@ describe('toProjectBooks', () => {
     expect(result[0].projectDisplayName).toBe('p1');
   });
 
-  it('trims whitespace from book identifiers', () => {
+  it('filters out empty tokens from trailing semicolons', () => {
     const ranges: BuildReportProjectScriptureRange[] = [
-      { sfProjectId: 'p1', scriptureRange: ' GEN ; EXO ', shortName: 'PRJ', name: undefined }
+      { sfProjectId: 'p1', scriptureRange: 'GEN;EXO;', shortName: 'PRJ', name: undefined }
     ];
 
     const result: ProjectBooks[] = toProjectBooks(ranges);
@@ -105,9 +105,9 @@ describe('toProjectBooks', () => {
     expect(result[0].books).toEqual(['GEN', 'EXO']);
   });
 
-  it('filters out empty tokens from trailing semicolons', () => {
+  it('filters out invalid book identifiers after parsing', () => {
     const ranges: BuildReportProjectScriptureRange[] = [
-      { sfProjectId: 'p1', scriptureRange: 'GEN;EXO;', shortName: 'PRJ', name: undefined }
+      { sfProjectId: 'p1', scriptureRange: 'GEN;NOT_A_BOOK;EXO', shortName: 'PRJ', name: undefined }
     ];
 
     const result: ProjectBooks[] = toProjectBooks(ranges);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
@@ -114,6 +114,28 @@ describe('toProjectBooks', () => {
 
     expect(result[0].books).toEqual(['GEN', 'EXO']);
   });
+
+  it('populates shortName from the range shortName', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN', shortName: 'BSB', name: 'Berean Standard Bible' }
+    ];
+
+    // SUT
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].shortName).toBe('BSB');
+  });
+
+  it('leaves shortName undefined when the range has no shortName', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN', shortName: undefined, name: 'Some Project' }
+    ];
+
+    // SUT
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].shortName).toBeUndefined();
+  });
 });
 
 describe('buildProjectDisplayName', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -1,0 +1,200 @@
+import { BuildDto } from '../machine-api/build-dto';
+
+/**
+ * A report of a Serval build, combining Serval data with SF project information and event metrics.
+ * This mirrors the C# ServalBuildReportDto.
+ */
+export interface ServalBuildReportDto {
+  /** The Serval build data (unless we only had a record of the build request from event metrics). */
+  build: BuildDto | undefined;
+  /** SF project context for the build. Undefined if the project could not be found. */
+  project: BuildReportProject | undefined;
+  /** Timeline of events from both Serval and SF event metrics. */
+  timeline: BuildReportTimeline;
+  /** Build configuration: Scripture ranges and training data files. */
+  config: BuildReportConfig;
+  /** Problems or warnings identified for this build. */
+  problems: string[];
+  /** The SF draft generation request identifier. */
+  draftGenerationRequestId: string | undefined;
+  /** The SF user who requested this build, if known. */
+  requesterSFUserId: string | undefined;
+  /** Status of the build. */
+  status: DraftGenerationBuildStatus;
+}
+
+/** SF project info for a build report entry. */
+export interface BuildReportProject {
+  sfProjectId: string;
+  shortName: string | undefined;
+  name: string | undefined;
+}
+
+/** Serval build phase information. */
+export interface Phase {
+  /** Note that although ServalClient.PhaseStage shows only non-empty options for the enum, ServalClient.Phase.Stage
+   * says an empty string is allowed. */
+  stage: 'Train' | 'Inference' | '';
+  step: number | undefined;
+  stepCount: number | undefined;
+  started: Date | undefined;
+}
+
+/** Timeline of events for a build, combining Serval timestamps and SF event metric timestamps. */
+export interface BuildReportTimeline {
+  // Serval timestamps
+  servalCreated: Date | undefined;
+  servalStarted: Date | undefined;
+  servalCompleted: Date | undefined;
+  servalFinished: Date | undefined;
+  // SF event metric timestamps
+  sfUserRequested: Date | undefined;
+  sfBuildProjectSubmitted: Date | undefined;
+  sfUserCancelled: Date | undefined;
+  sfAcknowledgedCompletion: Date | undefined;
+  /** When the build was requested, with SF user request event time prioritized over Serval creation time. */
+  requestTime: Date | undefined;
+  /** Information on different activities during the build. */
+  phases: Phase[] | undefined;
+}
+
+/** Build configuration: which Scripture ranges were trained on and translated, and what training data files were used. */
+export interface BuildReportConfig {
+  trainingScriptureRanges: BuildReportProjectScriptureRange[];
+  translationScriptureRanges: BuildReportProjectScriptureRange[];
+  trainingDataFileIds: string[];
+}
+
+/**
+ * A scripture range entry enriched with the referenced project's display information.
+ * Mirrors the C# BuildReportProjectScriptureRange.
+ */
+export interface BuildReportProjectScriptureRange {
+  sfProjectId: string;
+  scriptureRange: string;
+  shortName: string | undefined;
+  name: string | undefined;
+}
+
+/** Takes a ServalBuildReportDto with JSON-typed values (date strings, status strings) and converts them to proper
+ * TypeScript types. */
+export function interpretTypes(report: ServalBuildReportDto): ServalBuildReportDto {
+  const parseDate = (value: unknown): Date | undefined => {
+    if (value instanceof Date) return value;
+    if (value == null) return undefined;
+    if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+
+    const parsed: Date = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return undefined;
+    return parsed;
+  };
+
+  const status: string = report.status;
+  if (!isDraftGenerationBuildStatus(status)) {
+    throw new Error(`Unknown DraftGenerationBuildStatus status: ${status}`);
+  }
+
+  const timeline: BuildReportTimeline = report.timeline;
+  const convertedPhases: Phase[] | undefined = timeline.phases?.map((phase: Phase) => ({
+    ...phase,
+    started: parseDate(phase.started)
+  }));
+
+  return {
+    ...report,
+    status: status,
+    timeline: {
+      ...timeline,
+      servalCreated: parseDate(timeline.servalCreated),
+      servalStarted: parseDate(timeline.servalStarted),
+      servalCompleted: parseDate(timeline.servalCompleted),
+      servalFinished: parseDate(timeline.servalFinished),
+      sfUserRequested: parseDate(timeline.sfUserRequested),
+      sfBuildProjectSubmitted: parseDate(timeline.sfBuildProjectSubmitted),
+      sfUserCancelled: parseDate(timeline.sfUserCancelled),
+      sfAcknowledgedCompletion: parseDate(timeline.sfAcknowledgedCompletion),
+      requestTime: parseDate(timeline.requestTime),
+      phases: convertedPhases
+    }
+  };
+}
+
+/**
+ * Status values for a draft generation build request, including SF-specific pre-submission states.
+ * Values match the C# DraftGenerationBuildStatus enum.
+ */
+export const DraftGenerationBuildStatus = {
+  UserRequested: 'UserRequested',
+  SubmittedToServal: 'SubmittedToServal',
+  Pending: 'Pending',
+  Active: 'Active',
+  Completed: 'Completed',
+  Faulted: 'Faulted',
+  Canceled: 'Canceled'
+} as const;
+
+/** Status of a draft generation request, including states before reported on by Serval. */
+export type DraftGenerationBuildStatus = (typeof DraftGenerationBuildStatus)[keyof typeof DraftGenerationBuildStatus];
+
+/** Set of all valid DraftGenerationBuildStatus values. */
+const draftGenerationBuildStatusValues: Set<string> = new Set(Object.values(DraftGenerationBuildStatus));
+
+/** Returns whether the given string is a valid DraftGenerationBuildStatus value. */
+export function isDraftGenerationBuildStatus(value: string): value is DraftGenerationBuildStatus {
+  return draftGenerationBuildStatusValues.has(value);
+}
+
+/** Maps a project to the list of book identifiers involved in a build. */
+export interface ProjectBooks {
+  sfProjectId: string;
+  /** Display string for the project, e.g. "ABC - My Project" or just "ABC". */
+  projectDisplayName: string;
+  books: string[];
+}
+
+/**
+ * Parses BuildReportProjectScriptureRange entries into ProjectBooks records by splitting semicolon-delimited scripture
+ * ranges into individual book identifiers.
+ */
+export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | undefined): ProjectBooks[] {
+  if (ranges == null) {
+    return [];
+  }
+  const projectBooks: ProjectBooks[] = [];
+  for (const range of ranges) {
+    if (range == null) {
+      continue;
+    }
+    const sfProjectId: string | undefined = range.sfProjectId;
+    const scriptureRange: string | undefined = range.scriptureRange;
+    if (sfProjectId == null || scriptureRange == null) {
+      continue;
+    }
+
+    const displayName: string = buildProjectDisplayName(range.shortName, range.name, sfProjectId);
+    const books: string[] = scriptureRange
+      .split(';')
+      .map(token => token.trim())
+      .filter(token => token.length > 0);
+    projectBooks.push({ sfProjectId: sfProjectId, projectDisplayName: displayName, books: books });
+  }
+  return projectBooks;
+}
+
+/** Builds a display name for a project from its short name, name, and ID, falling back gracefully. */
+export function buildProjectDisplayName(
+  shortName: string | undefined,
+  name: string | undefined,
+  projectId: string | undefined
+): string {
+  if (shortName != null && name != null) {
+    return `${shortName} - ${name}`;
+  }
+  if (shortName != null) {
+    return shortName;
+  }
+  if (name != null) {
+    return name;
+  }
+  return projectId ?? 'Unknown project';
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -1,29 +1,21 @@
 import { BuildDto } from '../machine-api/build-dto';
 
 /**
- * A report of a Serval build, combining Serval data with SF project information and event metrics.
- * This mirrors the C# ServalBuildReportDto.
+ * A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
+ * See C# comments.
  */
 export interface ServalBuildReportDto {
-  /** The Serval build data (unless we only had a record of the build request from event metrics). */
   build: BuildDto | undefined;
-  /** SF project context for the build. Undefined if the project could not be found. */
   project: BuildReportProject | undefined;
-  /** Timeline of events from both Serval and SF event metrics. */
   timeline: BuildReportTimeline;
-  /** Build configuration: Scripture ranges and training data files. */
   config: BuildReportConfig;
-  /** Problems or warnings identified for this build. */
   problems: string[];
-  /** The SF draft generation request identifier. */
   draftGenerationRequestId: string | undefined;
-  /** The SF user who requested this build, if known. */
   requesterSFUserId: string | undefined;
-  /** Status of the build. */
   status: DraftGenerationBuildStatus;
 }
 
-/** SF project info for a build report entry. */
+/** SF project information for a build report entry.*/
 export interface BuildReportProject {
   sfProjectId: string;
   shortName: string | undefined;
@@ -40,21 +32,19 @@ export interface Phase {
   started: Date | undefined;
 }
 
-/** Timeline of events for a build, combining Serval timestamps and SF event metric timestamps. */
+/** Timeline of events for a build, combining Serval timestamps and SF event metric timestamps. See C# comments. */
 export interface BuildReportTimeline {
-  // Serval timestamps
   servalCreated: Date | undefined;
   servalStarted: Date | undefined;
   servalCompleted: Date | undefined;
   servalFinished: Date | undefined;
-  // SF event metric timestamps
+
   sfUserRequested: Date | undefined;
   sfBuildProjectSubmitted: Date | undefined;
   sfUserCancelled: Date | undefined;
   sfAcknowledgedCompletion: Date | undefined;
-  /** When the build was requested, with SF user request event time prioritized over Serval creation time. */
+
   requestTime: Date | undefined;
-  /** Information on different activities during the build. */
   phases: Phase[] | undefined;
 }
 
@@ -67,7 +57,6 @@ export interface BuildReportConfig {
 
 /**
  * A scripture range entry enriched with the referenced project's display information.
- * Mirrors the C# BuildReportProjectScriptureRange.
  */
 export interface BuildReportProjectScriptureRange {
   sfProjectId: string;
@@ -120,8 +109,7 @@ export function interpretTypes(report: ServalBuildReportDto): ServalBuildReportD
 }
 
 /**
- * Status values for a draft generation build request, including SF-specific pre-submission states.
- * Values match the C# DraftGenerationBuildStatus enum.
+ * Status of a draft generation build request. See C# DraftGenerationBuildStatus enum comments.
  */
 export const DraftGenerationBuildStatus = {
   UserRequested: 'UserRequested',
@@ -133,7 +121,7 @@ export const DraftGenerationBuildStatus = {
   Canceled: 'Canceled'
 } as const;
 
-/** Status of a draft generation request, including states before reported on by Serval. */
+/** Status of a draft generation request. */
 export type DraftGenerationBuildStatus = (typeof DraftGenerationBuildStatus)[keyof typeof DraftGenerationBuildStatus];
 
 /** Set of all valid DraftGenerationBuildStatus values. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -1,4 +1,6 @@
+import { Canon } from '@sillsdev/scripture';
 import { BuildDto } from '../machine-api/build-dto';
+import { booksFromScriptureRange } from '../shared/utils';
 
 /**
  * A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
@@ -141,7 +143,7 @@ export interface ProjectBooks {
 }
 
 /**
- * Parses BuildReportProjectScriptureRange entries into ProjectBooks records by splitting semicolon-delimited scripture
+ * Parses BuildReportProjectScriptureRange entries into ProjectBooks records by parsing semicolon-delimited scripture
  * ranges into individual book identifiers.
  */
 export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | undefined): ProjectBooks[] {
@@ -160,10 +162,8 @@ export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | unde
     }
 
     const displayName: string = buildProjectDisplayName(range.shortName, range.name, sfProjectId);
-    const books: string[] = scriptureRange
-      .split(';')
-      .map(token => token.trim())
-      .filter(token => token.length > 0);
+    const bookNumbers: number[] = booksFromScriptureRange(scriptureRange);
+    const books: string[] = bookNumbers.map(bookNum => Canon.bookNumberToId(bookNum));
     projectBooks.push({ sfProjectId: sfProjectId, projectDisplayName: displayName, books: books });
   }
   return projectBooks;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -82,6 +82,7 @@ export function interpretTypes(report: ServalBuildReportDto): ServalBuildReportD
 
   const status: string = report.status;
   if (!isDraftGenerationBuildStatus(status)) {
+    // Noisily handle invalid data.
     throw new Error(`Unknown DraftGenerationBuildStatus status: ${status}`);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -139,6 +139,8 @@ export interface ProjectBooks {
   sfProjectId: string;
   /** Display string for the project, e.g. "ABC - My Project" or just "ABC". */
   projectDisplayName: string;
+  /** Short name of the project if available. */
+  shortName?: string;
   books: string[];
 }
 
@@ -164,7 +166,12 @@ export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | unde
     const displayName: string = buildProjectDisplayName(range.shortName, range.name, sfProjectId);
     const bookNumbers: number[] = booksFromScriptureRange(scriptureRange);
     const books: string[] = bookNumbers.map(bookNum => Canon.bookNumberToId(bookNum));
-    projectBooks.push({ sfProjectId: sfProjectId, projectDisplayName: displayName, books: books });
+    projectBooks.push({
+      sfProjectId: sfProjectId,
+      projectDisplayName: displayName,
+      shortName: range.shortName,
+      books: books
+    });
   }
   return projectBooks;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -1,0 +1,282 @@
+import { notNull } from '../../type-utils';
+import {
+  BuildReportProject,
+  DraftGenerationBuildStatus,
+  ProjectBooks,
+  ServalBuildReportDto
+} from './serval-build-report';
+import { ServalBuildRow, ServalBuildSummary } from './serval-builds.component';
+
+/*
+ * This file contains pure functions for computing aggregate statistics over a number of Serval build records. Tests are
+ * in serval-builds.component.spec.ts.
+ */
+
+/** Returns whether a build status represents an in-progress build. */
+export function isInProgress(status: DraftGenerationBuildStatus): boolean {
+  return (
+    status === DraftGenerationBuildStatus.Active ||
+    status === DraftGenerationBuildStatus.Pending ||
+    status === DraftGenerationBuildStatus.UserRequested ||
+    status === DraftGenerationBuildStatus.SubmittedToServal
+  );
+}
+
+/** Extracts the millisecond timestamp from a Date, returning undefined if the date is null or invalid. */
+export function validDateMsFrom(date: Date | undefined): number | undefined {
+  if (date == null) return undefined;
+  const value: number = date.getTime();
+  if (Number.isNaN(value)) return undefined;
+  return value;
+}
+
+/** Counts the total number of books across all project-book entries. */
+export function countBooks(projectBooks: ProjectBooks[]): number {
+  return projectBooks.reduce((total: number, projectBook: ProjectBooks) => total + projectBook.books.length, 0);
+}
+
+/** Computes the arithmetic mean, returning undefined for an empty array. */
+export function averageNumbers(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  const total: number = values.reduce((sum: number, value: number) => sum + value, 0);
+  return total / values.length;
+}
+
+/**
+ * Computes the gap in milliseconds between consecutive builds for the same project. Builds are ordered by effective
+ * start time. Gaps are measured from the previous build's finish (SF acknowledged time, falling back to Serval finish)
+ * to the next build's request time. Returns undefined entries where builds are missing timing data.
+ */
+export function gapsBetweenBuildsMs(rows: ServalBuildRow[]): Array<number | undefined> {
+  if (rows.length < 2) return [];
+
+  const sortableRows: ServalBuildRow[] = [...rows];
+
+  // Sort by effective start time (SF user request time with fallback to Serval created time)
+  sortableRows.sort((left: ServalBuildRow, right: ServalBuildRow) => {
+    const leftStartMs: number = validDateMsFrom(left.report.timeline.requestTime) ?? 0;
+    const rightStartMs: number = validDateMsFrom(right.report.timeline.requestTime) ?? 0;
+    return leftStartMs - rightStartMs;
+  });
+
+  const gaps: Array<number | undefined> = [];
+  for (let index = 1; index < sortableRows.length; index++) {
+    const previous: ServalBuildRow = sortableRows[index - 1];
+    const next: ServalBuildRow = sortableRows[index];
+    // Use SF acknowledged time with fallback to Serval finish time for previous build
+    const previousFinishMs: number | undefined =
+      validDateMsFrom(previous.report.timeline.sfAcknowledgedCompletion) ??
+      validDateMsFrom(previous.report.timeline.servalFinished);
+    // Use request time with fallback to Serval created time for next build
+    const nextStartMs: number | undefined = validDateMsFrom(next.report.timeline.requestTime);
+    if (previousFinishMs == null || nextStartMs == null) {
+      // If any build lacks a beginning or ending time, log that gap as undefined and callers can decide how to handle
+      // that.
+      gaps.push(undefined);
+      continue;
+    }
+    const gap: number = nextStartMs - previousFinishMs;
+    if (gap < 0) {
+      // Somehow the two build times were overlapping.
+      const previousId: string =
+        previous.report.build?.additionalInfo?.buildId ?? previous.report.draftGenerationRequestId ?? 'unknown id';
+      const nextId: string =
+        next.report.build?.additionalInfo?.buildId ?? next.report.draftGenerationRequestId ?? 'unknown id';
+      console.error(`Two consecutive builds (${previousId}, ${nextId}) have overlapping durations.`);
+      gaps.push(undefined);
+      continue;
+    }
+    gaps.push(gap);
+  }
+  return gaps;
+}
+
+/**
+ * Calculates the percentage of time that successfully completed builds spent in SF rather than in Serval.
+ * Only considers builds that have all four required timing values: sfUserRequestTime,
+ * sfAcknowledgedServalCompletionTime, servalCreated, and servalFinished.
+ */
+export function calculatePercentTimeOnSF(rows: ServalBuildRow[]): number | undefined {
+  let totalDurationMs: number = 0;
+  let totalServalDurationMs: number = 0;
+
+  for (const row of rows) {
+    // Only consider successfully completed builds
+    if (row.report.status !== DraftGenerationBuildStatus.Completed) {
+      continue;
+    }
+
+    // All four timing values are required
+    const sfUserRequestTimeMs: number | undefined = validDateMsFrom(row.report.timeline.sfUserRequested);
+    const sfAcknowledgedTimeMs: number | undefined = validDateMsFrom(row.report.timeline.sfAcknowledgedCompletion);
+    const servalCreatedMs: number | undefined = validDateMsFrom(row.report.timeline.servalCreated);
+    const servalFinishedMs: number | undefined = validDateMsFrom(row.report.timeline.servalFinished);
+
+    if (
+      sfUserRequestTimeMs == null ||
+      sfAcknowledgedTimeMs == null ||
+      servalCreatedMs == null ||
+      servalFinishedMs == null
+    ) {
+      continue;
+    }
+
+    const fullDurationMs: number = sfAcknowledgedTimeMs - sfUserRequestTimeMs;
+    const servalDurationMs: number = servalFinishedMs - servalCreatedMs;
+
+    // Skip builds with inconsistent timing: negative durations or Serval time exceeding total time
+    if (fullDurationMs <= 0 || servalDurationMs < 0 || servalDurationMs > fullDurationMs) {
+      continue;
+    }
+
+    totalDurationMs += fullDurationMs;
+    totalServalDurationMs += servalDurationMs;
+  }
+
+  if (totalDurationMs === 0) {
+    return undefined;
+  }
+
+  const sfDurationMs: number = totalDurationMs - totalServalDurationMs;
+  const percentOnSF: number = (sfDurationMs / totalDurationMs) * 100;
+  return percentOnSF;
+}
+
+/**
+ * Computes aggregate statistics over all build rows. Rows without an associated SF project are
+ * counted as "unconsidered" and excluded from most aggregation. Returns a ServalBuildSummary
+ * containing counts, averages, and timing statistics.
+ */
+export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
+  // Type for a build row where the SF project is known.
+  type KnowableBuildRow = ServalBuildRow & { report: ServalBuildReportDto & { project: BuildReportProject } };
+  // Rows with a known SF project. Any build that is not associable with a project will not be included or
+  // considered for much of the data summarization.
+  const buildRows: KnowableBuildRow[] = rows.filter(
+    (row: ServalBuildRow): row is KnowableBuildRow => row.report.project != null
+  );
+  const unconsideredBuilds: number = rows.length - buildRows.length;
+  const totalBuilds: number = buildRows.length;
+  if (totalBuilds < 1) {
+    return {
+      totalBuilds: totalBuilds,
+      totalProjects: 0,
+      buildsPerProjectRatio: undefined,
+      averageInterBuildTimeMs: undefined,
+      totalRequesters: 0,
+      averageRequestersPerProject: undefined,
+      faultedBuilds: 0,
+      averageTrainingBooksPerBuild: undefined,
+      averageTranslationBooksPerBuild: undefined,
+      completedBuilds: 0,
+      inProgressBuilds: 0,
+      buildsWithProblems: 0,
+      unconsideredBuilds: unconsideredBuilds,
+      meanDurationMs: undefined,
+      maxDurationMs: undefined,
+      percentTimeOnSF: undefined,
+      buildsServalDidNotKnowAbout: 0,
+      buildsSfDidNotKnowAbout: 0
+    };
+  }
+
+  // Group ServalBuildRows by their project.
+  const rowsBySFProjectId: Map<string, KnowableBuildRow[]> = Map.groupBy(
+    buildRows,
+    (buildRow: KnowableBuildRow) => buildRow.report.project.sfProjectId
+  );
+  const sfProjectIdsUsed: Set<string> = new Set(rowsBySFProjectId.keys());
+  const totalProjects: number = sfProjectIdsUsed.size;
+  const buildsPerProjectRatio: number = totalBuilds / totalProjects;
+
+  // Determine the average amount of time between Serval builds of the same project.
+  const allGapsMs: number[] = [];
+  for (const rowsForProject of rowsBySFProjectId.values()) {
+    const gapsMs: number[] = gapsBetweenBuildsMs(rowsForProject).filter(notNull);
+    allGapsMs.push(...gapsMs);
+  }
+  const averageInterBuildTimeMs: number | undefined = averageNumbers(allGapsMs);
+
+  // Determine requesting SF user ids for each project.
+  const requesters: Set<string | undefined> = new Set(
+    buildRows.map(row => row.report.requesterSFUserId).filter(notNull)
+  );
+  const totalRequesters: number = requesters.size;
+
+  let averageRequestersPerProject: number | undefined = undefined;
+  // (Only compute average if we know the requester of each build.)
+  if (buildRows.every((r: KnowableBuildRow) => notNull(r.report.requesterSFUserId))) {
+    const projectsAndRequesters: Set<string> = new Set(
+      buildRows.map(row => `${row.report.project.sfProjectId}-${row.report.requesterSFUserId}`)
+    );
+
+    averageRequestersPerProject = projectsAndRequesters.size / totalProjects;
+  }
+
+  const faultedBuilds: number = buildRows.filter(
+    row => row.report.status === DraftGenerationBuildStatus.Faulted
+  ).length;
+  const completedBuilds: number = buildRows.filter(
+    row => row.report.status === DraftGenerationBuildStatus.Completed
+  ).length;
+  const inProgressBuilds: number = buildRows.filter(row => isInProgress(row.report.status)).length;
+  const buildsWithProblems: number = buildRows.filter(row => row.report.problems.length > 0).length;
+
+  const durations: number[] = buildRows.map((row: KnowableBuildRow) => row.durationMs).filter(notNull);
+  const completedRows: KnowableBuildRow[] = buildRows.filter(
+    (row: KnowableBuildRow) => row.report.status === DraftGenerationBuildStatus.Completed
+  );
+  const completedDurations: number[] = completedRows.map((row: KnowableBuildRow) => row.durationMs).filter(notNull);
+  const meanDurationMs: number | undefined = averageNumbers(completedDurations);
+  const maxDurationMs: number | undefined = durations.length > 0 ? Math.max(...durations) : undefined;
+
+  // Book averages are calculated only from builds that have Serval data.
+  const rowsWithServalData: KnowableBuildRow[] = buildRows.filter((row: KnowableBuildRow) => row.report.build != null);
+  const servalBuildCount: number = rowsWithServalData.length;
+
+  const totalTrainingBooks: number = rowsWithServalData.reduce(
+    (sum: number, row: KnowableBuildRow) => sum + countBooks(row.trainingBooks),
+    0
+  );
+  const totalTranslationBooks: number = rowsWithServalData.reduce(
+    (sum: number, row: KnowableBuildRow) => sum + countBooks(row.translationBooks),
+    0
+  );
+
+  const averageTrainingBooksPerBuild: number | undefined =
+    servalBuildCount > 0 ? totalTrainingBooks / servalBuildCount : undefined;
+  const averageTranslationBooksPerBuild: number | undefined =
+    servalBuildCount > 0 ? totalTranslationBooks / servalBuildCount : undefined;
+
+  const percentTimeOnSF: number | undefined = calculatePercentTimeOnSF(buildRows);
+
+  // Builds with no Serval build data (events-only reports from backend)
+  const buildsServalDidNotKnowAbout: number = buildRows.filter(
+    (row: KnowableBuildRow) => row.report.build == null
+  ).length;
+  // Builds with Serval build data but no SF event timeline data
+  const buildsSfDidNotKnowAbout: number = buildRows.filter(
+    (row: KnowableBuildRow) => row.report.build != null && row.report.timeline.sfUserRequested == null
+  ).length;
+
+  return {
+    totalBuilds: totalBuilds,
+    totalProjects: totalProjects,
+    buildsPerProjectRatio: buildsPerProjectRatio,
+    averageInterBuildTimeMs: averageInterBuildTimeMs,
+    totalRequesters: totalRequesters,
+    averageRequestersPerProject: averageRequestersPerProject,
+    faultedBuilds: faultedBuilds,
+    averageTrainingBooksPerBuild: averageTrainingBooksPerBuild,
+    averageTranslationBooksPerBuild: averageTranslationBooksPerBuild,
+    completedBuilds: completedBuilds,
+    inProgressBuilds: inProgressBuilds,
+    buildsWithProblems: buildsWithProblems,
+    unconsideredBuilds: unconsideredBuilds,
+    meanDurationMs: meanDurationMs,
+    maxDurationMs: maxDurationMs,
+    percentTimeOnSF: percentTimeOnSF,
+    buildsServalDidNotKnowAbout: buildsServalDidNotKnowAbout,
+    buildsSfDidNotKnowAbout: buildsSfDidNotKnowAbout
+  };
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -161,7 +161,7 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
     return {
       totalBuilds: totalBuilds,
       totalProjects: 0,
-      buildsPerProjectRatio: undefined,
+      buildsPerProject: undefined,
       averageInterBuildTimeMs: undefined,
       totalRequesters: 0,
       averageRequestersPerProject: undefined,
@@ -187,7 +187,7 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
   );
   const sfProjectIdsUsed: Set<string> = new Set(rowsBySFProjectId.keys());
   const totalProjects: number = sfProjectIdsUsed.size;
-  const buildsPerProjectRatio: number = totalBuilds / totalProjects;
+  const buildsPerProject: number = totalBuilds / totalProjects;
 
   // Determine the average amount of time between Serval builds of the same project.
   const allGapsMs: number[] = [];
@@ -262,7 +262,7 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
   return {
     totalBuilds: totalBuilds,
     totalProjects: totalProjects,
-    buildsPerProjectRatio: buildsPerProjectRatio,
+    buildsPerProject: buildsPerProject,
     averageInterBuildTimeMs: averageInterBuildTimeMs,
     totalRequesters: totalRequesters,
     averageRequestersPerProject: averageRequestersPerProject,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -1,0 +1,495 @@
+@if (isOnline) {
+  <div class="filter-controls">
+    <app-date-range-picker (dateRangeChange)="onDateRangeChange($event)"></app-date-range-picker>
+    <div class="export-button-group">
+      <button mat-raised-button color="primary" class="export-csv-button" (click)="exportCsv()">
+        <mat-icon>download</mat-icon>
+        <span class="export-item-label">
+          Export CSV <app-info text="Download a .csv spreadsheet of the table data"></app-info>
+        </span>
+      </button>
+      <button mat-raised-button color="primary" class="export-menu-button" [matMenuTriggerFor]="exportMenu">
+        <mat-icon>arrow_drop_down</mat-icon>
+      </button>
+    </div>
+    <mat-menu #exportMenu="matMenu" xPosition="before">
+      <button mat-menu-item (click)="exportRsv()">
+        <mat-icon>download</mat-icon>
+        <span class="export-item-label">
+          Export RSV
+          <app-info
+            text="Download an .rsv Rows of String Values spreadsheet of the table data (https://github.com/Stenway/RSV-Specification)"
+          >
+          </app-info>
+        </span>
+      </button>
+    </mat-menu>
+    <div class="duration-area-toggle">
+      <mat-slide-toggle [checked]="includeDeleted" (change)="onIncludeDeletedChange($event.checked)">
+        Include deleted projects
+      </mat-slide-toggle>
+      <app-info
+        text="Include builds in the list that do not correspond to any projects that are currently in this site database."
+      ></app-info>
+    </div>
+  </div>
+
+  @if (summaryDisplayItems.length > 0) {
+    <div class="summary-area">
+      <div class="summary-grid">
+        @for (item of summaryDisplayItems; track item.label) {
+          @if (item.prominence === "top" || summaryIsExpanded) {
+            <div class="summary-item">
+              <span class="summary-label">
+                {{ item.label }}
+                @if (item.explanation != null) {
+                  <app-info [text]="item.explanation"></app-info>
+                }
+              </span>
+              <span class="summary-value">{{ item.value }}</span>
+            </div>
+          }
+        }
+      </div>
+      <button
+        mat-icon-button
+        class="expand-button"
+        (click)="summaryIsExpanded = !summaryIsExpanded"
+        [attr.aria-label]="summaryIsExpanded ? 'Collapse summary' : 'Expand summary'"
+      >
+        <mat-icon>{{ summaryIsExpanded ? "expand_less" : "expand_more" }}</mat-icon>
+      </button>
+    </div>
+  }
+
+  @if (!isLoadingData) {
+    <div class="table-wrapper">
+      <table mat-table [dataSource]="rows" multiTemplateDataRows>
+        <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+        <tr
+          class="build-row"
+          mat-row
+          *matRowDef="let row; columns: columnsToDisplay"
+          [class.expanded-row]="isRowExpanded(row)"
+        ></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: ['expandedDetail']"
+          class="detail-row"
+          [class.detail-row-collapsed]="!isRowExpanded(row)"
+        ></tr>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="status-cell">
+              <div class="status-icon-container">
+                <mat-icon
+                  class="status-icon status-is-{{ row.report.status.toLowerCase() }}"
+                  [matTooltip]="ServalBuildsComponent.formatStatusLabel(row.report.status)"
+                >
+                  {{ statusIcon(row.report.status) }}
+                </mat-icon>
+                @if (row.report.problems.length > 0) {
+                  <mat-icon class="problem-badge" [matTooltip]="row.report.problems.join('; ')">warning</mat-icon>
+                }
+              </div>
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="project">
+          <th mat-header-cell *matHeaderCellDef>Project</th>
+          <td mat-cell *matCellDef="let row">
+            @if (!row.projectDeleted) {
+              <div class="project-lines">
+                @if (row.projectServalAdminUrl != null) {
+                  <a [href]="row.projectServalAdminUrl" class="project-link" target="_blank" rel="noopener">
+                    {{ row.projectNameDisplay || "Unknown" }}
+                  </a>
+                } @else {
+                  <span>{{ row.projectNameDisplay || "Unknown" }}</span>
+                }
+                <div class="owner-line">
+                  <app-owner [ownerRef]="row.report.requesterSFUserId" [includeAvatar]="true"></app-owner>
+                </div>
+              </div>
+            } @else {
+              <div class="project-lines deleted-project">
+                <div class="deleted-project-name">
+                  <mat-icon class="deleted-project-icon" matTooltip="Project may have been deleted">delete</mat-icon>
+
+                  <span>Unknown or deleted project</span>
+                </div>
+                <div class="owner-line">
+                  <app-owner [ownerRef]="row.report.requesterSFUserId" [includeAvatar]="true"></app-owner>
+                </div>
+              </div>
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="source">
+          <th mat-header-cell *matHeaderCellDef>Source</th>
+          <td mat-cell *matCellDef="let row">
+            @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
+              <div>
+                @let translationLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
+                @if (translationLink != null) {
+                  <a [href]="translationLink" target="_blank" rel="noopener" class="project-link">
+                    {{ projectBook.projectDisplayName }}
+                  </a>
+                } @else {
+                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                }
+                :
+                @if (projectBook.books.length <= 2) {
+                  {{ projectBook.books.join(", ") }}
+                } @else {
+                  <span [matTooltip]="projectBook.books.join(', ')" class="book-count">
+                    {{ projectBook.books.length }} books
+                  </span>
+                }
+              </div>
+            } @empty {
+              None
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="requested">
+          <th mat-header-cell *matHeaderCellDef>Requested</th>
+          <td mat-cell *matCellDef="let row">
+            {{ row.report.timeline.requestTime != null ? localizedDate(row.report.timeline.requestTime) : "-" }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="language">
+          <th mat-header-cell *matHeaderCellDef>Language</th>
+          <td mat-cell *matCellDef="let row">
+            @let sourceLang = row.report.build?.executionData?.sourceLanguageTag;
+            @let targetLang = row.report.build?.executionData?.targetLanguageTag;
+            @if (sourceLang != null && targetLang != null) {
+              {{ sourceLang }} ➔ {{ targetLang }}
+            } @else {
+              -
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="expand">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let row">
+            <button
+              mat-icon-button
+              class="expand-button"
+              (click)="toggleRowExpansion(row)"
+              [attr.aria-label]="isRowExpanded(row) ? 'Collapse row' : 'Expand row'"
+            >
+              <mat-icon>{{ isRowExpanded(row) ? "expand_less" : "expand_more" }}</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="expandedDetail">
+          <td mat-cell *matCellDef="let row" [attr.colspan]="columnsToDisplay.length">
+            <div
+              class="expanded-detail"
+              [class.expanded-detail-collapsed]="!isRowExpanded(row)"
+              [attr.aria-hidden]="!isRowExpanded(row)"
+            >
+              <div class="detail-grid">
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>fingerprint</mat-icon>
+                      <mat-card-title>Identifiers</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Serval build ID</span>
+                        @let servalBuildId = row.report.build?.additionalInfo?.buildId;
+                        <span class="detail-value detail-value-with-copy code">
+                          <span>{{ servalBuildId ?? "Unknown" }}</span>
+                          @if (servalBuildId != null) {
+                            <app-copy [value]="servalBuildId"></app-copy>
+                          }
+                        </span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF draft generation request ID</span>
+                        @let draftGenerationRequestId = row.report.draftGenerationRequestId;
+                        <span class="detail-value detail-value-with-copy code">
+                          <span>{{ draftGenerationRequestId ?? "-" }}</span>
+                          @if (draftGenerationRequestId != null) {
+                            <app-copy [value]="draftGenerationRequestId"></app-copy>
+                          }
+                        </span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF project ID</span>
+                        <span class="detail-value detail-value-with-copy code">
+                          <span>{{ row.report.project?.sfProjectId ?? "-" }}</span>
+                          @if (row.report.project?.sfProjectId != null) {
+                            <app-copy [value]="row.report.project?.sfProjectId"></app-copy>
+                          }
+                        </span>
+                      </div>
+
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Serval version</span>
+                        <span class="detail-value">{{ row.report.build?.deploymentVersion ?? "Unknown" }}</span>
+                      </div>
+                    </span>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>emoji_people</mat-icon>
+                      <mat-card-title>Requesting user</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF user ID</span>
+                        <span class="detail-value detail-value-with-copy code">
+                          <span>{{ row.report.requesterSFUserId ?? "-" }}</span>
+                          @if (row.report.requesterSFUserId != null) {
+                            <app-copy [value]="row.report.requesterSFUserId"></app-copy>
+                          }
+                        </span>
+                      </div>
+
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Display name</span>
+                        @let requesterName = requesterDisplayName(row.report.requesterSFUserId) | async;
+                        <span class="detail-value">{{ requesterName ?? "Unknown" }}</span>
+                      </div>
+                    </span>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>merge</mat-icon>
+                      <mat-card-title>Training</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Training books</span>
+                        <span class="detail-value">
+                          <div class="detail-books-list">
+                            @for (projectBook of row.trainingBooks; track projectBook.sfProjectId) {
+                              <div>
+                                @let detailTrainingLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
+                                @if (detailTrainingLink != null) {
+                                  <a [href]="detailTrainingLink" target="_blank" rel="noopener" class="project-link">
+                                    {{ projectBook.projectDisplayName }}
+                                  </a>
+                                } @else {
+                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                                }
+                                : {{ projectBook.books.join(", ") }}
+                              </div>
+                            } @empty {
+                              <span>None</span>
+                            }
+                          </div>
+                        </span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Translation books</span>
+                        <span class="detail-value">
+                          <div class="detail-books-list">
+                            @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
+                              <div>
+                                @let detailTranslationLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
+                                @if (detailTranslationLink != null) {
+                                  <a [href]="detailTranslationLink" target="_blank" rel="noopener" class="project-link">
+                                    {{ projectBook.projectDisplayName }}
+                                  </a>
+                                } @else {
+                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                                }
+                                : {{ projectBook.books.join(", ") }}
+                              </div>
+                            } @empty {
+                              <span>None</span>
+                            }
+                          </div>
+                        </span>
+                      </div>
+                    </span>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>translate</mat-icon>
+                      <mat-card-title>Language info</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Source language</span>
+                        <span class="detail-value">{{
+                          formatLanguageWithName(row.report.build?.executionData?.sourceLanguageTag)
+                        }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Target language</span>
+                        <span class="detail-value">{{
+                          formatLanguageWithName(row.report.build?.executionData?.targetLanguageTag)
+                        }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Strings trained on</span>
+                        <span class="detail-value">{{ row.report.build?.executionData?.trainCount ?? "-" }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Strings translated</span>
+                        <span class="detail-value">{{
+                          row.report.build?.executionData?.pretranslateCount ?? "-"
+                        }}</span>
+                      </div>
+                    </span>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>timer</mat-icon>
+                      <mat-card-title>Timing</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <div class="detail-area-stacked-keyvalues timing-grid">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">User request</span>
+                        <span class="detail-value"
+                          >{{ formatDateTime(row.report.timeline.sfUserRequested) ?? "-" }} &nbsp;
+                          {{ durationUserRequestToCompletionAcknowledged(row.report) }}</span
+                        >
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF build request</span>
+                        <span class="detail-value">{{
+                          formatDateTime(row.report.timeline.sfBuildProjectSubmitted) ?? "-"
+                        }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Serval creation</span>
+                        <span class="detail-value"
+                          >{{ formatDateTime(row.report.timeline.servalCreated) ?? "-" }} &nbsp;
+                          {{ durationServalCreatedToFinish(row.report) }}</span
+                        >
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Train phase</span>
+                        <span class="detail-value"
+                          >{{ formatDateTime(getPhase(row.report, "Train")?.started) ?? "-" }} &nbsp;
+                          {{ durationPhaseTrain(row.report) }}</span
+                        >
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Inference phase</span>
+                        <span class="detail-value"
+                          >{{ formatDateTime(getPhase(row.report, "Inference")?.started) ?? "-" }} &nbsp;
+                          {{ durationPhaseInference(row.report) }}</span
+                        >
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Serval finish</span>
+                        <span class="detail-value">{{
+                          formatDateTime(row.report.timeline.servalFinished) ?? "-"
+                        }}</span>
+                      </div>
+                      @if (row.report.timeline.sfUserCancelled != null) {
+                        <div class="detail-keyvalue">
+                          <span class="detail-key">User cancel</span>
+                          <span class="detail-value">{{ formatDateTime(row.report.timeline.sfUserCancelled) }}</span>
+                        </div>
+                      }
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF acknowledges Serval completion</span>
+                        <span class="detail-value">{{
+                          formatDateTime(row.report.timeline.sfAcknowledgedCompletion) ?? "-"
+                        }}</span>
+                      </div>
+                      @if (row.report.timeline.servalCreated != null && row.report.timeline.servalFinished != null) {
+                        <div
+                          class="timing-bar timing-bar-serval"
+                          [style.gridRow]="getTimingBarRowRange(row, 'serval')"
+                          aria-hidden="true"
+                        ></div>
+                      }
+                      @if (
+                        row.report.timeline.sfUserRequested != null &&
+                        row.report.timeline.sfAcknowledgedCompletion != null
+                      ) {
+                        <div
+                          class="timing-bar timing-bar-user"
+                          [style.gridRow]="getTimingBarRowRange(row, 'user')"
+                          aria-hidden="true"
+                        ></div>
+                      }
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+
+              <div class="detail-actions">
+                @let id = row.report.build?.additionalInfo?.buildId;
+                @if (id != null) {
+                  <a
+                    mat-button
+                    class="details-dialog-button"
+                    href="{{ clearMLUrl(id) }}"
+                    target="_blank"
+                    rel="noopener"
+                  >
+                    <mat-icon>engineering</mat-icon>
+                    View in ClearML
+                  </a>
+                } @else {
+                  <button
+                    mat-button
+                    class="details-dialog-button"
+                    [disabled]="true"
+                    matTooltip="No Serval build ID available"
+                  >
+                    <mat-icon>engineering</mat-icon>
+                    View in ClearML
+                  </button>
+                }
+                <button mat-button class="details-dialog-button" (click)="openBuildDetails(row)">
+                  <mat-icon>manage_search</mat-icon>
+                  View more details
+                </button>
+              </div>
+            </div>
+          </td>
+        </ng-container>
+      </table>
+    </div>
+
+    @if (rows.length === 0) {
+      <p class="empty-message">No Serval builds found for the selected time period.</p>
+    }
+  } @else {
+    <p>Loading Serval builds ...</p>
+  }
+} @else {
+  <p>You are offline.</p>
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -278,7 +278,7 @@
                   <mat-card-header>
                     <mat-card-title-group>
                       <mat-icon>merge</mat-icon>
-                      <mat-card-title>Training</mat-card-title>
+                      <mat-card-title>Input</mat-card-title>
                     </mat-card-title-group>
                   </mat-card-header>
                   <mat-card-content class="detail-card-content">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -1,0 +1,436 @@
+.filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 16px;
+
+  app-date-range-picker {
+    margin-top: 16px;
+  }
+}
+
+.export-button-group {
+  display: flex;
+
+  .export-csv-button {
+    // Be flush with the drop-down arrow
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+  }
+
+  .export-menu-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    min-width: 40px;
+    padding: 0 8px;
+
+    mat-icon {
+      margin: 0;
+    }
+  }
+}
+
+.export-item-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.duration-area-toggle {
+  app-info {
+    display: inline-block;
+    vertical-align: middle;
+    margin-inline-start: 0.25em;
+  }
+}
+
+.summary-area {
+  display: flex;
+  flex-direction: row;
+  margin-inline: 1em;
+}
+
+.summary-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(182px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+  align-items: stretch;
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-label {
+  font-size: 1em;
+  color: var(--sf-serval-builds-label-color);
+  app-info {
+    display: inline-block;
+    vertical-align: top;
+    margin-inline-start: 0.25em;
+  }
+}
+
+.summary-value {
+  font-size: 1.2em;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+
+  th.mat-mdc-header-cell {
+    border-bottom: none;
+  }
+}
+
+.build-row {
+  border-bottom: none;
+
+  td.mat-mdc-cell {
+    border-bottom: none;
+  }
+}
+
+/* The rows of build information will alternate color. */
+.build-row:nth-child(4n + 1) {
+  background-color: var(--sf-serval-builds-table-odd-row-background);
+}
+
+/* The expansion areas are actually rows. They too will alternate color. */
+.detail-row:nth-child(4n + 2) {
+  background-color: var(--sf-serval-builds-table-odd-row-expanded-background);
+
+  /* Detail card styling specification for odd rows. */
+  .detail-card {
+    background-color: var(--sf-serval-builds-table-odd-row-detail-card-background);
+  }
+}
+
+/* Detail card styling specification for even rows. */
+.detail-card {
+  background-color: var(--sf-serval-builds-table-even-row-detail-card-background);
+}
+
+.status-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Ensure the mat-cell for the status column centers its content. */
+:host ::ng-deep .mat-column-status {
+  text-align: center;
+}
+
+.status-icon-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.status-icon {
+  font-size: 24px;
+}
+
+.problem-badge {
+  /* The problem badge will have a thin border outline. This will be done by drawing the icon in the border colour, and
+  then drawing the icon again inside of that, smaller, and with the desired icon colour. */
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  color: var(--sf-serval-builds-problem-border-color);
+  overflow: visible;
+
+  /* Layer the slightly smaller yellow warning glyph atop the black base. */
+  &::after {
+    content: 'warning';
+    position: absolute;
+    top: 2.5px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Material Icons';
+    font-size: 14px;
+    line-height: 1;
+    color: var(--sf-serval-builds-problem-color);
+    pointer-events: none;
+  }
+}
+
+.status-icon.status-is-userrequested {
+  color: var(--sf-serval-builds-status-userrequested);
+}
+.status-icon.status-is-submittedtoserval {
+  color: var(--sf-serval-builds-status-submittedtoserval);
+}
+.status-icon.status-is-queued {
+  color: var(--sf-serval-builds-status-queued);
+}
+.status-icon.status-is-pending {
+  color: var(--sf-serval-builds-status-pending);
+}
+.status-icon.status-is-active {
+  color: var(--sf-serval-builds-status-active);
+}
+.status-icon.status-is-finishing {
+  color: var(--sf-serval-builds-status-finishing);
+}
+.status-icon.status-is-completed {
+  color: var(--sf-serval-builds-status-completed);
+}
+.status-icon.status-is-faulted {
+  color: var(--sf-serval-builds-status-faulted);
+}
+.status-icon.status-is-canceled {
+  color: var(--sf-serval-builds-status-canceled);
+}
+
+.project-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  a {
+    text-decoration: none;
+  }
+}
+
+.owner-line {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.4;
+}
+
+/* Make avatar one line high, rather than two. */
+.owner-line ::ng-deep .avatar .wrapper {
+  width: 1em;
+  height: 1em;
+  font-size: 1em;
+  .user-icon {
+    scale: inherit;
+  }
+}
+.owner-line ::ng-deep .owner-text {
+  font-size: inherit;
+}
+
+.project-link {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.book-count {
+  text-decoration: underline dotted;
+  cursor: help;
+}
+
+.deleted-project {
+  color: var(--sf-serval-builds-deleted-project-color);
+}
+
+.deleted-project-name {
+  display: flex;
+  align-items: center;
+}
+
+.deleted-project-icon {
+  /* Make the icon line up with the avatar icon below (if any) */
+  margin-left: -2.5px;
+  font-size: 1.5em;
+}
+
+.empty-message {
+  margin-top: 12px;
+  color: var(--sf-serval-builds-subdued-text);
+}
+
+/* Expandable row styles */
+.expand-button {
+  color: var(--mat-sys-primary);
+}
+
+.detail-row {
+  min-height: 0;
+  height: auto;
+  &.mat-mdc-row {
+    height: auto;
+  }
+  td {
+    border-bottom: none;
+    padding: 0;
+    min-height: 0;
+    height: auto;
+  }
+}
+
+.expanded-detail {
+  padding: 16px 24px 16px 48px;
+  max-height: 1000px;
+  opacity: 1;
+  transition:
+    max-height 100ms cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 100ms cubic-bezier(0.4, 0, 0.2, 1),
+    padding 100ms cubic-bezier(0.4, 0, 0.2, 1),
+    margin 100ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 12px 24px;
+  margin-bottom: 16px;
+}
+
+.detail-row-collapsed {
+  min-height: 0;
+  height: auto;
+  &.mat-mdc-row {
+    height: auto;
+  }
+  td {
+    padding: 0;
+    height: auto;
+    line-height: 0;
+    min-height: 0;
+    overflow: hidden;
+    border: 0;
+  }
+}
+
+.expanded-detail-collapsed {
+  max-height: 0;
+  opacity: 0;
+  padding: 0 24px 0 48px;
+  margin: 0;
+  border-bottom: none;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.detail-card-content {
+  margin-top: 1em;
+}
+
+.detail-key {
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--sf-serval-builds-label-color);
+}
+
+.detail-value-with-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  app-copy ::ng-deep {
+    .copy-button,
+    .copied,
+    .copy {
+      width: 1em;
+      height: 1em;
+      font-size: 1em;
+    }
+
+    .copy-button {
+      padding: 0;
+    }
+  }
+}
+
+.code {
+  font-family: monospace;
+}
+
+.detail-area-stacked-keyvalues {
+  word-break: break-word;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+
+  .detail-keyvalue {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.timing-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 0.5rem 0.5rem;
+  column-gap: 8px;
+  row-gap: 1em;
+
+  .detail-keyvalue {
+    grid-column: 1;
+  }
+}
+
+.timing-bar {
+  --timing-bar-width: 0.5rem;
+  --timing-hook-length: 0.5rem;
+  width: var(--timing-bar-width);
+  background-color: var(--sf-serval-builds-duration-bar-color);
+  justify-self: center;
+  align-self: stretch;
+  position: relative;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: var(--timing-hook-length);
+    height: var(--timing-bar-width);
+    background-color: inherit;
+    left: calc(-1 * var(--timing-hook-length));
+  }
+
+  &::before {
+    top: 0;
+  }
+
+  &::after {
+    bottom: 0;
+  }
+}
+
+.timing-bar-serval {
+  grid-column: 2;
+}
+
+.timing-bar-user {
+  grid-column: 3;
+}
+
+.detail-books-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.details-dialog-button {
+  mat-icon {
+    margin-right: 8px;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,0 +1,1405 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { BehaviorSubject } from 'rxjs';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { DialogService } from 'xforge-common/dialog.service';
+import { MockConsole } from 'xforge-common/mock-console';
+import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
+import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
+import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
+import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
+import { UserService } from 'xforge-common/user.service';
+import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
+import { BuildDto } from '../machine-api/build-dto';
+import { BuildStates } from '../machine-api/build-states';
+import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
+import { NormalizedDateRange } from './date-range-picker.component';
+import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
+import {
+  buildProjectDisplayName,
+  BuildReportTimeline,
+  DraftGenerationBuildStatus,
+  ProjectBooks,
+  ServalBuildReportDto
+} from './serval-build-report';
+import { buildSummary, gapsBetweenBuildsMs } from './serval-builds-statistics';
+import { ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
+
+const mockNoticeService = mock(NoticeService);
+const mockDraftGenerationService = mock(DraftGenerationService);
+const mockDialogService = mock(DialogService);
+const mockExportService = mock(DraftJobsExportService);
+const mockUserService = mock(UserService);
+const mockedConsole: MockConsole = MockConsole.install();
+
+describe('ServalBuildsComponent', () => {
+  configureTestingModule(() => ({
+    imports: [ServalBuildsComponent, getTestTranslocoModule()],
+    providers: [
+      provideTestRealtime(SF_TYPE_REGISTRY),
+      provideTestOnlineStatus(),
+      { provide: NoticeService, useMock: mockNoticeService },
+      { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+      { provide: DraftGenerationService, useMock: mockDraftGenerationService },
+      { provide: DialogService, useMock: mockDialogService },
+      { provide: DraftJobsExportService, useMock: mockExportService },
+      { provide: UserService, useMock: mockUserService },
+      provideNoopAnimations()
+    ]
+  }));
+
+  describe('include deleted toggle', () => {
+    it('excludes deleted projects when toggle is off', () => {
+      const env = new TestEnvironment();
+      const activeRow = env.createRow(false, 1000);
+      const deletedRow = env.createRow(true, 3000);
+      env.component['allRows'] = [activeRow, deletedRow];
+
+      // SUT
+      env.component['onIncludeDeletedChange'](false);
+
+      expect(env.component['rows'].length).toBe(1);
+      expect(env.component['rows'][0].report.project?.sfProjectId).toBeDefined();
+    });
+
+    it('includes deleted projects when toggle is on', () => {
+      const env = new TestEnvironment();
+      const activeRow = env.createRow(false, 1000);
+      const deletedRow = env.createRow(true, 3000);
+      env.component['allRows'] = [activeRow, deletedRow];
+
+      // SUT
+      env.component['onIncludeDeletedChange'](true);
+
+      expect(env.component['rows'].length).toBe(2);
+      expect(env.component['rows'][1].report.project?.sfProjectId).toBeUndefined();
+    });
+  });
+
+  describe('summary stats', () => {
+    it('returns undefined average requesters when a requester is missing', () => {
+      // Suppose some builds for a project have a record of who requested them, and some builds for that or another
+      // project don't. We can't very meaningfully determine the "average" number of requesters per project in this
+      // situation. So the average will be undefined.
+
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: any[] = [
+        env.createRowWithDetails({
+          projectId: 'project-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'project-a',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: undefined,
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: {
+        totalBuilds: number;
+        totalProjects: number;
+        totalRequesters: number;
+        averageRequestersPerProject?: number;
+      } = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(2);
+      expect(summary.totalProjects).toBe(1);
+      expect(summary.totalRequesters).toBe(1);
+      expect(summary.averageRequestersPerProject).toBeUndefined();
+    });
+
+    it('computes summary statistics from rows', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          translationBooks: env.createProjectBooks('proj-a', ['PSA']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 3),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-2',
+          trainingBooks: env.createProjectBooks('proj-a', ['MRK']),
+          translationBooks: [],
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 7),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-2',
+          trainingBooks: env.createProjectBooks('proj-a', ['ROM', '1CO', '2CO']),
+          translationBooks: env.createProjectBooks('proj-a', ['MAT', 'LUK']),
+          problems: ['Low confidence'],
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 2.5),
+          requesterId: 'user-2',
+          trainingBooks: [],
+          translationBooks: [],
+          status: DraftGenerationBuildStatus.Active
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 5),
+          finishDate: env.addHours(baseStart, 6),
+          requesterId: 'user-3',
+          trainingBooks: env.createProjectBooks('proj-b', ['ACT']),
+          translationBooks: env.createProjectBooks('proj-b', ['ISA', 'JER', 'EZE']),
+          status: DraftGenerationBuildStatus.Faulted
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-c',
+          startDate: env.addHours(baseStart, 9),
+          finishDate: env.addHours(baseStart, 10),
+          trainingBooks: [],
+          translationBooks: [],
+          status: DraftGenerationBuildStatus.Pending,
+          requesterId: 'user-4'
+        }),
+        // This build could not be associated with a project. And so it also will not have been associated with a requester.
+        env.createRowWithDetails({
+          projectId: undefined,
+          startDate: env.addHours(baseStart, 11),
+          finishDate: env.addHours(baseStart, 12),
+          trainingBooks: [],
+          translationBooks: [],
+          status: DraftGenerationBuildStatus.Pending,
+          requesterId: undefined
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(6);
+      expect(summary.totalProjects).toBe(3);
+      expect(summary.buildsPerProjectRatio).toBeCloseTo(2);
+      expect(summary.averageInterBuildTimeMs).toBeCloseTo(9000000);
+      expect(summary.totalRequesters).toBe(4);
+      expect(summary.averageRequestersPerProject).toBeCloseTo(1.667);
+      expect(summary.faultedBuilds).toBe(1);
+      expect(summary.averageTrainingBooksPerBuild).toBeCloseTo(1.1666666667);
+      expect(summary.averageTranslationBooksPerBuild).toBeCloseTo(1);
+      expect(summary.completedBuilds).toBe(3);
+      expect(summary.inProgressBuilds).toBe(2);
+      expect(summary.buildsWithProblems).toBe(1);
+      expect(summary.unconsideredBuilds).toBe(1);
+      expect(summary.meanDurationMs).toBe(3600000);
+      expect(summary.maxDurationMs).toBe(3600000);
+      // All rows created above with createRowWithDetails have a servalBuild and no events, so all are "SF did not know about"
+      expect(summary.buildsServalDidNotKnowAbout).toBe(0);
+      expect(summary.buildsSfDidNotKnowAbout).toBe(6);
+    });
+
+    it('uses only completed builds for mean duration', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 2),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 3),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 5),
+          finishDate: env.addHours(baseStart, 10),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Active
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Completed durations: 2h and 1h => mean = 1.5h
+      const expectedMeanMs: number = 1.5 * 60 * 60 * 1000;
+      expect(summary.meanDurationMs).toBe(expectedMeanMs);
+      // Max duration considers all builds including Active (5h), so it should be 5h not 2h
+      const expectedMaxMs: number = 5 * 60 * 60 * 1000;
+      expect(summary.maxDurationMs).toBe(expectedMaxMs);
+    });
+
+    it('computes average requesters per project when each project has one requester', () => {
+      // Suppose there are 100 projects, and 1 draft request for each project. So 100 draft requests. Suppose that half
+      // of the requests are by one user, and the other half are by another user. The average requesters per project
+      // should be 1.
+
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: any[] = [];
+      const totalProjects: number = 100;
+
+      for (let index = 0; index < totalProjects; index++) {
+        const requesterId: string = index < 50 ? 'user-1' : 'user-2';
+        rows.push(
+          env.createRowWithDetails({
+            projectId: `project-${index}`,
+            startDate: env.addHours(baseStart, index * 2),
+            finishDate: env.addHours(baseStart, index * 2 + 1),
+            requesterId: requesterId,
+            status: DraftGenerationBuildStatus.Completed
+          })
+        );
+      }
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(100);
+      expect(summary.totalProjects).toBe(100);
+      expect(summary.totalRequesters).toBe(2);
+      expect(summary.averageRequestersPerProject).toBeCloseTo(1);
+    });
+
+    it('computes average requesters per project when one project has multiple requesters', () => {
+      // Suppose there is 1 project, and 100 build requests for that project. Half of them are requested by 1 person and
+      // the other half are requested by another person. The average requesters per project should be 2.
+
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: any[] = [];
+      const totalBuilds: number = 100;
+
+      for (let index = 0; index < totalBuilds; index++) {
+        const requesterId: string = index < 50 ? 'user-1' : 'user-2';
+        rows.push(
+          env.createRowWithDetails({
+            projectId: 'project-1',
+            startDate: env.addHours(baseStart, index * 2),
+            finishDate: env.addHours(baseStart, index * 2 + 1),
+            requesterId: requesterId,
+            status: DraftGenerationBuildStatus.Completed
+          })
+        );
+      }
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(100);
+      expect(summary.totalProjects).toBe(1);
+      expect(summary.totalRequesters).toBe(2);
+      expect(summary.averageRequestersPerProject).toBeCloseTo(2);
+    });
+
+    it('computes average requesters per project when one project has mixed requesters', () => {
+      // Suppose there are 100 build requests. Half are for project A and all are requested by user-1. The other half
+      // are for project B, with half requested by user-1 and half by user-2. The average requesters per project should
+      // be 1.5.
+
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: any[] = [];
+      const totalBuildsPerProject: number = 50;
+
+      for (let index = 0; index < totalBuildsPerProject; index++) {
+        rows.push(
+          env.createRowWithDetails({
+            projectId: 'project-a',
+            startDate: env.addHours(baseStart, index * 2),
+            finishDate: env.addHours(baseStart, index * 2 + 1),
+            requesterId: 'user-1',
+            status: DraftGenerationBuildStatus.Completed
+          })
+        );
+      }
+
+      for (let index = 0; index < totalBuildsPerProject; index++) {
+        const requesterId: string = index < 25 ? 'user-1' : 'user-2';
+        rows.push(
+          env.createRowWithDetails({
+            projectId: 'project-b',
+            startDate: env.addHours(baseStart, index * 2),
+            finishDate: env.addHours(baseStart, index * 2 + 1),
+            requesterId: requesterId,
+            status: DraftGenerationBuildStatus.Completed
+          })
+        );
+      }
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(100);
+      expect(summary.totalProjects).toBe(2);
+      expect(summary.totalRequesters).toBe(2);
+      expect(summary.averageRequestersPerProject).toBeCloseTo(1.5);
+    });
+
+    it('excludes events-only builds from book averages calculation', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        // Build with Serval data - has 2 training books and 1 translation book
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          translationBooks: env.createProjectBooks('proj-a', ['PSA']),
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: true,
+          hasEvents: true
+        }),
+        // Build with Serval data - has 3 training books and 2 translation books
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['MRK', 'LUK', 'JHN']),
+          translationBooks: env.createProjectBooks('proj-a', ['MAT', 'ROM']),
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: true,
+          hasEvents: true
+        }),
+        // Events-only build - has no Serval data, so no book info is present
+        // This should not be counted in the book averages denominator
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-2',
+          trainingBooks: [],
+          translationBooks: [],
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: false,
+          hasEvents: true
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Total builds is 3 (all are considered since they have projectId)
+      expect(summary.totalBuilds).toBe(3);
+      // But book averages should only consider the 2 Serval builds:
+      // Training: (2 + 3) / 2 = 2.5
+      // Translation: (1 + 2) / 2 = 1.5
+      // NOT (2 + 3 + 0) / 3 = 1.67 for training
+      // NOT (1 + 2 + 0) / 3 = 1.0 for translation
+      expect(summary.averageTrainingBooksPerBuild).toBeCloseTo(2.5);
+      expect(summary.averageTranslationBooksPerBuild).toBeCloseTo(1.5);
+    });
+
+    it('counts builds Serval did not know about', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        // Build with Serval data and events (fully known)
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: true,
+          hasEvents: true
+        }),
+        // Build with events only - no Serval data (Serval did not know about)
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: false,
+          hasEvents: true
+        }),
+        // Another build with events only (Serval did not know about)
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Active,
+          hasServalBuild: false,
+          hasEvents: true
+        }),
+        // Build without SF project ID (unconsidered - should not count)
+        env.createRowWithDetails({
+          projectId: undefined,
+          startDate: env.addHours(baseStart, 6),
+          finishDate: env.addHours(baseStart, 7),
+          requesterId: undefined,
+          status: DraftGenerationBuildStatus.Pending,
+          hasServalBuild: false,
+          hasEvents: true
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Only 2 considered rows have events but no servalBuild
+      expect(summary.buildsServalDidNotKnowAbout).toBe(2);
+      expect(summary.unconsideredBuilds).toBe(1);
+    });
+
+    it('counts builds SF did not know about', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        // Build with Serval data and events (fully known)
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: true,
+          hasEvents: true
+        }),
+        // Build with Serval data only - no SF events (SF did not know about)
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed,
+          hasServalBuild: true,
+          hasEvents: false
+        }),
+        // Another build with Serval data only (SF did not know about)
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Active,
+          hasServalBuild: true,
+          hasEvents: false
+        }),
+        // Build without SF project ID (unconsidered - should not count)
+        env.createRowWithDetails({
+          projectId: undefined,
+          startDate: env.addHours(baseStart, 6),
+          finishDate: env.addHours(baseStart, 7),
+          requesterId: undefined,
+          status: DraftGenerationBuildStatus.Pending,
+          hasServalBuild: true,
+          hasEvents: false
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Only 2 considered rows have servalBuild but no events
+      expect(summary.buildsSfDidNotKnowAbout).toBe(2);
+      expect(summary.unconsideredBuilds).toBe(1);
+    });
+
+    it('uses SF timestamps for inter-build gap calculation when available', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      // Build 1: Serval created at hour 0, finished at hour 1
+      // SF acknowledged at hour 1.5
+      // Build 2: Serval created at hour 4, finished at hour 5
+      // SF requested at hour 3
+      // Expected gap: From SF acknowledged (hour 1.5) to SF requested (hour 3) = 1.5 hours = 5400000 ms
+      // Without SF timestamps, gap would be: Serval finish (hour 1) to Serval created (hour 4) = 3 hours = 10800000 ms
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          sfAcknowledgedTime: env.addHours(baseStart, 1.5),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          sfUserRequestTime: env.addHours(baseStart, 3),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Gap should be from SF acknowledged (hour 1.5) to SF requested (hour 3) = 1.5 hours
+      const expectedGapMs: number = 1.5 * 60 * 60 * 1000; // 5400000 ms
+      expect(summary.averageInterBuildTimeMs).toBeCloseTo(expectedGapMs);
+    });
+
+    it('falls back to Serval timestamps for inter-build gap when SF timestamps are missing', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      // Build 1: Serval created at hour 0, finished at hour 1 (no SF timestamps)
+      // Build 2: Serval created at hour 4, finished at hour 5 (no SF timestamps)
+      // Expected gap: From Serval finish (hour 1) to Serval created (hour 4) = 3 hours = 10800000 ms
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Gap should be from Serval finish (hour 1) to Serval created (hour 4) = 3 hours
+      const expectedGapMs: number = 3 * 60 * 60 * 1000; // 10800000 ms
+      expect(summary.averageInterBuildTimeMs).toBeCloseTo(expectedGapMs);
+    });
+
+    it('computes flat average of all inter-build gaps across projects', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      // proj-a has 3 builds producing gaps of 1h and 3h (per-project average would be 2h)
+      // proj-b has 2 builds producing a gap of 1h (per-project average would be 1h)
+      // Average-of-averages would give (2h + 1h) / 2 = 1.5h
+      // Flat average of all gaps [1h, 3h, 1h] gives (1 + 3 + 1) / 3 = 5/3 h ≈ 1.667h
+      const rows: ServalBuildRow[] = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 6),
+          finishDate: env.addHours(baseStart, 7),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      // Flat average of all gaps: (1h + 3h + 1h) / 3 = 5/3 hours
+      const expectedFlatAverageMs: number = (5 / 3) * 60 * 60 * 1000;
+      expect(summary.averageInterBuildTimeMs).toBeCloseTo(expectedFlatAverageMs);
+    });
+
+    it('computes percentTimeOnSF for successfully completed builds with all timing data', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      // Build 1: Total duration 10 hours (SF user request to SF acknowledged), Serval duration 6 hours
+      // SF time = 10 - 6 = 4 hours. % on SF = 4/10 = 40%
+      // Build 2: Total duration 8 hours, Serval duration 4 hours
+      // SF time = 8 - 4 = 4 hours. % on SF = 4/8 = 50%
+      // Overall: Total SF+Serval = 18 hours, Total Serval = 10 hours, Total SF = 8 hours
+      // % on SF = 8/18 = 44.44%
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 10),
+          startDate: env.addHours(baseStart, 2), // Serval created
+          finishDate: env.addHours(baseStart, 8), // Serval finished (6 hours on Serval)
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 8),
+          startDate: env.addHours(baseStart, 2), // Serval created
+          finishDate: env.addHours(baseStart, 6), // Serval finished (4 hours on Serval)
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Total duration = 10 + 8 = 18 hours
+      // Total Serval duration = 6 + 4 = 10 hours
+      // Total SF time = 18 - 10 = 8 hours
+      // % on SF = 8/18 * 100 = 44.44%
+      expect(summary.percentTimeOnSF).toBeCloseTo(44.44, 1);
+    });
+
+    it('excludes non-completed builds from percentTimeOnSF calculation', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 10),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed // This one counts: 40% SF time
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 20),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Active // In progress - should be excluded
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-c',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 20),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-3',
+          status: DraftGenerationBuildStatus.Faulted // Faulted - should be excluded
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-d',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 20),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-4',
+          status: DraftGenerationBuildStatus.Canceled // Cancelled - should be excluded
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Only the completed build is considered: 10 hours total, 6 hours Serval, 4 hours SF = 40%
+      expect(summary.percentTimeOnSF).toBeCloseTo(40, 0);
+    });
+
+    it('returns undefined for percentTimeOnSF when no builds have all required timing data', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          // Missing sfUserRequestTime
+          sfAcknowledgedTime: env.addHours(baseStart, 10),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          // Missing sfAcknowledgedTime
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      expect(summary.percentTimeOnSF).toBeUndefined();
+    });
+
+    it('ignores builds with inconsistent percentTimeOnSF timing ranges', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-valid',
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 10),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-1',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-invalid-total',
+          // Invalid total duration: acknowledgment before request
+          sfUserRequestTime: env.addHours(baseStart, 10),
+          sfAcknowledgedTime: env.addHours(baseStart, 8),
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 4),
+          requesterId: 'user-2',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-invalid-serval',
+          // Invalid Serval duration: finish before created
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 10),
+          startDate: env.addHours(baseStart, 7),
+          finishDate: env.addHours(baseStart, 6),
+          requesterId: 'user-3',
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-invalid-overlap',
+          // Invalid overlap: Serval runtime longer than full lifecycle in SF
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          sfAcknowledgedTime: env.addHours(baseStart, 5),
+          startDate: env.addHours(baseStart, 1),
+          finishDate: env.addHours(baseStart, 8),
+          requesterId: 'user-4',
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary = buildSummary(rows);
+
+      // Only the valid build should contribute to the percentage: 40%
+      expect(summary.percentTimeOnSF).toBeCloseTo(40, 0);
+    });
+
+    it('ignores unknown inter-build gaps when averaging', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows = [
+        // Build 1: has Serval data, finishes at hour 1 (servalFinished). No sfAcknowledgedTime, so the gap
+        // calculation will fall back to servalFinished for the "previous finish" time.
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          hasServalBuild: true
+        }),
+        // Build 2: NO Serval data (hasServalBuild=false), so servalFinished is undefined. Since sfAcknowledgedTime
+        // is also undefined, this build has no known finish time.
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: undefined,
+          finishDate: undefined,
+          sfUserRequestTime: env.addHours(baseStart, 3),
+          sfAcknowledgedTime: undefined,
+          hasServalBuild: false
+        }),
+        // Build 3: has Serval data, starts at hour 6.
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 6),
+          finishDate: env.addHours(baseStart, 7),
+          sfUserRequestTime: env.addHours(baseStart, 6),
+          hasServalBuild: true
+        })
+      ];
+
+      // SUT
+      const gaps: Array<number | undefined> = gapsBetweenBuildsMs(rows);
+      const summary = buildSummary(rows);
+
+      expect(gaps.length).toBe(2);
+      // Gap 1→2: Build 1 finishes (servalFinished) at hour 1, Build 2 starts (sfUserRequestTime) at hour 3 = 2h gap.
+      expect(gaps[0]).toBe(2 * 60 * 60 * 1000);
+      // Gap 2→3: Build 2 has no finish time (no sfAcknowledgedTime and no servalFinished), so the gap is unknown.
+      expect(gaps[1]).toBeUndefined();
+      // The average only counts known gaps, so the average is just the 2h gap.
+      expect(summary.averageInterBuildTimeMs).toBe(2 * 60 * 60 * 1000);
+    });
+
+    it('records undefined gap and logs error when consecutive builds have overlapping durations', () => {
+      const env = new TestEnvironment();
+      mockedConsole.reset();
+      mockedConsole.expectAndHide(/Two consecutive builds \(build-id, build-id\) have overlapping durations\./);
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      // Build 1 finishes at hour 5, but build 2 starts at hour 3 — the next build started before the previous
+      // finished, so the gap is negative (overlapping).
+      const rows = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 5),
+          sfUserRequestTime: env.addHours(baseStart, 0),
+          hasServalBuild: true
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 3),
+          finishDate: env.addHours(baseStart, 6),
+          sfUserRequestTime: env.addHours(baseStart, 3),
+          hasServalBuild: true
+        })
+      ];
+
+      // SUT
+      const gaps: Array<number | undefined> = gapsBetweenBuildsMs(rows);
+
+      expect(gaps.length).toBe(1);
+      // The gap is undefined because the builds overlap
+      expect(gaps[0]).toBeUndefined();
+      mockedConsole.verify();
+      mockedConsole.reset();
+    });
+  });
+
+  describe('duration calculation', () => {
+    it('uses SF timestamps when both are available', () => {
+      const env = new TestEnvironment();
+      const sfUserRequestTime: Date = new Date('2024-01-01T00:00:00Z');
+      const sfAcknowledgedTime: Date = new Date('2024-01-01T02:00:00Z'); // 2 hours later
+      const servalCreated: Date = new Date('2024-01-01T00:30:00Z');
+      const servalFinished: Date = new Date('2024-01-01T01:30:00Z'); // 1 hour Serval duration
+
+      const report: ServalBuildReportDto = env.createReport({
+        dateCreated: servalCreated,
+        dateFinished: servalFinished,
+        userRequestTime: sfUserRequestTime,
+        acknowledgedTime: sfAcknowledgedTime
+      });
+
+      // SUT
+      const rows = env.component['buildRows']([report]);
+
+      // Expect duration from SF timestamps (2 hours = 7200000 ms), not Serval (1 hour)
+      expect(rows[0].durationMs).toBe(7200000);
+    });
+
+    it('falls back to Serval timestamps when SF timestamps are missing', () => {
+      const env = new TestEnvironment();
+      const servalCreated: Date = new Date('2024-01-01T00:00:00Z');
+      const servalFinished: Date = new Date('2024-01-01T01:00:00Z'); // 1 hour duration
+
+      const report: ServalBuildReportDto = env.createReport({
+        dateCreated: servalCreated,
+        dateFinished: servalFinished,
+        userRequestTime: undefined,
+        acknowledgedTime: undefined
+      });
+
+      // SUT
+      const rows = env.component['buildRows']([report]);
+
+      // Expect duration from Serval timestamps (1 hour = 3600000 ms)
+      expect(rows[0].durationMs).toBe(3600000);
+    });
+
+    it('uses SF start with Serval end when only SF start is available', () => {
+      const env = new TestEnvironment();
+      const sfUserRequestTime: Date = new Date('2024-01-01T00:00:00Z');
+      const servalCreated: Date = new Date('2024-01-01T00:30:00Z');
+      const servalFinished: Date = new Date('2024-01-01T01:30:00Z');
+
+      const report: ServalBuildReportDto = env.createReport({
+        dateCreated: servalCreated,
+        dateFinished: servalFinished,
+        userRequestTime: sfUserRequestTime,
+        acknowledgedTime: undefined
+      });
+
+      // SUT
+      const rows = env.component['buildRows']([report]);
+
+      // Expect duration from SF start to Serval finish (1.5 hours = 5400000 ms)
+      expect(rows[0].durationMs).toBe(5400000);
+    });
+
+    it('uses Serval start with SF end when only SF end is available', () => {
+      const env = new TestEnvironment();
+      const servalCreated: Date = new Date('2024-01-01T00:00:00Z');
+      const servalFinished: Date = new Date('2024-01-01T01:00:00Z');
+      const sfAcknowledgedTime: Date = new Date('2024-01-01T01:30:00Z');
+
+      const report: ServalBuildReportDto = env.createReport({
+        dateCreated: servalCreated,
+        dateFinished: servalFinished,
+        userRequestTime: undefined,
+        acknowledgedTime: sfAcknowledgedTime
+      });
+
+      // SUT
+      const rows = env.component['buildRows']([report]);
+
+      // Expect duration from Serval start to SF acknowledged (1.5 hours = 5400000 ms)
+      expect(rows[0].durationMs).toBe(5400000);
+    });
+  });
+
+  describe('date range filtering', () => {
+    it('SF user request time out of range', () => {
+      const env = new TestEnvironment();
+      const rangeStart: Date = new Date('2024-01-10T00:00:00Z');
+      const rangeEnd: Date = new Date('2024-01-20T23:59:59Z');
+      const range: NormalizedDateRange = { start: rangeStart, end: rangeEnd };
+      const userRequestTime: Date = new Date('2024-01-05T12:00:00Z');
+      const report: ServalBuildReportDto = env.makeReport({ requestTime: userRequestTime });
+
+      // SUT
+      const result: boolean = env.component['didReportBeginOutOfDateRange'](report, range);
+
+      expect(result).toBe(true);
+    });
+
+    it('SF user request time in range', () => {
+      const env = new TestEnvironment();
+      const rangeStart: Date = new Date('2024-01-10T00:00:00Z');
+      const rangeEnd: Date = new Date('2024-01-20T23:59:59Z');
+      const range: NormalizedDateRange = { start: rangeStart, end: rangeEnd };
+      const userRequestTime: Date = new Date('2024-01-15T12:00:00Z');
+      const report: ServalBuildReportDto = env.makeReport({ requestTime: userRequestTime });
+
+      // SUT
+      const result: boolean = env.component['didReportBeginOutOfDateRange'](report, range);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createSpreadsheetRows', () => {
+    it('should use SF timestamps with fallback to Serval timestamps', () => {
+      const env = new TestEnvironment();
+      const sfUserRequestTime: Date = new Date('2024-06-01T08:00:00Z');
+      const sfAcknowledgedTime: Date = new Date('2024-06-01T10:00:00Z');
+      const servalCreated: Date = new Date('2024-06-01T08:05:00Z');
+      const servalFinished: Date = new Date('2024-06-01T09:55:00Z');
+
+      const rowWithSfTimestamps: ServalBuildRow = env.createRowWithDetails({
+        projectId: 'proj-1',
+        startDate: servalCreated,
+        finishDate: servalFinished,
+        sfUserRequestTime: sfUserRequestTime,
+        sfAcknowledgedTime: sfAcknowledgedTime,
+        hasServalBuild: true
+      });
+      const rowWithServalOnly: ServalBuildRow = env.createRowWithDetails({
+        projectId: 'proj-2',
+        startDate: servalCreated,
+        finishDate: servalFinished,
+        sfUserRequestTime: undefined,
+        sfAcknowledgedTime: undefined,
+        hasServalBuild: true
+      });
+
+      // SUT
+      const result: SpreadsheetRow[] = ServalBuildsComponent['createSpreadsheetRows']([
+        rowWithSfTimestamps,
+        rowWithServalOnly
+      ]);
+
+      // Row with SF timestamps should use SF timestamps
+      expect(result[0].startTime).toBe(sfUserRequestTime.toISOString());
+      expect(result[0].endTime).toBe(sfAcknowledgedTime.toISOString());
+
+      // Row without SF timestamps should fall back to Serval timestamps
+      expect(result[1].startTime).toBe(servalCreated.toISOString());
+      expect(result[1].endTime).toBe(servalFinished.toISOString());
+    });
+
+    it('should compute duration from effective start and end timestamps', () => {
+      const env = new TestEnvironment();
+      const sfUserRequestTime: Date = new Date('2024-06-01T08:00:00Z');
+      const sfAcknowledgedTime: Date = new Date('2024-06-01T10:00:00Z');
+
+      const row: ServalBuildRow = env.createRowWithDetails({
+        projectId: 'proj-1',
+        startDate: new Date('2024-06-01T08:05:00Z'),
+        finishDate: new Date('2024-06-01T09:55:00Z'),
+        sfUserRequestTime: sfUserRequestTime,
+        sfAcknowledgedTime: sfAcknowledgedTime,
+        hasServalBuild: true
+      });
+
+      // SUT
+      const result: SpreadsheetRow[] = ServalBuildsComponent['createSpreadsheetRows']([row]);
+
+      // Duration should be based on SF timestamps: 2 hours = 120 minutes
+      expect(result[0].durationMinutes).toBe('120');
+    });
+  });
+
+  describe('requested sorting', () => {
+    it('sorts by user request time with serval created fallback', () => {
+      const env = new TestEnvironment();
+      const userRequestLater: Date = new Date('2024-01-02T00:00:00Z');
+      const userRequestEarlier: Date = new Date('2024-01-01T00:00:00Z');
+      const servalCreatedFallback: Date = new Date('2024-01-01T12:00:00Z');
+
+      const reports: ServalBuildReportDto[] = [
+        // This build will be in the middle of the list.
+        env.createReport({
+          buildId: 'build-1',
+          dateCreated: servalCreatedFallback,
+          dateFinished: new Date('2024-01-01T13:00:00Z'),
+          userRequestTime: undefined
+        }),
+        // This build will be last on the list (at the top).
+        env.createReport({
+          buildId: 'build-2',
+          dateCreated: new Date('2024-01-01T10:00:00Z'),
+          dateFinished: new Date('2024-01-01T11:00:00Z'),
+          userRequestTime: userRequestLater
+        }),
+        // This build will be earliest in the list (at the bottom)
+        env.createReport({
+          buildId: 'build-3',
+          dateCreated: new Date('2024-01-01T09:00:00Z'),
+          dateFinished: new Date('2024-01-01T10:00:00Z'),
+          userRequestTime: userRequestEarlier
+        })
+      ];
+
+      // SUT
+      const rows: Array<{ report: ServalBuildReportDto }> = env.component['buildRows'](reports);
+
+      expect(rows[0].report.build?.additionalInfo?.buildId).toBe('build-2');
+      expect(rows[1].report.build?.additionalInfo?.buildId).toBe('build-1');
+      expect(rows[2].report.build?.additionalInfo?.buildId).toBe('build-3');
+      expect(rows[1].report.timeline.requestTime?.toISOString()).toBe(servalCreatedFallback.toISOString());
+    });
+  });
+});
+
+/** Provides helpers for constructing test data for ServalBuildsComponent tests. */
+class TestEnvironment {
+  readonly component: ServalBuildsComponent;
+  readonly fixture: ComponentFixture<ServalBuildsComponent>;
+  readonly builds$: BehaviorSubject<ServalBuildReportDto[] | undefined> = new BehaviorSubject<
+    ServalBuildReportDto[] | undefined
+  >(undefined);
+
+  constructor() {
+    const mockedUserProfileDoc = mock(UserProfileDoc);
+    const userProfileDoc: UserProfileDoc = instance(mockedUserProfileDoc);
+    const profileData: { displayName: string; avatarUrl: string } = {
+      displayName: 'Test User',
+      avatarUrl: ''
+    };
+
+    when(mockedUserProfileDoc.data).thenReturn(profileData);
+    when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
+    when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);
+    when(mockDraftGenerationService.getBuildsSince(anything())).thenReturn(this.builds$);
+    when(mockDialogService.openMatDialog(anything(), anything(), anything())).thenReturn(undefined as never);
+    when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
+    when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
+    when(mockUserService.getProfile(anything())).thenReturn(Promise.resolve(userProfileDoc));
+
+    this.fixture = TestBed.createComponent(ServalBuildsComponent);
+    this.component = this.fixture.componentInstance;
+  }
+
+  /** Creates a default BuildReportTimeline with optional overrides. */
+  makeTimeline(overrides: Partial<BuildReportTimeline> = {}): BuildReportTimeline {
+    return {
+      servalCreated: undefined,
+      servalStarted: undefined,
+      servalCompleted: undefined,
+      servalFinished: undefined,
+      sfUserRequested: undefined,
+      sfBuildProjectSubmitted: undefined,
+      sfUserCancelled: undefined,
+      sfAcknowledgedCompletion: undefined,
+      requestTime: undefined,
+      phases: undefined,
+      ...overrides
+    };
+  }
+
+  /** Creates a default ServalBuildReportDto with optional timeline overrides. */
+  makeReport(timelineOverrides: Partial<BuildReportTimeline> = {}): ServalBuildReportDto {
+    return {
+      build: undefined,
+      project: undefined,
+      timeline: this.makeTimeline(timelineOverrides),
+      config: {
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        trainingDataFileIds: []
+      },
+      problems: [],
+      draftGenerationRequestId: undefined,
+      requesterSFUserId: undefined,
+      status: DraftGenerationBuildStatus.Completed
+    };
+  }
+
+  createRow(projectDeleted: boolean, durationMs: number): any {
+    const sfProjectId: string | undefined = projectDeleted ? undefined : 'active-project-id';
+    const shortName: string = projectDeleted ? 'DEL' : 'ACT';
+    const name: string = projectDeleted ? 'Deleted Project' : 'Active Project';
+
+    const servalBuild: BuildDto = {
+      id: 'resource-id',
+      href: 'resource-href',
+      revision: 1,
+      engine: { id: 'engine-id', href: 'engine-href' },
+      percentCompleted: 100,
+      message: 'done',
+      state: BuildStates.Completed,
+      queueDepth: 0,
+      additionalInfo: {
+        buildId: 'build-id',
+        step: 0,
+        trainingScriptureRanges: [],
+        translationEngineId: 'translation-engine-id',
+        translationScriptureRanges: [],
+        trainingDataFileIds: [],
+        canDenormalizeQuotes: true
+      }
+    };
+
+    const report: ServalBuildReportDto = {
+      build: servalBuild,
+      project: sfProjectId != null ? { sfProjectId: sfProjectId, shortName: shortName, name: name } : undefined,
+      timeline: this.makeTimeline({
+        servalCreated: new Date(0),
+        servalFinished: new Date(durationMs)
+      }),
+      config: {
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        trainingDataFileIds: []
+      },
+      problems: [],
+      draftGenerationRequestId: undefined,
+      requesterSFUserId: sfProjectId == null ? undefined : 'requester-user-id',
+      status: DraftGenerationBuildStatus.Completed
+    };
+
+    return {
+      report: report,
+      trainingBooks: [],
+      translationBooks: [],
+      projectNameDisplay: buildProjectDisplayName(shortName, name, sfProjectId),
+      durationMs: durationMs,
+      projectServalAdminUrl: undefined,
+      projectDeleted: sfProjectId == null
+    };
+  }
+
+  createRowWithDetails({
+    durationMs = 1000,
+    projectId = undefined,
+    projectShortName = 'PRJ',
+    projectName = 'Project Name',
+    requesterId = undefined,
+    startDate = new Date(0),
+    finishDate,
+    trainingBooks = [],
+    translationBooks = [],
+    status = DraftGenerationBuildStatus.Completed,
+    problems = [],
+    sfUserRequestTime = undefined,
+    sfAcknowledgedTime = undefined,
+    hasServalBuild = true,
+    hasEvents = false
+  }: {
+    durationMs?: number;
+    projectId?: string;
+    projectShortName?: string;
+    projectName?: string;
+    requesterId?: string;
+    startDate?: Date;
+    finishDate?: Date;
+    trainingBooks?: ProjectBooks[];
+    translationBooks?: ProjectBooks[];
+    status?: DraftGenerationBuildStatus;
+    problems?: string[];
+    sfUserRequestTime?: Date;
+    sfAcknowledgedTime?: Date;
+    hasServalBuild?: boolean;
+    hasEvents?: boolean;
+  } = {}): any {
+    const start: Date = startDate ?? new Date(0);
+    const computedFinish: Date = finishDate ?? new Date(start.getTime() + durationMs);
+
+    const servalBuild: BuildDto | undefined = hasServalBuild
+      ? {
+          id: 'resource-id',
+          href: 'resource-href',
+          revision: 1,
+          engine: { id: 'engine-id', href: 'engine-href' },
+          percentCompleted: 100,
+          message: 'done',
+          state: status.toUpperCase() as BuildStates,
+          queueDepth: 0,
+          additionalInfo: {
+            buildId: 'build-id',
+            step: 0,
+            trainingScriptureRanges: [],
+            translationEngineId: 'translation-engine-id',
+            translationScriptureRanges: [],
+            trainingDataFileIds: [],
+            canDenormalizeQuotes: true,
+            requestedByUserId: requesterId
+          }
+        }
+      : undefined;
+
+    const report: ServalBuildReportDto = {
+      build: servalBuild,
+      project:
+        projectId != null ? { sfProjectId: projectId, shortName: projectShortName, name: projectName } : undefined,
+      timeline: this.makeTimeline({
+        servalCreated: hasServalBuild ? start : undefined,
+        servalFinished: hasServalBuild ? computedFinish : undefined,
+        sfUserRequested: sfUserRequestTime ?? (hasEvents ? start : undefined),
+        sfAcknowledgedCompletion: sfAcknowledgedTime,
+        requestTime: sfUserRequestTime ?? start
+      }),
+      config: {
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        trainingDataFileIds: []
+      },
+      problems: problems,
+      draftGenerationRequestId: undefined,
+      requesterSFUserId: requesterId,
+      status: status
+    };
+
+    const durationValue: number = computedFinish.getTime() - start.getTime();
+
+    return {
+      report: report,
+      trainingBooks: trainingBooks,
+      translationBooks: translationBooks,
+      projectNameDisplay: buildProjectDisplayName(projectShortName, projectName, projectId),
+      durationMs: durationValue,
+      projectServalAdminUrl: undefined,
+      projectDeleted: projectId == null
+    };
+  }
+
+  createProjectBooks(projectId: string, books: string[], projectDisplayName?: string): ProjectBooks[] {
+    const displayName: string = projectDisplayName ?? projectId.toUpperCase();
+    return [{ sfProjectId: projectId, projectDisplayName: displayName, books: books }];
+  }
+
+  createReport({
+    buildId = 'build-id',
+    dateCreated = new Date(0),
+    dateFinished = new Date(0),
+    userRequestTime = undefined,
+    acknowledgedTime = undefined
+  }: {
+    buildId?: string;
+    dateCreated?: Date;
+    dateFinished?: Date;
+    userRequestTime?: Date;
+    acknowledgedTime?: Date;
+  } = {}): ServalBuildReportDto {
+    const servalBuild: BuildDto = {
+      id: buildId,
+      href: 'resource-href',
+      revision: 1,
+      engine: { id: 'engine-id', href: 'engine-href' },
+      percentCompleted: 100,
+      message: 'done',
+      state: BuildStates.Completed,
+      queueDepth: 0,
+      additionalInfo: {
+        buildId: buildId,
+        step: 0,
+        trainingScriptureRanges: [],
+        translationEngineId: 'translation-engine-id',
+        translationScriptureRanges: [],
+        trainingDataFileIds: [],
+        canDenormalizeQuotes: true
+      }
+    };
+
+    return {
+      build: servalBuild,
+      project: { sfProjectId: 'project-id', shortName: 'PRJ', name: 'Project Name' },
+      timeline: this.makeTimeline({
+        servalCreated: dateCreated,
+        servalFinished: dateFinished,
+        sfUserRequested: userRequestTime,
+        sfAcknowledgedCompletion: acknowledgedTime,
+        requestTime: userRequestTime ?? dateCreated
+      }),
+      config: {
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        trainingDataFileIds: []
+      },
+      problems: [],
+      draftGenerationRequestId: undefined,
+      requesterSFUserId: undefined,
+      status: DraftGenerationBuildStatus.Completed
+    };
+  }
+
+  addHours(date: Date, hours: number): Date {
+    const millisecondsPerHour: number = 1000 * 60 * 60;
+    const startMs: number = date.getTime();
+    return new Date(startMs + hours * millisecondsPerHour);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1086,6 +1086,41 @@ describe('ServalBuildsComponent', () => {
     });
   });
 
+  describe('formatProjectBooks', () => {
+    it('includes the SF project ID and short name before the colon when short name is available', () => {
+      const projectBooks: ProjectBooks[] = [
+        {
+          sfProjectId: '112233',
+          projectDisplayName: 'BSB - Berean Standard Bible',
+          shortName: 'BSB',
+          books: ['GEN', 'EXO']
+        },
+        {
+          sfProjectId: '222333',
+          projectDisplayName: 'ASV - American Standard Version',
+          shortName: 'ASV',
+          books: ['EXO', 'LEV']
+        }
+      ];
+
+      // SUT
+      const result: string = ServalBuildsComponent.formatProjectBooks(projectBooks);
+
+      expect(result).toBe('112233 BSB: GEN; EXO. 222333 ASV: EXO; LEV');
+    });
+
+    it('falls back to just the project ID when short name is unavailable', () => {
+      const projectBooks: ProjectBooks[] = [
+        { sfProjectId: '112233', projectDisplayName: '112233', shortName: undefined, books: ['GEN'] }
+      ];
+
+      // SUT
+      const result: string = ServalBuildsComponent.formatProjectBooks(projectBooks);
+
+      expect(result).toBe('112233: GEN');
+    });
+  });
+
   describe('requested sorting', () => {
     it('sorts by user request time with serval created fallback', () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -3,6 +3,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
 import { MockConsole } from 'xforge-common/mock-console';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -33,6 +34,7 @@ const mockDraftGenerationService = mock(DraftGenerationService);
 const mockDialogService = mock(DialogService);
 const mockExportService = mock(DraftJobsExportService);
 const mockUserService = mock(UserService);
+const mockI18nService = mock(I18nService);
 const mockedConsole: MockConsole = MockConsole.install();
 
 describe('ServalBuildsComponent', () => {
@@ -47,6 +49,7 @@ describe('ServalBuildsComponent', () => {
       { provide: DialogService, useMock: mockDialogService },
       { provide: DraftJobsExportService, useMock: mockExportService },
       { provide: UserService, useMock: mockUserService },
+      { provide: I18nService, useMock: mockI18nService },
       provideNoopAnimations()
     ]
   }));
@@ -1123,6 +1126,18 @@ describe('ServalBuildsComponent', () => {
       expect(rows[1].report.timeline.requestTime?.toISOString()).toBe(servalCreatedFallback.toISOString());
     });
   });
+
+  describe('formatLanguageWithName', () => {
+    it('formats code with name', () => {
+      const env = new TestEnvironment();
+      when(mockI18nService.getLanguageDisplayName('es')).thenReturn('Spanish');
+
+      // SUT
+      const formatted: string = env.component['formatLanguageWithName']('es');
+
+      expect(formatted).toBe('es (Spanish)');
+    });
+  });
 });
 
 /** Provides helpers for constructing test data for ServalBuildsComponent tests. */
@@ -1149,6 +1164,8 @@ class TestEnvironment {
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockUserService.getProfile(anything())).thenReturn(Promise.resolve(userProfileDoc));
+    when(mockI18nService.localeCode).thenReturn('en');
+    when(mockI18nService.getLanguageDisplayName(anything())).thenReturn(undefined);
 
     this.fixture = TestBed.createComponent(ServalBuildsComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -195,7 +195,7 @@ describe('ServalBuildsComponent', () => {
 
       expect(summary.totalBuilds).toBe(6);
       expect(summary.totalProjects).toBe(3);
-      expect(summary.buildsPerProjectRatio).toBeCloseTo(2);
+      expect(summary.buildsPerProject).toBeCloseTo(2);
       expect(summary.averageInterBuildTimeMs).toBeCloseTo(9000000);
       expect(summary.totalRequesters).toBe(4);
       expect(summary.averageRequestersPerProject).toBeCloseTo(1.667);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -1,0 +1,750 @@
+import { AsyncPipe } from '@angular/common';
+import { Component, DestroyRef, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatCard, MatCardContent, MatCardHeader, MatCardTitle, MatCardTitleGroup } from '@angular/material/card';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { MatIcon } from '@angular/material/icon';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable
+} from '@angular/material/table';
+import { MatTooltip } from '@angular/material/tooltip';
+import { BehaviorSubject, catchError, combineLatest, filter, firstValueFrom, from, map, Observable, of } from 'rxjs';
+import { CopyComponent } from 'xforge-common/copy/copy.component';
+import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
+import { I18nService } from 'xforge-common/i18n.service';
+import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { NoticeService } from 'xforge-common/notice.service';
+import { OnlineStatusService } from 'xforge-common/online-status.service';
+import { OwnerComponent } from 'xforge-common/owner/owner.component';
+import { UserService } from 'xforge-common/user.service';
+import { notNull } from '../../type-utils';
+import { InfoComponent } from '../shared/info/info.component';
+import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
+import { DateRangePickerComponent, NormalizedDateRange } from './date-range-picker.component';
+import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
+import { JobDetailsDialogComponent } from './job-details-dialog.component';
+import {
+  buildProjectDisplayName,
+  DraftGenerationBuildStatus,
+  Phase,
+  ProjectBooks,
+  ServalBuildReportDto,
+  toProjectBooks
+} from './serval-build-report';
+import { buildSummary } from './serval-builds-statistics';
+
+/** Represents a row of Serval build data in the builds table. */
+export interface ServalBuildRow {
+  report: ServalBuildReportDto;
+  trainingBooks: ProjectBooks[];
+  translationBooks: ProjectBooks[];
+  projectNameDisplay?: string;
+  durationMs?: number;
+  projectServalAdminUrl?: string;
+  /** True if the build is not associable with any SF project currently in the database. */
+  projectDeleted: boolean;
+}
+
+/** Aggregated statistics for the currently visible Serval build rows. */
+export interface ServalBuildSummary {
+  totalBuilds: number;
+  totalProjects: number;
+  buildsPerProjectRatio?: number;
+  averageInterBuildTimeMs?: number;
+  totalRequesters: number;
+  averageRequestersPerProject?: number;
+  faultedBuilds: number;
+  averageTrainingBooksPerBuild?: number;
+  averageTranslationBooksPerBuild?: number;
+  completedBuilds: number;
+  inProgressBuilds: number;
+  buildsWithProblems: number;
+  /** Builds which were excluded from statistics because they were not associable with a project. */
+  unconsideredBuilds: number;
+  meanDurationMs?: number;
+  maxDurationMs?: number;
+  /** Percentage of time that successful builds spent in SF rather than in Serval. */
+  percentTimeOnSF?: number;
+  /**
+   * Number of builds that we had SF event metrics for, but we did not have Serval information for.
+   * This assumes that every build with events will have a StartPreTranslationBuildAsync event.
+   */
+  buildsServalDidNotKnowAbout: number;
+  /** Number of builds that we had Serval information for, but we did not have any SF event metrics for. */
+  buildsSfDidNotKnowAbout: number;
+}
+
+/** Presentation details for a summary item displayed above the builds table. */
+interface SummaryDisplayItem {
+  label: string;
+  explanation?: string;
+  value: string;
+  /** Preference to show this item without clicking to expand the view. */
+  prominence: 'top' | 'hidden';
+}
+
+/**
+ * Displays Serval builds in the Serval Administration area.
+ */
+@Component({
+  selector: 'app-serval-builds',
+  templateUrl: './serval-builds.component.html',
+  styleUrls: ['./serval-builds.component.scss'],
+  providers: [provideNativeDateAdapter()],
+  imports: [
+    AsyncPipe,
+    MatButton,
+    MatIconButton,
+    MatIcon,
+    MatMenu,
+    MatMenuItem,
+    MatMenuTrigger,
+    MatTable,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCell,
+    MatCellDef,
+    MatTooltip,
+    DateRangePickerComponent,
+    OwnerComponent,
+    InfoComponent,
+    MatCard,
+    MatCardTitle,
+    MatCardHeader,
+    MatCardContent,
+    MatCardTitleGroup,
+    CopyComponent,
+    MatSlideToggle
+  ]
+})
+export class ServalBuildsComponent extends DataLoadingComponent implements OnInit {
+  /** Help template access static methods. */
+  protected ServalBuildsComponent = ServalBuildsComponent;
+  protected columnsToDisplay: string[] = ['status', 'project', 'source', 'language', 'requested', 'expand'];
+  /** Tracks which rows are currently expanded (by Serval build ID). */
+  private expandedRows: Set<string> = new Set();
+  /** Data rows, excluding those that might be filtered out by the includeDeleted toggle. */
+  protected rows: ServalBuildRow[] = [];
+  /** Summary statistics for the currently displayed Serval builds. */
+  private summaryStats: ServalBuildSummary | undefined;
+  /** Display-ready summary values shown above the table. */
+  protected summaryDisplayItems: SummaryDisplayItem[] = [];
+  /** Include Serval builds that we are not able to associate with any project in the SF DB. Maybe the project existed
+   * and was deleted. Maybe another SF installation has that project and requested a Serval build. */
+  protected includeDeleted: boolean = false;
+  protected summaryIsExpanded: boolean = false;
+  /** Data rows, including those that are filtered out by the includeDeleted toggle. */
+  private allRows: ServalBuildRow[] = [];
+  private readonly dateRange$ = new BehaviorSubject<NormalizedDateRange | undefined>(undefined);
+  private readonly requesterDisplayNameCache: Map<string, Observable<string>> = new Map();
+
+  constructor(
+    noticeService: NoticeService,
+    private readonly draftGenerationService: DraftGenerationService,
+    private readonly dialogService: DialogService,
+    private readonly onlineStatusService: OnlineStatusService,
+    private readonly i18n: I18nService,
+    private readonly exportService: DraftJobsExportService,
+    private readonly userService: UserService,
+    private readonly destroyRef: DestroyRef
+  ) {
+    super(noticeService);
+  }
+
+  protected get isOnline(): boolean {
+    return this.onlineStatusService.isOnline;
+  }
+
+  ngOnInit(): void {
+    combineLatest([this.onlineStatusService.onlineStatus$, this.dateRange$.pipe(filter(notNull))])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([isOnline, range]) => {
+        this.loadingStarted();
+        void this.loadBuilds(range, isOnline);
+      });
+  }
+
+  protected onDateRangeChange(range: NormalizedDateRange): void {
+    this.dateRange$.next(range);
+  }
+
+  /** Toggle whether a row is expanded. */
+  protected toggleRowExpansion(row: ServalBuildRow): void {
+    const id: string | undefined = row.report.build?.additionalInfo?.buildId ?? row.report.draftGenerationRequestId;
+    if (id == null) return;
+    if (this.expandedRows.has(id)) {
+      this.expandedRows.delete(id);
+    } else {
+      this.expandedRows.add(id);
+    }
+  }
+
+  /** Check if a row is currently expanded. */
+  protected isRowExpanded(row: ServalBuildRow): boolean {
+    const id: string | undefined = row.report.build?.additionalInfo?.buildId ?? row.report.draftGenerationRequestId;
+    if (id == null) return false;
+    return this.expandedRows.has(id);
+  }
+
+  protected exportCsv(): void {
+    const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
+    if (dateRange == null) throw new Error('Date range is not set');
+    const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
+    const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
+    const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
+    this.exportService.exportCsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  }
+
+  protected exportRsv(): void {
+    const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
+    if (dateRange == null) throw new Error('Date range is not set');
+    const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
+    const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
+    const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
+    this.exportService.exportRsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  }
+
+  protected clearMLUrl(servalBuildId: string): string {
+    return `https://app.sil.hosted.allegro.ai/projects?gq=${servalBuildId}&tab=tasks`;
+  }
+
+  protected openBuildDetails(row: ServalBuildRow): void {
+    const buildId: string | undefined = row.report.build?.additionalInfo?.buildId;
+    const sfProjectId: string | undefined = row.report.project?.sfProjectId;
+
+    if (buildId == null || sfProjectId == null) {
+      void this.noticeService.show(
+        'Unable to show details. No Serval build ID or SF project ID was available for this Serval build'
+      );
+      return;
+    }
+
+    const durationText: string | undefined =
+      row.durationMs != null ? this.formatDurationHours(row.durationMs) : undefined;
+    const servalCreated: Date | undefined = row.report.timeline.servalCreated;
+    const createdDisplay: string | undefined =
+      servalCreated != null ? this.i18n.formatDate(servalCreated, { showTimeZone: true }) : undefined;
+
+    const buildsCreatedSince: number = this.rows.filter(other => {
+      if (other.report.project?.sfProjectId !== sfProjectId) return false;
+      const otherCreated: Date | undefined = other.report.timeline.servalCreated;
+      if (otherCreated == null || servalCreated == null) return false;
+      return otherCreated > servalCreated;
+    }).length;
+
+    const dialogData = {
+      buildId: buildId,
+      projectId: sfProjectId,
+      jobStatus: ServalBuildsComponent.formatStatusLabel(row.report.status),
+      events: [],
+      additionalEvents: [],
+      eventBasedDuration: durationText,
+      startTime: createdDisplay,
+      clearmlUrl: this.clearMLUrl(buildId),
+      buildsStartedSince: buildsCreatedSince,
+      draftGenerationRequestId: row.report.draftGenerationRequestId
+    };
+
+    this.dialogService.openMatDialog(JobDetailsDialogComponent, {
+      data: dialogData,
+      width: '1000px',
+      maxHeight: '80vh'
+    });
+  }
+
+  protected statusIcon(status: DraftGenerationBuildStatus): string {
+    switch (status) {
+      case DraftGenerationBuildStatus.UserRequested:
+      case DraftGenerationBuildStatus.SubmittedToServal:
+      case DraftGenerationBuildStatus.Pending:
+      case DraftGenerationBuildStatus.Active:
+        return 'hourglass_top';
+      case DraftGenerationBuildStatus.Completed:
+        return 'done';
+      case DraftGenerationBuildStatus.Faulted:
+        return 'error';
+      case DraftGenerationBuildStatus.Canceled:
+        return 'cancel';
+      default:
+        return 'help';
+    }
+  }
+
+  static formatStatusLabel(status: DraftGenerationBuildStatus): string {
+    if (status === DraftGenerationBuildStatus.UserRequested) {
+      return 'User requested';
+    }
+    if (status === DraftGenerationBuildStatus.SubmittedToServal) {
+      return 'Submitted to Serval';
+    }
+    return status;
+  }
+
+  /** Returns the requested phase of the build.  */
+  protected getPhase(report: ServalBuildReportDto, stage: 'Train' | 'Inference'): Phase | undefined {
+    return report.timeline.phases?.find((phase: Phase) => phase.stage === stage);
+  }
+
+  protected durationServalCreatedToFinish(report: ServalBuildReportDto): string {
+    if (report.build == null) return '-';
+    const servalCreated: Date | undefined = report.timeline.servalCreated;
+    const servalFinish: Date | undefined = report.timeline.servalFinished;
+    const durationMinutes: string | undefined = ServalBuildsComponent.durationMinutes(
+      servalCreated,
+      servalFinish
+    )?.toFixed(0);
+    if (durationMinutes == null) return '-';
+    return `${durationMinutes} m`;
+  }
+
+  protected durationUserRequestToCompletionAcknowledged(report: ServalBuildReportDto): string {
+    const userRequestTime: Date | undefined = report.timeline.sfUserRequested;
+    const acknowledgedTime: Date | undefined = report.timeline.sfAcknowledgedCompletion;
+    const durationMinutes: number | undefined = ServalBuildsComponent.durationMinutes(
+      userRequestTime,
+      acknowledgedTime
+    );
+    if (durationMinutes == null) return '-';
+    const durationDisplay: string = durationMinutes.toFixed(0);
+    return `${durationDisplay} m`;
+  }
+
+  /** Returns the range of rows across which to show the visual duration bar, in the Timing card. */
+  protected getTimingBarRowRange(row: ServalBuildRow, bar: 'serval' | 'user'): string {
+    const hasUserCancel: boolean = row.report.timeline.sfUserCancelled != null;
+    const userRequestRowIndex: number = 1;
+    const servalCreatedRowIndex: number = 3;
+    const servalFinishRowIndex: number = 6;
+    const acknowledgedRowIndex: number = hasUserCancel ? 8 : 7;
+    const startRowIndex: number = bar === 'serval' ? servalCreatedRowIndex : userRequestRowIndex;
+    const endRowIndex: number = bar === 'serval' ? servalFinishRowIndex : acknowledgedRowIndex;
+    const endRowExclusive: number = endRowIndex + 1;
+    return `${startRowIndex} / ${endRowExclusive}`;
+  }
+
+  protected durationPhaseTrain(report: ServalBuildReportDto): string {
+    if (report.build == null) return '-';
+    const phaseTrain: Phase | undefined = this.getPhase(report, 'Train');
+    const phaseInference: Phase | undefined = this.getPhase(report, 'Inference');
+    const durationMinutes: string | undefined = ServalBuildsComponent.durationMinutes(
+      phaseTrain?.started,
+      phaseInference?.started
+    )?.toFixed(0);
+    if (durationMinutes == null) return '-';
+    return `${durationMinutes} m`;
+  }
+
+  protected durationPhaseInference(report: ServalBuildReportDto): string {
+    if (report.build == null) return '-';
+    const phaseInference: Phase | undefined = this.getPhase(report, 'Inference');
+    const servalFinish: Date | undefined = report.timeline.servalFinished;
+    const durationMinutes: string | undefined = ServalBuildsComponent.durationMinutes(
+      phaseInference?.started,
+      servalFinish
+    )?.toFixed(0);
+    if (durationMinutes == null) return '-';
+    return `${durationMinutes} m`;
+  }
+
+  protected requesterDisplayName(requesterSFUserId: string | undefined): Observable<string> {
+    if (requesterSFUserId == null) return of('Unknown');
+
+    const requesterKey: string = requesterSFUserId;
+    const cached$: Observable<string> | undefined = this.requesterDisplayNameCache.get(requesterKey);
+    if (cached$ != null) return cached$;
+
+    // Cache the lookups so multiple rows don't need to request the same thing.
+    const displayName$: Observable<string> = from(this.userService.getProfile(requesterSFUserId)).pipe(
+      catchError(() => of(undefined)),
+      map((userProfileDoc: UserProfileDoc | undefined) => {
+        const displayName: string | undefined = userProfileDoc?.data?.displayName;
+        if (displayName == null) return 'Unknown';
+        if (displayName.trim().length === 0) return 'Unknown';
+        return displayName;
+      }),
+      catchError(() => of('Unknown'))
+    );
+    this.requesterDisplayNameCache.set(requesterKey, displayName$);
+    return displayName$;
+  }
+
+  private async loadBuilds(range: NormalizedDateRange, isOnline: boolean): Promise<void> {
+    try {
+      if (!isOnline) {
+        this.allRows = [];
+        this.rows = [];
+        this.summaryStats = undefined;
+        this.summaryDisplayItems = [];
+        return;
+      }
+
+      const reports: ServalBuildReportDto[] | undefined = await firstValueFrom(
+        this.draftGenerationService.getBuildsSince(range.start)
+      );
+
+      const reportsInRange: ServalBuildReportDto[] = (reports ?? []).filter(
+        (report: ServalBuildReportDto) => !this.didReportBeginOutOfDateRange(report, range)
+      );
+      this.allRows = this.buildRows(reportsInRange);
+      this.applyFiltersAndStats();
+    } finally {
+      this.loadingFinished();
+    }
+  }
+
+  private buildRows(reports: ServalBuildReportDto[]): ServalBuildRow[] {
+    const rows: ServalBuildRow[] = reports.map((report: ServalBuildReportDto) => {
+      const sfProjectId: string | undefined = report.project?.sfProjectId;
+      const servalCreationDate: Date | undefined = report.timeline.servalCreated;
+      const servalFinishDate: Date | undefined = report.timeline.servalFinished;
+      if (report.timeline.requestTime == null) {
+        console.error(
+          'Row has no user request time or serval creation date. This should be impossible because build records are based either on Serval build data or on SF user request events.'
+        );
+      }
+      // Use SF timestamps if available, with fallback to Serval timestamps
+      const effectiveStart: Date | undefined = report.timeline.sfUserRequested ?? servalCreationDate;
+      const effectiveEnd: Date | undefined = report.timeline.sfAcknowledgedCompletion ?? servalFinishDate;
+      const durationMs: number | undefined = ServalBuildsComponent.calculateDurationMs(effectiveStart, effectiveEnd);
+      const projectNameDisplay: string = buildProjectDisplayName(
+        report.project?.shortName,
+        report.project?.name,
+        sfProjectId
+      );
+      const projectLink: string | undefined = this.servalAdminProjectLinkFor(sfProjectId);
+      const trainingBooks: ProjectBooks[] = toProjectBooks(report.config.trainingScriptureRanges);
+      const translationBooks: ProjectBooks[] = toProjectBooks(report.config.translationScriptureRanges);
+
+      return {
+        report: report,
+        trainingBooks: trainingBooks,
+        translationBooks: translationBooks,
+        projectNameDisplay: projectNameDisplay,
+        durationMs: durationMs,
+        projectServalAdminUrl: projectLink,
+        projectDeleted: sfProjectId == null
+      };
+    });
+    return rows.sort((left: ServalBuildRow, right: ServalBuildRow) => {
+      const leftTime: number | undefined = left.report.timeline.requestTime?.getTime();
+      const rightTime: number | undefined = right.report.timeline.requestTime?.getTime();
+      if (leftTime == null && rightTime == null) return 0;
+      if (leftTime == null) return 1;
+      if (rightTime == null) return -1;
+      return rightTime - leftTime;
+    });
+  }
+
+  protected onIncludeDeletedChange(includeDeleted: boolean): void {
+    this.includeDeleted = includeDeleted;
+    this.applyFiltersAndStats();
+  }
+
+  private applyFiltersAndStats(): void {
+    this.rows = this.filteredRows();
+    this.updateSummaryStats();
+  }
+
+  private filteredRows(): ServalBuildRow[] {
+    if (this.includeDeleted === true) {
+      return [...this.allRows];
+    }
+    return this.allRows.filter((row: ServalBuildRow) => !row.projectDeleted);
+  }
+
+  private updateSummaryStats(): void {
+    this.summaryStats = buildSummary(this.rows);
+    this.summaryDisplayItems = this.buildSummaryDisplayItems(this.summaryStats);
+  }
+
+  private buildSummaryDisplayItems(summary: ServalBuildSummary | undefined): SummaryDisplayItem[] {
+    if (summary == null) return [];
+
+    const items: SummaryDisplayItem[] = [];
+
+    const buildsItem: SummaryDisplayItem = {
+      label: 'Builds',
+      value: this.formatCount(summary.totalBuilds),
+      prominence: 'top'
+    };
+    items.push(buildsItem);
+
+    const projectsItem: SummaryDisplayItem = {
+      label: 'Projects',
+      value: this.formatCount(summary.totalProjects),
+      prominence: 'top'
+    };
+    items.push(projectsItem);
+
+    const buildsPerProjectItem: SummaryDisplayItem = {
+      label: 'Builds per project',
+      value: this.formatAverage(summary.buildsPerProjectRatio),
+      prominence: 'top'
+    };
+    items.push(buildsPerProjectItem);
+
+    const meanDurationItem: SummaryDisplayItem = {
+      label: 'Mean successful duration',
+      value: this.formatDurationHoursFromMs(summary.meanDurationMs),
+      prominence: 'top'
+    };
+    items.push(meanDurationItem);
+
+    const maxDurationItem: SummaryDisplayItem = {
+      label: 'Max all durations',
+      value: this.formatDurationHoursFromMs(summary.maxDurationMs),
+      prominence: 'top'
+    };
+    items.push(maxDurationItem);
+
+    const requestersItem: SummaryDisplayItem = {
+      label: 'Requesting users',
+      value: this.formatCount(summary.totalRequesters),
+      prominence: 'hidden'
+    };
+    items.push(requestersItem);
+
+    const averageRequestersItem: SummaryDisplayItem = {
+      label: 'Average requesters per project',
+      value: this.formatAverage(summary.averageRequestersPerProject),
+      prominence: 'hidden'
+    };
+    items.push(averageRequestersItem);
+
+    const percentTimeOnSFItem: SummaryDisplayItem = {
+      label: '% time on SF',
+      explanation:
+        'Percentage of time that successful builds are being processed in SF before being sent to Serval, and in SF after hearing back from Serval. This is time that the build is waiting for SF rather than for Serval. It will also include network time in between, as well as any amount of time that it takes Serval to start timing, and after Serval stops timing until Serval sends the completion notice. Excludes builds known only from SF events.',
+      value: this.formatPercentage(summary.percentTimeOnSF),
+      prominence: 'hidden'
+    };
+    items.push(percentTimeOnSFItem);
+
+    const averageGapItem: SummaryDisplayItem = {
+      label: 'Average time between project builds',
+      explanation:
+        'For projects with more than one build, the average length of time after a build completion is acknowledged until the next build is requested for the same project.',
+      value: this.formatDurationHoursFromMs(summary.averageInterBuildTimeMs),
+      prominence: 'hidden'
+    };
+    items.push(averageGapItem);
+
+    const completedItem: SummaryDisplayItem = {
+      label: 'Completed (successful) builds',
+      explanation: 'Excludes builds known only from SF events.',
+      value: this.formatCount(summary.completedBuilds),
+      prominence: 'hidden'
+    };
+    items.push(completedItem);
+
+    const faultedItem: SummaryDisplayItem = {
+      label: 'Faulted builds',
+      explanation: 'Excludes builds known only from SF events.',
+      value: this.formatCount(summary.faultedBuilds),
+      prominence: 'hidden'
+    };
+    items.push(faultedItem);
+
+    const inProgressItem: SummaryDisplayItem = {
+      label: 'In-progress builds',
+      explanation: 'Builds with status UserRequested, SubmittedToServal, Pending, or Active.',
+      value: this.formatCount(summary.inProgressBuilds),
+      prominence: 'hidden'
+    };
+    items.push(inProgressItem);
+
+    const problemsItem: SummaryDisplayItem = {
+      label: 'Builds with problems',
+      explanation: 'Builds that SF flagged a problem for.',
+      value: this.formatCount(summary.buildsWithProblems),
+      prominence: 'hidden'
+    };
+    items.push(problemsItem);
+
+    const averageTrainingBooksItem: SummaryDisplayItem = {
+      label: 'Average training books per build',
+      explanation: 'Excludes builds known only from SF events.',
+      value: this.formatAverage(summary.averageTrainingBooksPerBuild),
+      prominence: 'hidden'
+    };
+    items.push(averageTrainingBooksItem);
+
+    const averageTranslationBooksItem: SummaryDisplayItem = {
+      label: 'Average translation books per build',
+      explanation: 'Excludes builds known only from SF events.',
+      value: this.formatAverage(summary.averageTranslationBooksPerBuild),
+      prominence: 'hidden'
+    };
+    items.push(averageTranslationBooksItem);
+
+    const buildsServalDidNotKnowAboutItem: SummaryDisplayItem = {
+      label: 'Builds Serval did not know about',
+      explanation: 'Number of builds that we had SF event metrics for, but we did not have Serval information for.',
+      value: this.formatCount(summary.buildsServalDidNotKnowAbout),
+      prominence: 'hidden'
+    };
+    items.push(buildsServalDidNotKnowAboutItem);
+
+    const buildsSfDidNotKnowAboutItem: SummaryDisplayItem = {
+      label: 'Builds SF did not know about',
+      explanation: 'Number of builds that we had Serval information for, but we did not have SF event metrics for.',
+      value: this.formatCount(summary.buildsSfDidNotKnowAbout),
+      prominence: 'hidden'
+    };
+    items.push(buildsSfDidNotKnowAboutItem);
+
+    const unconsideredBuildsItem: SummaryDisplayItem = {
+      label: 'Unconsidered builds',
+      explanation: 'Builds not included in the above figures, that were not associated with a SF project.',
+      value: this.formatCount(summary.unconsideredBuilds),
+      prominence: 'hidden'
+    };
+    items.push(unconsideredBuildsItem);
+
+    return items;
+  }
+
+  private formatCount(value: number | undefined): string {
+    if (value == null) return 'n/a';
+    return value.toLocaleString(this.i18n.localeCode);
+  }
+
+  private formatAverage(value: number | undefined): string {
+    if (value == null) return 'n/a';
+    return value.toLocaleString(this.i18n.localeCode, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+  }
+
+  private formatDurationHoursFromMs(milliseconds: number | undefined): string {
+    if (milliseconds == null) return 'n/a';
+    return this.formatDurationHours(milliseconds);
+  }
+
+  private formatPercentage(value: number | undefined): string {
+    if (value == null) return 'n/a';
+    return `${Math.round(value)}%`;
+  }
+
+  /** If the Serval build request has a beginning date outside of the date range. */
+  private didReportBeginOutOfDateRange(report: ServalBuildReportDto, range: NormalizedDateRange): boolean {
+    const beginDate: Date | undefined = report.timeline.requestTime;
+    if (beginDate == null) return false;
+    if (Number.isNaN(beginDate.getTime())) return false;
+    return beginDate < range.start || beginDate > range.end;
+  }
+
+  private static calculateDurationMs(startDate: Date | undefined, finishDate: Date | undefined): number | undefined {
+    if (startDate == null || finishDate == null) return undefined;
+    return finishDate.getTime() - startDate.getTime();
+  }
+
+  private static durationMinutes(startDate: Date | undefined, finishDate: Date | undefined): number | undefined {
+    const durationMs: number | undefined = ServalBuildsComponent.calculateDurationMs(startDate, finishDate);
+    if (durationMs == null) return undefined;
+    return durationMs / 1000 / 60;
+  }
+
+  /** Formats a Date object into a string with the format "YYYY-MM-DD HH:mm:ss TZ", to be used for comparative vertical
+   * display, and in the viewer's timezone. */
+  protected formatDateTime(date: Date | undefined): string | undefined {
+    if (date == null) return undefined;
+    const year = date.getFullYear().toString();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    const hour = date.getHours().toString().padStart(2, '0');
+    const minute = date.getMinutes().toString().padStart(2, '0');
+    const second = date.getSeconds().toString().padStart(2, '0');
+
+    const tzFormatter = new Intl.DateTimeFormat(this.i18n.localeCode, { timeZoneName: 'short' });
+    const tzParts: Intl.DateTimeFormatPart | undefined = tzFormatter
+      .formatToParts(date)
+      .find(p => p.type === 'timeZoneName');
+    const timeZoneName = tzParts?.value ?? 'UNK';
+    return `${year}-${month}-${day} ${hour}:${minute}:${second} ${timeZoneName}`;
+  }
+
+  /** Formats a Date object into a localized string. Includes date part but not time part. This Serval Administration
+   * method is not trying to be as broad in locale support as i18n.service.ts formatDate(). */
+  protected localizedDate(date: Date | undefined): string | undefined {
+    if (date == null) return undefined;
+    return date.toLocaleString([this.i18n.localeCode, I18nService.defaultLocale.canonicalTag], {
+      month: 'numeric',
+      year: 'numeric',
+      day: 'numeric'
+    });
+  }
+
+  private formatDurationHours(milliseconds: number): string {
+    const hours = milliseconds / 1000 / 60 / 60;
+    return `${hours.toFixed(1)} h`;
+  }
+
+  private static createSpreadsheetRows(rows: ServalBuildRow[]): SpreadsheetRow[] {
+    return rows.map((row: ServalBuildRow) => {
+      const trainingBooksList = ServalBuildsComponent.formatProjectBooks(row.trainingBooks);
+      const translationBooksList = ServalBuildsComponent.formatProjectBooks(row.translationBooks);
+      const servalCreated: Date | undefined = row.report.timeline.servalCreated;
+      const servalFinish: Date | undefined = row.report.timeline.servalFinished;
+      // Use SF timestamps if available, with fallback to Serval timestamps
+      const effectiveStart: Date | undefined = row.report.timeline.sfUserRequested ?? servalCreated;
+      const effectiveEnd: Date | undefined = row.report.timeline.sfAcknowledgedCompletion ?? servalFinish;
+      const durationMinutes: string =
+        ServalBuildsComponent.durationMinutes(effectiveStart, effectiveEnd)?.toFixed(0) ?? '';
+
+      return {
+        servalBuildId: row.report.build?.additionalInfo?.buildId,
+        draftGenerationRequestId: row.report.draftGenerationRequestId,
+        startTime: effectiveStart?.toISOString(),
+        endTime: effectiveEnd?.toISOString(),
+        durationMinutes: durationMinutes,
+        status: ServalBuildsComponent.formatStatusLabel(row.report.status),
+        sfProjectId: row.report.project?.sfProjectId ?? '',
+        projectName: row.projectNameDisplay,
+        sfUserId: row.report.requesterSFUserId,
+        trainingBooks: trainingBooksList,
+        translationBooks: translationBooksList
+      };
+    });
+  }
+
+  static formatProjectBooks(projectBooks: ProjectBooks[]): string {
+    return projectBooks.map(pb => `${pb.sfProjectId}: ${pb.books.join(', ')}`).join('; ');
+  }
+
+  protected servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {
+    if (sfProjectId == null) return undefined;
+    return `/serval-administration/${sfProjectId}`;
+  }
+
+  /** Formats a language code with its display name, e.g. "es (Spanish)". Falls back to just the code. */
+  protected formatLanguageWithName(langCode: string | undefined): string {
+    if (langCode == null) return 'Unknown';
+    try {
+      const displayNames: Intl.DisplayNames = new Intl.DisplayNames(['en'], { type: 'language' });
+      const languageName: string | undefined = displayNames.of(langCode);
+      if (languageName != null && languageName !== langCode) {
+        return `${langCode} (${languageName})`;
+      }
+    } catch {
+      // If Intl.DisplayNames fails or doesn't recognize the code, just return the code
+    }
+    return langCode;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -725,7 +725,12 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   static formatProjectBooks(projectBooks: ProjectBooks[]): string {
-    return projectBooks.map(pb => `${pb.sfProjectId}: ${pb.books.join('; ')}`).join('. ');
+    return projectBooks
+      .map((pb: ProjectBooks) => {
+        const prefix: string = pb.shortName != null ? `${pb.sfProjectId} ${pb.shortName}` : pb.sfProjectId;
+        return `${prefix}: ${pb.books.join('; ')}`;
+      })
+      .join('. ');
   }
 
   protected servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -736,14 +736,9 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   /** Formats a language code with its display name, e.g. "es (Spanish)". Falls back to just the code. */
   protected formatLanguageWithName(langCode: string | undefined): string {
     if (langCode == null) return 'Unknown';
-    try {
-      const displayNames: Intl.DisplayNames = new Intl.DisplayNames(['en'], { type: 'language' });
-      const languageName: string | undefined = displayNames.of(langCode);
-      if (languageName != null && languageName !== langCode) {
-        return `${langCode} (${languageName})`;
-      }
-    } catch {
-      // If Intl.DisplayNames fails or doesn't recognize the code, just return the code
+    const languageName: string | undefined = this.i18n.getLanguageDisplayName(langCode);
+    if (languageName != null && languageName !== langCode) {
+      return `${langCode} (${languageName})`;
     }
     return langCode;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -62,7 +62,7 @@ export interface ServalBuildRow {
 export interface ServalBuildSummary {
   totalBuilds: number;
   totalProjects: number;
-  buildsPerProjectRatio?: number;
+  buildsPerProject?: number;
   averageInterBuildTimeMs?: number;
   totalRequesters: number;
   averageRequestersPerProject?: number;
@@ -496,7 +496,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
     const buildsPerProjectItem: SummaryDisplayItem = {
       label: 'Builds per project',
-      value: this.formatAverage(summary.buildsPerProjectRatio),
+      value: this.formatAverage(summary.buildsPerProject),
       prominence: 'top'
     };
     items.push(buildsPerProjectItem);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -166,7 +166,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     private readonly userService: UserService,
     private readonly destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'ServalBuildsComponent');
   }
 
   protected get isOnline(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -725,8 +725,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
         ServalBuildsComponent.durationMinutes(effectiveStart, effectiveEnd)?.toFixed(0) ?? '';
 
       return {
-        servalBuildId: row.report.build?.additionalInfo?.buildId,
         draftGenerationRequestId: row.report.draftGenerationRequestId,
+        servalBuildId: row.report.build?.additionalInfo?.buildId,
         startTime: effectiveStart?.toISOString(),
         endTime: effectiveEnd?.toISOString(),
         durationMinutes: durationMinutes,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -725,7 +725,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   static formatProjectBooks(projectBooks: ProjectBooks[]): string {
-    return projectBooks.map(pb => `${pb.sfProjectId}: ${pb.books.join(', ')}`).join('; ');
+    return projectBooks.map(pb => `${pb.sfProjectId}: ${pb.books.join('; ')}`).join('. ');
   }
 
   protected servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -20,7 +20,20 @@ import {
   MatTable
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
-import { BehaviorSubject, catchError, combineLatest, filter, firstValueFrom, from, map, Observable, of } from 'rxjs';
+import {
+  BehaviorSubject,
+  catchError,
+  combineLatest,
+  filter,
+  firstValueFrom,
+  from,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  startWith,
+  switchMap
+} from 'rxjs';
 import { CopyComponent } from 'xforge-common/copy/copy.component';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -30,7 +43,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { UserService } from 'xforge-common/user.service';
-import { notNull } from '../../type-utils';
+import { isPopulatedString, notNull } from '../../type-utils';
 import { InfoComponent } from '../shared/info/info.component';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DateRangePickerComponent, NormalizedDateRange } from './date-range-picker.component';
@@ -373,13 +386,16 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
     // Cache the lookups so multiple rows don't need to request the same thing.
     const displayName$: Observable<string> = from(this.userService.getProfile(requesterSFUserId)).pipe(
-      catchError(() => of(undefined)),
-      map((userProfileDoc: UserProfileDoc | undefined) => {
-        const displayName: string | undefined = userProfileDoc?.data?.displayName;
-        if (displayName == null) return 'Unknown';
-        if (displayName.trim().length === 0) return 'Unknown';
-        return displayName;
-      }),
+      switchMap((userProfileDoc: UserProfileDoc) =>
+        userProfileDoc.changes$.pipe(
+          startWith(undefined),
+          map(() => {
+            const displayName: string | undefined = userProfileDoc.data?.displayName?.trim();
+            return isPopulatedString(displayName) ? displayName : 'Unknown';
+          })
+        )
+      ),
+      shareReplay(1),
       catchError(() => of('Unknown'))
     );
     this.requesterDisplayNameCache.set(requesterKey, displayName$);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -24,6 +24,7 @@ import { TextDocSource } from '../../core/models/text-doc';
 import { BuildDto, ServalBuildAdditionalInfo } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { MACHINE_API_BASE_URL } from '../../machine-api/http-client';
+import { DraftGenerationBuildStatus, ServalBuildReportDto } from '../../serval-administration/serval-build-report';
 import { BuildConfig } from './draft-generation';
 import { DraftGenerationService } from './draft-generation.service';
 
@@ -325,6 +326,57 @@ describe('DraftGenerationService', () => {
 
       // SUT
       service.getBuildHistory(projectId).subscribe(result => {
+        expect(result).toBeUndefined();
+      });
+      tick();
+    }));
+  });
+
+  describe('getBuildsSince', () => {
+    const sampleReport: ServalBuildReportDto = {
+      build: buildDto,
+      project: undefined,
+      timeline: {
+        servalCreated: undefined,
+        servalStarted: undefined,
+        servalCompleted: undefined,
+        servalFinished: undefined,
+        sfUserRequested: undefined,
+        sfBuildProjectSubmitted: undefined,
+        sfUserCancelled: undefined,
+        sfAcknowledgedCompletion: undefined,
+        requestTime: undefined,
+        phases: undefined
+      },
+      config: { trainingScriptureRanges: [], translationScriptureRanges: [], trainingDataFileIds: [] },
+      problems: [],
+      draftGenerationRequestId: undefined,
+      requesterSFUserId: undefined,
+      status: DraftGenerationBuildStatus.UserRequested
+    };
+
+    it('should request builds', fakeAsync(() => {
+      const sinceDate = new Date('2025-01-01T00:00:00.000Z');
+
+      // SUT
+      service.getBuildsSince(sinceDate).subscribe(result => {
+        expect(result).toEqual([sampleReport]);
+      });
+      tick();
+
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/since:${sinceDate.toISOString()}`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush([sampleReport]);
+      tick();
+    }));
+
+    it('should return undefined if offline', fakeAsync(() => {
+      const sinceDate = new Date('2025-01-01T00:00:00.000Z');
+      testOnlineStatusService.setIsOnline(false);
+
+      service.getBuildsSince(sinceDate).subscribe(result => {
         expect(result).toBeUndefined();
       });
       tick();
@@ -970,7 +1022,7 @@ describe('DraftGenerationService', () => {
         })
       } as SFProjectProfileDoc;
       const lastCompletedBuild: BuildDto = {
-        additionalInfo: { dateFinished: '2024-08-27T00:00:00.000+00:00' }
+        additionalInfo: { dateFinished: '2024-08-27T00:00:00.000Z' }
       } as BuildDto;
 
       service.downloadGeneratedDraftZip(projectDoc, lastCompletedBuild).subscribe({
@@ -1011,8 +1063,8 @@ describe('DraftGenerationService', () => {
       } as SFProjectProfileDoc;
       const lastCompletedBuild: BuildDto = {
         additionalInfo: {
-          dateFinished: '2024-08-27T00:00:00.000+00:00',
-          dateGenerated: '2024-08-27T01:02:03.004+00:00'
+          dateFinished: '2024-08-27T00:00:00.000Z',
+          dateGenerated: '2024-08-27T01:02:03.004Z'
         }
       } as BuildDto;
 
@@ -1044,8 +1096,8 @@ describe('DraftGenerationService', () => {
       } as SFProjectProfileDoc;
       const lastCompletedBuild: BuildDto = {
         additionalInfo: {
-          dateFinished: '2024-08-27T00:00:00.000+00:00',
-          dateGenerated: '2024-08-27T01:02:03.004+00:00',
+          dateFinished: '2024-08-27T00:00:00.000Z',
+          dateGenerated: '2024-08-27T01:02:03.004Z',
           translationScriptureRanges: [{ projectId, scriptureRange: '1JN' }]
         }
       } as BuildDto;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -16,6 +16,7 @@ import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { Revision } from '../../core/paratext.service';
 import { BuildDto } from '../../machine-api/build-dto';
 import { HttpClient } from '../../machine-api/http-client';
+import { interpretTypes, ServalBuildReportDto } from '../../serval-administration/serval-build-report';
 import { booksFromScriptureRange, formatDateForFilename, getBookFileNameDigits } from '../../shared/utils';
 import {
   activeBuildStates,
@@ -116,6 +117,29 @@ export class DraftGenerationService {
   }
 
   /**
+   * Gets Serval builds created since the specified timestamp.
+   */
+  getBuildsSince(since: Date): Observable<ServalBuildReportDto[] | undefined> {
+    if (!this.onlineStatusService.isOnline) {
+      return of(undefined);
+    }
+
+    const sinceIso: string = since.toISOString();
+    return this.httpClient.get<ServalBuildReportDto[]>(`translation/builds/since:${sinceIso}`).pipe(
+      map(res => this.interpretTypesMany(res.data)),
+      catchError(err => {
+        if (err.status === 403 || err.status === 404) {
+          return of(undefined);
+        }
+
+        console.error(err);
+        this.noticeService.showError(this.i18n.translateStatic('draft_generation.problem_fetching_build_history'));
+        return of(undefined);
+      })
+    );
+  }
+
+  /**
    * Gets the last completed pre-translation build.
    * @param projectId The SF project id for the target translation.
    * @returns An observable BuildDto for the last build with state 'Completed',
@@ -139,6 +163,14 @@ export class DraftGenerationService {
           return of(undefined);
         })
       );
+  }
+
+  /** Apply type conformity (dates, status enum) to a set of ServalBuildReportDto objects from JSON. */
+  private interpretTypesMany(reports: ServalBuildReportDto[] | undefined): ServalBuildReportDto[] | undefined {
+    if (reports == null) {
+      return undefined;
+    }
+    return reports.map(report => interpretTypes(report));
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.spec.ts
@@ -9,6 +9,7 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { BuildDto } from '../../machine-api/build-dto';
+import { BuildStates } from '../../machine-api/build-states';
 import { DraftOptionsService, FORMATTING_OPTIONS_SUPPORTED_DATE } from './draft-options.service';
 
 const mockedActivatedProject = mock(ActivatedProjectService);
@@ -47,10 +48,25 @@ describe('DraftOptionsService', () => {
 
   function buildDtoWithDate(date: Date): BuildDto {
     return {
+      id: 'build-id',
+      href: 'href',
+      revision: 1,
+      engine: { id: 'engine01', href: 'href' },
+      percentCompleted: 100,
+      message: '',
+      state: BuildStates.Completed,
+      queueDepth: 0,
       additionalInfo: {
-        dateFinished: date.toJSON()
+        dateFinished: date.toISOString(),
+        trainingScriptureRanges: [],
+        translationScriptureRanges: [],
+        trainingDataFileIds: [],
+        buildId: 'build-id',
+        step: 0,
+        translationEngineId: 'engine01',
+        canDenormalizeQuotes: true
       }
-    } as BuildDto;
+    };
   }
 
   const SUPPORTED_BUILD_ENTRY: BuildDto = buildDtoWithDate(new Date(FORMATTING_OPTIONS_SUPPORTED_DATE.getTime() + 1));
@@ -122,7 +138,16 @@ describe('DraftOptionsService', () => {
     function buildWith(date: Date | undefined, flagEnabled: boolean = true): BuildDto | undefined {
       when(mockedFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(flagEnabled));
       if (date == null) {
-        return { additionalInfo: {} } as BuildDto;
+        return {
+          id: 'build-id',
+          href: 'href',
+          revision: 1,
+          engine: { id: 'engine01', href: 'href' },
+          percentCompleted: 0,
+          message: '',
+          state: BuildStates.Completed,
+          queueDepth: 0
+        };
       }
       return buildDtoWithDate(date);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -131,6 +131,9 @@
     "source_text_placeholder": "Source text (optional)",
     "you_can_change_later": "You can change these later."
   },
+  "copy_component": {
+    "copy_to_clipboard": "Copy to clipboard"
+  },
   "delete_project_dialog": {
     "are_you_sure_you_want_to_delete": "Are you sure you want to delete this project?",
     "cancel": "Cancel",
@@ -224,6 +227,7 @@
     "signup_already_submitted": "{{ name }} submitted a request to sign up for drafting on {{ date }}. A team member will contact you within {{ min }} to {{ max }} business days to discuss your project and next steps.",
     "sign_up_for_drafting": "Sign up for drafting",
     "temporarily_unavailable": "Generating drafts is temporarily unavailable.",
+    "problem_fetching_build_history": "There was a problem fetching build history.",
     "warning_generation_faulted": "Last generation attempt failed. Click [em]\"{{ generateButtonText }}\"[/em] below to try again.",
     "click_book_to_preview": "Click a book below to preview the draft and add it to your project.",
     "nt_drafting_notice": "Draft generation is now available to help New Testament translation teams prepare their first drafts. Review our { 1 }help resources{ 2 } to find out how to get started, and to understand how incremental drafting and quality estimates might benefit your project. You will need to contact us to use this feature."

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -41,6 +41,7 @@
 @use 'src/app/serval-administration/draft-jobs-theme' as sf-draft-jobs;
 @use 'src/app/serval-administration/job-details-dialog-theme' as sf-job-details-dialog;
 @use 'src/app/serval-administration/onboarding-requests/onboarding-requests-theme' as sf-onboarding-requests;
+@use 'src/app/serval-administration/serval-builds-theme' as sf-serval-builds;
 
 @use 'text' as sf-text;
 
@@ -88,6 +89,7 @@
   @include sf-draft-jobs.theme($theme);
   @include sf-job-details-dialog.theme($theme);
   @include sf-onboarding-requests.theme($theme);
+  @include sf-serval-builds.theme($theme);
   @include sf-sync.theme($theme);
 
   // Custom variables

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.html
@@ -1,0 +1,14 @@
+<button
+  mat-icon-button
+  class="copy-button"
+  type="button"
+  (click)="onCopyClick()"
+  [matTooltip]="tooltip"
+  [attr.aria-label]="tooltip"
+>
+  @if (isCopied) {
+    <mat-icon class="copied">{{ copiedIconName }}</mat-icon>
+  } @else {
+    <mat-icon class="copy">{{ iconName }}</mat-icon>
+  }
+</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: inline-flex;
+}
+
+.copy-button {
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.spec.ts
@@ -1,0 +1,140 @@
+import { Clipboard } from '@angular/cdk/clipboard';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
+import { CopyComponent } from './copy.component';
+
+describe('CopyComponent', () => {
+  configureTestingModule(() => ({
+    imports: [CopyComponent, getTestTranslocoModule()],
+    providers: [provideNoopAnimations()]
+  }));
+
+  it('should set default tooltip from i18n', () => {
+    const env: TestEnvironment = new TestEnvironment();
+    expect(env.component.tooltip).toBe('Copy to clipboard');
+  });
+
+  it('should copy value to clipboard on click', () => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'test-value' });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+    env.clickCopyButton();
+    expect(env.clipboard.copy).toHaveBeenCalledWith('test-value');
+  });
+
+  it('should not copy when value is undefined', () => {
+    const env: TestEnvironment = new TestEnvironment({ value: undefined });
+    spyOn(env.clipboard, 'copy');
+    env.clickCopyButton();
+    expect(env.clipboard.copy).not.toHaveBeenCalled();
+  });
+
+  it('should show copied state after successful copy', () => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc' });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+    expect(env.component.isCopied).toBe(false);
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(true);
+  });
+
+  it('should not show copied state when clipboard copy fails', () => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc' });
+    spyOn(env.clipboard, 'copy').and.returnValue(false);
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(false);
+  });
+
+  it('should reset copied state after copiedDurationMs', fakeAsync(() => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc', copiedDurationMs: 500 });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(true);
+    tick(499);
+    expect(env.component.isCopied).toBe(true);
+    tick(1);
+    expect(env.component.isCopied).toBe(false);
+  }));
+
+  it('should immediately reset copied state when copiedDurationMs is zero', () => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc', copiedDurationMs: 0 });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(false);
+  });
+
+  it('should show copied icon when isCopied is true', fakeAsync(() => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc', copiedDurationMs: 500 });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+
+    env.fixture.detectChanges();
+    expect(env.displayedIconName).toBe('content_copy');
+
+    env.clickCopyButton();
+    env.fixture.detectChanges();
+    expect(env.displayedIconName).toBe('done');
+
+    tick(500);
+    env.fixture.detectChanges();
+    expect(env.displayedIconName).toBe('content_copy');
+  }));
+
+  it('should reset timeout on rapid double-click', fakeAsync(() => {
+    const env: TestEnvironment = new TestEnvironment({ value: 'abc', copiedDurationMs: 500 });
+    spyOn(env.clipboard, 'copy').and.returnValue(true);
+
+    // First click
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(true);
+    tick(300);
+
+    // Second click before timeout expires
+    env.clickCopyButton();
+    expect(env.component.isCopied).toBe(true);
+
+    // 300ms after second click: still copied since timeout was reset
+    tick(300);
+    expect(env.component.isCopied).toBe(true);
+
+    // 200ms more after second click: should now be reset (500ms total from second click)
+    tick(200);
+    expect(env.component.isCopied).toBe(false);
+  }));
+});
+
+/** Provides helpers for constructing test data for CopyComponent tests. */
+class TestEnvironment {
+  readonly component: CopyComponent;
+  readonly fixture: ComponentFixture<CopyComponent>;
+  readonly clipboard: Clipboard;
+
+  constructor({
+    value,
+    copiedDurationMs
+  }: {
+    value?: string;
+    copiedDurationMs?: number;
+  } = {}) {
+    this.fixture = TestBed.createComponent(CopyComponent);
+    this.component = this.fixture.componentInstance;
+    this.clipboard = TestBed.inject(Clipboard);
+
+    if (value !== undefined) {
+      this.component.value = value;
+    }
+    if (copiedDurationMs !== undefined) {
+      this.component.copiedDurationMs = copiedDurationMs;
+    }
+
+    this.fixture.detectChanges();
+  }
+
+  get displayedIconName(): string {
+    const iconElement: HTMLElement = this.fixture.debugElement.query(By.css('mat-icon')).nativeElement;
+    return iconElement.textContent?.trim() ?? '';
+  }
+
+  clickCopyButton(): void {
+    this.component.onCopyClick();
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.ts
@@ -1,0 +1,67 @@
+import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
+import { Component, DestroyRef, Input } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+import { I18nService } from 'xforge-common/i18n.service';
+
+/**
+ * CopyComponent shows a small copy control and copies a provided value to the clipboard with brief success feedback.
+ */
+@Component({
+  selector: 'app-copy',
+  standalone: true,
+  imports: [ClipboardModule, MatIconButton, MatIcon, MatTooltip],
+  templateUrl: './copy.component.html',
+  styleUrls: ['./copy.component.scss']
+})
+export class CopyComponent {
+  /** Value to be copied to the clipboard. */
+  @Input() value: string | undefined;
+  @Input() tooltip: string = '';
+  @Input() iconName: string = 'content_copy';
+  @Input() copiedIconName: string = 'done';
+  @Input() copiedDurationMs: number = 1000;
+
+  isCopied: boolean = false;
+  private copyTimeoutId: number | undefined;
+
+  constructor(
+    private readonly clipboard: Clipboard,
+    private readonly destroyRef: DestroyRef,
+    private readonly i18n: I18nService
+  ) {
+    this.tooltip = this.i18n.translateStatic('copy_component.copy_to_clipboard');
+    this.destroyRef.onDestroy(() => {
+      if (this.copyTimeoutId != null) {
+        clearTimeout(this.copyTimeoutId);
+      }
+    });
+  }
+
+  onCopyClick(): void {
+    if (this.value == null) return;
+    const copied: boolean = this.clipboard.copy(this.value);
+    if (!copied) return;
+    this.showCopiedState();
+  }
+
+  private showCopiedState(): void {
+    if (this.copyTimeoutId != null) {
+      clearTimeout(this.copyTimeoutId);
+    }
+
+    this.isCopied = true;
+
+    if (this.copiedDurationMs <= 0) {
+      this.copyTimeoutId = undefined;
+      this.isCopied = false;
+      return;
+    }
+
+    this.copyTimeoutId = window.setTimeout(() => {
+      this.isCopied = false;
+      this.copyTimeoutId = undefined;
+    }, this.copiedDurationMs);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/copy/copy.component.ts
@@ -21,7 +21,7 @@ export class CopyComponent {
   @Input() tooltip: string = '';
   @Input() iconName: string = 'content_copy';
   @Input() copiedIconName: string = 'done';
-  @Input() copiedDurationMs: number = 1000;
+  @Input() copiedDurationMs: number = 5000;
 
   isCopied: boolean = false;
   private copyTimeoutId: number | undefined;

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -272,6 +272,49 @@ public class MachineApiController : ControllerBase
     }
 
     /// <summary>
+    /// Gets all Serval builds created after the specified date, across all projects.
+    /// </summary>
+    /// <param name="dateTime">The beginning date to filter build results.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The builds are returned.</response>
+    /// <response code="403">You do not have permission to retrieve builds.</response>
+    /// <response code="400">The timestamp could not be parsed.</response>
+    /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
+    [HttpGet(MachineApi.GetBuildsSince)]
+    public async Task<ActionResult<IReadOnlyList<ServalBuildReportDto>>> GetBuildsSinceAsync(
+        string dateTime,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!DateTimeOffset.TryParse(dateTime, out DateTimeOffset beginning))
+        {
+            return BadRequest($"Could not parse provided datetime: {dateTime}");
+        }
+
+        try
+        {
+            bool isServalAdmin = _userAccessor.SystemRoles.Contains(SystemRole.ServalAdmin);
+            return Ok(
+                await _machineApiService.GetBuildsSinceAsync(
+                    _userAccessor.UserId,
+                    beginning,
+                    isServalAdmin,
+                    cancellationToken
+                )
+            );
+        }
+        catch (BrokenCircuitException e)
+        {
+            _exceptionHandler.ReportException(e);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, MachineApiUnavailable);
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>
     /// Gets a translation engine.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>

--- a/src/SIL.XForge.Scripture/Models/DraftGenerationBuildStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftGenerationBuildStatus.cs
@@ -1,0 +1,29 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Status of a draft generation build request, including states before and after Serval processing.
+/// Values include Serval-reported build states as well as SF-specific pre-submission states.
+/// </summary>
+public enum DraftGenerationBuildStatus
+{
+    /// <summary>SF state. The user has requested a draft generation but it has not yet been submitted to Serval.</summary>
+    UserRequested,
+
+    /// <summary>SF state. The build has been submitted to Serval but no Serval build record exists yet.</summary>
+    SubmittedToServal,
+
+    /// <summary>Serval state. The build is pending in Serval's queue.</summary>
+    Pending,
+
+    /// <summary>Serval state. The build is actively running in Serval.</summary>
+    Active,
+
+    /// <summary>Serval state. The build completed successfully.</summary>
+    Completed,
+
+    /// <summary>Serval state. The build failed.</summary>
+    Faulted,
+
+    /// <summary>Serval state. The build was canceled.</summary>
+    Canceled,
+}

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -12,6 +12,7 @@ public static class MachineApi
     public const string GetBuild = "translation/builds/id:{sfProjectId}.{buildId?}";
     public const string GetRawBuild = "translation/builds/id:{sfProjectId}.{buildId}/raw";
     public const string GetBuilds = "translation/builds/project:{sfProjectId}";
+    public const string GetBuildsSince = "translation/builds/since:{dateTime}";
     public const string GetEngine = "translation/engines/project:{sfProjectId}";
     public const string GetRawEngine = "translation/engines/project:{sfProjectId}/raw";
     public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";

--- a/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildAdditionalInfo.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace SIL.XForge.Scripture.Models;
 
+/// <summary>
+/// Additional information about a Serval build.
+/// </summary>
 public class ServalBuildAdditionalInfo
 {
     public string BuildId { get; init; } = string.Empty;

--- a/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
@@ -10,4 +10,14 @@ public class ServalBuildDto : ServalResourceDto
     public double PercentCompleted { get; set; }
     public string? Message { get; set; }
     public string State { get; set; }
+
+    /// <summary>
+    /// The Serval deployment version that executed this build.
+    /// </summary>
+    public string? DeploymentVersion { get; set; }
+
+    /// <summary>
+    /// Execution data from the Serval build, including training/pretranslation counts and language tags.
+    /// </summary>
+    public ServalBuildExecutionData? ExecutionData { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/ServalBuildExecutionData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildExecutionData.cs
@@ -1,0 +1,13 @@
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// Execution data from a Serval translation build, including training and pretranslation counts
+/// and the language tags used during the build.
+/// </summary>
+public class ServalBuildExecutionData
+{
+    public int TrainCount { get; set; }
+    public int PretranslateCount { get; set; }
+    public string? SourceLanguageTag { get; set; }
+    public string? TargetLanguageTag { get; set; }
+}

--- a/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Serval.Client;
+
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A report of a Serval build, combining Serval-native data with SF project context and event metrics information.
+/// Returned by the builds-since endpoint for the Serval admin page.
+/// </summary>
+public class ServalBuildReportDto
+{
+    /// <summary>
+    /// The Serval build data. Null for records with only event metrics where SF recorded draft generation events but
+    /// Serval did not report a corresponding build.
+    /// </summary>
+    public ServalBuildDto? Build { get; init; }
+
+    /// <summary>
+    /// SF project context for the build. Null if the project could not be identified.
+    /// </summary>
+    public BuildReportProject? Project { get; init; }
+
+    /// <summary>
+    /// Timeline of events from both Serval and SF event metrics.
+    /// </summary>
+    public BuildReportTimeline Timeline { get; init; } = new();
+
+    /// <summary>
+    /// Build configuration: Scripture ranges and training data files.
+    /// </summary>
+    public BuildReportConfig Config { get; init; } = new();
+
+    /// <summary>
+    /// Problems or warnings identified for this build.
+    /// </summary>
+    public List<string> Problems { get; init; } = [];
+
+    /// <summary>
+    /// The SF draft generation request identifier, if one was found.
+    /// </summary>
+    public string? DraftGenerationRequestId { get; init; }
+
+    /// <summary>
+    /// The SF user who requested this build, if known.
+    /// </summary>
+    public string? RequesterSFUserId { get; init; }
+
+    /// <summary>
+    /// Status of the build.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public DraftGenerationBuildStatus Status { get; init; }
+}
+
+/// <summary>
+/// SF project context for a build report entry.
+/// </summary>
+public class BuildReportProject
+{
+    public string SFProjectId { get; init; } = string.Empty;
+    public string? ShortName { get; init; }
+    public string? Name { get; init; }
+}
+
+/// <summary>
+/// Timeline of events for a build, combining Serval timestamps and SF event metric timestamps.
+/// </summary>
+public class BuildReportTimeline
+{
+    // Serval timestamps
+    public DateTimeOffset? ServalCreated { get; init; }
+    public DateTimeOffset? ServalStarted { get; init; }
+    public DateTimeOffset? ServalCompleted { get; init; }
+    public DateTimeOffset? ServalFinished { get; init; }
+
+    // SF event metric timestamps
+
+    /// <summary>
+    /// When SF began working on the user's draft generation request.  Associated with the StartPreTranslationBuildAsync event.
+    /// </summary>
+    public DateTimeOffset? SFUserRequested { get; init; }
+
+    /// <summary>
+    /// When SF started the last steps that lead to sending a build request to Serval. Associated with the
+    /// BuildProjectAsync event.
+    /// </summary>
+    public DateTimeOffset? SFBuildProjectSubmitted { get; init; }
+
+    /// <summary>
+    /// When SF received a user cancellation request.
+    /// </summary>
+    public DateTimeOffset? SFUserCancelled { get; init; }
+
+    /// <summary>
+    /// When SF received a Serval completion notice.
+    /// </summary>
+    public DateTimeOffset? SFAcknowledgedCompletion { get; init; }
+
+    /// <summary>
+    /// When the build was requested, with SF event time preferred over Serval creation time.
+    /// This is a computed convenience property.
+    /// </summary>
+    public DateTimeOffset? RequestTime { get; init; }
+
+    /// <summary>
+    /// Information on different activities during the build.
+    /// </summary>
+    public IList<Phase>? Phases { get; init; }
+}
+
+/// <summary>
+/// Build configuration: which Scripture ranges were trained on and translated, and what training data files were used.
+/// </summary>
+public class BuildReportConfig
+{
+    public HashSet<BuildReportProjectScriptureRange> TrainingScriptureRanges { get; init; } = [];
+    public HashSet<BuildReportProjectScriptureRange> TranslationScriptureRanges { get; init; } = [];
+    public HashSet<string> TrainingDataFileIds { get; init; } = [];
+}
+
+/// <summary>
+/// A scripture range entry enriched with the referenced project's display information.
+/// Similar to <see cref="ProjectScriptureRange"/> but includes the project short name and name for display purposes.
+/// </summary>
+public class BuildReportProjectScriptureRange
+{
+    public string SFProjectId { get; init; } = string.Empty;
+    public string ScriptureRange { get; init; } = string.Empty;
+    public string? ShortName { get; init; }
+    public string? Name { get; init; }
+}

--- a/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
@@ -7,7 +7,7 @@ using Serval.Client;
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>
-/// A report of a Serval build, combining Serval-native data with SF project context and event metrics information.
+/// A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
 /// Returned by the builds-since endpoint for the Serval admin page.
 /// </summary>
 public class ServalBuildReportDto
@@ -19,7 +19,7 @@ public class ServalBuildReportDto
     public ServalBuildDto? Build { get; init; }
 
     /// <summary>
-    /// SF project context for the build. Null if the project could not be identified.
+    /// SF project information for the build. Null if the project could not be identified.
     /// </summary>
     public BuildReportProject? Project { get; init; }
 
@@ -56,7 +56,7 @@ public class ServalBuildReportDto
 }
 
 /// <summary>
-/// SF project context for a build report entry.
+/// SF project information for a build report entry.
 /// </summary>
 public class BuildReportProject
 {

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -53,6 +53,12 @@ public interface IMachineApiService
         bool isServalAdmin,
         CancellationToken cancellationToken
     );
+    Task<IReadOnlyList<ServalBuildReportDto>> GetBuildsSinceAsync(
+        string curUserId,
+        DateTimeOffset beginning,
+        bool isServalAdmin,
+        CancellationToken cancellationToken
+    );
     Task<IReadOnlyList<ServalBuildDto>> GetBuildsAsync(
         string curUserId,
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -59,6 +59,7 @@ public class MachineApiService(
     IOptions<ServalOptions> servalOptions,
     IOptions<SiteOptions> siteOptions,
     ISyncService syncService,
+    ITranslationBuildsClient translationBuildsClient,
     ITranslationEnginesClient translationEnginesClient,
     ITranslationEngineTypesClient translationEngineTypesClient,
     IRepository<UserSecret> userSecrets
@@ -1135,6 +1136,611 @@ public class MachineApiService(
 
         return builds;
     }
+
+    /// <summary>
+    /// Retrieves build reports for Serval builds created after the specified time, including
+    /// events-only records for SF draft generation events that don't match any known Serval build.
+    /// </summary>
+    public async Task<IReadOnlyList<ServalBuildReportDto>> GetBuildsSinceAsync(
+        string curUserId,
+        DateTimeOffset beginning,
+        bool isServalAdmin,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!isServalAdmin)
+        {
+            throw new ForbiddenException();
+        }
+
+        IList<TranslationBuild> translationBuilds = [];
+        try
+        {
+            translationBuilds = await translationBuildsClient.GetAllBuildsCreatedAfterAsync(
+                beginning,
+                cancellationToken
+            );
+        }
+        catch (ServalApiException e)
+        {
+            ProcessServalApiException(e);
+        }
+
+        // Fetch projects and project secrets.
+        Dictionary<string, (string sfProjectId, SFProject? sfProject)> engineToProject =
+            await BuildEngineToProjectMapAsync(translationBuilds, cancellationToken);
+
+        // Note that we do not trim the list of translation builds by removing builds that do not map to a pre-translation
+        // engine that we have a record of. The reason for this is to surface something we may have missed.
+
+        // Fetch draft generation events for the time range
+        Dictionary<string, List<EventMetric>> eventsByProject = await FetchDraftEventsAsync(beginning);
+
+        // Build a map from SF project IDs to SFProject snapshots, for resolving project display names.
+        // This is seeded from the engine-to-project map and extended as needed by BuildReport.
+        Dictionary<string, SFProject?> projectSnapshots = engineToProject
+            .Values.GroupBy(entry => entry.sfProjectId)
+            .ToDictionary(group => group.Key, group => group.First().sfProject);
+
+        // Build reports from Serval builds
+        HashSet<string> matchedRequestIds = [];
+        List<ServalBuildReportDto> reports = [];
+        foreach (TranslationBuild translationBuild in translationBuilds)
+        {
+            ServalBuildReportDto report = await BuildReportAsync(
+                translationBuild,
+                engineToProject,
+                eventsByProject,
+                projectSnapshots,
+                cancellationToken
+            );
+            if (report.DraftGenerationRequestId != null)
+            {
+                matchedRequestIds.Add(report.DraftGenerationRequestId);
+            }
+            reports.Add(report);
+        }
+
+        // Build events-only reports for unmatched draft generation events. Note that it should be rare to have build
+        // reports where we only have events and no Serval build. Importantly, they will be present in the set of
+        // returned data, but they will not have as many details as build reports derived from Serval build information.
+        Dictionary<string, List<EventMetric>> unmatchedEventsByProject = eventsByProject
+            .ToDictionary(
+                kvp => kvp.Key,
+                kvp =>
+                    kvp.Value.Where(e =>
+                        {
+                            string? requestId = GetRequestIdFromEvent(e);
+                            return requestId == null || !matchedRequestIds.Contains(requestId);
+                        })
+                        .ToList()
+            )
+            .Where(kvp => kvp.Value.Count > 0)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        List<ServalBuildReportDto> eventsOnlyReports = BuildEventsOnlyReports(unmatchedEventsByProject);
+        reports.AddRange(eventsOnlyReports);
+
+        return reports;
+    }
+
+    /// <summary>
+    /// Builds a map from Serval pre-translation engine IDs to SF project info, for all engines referenced in the
+    /// builds.
+    /// </summary>
+    private async Task<Dictionary<string, (string sfProjectId, SFProject? sfProject)>> BuildEngineToProjectMapAsync(
+        IList<TranslationBuild> builds,
+        CancellationToken cancellationToken
+    )
+    {
+        HashSet<string> engineIds = [.. builds.Select(b => b.Engine.Id)];
+
+        List<SFProjectSecret> secrets = await projectSecrets
+            .Query()
+            .Where(s => s.ServalData != null && engineIds.Contains(s.ServalData.PreTranslationEngineId ?? ""))
+            .ToListAsync(cancellationToken);
+
+        // Group by engine ID
+        Dictionary<string, (string sfProjectId, SFProject? sfProject)> result = [];
+        foreach (string engineId in engineIds)
+        {
+            List<SFProjectSecret> matchingSecrets =
+            [
+                .. secrets.Where(s => s.ServalData?.PreTranslationEngineId == engineId),
+            ];
+
+            if (matchingSecrets.Count > 1)
+            {
+                string sfProjectIds = string.Join(", ", matchingSecrets.Select(s => s.Id));
+                logger.LogError(
+                    $"{nameof(BuildEngineToProjectMapAsync)}: Multiple SF projects ({sfProjectIds}) unexpectedly share the same Serval translation engine identifier. Picking one of them."
+                );
+            }
+
+            if (matchingSecrets.Count == 0)
+            {
+                continue;
+            }
+
+            string sfProjectId = matchingSecrets[0].Id;
+            Attempt<SFProject> attempt = await realtimeService.TryGetSnapshotAsync<SFProject>(
+                sfProjectId,
+                cancellationToken
+            );
+            if (attempt.TryResult(out SFProject project))
+            {
+                result[engineId] = (sfProjectId, project);
+            }
+            else
+            {
+                logger.LogError(
+                    $"{nameof(BuildEngineToProjectMapAsync)}: An SF project secret for SF project id {sfProjectId} did not have a corresponding project snapshot. Ignoring."
+                );
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Fetches draft generation events across all projects in the specified time range.
+    /// Returns a dictionary keyed by SF project ID.
+    /// </summary>
+    private async Task<Dictionary<string, List<EventMetric>>> FetchDraftEventsAsync(DateTimeOffset since)
+    {
+        QueryResults<EventMetric> events = await eventMetricService.GetEventMetricsAsync(
+            projectId: null,
+            scopes: [EventScope.Drafting],
+            eventTypes:
+            [
+                nameof(MachineProjectService.BuildProjectAsync),
+                nameof(StartPreTranslationBuildAsync),
+                nameof(CancelPreTranslationBuildAsync),
+                nameof(BuildCompletedAsync),
+            ],
+            fromDate: since.UtcDateTime
+        );
+
+        // Group by SF project ID
+        Dictionary<string, List<EventMetric>> result = [];
+        if (events?.Results == null)
+        {
+            return result;
+        }
+        foreach (EventMetric eventMetric in events.Results)
+        {
+            string? sfProjectId = eventMetric.ProjectId;
+            if (sfProjectId == null)
+            {
+                // Skip events with no project ID, as they cannot be meaningfully reported on
+                logger.LogWarning(
+                    $"{nameof(FetchDraftEventsAsync)}: Skipping event metric with null ProjectId (EventType: {eventMetric.EventType})."
+                );
+                continue;
+            }
+            if (!result.TryGetValue(sfProjectId, out List<EventMetric>? projectEvents))
+            {
+                projectEvents = [];
+                result[sfProjectId] = projectEvents;
+            }
+            projectEvents.Add(eventMetric);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a single ServalBuildReportDto from a Serval build and correlated SF data.
+    /// </summary>
+    private async Task<ServalBuildReportDto> BuildReportAsync(
+        TranslationBuild translationBuild,
+        Dictionary<string, (string sfProjectId, SFProject? sfProject)> engineToProject,
+        Dictionary<string, List<EventMetric>> eventsByProject,
+        Dictionary<string, SFProject?> projectSnapshots,
+        CancellationToken cancellationToken
+    )
+    {
+        ServalBuildDto buildDto = CreateDto(translationBuild);
+
+        BuildReportProject? projectInfo = null;
+        string? sfProjectId = null;
+        if (engineToProject.TryGetValue(translationBuild.Engine.Id, out var projectEntry))
+        {
+            sfProjectId = projectEntry.sfProjectId;
+            SFProject? sfProject = projectEntry.sfProject;
+            projectInfo = new BuildReportProject
+            {
+                SFProjectId = sfProjectId,
+                ShortName = sfProject?.ShortName,
+                Name = sfProject?.Name,
+            };
+        }
+
+        // Find correlated events for this build
+        List<EventMetric> projectEvents =
+            sfProjectId != null && eventsByProject.TryGetValue(sfProjectId, out List<EventMetric>? events)
+                ? events
+                : [];
+
+        string? draftGenerationRequestId = FindDraftGenerationRequestIdForBuild(projectEvents, translationBuild.Id);
+        string? requesterUserId = FindRequesterUserId(projectEvents, translationBuild.Id);
+
+        // Build the config from event metrics
+        BuildReportConfig config = await BuildConfigFromEventsAsync(
+            projectEvents,
+            translationBuild.Id,
+            projectSnapshots,
+            cancellationToken
+        );
+
+        // Build the timeline
+        BuildReportTimeline timeline = BuildTimeline(translationBuild, projectEvents, draftGenerationRequestId);
+
+        return new ServalBuildReportDto
+        {
+            Build = buildDto,
+            Project = projectInfo,
+            Timeline = timeline,
+            Config = config,
+            DraftGenerationRequestId = draftGenerationRequestId,
+            RequesterSFUserId = requesterUserId,
+            Status = ToDraftGenerationBuildStatus(translationBuild.State),
+        };
+    }
+
+    /// <summary>
+    /// Finds the BuildProjectAsync event metric that produced a specific Serval build.
+    /// </summary>
+    private static EventMetric? FindBuildProjectEvent(List<EventMetric> projectEvents, string servalBuildId)
+    {
+        return projectEvents.FirstOrDefault(e =>
+            e.EventType == nameof(MachineProjectService.BuildProjectAsync) && e.Result?.ToString() == servalBuildId
+        );
+    }
+
+    /// <summary>
+    /// Finds the draft generation request ID for a specific Serval build by looking at BuildProjectAsync events.
+    /// </summary>
+    private static string? FindDraftGenerationRequestIdForBuild(List<EventMetric> projectEvents, string servalBuildId)
+    {
+        EventMetric? buildEvent = FindBuildProjectEvent(projectEvents, servalBuildId);
+        return buildEvent != null ? GetRequestIdFromEvent(buildEvent) : null;
+    }
+
+    /// <summary>
+    /// Finds the SF user ID that requested a specific Serval build.
+    /// </summary>
+    private static string? FindRequesterUserId(List<EventMetric> projectEvents, string servalBuildId)
+    {
+        EventMetric? buildEvent = FindBuildProjectEvent(projectEvents, servalBuildId);
+        return buildEvent?.UserId;
+    }
+
+    /// <summary>
+    /// Builds the configuration section of a build report from the event metrics for a specific build.
+    /// </summary>
+    private async Task<BuildReportConfig> BuildConfigFromEventsAsync(
+        List<EventMetric> projectEvents,
+        string servalBuildId,
+        Dictionary<string, SFProject?> projectSnapshots,
+        CancellationToken cancellationToken
+    )
+    {
+        EventMetric? buildProjectEvent = FindBuildProjectEvent(projectEvents, servalBuildId);
+
+        if (
+            buildProjectEvent?.Payload?.TryGetValue("buildConfig", out BsonValue? buildConfigBson) == true
+            && buildConfigBson != null
+        )
+        {
+            BuildConfig buildConfig = JsonConvert.DeserializeObject<BuildConfig>(buildConfigBson.ToJson());
+
+            // Look up project snapshots for any referenced project IDs not already cached
+            HashSet<string> referencedProjectIds =
+            [
+                .. buildConfig.TrainingScriptureRanges.Select(r => r.ProjectId),
+                .. buildConfig.TranslationScriptureRanges.Select(r => r.ProjectId),
+            ];
+            foreach (string projectId in referencedProjectIds)
+            {
+                if (string.IsNullOrEmpty(projectId) || projectSnapshots.ContainsKey(projectId))
+                {
+                    continue;
+                }
+                Attempt<SFProject> attempt = await realtimeService.TryGetSnapshotAsync<SFProject>(
+                    projectId,
+                    cancellationToken
+                );
+                projectSnapshots[projectId] = attempt.TryResult(out SFProject project) ? project : null;
+            }
+
+            return new BuildReportConfig
+            {
+                TrainingScriptureRanges =
+                [
+                    .. buildConfig.TrainingScriptureRanges.Select(range =>
+                        EnrichScriptureRange(range, projectSnapshots)
+                    ),
+                ],
+                TranslationScriptureRanges =
+                [
+                    .. buildConfig.TranslationScriptureRanges.Select(range =>
+                        EnrichScriptureRange(range, projectSnapshots)
+                    ),
+                ],
+                TrainingDataFileIds = [.. buildConfig.TrainingDataFiles],
+            };
+        }
+
+        // Fall back to empty config when the event metric doesn't contain buildConfig
+        return new BuildReportConfig();
+    }
+
+    /// <summary>
+    /// Converts a <see cref="ProjectScriptureRange"/> to a <see cref="BuildReportProjectScriptureRange"/> by looking
+    /// up the project's short name and display name from the provided snapshots.
+    /// </summary>
+    private static BuildReportProjectScriptureRange EnrichScriptureRange(
+        ProjectScriptureRange range,
+        Dictionary<string, SFProject?> projectSnapshots
+    )
+    {
+        projectSnapshots.TryGetValue(range.ProjectId, out SFProject? project);
+        return new BuildReportProjectScriptureRange
+        {
+            SFProjectId = range.ProjectId,
+            ScriptureRange = range.ScriptureRange,
+            ShortName = project?.ShortName,
+            Name = project?.Name,
+        };
+    }
+
+    /// <summary>
+    /// Builds the timeline section of a build report from Serval timestamps and SF event metric timestamps.
+    /// </summary>
+    private static BuildReportTimeline BuildTimeline(
+        TranslationBuild translationBuild,
+        List<EventMetric> projectEvents,
+        string? draftGenerationRequestId
+    )
+    {
+        // Find SF event timestamps by correlating on draftGenerationRequestId or serval build ID
+        DateTimeOffset? sfUserRequested = FindEventTime(
+            projectEvents,
+            nameof(StartPreTranslationBuildAsync),
+            translationBuild.Id,
+            draftGenerationRequestId
+        );
+        DateTimeOffset? sfBuildProjectSubmitted = FindEventTime(
+            projectEvents,
+            nameof(MachineProjectService.BuildProjectAsync),
+            translationBuild.Id,
+            draftGenerationRequestId
+        );
+        DateTimeOffset? sfUserCancelled = FindEventTime(
+            projectEvents,
+            "CancelPreTranslationBuildAsync",
+            translationBuild.Id,
+            draftGenerationRequestId
+        );
+        DateTimeOffset? sfAcknowledgedCompletion = FindEventTime(
+            projectEvents,
+            "BuildCompletedAsync",
+            translationBuild.Id,
+            draftGenerationRequestId
+        );
+
+        DateTimeOffset? servalCreated = translationBuild.DateCreated?.ToUniversalTime();
+        DateTimeOffset? requestTime = sfUserRequested ?? servalCreated;
+
+        return new BuildReportTimeline
+        {
+            ServalCreated = servalCreated,
+            ServalStarted = translationBuild.DateStarted?.ToUniversalTime(),
+            ServalCompleted = translationBuild.DateCompleted?.ToUniversalTime(),
+            ServalFinished = translationBuild.DateFinished?.ToUniversalTime(),
+            SFUserRequested = sfUserRequested,
+            SFBuildProjectSubmitted = sfBuildProjectSubmitted,
+            SFUserCancelled = sfUserCancelled,
+            SFAcknowledgedCompletion = sfAcknowledgedCompletion,
+            RequestTime = requestTime,
+            Phases = NormalizePhaseTimestamps(translationBuild.Phases),
+        };
+    }
+
+    /// <summary>
+    /// Finds the earliest timestamp of a particular event type that correlates with a given build.
+    /// </summary>
+    private static DateTimeOffset? FindEventTime(
+        List<EventMetric> events,
+        string eventType,
+        string servalBuildId,
+        string? draftGenerationRequestId
+    )
+    {
+        List<EventMetric> matching =
+        [
+            .. events.Where(e =>
+            {
+                if (e.EventType != eventType)
+                    return false;
+
+                bool matchesBuildId = e.Result?.ToString() == servalBuildId;
+                if (matchesBuildId)
+                {
+                    return true;
+                }
+                bool matchesRequestId =
+                    draftGenerationRequestId != null && GetRequestIdFromEvent(e) == draftGenerationRequestId;
+                if (matchesRequestId)
+                {
+                    return true;
+                }
+                return false;
+            }),
+        ];
+
+        if (matching.Count == 0)
+        {
+            return null;
+        }
+
+        DateTime earliest = matching.Min(e => e.TimeStamp);
+        return new DateTimeOffset(earliest, TimeSpan.Zero).ToUniversalTime();
+    }
+
+    /// <summary>
+    /// Ensure phase timestamps are in UTC.
+    /// </summary>
+    private static IList<Phase>? NormalizePhaseTimestamps(IList<Phase>? phases)
+    {
+        if (phases == null)
+        {
+            return null;
+        }
+
+        foreach (Phase phase in phases)
+        {
+            DateTimeOffset? started = phase.Started;
+            if (started.HasValue)
+            {
+                phase.Started = started.Value.ToUniversalTime();
+            }
+        }
+
+        return phases;
+    }
+
+    /// <summary>
+    /// Builds events-only report entries for draft generation events that did not match any known Serval build.
+    /// </summary>
+    private static List<ServalBuildReportDto> BuildEventsOnlyReports(
+        Dictionary<string, List<EventMetric>> eventsByProject
+    )
+    {
+        // Suppose that when gathering information about Serval builds, we have event metrics that refer to a draft
+        // generation request, but that do not correspond to Serval build information reported by Serval. Use the
+        // information in the SF events to create a draft generation build report.
+
+        List<ServalBuildReportDto> reports = [];
+        foreach ((string sfProjectId, List<EventMetric> events) in eventsByProject)
+        {
+            // Group events by their draft generation request ID
+            var groupedByRequestId = events.GroupBy(e => GetRequestIdFromEvent(e)).ToList();
+
+            foreach (var group in groupedByRequestId)
+            {
+                string? requestId = group.Key;
+                List<EventMetric> groupEvents = [.. group];
+
+                if (requestId != null)
+                {
+                    // The group of event metrics we are processing has a draft generation request ID.
+
+                    bool hasBuildProject = groupEvents.Any(e =>
+                        e.EventType == nameof(MachineProjectService.BuildProjectAsync)
+                    );
+                    DraftGenerationBuildStatus status = hasBuildProject
+                        ? DraftGenerationBuildStatus.SubmittedToServal
+                        : DraftGenerationBuildStatus.UserRequested;
+
+                    EventMetric? startEvent = groupEvents.FirstOrDefault(e =>
+                        e.EventType == nameof(StartPreTranslationBuildAsync)
+                    );
+
+                    DateTimeOffset? sfUserRequested =
+                        startEvent != null
+                            ? new DateTimeOffset(startEvent.TimeStamp, TimeSpan.Zero).ToUniversalTime()
+                            : null;
+
+                    // We could add more details to the report if we are finding that it is often occurring to have build requests that
+                    // Serval is not reporting on and it's useful to have those details.
+                    reports.Add(
+                        new ServalBuildReportDto
+                        {
+                            Build = null,
+                            Project = new BuildReportProject { SFProjectId = sfProjectId },
+                            Timeline = new BuildReportTimeline
+                            {
+                                SFUserRequested = sfUserRequested,
+                                RequestTime = sfUserRequested,
+                            },
+                            Config = new BuildReportConfig(),
+                            Problems = ["No Serval build was reported for this draft generation request."],
+                            DraftGenerationRequestId = requestId,
+                            RequesterSFUserId = startEvent?.UserId,
+                            Status = status,
+                        }
+                    );
+                }
+                else
+                {
+                    // The group of event metrics we are processing has no draft generation request ID, which was the
+                    // norm before 2026. For such older events that have no request ID at all, we will just create
+                    // individual reports for StartPreTranslationBuildAsync events. We can look into adding more details
+                    // here in the future if that would be helpful.
+
+                    foreach (
+                        EventMetric startEvent in groupEvents.Where(e =>
+                            e.EventType == nameof(StartPreTranslationBuildAsync)
+                        )
+                    )
+                    {
+                        DateTimeOffset sfUserRequested = new DateTimeOffset(
+                            startEvent.TimeStamp,
+                            TimeSpan.Zero
+                        ).ToUniversalTime();
+                        reports.Add(
+                            new ServalBuildReportDto
+                            {
+                                Build = null,
+                                Project = new BuildReportProject { SFProjectId = sfProjectId },
+                                Timeline = new BuildReportTimeline
+                                {
+                                    SFUserRequested = sfUserRequested,
+                                    RequestTime = sfUserRequested,
+                                },
+                                Config = new BuildReportConfig(),
+                                Problems = ["No Serval build was reported for this draft generation request."],
+                                RequesterSFUserId = startEvent.UserId,
+                                Status = DraftGenerationBuildStatus.UserRequested,
+                            }
+                        );
+                    }
+                }
+            }
+        }
+
+        return reports;
+    }
+
+    /// <summary>
+    /// Gets the draft generation request ID from an event's tags, if present.
+    /// </summary>
+    private static string? GetRequestIdFromEvent(EventMetric eventMetric)
+    {
+        if (
+            eventMetric.Tags?.TryGetValue(MachineProjectService.DraftGenerationRequestIdKey, out BsonValue? requestId)
+            == true
+        )
+        {
+            return requestId?.AsString;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Converts a Serval <see cref="JobState"/> to the corresponding <see cref="DraftGenerationBuildStatus"/>.
+    /// </summary>
+    private static DraftGenerationBuildStatus ToDraftGenerationBuildStatus(JobState jobState) =>
+        jobState switch
+        {
+            JobState.Pending => DraftGenerationBuildStatus.Pending,
+            JobState.Active => DraftGenerationBuildStatus.Active,
+            JobState.Completed => DraftGenerationBuildStatus.Completed,
+            JobState.Faulted => DraftGenerationBuildStatus.Faulted,
+            JobState.Canceled => DraftGenerationBuildStatus.Canceled,
+            _ => throw new ArgumentOutOfRangeException(nameof(jobState), jobState, "Unknown Serval job state."),
+        };
 
     public async Task<ServalBuildDto?> GetLastCompletedPreTranslationBuildAsync(
         string curUserId,
@@ -2367,6 +2973,7 @@ public class MachineApiService(
     /// <returns>The build DTO.</returns>
     private static ServalBuildDto CreateDto(TranslationBuild translationBuild)
     {
+        ExecutionData? executionData = translationBuild.ExecutionData;
         var buildDto = new ServalBuildDto
         {
             Id = translationBuild.Id,
@@ -2403,6 +3010,17 @@ public class MachineApiService(
                 Step = translationBuild.Step,
                 TranslationEngineId = translationBuild.Engine.Id,
             },
+            DeploymentVersion = translationBuild.DeploymentVersion,
+            ExecutionData =
+                executionData == null
+                    ? null
+                    : new ServalBuildExecutionData
+                    {
+                        TrainCount = executionData.TrainCount,
+                        PretranslateCount = executionData.PretranslateCount,
+                        SourceLanguageTag = executionData.EngineSourceLanguageTag,
+                        TargetLanguageTag = executionData.EngineTargetLanguageTag,
+                    },
         };
 
         // Create an initial value for the date requested, based on the object id from Mongo
@@ -2645,7 +3263,10 @@ public class MachineApiService(
         );
         if (eventMetric is not null)
         {
-            buildDto.AdditionalInfo!.DateGenerated = new DateTimeOffset(eventMetric.TimeStamp, TimeSpan.Zero);
+            buildDto.AdditionalInfo!.DateGenerated = new DateTimeOffset(
+                eventMetric.TimeStamp,
+                TimeSpan.Zero
+            ).ToUniversalTime();
         }
 
         // If we have event metrics for sending the build to Serval, add the scripture ranges to the DTO
@@ -2854,7 +3475,10 @@ public class MachineApiService(
         buildDto.AdditionalInfo ??= new ServalBuildAdditionalInfo();
 
         // Set the user who requested the build and when they did so
-        buildDto.AdditionalInfo.DateRequested = new DateTimeOffset(eventMetric.TimeStamp, TimeSpan.Zero);
+        buildDto.AdditionalInfo.DateRequested = new DateTimeOffset(
+            eventMetric.TimeStamp,
+            TimeSpan.Zero
+        ).ToUniversalTime();
         buildDto.AdditionalInfo.RequestedByUserId = eventMetric.UserId;
 
         // Retrieve the training and translation books from the build config, as the build from Serval
@@ -2953,12 +3577,7 @@ public class MachineApiService(
             fromDate: startDate
         );
         EventMetric? buildEvent = buildProjectEvents.Results.FirstOrDefault(e => e.Result?.ToString() == servalBuildId);
-        return (
-            buildEvent?.Tags?.TryGetValue(MachineProjectService.DraftGenerationRequestIdKey, out BsonValue? requestId)
-            == true
-        )
-            ? requestId?.AsString
-            : null;
+        return buildEvent != null ? GetRequestIdFromEvent(buildEvent) : null;
     }
 
     private async Task<string> GetTranslationIdAsync(

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -78,6 +78,13 @@ public static class MachineServiceCollectionExtensions
             var httpClient = factory.CreateClient(MachineApi.HttpClientName);
             return new TranslationEnginesClient(httpClient);
         });
+        services.AddSingleton<ITranslationBuildsClient, TranslationBuildsClient>(sp =>
+        {
+            // Instantiate the translation builds client with our named HTTP client
+            var factory = sp.GetService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient(MachineApi.HttpClientName);
+            return new TranslationBuildsClient(httpClient);
+        });
         services.AddSingleton<ITranslationEngineTypesClient, TranslationEngineTypesClient>(sp =>
         {
             // Instantiate the translation engines client with our named HTTP client

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1217,6 +1217,495 @@ public class MachineApiServiceTests
     }
 
     [Test]
+    public void GetBuildsSinceAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() =>
+            env.Service.GetBuildsSinceAsync(User02, DateTimeOffset.UtcNow, isServalAdmin: false, CancellationToken.None)
+        );
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_ReturnsBuildReport()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        SFProjectSecret project02Secret = env.ProjectSecrets.Get(Project02);
+        project02Secret.ServalData.PreTranslationEngineId = "differentEngine";
+        env.ProjectSecrets.Replace(project02Secret);
+        SFProject project01 = env.Projects.Get(Project01);
+        project01.Name = "Project 1";
+        env.Projects.Replace(project01);
+        DateTimeOffset dateCreated = DateTimeOffset.UtcNow.AddDays(-2);
+        DateTimeOffset dateStarted = dateCreated.AddHours(6);
+        DateTimeOffset dateFinished = dateCreated.AddDays(1);
+        DateTimeOffset dateCompleted = dateFinished;
+        TranslationBuild translationBuild = new TranslationBuild
+        {
+            Id = ServalBuildId01,
+            Engine = { Id = TranslationEngine01 },
+            State = JobState.Completed,
+            DateCreated = dateCreated,
+            DateStarted = dateStarted,
+            DateCompleted = dateCompleted,
+            DateFinished = dateFinished,
+        };
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IList<TranslationBuild>>([translationBuild]));
+        const string draftGenerationRequestId = "draft-req";
+        env.SetDraftGenerationMetricAssociation(draftGenerationRequestId);
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            dateCreated.AddDays(-3),
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        ServalBuildReportDto report = reports[0];
+        Assert.IsNotNull(report.Build);
+        Assert.IsNotNull(report.Project);
+        Assert.AreEqual(Project01, report.Project!.SFProjectId);
+        Assert.AreEqual(project01.ShortName, report.Project.ShortName);
+        Assert.AreEqual(project01.Name, report.Project.Name);
+        Assert.AreEqual(dateCreated, report.Timeline.ServalCreated);
+        Assert.AreEqual(dateStarted, report.Timeline.ServalStarted);
+        Assert.AreEqual(dateCompleted, report.Timeline.ServalCompleted);
+        Assert.AreEqual(dateFinished, report.Timeline.ServalFinished);
+        Assert.AreEqual(draftGenerationRequestId, report.DraftGenerationRequestId);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_IncludesDeploymentVersion()
+    {
+        var env = new TestEnvironment();
+        const string deploymentVersion = "v2.3.4";
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-1);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<TranslationBuild>>([
+                    new TranslationBuild
+                    {
+                        Id = ServalBuildId01,
+                        Engine = { Id = TranslationEngine01 },
+                        State = JobState.Completed,
+                        DeploymentVersion = deploymentVersion,
+                    },
+                ])
+            );
+        env.SetEmptyDraftGenerationMetricAssociations();
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        Assert.AreEqual(deploymentVersion, reports[0].Build?.DeploymentVersion);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_IncludesExecutionData()
+    {
+        var env = new TestEnvironment();
+        const int trainCount = 1234;
+        const int pretranslateCount = 567;
+        const string sourceLanguageTag = "es";
+        const string targetLanguageTag = "en";
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-1);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<TranslationBuild>>([
+                    new TranslationBuild
+                    {
+                        Id = ServalBuildId01,
+                        Engine = { Id = TranslationEngine01 },
+                        State = JobState.Completed,
+                        ExecutionData = new ExecutionData
+                        {
+                            TrainCount = trainCount,
+                            PretranslateCount = pretranslateCount,
+                            EngineSourceLanguageTag = sourceLanguageTag,
+                            EngineTargetLanguageTag = targetLanguageTag,
+                        },
+                    },
+                ])
+            );
+        env.SetEmptyDraftGenerationMetricAssociations();
+
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        ServalBuildDto? build = reports[0].Build;
+        Assert.IsNotNull(build);
+        Assert.IsNotNull(build!.ExecutionData);
+        Assert.AreEqual(trainCount, build.ExecutionData!.TrainCount);
+        Assert.AreEqual(pretranslateCount, build.ExecutionData.PretranslateCount);
+        Assert.AreEqual(sourceLanguageTag, build.ExecutionData.SourceLanguageTag);
+        Assert.AreEqual(targetLanguageTag, build.ExecutionData.TargetLanguageTag);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_NullExecutionData_MapsExecutionDataAsNull()
+    {
+        var env = new TestEnvironment();
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-1);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<TranslationBuild>>([
+                    new TranslationBuild
+                    {
+                        Id = ServalBuildId01,
+                        Engine = { Id = TranslationEngine01 },
+                        State = JobState.Completed,
+                        ExecutionData = null!,
+                    },
+                ])
+            );
+        env.SetEmptyDraftGenerationMetricAssociations();
+
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        ServalBuildDto? build = reports[0].Build;
+        Assert.IsNotNull(build);
+        Assert.IsNull(build!.ExecutionData);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_DuplicateEngineIdsAsync()
+    {
+        // Suppose multiple records in project secrets indicate that multiple SF projects are using the same Serval
+        // translation engine id. This is unexpected and may indicate a problem in the SF DB. But don't crash about it. We'll log an error and pick one of the projects to use.
+
+        // Set up test environment
+        var env = new TestEnvironment();
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-1);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<TranslationBuild>>([
+                    new TranslationBuild
+                    {
+                        Id = ServalBuildId01,
+                        Engine = { Id = TranslationEngine01 },
+                        State = JobState.Completed,
+                    },
+                ])
+            );
+        env.SetEmptyDraftGenerationMetricAssociations();
+
+        Assert.GreaterOrEqual(
+            (await env.ProjectSecrets.GetAllAsync()).Count(
+                (SFProjectSecret ps) => ps.ServalData?.PreTranslationEngineId == TranslationEngine01
+            ),
+            2,
+            "Invalid test setup."
+        );
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> result = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, result.Count);
+        env.MockLogger.AssertHasEvent(logEvent => logEvent.LogLevel == LogLevel.Error);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_UnknownProject()
+    {
+        // Suppose when we look in the SF DB for project information, we don't find any SF projects that we understand
+        // to be using a given Serval translation engine id. The project may have existed at SF but was deleted, or
+        // something else may be happening. We should have a report of this draft generation request, though without project information.
+
+        // Set up test environment
+        var env = new TestEnvironment();
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-1);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(
+                Task.FromResult<IList<TranslationBuild>>([
+                    new TranslationBuild
+                    {
+                        Id = ServalBuildId01,
+                        Engine = { Id = "some-unrecognized-engine-id" },
+                        State = JobState.Completed,
+                    },
+                ])
+            );
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        Assert.IsNull(reports[0].Project);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_ScriptureRangesIncludeProjectNames()
+    {
+        // When scripture ranges reference different source projects (not the target), the returned report should
+        // include the short name and name of each referenced project in the scripture range entries.
+
+        // Set up test environment
+        var env = new TestEnvironment();
+        SFProjectSecret project02Secret = env.ProjectSecrets.Get(Project02);
+        project02Secret.ServalData.PreTranslationEngineId = "differentEngine";
+        env.ProjectSecrets.Replace(project02Secret);
+
+        // Configure project names for source projects
+        SFProject project02 = env.Projects.Get(Project02);
+        project02.ShortName = "SRC";
+        project02.Name = "Source Project";
+        env.Projects.Replace(project02);
+
+        SFProject project03 = env.Projects.Get(Project03);
+        project03.ShortName = "TRN";
+        project03.Name = "Training Source";
+        env.Projects.Replace(project03);
+
+        DateTimeOffset dateCreated = DateTimeOffset.UtcNow.AddDays(-2);
+        TranslationBuild translationBuild = new TranslationBuild
+        {
+            Id = ServalBuildId01,
+            Engine = { Id = TranslationEngine01 },
+            State = JobState.Completed,
+            DateCreated = dateCreated,
+        };
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromResult<IList<TranslationBuild>>([translationBuild]));
+
+        const string trainingRange = "GEN;EXO";
+        const string translationRange = "LEV;NUM";
+        env.EventMetricService.GetEventMetricsAsync(
+                Arg.Any<string?>(),
+                Arg.Any<EventScope[]?>(),
+                Arg.Any<string[]>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            )
+            .Returns(
+                Task.FromResult(
+                    new QueryResults<EventMetric>
+                    {
+                        Results =
+                        [
+                            new EventMetric
+                            {
+                                EventType = nameof(MachineProjectService.BuildProjectAsync),
+                                Payload =
+                                {
+                                    {
+                                        "buildConfig",
+                                        BsonDocument.Parse(
+                                            JsonConvert.SerializeObject(
+                                                new BuildConfig
+                                                {
+                                                    TrainingScriptureRanges =
+                                                    [
+                                                        new ProjectScriptureRange
+                                                        {
+                                                            ProjectId = Project03,
+                                                            ScriptureRange = trainingRange,
+                                                        },
+                                                    ],
+                                                    TranslationScriptureRanges =
+                                                    [
+                                                        new ProjectScriptureRange
+                                                        {
+                                                            ProjectId = Project02,
+                                                            ScriptureRange = translationRange,
+                                                        },
+                                                    ],
+                                                    ProjectId = Project01,
+                                                }
+                                            )
+                                        )
+                                    },
+                                },
+                                ProjectId = Project01,
+                                Result = new BsonString(ServalBuildId01),
+                                Scope = EventScope.Drafting,
+                            },
+                        ],
+                        UnpagedCount = 1,
+                    }
+                )
+            );
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            dateCreated.AddDays(-3),
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        ServalBuildReportDto report = reports[0];
+
+        // Training scripture ranges should have Project03's short name and name
+        BuildReportProjectScriptureRange trainingEntry = report.Config.TrainingScriptureRanges.Single();
+        Assert.AreEqual(Project03, trainingEntry.SFProjectId);
+        Assert.AreEqual(trainingRange, trainingEntry.ScriptureRange);
+        Assert.AreEqual("TRN", trainingEntry.ShortName);
+        Assert.AreEqual("Training Source", trainingEntry.Name);
+
+        // Translation scripture ranges should have Project02's short name and name
+        BuildReportProjectScriptureRange translationEntry = report.Config.TranslationScriptureRanges.Single();
+        Assert.AreEqual(Project02, translationEntry.SFProjectId);
+        Assert.AreEqual(translationRange, translationEntry.ScriptureRange);
+        Assert.AreEqual("SRC", translationEntry.ShortName);
+        Assert.AreEqual("Source Project", translationEntry.Name);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_IncludesEventsOnlyReports()
+    {
+        // When there are SF draft generation events without a corresponding Serval build, they should appear as
+        // events-only reports with a null Build and appropriate status.
+
+        // Set up test environment
+        var env = new TestEnvironment();
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-7);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(Task.FromResult<IList<TranslationBuild>>([]));
+
+        // Set up events that don't match any Serval build
+        env.EventMetricService.GetEventMetricsAsync(
+                Arg.Any<string?>(),
+                Arg.Any<EventScope[]?>(),
+                Arg.Any<string[]>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            )
+            .Returns(
+                Task.FromResult(
+                    new QueryResults<EventMetric>
+                    {
+                        Results =
+                        [
+                            new EventMetric
+                            {
+                                EventType = nameof(MachineApiService.StartPreTranslationBuildAsync),
+                                ProjectId = Project01,
+                                UserId = User01,
+                                Tags = new Dictionary<string, BsonValue?>
+                                {
+                                    { MachineProjectService.DraftGenerationRequestIdKey, "orphan-request-1" },
+                                },
+                            },
+                        ],
+                        UnpagedCount = 1,
+                    }
+                )
+            );
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        Assert.AreEqual(1, reports.Count);
+        Assert.IsNull(reports[0].Build);
+        Assert.AreEqual(DraftGenerationBuildStatus.UserRequested, reports[0].Status);
+        Assert.AreEqual("orphan-request-1", reports[0].DraftGenerationRequestId);
+        Assert.AreEqual(User01, reports[0].RequesterSFUserId);
+    }
+
+    [Test]
+    public async Task GetBuildsSinceAsync_SkipsEventsWithNullProjectId()
+    {
+        // Events with no ProjectId should be skipped and not included in the results.
+
+        var env = new TestEnvironment();
+        DateTimeOffset beginning = DateTimeOffset.UtcNow.AddDays(-7);
+        env.TranslationBuildsClient.GetAllBuildsCreatedAfterAsync(beginning, CancellationToken.None)
+            .Returns(Task.FromResult<IList<TranslationBuild>>([]));
+
+        // Set up an event with null ProjectId
+        env.EventMetricService.GetEventMetricsAsync(
+                Arg.Any<string?>(),
+                Arg.Any<EventScope[]?>(),
+                Arg.Any<string[]>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<int>(),
+                Arg.Any<int>()
+            )
+            .Returns(
+                Task.FromResult(
+                    new QueryResults<EventMetric>
+                    {
+                        Results =
+                        [
+                            new EventMetric
+                            {
+                                EventType = nameof(MachineApiService.StartPreTranslationBuildAsync),
+                                ProjectId = null,
+                                UserId = User01,
+                                Tags = new Dictionary<string, BsonValue?>
+                                {
+                                    { MachineProjectService.DraftGenerationRequestIdKey, "null-project-request" },
+                                },
+                            },
+                        ],
+                        UnpagedCount = 1,
+                    }
+                )
+            );
+
+        // SUT
+        IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
+            User01,
+            beginning,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        // Events with null ProjectId should be skipped entirely
+        Assert.AreEqual(0, reports.Count);
+    }
+
+    [Test]
     public async Task GetBuildsAsync_QueuedStateWithEventMetric()
     {
         // Set up test environment
@@ -4952,6 +5441,7 @@ public class MachineApiServiceTests
             var siteOptions = Options.Create(new SiteOptions { IssuesEmail = "help@scriptureforge.org" });
             SyncService = Substitute.For<ISyncService>();
             SyncService.SyncAsync(Arg.Any<SyncConfig>()).Returns(Task.FromResult(HangfireJobId));
+            TranslationBuildsClient = Substitute.For<ITranslationBuildsClient>();
             TranslationEnginesClient = Substitute.For<ITranslationEnginesClient>();
             TranslationEnginesClient
                 .GetAsync(TranslationEngine01, CancellationToken.None)
@@ -4992,6 +5482,7 @@ public class MachineApiServiceTests
                 ServalOptions,
                 siteOptions,
                 SyncService,
+                TranslationBuildsClient,
                 TranslationEnginesClient,
                 TranslationEngineTypesClient,
                 UserSecrets
@@ -5017,6 +5508,7 @@ public class MachineApiServiceTests
         public MachineApiService Service { get; }
         public IOptions<ServalOptions> ServalOptions { get; }
         public ISyncService SyncService { get; }
+        public ITranslationBuildsClient TranslationBuildsClient { get; }
         public ITranslationEnginesClient TranslationEnginesClient { get; }
         public ITranslationEngineTypesClient TranslationEngineTypesClient { get; }
         public MemoryRepository<UserSecret> UserSecrets { get; }
@@ -5558,6 +6050,7 @@ public class MachineApiServiceTests
             Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
         }
 
+        /// <remarks>Either to test the empty situation, or because it is not important for the test.</remarks>
         public void SetEmptyDraftGenerationMetricAssociations()
         {
             // Mock for GetEventMetricsAsync in GetDraftGenerationRequestIdForBuildAsync
@@ -5577,7 +6070,6 @@ public class MachineApiServiceTests
         public void SetDraftGenerationMetricAssociation(string draftGenerationRequestId)
         {
             // Mock the event metrics service to return a build event with draftGenerationRequestId tag
-            // This is for GetDraftGenerationRequestIdForBuildAsync
             EventMetricService
                 .GetEventMetricsAsync(
                     Arg.Any<string?>(),
@@ -5597,6 +6089,7 @@ public class MachineApiServiceTests
                                 new EventMetric
                                 {
                                     EventType = nameof(Services.MachineProjectService.BuildProjectAsync),
+                                    ProjectId = Project01,
                                     Result = ServalBuildId01,
                                     Tags = new Dictionary<string, BsonValue?>
                                     {


### PR DESCRIPTION
This introduces the Serval builds tab without yet removing the Draft jobs tab.

---

Currently, the Serval Administration area has a Draft Jobs tab which shows a list of Serval builds. It does this by fetching and correlating EventMetric records on the frontend. More information for a build is then obtained by looking up Serval build information, user information, etc.

This PR is a step toward replacing the functionality of the Draft Jobs tab. This PR adds a Serval Builds tab which shows a list of Serval builds. It does this by fetching Serval build data on the backend, and augmenting the data on the backend with details from EventMetric records and project and user metadata. The information is received by the frontend to render to the user.

The Serval Builds tab is designed to be a suitable replacement for the Draft Jobs tab. However, the Draft Jobs tab is still present so the Serval Builds tab can get some vetting first.



<img width="1049" height="676" alt="image" src="https://github.com/user-attachments/assets/71488179-4b04-42d9-a04f-0a4331753fdc" />



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3719)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
