### PR TITLE
Fix Grit install in GitHub action

### DIFF
--- a/.github/workflows/grit.yml
+++ b/.github/workflows/grit.yml
@@ -16,5 +16,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: grit-check
-        uses: getgrit/github-action-check@c1ba5f99fd0e46f4cdc35d8dbc4622610ccc1784 # v0
+      # Install Node so npm can be used to install Grit
+      - name: Set up Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22.13.0"
+
+      # The following steps were copied from github.com/honeycombio/github-action-check/blob/main/action.yaml with
+      # slight simplifications.
+      # The install method was changed from running https://docs.grit.io/install to using npm because the install URL
+      # redirects to https://github.com/biomejs/gritql/releases/download/v0.0.2/grit-installer.sh, which returns 404.
+      - name: Install Grit
+        run: npm install --location=global @getgrit/cli@0.1.0-alpha.1743007075
+      - name: Init Grit
+        run: grit init
+      - name: Run Grit check
+        run: grit check --github-actions

--- a/.github/workflows/update-npm-audit.yml
+++ b/.github/workflows/update-npm-audit.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # 5.0.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "22.13.0"
           cache: "npm"


### PR DESCRIPTION
Recent Grit checks have started to fail due to the action we are using trying to us an installer that is no longer published. It appears the GitHub action for Grit has been passed off to honeycombio, and something got dropped in the hand off.

On this branch, the Grit check passes, and you can also see that there are two findings, meaning the results do get reported to GitHub.

I've created an issue in the action's repo: https://github.com/honeycombio/github-action-check/issues/3

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3755)
<!-- Reviewable:end -->
