### PR TITLE
SF-3775 Optimize Permission Ops

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.spec.ts
@@ -105,16 +105,16 @@ describe('PermissionsService', () => {
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
 
-    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(true);
+    expect(await env.service.canAccessTextAsync(cloneDeep(textDoc) as TextDocId)).toBe(true);
   }));
 
   it('allows access to text if user is on project and does not have chapter permission', fakeAsync(async () => {
     const env = new TestEnvironment();
-    env.setupProjectData(undefined);
+    env.setupProjectData(undefined, false);
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
 
-    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(true);
+    expect(await env.service.canAccessTextAsync(cloneDeep(textDoc) as TextDocId)).toBe(true);
   }));
 
   it('does not allow access to text if user is not on project', fakeAsync(async () => {
@@ -123,7 +123,7 @@ describe('PermissionsService', () => {
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
 
-    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(false);
+    expect(await env.service.canAccessTextAsync(cloneDeep(textDoc) as TextDocId)).toBe(false);
   }));
 
   it('does not allow access to text if user has no access', fakeAsync(async () => {
@@ -132,7 +132,7 @@ describe('PermissionsService', () => {
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 1 };
 
-    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(false);
+    expect(await env.service.canAccessTextAsync(cloneDeep(textDoc) as TextDocId)).toBe(false);
   }));
 
   it('does not allow access to text if the chapter does not exist', fakeAsync(async () => {
@@ -141,7 +141,7 @@ describe('PermissionsService', () => {
 
     const textDoc: Partial<TextDocId> = { projectId: 'project01', bookNum: 41, chapterNum: 2 };
 
-    expect(await env.service.canAccessText(cloneDeep(textDoc) as TextDocId)).toBe(false);
+    expect(await env.service.canAccessTextAsync(cloneDeep(textDoc) as TextDocId)).toBe(false);
   }));
 
   it('checks current user doc to determine if user is on project', fakeAsync(async () => {
@@ -264,7 +264,7 @@ class TestEnvironment {
     this.setupUserData();
   }
 
-  setupProjectData(textPermission?: TextInfoPermission | undefined): void {
+  setupProjectData(textPermission?: TextInfoPermission | undefined, chapterPermissions: boolean = true): void {
     const projectId: string = 'project01';
     const permission: TextInfoPermission = textPermission ?? TextInfoPermission.Write;
 
@@ -284,10 +284,12 @@ class TestEnvironment {
                 number: 1,
                 lastVerse: 3,
                 isValid: true,
-                permissions: {
-                  user01: permission,
-                  user02: permission
-                }
+                permissions: chapterPermissions
+                  ? {
+                      user01: permission,
+                      user02: permission
+                    }
+                  : {}
               }
             ],
             hasSource: true,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/permissions.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
+import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
-import { Chapter } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
+import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { UserService } from 'xforge-common/user.service';
@@ -58,29 +59,46 @@ export class PermissionsService {
     return isParatextRole(projectDoc.data?.userRoles[currentUserDoc.id] ?? SFProjectRole.None);
   }
 
-  async canAccessText(textDocId: TextDocId): Promise<boolean> {
+  /**
+   * Determines if a user can access the text in the specified project.
+   * @param textDocId The text document id.
+   * @param project The project.
+   * @returns A boolean value.
+   */
+  canAccessText(textDocId: TextDocId, project?: SFProjectProfile): boolean {
+    // Ensure the user has project level permission to view the text
+    if (
+      project != null &&
+      SF_PROJECT_RIGHTS.hasRight(project, this.userService.currentUserId, SFProjectDomain.Texts, Operation.View)
+    ) {
+      // Check chapter permissions
+      const text: TextInfo | undefined = project.texts.find(t => t.bookNum === textDocId.bookNum);
+      const chapter: Chapter | undefined = text?.chapters.find(c => c.number === textDocId.chapterNum);
+      if (text != null && chapter != null) {
+        // If the chapter permission is not present, use the book permission instead
+        const chapterPermission: string | undefined =
+          chapter.permissions[this.userService.currentUserId] ?? text.permissions[this.userService.currentUserId];
+        // If there is no chapter permission, they will have access to the chapter as they have access to the project.
+        // We should only deny access if there is an explicit "None" permission.
+        return chapterPermission !== TextInfoPermission.None;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Determines if a user can access a text.
+   * @param textDocId The text document id.
+   * @returns A promise for a boolean value.
+   */
+  async canAccessTextAsync(textDocId: TextDocId): Promise<boolean> {
     // Get the project doc, if the user is on that project
     let projectDoc: SFProjectProfileDoc | undefined;
     if (textDocId.projectId != null) {
       const isUserOnProject = await this.isUserOnProject(textDocId.projectId);
       projectDoc = isUserOnProject ? await this.projectService.getProfile(textDocId.projectId) : undefined;
-    }
-
-    // Ensure the user has project level permission to view the text
-    if (
-      projectDoc?.data != null &&
-      SF_PROJECT_RIGHTS.hasRight(projectDoc.data, this.userService.currentUserId, SFProjectDomain.Texts, Operation.View)
-    ) {
-      // Check chapter permissions
-      const chapter: Chapter | undefined = projectDoc.data.texts
-        .find(t => t.bookNum === textDocId.bookNum)
-        ?.chapters.find(c => c.number === textDocId.chapterNum);
-      if (chapter != null) {
-        const chapterPermission: string | undefined = chapter.permissions[this.userService.currentUserId];
-        // If there is no chapter permission, they will have access to the chapter as they have access to the project.
-        // We should only deny access if there is an explicit "None" permission.
-        return chapterPermission !== TextInfoPermission.None;
-      }
+      return this.canAccessText(textDocId, projectDoc?.data);
     }
 
     return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
@@ -391,18 +391,19 @@ describe('TextDocService', () => {
       expect(actual).toBeUndefined();
     });
 
-    it('should return undefined if the user does not have the permission', () => {
+    it('should return false if the user does not have the permission', () => {
       const env = new TestEnvironment();
       const text: Partial<TextInfo> = { chapters: [{ number: 1 } as Chapter] };
 
       // SUT
       const actual: boolean | undefined = env.textDocService.hasChapterEditPermissionForText(text as TextInfo, 1);
-      expect(actual).toBeUndefined();
+      expect(actual).toBe(false);
     });
 
-    it('should return false if the user does not have the edit permission', () => {
+    it('should return false if the user does not have the write permission for the chapter', () => {
       const env = new TestEnvironment();
       const text: Partial<TextInfo> = {
+        permissions: { user01: TextInfoPermission.Write },
         chapters: [
           { number: 1, permissions: { user01: TextInfoPermission.Read }, lastVerse: 0, isValid: true } as Chapter
         ]
@@ -413,12 +414,24 @@ describe('TextDocService', () => {
       expect(actual).toBe(false);
     });
 
-    it('should return true if the user has the write permission', () => {
+    it('should return true if the user has the write permission for the chapter', () => {
       const env = new TestEnvironment();
       const text: Partial<TextInfo> = {
         chapters: [
           { number: 1, permissions: { user01: TextInfoPermission.Write }, lastVerse: 0, isValid: true } as Chapter
         ]
+      };
+
+      // SUT
+      const actual: boolean | undefined = env.textDocService.hasChapterEditPermissionForText(text as TextInfo, 1);
+      expect(actual).toBe(true);
+    });
+
+    it('should return true if the user has the write permission for the book and no chapter permission set', () => {
+      const env = new TestEnvironment();
+      const text: Partial<TextInfo> = {
+        permissions: { user01: TextInfoPermission.Write },
+        chapters: [{ number: 1, lastVerse: 0, isValid: true } as Chapter]
       };
 
       // SUT

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
@@ -172,10 +172,12 @@ export class TextDocService {
    */
   hasChapterEditPermissionForText(text: TextInfo | undefined, chapterNum: number | undefined): boolean | undefined {
     const chapter: Chapter | undefined = text?.chapters.find(c => c.number === chapterNum);
+    if (chapter == null) return undefined;
     // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
     // is accessed after migration
-    const permission: string | undefined = chapter?.permissions?.[this.userService.currentUserId];
-    return permission == null ? undefined : permission === TextInfoPermission.Write;
+    const permission: string | undefined =
+      chapter?.permissions?.[this.userService.currentUserId] ?? text?.permissions?.[this.userService.currentUserId];
+    return permission === TextInfoPermission.Write;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.spec.ts
@@ -24,7 +24,7 @@ describe('cache service', () => {
   describe('load all texts', () => {
     it('does not get texts from project service if no permission', fakeAsync(async () => {
       const env = new TestEnvironment();
-      when(mockedPermissionService.canAccessText(anything())).thenResolve(false);
+      when(mockedPermissionService.canAccessTextAsync(anything())).thenResolve(false);
       await env.service.cache(env.projectDoc);
       env.wait();
 
@@ -72,9 +72,9 @@ describe('cache service', () => {
 
     it('gets the source texts if they are present and the user can access', fakeAsync(async () => {
       const env = new TestEnvironment();
-      when(mockedPermissionService.canAccessText(deepEqual(new TextDocId('sourceId', 0, 0, 'target')))).thenResolve(
-        false
-      ); //remove access for one source doc
+      when(
+        mockedPermissionService.canAccessTextAsync(deepEqual(new TextDocId('sourceId', 0, 0, 'target')))
+      ).thenResolve(false); //remove access for one source doc
 
       await env.service.cache(env.projectDoc);
       env.wait();
@@ -106,7 +106,7 @@ class TestEnvironment {
     });
 
     when(mockedProjectDoc.data).thenReturn(data);
-    when(mockedPermissionService.canAccessText(anything())).thenResolve(true);
+    when(mockedPermissionService.canAccessTextAsync(anything())).thenResolve(true);
   }
 
   createTexts(): TextInfo[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/cache-service/cache.service.ts
@@ -32,13 +32,13 @@ export class CacheService {
           }
 
           const textDocId = new TextDocId(project.id, text.bookNum, chapter.number, 'target');
-          if (await this.permissionsService.canAccessText(textDocId)) {
+          if (await this.permissionsService.canAccessTextAsync(textDocId)) {
             await this.projectService.getText(textDocId);
           }
 
           if (text.hasSource && sourceId != null) {
             const sourceTextDocId = new TextDocId(sourceId, text.bookNum, chapter.number, 'target');
-            if (await this.permissionsService.canAccessText(sourceTextDocId)) {
+            if (await this.permissionsService.canAccessTextAsync(sourceTextDocId)) {
               await this.projectService.getText(sourceTextDocId);
             }
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.spec.ts
@@ -1,12 +1,20 @@
 import { TestBed } from '@angular/core/testing';
-import { mock } from 'ts-mockito';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
+import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { mock, when } from 'ts-mockito';
 import { AuthGuard } from 'xforge-common/auth.guard';
+import { AuthService } from 'xforge-common/auth.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { UserService } from 'xforge-common/user.service';
+import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../core/sf-project.service';
-import { DraftNavigationAuthGuard } from './project-router.guard';
+import { DraftNavigationAuthGuard, SyncAuthGuard } from './project-router.guard';
 
 const mockedAuthGuard = mock(AuthGuard);
+const mockedAuthService = mock(AuthService);
 const mockedProjectService = mock(SFProjectService);
+const mockedUserService = mock(UserService);
 
 describe('DraftNavigationAuthGuard', () => {
   configureTestingModule(() => ({
@@ -29,9 +37,88 @@ describe('DraftNavigationAuthGuard', () => {
   });
 });
 
+describe('SyncAuthGuard', () => {
+  configureTestingModule(() => ({
+    providers: [
+      { provide: AuthGuard, useMock: mockedAuthGuard },
+      { provide: AuthService, useMock: mockedAuthService },
+      { provide: SFProjectService, useMock: mockedProjectService },
+      { provide: UserService, useMock: mockedUserService }
+    ]
+  }));
+
+  it('administrators can access sync', async () => {
+    // navigate away
+    const env = new SyncAuthGuardTestEnvironment(false);
+    expect(
+      env.service.check({
+        data: createTestProjectProfile({ userRoles: { user01: SFProjectRole.ParatextAdministrator } })
+      } as SFProjectProfileDoc)
+    ).toBe(true);
+  });
+
+  it('translators can access sync', async () => {
+    // navigate away
+    const env = new SyncAuthGuardTestEnvironment(false);
+    expect(
+      env.service.check({
+        data: createTestProjectProfile({ userRoles: { user01: SFProjectRole.ParatextTranslator } })
+      } as SFProjectProfileDoc)
+    ).toBe(true);
+  });
+
+  it('consultants cannot access sync', async () => {
+    // navigate away
+    const env = new SyncAuthGuardTestEnvironment(false);
+    expect(
+      env.service.check({
+        data: createTestProjectProfile({ userRoles: { user01: SFProjectRole.ParatextConsultant } })
+      } as SFProjectProfileDoc)
+    ).toBe(false);
+  });
+
+  it('serval administrators can sync resources they have read access to', async () => {
+    // navigate away
+    const env = new SyncAuthGuardTestEnvironment(true);
+    expect(
+      env.service.check({
+        data: createTestProjectProfile({
+          userRoles: { user01: SFProjectRole.ParatextObserver },
+          paratextId: 'ResourceResource'
+        })
+      } as SFProjectProfileDoc)
+    ).toBe(true);
+  });
+
+  it('serval administrators cannot sync projects they have read access to', async () => {
+    // navigate away
+    const env = new SyncAuthGuardTestEnvironment(true);
+    expect(
+      env.service.check({
+        data: createTestProjectProfile({
+          userRoles: { user01: SFProjectRole.ParatextObserver }
+        })
+      } as SFProjectProfileDoc)
+    ).toBe(false);
+  });
+});
+
 class DraftNavigationTestEnvironment {
   service: DraftNavigationAuthGuard;
   constructor() {
     this.service = TestBed.inject(DraftNavigationAuthGuard);
+  }
+}
+
+class SyncAuthGuardTestEnvironment {
+  service: SyncAuthGuard;
+  constructor(servalAdmin: boolean) {
+    this.service = TestBed.inject(SyncAuthGuard);
+    when(mockedUserService.currentUserId).thenReturn('user01');
+    if (servalAdmin) {
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.ServalAdmin]);
+    } else {
+      when(mockedAuthService.currentUserRoles).thenReturn([SystemRole.User]);
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/project-router.guard.ts
@@ -1,11 +1,14 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanDeactivate, Router, RouterStateSnapshot } from '@angular/router';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
+import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
+import { isResource } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { SF_PROJECT_RIGHTS, SFProjectDomain } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-rights';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { from, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { AuthGuard } from 'xforge-common/auth.guard';
+import { AuthService } from 'xforge-common/auth.service';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { PermissionsService } from '../core/permissions.service';
@@ -83,18 +86,29 @@ export class SyncAuthGuard extends RouterGuard {
   constructor(
     authGuard: AuthGuard,
     projectService: SFProjectService,
-    private userService: UserService
+    private readonly userService: UserService,
+    private readonly authService: AuthService
   ) {
     super(authGuard, projectService);
   }
 
   check(projectDoc: SFProjectProfileDoc): boolean {
     if (projectDoc.data == null) return false;
-    return SF_PROJECT_RIGHTS.hasRight(
-      projectDoc.data,
-      this.userService.currentUserId,
-      SFProjectDomain.Texts,
-      Operation.Edit
+    return (
+      SF_PROJECT_RIGHTS.hasRight(
+        projectDoc.data,
+        this.userService.currentUserId,
+        SFProjectDomain.Texts,
+        Operation.Edit
+      ) ||
+      (this.authService.currentUserRoles.includes(SystemRole.ServalAdmin) &&
+        isResource(projectDoc.data) &&
+        SF_PROJECT_RIGHTS.hasRight(
+          projectDoc.data,
+          this.userService.currentUserId,
+          SFProjectDomain.Texts,
+          Operation.View
+        ))
     );
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -5008,6 +5008,7 @@ class TestEnvironment {
     when(mockedDraftGenerationService.getLastCompletedBuild(anything())).thenReturn(of({} as BuildDto));
     when(mockedDraftOptionsService.areFormattingOptionsAvailableButUnselected(anything())).thenReturn(false);
     when(mockedPermissionsService.isUserOnProject(anything())).thenResolve(true);
+    when(mockedPermissionsService.canAccessText(anything(), anything())).thenReturn(true);
     when(mockedFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(false));
     when(mockedLynxWorkspaceService.rawInsightSource$).thenReturn(of([]));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -58,7 +58,6 @@ import { isParatextRole, SFProjectRole } from 'realtime-server/lib/esm/scripture
 import { TextAnchor } from 'realtime-server/lib/esm/scriptureforge/models/text-anchor';
 import { TextType } from 'realtime-server/lib/esm/scriptureforge/models/text-data';
 import { Chapter, TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
-import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { fromVerseRef } from 'realtime-server/lib/esm/scriptureforge/models/verse-ref-data';
 import { DeltaOperation } from 'rich-text';
@@ -319,7 +318,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private paratextUsers: ParatextUserProfile[] = [];
   private isParatextUserRole: boolean = false;
   private projectUserConfigChangesSub?: Subscription;
-  private sourceText?: TextInfo;
   private _bookNum?: number;
   sourceProjectDoc?: SFProjectProfileDoc;
   private _unsupportedTags = new Set<string>();
@@ -523,24 +521,12 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get hasSourceViewRight(): boolean {
     const sourceProject = this.sourceProjectDoc?.data;
-    if (sourceProject == null) {
+    const sourceId = this.source?.id;
+    if (sourceProject == null || sourceId == null) {
       return this.isParatextUserRole;
     }
 
-    if (
-      SF_PROJECT_RIGHTS.hasRight(sourceProject, this.userService.currentUserId, SFProjectDomain.Texts, Operation.View)
-    ) {
-      // Check for chapter rights
-      const chapter = this.sourceText?.chapters.find(c => c.number === this.chapter);
-      // Even though permissions is guaranteed to be there in the model, its not in IndexedDB the first time the project
-      // is accessed after migration
-      if (chapter != null && chapter.permissions != null && !this.isParatextUserRole) {
-        const chapterPermission: string = chapter.permissions[this.userService.currentUserId];
-        return chapterPermission === TextInfoPermission.Write || chapterPermission === TextInfoPermission.Read;
-      }
-    }
-
-    return this.isParatextUserRole;
+    return this.isParatextUserRole && this.permissionsService.canAccessText(sourceId, sourceProject);
   }
 
   get canInsertNote(): boolean {
@@ -834,10 +820,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         );
         this.books = Array.from(new Set([...projectTexts, ...draftedBooks])).sort((a, b) => a - b);
         this.text = this.projectDoc.data.texts.find(t => t.bookNum === bookNum);
-
-        if (this.sourceProjectDoc?.data != null) {
-          this.sourceText = this.sourceProjectDoc.data.texts.find(t => t.bookNum === bookNum);
-        }
 
         const allChapters: number = Math.max(
           this.text?.chapters[this.text.chapters.length - 1]?.number ?? 1,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -522,11 +522,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   get hasSourceViewRight(): boolean {
     const sourceProject = this.sourceProjectDoc?.data;
     const sourceId = this.source?.id;
-    if (sourceProject == null || sourceId == null) {
+    if (sourceProject == null || sourceId == null || this.isParatextUserRole) {
       return this.isParatextUserRole;
     }
 
-    return this.isParatextUserRole && this.permissionsService.canAccessText(sourceId, sourceProject);
+    return this.permissionsService.canAccessText(sourceId, sourceProject);
   }
 
   get canInsertNote(): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.spec.ts
@@ -376,7 +376,9 @@ class TestEnvironment {
     const projectId: string = projectConfig.projectId ?? 'project01';
     const translationSuggestionsEnabled = projectConfig.translationSuggestionsEnabled ?? true;
     const textPermission: TextInfoPermission = projectConfig?.textPermission ?? TextInfoPermission.Write;
-    when(mockedPermissionService.canAccessText(anything())).thenResolve(textPermission !== TextInfoPermission.None);
+    when(mockedPermissionService.canAccessTextAsync(anything())).thenResolve(
+      textPermission !== TextInfoPermission.None
+    );
 
     // Setup the project data
     this.realtimeService.addSnapshot<SFProjectProfile>(SFProjectProfileDoc.COLLECTION, {

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -607,12 +607,13 @@ public class MachineApiService(
                     continue;
                 }
 
-                bool canWriteChapter =
-                    targetProjectDoc
-                        .Data.Texts[textIndex]
-                        .Chapters[chapterIndex]
-                        .Permissions.TryGetValue(curUserId, out string chapterPermission)
-                    && chapterPermission == TextInfoPermission.Write;
+                // If a user does not have permission set at chapter level, use the book level permission
+                bool canWriteChapter = targetProjectDoc
+                    .Data.Texts[textIndex]
+                    .Chapters[chapterIndex]
+                    .Permissions.TryGetValue(curUserId, out string chapterPermission)
+                    ? chapterPermission == TextInfoPermission.Write
+                    : canWriteBook;
                 if (!canWriteChapter)
                 {
                     // Remove the chapter from the project if we created it, and proceed to add the next chapter

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -925,7 +925,8 @@ public class ParatextService : DisposableBase, IParatextService
                     || scrText!.Permissions.GetRole(userName) == UserRoles.None
                 )
                 {
-                    permissions.Add(uid, TextInfoPermission.None);
+                    // The user will either have read only access or no access
+                    // This will be handled by their role on the project (or lack of role) on the project
                 }
                 else
                 {
@@ -1870,11 +1871,13 @@ public class ParatextService : DisposableBase, IParatextService
                             {
                                 int chapterIndex = j;
                                 int chapterNumber = text.Chapters[chapterIndex].Number;
-                                if (editableChapters.Contains(chapterNumber) || currentUserIsAdministrator)
+
+                                // Only record chapter level permissions that contradict the book level permissions
+                                if (!(editableChapters.Contains(chapterNumber) || currentUserIsAdministrator))
                                 {
                                     op.Set(
                                         p => p.Texts[textIndex].Chapters[chapterIndex].Permissions[user.SFUserId],
-                                        TextInfoPermission.Write
+                                        TextInfoPermission.Read
                                     );
                                 }
                             }

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -393,11 +393,20 @@ public class ParatextSyncRunner : IParatextSyncRunner
 
             await NotifySyncProgress(SyncPhase.Phase5, 90.0);
 
-            bool resourceNeedsUpdating =
-                paratextProject is ParatextResource paratextResource
-                && _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
-            if (paratextProject is ParatextResource)
+            // A resource needs updating if it has changed in the DBL
+            bool resourceNeedsUpdating = false;
+            bool resourcePermissionsNeedUpdating = false;
+            if (paratextProject is ParatextResource paratextResource)
+            {
+                resourceNeedsUpdating = _paratextService.ResourceDocsNeedUpdating(_projectDoc.Data, paratextResource);
                 LogMetric($"Resource needs updating: {resourceNeedsUpdating}");
+
+                // A resource's permissions need updating if they are the old per-book and per-chapter permissions
+                resourcePermissionsNeedUpdating = _projectDoc.Data.Texts.Any(t =>
+                    t.Permissions.Any(p => p.Value == TextInfoPermission.Read)
+                );
+                LogMetric($"Resource permissions need updating: {resourcePermissionsNeedUpdating}");
+            }
 
             // If a resource needs updating, retrieve the books, as they were not retrieved previously
             if (resourceNeedsUpdating)
@@ -448,9 +457,14 @@ public class ParatextSyncRunner : IParatextSyncRunner
             }
 
             // Update permissions if not a resource, or if it is a resource and needs updating.
-            // A resource will need updating if its text or permissions have changed on the DBL.
+            // A resource will need updating if its text or permissions have changed on the DBL,
+            // or if it contains the old per-book and per-chapter permissions.
             // Source resources have their permissions updated above in the section "Updating user resource access".
-            if (!_paratextService.IsResource(targetParatextId) || resourceNeedsUpdating)
+            if (
+                !_paratextService.IsResource(targetParatextId)
+                || resourceNeedsUpdating
+                || resourcePermissionsNeedUpdating
+            )
             {
                 LogMetric("Updating permissions");
                 await _projectService.UpdatePermissionsAsync(userId, _projectDoc, users: _paratextUsers, token: token);

--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -1154,6 +1154,22 @@ public class ParatextSyncRunner : IParatextSyncRunner
         SortedList<int, IDocument<TextData>> textDocs
     )
     {
+        bool hasWritePermission(string userId, Chapter chapter)
+        {
+            // If the user has a chapter permission, use that, otherwise fall back to the book permission
+            if (!text.Permissions.TryGetValue(userId, out string bookPermission))
+            {
+                bookPermission = TextInfoPermission.None;
+            }
+
+            if (!chapter.Permissions.TryGetValue(userId, out string chapterPermission))
+            {
+                chapterPermission = bookPermission;
+            }
+
+            return chapterPermission == TextInfoPermission.Write;
+        }
+
         // Get all of the last editors for the chapters.
         var chapterAuthors = new Dictionary<int, string>();
         foreach (Chapter chapter in text.Chapters)
@@ -1171,11 +1187,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 userSFId = await _realtimeService.GetLastModifiedUserIdAsync<TextData>(textId, version);
 
                 // Check that this user still has write permissions
-                if (
-                    string.IsNullOrEmpty(userSFId)
-                    || !chapter.Permissions.TryGetValue(userSFId, out string permission)
-                    || permission != TextInfoPermission.Write
-                )
+                if (string.IsNullOrEmpty(userSFId) || !hasWritePermission(userSFId, chapter))
                 {
                     // They no longer have write access, so reset the user id, and find it below
                     userSFId = null;
@@ -1186,10 +1198,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             if (string.IsNullOrEmpty(userSFId))
             {
                 // See if the current user has permissions
-                if (
-                    chapter.Permissions.TryGetValue(_userSecret.Id, out string permission)
-                    && permission == TextInfoPermission.Write
-                )
+                if (hasWritePermission(_userSecret.Id, chapter))
                 {
                     userSFId = _userSecret.Id;
                 }
@@ -1197,7 +1206,9 @@ public class ParatextSyncRunner : IParatextSyncRunner
                 {
                     // Get the first user with write permission
                     // NOTE: As a KeyValuePair is a struct, we do not need a null-conditional (key will be null)
-                    userSFId = chapter.Permissions.FirstOrDefault(p => p.Value == TextInfoPermission.Write).Key;
+                    userSFId =
+                        chapter.Permissions.FirstOrDefault(p => p.Value == TextInfoPermission.Write).Key
+                        ?? text.Permissions.FirstOrDefault(p => p.Value == TextInfoPermission.Write).Key;
 
                     // If the userId is still null, find a project administrator, as they can escalate privilege
                     if (string.IsNullOrEmpty(userSFId))

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1467,19 +1467,23 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             }
             Models.TextInfo text = projectDoc.Data.Texts[textIndex];
             List<Chapter> chapters = text.Chapters;
-            Dictionary<string, string> bookPermissions = null;
+            Dictionary<string, string> bookPermissions;
             IEnumerable<(
                 int bookIndex,
                 int chapterIndex,
                 Dictionary<string, string> chapterPermissions
-            )> chapterPermissionsInBook = null;
+            )> chapterPermissionsInBook;
 
             if (isResource)
             {
-                bookPermissions = resourcePermissions;
-                // Prepare to write the same resource permission for each chapter in the book/text.
+                // Do not write any read permissions for resources
+                bookPermissions = resourcePermissions
+                    .Where(kvp => kvp.Value != TextInfoPermission.Read)
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+                // Chapter permissions will not vary from book permissions for resources
                 chapterPermissionsInBook = chapters.Select(
-                    (Chapter chapter, int chapterIndex) => (textIndex, chapterIndex, bookPermissions)
+                    (_, chapterIndex) => (textIndex, chapterIndex, new Dictionary<string, string>())
                 );
             }
             else
@@ -1506,11 +1510,25 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                                 chapter.Number,
                                 token
                             );
+
+                            // Only save chapter permissions where they differ from the book permissions
+                            chapterPermissions = chapterPermissions
+                                .Where(kvp =>
+                                    !bookPermissions.TryGetValue(kvp.Key, out string bookPermission)
+                                    || bookPermission != kvp.Value
+                                )
+                                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                             return (textIndex, chapterIndex, chapterPermissions);
                         }
                     )
                 );
+
+                // Only save write permissions - all other users will have read if they are on the project
+                bookPermissions = bookPermissions
+                    .Where(kvp => kvp.Value != TextInfoPermission.Read)
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             }
+
             projectChapterPermissions.AddRange(chapterPermissionsInBook);
             projectBookPermissions.Add((textIndex, bookPermissions));
         }
@@ -1638,19 +1656,24 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             throw new DataNotFoundException("The chapter does not exist.");
         }
 
-        // Ensure the user has permission for this chapter
+        // Ensure the user can write to this chapter
+        if (!projectDoc.Data.Texts[textIndex].Permissions.TryGetValue(userId, out string bookPermission))
+        {
+            bookPermission = TextInfoPermission.None;
+        }
+
         if (
             !projectDoc
                 .Data.Texts[textIndex]
                 .Chapters[chapterIndex]
-                .Permissions.TryGetValue(userId, out string permission)
+                .Permissions.TryGetValue(userId, out string chapterPermission)
         )
         {
-            throw new ForbiddenException();
+            chapterPermission = bookPermission;
         }
 
         // Ensure the user can write to this chapter
-        if (permission != TextInfoPermission.Write)
+        if (chapterPermission != TextInfoPermission.Write)
         {
             throw new ForbiddenException();
         }
@@ -1707,19 +1730,24 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             throw new DataNotFoundException("The chapter does not exist.");
         }
 
-        // Ensure the user has permission for this chapter
+        // Ensure the user can write to this chapter
+        if (!projectDoc.Data.Texts[textIndex].Permissions.TryGetValue(userId, out string bookPermission))
+        {
+            bookPermission = TextInfoPermission.None;
+        }
+
         if (
             !projectDoc
                 .Data.Texts[textIndex]
                 .Chapters[chapterIndex]
-                .Permissions.TryGetValue(userId, out string permission)
+                .Permissions.TryGetValue(userId, out string chapterPermission)
         )
         {
-            throw new ForbiddenException();
+            chapterPermission = bookPermission;
         }
 
         // Ensure the user can write to this chapter
-        if (permission != TextInfoPermission.Write)
+        if (chapterPermission != TextInfoPermission.Write)
         {
             throw new ForbiddenException();
         }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1533,28 +1533,120 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
             projectBookPermissions.Add((textIndex, bookPermissions));
         }
 
-        // Update project metadata
-        await projectDoc.SubmitJson0OpAsync(op =>
+        // Build a list of permission changes
+        List<(int bookIndex, int? chapterIndex, string userId, string? permission)> changes = [];
+        foreach (
+            (int bookIndex, Dictionary<string, string> oldBookPermissions) in projectDoc.Data.Texts.Select(
+                (t, i) => (i, t.Permissions)
+            )
+        )
         {
-            foreach ((int bookIndex, Dictionary<string, string> bookPermissions) in projectBookPermissions)
+            // Update the permission at a book level
+            Dictionary<string, string> newBookPermissions =
+                projectBookPermissions.SingleOrDefault(p => p.bookIndex == bookIndex).bookPermissions ?? [];
+
+            foreach ((string userId, string oldPermission) in oldBookPermissions)
             {
-                op.Set(pd => pd.Texts[bookIndex].Permissions, bookPermissions, _permissionDictionaryEqualityComparer);
+                if (!newBookPermissions.TryGetValue(userId, out string newPermission))
+                {
+                    // Remove permission
+                    changes.Add((bookIndex, null, userId, null));
+                }
+                else if (newPermission != oldPermission)
+                {
+                    // Update permission
+                    changes.Add((bookIndex, null, userId, newPermission));
+                }
             }
+
+            foreach ((string userId, string permission) in newBookPermissions)
+            {
+                if (!oldBookPermissions.ContainsKey(userId))
+                {
+                    // Add permission
+                    changes.Add((bookIndex, null, userId, permission));
+                }
+            }
+
+            // Update permissions for each chapter in the book
             foreach (
-                (
-                    int bookIndex,
-                    int chapterIndex,
-                    Dictionary<string, string> chapterPermissions
-                ) in projectChapterPermissions
+                (int chapterIndex, Dictionary<string, string> oldChapterPermissions) in projectDoc
+                    .Data.Texts[bookIndex]
+                    .Chapters.Select((c, i) => (i, c.Permissions))
             )
             {
-                op.Set(
-                    pd => pd.Texts[bookIndex].Chapters[chapterIndex].Permissions,
-                    chapterPermissions,
-                    _permissionDictionaryEqualityComparer
-                );
+                // Update the permission at a chapter level
+                Dictionary<string, string> newChapterPermissions =
+                    projectChapterPermissions
+                        .SingleOrDefault(p => p.bookIndex == bookIndex && p.chapterIndex == chapterIndex)
+                        .chapterPermissions
+                    ?? [];
+
+                foreach ((string userId, string oldPermission) in oldChapterPermissions)
+                {
+                    if (!newChapterPermissions.TryGetValue(userId, out string newPermission))
+                    {
+                        // Remove permission
+                        changes.Add((bookIndex, chapterIndex, userId, null));
+                    }
+                    else if (newPermission != oldPermission)
+                    {
+                        // Update permission
+                        changes.Add((bookIndex, chapterIndex, userId, newPermission));
+                    }
+                }
+
+                foreach ((string userId, string permission) in newChapterPermissions)
+                {
+                    if (!oldChapterPermissions.ContainsKey(userId))
+                    {
+                        // Add permission
+                        changes.Add((bookIndex, chapterIndex, userId, permission));
+                    }
+                }
             }
-        });
+        }
+
+        // Update the project document in batches of 1000
+        const int batchSize = 1000;
+        foreach (
+            (int bookIndex, int? chapterIndex, string userId, string? permission)[] batch in changes.Chunk(batchSize)
+        )
+        {
+            await projectDoc.SubmitJson0OpAsync(op =>
+            {
+                foreach ((int bookIndex, int? chapterIndex, string userId, string? permission) in batch)
+                {
+                    if (chapterIndex is null)
+                    {
+                        // Update book permissions
+                        if (permission is null)
+                        {
+                            op.Unset(pd => pd.Texts[bookIndex].Permissions[userId]);
+                        }
+                        else
+                        {
+                            op.Set(pd => pd.Texts[bookIndex].Permissions[userId], permission);
+                        }
+                    }
+                    else
+                    {
+                        // Update chapter permissions
+                        if (permission == TextInfoPermission.None)
+                        {
+                            op.Unset(pd => pd.Texts[bookIndex].Chapters[chapterIndex.Value].Permissions[userId]);
+                        }
+                        else
+                        {
+                            op.Set(
+                                pd => pd.Texts[bookIndex].Chapters[chapterIndex.Value].Permissions[userId],
+                                permission
+                            );
+                        }
+                    }
+                }
+            });
+        }
     }
 
     [Obsolete("Use MachineApiService.ApplyPreTranslationToProjectAsync instead. Deprecated 2025-12")]

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1542,8 +1542,13 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         )
         {
             // Update the permission at a book level
-            Dictionary<string, string> newBookPermissions =
-                projectBookPermissions.SingleOrDefault(p => p.bookIndex == bookIndex).bookPermissions ?? [];
+            Dictionary<string, string> newBookPermissions = projectBookPermissions
+                .SingleOrDefault(p => p.bookIndex == bookIndex)
+                .bookPermissions;
+
+            // If we are only updating a subset of books, skip updating permissions for other books
+            if (newBookPermissions is null)
+                continue;
 
             foreach ((string userId, string oldPermission) in oldBookPermissions)
             {
@@ -1632,14 +1637,14 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
                     else
                     {
                         // Update chapter permissions
-                        if (permission == TextInfoPermission.None)
+                        if ((permission ?? TextInfoPermission.None) == TextInfoPermission.None)
                         {
-                            op.Unset(pd => pd.Texts[bookIndex].Chapters[chapterIndex.Value].Permissions[userId]);
+                            op.Unset(pd => pd.Texts[bookIndex].Chapters[chapterIndex!.Value].Permissions[userId]);
                         }
                         else
                         {
                             op.Set(
-                                pd => pd.Texts[bookIndex].Chapters[chapterIndex.Value].Permissions[userId],
+                                pd => pd.Texts[bookIndex].Chapters[chapterIndex!.Value].Permissions[userId],
                                 permission
                             );
                         }

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -471,7 +471,7 @@ public class ParatextServiceTests
             ptUsernameMapping,
             40
         );
-        string[] expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
+        string[] expected = [TextInfoPermission.Write];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
         // User01 permission to Mark explicitly and automatically
         permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping, 41);
@@ -505,8 +505,8 @@ public class ParatextServiceTests
             40
         );
 
-        // Ensure the user has read only access to Matthew and Mark
-        string[] expected = [TextInfoPermission.Read, TextInfoPermission.None, TextInfoPermission.None];
+        // Ensure the user has read only access to Matthew
+        string[] expected = [TextInfoPermission.Read];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
     }
 
@@ -535,11 +535,11 @@ public class ParatextServiceTests
             ptUsernameMapping,
             40
         );
-        string[] expected = [TextInfoPermission.Read, TextInfoPermission.None, TextInfoPermission.None];
+        string[] expected = [TextInfoPermission.Read];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
         // User01 has permission to Mark automatically
         permissions = await env.Service.GetPermissionsAsync(user01Secret, project, ptUsernameMapping, 41);
-        expected = [TextInfoPermission.Write, TextInfoPermission.None, TextInfoPermission.None];
+        expected = [TextInfoPermission.Write];
         Assert.That(permissions.Values, Is.EquivalentTo(expected));
     }
 
@@ -6580,7 +6580,7 @@ public class ParatextServiceTests
         SyncMetricInfo expected = new SyncMetricInfo { Updated = 1 };
         Assert.AreEqual(expected, actual);
         Assert.AreEqual(TextInfoPermission.Write, projectDoc.Data.Texts[0].Permissions[env.User01]);
-        Assert.AreEqual(TextInfoPermission.Write, projectDoc.Data.Texts[0].Chapters[0].Permissions[env.User01]);
+        Assert.IsFalse(projectDoc.Data.Texts[0].Chapters[0].Permissions.ContainsKey(env.User01));
     }
 
     [Test]

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -971,7 +971,7 @@ public class SFProjectServiceTests
         user = env.GetUser(User03);
         Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
 
-        Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False);
         Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
 
         resource = env.GetProject(Resource01);
@@ -982,11 +982,9 @@ public class SFProjectServiceTests
         );
         Assert.That(resourceUserRole, Is.EqualTo(SFProjectRole.PTObserver), "user role not set correctly on resource");
         Assert.That(user.Sites[SiteId].Projects, Contains.Item(Resource01), "user not added to resource correctly");
-        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-        Assert.That(
-            resource.Texts.First().Chapters.First().Permissions[User03],
-            Is.EqualTo(userDBLPermissionForResource)
-        );
+        // Book and chapter level read permissions are not written for resources
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False);
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False);
     }
 
     [Test]
@@ -1364,16 +1362,9 @@ public class SFProjectServiceTests
             .ParatextService.Received()
             .GetResourcePermissionAsync(Resource01PTId, User03, Arg.Any<CancellationToken>());
         resource = env.GetProject(Resource01);
-        Assert.That(
-            resource.Texts.First().Permissions[User03],
-            Is.EqualTo(userDBLPermissionForResource),
-            "resource permissions should have been set for joining project user"
-        );
-        Assert.That(
-            resource.Texts.First().Chapters.First().Permissions[User03],
-            Is.EqualTo(userDBLPermissionForResource),
-            "resource permissions should have been set for joining project user"
-        );
+        // Book and chapter level read permissions are not written for resources
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False);
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False);
         Assert.That(
             resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
             Is.True,
@@ -1929,15 +1920,13 @@ public class SFProjectServiceTests
         user = env.GetUser(User03);
         Assert.That(user.Sites[SiteId].Projects, Contains.Item(Project05));
 
-        Assert.That(project.Texts.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(project.Texts.First().Permissions.ContainsKey(User03), Is.False);
         Assert.That(project.Texts.First().Chapters.First().Permissions[User03], Is.EqualTo(TextInfoPermission.Write));
 
         resource = env.GetProject(Resource01);
-        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-        Assert.That(
-            resource.Texts.First().Chapters.First().Permissions[User03],
-            Is.EqualTo(userDBLPermissionForResource)
-        );
+        // Book and chapter level read permissions are not written for resources
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False);
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False);
         Assert.That(
             resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
             Is.True,
@@ -2106,7 +2095,7 @@ public class SFProjectServiceTests
 
         // Permissions were set for the books and chapters that we were able to handle.
         sfProject = env.GetProject(Project01);
-        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions.ContainsKey(User01), Is.False);
         Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
         Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
         Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
@@ -2177,7 +2166,7 @@ public class SFProjectServiceTests
         await env.Service.UpdatePermissionsAsync(User01, project01Doc);
 
         sfProject = env.GetProject(Project01);
-        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions.ContainsKey(User01), Is.False);
         Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
         Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
         Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
@@ -2230,10 +2219,10 @@ public class SFProjectServiceTests
         await env.Service.UpdatePermissionsAsync(User01, project01Doc);
 
         sfProject = env.GetProject(Project01);
-        Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Permissions.ContainsKey(User01), Is.False);
         Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
-        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.ContainsKey(User01), Is.False);
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.ContainsKey(User02), Is.False);
     }
 
     [Test]
@@ -2253,7 +2242,7 @@ public class SFProjectServiceTests
         var ptChapterPermissions = new Dictionary<string, string>
         {
             { User01, TextInfoPermission.Write },
-            { User02, TextInfoPermission.Write },
+            { User02, TextInfoPermission.Read },
         };
         var ptSourcePermissions = new Dictionary<string, string>
         {
@@ -2308,12 +2297,12 @@ public class SFProjectServiceTests
         resource = env.GetProject(Resource01);
         Assert.That(sfProject.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
         Assert.That(sfProject.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
-        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Write));
-        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Write));
-        Assert.That(resource.Texts.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions.ContainsKey(User01), Is.False);
+        Assert.That(sfProject.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.Read));
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User01), Is.False);
         Assert.That(resource.Texts.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
-        Assert.That(resource.Texts.First().Chapters.First().Permissions[User01], Is.EqualTo(TextInfoPermission.Read));
-        Assert.That(resource.Texts.First().Chapters.First().Permissions[User02], Is.EqualTo(TextInfoPermission.None));
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User01), Is.False);
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User02), Is.False);
     }
 
     [Test]
@@ -2746,7 +2735,8 @@ public class SFProjectServiceTests
             );
         resource = env.GetProject(Resource01);
         Assert.That(resource.UserRoles.ContainsKey(User01), Is.True);
-        Assert.That(resource.Texts.All(t => t.Permissions.ContainsKey(User01)), Is.True);
+        // Book and chapter level read permissions are not written for resources
+        Assert.That(resource.Texts.All(t => t.Permissions.ContainsKey(User01)), Is.False);
     }
 
     [Test]
@@ -3203,11 +3193,9 @@ public class SFProjectServiceTests
         // But we can show that source resource permissions were set:
 
         resource = env.GetProject(Resource01);
-        Assert.That(resource.Texts.First().Permissions[User03], Is.EqualTo(userDBLPermissionForResource));
-        Assert.That(
-            resource.Texts.First().Chapters.First().Permissions[User03],
-            Is.EqualTo(userDBLPermissionForResource)
-        );
+        // Book and chapter level read permissions are not written for resources
+        Assert.That(resource.Texts.First().Permissions.ContainsKey(User03), Is.False);
+        Assert.That(resource.Texts.First().Chapters.First().Permissions.ContainsKey(User03), Is.False);
         Assert.That(
             resource.UserRoles.TryGetValue(User03, out string resourceUserRole),
             Is.True,
@@ -4188,6 +4176,35 @@ public class SFProjectServiceTests
     }
 
     [Test]
+    public async Task SetDraftAppliedAsync_RequiresAtLeastBookPermission()
+    {
+        var env = new TestEnvironment();
+        const int book = 40;
+        const int chapter = 1;
+        const bool draftApplied = true;
+        const int lastVerse = 25;
+
+        // Grant User01 write permission to the book
+        await env
+            .RealtimeService.GetRepository<SFProject>()
+            .UpdateAsync(
+                Project01,
+                u =>
+                    u.Set(
+                        p => p.Texts[0].Permissions,
+                        new Dictionary<string, string> { { User01, TextInfoPermission.Write } }
+                    )
+            );
+
+        // SUT
+        await env.Service.SetDraftAppliedAsync(User01, Project01, book, chapter, draftApplied, lastVerse);
+
+        SFProject project = env.GetProject(Project01);
+        Assert.IsTrue(project.Texts[0].Chapters[0].DraftApplied);
+        Assert.IsTrue(project.Texts[0].Chapters[0].LastVerse == lastVerse);
+    }
+
+    [Test]
     public async Task SetDraftAppliedAsync_Success()
     {
         var env = new TestEnvironment();
@@ -4327,6 +4344,32 @@ public class SFProjectServiceTests
         Assert.ThrowsAsync<ForbiddenException>(() =>
             env.Service.SetIsValidAsync(User01, Resource01, book, chapter, isValid)
         );
+    }
+
+    [Test]
+    public async Task SetIsValidAsync_RequiresAtLeastBookPermission()
+    {
+        var env = new TestEnvironment();
+        const int book = 40;
+        const int chapter = 1;
+        const bool isValid = true;
+
+        // Grant User01 write permission
+        await env
+            .RealtimeService.GetRepository<SFProject>()
+            .UpdateAsync(
+                Project01,
+                u =>
+                    u.Set(
+                        p => p.Texts[0].Permissions,
+                        new Dictionary<string, string> { { User01, TextInfoPermission.Write } }
+                    )
+            );
+
+        // SUT
+        await env.Service.SetIsValidAsync(User01, Project01, book, chapter, isValid);
+
+        Assert.IsTrue(env.GetProject(Project01).Texts[0].Chapters[0].IsValid);
     }
 
     [Test]


### PR DESCRIPTION
This PR is a reimplementation of SF-3637 / #3566, but with the following changes:

 * Serval Admins can sync resources.
 * Permission updates are performed as individual ops, which are submitted to the realtime server in batches of 1000.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3811)
<!-- Reviewable:end -->
