### PR TITLE
SF-3784 Show copyright messages on draft wizard

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -7,6 +7,12 @@
       <mat-step [completed]="true">
         <ng-template matStepLabel>{{ t("overview") }}</ng-template>
         <app-confirm-sources></app-confirm-sources>
+        @for (copyrightMessage of copyrightMessages; track copyrightMessage.banner) {
+          <app-copyright-banner
+            [notice]="copyrightMessage.notice"
+            [banner]="copyrightMessage.banner"
+          ></app-copyright-banner>
+        }
         @if (projectsPendingUpdate.length > 0) {
           @for (project of projectsPendingUpdate; track project.projectId) {
             <app-notice icon="info" type="info" class="pending-updates">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.scss
@@ -59,6 +59,11 @@ h2 {
   gap: 8px;
 }
 
+app-copyright-banner {
+  margin: 20px 0;
+  display: flex;
+}
+
 app-notice {
   margin: 20px 0;
   width: fit-content;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -1368,7 +1368,7 @@ describe('DraftGenerationStepsComponent', () => {
     });
   });
 
-  describe('pending updates', () => {
+  describe('project notices', () => {
     const availableBooks = [
       { bookNum: 1 },
       { bookNum: 2 },
@@ -1385,13 +1385,17 @@ describe('DraftGenerationStepsComponent', () => {
           projectRef: 'source1',
           shortName: 'sP1',
           writingSystem: { tag: 'eng' },
-          texts: availableBooks
+          texts: availableBooks,
+          copyrightBanner: 'Copyright Banner 1',
+          copyrightNotice: 'Copyright Notice 1'
         },
         {
           projectRef: 'source2',
           shortName: 'sP2',
           writingSystem: { tag: 'eng' },
-          texts: availableBooks
+          texts: availableBooks,
+          copyrightBanner: 'Copyright Banner 2',
+          copyrightNotice: 'Copyright Notice 2'
         }
       ] as [DraftSource, DraftSource],
       trainingTargets: [
@@ -1407,7 +1411,9 @@ describe('DraftGenerationStepsComponent', () => {
           projectRef: draftingSourceId,
           shortName: 'dS',
           writingSystem: { tag: 'eng' },
-          texts: availableBooks.concat({ bookNum: 7 })
+          texts: availableBooks.concat({ bookNum: 7 }),
+          copyrightBanner: 'Copyright Banner 1',
+          copyrightNotice: 'Copyright Notice 1'
         }
       ] as [DraftSource]
     };
@@ -1453,6 +1459,13 @@ describe('DraftGenerationStepsComponent', () => {
       fixture.detectChanges();
       tick();
     }));
+
+    it('should show copyright notices', () => {
+      expect(component.copyrightMessages).toEqual([
+        { banner: 'Copyright Banner 1', notice: 'Copyright Notice 1' },
+        { banner: 'Copyright Banner 2', notice: 'Copyright Notice 2' }
+      ]);
+    });
 
     it('should show projects pending updates', () => {
       expect(component.projectsPendingUpdate).toEqual([

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -46,6 +46,7 @@ import { ParatextService } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { Book } from '../../../shared/book-multi-select/book-multi-select';
 import { BookMultiSelectComponent } from '../../../shared/book-multi-select/book-multi-select.component';
+import { CopyrightBannerComponent } from '../../../shared/copyright-banner/copyright-banner.component';
 import { NoticeComponent } from '../../../shared/notice/notice.component';
 import { BookProgress, ProgressService, ProjectProgress } from '../../../shared/progress-service/progress.service';
 import { booksFromScriptureRange, projectLabel } from '../../../shared/utils';
@@ -83,6 +84,12 @@ interface ProjectPendingUpdate {
   syncUrl: string;
 }
 
+/** Copyright banner for a project. */
+interface CopyrightMessage {
+  banner: string;
+  notice?: string;
+}
+
 @Component({
   selector: 'app-draft-generation-steps',
   templateUrl: './draft-generation-steps.component.html',
@@ -113,7 +120,8 @@ interface ProjectPendingUpdate {
     TranslocoModule,
     TranslocoMarkupModule,
     BookMultiSelectComponent,
-    ConfirmSourcesComponent
+    ConfirmSourcesComponent,
+    CopyrightBannerComponent
   ]
 })
 export class DraftGenerationStepsComponent implements OnInit {
@@ -122,6 +130,7 @@ export class DraftGenerationStepsComponent implements OnInit {
   @ViewChild(MatStepper) stepper!: MatStepper;
 
   projectsPendingUpdate: ProjectPendingUpdate[] = [];
+  copyrightMessages: CopyrightMessage[] = [];
 
   allAvailableTranslateBooks: Book[] = []; // A flattened instance of the values from availableTranslateBooks
   availableTranslateBooks: { [projectRef: string]: Book[] } = {};
@@ -386,6 +395,15 @@ export class DraftGenerationStepsComponent implements OnInit {
 
           this.sendEmailOnBuildFinished =
             this.activatedProject.projectDoc?.data?.translateConfig.draftConfig.sendEmailOnBuildFinished ?? false;
+
+          // Load any copyright messages that are available
+          this.copyrightMessages = [...trainingSources, ...draftingSources]
+            .map(s => ({
+              banner: s.copyrightBanner,
+              notice: s.copyrightNotice
+            }))
+            .filter(s => s.banner != null)
+            .filter((value, index, self) => index === self.findIndex(v => v.banner === value.banner));
 
           // See if the target and any of the sources need updating
           const projectIds: string[] = [

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -2,14 +2,7 @@ import { AsyncPipe, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, DestroyRef, OnInit, ViewChild } from '@angular/core';
 import { MatAnchor, MatButton } from '@angular/material/button';
-import {
-  MatCard,
-  MatCardActions,
-  MatCardContent,
-  MatCardHeader,
-  MatCardSubtitle,
-  MatCardTitle
-} from '@angular/material/card';
+import { MatCard, MatCardContent, MatCardHeader, MatCardSubtitle, MatCardTitle } from '@angular/material/card';
 import { MatDialogRef, MatDialogState } from '@angular/material/dialog';
 import { MatExpansionPanel, MatExpansionPanelContent, MatExpansionPanelHeader } from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
@@ -47,9 +40,7 @@ import { BuildStates } from '../../machine-api/build-states';
 import { ServalProjectComponent } from '../../serval-administration/serval-project.component';
 import { NoticeComponent } from '../../shared/notice/notice.component';
 import { booksFromScriptureRange, projectLabel } from '../../shared/utils';
-import { WorkingAnimatedIndicatorComponent } from '../../shared/working-animated-indicator/working-animated-indicator.component';
 import { NllbLanguageService } from '../nllb-language.service';
-import { DraftDownloadButtonComponent } from './draft-download-button/draft-download-button.component';
 import { activeBuildStates, BuildConfig } from './draft-generation';
 import {
   DraftGenerationStepsComponent,
@@ -59,7 +50,6 @@ import { DraftGenerationService } from './draft-generation.service';
 import { DraftHistoryListComponent } from './draft-history-list/draft-history-list.component';
 import { DraftInformationComponent } from './draft-information/draft-information.component';
 import { DraftOptionsService } from './draft-options.service';
-import { DraftPreviewBooksComponent } from './draft-preview-books/draft-preview-books.component';
 import { DRAFT_SIGNUP_RESPONSE_DAYS } from './draft-signup-form/draft-onboarding-form.component';
 import { DraftSource } from './draft-source';
 import { DraftSourcesService } from './draft-sources.service';
@@ -82,7 +72,6 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
     MatCardTitle,
     MatCardSubtitle,
     MatCardContent,
-    MatCardActions,
     MatProgressBar,
     MatExpansionPanel,
     MatExpansionPanelHeader,
@@ -94,12 +83,9 @@ import { SupportedBackTranslationLanguagesDialogComponent } from './supported-ba
     NgCircleProgressModule,
     L10nNumberPipe,
     L10nPercentPipe,
-    WorkingAnimatedIndicatorComponent,
     DraftGenerationStepsComponent,
     DraftInformationComponent,
     ServalProjectComponent,
-    DraftDownloadButtonComponent,
-    DraftPreviewBooksComponent,
     DraftHistoryListComponent
   ]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-source.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-source.ts
@@ -7,6 +7,8 @@ interface DraftTextInfo {
 export interface DraftSource extends TranslateSource {
   texts: DraftTextInfo[];
   noAccess?: boolean;
+  copyrightBanner?: string;
+  copyrightNotice?: string;
 }
 
 export interface DraftSourcesAsArrays {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -248,10 +248,12 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
   async loadProjects(): Promise<void> {
     this.loadingStarted();
     try {
-      [this.projects, this.resources] = await Promise.all([
+      const [projects, resources] = await Promise.all([
         this.paratextService.getProjects(),
         this.paratextService.getResources()
       ]);
+      this.projects = projects;
+      this.resources = resources?.filter(r => !['ESVUK', 'ESVUS11', 'ESVUS16'].includes(r.shortName));
     } catch (error) {
       if (!isNetworkError(error)) {
         this.errorReportingService.silentError(


### PR DESCRIPTION
This PR shows copyright messages for translations on the draft wizard, and prevents translations that do not want to be used as the basis for other translations from being used as drafting or training sources.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3814)
<!-- Reviewable:end -->
