### PR TITLE
SF-3761 Enable navigating to drafted books missing from the project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.html
@@ -1,11 +1,6 @@
 <ng-container *transloco="let t; read: 'draft_preview_books'">
   @for (book of booksWithDrafts$ | async; track book.bookId) {
-    <button
-      mat-stroked-button
-      class="draft-book-button"
-      [disabled]="book.chaptersWithDrafts.length === 0"
-      (click)="navigate(book)"
-    >
+    <button mat-stroked-button class="draft-book-button" (click)="navigate(book)">
       {{ "canon.book_names." + book.bookId | transloco }}
     </button>
   } @empty {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.spec.ts
@@ -8,18 +8,12 @@ import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/model
 import { of, Subscription } from 'rxjs';
 import { anything, capture, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
-import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
-import { SFProjectService } from '../../../core/sf-project.service';
 import { BuildDto } from '../../../machine-api/build-dto';
-import { BookWithDraft, DraftPreviewBooksComponent } from './draft-preview-books.component';
+import { DraftPreviewBooksComponent } from './draft-preview-books.component';
 
 const mockedActivatedProjectService = mock(ActivatedProjectService);
-const mockedProjectService = mock(SFProjectService);
-const mockedUserService = mock(UserService);
-const mockedErrorReportingService = mock(ErrorReportingService);
 const mockedRouter = mock(Router);
 
 describe('DraftPreviewBooks', () => {
@@ -29,9 +23,6 @@ describe('DraftPreviewBooks', () => {
     imports: [getTestTranslocoModule()],
     providers: [
       { provide: ActivatedProjectService, useMock: mockedActivatedProjectService },
-      { provide: SFProjectService, useMock: mockedProjectService },
-      { provide: UserService, useMock: mockedUserService },
-      { provide: ErrorReportingService, useMock: mockedErrorReportingService },
       { provide: Router, useMock: mockedRouter }
     ]
   }));
@@ -42,24 +33,45 @@ describe('DraftPreviewBooks', () => {
 
   it('should show books for a build', fakeAsync(() => {
     env = new TestEnvironment({
-      additionalInfo: { translationScriptureRanges: [{ projectId: 'project01', scriptureRange: 'LEV' }] }
-    } as BuildDto);
+      build: {
+        additionalInfo: { translationScriptureRanges: [{ projectId: 'project01', scriptureRange: 'LEV' }] }
+      } as BuildDto
+    });
     expect(env.draftBookCount()).toEqual(1);
   }));
 
-  it('should show books for a project if no build', fakeAsync(() => {
+  it('should show books with drafts for a project if no build', fakeAsync(() => {
+    env = new TestEnvironment({ draftedScriptureRange: 'GEN;EXO' });
+    expect(env.draftBookCount()).toEqual(2);
+  }));
+
+  it('should show no books for a project with no drafts if no build', fakeAsync(() => {
     env = new TestEnvironment();
-    expect(env.draftBookCount()).toEqual(3);
+    expect(env.draftBookCount()).toEqual(0);
   }));
 
   it('can navigate to a specific book', fakeAsync(() => {
-    env = new TestEnvironment();
+    env = new TestEnvironment({ draftedScriptureRange: 'GEN' });
     env.getBookButtonAtIndex(0).click();
     tick();
     env.fixture.detectChanges();
     verify(mockedRouter.navigate(anything(), anything())).once();
     const [url, extras] = capture(mockedRouter.navigate).first();
     expect(url).toEqual(['/projects', 'project01', 'translate', 'GEN', '1']);
+    expect(extras).toEqual({
+      queryParams: { 'draft-active': true, 'draft-timestamp': undefined }
+    });
+  }));
+
+  it('can navigate to an empty target book', fakeAsync(() => {
+    const bookNotInProject = 'NUM';
+    env = new TestEnvironment({ draftedScriptureRange: bookNotInProject });
+    env.getBookButtonAtIndex(0).click();
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedRouter.navigate(anything(), anything())).once();
+    const [url, extras] = capture(mockedRouter.navigate).first();
+    expect(url).toEqual(['/projects', 'project01', 'translate', bookNotInProject, '1']);
     expect(extras).toEqual({
       queryParams: { 'draft-active': true, 'draft-timestamp': undefined }
     });
@@ -97,24 +109,19 @@ class TestEnvironment {
       ],
       userRoles: { user01: SFProjectRole.ParatextAdministrator, user02: SFProjectRole.ParatextTranslator },
       translateConfig: {
-        source: { projectRef: 'test' }
+        source: { projectRef: 'test' },
+        draftConfig: {}
       }
     })
   } as SFProjectProfileDoc;
 
-  booksWithDrafts: BookWithDraft[] = [
-    { bookNumber: 1, bookId: 'GEN', canEdit: true, chaptersWithDrafts: [1, 2, 3], draftApplied: false },
-    { bookNumber: 2, bookId: 'EXO', canEdit: true, chaptersWithDrafts: [1, 2], draftApplied: false },
-    { bookNumber: 3, bookId: 'LEV', canEdit: false, chaptersWithDrafts: [1, 2], draftApplied: false }
-  ];
-
-  constructor(build: BuildDto | undefined = undefined) {
+  constructor({ build, draftedScriptureRange }: { build?: BuildDto; draftedScriptureRange?: string } = {}) {
+    if (draftedScriptureRange != null) {
+      this.mockProjectDoc.data!.translateConfig.draftConfig.draftedScriptureRange = draftedScriptureRange;
+    }
     when(mockedActivatedProjectService.changes$).thenReturn(of(this.mockProjectDoc));
     when(mockedActivatedProjectService.projectDoc).thenReturn(this.mockProjectDoc);
     when(mockedActivatedProjectService.projectId).thenReturn('project01');
-    when(mockedUserService.currentUserId).thenReturn('user01');
-    when(mockedProjectService.hasDraft(anything(), anything())).thenReturn(true);
-    when(mockedProjectService.getProfile(anything())).thenResolve(this.mockProjectDoc);
     this.fixture = TestBed.createComponent(DraftPreviewBooksComponent);
     this.component = this.fixture.componentInstance;
     this.component.build = build;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.ts
@@ -5,21 +5,16 @@ import { Router } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { Canon } from '@sillsdev/scripture';
 import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { map, Observable, tap } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { UserService } from 'xforge-common/user.service';
 import { filterNullish } from 'xforge-common/util/rxjs-util';
-import { SFProjectService } from '../../../core/sf-project.service';
 import { BuildDto } from '../../../machine-api/build-dto';
 import { booksFromScriptureRange } from '../../../shared/utils';
 
 export interface BookWithDraft {
   bookNumber: number;
   bookId: string;
-  canEdit: boolean;
-  chaptersWithDrafts: number[];
-  draftApplied: boolean;
+  chaptersInBook: number[];
 }
 
 @Component({
@@ -40,18 +35,14 @@ export class DraftPreviewBooksComponent {
       }
       let draftBooks: BookWithDraft[];
       if (this.build == null) {
-        draftBooks = projectDoc.data.texts
-          .map(text => ({
-            bookNumber: text.bookNum,
-            bookId: Canon.bookNumberToId(text.bookNum),
-            canEdit: text.permissions[this.userService.currentUserId] === TextInfoPermission.Write,
-            chaptersWithDrafts: this.projectService.hasDraft(projectDoc.data, text.bookNum)
-              ? text.chapters.map(chapter => chapter.number)
-              : [],
-            draftApplied: text.chapters.every(chapter => chapter.draftApplied)
+        // show every book with generated drafts
+        draftBooks = booksFromScriptureRange(projectDoc.data.translateConfig.draftConfig.draftedScriptureRange)
+          .map(bookNum => ({
+            bookNumber: bookNum,
+            bookId: Canon.bookNumberToId(bookNum),
+            chaptersInBook: projectDoc.data?.texts.find(t => t.bookNum === bookNum)?.chapters.map(ch => ch.number) ?? []
           }))
-          .sort((a, b) => a.bookNumber - b.bookNumber)
-          .filter(book => book.chaptersWithDrafts.length > 0) as BookWithDraft[];
+          .sort((a, b) => a.bookNumber - b.bookNumber);
       } else {
         // TODO: Support books from multiple translation projects
         draftBooks = this.build.additionalInfo?.translationScriptureRanges
@@ -61,13 +52,9 @@ export class DraftPreviewBooksComponent {
             return {
               bookNumber: bookNum,
               bookId: Canon.bookNumberToId(bookNum),
-              canEdit: text?.permissions?.[this.userService.currentUserId] === TextInfoPermission.Write,
-              chaptersWithDrafts: text?.chapters?.map(ch => ch.number) ?? [],
-              draftApplied: text?.chapters?.every(ch => ch.draftApplied) ?? false
+              chaptersInBook: text?.chapters?.map(ch => ch.number) ?? []
             };
           })
-          // Do not filter chapters with drafts, as the book or chapters may have been removed.
-          // We still want to display these books to the user, but disabled so they cannot interact with them.
           .sort((a, b) => a.bookNumber - b.bookNumber) as BookWithDraft[];
       }
       return draftBooks;
@@ -78,9 +65,7 @@ export class DraftPreviewBooksComponent {
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
-    private readonly userService: UserService,
-    private readonly router: Router,
-    private readonly projectService: SFProjectService
+    private readonly router: Router
   ) {}
 
   linkForBookAndChapter(bookId: string, chapterNumber: number): string[] {
@@ -88,7 +73,7 @@ export class DraftPreviewBooksComponent {
   }
 
   navigate(book: BookWithDraft): void {
-    void this.router.navigate(this.linkForBookAndChapter(book.bookId, book.chaptersWithDrafts[0]), {
+    void this.router.navigate(this.linkForBookAndChapter(book.bookId, book.chaptersInBook[0] ?? 1), {
       queryParams: { 'draft-active': true, 'draft-timestamp': this.build?.additionalInfo?.dateGenerated }
     });
   }


### PR DESCRIPTION
This change allows users to select and navigate to draft books that are missing in the target project. Previously this was disabled if the drafted content existed for a book without the book existing in the target project.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3802)
<!-- Reviewable:end -->
