### PR TITLE
Use environment secrets for Crowdin actions

### DIFF
--- a/.github/workflows/push-changes-to-crowdin.yml
+++ b/.github/workflows/push-changes-to-crowdin.yml
@@ -18,6 +18,8 @@ jobs:
   push_files_to_crowdin:
     name: "Push files to Crowdin"
     runs-on: ubuntu-24.04
+    environment: Crowdin
+
     steps:
       - name: "Fail if not on master"
         if: github.ref != 'refs/heads/master'
@@ -42,5 +44,5 @@ jobs:
       - name: "Push files to Crowdin"
         run: scripts/push_changes_to_crowdin.mts
         env:
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
           CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}

--- a/.github/workflows/update-localizations.yml
+++ b/.github/workflows/update-localizations.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   update-localizations:
     runs-on: ubuntu-latest
+    environment: Crowdin
 
     steps:
       - name: Checkout repository
@@ -27,7 +28,7 @@ jobs:
       - name: Run update_from_crowdin.mts
         run: scripts/update_from_crowdin.mts
         env:
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
           CROWDIN_API_KEY: ${{ secrets.CROWDIN_API_KEY }}
 
       - name: Create Pull Request


### PR DESCRIPTION
Zizmor has flagged our use of secrets outside an environment as not being a security best-practice, since it means the secrets are available to every action that runs. See https://docs.zizmor.sh/audits/#secrets-outside-env

Instead, secrets should be put in an environment (e.g. a "Crowdin" environment), and then workflows should state which environment they use. 

What that means is that the security improvement isn't an update to a workflow; it's a change to how our secrets are stored in GitHub, to have better access control. However, doing that does necessitate an update to the workflows.

I've created a Crowdin environment in the repo settings, set `CROWDIN_PROJECT_ID` and `CROWDIN_API_KEY`, and updated the workflow to reference them. After this is merged the old secrets should be removed from the repo's main secrets, so they're only available via the environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3753)
<!-- Reviewable:end -->
