### PR TITLE
Update denoland/setup-deno to v2.0.4

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -468,7 +468,7 @@ jobs:
           base64 --decode - <<< "${E2E_SECRETS_JSON_BASE64}" > ./ClientApp/e2e/secrets.json
 
       - name: Set up Deno
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
       - name: Playwright install browsers and package dependencies

--- a/.github/workflows/push-changes-to-crowdin.yml
+++ b/.github/workflows/push-changes-to-crowdin.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Set up Deno"
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 

--- a/.github/workflows/update-font-list.yml
+++ b/.github/workflows/update-font-list.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up Deno
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 

--- a/.github/workflows/update-localizations.yml
+++ b/.github/workflows/update-localizations.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up Deno
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 


### PR DESCRIPTION
This update is necessary because we are currently getting this warning on workflow runs that use the setup-deno action:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3804)
<!-- Reviewable:end -->
