### PR TITLE
Improve Serval admin book list

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/draft-request-detail-utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/draft-request-detail-utils.spec.ts
@@ -1,0 +1,60 @@
+import { formatBookListForSILNLP } from './draft-request-detail-utils';
+
+function createRange(start: number, end: number): number[] {
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+}
+
+describe('formatBookListForSILNLP', () => {
+  it('should format a list of books with all OT books as "OT"', () => {
+    const otBooks = createRange(1, 39);
+    const formatted = formatBookListForSILNLP(otBooks);
+    expect(formatted).toBe('OT');
+  });
+
+  it('should format a list of books with all NT books as "NT"', () => {
+    const ntBooks = createRange(40, 66);
+    const formatted = formatBookListForSILNLP(ntBooks);
+    expect(formatted).toBe('NT');
+  });
+
+  it('should format a mixed list of books correctly', () => {
+    const books = [1, 2, 40, 41, 50];
+    const formatted = formatBookListForSILNLP(books);
+    expect(formatted).toBe('GEN;EXO;MAT;MRK;PHP');
+  });
+
+  it('should format an empty list as an empty string', () => {
+    const formatted = formatBookListForSILNLP([]);
+    expect(formatted).toBe('');
+  });
+
+  it('should format a list with all OT and NT books as "OT;NT"', () => {
+    const allBooks = createRange(1, 66);
+    const formatted = formatBookListForSILNLP(allBooks);
+    expect(formatted).toBe('OT;NT');
+  });
+
+  it('should format a list with all OT books and some NT books as "OT;[NT books]"', () => {
+    const books = [...createRange(1, 39), 40, 41];
+    const formatted = formatBookListForSILNLP(books);
+    expect(formatted).toBe('OT;MAT;MRK');
+  });
+
+  it('should format a list with some OT books and all NT books as "[OT books];NT"', () => {
+    const books = [1, 2, ...createRange(40, 66)];
+    const formatted = formatBookListForSILNLP(books);
+    expect(formatted).toBe('GEN;EXO;NT');
+  });
+
+  it('should format a list with duplicate books by removing duplicates', () => {
+    const books = [1, 1, 2, 2, 40, 40];
+    const formatted = formatBookListForSILNLP(books);
+    expect(formatted).toBe('GEN;EXO;MAT');
+  });
+
+  it('should sort the books in the output', () => {
+    const books = [40, 1, 41, 2];
+    const formatted = formatBookListForSILNLP(books);
+    expect(formatted).toBe('GEN;EXO;MAT;MRK');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/draft-request-detail-utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/draft-request-detail-utils.ts
@@ -1,0 +1,29 @@
+import { Canon } from '@sillsdev/scripture';
+
+const OT_RANGE = [1, 39];
+const NT_RANGE = [40, 66];
+
+function isOTBook(book: number): boolean {
+  return book >= OT_RANGE[0] && book <= OT_RANGE[1];
+}
+
+function isNTBook(book: number): boolean {
+  return book >= NT_RANGE[0] && book <= NT_RANGE[1];
+}
+
+export function formatBookListForSILNLP(value: number[]): string {
+  const bookList = Array.from(new Set(value)).sort((a, b) => a - b); // Remove duplicates and sort
+  const otBooks = bookList.filter(isOTBook);
+  const ntBooks = bookList.filter(isNTBook);
+  const otherBooks = bookList.filter(book => !isOTBook(book) && !isNTBook(book));
+
+  const hasEntireOT = otBooks.length === OT_RANGE[1] - OT_RANGE[0] + 1;
+  const hasEntireNT = ntBooks.length === NT_RANGE[1] - NT_RANGE[0] + 1;
+
+  const formattedBooks: string[] = [];
+  formattedBooks.push(...(hasEntireOT ? ['OT'] : otBooks.map(book => Canon.bookNumberToId(book))));
+  formattedBooks.push(...(hasEntireNT ? ['NT'] : ntBooks.map(book => Canon.bookNumberToId(book))));
+  formattedBooks.push(...otherBooks.map(book => Canon.bookNumberToId(book)));
+
+  return formattedBooks.join(';');
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
@@ -175,10 +175,16 @@
         <div class="info-row">
           <span class="label">Completed books:</span>
           <span class="value book-list">{{ formatBookList(formData.completedBooks) }}</span>
+          <button mat-icon-button (click)="copyBookList(formData.completedBooks)" matTooltip="Copy book list">
+            <mat-icon>content_copy</mat-icon>
+          </button>
         </div>
         <div class="info-row">
           <span class="label">Planned books to draft:</span>
           <span class="value book-list">{{ formatBookList(formData.nextBooksToDraft) }}</span>
+          <button mat-icon-button (click)="copyBookList(formData.nextBooksToDraft)" matTooltip="Copy book list">
+            <mat-icon>content_copy</mat-icon>
+          </button>
         </div>
       </mat-card-content>
     </mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -13,8 +13,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Canon } from '@sillsdev/scripture';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
@@ -41,6 +41,7 @@ import {
   OnboardingRequestService
 } from '../../translate/draft-generation/onboarding-request.service';
 import { ServalAdministrationService } from '../serval-administration.service';
+import { formatBookListForSILNLP } from './draft-request-detail-utils';
 
 /**
  * Component for displaying a single onboarding request's full details.
@@ -71,7 +72,8 @@ import { ServalAdministrationService } from '../serval-administration.service';
     MatFormFieldModule,
     MatInputModule,
     MobileNotSupportedComponent,
-    NoticeComponent
+    NoticeComponent,
+    MatTooltipModule
   ]
 })
 export class OnboardingRequestDetailComponent extends DataLoadingComponent implements OnInit {
@@ -251,7 +253,14 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
   }
 
   formatBookList(value: number[] | undefined): string {
-    return value?.map(b => Canon.bookNumberToId(b)).join(';') ?? '';
+    return value == null ? '' : formatBookListForSILNLP(value);
+  }
+
+  /** Copies the formatted book list to the clipboard. */
+  async copyBookList(books: number[] | undefined): Promise<void> {
+    const text: string = this.formatBookList(books);
+    await navigator.clipboard.writeText(text);
+    this.noticeService.show('Book list copied to clipboard');
   }
 
   getZipFileNames(): string[] {


### PR DESCRIPTION
The EITL team requested that when a project specifies all NT or all OT books, instead of listing them, just put NT or OT. SILNLP apparently accepts this as a valid book range.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3801)
<!-- Reviewable:end -->
