### PR TITLE
SF-3778 Fix question overview page showing stale stats

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.spec.ts
@@ -10,6 +10,7 @@ import { saveAs } from 'file-saver';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { User } from 'realtime-server/lib/esm/common/models/user';
 import { createTestUser } from 'realtime-server/lib/esm/common/models/user-test-data';
+import { Answer } from 'realtime-server/lib/esm/scriptureforge/models/answer';
 import {
   getQuestionDocId,
   Question,
@@ -193,6 +194,38 @@ describe('CheckingOverviewComponent', () => {
       env.waitForProjectDocChanges();
 
       expect(env.component.getQuestionDocs(new TextDocId('project01', 42, 1)).length).toEqual(numQuestions + 1);
+    }));
+
+    it('should show new answer count after remote change', fakeAsync(async () => {
+      const env = new TestEnvironment();
+      env.waitForQuestions();
+
+      const dateNow = new Date();
+      const newAnswer: Answer = {
+        dataId: 'newAId1',
+        ownerRef: env.checkerUser.id,
+        text: 'Checker answer',
+        dateCreated: dateNow.toJSON(),
+        dateModified: dateNow.toJSON(),
+        deleted: false,
+        likes: [],
+        comments: []
+      };
+
+      expect(env.answerTotal).toContain('3');
+
+      const questionDoc: QuestionDoc = env.realtimeService.get(
+        QUESTIONS_COLLECTION,
+        getQuestionDocId('project01', 'q4Id')
+      );
+      await questionDoc.submitJson0Op(op => {
+        op.insert(d => d.answers, 0, newAnswer);
+      }, false);
+
+      tick();
+      env.fixture.detectChanges();
+
+      expect(env.answerTotal).toContain('4');
     }));
 
     it('should show question in canonical order', fakeAsync(() => {
@@ -1036,6 +1069,10 @@ class TestEnvironment {
 
   get noQuestionsLabel(): DebugElement {
     return this.fixture.debugElement.query(By.css('#no-questions-label'));
+  }
+
+  get answerTotal(): string {
+    return this.fixture.debugElement.query(By.css('.card-content-answer .stat-total')).nativeElement.textContent;
   }
 
   get textRows(): DebugElement[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -243,7 +243,8 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       this.dataChangesSub = merge(
         this.projectDoc.remoteChanges$,
         this.questionsQuery.remoteChanges$,
-        this.questionsQuery.localChanges$
+        this.questionsQuery.localChanges$,
+        this.questionsQuery.remoteDocChanges$
       )
         .pipe(quietTakeUntilDestroyed(this.destroyRef))
         // TODO Find a better solution than merely throttling remote changes


### PR DESCRIPTION
The change that introduced OnPush detection strategy revealed a hole subscribing to remote changes to question docs. This change adds a subscription to remoteDocChanges$ on the question query and updates the stats on the overview page in real-time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3799)
<!-- Reviewable:end -->
