### PR TITLE
sync: fix GetOutgoingRevisions to use draft phases

### DIFF
--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -47,8 +47,8 @@ public class HgWrapper : IHgWrapper
     /// </returns>
     public string GetLastPublicRevision(string repository)
     {
-        string ids = RunCommand(repository, "log --rev \"public()\" --template \"{node}\n\"");
-        string revision = ids.Split(["\n"], StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
+        string ids = RunCommand(repository, """log --rev "public()" --template "{node}\n" """);
+        string revision = ids.Split('\n', StringSplitOptions.RemoveEmptyEntries).LastOrDefault()?.Trim();
         return revision;
     }
 
@@ -91,10 +91,10 @@ public class HgWrapper : IHgWrapper
     /// </summary>
     public string[] GetDraftRevisions(string repositoryPath)
     {
-        string ids = RunCommand(repositoryPath, "log --rev \"draft()\" --template \"{node}\n\"");
+        string ids = RunCommand(repositoryPath, """log --rev "draft()" --template "{node}\n" """);
         return
         [
-            .. ids.Split(["\n"], StringSplitOptions.RemoveEmptyEntries)
+            .. ids.Split('\n', StringSplitOptions.RemoveEmptyEntries)
                 .Select(id => id.Trim())
                 .Where(id => id.Length > 0),
         ];

--- a/src/SIL.XForge.Scripture/Services/HgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/HgWrapper.cs
@@ -86,6 +86,20 @@ public class HgWrapper : IHgWrapper
     /// <param name="repository">The repository.</param>
     public void MarkSharedChangeSetsPublic(string repository) => RunCommand(repository, "phase -p -r 'tip'");
 
+    /// <summary>
+    /// Returns the ids of commits with draft phase.
+    /// </summary>
+    public string[] GetDraftRevisions(string repositoryPath)
+    {
+        string ids = RunCommand(repositoryPath, "log --rev \"draft()\" --template \"{node}\n\"");
+        return
+        [
+            .. ids.Split(["\n"], StringSplitOptions.RemoveEmptyEntries)
+                .Select(id => id.Trim())
+                .Where(id => id.Length > 0),
+        ];
+    }
+
     /// <summary> Set the default Mercurial installation. Must be called for all other methods to work. </summary>
     public void SetDefault(Hg hgDefault)
     {

--- a/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
+++ b/src/SIL.XForge.Scripture/Services/IHgWrapper.cs
@@ -13,4 +13,5 @@ public interface IHgWrapper
     string GetLastPublicRevision(string repository);
     string GetRepoRevision(string repositoryPath);
     void MarkSharedChangeSetsPublic(string repository);
+    string[] GetDraftRevisions(string repositoryPath);
 }

--- a/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
+++ b/src/SIL.XForge.Scripture/Services/JwtInternetSharedRepositorySource.cs
@@ -137,6 +137,15 @@ public class JwtInternetSharedRepositorySource : InternetSharedRepositorySource,
     public override string GetHgUri(SharedRepository sharedRepository) => string.Empty;
 
     /// <summary>
+    /// Returns the ids of unpushed commits. Overriding here since InternetSharedRepositorySource.GetOutgoingRevisions
+    /// is going to SharedRepositorySource.GetOutgoingRevisions which doesn't work for us because it needs to look at
+    /// the remote repository. One difference with this implementation is that it looks at commit phase to determine
+    /// what is pushed. Distinguishing between public and draft commit phase is not something ParatextData uses.
+    /// </summary>
+    public override string[] GetOutgoingRevisions(string repository, SharedProject sharedProject) =>
+        _hgWrapper.GetDraftRevisions(repository);
+
+    /// <summary>
     /// Retrieve a list of <see cref="SharedRepository" />.
     /// </summary>
     public override IEnumerable<SharedRepository> GetRepositories() => GetRepositories(GetLicensesForUserProjects());

--- a/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/JwtInternetSharedRepositorySourceTests.cs
@@ -4,6 +4,7 @@ using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
 using Paratext.Data;
+using Paratext.Data.Repository;
 using Paratext.Data.Users;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
@@ -13,6 +14,11 @@ namespace SIL.XForge.Scripture.Services;
 [TestFixture]
 public class JwtInternetSharedRepositorySourceTests
 {
+    private const string RepoPath = "/sync/abc123/target";
+    private const string ProjectName = "TestProject";
+    private const string ProjectId = "4011111111111111111111111111111111111111";
+    private const string NewTipRevision = "bbb2222222222222222222222222222222222222";
+
     [Test]
     public void CanUserAuthenticateToPTArchives_Works()
     {
@@ -50,10 +56,48 @@ public class JwtInternetSharedRepositorySourceTests
         );
     }
 
+    [Test]
+    public void GetOutgoingRevisions_ReturnsDraftRevisions()
+    {
+        var env = new TestEnvironment();
+        SharedProject sharedProject = new SharedProject
+        {
+            SendReceiveId = HexId.FromStr(ProjectId),
+            ScrTextName = ProjectName,
+            Repository = TestEnvironment.CreatePushRepo(HexId.FromStr(ProjectId), ProjectName),
+        };
+        string[] expectedRevisions = [NewTipRevision];
+        env.MockHgWrapper.GetDraftRevisions(RepoPath).Returns(expectedRevisions);
+
+        // SUT
+        string[] result = env.RepoSource.GetOutgoingRevisions(RepoPath, sharedProject);
+
+        Assert.That(result, Is.EqualTo(expectedRevisions));
+    }
+
+    [Test]
+    public void GetOutgoingRevisions_NoDraftRevisions_ReturnsEmpty()
+    {
+        var env = new TestEnvironment();
+        SharedProject sharedProject = new SharedProject
+        {
+            SendReceiveId = HexId.FromStr(ProjectId),
+            ScrTextName = ProjectName,
+            Repository = TestEnvironment.CreatePushRepo(HexId.FromStr(ProjectId), ProjectName),
+        };
+        env.MockHgWrapper.GetDraftRevisions(RepoPath).Returns([]);
+
+        // SUT
+        string[] result = env.RepoSource.GetOutgoingRevisions(RepoPath, sharedProject);
+
+        Assert.That(result, Is.Empty);
+    }
+
     private class TestEnvironment
     {
         public readonly JwtInternetSharedRepositorySource RepoSource;
         public readonly IRESTClient MockPTArchivesClient;
+        public readonly IHgWrapper MockHgWrapper;
 
         public TestEnvironment()
         {
@@ -63,10 +107,11 @@ public class JwtInternetSharedRepositorySourceTests
                 "applicationName",
                 "jwtToken"
             );
+            MockHgWrapper = Substitute.For<IHgWrapper>();
             RepoSource = Substitute.ForPartsOf<JwtInternetSharedRepositorySource>(
                 "access-token",
                 mockPTRegistryClient,
-                Substitute.For<IHgWrapper>(),
+                MockHgWrapper,
                 ptUser,
                 "sr-server-uri",
                 new MockLogger<InternetSharedRepositorySourceProvider>()
@@ -74,5 +119,8 @@ public class JwtInternetSharedRepositorySourceTests
             MockPTArchivesClient = Substitute.For<RESTClient>("pt-archives-server.example.com", "product-version-123");
             RepoSource.Configure().GetClient().Returns(MockPTArchivesClient);
         }
+
+        public static SharedRepository CreatePushRepo(HexId ptProjectId, string projectName) =>
+            new SharedRepository { SendReceiveId = ptProjectId, ScrTextName = projectName };
     }
 }


### PR DESCRIPTION
- Overrides `GetOutgoingRevisions` from trying to use a remote
repository url (which was empty), to looking at what commits are in
draft phase.
- This enables our logging to start telling us what commits are being
pushed.

---
This patch changes something that is called in the Sync process. But I'm comfortable enough with existing testing without marking it as Needs Testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3775)
<!-- Reviewable:end -->
