### PR TITLE
Fix loading indicator diagnostics

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -140,7 +140,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     onlineStatusService: OnlineStatusService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'AppComponent');
     this.breakpointObserver
       .observe(this.breakpointService.width('>', Breakpoint.LG))
       .pipe(quietTakeUntilDestroyed(this.destroyRef))

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -105,7 +105,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
     private readonly onlineStatusService: OnlineStatusService,
     private readonly l10nNumberPipe: L10nNumberPipe
   ) {
-    super(noticeService);
+    super(noticeService, 'CheckingOverviewComponent');
   }
 
   get showQuestionsLoadingMessage(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.ts
@@ -219,7 +219,7 @@ export class CheckingComponent extends DataLoadingComponent implements OnInit, A
     private readonly onlineStatusService: OnlineStatusService,
     private readonly chapterAudioDialogService: ChapterAudioDialogService
   ) {
-    super(noticeService);
+    super(noticeService, 'CheckingComponent');
   }
 
   get activeQuestionVerseRef(): VerseRef | undefined {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/connect-project/connect-project.component.ts
@@ -82,7 +82,7 @@ export class ConnectProjectComponent extends DataLoadingComponent implements OnI
     private readonly translocoService: TranslocoService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'ConnectProjectComponent');
     this.connectProjectForm.disable();
     this.projectMetadata = {
       paratextId: this.router.currentNavigation()?.extras.state?.paratextId ?? '',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/event-metrics/event-metrics-log.component.ts
@@ -101,7 +101,7 @@ export class EventMetricsLogComponent extends DataLoadingComponent implements On
     private readonly projectService: SFProjectService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'EventMetricsLogComponent');
   }
 
   get isLoading(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -77,7 +77,7 @@ export class JoinComponent extends DataLoadingComponent {
     noticeService: NoticeService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'JoinComponent');
     const joining$ = this.route.params.pipe(
       map(params => ({
         shareKey: params['shareKey'] as string,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/project/project.component.ts
@@ -31,7 +31,7 @@ export class ProjectComponent extends DataLoadingComponent implements OnInit {
     noticeService: NoticeService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'ProjectComponent');
   }
 
   async ngOnInit(): Promise<void> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -181,7 +181,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     private readonly destroyRef: DestroyRef,
     private readonly exportService: DraftJobsExportService
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftJobsComponent');
   }
 
   get isLoading(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -93,7 +93,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     private readonly dialogService: DialogService,
     protected readonly noticeService: NoticeService
   ) {
-    super(noticeService, 'DraftRequestDetailComponent');
+    super(noticeService, 'OnboardingRequestDetailComponent');
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -93,7 +93,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     private readonly dialogService: DialogService,
     protected readonly noticeService: NoticeService
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftRequestDetailComponent');
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
@@ -111,7 +111,7 @@ export class OnboardingRequestsComponent extends DataLoadingComponent implements
     private readonly servalAdministrationService: ServalAdministrationService,
     private readonly onboardingRequestService: OnboardingRequestService
   ) {
-    super(noticeService);
+    super(noticeService, 'OnboardingRequestsComponent');
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -175,7 +175,7 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
     private readonly servalAdministrationService: ServalAdministrationService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'ServalProjectComponent');
   }
 
   get eventLogLink(): string[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -127,7 +127,7 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
     private readonly servalAdministrationService: ServalAdministrationService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'ServalProjectsComponent');
     this.searchTerm$ = new BehaviorSubject<string>('');
     this.queryParameters$ = new BehaviorSubject<QueryParameters>(this.getQueryParameters());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -142,7 +142,7 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
     private readonly activatedProjectService: ActivatedProjectService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'SettingsComponent');
     this.loading = true;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -60,7 +60,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
     private readonly authService: AuthService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'SyncComponent');
   }
 
   get isLoggedIntoParatext(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.ts
@@ -259,7 +259,7 @@ export class BiblicalTermsComponent extends DataLoadingComponent implements OnDe
     private readonly projectService: SFProjectService,
     private readonly userService: UserService
   ) {
-    super(noticeService);
+    super(noticeService, 'BiblicalTermsComponent');
   }
 
   @Input() set bookNum(bookNum: number | undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -182,7 +182,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly projectService: SFProjectService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftGenerationComponent');
   }
 
   get hasAnyCompletedBuild(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
@@ -141,7 +141,7 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
     private readonly cd: ChangeDetectorRef,
     private readonly i18n: I18nService
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftOnboardingFormComponent');
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -126,7 +126,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
     private readonly errorReportingService: ErrorReportingService,
     private readonly fileService: FileService
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftSourcesComponent');
   }
 
   ngOnInit(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -117,7 +117,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
     private readonly location: Location,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'DraftUsfmFormatComponent');
     this.activatedProjectService.projectId$
       .pipe(filterNullish(), first(), quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(async projectId => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -382,7 +382,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     private readonly permissionsService: PermissionsService,
     readonly editorInsightState: LynxInsightStateService
   ) {
-    super(noticeService);
+    super(noticeService, 'EditorComponent');
     const wordTokenizer = new LatinWordTokenizer();
     this.sourceWordTokenizer = wordTokenizer;
     this.targetWordTokenizer = wordTokenizer;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/training-progress/training-progress.component.ts
@@ -44,7 +44,7 @@ export class TrainingProgressComponent extends DataLoadingComponent implements O
     private destroyRef: DestroyRef,
     private readonly i18n: I18nService
   ) {
-    super(noticeService);
+    super(noticeService, 'TrainingProgressComponent');
   }
 
   @Input() set projectId(id: string | undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -104,7 +104,7 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
     readonly i18n: I18nService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'TranslateOverviewComponent');
     this.engineQualityStars = [];
     for (let i = 0; i < ENGINE_QUALITY_STAR_COUNT; i++) {
       this.engineQualityStars.push(i);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/users/collaborators/collaborators.component.ts
@@ -104,7 +104,7 @@ export class CollaboratorsComponent extends DataLoadingComponent implements OnIn
     readonly urls: ExternalUrlService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'CollaboratorsComponent');
   }
 
   get isLoading(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/data-loading-component.ts
@@ -6,6 +6,10 @@ import { NoticeService } from './notice.service';
  * This is the abstract base class for components that need to indicate when they are loading data in order to display
  * the loading indicator. Subclasses call `loadingStarted()` and `loadingFinished()` to indicate when they are loading
  * data. When the component is destroyed, it automatically calls `loadingFinished()`.
+ *
+ * Subclasses must pass their class name as a string literal to the `callerName` parameter, e.g.
+ * `super(noticeService, 'MyComponent')`. This is required because `this.constructor.name` is unreliable at runtime due
+ * to minification.
  */
 // Decorator required by Angular compiler
 @Directive()
@@ -13,7 +17,10 @@ export abstract class DataLoadingComponent implements OnDestroy {
   private _isLoading$ = new BehaviorSubject<boolean>(false);
   private _isLoaded$ = new BehaviorSubject<boolean>(false);
 
-  constructor(protected readonly noticeService: NoticeService) {}
+  constructor(
+    protected readonly noticeService: NoticeService,
+    private readonly callerName: string
+  ) {}
 
   get isLoadingData$(): Observable<boolean> {
     return this._isLoading$.asObservable();
@@ -37,7 +44,7 @@ export abstract class DataLoadingComponent implements OnDestroy {
 
   protected loadingStarted(): void {
     if (!this.isLoadingData) {
-      this.noticeService.loadingStarted(this.constructor.name);
+      this.noticeService.loadingStarted(this.callerName);
       this._isLoading$.next(true);
       this._isLoaded$.next(false);
     }
@@ -45,7 +52,7 @@ export abstract class DataLoadingComponent implements OnDestroy {
 
   protected loadingFinished(): void {
     if (this.isLoadingData) {
-      this.noticeService.loadingFinished(this.constructor.name);
+      this.noticeService.loadingFinished(this.callerName);
       this._isLoading$.next(false);
       this._isLoaded$.next(true);
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-projects.component.ts
@@ -108,7 +108,7 @@ export class SaProjectsComponent extends DataLoadingComponent implements OnInit 
     private readonly userService: UserService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'SaProjectsComponent');
     this.searchTerm$ = new BehaviorSubject<string>('');
     this.queryParameters$ = new BehaviorSubject<QueryParameters>(this.getQueryParameters());
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/system-administration/sa-users.component.ts
@@ -77,7 +77,7 @@ export class SaUsersComponent extends DataLoadingComponent implements OnInit {
     private readonly projectService: ProjectService,
     private destroyRef: DestroyRef
   ) {
-    super(noticeService);
+    super(noticeService, 'SaUsersComponent');
   }
 
   get currentUserId(): string {


### PR DESCRIPTION
The loading indicator is often broken. The diagnostics panel tries to help us investigate this by showing what components are causing the loading indicator to be displayed. However, the reliance on `this.constructor.name` causes it to fail in production (and in recent Angular versions, it's pretty useless in dev as well):

<img width="586" height="108" alt="Screenshot from 2026-04-14 17-10-06" src="https://github.com/user-attachments/assets/4ac4bde4-e407-46dc-911f-852bc76768b8" />

This PR fixes it, albeit in a way that isn't the most elegant, due to the amount of hard-coding.
<img width="583" height="304" alt="Screenshot from 2026-04-14 18-13-23" src="https://github.com/user-attachments/assets/6eb9c86f-9d17-47e9-aedb-fe4b8b22c17a" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3797)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
