### PR TITLE
SF-1359 Select all and backspacing deletes verse structure and chapter number

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/quill-editor-registration/quill-registrations.ts
@@ -4,6 +4,7 @@ import QuillCursors from 'quill-cursors';
 import QuillInlineBlot from 'quill/blots/inline';
 import QuillScrollBlot from 'quill/blots/scroll';
 import { DragAndDrop } from '../drag-and-drop';
+import { SelectAll } from '../select-all';
 import { DisableHtmlClipboard } from './quill-clipboard';
 import { FormattableBlotClass, QuillFormatRegistryService } from './quill-format-registry.service';
 import {
@@ -104,4 +105,5 @@ export function registerScriptureFormats(formatRegistry: QuillFormatRegistryServ
   Quill.register('modules/cursors', QuillCursors, true);
   Quill.register('modules/history', FixSelectionHistory, true);
   Quill.register('modules/dragAndDrop', DragAndDrop, true);
+  Quill.register('modules/selectAll', SelectAll, true);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
@@ -55,12 +55,15 @@ export class SelectAll {
 
       updatingSelection = true;
 
-      // Do not allow selecting further than the current segment
-      const length: number =
-        textComponent.segment == null
-          ? 0
-          : textComponent.segment.range.index + textComponent.segment?.range.length - range.index;
-      quill.setSelection(range.index, length, 'silent');
+      // Do not allow selecting before or further than the current segment
+      let index: number = 0;
+      let length: number = 0;
+      if (textComponent.segment != null) {
+        index = range.index < textComponent.segment.range.index ? textComponent.segment.range.index : range.index;
+        length = textComponent.segment.range.index + textComponent.segment?.range.length - range.index;
+      }
+
+      quill.setSelection(index, length, 'silent');
 
       updatingSelection = false;
     });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
@@ -1,11 +1,16 @@
 import Quill, { Range } from 'quill';
+import { StringMap } from 'rich-text';
+import { TextComponent } from './text.component';
 
 /**
  * "Select All" module for Quill, which converts browser menu
  * initiated "select all" requests to Quill selection-change events.
  */
 export class SelectAll {
-  constructor(quill: Quill) {
+  constructor(quill: Quill, options: StringMap) {
+    // Get the text component
+    const textComponent: TextComponent = options.textComponent;
+
     // Tracks the last Quill selection to avoid repetition/looping
     let lastRange: Range | null = quill.getSelection();
 
@@ -24,6 +29,32 @@ export class SelectAll {
         quill.emitter.emit('selection-change', quillRange, lastRange, 'user');
         lastRange = quillRange;
       }
+    });
+
+    // Do not allow selection to move beyond the segment
+    let updatingSelection = false;
+    quill.on('selection-change', (range, _oldRange, _source) => {
+      // Prevent infinite loops
+      if (updatingSelection) return;
+
+      // No range = lost focus
+      if (!range) return; // lost focus
+
+      // If there is no text selected, we do not need to modify the selection
+      const text = quill.getText(range.index, range.length);
+      if (text.length === 0) return;
+
+      // If the selection is valid with in the segment, we do not need to modify it
+      if (textComponent.isValidSelectionForCurrentSegment(range)) return;
+
+      updatingSelection = true;
+
+      // Do not allow selecting further than the current segment
+      const length =
+        (textComponent.segment?.range.index ?? 0) + (textComponent.segment?.range.length ?? 0) - range.index;
+      quill.setSelection(range.index, length, 'silent');
+
+      updatingSelection = false;
     });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
@@ -1,0 +1,29 @@
+import Quill, { Range } from 'quill';
+
+/**
+ * "Select All" module for Quill, which converts browser menu
+ * initiated "select all" requests to Quill selection-change events.
+ */
+export class SelectAll {
+  constructor(quill: Quill) {
+    // Tracks the last Quill selection to avoid repetition/looping
+    let lastRange: Range | null = quill.getSelection();
+
+    // Monitor the browser's selectionchange event from the document
+    document.addEventListener('selectionchange', () => {
+      // Ignore if the request is from another text box such as Add/Edit Answer, Biblical Terms, or Update Your Name
+      const sel: Selection | null = document.getSelection();
+      if (!sel || sel.rangeCount === 0 || !quill.root.contains(sel.getRangeAt(0).startContainer)) {
+        lastRange = null;
+        return;
+      }
+
+      // Only emit to Quill (and the onSelectionChanged handler in TextComponent) if the selection has actually changed
+      const quillRange: Range = quill.getSelection(true);
+      if (!lastRange || quillRange.index !== lastRange.index || quillRange.length !== lastRange.length) {
+        quill.emitter.emit('selection-change', quillRange, lastRange, 'user');
+        lastRange = quillRange;
+      }
+    });
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
@@ -1,5 +1,8 @@
+import { DestroyRef } from '@angular/core';
 import Quill, { Range } from 'quill';
 import { StringMap } from 'rich-text';
+import { fromEvent } from 'rxjs';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextComponent } from './text.component';
 
 /**
@@ -10,26 +13,29 @@ export class SelectAll {
   constructor(quill: Quill, options: StringMap) {
     // Get the text component
     const textComponent: TextComponent = options.textComponent;
+    const destroyRef: DestroyRef = options.destroyRef;
 
     // Tracks the last Quill selection to avoid repetition/looping
     let lastRange: Range | null = quill.getSelection();
 
     // Monitor the browser's selectionchange event from the document
-    document.addEventListener('selectionchange', () => {
-      // Ignore if the request is from another text box such as Add/Edit Answer, Biblical Terms, or Update Your Name
-      const sel: Selection | null = document.getSelection();
-      if (!sel || sel.rangeCount === 0 || !quill.root.contains(sel.getRangeAt(0).startContainer)) {
-        lastRange = null;
-        return;
-      }
+    fromEvent<Event>(document, 'selectionchange')
+      .pipe(quietTakeUntilDestroyed(destroyRef))
+      .subscribe(() => {
+        // Ignore if the request is from another text box such as Add/Edit Answer, Biblical Terms, or Update Your Name
+        const sel: Selection | null = document.getSelection();
+        if (!sel || sel.rangeCount === 0 || !quill.root.contains(sel.getRangeAt(0).startContainer)) {
+          lastRange = null;
+          return;
+        }
 
-      // Only emit to Quill (and the onSelectionChanged handler in TextComponent) if the selection has actually changed
-      const quillRange: Range = quill.getSelection(true);
-      if (!lastRange || quillRange.index !== lastRange.index || quillRange.length !== lastRange.length) {
-        quill.emitter.emit('selection-change', quillRange, lastRange, 'user');
-        lastRange = quillRange;
-      }
-    });
+        // Only emit to Quill (and the onSelectionChanged handler in TextComponent) if the selection has actually changed
+        const quillRange: Range = quill.getSelection(true);
+        if (!lastRange || quillRange.index !== lastRange.index || quillRange.length !== lastRange.length) {
+          quill.emitter.emit('selection-change', quillRange, lastRange, 'user');
+          lastRange = quillRange;
+        }
+      });
 
     // Do not allow selection to move beyond the segment
     let updatingSelection = false;
@@ -41,7 +47,7 @@ export class SelectAll {
       if (!range) return; // lost focus
 
       // If there is no text selected, we do not need to modify the selection
-      const text = quill.getText(range.index, range.length);
+      const text: string = quill.getText(range.index, range.length);
       if (text.length === 0) return;
 
       // If the selection is valid with in the segment, we do not need to modify it
@@ -50,8 +56,10 @@ export class SelectAll {
       updatingSelection = true;
 
       // Do not allow selecting further than the current segment
-      const length =
-        (textComponent.segment?.range.index ?? 0) + (textComponent.segment?.range.length ?? 0) - range.index;
+      const length: number =
+        textComponent.segment == null
+          ? 0
+          : textComponent.segment.range.index + textComponent.segment?.range.length - range.index;
       quill.setSelection(range.index, length, 'silent');
 
       updatingSelection = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/select-all.ts
@@ -22,16 +22,23 @@ export class SelectAll {
     fromEvent<Event>(document, 'selectionchange')
       .pipe(quietTakeUntilDestroyed(destroyRef))
       .subscribe(() => {
-        // Ignore if the request is from another text box such as Add/Edit Answer, Biblical Terms, or Update Your Name
+        // Ignore if the request is from another text box such as Add/Edit Answer, Biblical Terms, or Update Your Name;
+        // Or if it is from a readonly editor
         const sel: Selection | null = document.getSelection();
-        if (!sel || sel.rangeCount === 0 || !quill.root.contains(sel.getRangeAt(0).startContainer)) {
+        if (
+          !sel ||
+          sel.rangeCount === 0 ||
+          !quill.root.contains(sel.getRangeAt(0).startContainer) ||
+          !quill.isEnabled()
+        ) {
           lastRange = null;
           return;
         }
 
         // Only emit to Quill (and the onSelectionChanged handler in TextComponent) if the selection has actually changed
         const quillRange: Range = quill.getSelection(true);
-        if (!lastRange || quillRange.index !== lastRange.index || quillRange.length !== lastRange.length) {
+        if (quillRange == null) return;
+        if (lastRange == null || quillRange.index !== lastRange.index || quillRange.length !== lastRange.length) {
           quill.emitter.emit('selection-change', quillRange, lastRange, 'user');
           lastRange = quillRange;
         }
@@ -43,8 +50,9 @@ export class SelectAll {
       // Prevent infinite loops
       if (updatingSelection) return;
 
-      // No range = lost focus
+      // No range or segment = lost focus
       if (!range) return; // lost focus
+      if (textComponent.segment == null) return;
 
       // If there is no text selected, we do not need to modify the selection
       const text: string = quill.getText(range.index, range.length);
@@ -53,18 +61,12 @@ export class SelectAll {
       // If the selection is valid with in the segment, we do not need to modify it
       if (textComponent.isValidSelectionForCurrentSegment(range)) return;
 
-      updatingSelection = true;
-
       // Do not allow selecting before or further than the current segment
-      let index: number = 0;
-      let length: number = 0;
-      if (textComponent.segment != null) {
-        index = range.index < textComponent.segment.range.index ? textComponent.segment.range.index : range.index;
-        length = textComponent.segment.range.index + textComponent.segment?.range.length - range.index;
-      }
+      const newRange: Range | null = textComponent.conformToValidSelectionForCurrentSegment(range);
+      if (newRange == null) return;
 
-      quill.setSelection(index, length, 'silent');
-
+      updatingSelection = true;
+      quill.setSelection(newRange.index, newRange.length, 'silent');
       updatingSelection = false;
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -2067,8 +2067,8 @@ class TestEnvironment {
       keyCode = 'Delete';
       handler = 'handleDeleteWord';
     }
-    const matchingBindings = (this.component.editor!.keyboard as any).bindings[keyCode].filter((bindingItem: any) =>
-      bindingItem.handler.toString().includes(handler)
+    const matchingBindings = (this.component.editor!.keyboard as any).bindings[keyCode].filter(
+      (bindingItem: any) => !bindingItem.altKey && bindingItem.handler.toString().includes(handler)
     );
     expect(matchingBindings.length)
       .withContext('setup: should be grabbing a single, specific binding in quill with the desired handler')

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -2083,7 +2083,9 @@ class TestEnvironment {
     const cutKeyCode = 'x';
     const matchingBindings = (this.component.editor!.keyboard as any).bindings[cutKeyCode].filter(
       (bindingItem: any) =>
-        (bindingItem.ctrlKey || bindingItem.metaKey) && bindingItem.handler.toString().includes('isDeleteAllowed')
+        (bindingItem.ctrlKey || bindingItem.metaKey) &&
+        !bindingItem.shiftKey &&
+        bindingItem.handler.toString().includes('isDeleteAllowed')
     );
     expect(matchingBindings.length)
       .withContext('setup: should be grabbing a single, specific binding in quill with the desired handler')
@@ -2097,7 +2099,7 @@ class TestEnvironment {
   quillHandleDelete(range: QuillRange): boolean {
     const deleteKeyCode = 'Delete';
     const matchingBindings = (this.component.editor!.keyboard as any).bindings[deleteKeyCode].filter(
-      (bindingItem: any) => bindingItem.handler.toString().includes('isDeleteAllowed')
+      (bindingItem: any) => !bindingItem.shiftKey && bindingItem.handler.toString().includes('isDeleteAllowed')
     );
     expect(matchingBindings.length)
       .withContext('setup: should be grabbing a single, specific binding in quill with the desired handler')

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -240,6 +240,28 @@ export class TextComponent implements AfterViewInit, OnDestroy {
             return true;
           }
         },
+        'selection move next, segment end, right arrow': {
+          key: 'ArrowRight',
+          shiftKey: true,
+          handler: () => {
+            // Do not allow the user to move out of the current segment if holding down the shift key
+            if ((this.isLtr && this.isSelectionAtSegmentEnd) || (this.isRtl && this.isSelectionAtSegmentStart)) {
+              return false;
+            }
+            return true;
+          }
+        },
+        'selection move next, segment end, left arrow': {
+          key: 'ArrowLeft',
+          shiftKey: true,
+          handler: () => {
+            // Do not allow the user to move out of the current segment if holding down the shift key
+            if ((this.isRtl && this.isSelectionAtSegmentEnd) || (this.isLtr && this.isSelectionAtSegmentStart)) {
+              return false;
+            }
+            return true;
+          }
+        },
         redo: {
           key: 'y',
           shortKey: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -176,7 +176,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         },
         'disable backspace word': {
           key: 'Backspace',
-          ctrlKey: true,
+          shortKey: true,
           handler: (range: Range) => this.handleBackspaceWord(range)
         },
         'disable delete': {
@@ -185,7 +185,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         },
         'disable delete word': {
           key: 'Delete',
-          ctrlKey: true,
+          shortKey: true,
           handler: (range: Range) => this.handleDeleteWord(range)
         },
         'disable enter': {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -179,6 +179,11 @@ export class TextComponent implements AfterViewInit, OnDestroy {
           shortKey: true,
           handler: (range: Range) => this.handleBackspaceWord(range)
         },
+        'disable backspace word on mac': {
+          key: 'Backspace',
+          altKey: true,
+          handler: (range: Range) => this.handleBackspaceWord(range)
+        },
         'disable delete': {
           key: 'Delete',
           handler: (range: Range) => this.isDeleteAllowed(range)
@@ -191,6 +196,11 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         'disable delete word': {
           key: 'Delete',
           shortKey: true,
+          handler: (range: Range) => this.handleDeleteWord(range)
+        },
+        'disable delete word on mac': {
+          key: 'Delete',
+          altKey: true,
           handler: (range: Range) => this.handleDeleteWord(range)
         },
         'disable enter': {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -289,7 +289,8 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       userOnly: true
     },
     clipboard: { textComponent: this },
-    dragAndDrop: {}
+    dragAndDrop: {},
+    selectAll: {}
   };
   private _id?: TextDocId;
   private _isRightToLeft: boolean = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -255,28 +255,6 @@ export class TextComponent implements AfterViewInit, OnDestroy {
             return true;
           }
         },
-        'selection move next, segment end, right arrow': {
-          key: 'ArrowRight',
-          shiftKey: true,
-          handler: () => {
-            // Do not allow the user to move out of the current segment if holding down the shift key
-            if ((this.isLtr && this.isSelectionAtSegmentEnd) || (this.isRtl && this.isSelectionAtSegmentStart)) {
-              return false;
-            }
-            return true;
-          }
-        },
-        'selection move next, segment end, left arrow': {
-          key: 'ArrowLeft',
-          shiftKey: true,
-          handler: () => {
-            // Do not allow the user to move out of the current segment if holding down the shift key
-            if ((this.isRtl && this.isSelectionAtSegmentEnd) || (this.isLtr && this.isSelectionAtSegmentStart)) {
-              return false;
-            }
-            return true;
-          }
-        },
         redo: {
           key: 'y',
           shortKey: true,
@@ -1903,7 +1881,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
   /** Given a selection, return a possibly modified selection that is a valid for editing the current segment.
    * For example, a selection over a segment boundary is sometimes not valid. */
-  private conformToValidSelectionForCurrentSegment(sel: Range): Range | null {
+  conformToValidSelectionForCurrentSegment(sel: Range): Range | null {
     if (this._editor == null || this._segment == null) {
       return null;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -183,6 +183,11 @@ export class TextComponent implements AfterViewInit, OnDestroy {
           key: 'Delete',
           handler: (range: Range) => this.isDeleteAllowed(range)
         },
+        'disable delete holding down shift': {
+          key: 'Delete',
+          shiftKey: true,
+          handler: (range: Range) => this.isDeleteAllowed(range)
+        },
         'disable delete word': {
           key: 'Delete',
           shortKey: true,
@@ -290,7 +295,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     },
     clipboard: { textComponent: this },
     dragAndDrop: {},
-    selectAll: {}
+    selectAll: { textComponent: this }
   };
   private _id?: TextDocId;
   private _isRightToLeft: boolean = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -275,6 +275,12 @@ export class TextComponent implements AfterViewInit, OnDestroy {
           key: 'x',
           shortKey: true,
           handler: (range: Range) => this.isDeleteAllowed(range)
+        },
+        'cut from menu while holding down shift': {
+          key: 'x',
+          shortKey: true,
+          shiftKey: true,
+          handler: (range: Range) => this.isDeleteAllowed(range)
         }
       }
     },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -295,7 +295,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     },
     clipboard: { textComponent: this },
     dragAndDrop: {},
-    selectAll: { textComponent: this }
+    selectAll: { textComponent: this, destroyRef: this.destroyRef }
   };
   private _id?: TextDocId;
   private _isRightToLeft: boolean = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1945,6 +1945,7 @@ describe('EditorComponent', () => {
       const length = 3;
       const noteEmbedLength = 1;
       let notePosition = env.getNoteThreadEditorPosition('dataid01');
+      env.targetEditor.setSelection(notePosition); // Emulate mouse click into segment
       env.targetEditor.setSelection(notePosition - length, length, 'user');
       env.deleteCharacters();
       expect(noteThreadDoc.data!.position).toEqual({ start: 8 - length, length: 9 });
@@ -2049,6 +2050,7 @@ describe('EditorComponent', () => {
       const position: number = env.getNoteThreadEditorPosition('dataid03');
       const length = 9;
       // $target: chapter 1, |->$$verse 3<-|.
+      env.targetEditor.setSelection(position); // Emulate mouse click into segment
       env.targetEditor.setSelection(position, length, 'api');
       env.deleteCharacters();
       const range: Range = env.component.target!.getSegmentRange('verse_1_3')!;
@@ -2073,6 +2075,7 @@ describe('EditorComponent', () => {
       env.wait();
 
       // 1 target: $chapter|-> 1, $ve<-|rse 1.
+      env.targetEditor.setSelection(19); // Emulate mouse click into segment
       env.targetEditor.setSelection(19, 7, 'user');
       env.deleteCharacters();
       const note1 = env.getNoteThreadDoc('project01', 'dataid01');
@@ -2109,6 +2112,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: 8, length: 9 });
       // delete text that spans across the end boundary
       const notePosition = env.getNoteThreadEditorPosition('dataid01');
+      env.targetEditor.setSelection(notePosition); // Emulate mouse click into segment
       const deletionLength = 10;
       const noteEmbedLength: number = 1;
       // Arbitrary text position within thread anchoring, at which to start deleting.
@@ -2171,6 +2175,7 @@ describe('EditorComponent', () => {
 
       // delete the entire text anchor
       let notePosition = env.getNoteThreadEditorPosition('dataid01');
+      env.targetEditor.setSelection(notePosition); // Emulate mouse click into segment
       let length = 9;
       env.targetEditor.setSelection(notePosition + 1, length, 'user');
       env.deleteCharacters();
@@ -2181,6 +2186,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual({ start: 20, length: 7 });
       notePosition = env.getNoteThreadEditorPosition('dataid03');
       length = 8;
+      env.targetEditor.setSelection(notePosition); // Emulate mouse click into segment
       env.targetEditor.setSelection(notePosition + 1, length, 'user');
       env.deleteCharacters();
       expect(noteThreadDoc.data!.position).toEqual({ start: 0, length: 0 });
@@ -2275,6 +2281,7 @@ describe('EditorComponent', () => {
       expect(noteThreadDoc.data!.position).toEqual(origNoteAnchor);
 
       const notePosition: number = env.getNoteThreadEditorPosition('dataid01');
+      env.targetEditor.setSelection(notePosition); // Emulate mouse click into segment
       const deleteStart: number = notePosition + 1;
       const text = 'chap';
 
@@ -2354,6 +2361,7 @@ describe('EditorComponent', () => {
       expect(env.getNoteThreadEditorPosition('dataid05')).toEqual(verse4p1Index);
       // user deletes all of the text in segment before
       const range = env.component.target!.getSegmentRange('verse_1_4')!;
+      env.targetEditor.setSelection(range.index); // Emulate mouse click into segment
       env.targetEditor.setSelection(range.index, range.length, 'user');
       env.deleteCharacters();
       expect(noteThreadDoc.data!.position).toEqual({ start: 2, length: 9 });
@@ -2637,6 +2645,7 @@ describe('EditorComponent', () => {
       expect(textDoc.data!.ops![3].insert).toEqual('target: chapter 1, verse 1.');
       const note1Position: number = env.getNoteThreadEditorPosition('dataid01');
       // target: |->$<-|chapter 1, $verse 1.
+      env.targetEditor.setSelection(note1Position); // Emulate mouse click into segment
       env.targetEditor.setSelection(note1Position, 1, 'user');
       env.deleteCharacters();
       const positionAfterDelete: number = env.getNoteThreadEditorPosition('dataid01');
@@ -2706,6 +2715,7 @@ describe('EditorComponent', () => {
       const note4Position: number = env.getNoteThreadEditorPosition('dataid04');
       deleteLength = 6;
       // $target: chapter 1|->, $$ve<-|rse 3.
+      env.targetEditor.setSelection(note3Position); // Emulate mouse click into segment
       env.targetEditor.setSelection(note3Position - beforeNoteLength, deleteLength, 'api');
       env.deleteCharacters();
       newNotePosition = env.getNoteThreadEditorPosition('dataid03');


### PR DESCRIPTION
This PR updates our use of Quill to restrict selecting all, and selecting more than the current verse, especially when those actions involve overwriting, cutting, or deleting characters across segments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3791)
<!-- Reviewable:end -->
