### PR TITLE
Fix checkbox theme inside notice components and reduce bundle size

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -1,9 +1,6 @@
 @use 'sass:color';
 @use 'sass:list';
-@use 'sass:map';
-@use '@angular/material' as mat;
 @use 'src/variables' as sfColors;
-@use 'src/themes/default' as default;
 
 // prettier-ignore
 $colors: (
@@ -20,27 +17,6 @@ $colors: (
 // Helper function just to clean up the syntax
 @function scaleLightness($color, $lightness) {
   @return color.scale($color, $lightness: $lightness);
-}
-
-@function create-dark-palette($base-color) {
-  @return (
-    0: scaleLightness($base-color, -95%),
-    10: scaleLightness($base-color, -90%),
-    20: scaleLightness($base-color, -80%),
-    25: scaleLightness($base-color, -75%),
-    30: scaleLightness($base-color, -70%),
-    35: scaleLightness($base-color, -65%),
-    40: scaleLightness($base-color, -60%),
-    50: scaleLightness($base-color, -50%),
-    60: scaleLightness($base-color, -40%),
-    70: scaleLightness($base-color, -30%),
-    80: scaleLightness($base-color, -25%),
-    90: scaleLightness($base-color, -10%),
-    95: scaleLightness($base-color, -5%),
-    98: scaleLightness($base-color, -2%),
-    99: scaleLightness($base-color, -1%),
-    100: $base-color
-  );
 }
 
 :host {
@@ -84,20 +60,6 @@ $colors: (
       --notice-color-button-hover-bg-alt: #{scaleLightness($colorLight, 80%)};
       --notice-color-button-text-alt: #{scaleLightness($colorLight, -60%)};
 
-      // prettier-ignore
-      &.mode-fill-dark,
-      &.mode-fill-light {
-        $_notice_theme: mat.define-theme(
-          (
-            color: (
-                primary: map.merge(create-dark-palette($colorLight), default.$rest)
-              )
-          )
-        );
-
-        @include mat.checkbox-color($_notice_theme);
-      }
-
       // Dark theme
       :host-context(html.theme-default-dark) & {
         --notice-color: #{scaleLightness($colorDark, -35%)};
@@ -114,6 +76,18 @@ $colors: (
         --notice-color-button-text: #{scaleLightness($colorLight, 55%)};
         --notice-color-button-text-alt: #{scaleLightness($colorLight, -55%)};
       }
+    }
+  }
+
+  // Theme checkboxes to use the notice's color scheme
+  &.mode-fill-dark,
+  &.mode-fill-light {
+    ::ng-deep mat-checkbox {
+      --mat-checkbox-selected-icon-color: var(--notice-color-button-text-alt);
+      --mat-checkbox-selected-focus-icon-color: var(--notice-color-button-text-alt);
+      --mat-checkbox-selected-hover-icon-color: var(--notice-color-button-text-alt);
+      --mat-checkbox-selected-pressed-icon-color: var(--notice-color-button-text-alt);
+      --mat-checkbox-selected-checkmark-color: #fff;
     }
   }
 


### PR DESCRIPTION
Nearly 5% of our bundle is dedicated to trying to theme checkboxes inside app-notice components. This used to work until I broke it in #3621 while fixing the accent theme. (This means the ~5% was dedicated to *unsuccessfully* theming checkboxes).

This PR reduces the bundle size while fixing the theme.

**Before** Accent theme is used

<img width="439" height="52" alt="Screenshot from 2026-04-21 10-29-39" src="https://github.com/user-attachments/assets/f57c57ee-db4d-4aa8-8bf3-60c6285fc89f" />

<br>

**After** Notice theme is used
<img width="439" height="52" alt="Screenshot from 2026-04-21 09-54-04" src="https://github.com/user-attachments/assets/b53363c0-3826-4220-8f85-da49e13707fd" />
<img width="306" height="55" alt="Screenshot from 2026-04-21 09-53-48" src="https://github.com/user-attachments/assets/9fd0d3d2-b9dd-4550-ae31-9576ab47d45d" />

The actual estimated transfer size drops by only 1.1%, since the ~5% was quite redundant and so it compressed quite a bit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3815)
<!-- Reviewable:end -->
