### PR TITLE
Improve default onboarding request filter to exclude completed requests

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
@@ -32,10 +32,10 @@ interface FilterOption {
 }
 
 const filterOptions = {
-  newAndMine: {
-    name: 'New + Mine',
+  newAndMyActiveRequests: {
+    name: 'New + My Active Requests',
     filter: (request: OnboardingRequest, currentUserId: string | undefined) =>
-      request.status === 'new' || request.assigneeId === currentUserId
+      request.status === 'new' || (request.assigneeId === currentUserId && request.status === 'in_progress')
   },
   new: {
     name: 'New',
@@ -234,7 +234,7 @@ export class OnboardingRequestsComponent extends DataLoadingComponent implements
     return r1 === r2 || (r1 == null && r2 == null);
   }
 
-  private _activeFilter: FilterName = 'newAndMine';
+  private _activeFilter: FilterName = 'newAndMyActiveRequests';
   get activeFilter(): string {
     return this._activeFilter;
   }


### PR DESCRIPTION
From this morning's meeting.

The older filter would show requests that were already completed. The new filter shows new (unassigned) requests, plus those that the user is still working on.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3817)
<!-- Reviewable:end -->
