### PR TITLE
Fix Serval admin tab persistence

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-administration.component.ts
@@ -47,7 +47,7 @@ export class ServalAdministrationComponent implements OnInit {
     void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { tab: this.availableTabs[index] },
-      queryParamsHandling: 'preserve'
+      queryParamsHandling: 'merge'
     });
   }
 }


### PR DESCRIPTION
If you go to the `/serval-administration` page and navigate between tabs and then refresh the page, it doesn't remember the tab you're on. This change fixes that.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3779)
<!-- Reviewable:end -->
