### PR TITLE
Prevent merging PRs without the correct labels

### DIFF
--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,0 +1,35 @@
+# Checks that a PR has the required labels before merging is allowed.
+# Posts a commit status (pending or success) rather than failing the workflow run,
+# so that the merge button stays blocked without showing a red failure.
+name: Check PR labels
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-labels:
+    name: "Check PR labels"
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Check labels and set commit status
+        run: scripts/check_pr_labels.mts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          # toJSON produces a JSON array of label name strings, e.g. ["testing complete","do not merge"]
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,0 +1,35 @@
+# Checks that a PR has the required labels before merging is allowed.
+# Posts a commit status (pending or success) rather than failing the workflow run,
+# so that the merge button stays blocked without showing a red failure.
+name: Check PR labels
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-labels:
+    name: "Check PR labels"
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: v2.x
+
+      - name: Check labels and set commit status
+        run: scripts/check_pr_labels.mts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          # toJSON produces a JSON array of label name strings, e.g. ["testing complete","do not merge"]
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}

--- a/scripts/check_pr_labels.mts
+++ b/scripts/check_pr_labels.mts
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+
+// Checks a PR's labels and posts a commit status to GitHub. Invoked by check-pr-labels.yml on
+// pull_request events. The status stays "pending" until the PR has the required labels,
+// keeping the merge button blocked without showing a red workflow failure.
+
+const token: string | undefined = Deno.env.get('GITHUB_TOKEN');
+const sha: string | undefined = Deno.env.get('SHA');
+const repo: string | undefined = Deno.env.get('REPO');
+const labelsJson: string | undefined = Deno.env.get('LABELS_JSON');
+
+if (token == null || sha == null || repo == null || labelsJson == null) {
+  console.error('GITHUB_TOKEN, SHA, REPO, and LABELS_JSON environment variables are required');
+  Deno.exit(1);
+}
+
+const labels: string[] = JSON.parse(labelsJson);
+
+const hasTestingComplete: boolean = labels.includes('testing complete');
+const hasTestingNotRequired: boolean = labels.includes('testing not required');
+const hasDoNotMerge: boolean = labels.includes('do not merge');
+
+type CommitState = 'pending' | 'success';
+
+let state: CommitState;
+let description: string;
+
+if (hasDoNotMerge) {
+  state = 'pending';
+  description = "Remove the 'do not merge' label before merging";
+} else if (hasTestingComplete || hasTestingNotRequired) {
+  state = 'success';
+  description = 'PR is ready to merge';
+} else {
+  state = 'pending';
+  description = "Add 'testing complete' or 'testing not required' label before merging";
+}
+
+const response = await fetch(`https://api.github.com/repos/${repo}/statuses/${sha}`, {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/vnd.github+json'
+  },
+  body: JSON.stringify({ state, description, context: 'Merge readiness' })
+});
+
+if (!response.ok) {
+  const body: string = await response.text();
+  console.error(`GitHub API request failed with status ${response.status}: ${response.statusText}`);
+  console.error(`Response body: ${body}`);
+  Deno.exit(1);
+}
+
+console.log(`Set commit status to '${state}': ${description}`);


### PR DESCRIPTION
This adds an action that puts a check on a PR such that:
- PRs with `do not merge` cannot be merged
- PRs that lack `testing complete` or `testing not required` cannot be merged

Here's what it looks like in a PR status check:

<img width="775" height="65" alt="do_not_merge" src="https://github.com/user-attachments/assets/3d7817be-d98c-4d0e-82a7-20b7620e4a07" />

<img width="775" height="65" alt="no_labels" src="https://github.com/user-attachments/assets/306f54fc-139a-4ceb-b5b6-bbeb4d94aa5c" />

<img width="759" height="37" alt="ready_to_merge" src="https://github.com/user-attachments/assets/e38bae22-d54e-4d6e-aa80-9dc17b9478fa" />


Notice it says it's "waiting for status to be reported". Unfortunately a check that is "pending" is shown this way. This state prevents the PR from being merged, without actually marking it as failing anything.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3805)
<!-- Reviewable:end -->
