### PR TITLE
SF-3740 Do not select previously used and now empty books for training

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -245,7 +245,7 @@ describe('DraftGenerationStepsComponent', () => {
   describe('one training source', async () => {
     const sourceProjectId = 'sourceProject';
     const availableBooks = [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 5 }];
-    const allBooks = [...availableBooks, { bookNum: 6 }, { bookNum: 7 }];
+    const allBooks = [...availableBooks, { bookNum: 6 }, { bookNum: 7 }, { bookNum: 8 }];
     const sourceBooks = allBooks.filter(b => b.bookNum !== 6);
     const config: DraftSourcesAsArrays = {
       trainingSources: [
@@ -286,14 +286,26 @@ describe('DraftGenerationStepsComponent', () => {
         data: createTestProjectProfile({
           texts: allBooks,
           translateConfig: {
-            source: { projectRef: sourceProjectId, shortName: 'sP', writingSystem: { tag: 'xyz' } }
+            source: { projectRef: sourceProjectId, shortName: 'sP', writingSystem: { tag: 'xyz' } },
+            draftConfig: {
+              lastSelectedTrainingScriptureRanges: [{ projectId: sourceProjectId, scriptureRange: 'GEN;EXO;RUT' }]
+            }
           },
           writingSystem: { tag: 'eng' }
         })
       } as SFProjectProfileDoc;
       const targetProjectDoc$ = new BehaviorSubject<SFProjectProfileDoc>(mockTargetProjectDoc);
-      const emptyBookNums = [5];
+      // setup empty books in the target
+      const emptyBooksInTarget = [3, 8];
+      const books: BookProgress[] = allBooks.map(b => ({
+        bookId: Canon.bookNumberToId(b.bookNum),
+        verseSegments: 100,
+        blankVerseSegments: emptyBooksInTarget.includes(b.bookNum) ? 100 : 0
+      }));
+      const progress = new ProjectProgress(books);
+      when(mockProgressService.getProgress('project01', anything())).thenResolve(progress);
 
+      const emptyBookNums = [5];
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockActivatedProjectService.changes$).thenReturn(targetProjectDoc$);
@@ -319,7 +331,8 @@ describe('DraftGenerationStepsComponent', () => {
         { number: 1, selected: false },
         { number: 2, selected: false },
         { number: 3, selected: false },
-        { number: 5, selected: false }
+        { number: 5, selected: false },
+        { number: 8, selected: false }
       ]);
     }));
 
@@ -328,7 +341,8 @@ describe('DraftGenerationStepsComponent', () => {
         sourceProject: [
           { number: 1, selected: false },
           { number: 2, selected: false },
-          { number: 3, selected: false }
+          { number: 3, selected: false },
+          { number: 8, selected: false }
         ]
       });
     }));
@@ -342,7 +356,8 @@ describe('DraftGenerationStepsComponent', () => {
         sourceProject: [
           { number: 1, selected: true },
           { number: 2, selected: true },
-          { number: 3, selected: false }
+          { number: 3, selected: false },
+          { number: 8, selected: false }
         ]
       });
     }));
@@ -377,7 +392,7 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should set "trainingBooksWithoutEnoughData"', fakeAsync(() => {
-      expect(component.trainingBooksWithoutEnoughData).toEqual([3, 5]);
+      expect(component.trainingBooksWithoutEnoughData).toEqual([3, 5, 8]);
     }));
 
     it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -670,12 +670,13 @@ export class DraftGenerationStepsComponent implements OnInit {
         for (const bookNum of booksFromScriptureRange(range.scriptureRange)) {
           //select in the source
           const sourceBook = this.availableTrainingBooks[source.projectRef].find(b => b.number === bookNum);
-          if (sourceBook !== undefined) {
+          // We should only select the book for training if the target book has verse content
+          if (sourceBook !== undefined && this.bookHasVerseContent(targetProjectId, bookNum)) {
             sourceBook.selected = true;
           }
           //select in the target
           const targetBook = this.availableTrainingBooks[targetProjectId].find(b => b.number === bookNum);
-          if (targetBook !== undefined) {
+          if (targetBook !== undefined && this.bookHasVerseContent(targetProjectId, bookNum)) {
             targetBook.selected = true;
           }
         }


### PR DESCRIPTION
This PR prevents auto-selection of training books that are now empty in the target project, which were previously used for training.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3765)
<!-- Reviewable:end -->
