### PR TITLE
dev: enable nullable in C# where no errors, treat warnings as errors

### DIFF
--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Controllers/OnboardingRequestRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/OnboardingRequestRpcController.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/ParatextController.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsUploadController.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Microsoft.Extensions.Configuration;
 using MongoDB.Driver;
 using SIL.XForge.DataAccess;

--- a/src/SIL.XForge.Scripture/Migrator.cs
+++ b/src/SIL.XForge.Scripture/Migrator.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Models/AudioTiming.cs
+++ b/src/SIL.XForge.Scripture/Models/AudioTiming.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class AudioTiming

--- a/src/SIL.XForge.Scripture/Models/EditorTabPersistData.cs
+++ b/src/SIL.XForge.Scripture/Models/EditorTabPersistData.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
+++ b/src/SIL.XForge.Scripture/Models/InviteeStatus.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class InviteeStatus

--- a/src/SIL.XForge.Scripture/Models/Like.cs
+++ b/src/SIL.XForge.Scripture/Models/Like.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class Like

--- a/src/SIL.XForge.Scripture/Models/Note.cs
+++ b/src/SIL.XForge.Scripture/Models/Note.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>Represents a project note.</summary>

--- a/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteSyncMetricInfo.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/NoteThread.cs
+++ b/src/SIL.XForge.Scripture/Models/NoteThread.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using SIL.XForge.Models;
 

--- a/src/SIL.XForge.Scripture/Models/OnboardingRequest.cs
+++ b/src/SIL.XForge.Scripture/Models/OnboardingRequest.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;

--- a/src/SIL.XForge.Scripture/Models/ParatextResource.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextResource.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Globalization;
 using System.Text;

--- a/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
+++ b/src/SIL.XForge.Scripture/Models/ParatextUserProfile.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/Question.cs
+++ b/src/SIL.XForge.Scripture/Models/Question.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;

--- a/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/ResourceConfig.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 
 namespace SIL.XForge.Scripture.Models;

--- a/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectCreateSettings.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/SFProjectUserConfig.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;

--- a/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildDto.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class ServalBuildDto : ServalResourceDto

--- a/src/SIL.XForge.Scripture/Models/ServalResourceDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalResourceDto.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetricInfo.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/SyncMetrics.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;

--- a/src/SIL.XForge.Scripture/Models/TextAnchor.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAnchor.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/TextAudio.cs
+++ b/src/SIL.XForge.Scripture/Models/TextAudio.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using SIL.Scripture;
 using SIL.XForge.Models;

--- a/src/SIL.XForge.Scripture/Models/TextData.cs
+++ b/src/SIL.XForge.Scripture/Models/TextData.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using SIL.Scripture;

--- a/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
+++ b/src/SIL.XForge.Scripture/Models/TransceleratorQuestion.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class TransceleratorQuestion

--- a/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateMetrics.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using SIL.XForge.Models;
 

--- a/src/SIL.XForge.Scripture/Models/TranslateSource.cs
+++ b/src/SIL.XForge.Scripture/Models/TranslateSource.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using SIL.XForge.Models;
 
 namespace SIL.XForge.Scripture.Models;

--- a/src/SIL.XForge.Scripture/Models/VerseRefData.cs
+++ b/src/SIL.XForge.Scripture/Models/VerseRefData.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using SIL.Scripture;
 
 namespace SIL.XForge.Scripture.Models;

--- a/src/SIL.XForge.Scripture/Pages/Shared/_Footer.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_Footer.cshtml
@@ -8,6 +8,7 @@
 @inject IOptions<RequestLocalizationOptions> LocOptions
 
 @{
+    #nullable disable warnings
     var requestCulture = Context.Features.Get<IRequestCultureFeature>();
     InterfaceLanguage? locale = LocOptions.Value.SupportedUICultures?.Where(c =>
     SharedResource.Cultures[c.IetfLanguageTag].Tags.Contains(requestCulture.RequestCulture.UICulture.Name)

--- a/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
+++ b/src/SIL.XForge.Scripture/Pages/Shared/_SelectLanguagePartial.cshtml
@@ -28,9 +28,12 @@
         @* Include the query string so users return to the exact page (including errors/404) after changing language. *@
         <input type="hidden" name="returnUrl" value="@(Context.Request.Path + Context.Request.QueryString)" />
         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-            <select name="culture" class="mdl-textfield__input" onchange="this.form.submit();"
-                    asp-for="@requestCulture.RequestCulture.UICulture.Name" asp-items="cultureItems">
-            </select>
+            @if (requestCulture != null)
+            {
+                <select name="culture" class="mdl-textfield__input" onchange="this.form.submit();"
+                        asp-for="@requestCulture.RequestCulture.UICulture.Name" asp-items="cultureItems">
+                </select>
+            }
         </div>
     </form>
 </div>

--- a/src/SIL.XForge.Scripture/Program.cs
+++ b/src/SIL.XForge.Scripture/Program.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore;

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
@@ -10,7 +11,7 @@
     <UserSecretsId>4d0606c3-0fc7-4d76-b43b-236485004e81</UserSecretsId>
     <RealtimeServerRoot>..\RealtimeServer\</RealtimeServerRoot>
     <AngularConfig>production</AngularConfig>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Suppress complier warning "Missing XML comment for publicly visible type or member" -->
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
+++ b/src/SIL.XForge.Scripture/Services/BuildConfigJsonConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using Newtonsoft.Json;
 using SIL.XForge.Scripture.Models;

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Newtonsoft.Json.Linq;
 using SIL.XForge.Realtime.RichText;
 

--- a/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/DeltaUsxMapper.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge.Scripture/Services/DotNetCoreRegistry.cs
+++ b/src/SIL.XForge.Scripture/Services/DotNetCoreRegistry.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Microsoft.Win32;
 using PtxUtils;
 

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IO;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Services/IParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/IParatextService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/IScrTextCollection.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Paratext.Data;
 using Paratext.Data.ProjectFileAccess;
 

--- a/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
+++ b/src/SIL.XForge.Scripture/Services/InternetSharedRepositorySourceProvider.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtTokenHelper.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;

--- a/src/SIL.XForge.Scripture/Services/LambdaTraceListener.cs
+++ b/src/SIL.XForge.Scripture/Services/LambdaTraceListener.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Text;
 

--- a/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/LazyScrTextCollection.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineProjectService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
+++ b/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Globalization;
 using Hangfire.Common;

--- a/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
+++ b/src/SIL.XForge.Scripture/Services/NotesFormatter.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextNotesMapper.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedParatextDataSettings.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Paratext.Data;
 using PtxUtils;
 

--- a/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
+++ b/src/SIL.XForge.Scripture/Services/PersistedPtxUtilsSettings.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using PtxUtils;
 
 namespace SIL.XForge.Scripture;

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/Services/SFApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/SFApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.Scripture.Services;
 

--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Services/SFProjectRights.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectRights.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Services/SyncService.cs
+++ b/src/SIL.XForge.Scripture/Services/SyncService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
+++ b/src/SIL.XForge.Scripture/Services/TrainingDataService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
+++ b/src/SIL.XForge.Scripture/Services/TransceleratorService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/SIL.XForge.Scripture/SharedResource.cs
+++ b/src/SIL.XForge.Scripture/SharedResource.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/SIL.XForge/Configuration/AudioOptions.cs
+++ b/src/SIL.XForge/Configuration/AudioOptions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Configuration;
 
 /// <summary>

--- a/src/SIL.XForge/Configuration/DataAccessOptions.cs
+++ b/src/SIL.XForge/Configuration/DataAccessOptions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Configuration;
 
 public class DataAccessOptions

--- a/src/SIL.XForge/Configuration/ParatextOptions.cs
+++ b/src/SIL.XForge/Configuration/ParatextOptions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Configuration;
 
 public class ParatextOptions

--- a/src/SIL.XForge/Configuration/RealtimeOptions.cs
+++ b/src/SIL.XForge/Configuration/RealtimeOptions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using SIL.XForge.Models;
 

--- a/src/SIL.XForge/Configuration/SiteOptions.cs
+++ b/src/SIL.XForge/Configuration/SiteOptions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Configuration;
 
 public class SiteOptions

--- a/src/SIL.XForge/DataAccess/BsonValueConverter.cs
+++ b/src/SIL.XForge/DataAccess/BsonValueConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.DataAccess;
 using SIL.XForge.EventMetrics;

--- a/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/DataAccess/DataAccessServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using Hangfire;
 using Hangfire.Mongo;

--- a/src/SIL.XForge/DataAccess/MemoryRepository.cs
+++ b/src/SIL.XForge/DataAccess/MemoryRepository.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
+++ b/src/SIL.XForge/DataAccess/MemoryUpdateBuilder.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/EventMetrics/EventMetricLogger.cs
+++ b/src/SIL.XForge/EventMetrics/EventMetricLogger.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/SIL.XForge/EventMetrics/EventMetricsContainerBuilderExtensions.cs
+++ b/src/SIL.XForge/EventMetrics/EventMetricsContainerBuilderExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Autofac;
 using Autofac.Extras.DynamicProxy;
 using Castle.DynamicProxy;

--- a/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
+++ b/src/SIL.XForge/ExceptionLogging/ExceptionHandler.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/Models/InterfaceLanguage.cs
+++ b/src/SIL.XForge/Models/InterfaceLanguage.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Models;
 
 public class InterfaceLanguage

--- a/src/SIL.XForge/Models/Json0Snapshot.cs
+++ b/src/SIL.XForge/Models/Json0Snapshot.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/SIL.XForge/Models/Project.cs
+++ b/src/SIL.XForge/Models/Project.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 
 namespace SIL.XForge.Models;

--- a/src/SIL.XForge/Models/ProjectData.cs
+++ b/src/SIL.XForge/Models/ProjectData.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Models;
 
 public abstract class ProjectData : Json0Snapshot, IOwnedData

--- a/src/SIL.XForge/Models/ProjectSecret.cs
+++ b/src/SIL.XForge/Models/ProjectSecret.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 
 namespace SIL.XForge.Models;

--- a/src/SIL.XForge/Models/QueuedOperation.cs
+++ b/src/SIL.XForge/Models/QueuedOperation.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using SIL.XForge.Realtime;
 
 namespace SIL.XForge.Models;

--- a/src/SIL.XForge/Models/Site.cs
+++ b/src/SIL.XForge/Models/Site.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/SIL.XForge/Models/Tokens.cs
+++ b/src/SIL.XForge/Models/Tokens.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IdentityModel.Tokens.Jwt;
 

--- a/src/SIL.XForge/Models/User.cs
+++ b/src/SIL.XForge/Models/User.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 
 namespace SIL.XForge.Models;

--- a/src/SIL.XForge/Models/UserSecret.cs
+++ b/src/SIL.XForge/Models/UserSecret.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Models;
 
 /// <summary>

--- a/src/SIL.XForge/Realtime/Connection.cs
+++ b/src/SIL.XForge/Realtime/Connection.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/SIL.XForge/Realtime/Document.cs
+++ b/src/SIL.XForge/Realtime/Document.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/SIL.XForge/Realtime/IRealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeServer.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/SIL.XForge/Realtime/IRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/IRealtimeService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Linq;
 using System.Threading.Tasks;
 using SIL.XForge.Models;

--- a/src/SIL.XForge/Realtime/IntegerToUtcDateTimeConverter.cs
+++ b/src/SIL.XForge/Realtime/IntegerToUtcDateTimeConverter.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using Newtonsoft.Json;
 

--- a/src/SIL.XForge/Realtime/Json0/Json0Op.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0Op.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
+++ b/src/SIL.XForge/Realtime/Json0/Json0OpBuilder.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/Realtime/MemoryConnection.cs
+++ b/src/SIL.XForge/Realtime/MemoryConnection.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/SIL.XForge/Realtime/MemoryDocument.cs
+++ b/src/SIL.XForge/Realtime/MemoryDocument.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;

--- a/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
+++ b/src/SIL.XForge/Realtime/MemoryRealtimeService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge/Realtime/RealtimeApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Microsoft.Extensions.DependencyInjection;
 using SIL.XForge.Realtime;
 

--- a/src/SIL.XForge/Realtime/RealtimeExtensions.cs
+++ b/src/SIL.XForge/Realtime/RealtimeExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/SIL.XForge/Realtime/RealtimeJsonService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeJsonService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IO;
 using System.Threading;

--- a/src/SIL.XForge/Realtime/RealtimeServer.cs
+++ b/src/SIL.XForge/Realtime/RealtimeServer.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge/Realtime/RealtimeService.cs
+++ b/src/SIL.XForge/Realtime/RealtimeService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge/Realtime/RichText/Delta.cs
+++ b/src/SIL.XForge/Realtime/RichText/Delta.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/Realtime/RichText/DeltaEqualityComparer.cs
+++ b/src/SIL.XForge/Realtime/RichText/DeltaEqualityComparer.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;

--- a/src/SIL.XForge/Realtime/RichText/OpExtensions.cs
+++ b/src/SIL.XForge/Realtime/RichText/OpExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using Newtonsoft.Json.Linq;
 
 namespace SIL.XForge.Realtime.RichText;

--- a/src/SIL.XForge/Realtime/Snapshot.cs
+++ b/src/SIL.XForge/Realtime/Snapshot.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Realtime;
 
 /// <summary>

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>annotations</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SIL.XForge/Services/AudioService.cs
+++ b/src/SIL.XForge/Services/AudioService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;

--- a/src/SIL.XForge/Services/EventMetricService.cs
+++ b/src/SIL.XForge/Services/EventMetricService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/SIL.XForge/Services/HangfireDashboardAuthorizationFilter.cs
+++ b/src/SIL.XForge/Services/HangfireDashboardAuthorizationFilter.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Diagnostics.CodeAnalysis;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;

--- a/src/SIL.XForge/Services/JsonRpcApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge/Services/JsonRpcApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Security.Claims;
 using EdjCase.JsonRpc.Router;

--- a/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/JsonRpcServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using EdjCase.JsonRpc.Common;

--- a/src/SIL.XForge/Services/OpenIdConnectSigningKeyResolver.cs
+++ b/src/SIL.XForge/Services/OpenIdConnectSigningKeyResolver.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.IdentityModel.Protocols;

--- a/src/SIL.XForge/Services/ProjectService.cs
+++ b/src/SIL.XForge/Services/ProjectService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/SIL.XForge/Services/UserAccessor.cs
+++ b/src/SIL.XForge/Services/UserAccessor.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Linq;
 using System.Security.Claims;
 using Duende.IdentityModel;

--- a/src/SIL.XForge/Services/UserService.cs
+++ b/src/SIL.XForge/Services/UserService.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/Utils/Attempt.cs
+++ b/src/SIL.XForge/Utils/Attempt.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Utils;
 
 public static class Attempt

--- a/src/SIL.XForge/Utils/ConstantFinder.cs
+++ b/src/SIL.XForge/Utils/ConstantFinder.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/SIL.XForge/Utils/DictionaryComparer.cs
+++ b/src/SIL.XForge/Utils/DictionaryComparer.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/SIL.XForge/Utils/ObjectPath.cs
+++ b/src/SIL.XForge/Utils/ObjectPath.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/AnonymousControllerTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/ParatextControllerTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/I18N/SharedResourceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Localization;

--- a/test/SIL.XForge.Scripture.Tests/Models/CharAttr.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/CharAttr.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace SIL.XForge.Scripture.Models;
 
 public class CharAttr

--- a/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/NoteSyncMetricInfoTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using NUnit.Framework;
 
 namespace SIL.XForge.Scripture.Models;

--- a/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Models/SyncMetricInfoTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using NUnit.Framework;
 
 namespace SIL.XForge.Scripture.Models;

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <RootNamespace>SIL.XForge.Scripture</RootNamespace>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <!--
     This is for compatibility between ICU4C (a dependency of ParatextData) and .NET 8.0 see:
     https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph

--- a/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/AnonymousServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Linq;
 using System.Threading.Tasks;
 using NSubstitute;

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxMapperTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/DeltaUsxTestExtensions.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;

--- a/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/InternetSharedRepositorySourceProviderTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/LazyScrTextCollectionTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.IO;
 using NSubstitute;
 using NUnit.Framework;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineProjectServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrStylesheet.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrStylesheet.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 namespace Paratext.Data;
 
 /// <summary>Mock for tests.</summary>

--- a/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockScrText.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using NSubstitute;
 using Paratext.Data;

--- a/test/SIL.XForge.Scripture.Tests/Services/MockZippedProjectFileManager.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MockZippedProjectFileManager.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IO;
 using System.Text;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextNotesMapperTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFInstallableDblResourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFInstallableDblResourceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IO;
 using System.Text;

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SyncServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/SIL.XForge.Tests/DataAccess/BsonValueConverterTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/BsonValueConverterTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.IO;
 using System.Text;

--- a/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MemoryUpdateBuilderTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using NUnit.Framework;
 using SIL.XForge.Models;

--- a/test/SIL.XForge.Tests/DataAccess/MongoRepositoryTests.cs
+++ b/test/SIL.XForge.Tests/DataAccess/MongoRepositoryTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Linq;
 using System.Net;

--- a/test/SIL.XForge.Tests/Models/TokensTests.cs
+++ b/test/SIL.XForge.Tests/Models/TokensTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using NUnit.Framework;
 using SIL.XForge.Services;

--- a/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/ConnectionTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RealtimeServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
+++ b/test/SIL.XForge.Tests/Realtime/RichText/DeltaTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <RootNamespace>SIL.XForge</RootNamespace>
     <LangVersion>latest</LangVersion>
     <RealtimeServerRoot>..\..\src\RealtimeServer\</RealtimeServerRoot>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <!--
     This is for compatibility between ICU4C (a dependency of ParatextData) and .NET 8.0 see:
     https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph

--- a/test/SIL.XForge.Tests/Services/EventMetricLoggerTests.cs
+++ b/test/SIL.XForge.Tests/Services/EventMetricLoggerTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/test/SIL.XForge.Tests/Services/EventMetricServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/EventMetricServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/SIL.XForge.Tests/Services/MockLogger.cs
+++ b/test/SIL.XForge.Tests/Services/MockLogger.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/ProjectServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Files with `#nullable enable` will have an error from new code like
`string foo = null`. (Instead of `string? foo = null`.)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3750)
<!-- Reviewable:end -->
