### PR TITLE
Enable in-app onboarding form

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
@@ -193,7 +193,7 @@ export async function localizedScreenshots(
   await navLocator(page, 'generate_draft').click();
 
   await forEachLocale(async locale => {
-    await user.hover(page.locator('[data-test-id="approval-needed"]').getByRole('link'), defaultArrowLocation);
+    await user.hover(page.locator('[data-test-id="approval-needed"]').getByRole('button'), defaultArrowLocation);
     await screenshot(page, { ...context, pageName: 'sign_up_for_drafting', locale });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -367,7 +367,7 @@ export class FeatureFlagService {
     'InAppDraftSignupForm',
     'Show in-app draft signup form instead of external link',
     19,
-    this.featureFlagStore
+    new StaticFeatureFlagStore(true)
   );
 
   get featureFlags(): FeatureFlag[] {


### PR DESCRIPTION
This feature has been complete for some time, but the decision was made not to ship it until after the workshop that is completing this week.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3758)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
