### PR TITLE
SF-3772 Prevent duplicate onboarding requests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -36,9 +36,9 @@ import { NoticeComponent } from '../../shared/notice/notice.component';
 import { projectLabel } from '../../shared/utils';
 import { normalizeLanguageCodeToISO639_3 } from '../../translate/draft-generation/draft-utils';
 import {
-  DraftingSignupFormData,
   ONBOARDING_REQUEST_RESOLUTION_OPTIONS,
   OnboardingRequest,
+  OnboardingRequestFormData,
   OnboardingRequestResolutionKey,
   OnboardingRequestResolutionMetadata,
   OnboardingRequestService
@@ -258,7 +258,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     return this.request?.resolution != null && this.request.resolution !== 'unresolved';
   }
 
-  get formData(): DraftingSignupFormData {
+  get formData(): OnboardingRequestFormData {
     return this.request!.submission.formData;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -154,7 +154,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly nllbService: NllbLanguageService,
     protected readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
-    private readonly draftingSignupService: OnboardingRequestService,
+    private readonly onboardingRequestService: OnboardingRequestService,
     protected readonly noticeService: NoticeService,
     protected readonly urlService: ExternalUrlService,
     protected readonly draftOptionsService: DraftOptionsService,
@@ -265,7 +265,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
         // Check if user has already submitted a signup for this project
         if (this.activatedProject.projectId != null) {
           try {
-            this.onboardingRequest = await this.draftingSignupService.getOpenOnboardingRequest(
+            this.onboardingRequest = await this.onboardingRequestService.getOpenOnboardingRequest(
               this.activatedProject.projectId
             );
           } catch {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
@@ -15,6 +15,7 @@ import { Canon } from '@sillsdev/scripture';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
+import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { UserService } from 'xforge-common/user.service';
@@ -28,7 +29,7 @@ import { DevOnlyComponent } from '../../../shared/dev-only/dev-only.component';
 import { JsonViewerComponent } from '../../../shared/json-viewer/json-viewer.component';
 import { compareProjectsForSorting, projectLabel } from '../../../shared/utils';
 import {
-  DraftingSignupFormData,
+  OnboardingRequestFormData,
   OnboardingRequestService,
   PARTNER_ORGANIZATION_OPTIONS,
   PartnerOrganization
@@ -36,7 +37,7 @@ import {
 
 export const DRAFT_SIGNUP_RESPONSE_DAYS = { min: 1, max: 3 } as const;
 
-type DraftOnboardingFormUiState = 'editing' | 'submitting' | 'submitted';
+type OnboardingFormUiState = 'editing' | 'submitting' | 'submitted';
 
 /**
  * Component for the in-app draft signup form.
@@ -132,7 +133,7 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
 
   submittedData?: any;
 
-  uiState: DraftOnboardingFormUiState = 'editing';
+  uiState: OnboardingFormUiState = 'editing';
 
   readonly responseDays = DRAFT_SIGNUP_RESPONSE_DAYS;
 
@@ -141,8 +142,9 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
     private readonly activatedProject: ActivatedProjectService,
     private readonly userService: UserService,
     private readonly paratextService: ParatextService,
-    private readonly draftingSignupService: OnboardingRequestService,
+    private readonly onboardingRequestService: OnboardingRequestService,
     protected readonly noticeService: NoticeService,
+    protected readonly dialogService: DialogService,
     private readonly destroyRef: DestroyRef,
     private readonly cd: ChangeDetectorRef,
     private readonly i18n: I18nService
@@ -152,6 +154,8 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
 
   ngOnInit(): void {
     this.loadingStarted();
+
+    void this.checkAndWarnIfAlreadySubmitted();
 
     // Get the current user and pre-fill the form
     this.userService
@@ -215,18 +219,23 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
 
   async onSubmit(): Promise<void> {
     const projectId = this.activatedProject.projectId;
-    if (projectId == null || this.uiState === 'submitting') {
-      return;
-    }
+    if (projectId == null || this.uiState === 'submitting') return;
+
+    if (await this.checkAndWarnIfAlreadySubmitted()) return;
+
+    // Handle race condition when submit is double clicked and the second click happens before the form state is updated
+    // to 'submitting'. The type of this.uiState has to be widened after TS narrowed it to `"editing" | "submitted"`
+    // due to the check at the beginning of the function.
+    if ((this.uiState as OnboardingFormUiState) === 'submitting') return;
 
     if (this.signupForm.valid === true) {
       this.uiState = 'submitting';
       this.cd.markForCheck();
 
-      const formData: DraftingSignupFormData = this.signupForm.getRawValue() as DraftingSignupFormData;
+      const formData = this.signupForm.getRawValue() as OnboardingRequestFormData;
 
       try {
-        const requestId = await this.draftingSignupService.submitOnboardingRequest(projectId, formData);
+        const requestId = await this.onboardingRequestService.submitOnboardingRequest(projectId, formData);
 
         // For testing purposes, store and display the submitted data
         this.submittedData = { requestId, projectId, formData };
@@ -322,6 +331,26 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
         // Clear the language name if we couldn't determine a reasonable value
         this.signupForm.controls.backTranslationLanguageName.setValue('');
       }
+    }
+  }
+
+  /**
+   * If a request has already been submitted:
+   * - Informs user with a message dialog
+   * - Redirects to drafting page when user closes dialog
+   * - Resolves to true
+   *
+   * Otherwise, resolves to false
+   */
+  private async checkAndWarnIfAlreadySubmitted(): Promise<boolean> {
+    if (this.activatedProject.projectId == null) return false;
+
+    if ((await this.onboardingRequestService.getOpenOnboardingRequest(this.activatedProject.projectId)) == null) {
+      return false;
+    } else {
+      await this.dialogService.message('draft_sources.request_already_submitted', undefined, true);
+      this.cancel();
+      return true;
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/onboarding-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/onboarding-request.service.ts
@@ -3,19 +3,12 @@ import { CommandService } from 'xforge-common/command.service';
 import { ONBOARDING_REQUESTS_URL } from 'xforge-common/url-constants';
 import { SFProjectService } from '../../core/sf-project.service';
 
-export interface OnboardingRequestComment {
-  id: string;
-  userId: string;
-  text: string;
-  dateCreated: string;
-}
-
 /** The available partner organization options for the onboarding form. */
 export const PARTNER_ORGANIZATION_OPTIONS = ['Bolshoi Group', 'Seed Company', 'none'] as const;
 /** A valid partner organization selection from the onboarding form. */
 export type PartnerOrganization = (typeof PARTNER_ORGANIZATION_OPTIONS)[number];
 
-export interface DraftingSignupFormData {
+export interface OnboardingRequestFormData {
   name: string;
   email: string;
   organization: string;
@@ -50,7 +43,7 @@ export interface OnboardingRequest {
     projectId: string;
     userId: string;
     timestamp: string;
-    formData: DraftingSignupFormData;
+    formData: OnboardingRequestFormData;
   };
   assigneeId: string;
   status: OnboardingRequestStatusOption;
@@ -119,7 +112,7 @@ export class OnboardingRequestService {
   }
 
   /** Submits a new onboarding request. */
-  async submitOnboardingRequest(projectId: string, formData: DraftingSignupFormData): Promise<string> {
+  async submitOnboardingRequest(projectId: string, formData: OnboardingRequestFormData): Promise<string> {
     return (await this.onlineInvoke<string>('submitOnboardingRequest', { projectId, formData }))!;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -409,6 +409,7 @@
     "some_projects_use_back_translation": "Some projects get better results by adding a back translation as another reference.",
     "source_language": "the source language",
     "source_side_language_codes_differ": "All source and reference projects must be in the same language. Please select different source or reference projects.",
+    "request_already_submitted": "A request to activate drafting on this project has already been submitted. Please wait for a response from the team.",
     "state_connecting": "Connecting",
     "state_sync_failed": "There was an error syncing",
     "state_sync_successful": "Sync successful",


### PR DESCRIPTION
Before this change, the UI already informs the user when a request has already been submitted and doesn't allow submitting another. However, the check is only done when the drafting component loads, so by using multiple tabs, or possibly by using browser history, it's possible to submit the form twice. This change adds additional checks to prevent duplicate submissions.

EDIT: I think the *actual* reason we were getting duplicate requests was network errors when submitting the form:
<img width="1026" height="168" alt="Screenshot from 2026-04-08 12-27-44" src="https://github.com/user-attachments/assets/04f9207f-ce7c-4624-8784-2b6da351c9f1" />

The request *did* however get saved, but the client didn't know it, so the user was able to re-submit.

EDIT 2: I think the network errors are timeouts. I've created a PR to fix them: #3785. However, I think this PR is still a good change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3784)
<!-- Reviewable:end -->
