### PR TITLE
Pre-fill language code in onboarding form

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
@@ -163,6 +163,10 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
       })
       .catch(err => console.error('Error loading user:', err));
 
+    this.signupForm.controls.translationLanguageIsoCode.setValue(
+      this.activatedProject.projectDoc?.data?.writingSystem.tag ?? ''
+    );
+
     // Load available projects and resources
     void this.loadProjectsAndResources();
 


### PR DESCRIPTION
Pre-filling the language code was decided upon this in a meeting this morning. This allows the user to edit it in case it might be incorrect, but helps reduce user confusion (a lot of submissions have been completely incorrect).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3795)
<!-- Reviewable:end -->
