### PR TITLE
Move onboarding request status to first column

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.html
@@ -22,6 +22,12 @@
       <p class="no-requests">No requests are in the "{{ currentFilterName }}" category.</p>
     } @else {
       <table mat-table [dataSource]="filteredRequests" class="requests-table">
+        <!-- Status Column (read-only, calculated from assignee and resolution) -->
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let request">{{ getStatus(request.status).label }}</td>
+        </ng-container>
+
         <!-- Project Column -->
         <ng-container matColumnDef="project">
           <th mat-header-cell *matHeaderCellDef>Project</th>
@@ -50,12 +56,6 @@
               [includeAvatar]="true"
             ></app-owner>
           </td>
-        </ng-container>
-
-        <!-- Status Column (read-only, calculated from assignee and resolution) -->
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>Status</th>
-          <td mat-cell *matCellDef="let request">{{ getStatus(request.status).label }}</td>
         </ng-container>
 
         <!-- Assignee Column -->

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
@@ -93,7 +93,7 @@ type FilterName = keyof typeof filterOptions;
 export class OnboardingRequestsComponent extends DataLoadingComponent implements OnInit {
   requests: OnboardingRequest[] = [];
   filteredRequests: OnboardingRequest[] = [];
-  displayedColumns: string[] = ['project', 'languageCode', 'user', 'status', 'assignee', 'resolution'];
+  displayedColumns: string[] = ['status', 'project', 'languageCode', 'user', 'assignee', 'resolution'];
   currentUserId?: string;
   assignedUserIds: Set<string> = new Set();
   userDisplayNames: Map<string, string> = new Map();


### PR DESCRIPTION
From this morning's meeting

Technically updating the template is unnecessary; the column order comes only from the `displayedColumns` of the component, but I think it's confusing if you have a different order in the template.

<img width="636" height="189" alt="Screenshot from 2026-04-21 12-47-13" src="https://github.com/user-attachments/assets/8de506f9-1857-4e4f-80b9-5359fa946b43" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3816)
<!-- Reviewable:end -->
