### PR TITLE
Fix contrast for failed message on sync page in dark theme

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/_sync-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/_sync-theme.scss
@@ -1,0 +1,13 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-sync-last-attempt-unsuccessful-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 70, 40))};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/_sync-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/_sync-theme.scss
@@ -3,7 +3,7 @@
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
-  --sf-sync-last-attempt-unsuccessful-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 70, 40))};
+  --sf-sync-warning-message-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 70, 40))};
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -77,5 +77,5 @@ app-sync-progress {
 #sync-disabled-message,
 #sync-failure-support-message {
   max-width: 40rem;
-  color: var(--sf-sync-last-attempt-unsuccessful-color);
+  color: var(--sf-sync-warning-message-color);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -77,5 +77,5 @@ app-sync-progress {
 #sync-disabled-message,
 #sync-failure-support-message {
   max-width: 40rem;
-  color: variables.$lighterTextColor;
+  color: var(--sf-sync-last-attempt-unsuccessful-color);
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -17,6 +17,7 @@
 @use 'src/app/shared/book-multi-select/book-multi-select-theme' as sf-book-multi-select;
 @use 'src/app/shared/json-viewer/json-viewer-theme' as sf-json-viewer;
 @use 'src/app/shared/audio-recorder-dialog/audio-recorder-dialog-theme' as sf-audio-recorder-dialog;
+@use 'src/app/sync/sync-theme' as sf-sync;
 @use 'src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps-theme' as
   sf-draft-generation-steps;
 @use 'src/app/translate/draft-generation/confirm-sources/confirm-sources-theme' as sf-confirm-sources;
@@ -87,6 +88,7 @@
   @include sf-draft-jobs.theme($theme);
   @include sf-job-details-dialog.theme($theme);
   @include sf-onboarding-requests.theme($theme);
+  @include sf-sync.theme($theme);
 
   // Custom variables
   --sf-disabled-foreground: #{mat.get-theme-color($theme, neutral, 70)};


### PR DESCRIPTION
This came up in a user report. I have implemented material theming for the sync page.

Before
<img width="719" height="330" alt="Dark theme sync before" src="https://github.com/user-attachments/assets/f47cc2ec-a10e-45ab-bb5b-4b23db2ed25d" />

After
<img width="742" height="345" alt="Dark theme sync after" src="https://github.com/user-attachments/assets/b2b54f78-5826-4cdc-9c83-9e1f06668539" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3794)
<!-- Reviewable:end -->
