### PR TITLE
Increase notice margin on draft generation stepper

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -60,7 +60,7 @@ h2 {
 }
 
 app-notice {
-  margin-top: 20px;
+  margin: 20px 0;
   width: fit-content;
 
   &.pending-updates {


### PR DESCRIPTION
Testers noticed that notices in the draft generation stepper needed more margin.

Before
<img width="578" height="708" alt="Notice spacing original" src="https://github.com/user-attachments/assets/776396a0-e23f-412b-8eb2-c452cbf18964" />

After
<img width="563" height="644" alt="Notice Spacing Increased" src="https://github.com/user-attachments/assets/32093ad8-e16f-478e-b920-c0c610709ce6" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3787)
<!-- Reviewable:end -->
