### PR TITLE
Use actions/checkout@v6.0.2 for all workflows

### DIFF
--- a/.github/workflows/push-changes-to-crowdin.yml
+++ b/.github/workflows/push-changes-to-crowdin.yml
@@ -31,7 +31,7 @@ jobs:
           exit 1
 
       - name: "Checkout"
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/update-npm-audit.yml
+++ b/.github/workflows/update-npm-audit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # 5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 
@@ -33,7 +33,6 @@ jobs:
           cd src/RealtimeServer
           npm ci
           npm audit fix
-          npm dedupe
         continue-on-error: true
 
       - name: Run npm audit fix on ClientApp
@@ -41,7 +40,6 @@ jobs:
           cd src/SIL.XForge.Scripture/ClientApp
           npm ci
           npm audit fix
-          npm dedupe
         continue-on-error: true
 
       - name: Run npm audit fix on db_tools
@@ -49,7 +47,6 @@ jobs:
           cd scripts/db_tools
           npm ci
           npm audit fix
-          npm dedupe
         continue-on-error: true
 
       - name: Create Pull Request


### PR DESCRIPTION
All but two actions have been specifying the exact same version of actions/checkout. This updates the two that weren't to match.

It should also fix a Zizmor warning about this line:
```yml
        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # 5.0.1
```
It claims the `5.0.1` is incorrect because the actual tag is `v5.0.1`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3803)
<!-- Reviewable:end -->
