### PR TITLE
Warn Serval admins when back translation language is same as project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -461,6 +461,17 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
       );
     }
 
+    const backTranslationIsoCode = this.request?.submission.formData.backTranslationLanguageIsoCode;
+    if (
+      isPopulatedString(backTranslationIsoCode) &&
+      isPopulatedString(projectISOCode) &&
+      normalizeLanguageCodeToISO639_3(backTranslationIsoCode) === normalizeLanguageCodeToISO639_3(projectISOCode)
+    ) {
+      warnings.push(
+        `The language code for the back translation (${backTranslationIsoCode}) is equivalent to the project language code (${projectISOCode}).`
+      );
+    }
+
     // Find projects that failed their last sync
     for (const [id, projectDoc] of this.projectDocs.entries()) {
       if (projectDoc.data?.sync.lastSyncSuccessful === false) {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3806)
<!-- Reviewable:end -->
