### PR TITLE
Retire NT drafting notice after 90 days

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -8,16 +8,18 @@
       </h1>
     }
 
-    <app-notice type="primary" mode="fill-dark">
-      @for (entry of ntDraftingNotice | async; track $index) {
-        @if (entry.id == null) {
-          {{ entry.text }}
+    @if (showNtDraftingNotice) {
+      <app-notice type="primary" mode="fill-dark">
+        @for (entry of ntDraftingNotice | async; track $index) {
+          @if (entry.id == null) {
+            {{ entry.text }}
+          }
+          @if (entry.id === 1) {
+            <a [href]="urlService.newTestamentDrafting" target="_blank">{{ entry.text }}</a>
+          }
         }
-        @if (entry.id === 1) {
-          <a [href]="urlService.newTestamentDrafting" target="_blank">{{ entry.text }}</a>
-        }
-      }
-    </app-notice>
+      </app-notice>
+    }
 
     <section>
       @if (isDraftJobFetched && !isDraftInProgress(draftJob) && !hasAnyCompletedBuild) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -110,6 +110,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   // This component url, but with a hash for opening a dialog
   supportedLanguagesUrl: RouterLink = { route: [], fragment: 'supported-languages' };
   draftHelp = this.i18n.interpolate('draft_generation.instructions_help');
+  showNtDraftingNotice = new Date() < new Date('2026-05-25');
   ntDraftingNotice = this.i18n.interpolate('draft_generation.nt_drafting_notice');
 
   sourceLanguage?: string;


### PR DESCRIPTION
This should have been included when the notice originally was created, but I'm not sure if we'd decided how long it would be up at the time. The latest decision is for 90 days. 

Hard-coding an EOL for a notice is something we've done before and:
- Prevents us from forgetting to remove it
- Documents how long it is intended to remain
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3747)
<!-- Reviewable:end -->
