### PR TITLE
Separate onboarding commands for projects and resources

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
@@ -248,15 +248,36 @@
 
     <h2>Tools</h2>
 
-    @if (getSuggestedCommand()) {
-      <mat-card>
-        <mat-card-header> <mat-card-title>Suggested Onboarding Command</mat-card-title> </mat-card-header>
-        <mat-card-content>
-          <p>After downloading all project files, run this command to onboard them:</p>
-          <code class="command-text">{{ getSuggestedCommand() }}</code>
-        </mat-card-content>
-      </mat-card>
-    }
+    <mat-card>
+      <mat-card-header> <mat-card-title>Suggested Onboarding Commands</mat-card-title> </mat-card-header>
+      <mat-card-content>
+        <h3>After downloading projects, run these commands</h3>
+        <p>For projects:</p>
+        <div class="command-wrapper">
+          <code class="command-text">{{ getSuggestedProjectOnboardingCommand() }}</code>
+          <button
+            mat-icon-button
+            color="primary"
+            (click)="copyToClipboard(getSuggestedProjectOnboardingCommand())"
+            matTooltip="Copy command to clipboard"
+          >
+            <mat-icon>content_copy</mat-icon>
+          </button>
+        </div>
+        <p>For resources:</p>
+        <div class="command-wrapper">
+          <code class="command-text">{{ getSuggestedResourceOnboardingCommand() }}</code>
+          <button
+            mat-icon-button
+            color="primary"
+            (click)="copyToClipboard(getSuggestedResourceOnboardingCommand())"
+            matTooltip="Copy command to clipboard"
+          >
+            <mat-icon>content_copy</mat-icon>
+          </button>
+        </div>
+      </mat-card-content>
+    </mat-card>
 
     <app-dev-only>
       <mat-accordion class="json-accordion" multi>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.scss
@@ -123,3 +123,9 @@
 .book-list {
   word-wrap: anywhere;
 }
+
+.command-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -256,19 +256,11 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     return value == null ? '' : formatBookListForSILNLP(value);
   }
 
-  /** Copies the formatted book list to the clipboard. */
-  async copyBookList(books: number[] | undefined): Promise<void> {
-    const text: string = this.formatBookList(books);
-    await navigator.clipboard.writeText(text);
-    this.noticeService.show('Book list copied to clipboard');
-  }
+  getZipFileNames(): { projects: string[]; resources: string[] } {
+    if (this.request == null) return { projects: [], resources: [] };
 
-  getZipFileNames(): string[] {
-    if (this.request == null) {
-      return [];
-    }
-
-    const zipFileNamesSet = new Set<string>();
+    const projectFilesNameSet = new Set<string>();
+    const resourceFilesNamesSet = new Set<string>();
     const formData = this.request.submission.formData;
 
     // Helper function to add a zip file name if the project exists (for Paratext IDs)
@@ -280,7 +272,11 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
       if (sfProjectId != null) {
         const shortName = this.projectShortNames.get(paratextId);
         if (shortName != null) {
-          zipFileNamesSet.add(`${shortName}.zip`);
+          if (ParatextService.isResource(paratextId)) {
+            resourceFilesNamesSet.add(`${shortName}.zip`);
+          } else {
+            projectFilesNameSet.add(`${shortName}.zip`);
+          }
         }
       }
     };
@@ -288,7 +284,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     // Add the main project (submission.projectId is already an SF project ID)
     const mainProjectShortName = this.projectShortNames.get(this.request.submission.projectId);
     if (mainProjectShortName != null) {
-      zipFileNamesSet.add(`${mainProjectShortName}.zip`);
+      projectFilesNameSet.add(`${mainProjectShortName}.zip`);
     }
 
     // Add all source project zip file names
@@ -298,7 +294,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     addZipFileName(formData.draftingSourceProject);
     addZipFileName(formData.backTranslationProject);
 
-    return Array.from(zipFileNamesSet);
+    return { projects: Array.from(projectFilesNameSet), resources: Array.from(resourceFilesNamesSet) };
   }
 
   getAllProjectSFIds(options = { includeResources: true }): string[] {
@@ -316,13 +312,16 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     return [...new Set([mainProject, ...sourceIds].filter(id => id != null))];
   }
 
-  /** Gets the suggested onboarding command based on all downloadable projects. */
-  getSuggestedCommand(): string {
-    const zipFileNames = this.getZipFileNames();
-    if (zipFileNames.length === 0) {
-      return '';
-    }
-    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest --datestamp ${zipFileNames.join(' ')}`;
+  getSuggestedProjectOnboardingCommand(): string {
+    const projects = this.getZipFileNames().projects;
+    if (projects.length === 0) return '';
+    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest --datestamp ${projects.join(' ')}`;
+  }
+
+  getSuggestedResourceOnboardingCommand(): string {
+    const resources = this.getZipFileNames().resources;
+    if (resources.length === 0) return '';
+    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest ${resources.join(' ')}`;
   }
 
   /** Adds a comment to the current onboarding request. */
@@ -481,6 +480,16 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     }
 
     return warnings;
+  }
+
+  async copyBookList(books: number[] | undefined): Promise<void> {
+    const text: string = this.formatBookList(books);
+    await this.copyToClipboard(text);
+  }
+
+  async copyToClipboard(text: string): Promise<void> {
+    await navigator.clipboard.writeText(text);
+    this.noticeService.show('Copied to clipboard');
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -256,19 +256,11 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     return value == null ? '' : formatBookListForSILNLP(value);
   }
 
-  /** Copies the formatted book list to the clipboard. */
-  async copyBookList(books: number[] | undefined): Promise<void> {
-    const text: string = this.formatBookList(books);
-    await navigator.clipboard.writeText(text);
-    this.noticeService.show('Book list copied to clipboard');
-  }
+  getZipFileNames(): { projects: string[]; resources: string[] } {
+    if (this.request == null) return { projects: [], resources: [] };
 
-  getZipFileNames(): string[] {
-    if (this.request == null) {
-      return [];
-    }
-
-    const zipFileNamesSet = new Set<string>();
+    const projectFilesNameSet = new Set<string>();
+    const resourceFilesNamesSet = new Set<string>();
     const formData = this.request.submission.formData;
 
     // Helper function to add a zip file name if the project exists (for Paratext IDs)
@@ -280,7 +272,11 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
       if (sfProjectId != null) {
         const shortName = this.projectShortNames.get(paratextId);
         if (shortName != null) {
-          zipFileNamesSet.add(`${shortName}.zip`);
+          if (ParatextService.isResource(paratextId)) {
+            resourceFilesNamesSet.add(`${shortName}.zip`);
+          } else {
+            projectFilesNameSet.add(`${shortName}.zip`);
+          }
         }
       }
     };
@@ -288,7 +284,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     // Add the main project (submission.projectId is already an SF project ID)
     const mainProjectShortName = this.projectShortNames.get(this.request.submission.projectId);
     if (mainProjectShortName != null) {
-      zipFileNamesSet.add(`${mainProjectShortName}.zip`);
+      projectFilesNameSet.add(`${mainProjectShortName}.zip`);
     }
 
     // Add all source project zip file names
@@ -298,7 +294,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     addZipFileName(formData.draftingSourceProject);
     addZipFileName(formData.backTranslationProject);
 
-    return Array.from(zipFileNamesSet);
+    return { projects: Array.from(projectFilesNameSet), resources: Array.from(resourceFilesNamesSet) };
   }
 
   getAllProjectSFIds(options = { includeResources: true }): string[] {
@@ -316,13 +312,16 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     return [...new Set([mainProject, ...sourceIds].filter(id => id != null))];
   }
 
-  /** Gets the suggested onboarding command based on all downloadable projects. */
-  getSuggestedCommand(): string {
-    const zipFileNames = this.getZipFileNames();
-    if (zipFileNames.length === 0) {
-      return '';
-    }
-    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest --datestamp ${zipFileNames.join(' ')}`;
+  getSuggestedProjectOnboardingCommand(): string {
+    const projects = this.getZipFileNames().projects;
+    if (projects.length === 0) return '';
+    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest --datestamp ${projects.join(' ')}`;
+  }
+
+  getSuggestedResourceOnboardingCommand(): string {
+    const resources = this.getZipFileNames().resources;
+    if (resources.length === 0) return '';
+    return `poetry run python -m silnlp.common.onboard_project --copy-from $DOWNLOAD_FOLDER --extract-corpora --collect-verse-counts --wildebeest ${resources.join(' ')}`;
   }
 
   /** Adds a comment to the current onboarding request. */
@@ -470,6 +469,16 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     }
 
     return warnings;
+  }
+
+  async copyBookList(books: number[] | undefined): Promise<void> {
+    const text: string = this.formatBookList(books);
+    await this.copyToClipboard(text);
+  }
+
+  async copyToClipboard(text: string): Promise<void> {
+    await navigator.clipboard.writeText(text);
+    this.noticeService.show('Copied to clipboard');
   }
 
   /**


### PR DESCRIPTION
The EITL team has indicated they want to separate onboarding commands, one for projects, and one for resources, with the latter command omitting `--datestamp`

A screenshot of the change was shown and approved.

<img width="1186" height="336" alt="Screenshot from 2026-04-16 22-52-34" src="https://github.com/user-attachments/assets/b5e0278e-6b1b-4504-8732-88cd869c834f" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3807)
<!-- Reviewable:end -->
