### PR TITLE
SF-3785 Fix Serval admins not being able to download training data

### DIFF
--- a/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-service.spec.ts
@@ -1,6 +1,7 @@
 import ShareDB from 'sharedb';
 import ShareDBMingo from 'sharedb-mingo-memory';
 import { instance, mock } from 'ts-mockito';
+import { SystemRole } from '../../common/models/system-role';
 import { User, USERS_COLLECTION } from '../../common/models/user';
 import { createTestUser } from '../../common/models/user-test-data';
 import { RealtimeServer } from '../../common/realtime-server';
@@ -43,6 +44,17 @@ describe('TrainingDataService', () => {
     await expect(
       fetchDoc(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'))
     ).rejects.toThrow();
+  });
+
+  it('allows serval admin to view training data even if not a project member', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    // SUT
+    const conn = clientConnect(env.server, 'servalAdmin', SystemRole.ServalAdmin);
+    await expect(
+      fetchDoc(conn, TRAINING_DATA_COLLECTION, getTrainingDataId('project01', 'dataid01'))
+    ).resolves.not.toThrow();
   });
 });
 

--- a/src/RealtimeServer/scriptureforge/services/training-data-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/training-data-service.ts
@@ -1,3 +1,5 @@
+import { ConnectSession } from '../../common/connect-session';
+import { SystemRole } from '../../common/models/system-role';
 import { ValidationSchema } from '../../common/models/validation-schema';
 import { ProjectDomainConfig } from '../../common/services/project-data-service';
 import { SFProjectDomain } from '../models/sf-project-rights';
@@ -49,6 +51,13 @@ export class TrainingDataService extends SFProjectDataService<TrainingData> {
 
     const immutableProps = [this.pathTemplate(t => t.dataId)];
     this.immutableProps.push(...immutableProps);
+  }
+
+  protected async allowRead(docId: string, doc: TrainingData, session: ConnectSession): Promise<boolean> {
+    if (session.roles.includes(SystemRole.ServalAdmin)) {
+      return true;
+    }
+    return super.allowRead(docId, doc, session);
   }
 
   protected setupDomains(): ProjectDomainConfig[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.spec.ts
@@ -9,21 +9,19 @@ import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { DraftConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { BehaviorSubject, of, throwError } from 'rxjs';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
 import { TestOnlineStatusService } from 'xforge-common/test-online-status.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
-import { TrainingDataDoc } from '../core/models/training-data-doc';
 import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
 import { DraftZipProgress } from '../translate/draft-generation/draft-generation';
@@ -512,19 +510,14 @@ describe('ServalProjectComponent', () => {
       when(mockSFProjectService.hasDraft(anything())).thenReturn(args.preTranslate);
       when(mockSFProjectService.onlineSetServalConfig(this.mockProjectId, anything())).thenResolve();
       when(mockSFProjectService.onlineSetQualityEstimationConfig(this.mockProjectId, anything())).thenResolve();
-      const trainingData: TrainingDataDoc[] = [
+      const trainingData: TrainingData[] = [
         {
-          id: 'training01',
-          data: {
-            fileUrl: 'file-url',
-            dataId: 'dataId01',
-            title: 'training-data-01.csv'
-          } as TrainingData
-        } as TrainingDataDoc
+          fileUrl: 'file-url',
+          dataId: 'dataId01',
+          title: 'training-data-01.csv'
+        } as TrainingData
       ];
-      const mockQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery<TrainingDataDoc>);
-      when(mockQuery.docs).thenReturn(trainingData);
-      when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(instance(mockQuery));
+      when(mockTrainingDataService.getTrainingData(anything(), anything())).thenReturn(of(trainingData));
 
       spyOn(saveAs, 'saveAs').and.stub();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -30,30 +30,18 @@ import {
   QualityEstimationConfig,
   TranslateSource
 } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import {
-  catchError,
-  filter,
-  firstValueFrom,
-  lastValueFrom,
-  Observable,
-  of,
-  Subscription,
-  switchMap,
-  throwError
-} from 'rxjs';
+import { catchError, firstValueFrom, lastValueFrom, Observable, of, Subscription, switchMap, throwError } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { FileType } from 'xforge-common/models/file-offline-data';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { RouterLinkDirective } from 'xforge-common/router-link.directive';
 import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { WriteStatusComponent } from 'xforge-common/write-status/write-status.component';
-import { TrainingDataDoc } from '../core/models/training-data-doc';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { BuildDto } from '../machine-api/build-dto';
@@ -159,8 +147,6 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   rawLastCompletedBuild: any;
   zipSubscription: Subscription | undefined;
   trainingDataFiles: TrainingData[] = [];
-
-  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
 
   constructor(
     private readonly activatedProjectService: ActivatedProjectService,
@@ -290,13 +276,12 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
     this.activatedProjectService.projectId$
       .pipe(
-        filter(p => p != null),
-        quietTakeUntilDestroyed(this.destroyRef)
+        quietTakeUntilDestroyed(this.destroyRef),
+        filterNullish(),
+        switchMap(projectId => this.trainingDataService.getTrainingData(projectId, this.destroyRef))
       )
-      .subscribe(async projectId => {
-        this.trainingDataQuery?.dispose();
-        this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectId, this.destroyRef);
-        this.trainingDataFiles = this.trainingDataQuery.docs.map(doc => doc.data).filter(d => d != null);
+      .subscribe(activeFiles => {
+        this.trainingDataFiles = activeFiles;
       });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.component.ts
@@ -2,13 +2,11 @@ import { Component, DestroyRef } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
-import { merge, Subscription } from 'rxjs';
+import { EMPTY, switchMap } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SelectableProjectWithLanguageCode } from '../../../core/models/selectable-project';
-import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { projectLabel } from '../../../shared/utils';
 import {
   DraftSourcesAsSelectableProjectArrays,
@@ -31,40 +29,29 @@ export class ConfirmSourcesComponent {
   };
   protected trainingDataFiles: TrainingData[] = [];
 
-  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
-  private trainingDataQuerySubscription?: Subscription;
-
   constructor(
     private readonly destroyRef: DestroyRef,
     private readonly i18nService: I18nService,
     private readonly activatedProject: ActivatedProjectService,
     private readonly trainingDataService: TrainingDataService
   ) {
-    this.activatedProject.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectDoc => {
-      if (projectDoc?.data != null) {
-        this.draftSources = draftSourcesAsTranslateSourceArraysToDraftSourcesAsSelectableProjectArrays(
-          projectToDraftSources(projectDoc?.data)
-        );
-
-        this.trainingDataQuery?.dispose();
-        this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id, this.destroyRef);
-        this.trainingDataQuerySubscription?.unsubscribe();
-
-        this.trainingDataQuerySubscription = merge(
-          this.trainingDataQuery.localChanges$,
-          this.trainingDataQuery.ready$,
-          this.trainingDataQuery.remoteChanges$,
-          this.trainingDataQuery.remoteDocChanges$
-        )
-          .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
-          .subscribe(() => {
-            this.trainingDataFiles =
-              (this.trainingDataQuery?.docs
-                .map(doc => doc.data)
-                .filter(d => d != null && d.deleted !== true) as TrainingData[]) ?? [];
-          });
-      }
+    this.activatedProject.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
+      if (projectDoc?.data == null) return;
+      this.draftSources = draftSourcesAsTranslateSourceArraysToDraftSourcesAsSelectableProjectArrays(
+        projectToDraftSources(projectDoc.data)
+      );
     });
+
+    this.activatedProject.projectId$
+      .pipe(
+        quietTakeUntilDestroyed(this.destroyRef),
+        switchMap(projectId =>
+          projectId == null ? EMPTY : this.trainingDataService.getTrainingData(projectId, this.destroyRef)
+        )
+      )
+      .subscribe(activeFiles => {
+        this.trainingDataFiles = activeFiles;
+      });
   }
 
   projectLabel(project: SelectableProjectWithLanguageCode): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/confirm-sources/confirm-sources.stories.ts
@@ -3,7 +3,7 @@ import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-role';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { of } from 'rxjs';
-import { instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { SFProjectProfileDoc } from '../../../core/models/sf-project-profile-doc';
@@ -61,11 +61,13 @@ when(mockActivatedProject.changes$).thenReturn(
 );
 
 when(mockActivatedProject.projectId).thenReturn('test-proj');
+when(mockActivatedProject.projectId$).thenReturn(of('test-proj'));
 when(mockActivatedProject.projectDoc).thenReturn({
   id: 'test-proj',
   data: createTestProjectProfile({ userRoles: { user1: SFProjectRole.ParatextAdministrator } })
 } as SFProjectProfileDoc);
 when(mockAuthService.currentUserId).thenReturn('user1');
+when(mockTrainingService.getTrainingData(anything(), anything())).thenReturn(of([]));
 
 const meta: Meta = {
   title: 'Translate/ConfirmSources',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -28,20 +28,18 @@ import {
   ProjectScriptureRange,
   TranslateSource
 } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
-import { combineLatest, merge, Subscription } from 'rxjs';
+import { combineLatest, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter } from 'rxjs/operators';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { ParatextProject } from '../../../core/models/paratext-project';
-import { TrainingDataDoc } from '../../../core/models/training-data-doc';
 import { ParatextService } from '../../../core/paratext.service';
 import { SFProjectService } from '../../../core/sf-project.service';
 import { Book } from '../../../shared/book-multi-select/book-multi-select';
@@ -168,8 +166,7 @@ export class DraftGenerationStepsComponent implements OnInit {
   protected trainingDataFiles: Readonly<TrainingData>[] = [];
   protected isCustomConfigSet = false;
 
-  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
-  private trainingDataQuerySubscription?: Subscription;
+  private trainingDataSubscription?: Subscription;
   private currentUserDoc?: UserDoc;
   private projectProgress: Map<string, ProjectProgress> = new Map<string, ProjectProgress>();
 
@@ -264,22 +261,12 @@ export class DraftGenerationStepsComponent implements OnInit {
             this.projectProgress.set(source.projectRef, trainingSourceProgress);
           }
 
-          this.trainingDataQuery?.dispose();
-          this.trainingDataQuery = await this.trainingFileService.queryTrainingDataAsync(projectId!, this.destroyRef);
-          this.trainingDataQuerySubscription?.unsubscribe();
-
-          this.trainingDataQuerySubscription = merge(
-            this.trainingDataQuery.localChanges$,
-            this.trainingDataQuery.ready$,
-            this.trainingDataQuery.remoteChanges$,
-            this.trainingDataQuery.remoteDocChanges$
-          )
+          this.trainingDataSubscription?.unsubscribe();
+          this.trainingDataSubscription = this.trainingFileService
+            .getTrainingData(projectId!, this.destroyRef)
             .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
-            .subscribe(() => {
-              this.trainingDataFiles =
-                (this.trainingDataQuery?.docs
-                  .map(doc => doc.data)
-                  .filter(d => d != null && !d.deleted) as Readonly<TrainingData>[]) ?? [];
+            .subscribe(activeFiles => {
+              this.trainingDataFiles = activeFiles;
             });
 
           // Reset the field that toggles a notice that books were automatically selected

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -15,7 +15,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -24,7 +23,6 @@ import { TestOnlineStatusService } from 'xforge-common/test-online-status.servic
 import { getTestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
-import { TrainingDataDoc } from '../../core/models/training-data-doc';
 import { ProjectNotificationService } from '../../core/project-notification.service';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
@@ -154,13 +152,8 @@ describe('DraftGenerationComponent', () => {
       mockNllbLanguageService = jasmine.createSpyObj<NllbLanguageService>(['isNllbLanguageAsync']);
       mockNllbLanguageService.isNllbLanguageAsync.and.returnValue(Promise.resolve(false));
 
-      const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
-      when(mockTrainingDataQuery.localChanges$).thenReturn(of());
-      when(mockTrainingDataQuery.ready$).thenReturn(of(true));
-      when(mockTrainingDataQuery.remoteChanges$).thenReturn(of());
-      when(mockTrainingDataQuery.remoteDocChanges$).thenReturn(of());
-      mockTrainingDataService = jasmine.createSpyObj<TrainingDataService>(['queryTrainingDataAsync']);
-      mockTrainingDataService.queryTrainingDataAsync.and.returnValue(Promise.resolve(instance(mockTrainingDataQuery)));
+      mockTrainingDataService = jasmine.createSpyObj<TrainingDataService>(['getTrainingData']);
+      mockTrainingDataService.getTrainingData.and.returnValue(of([]));
       mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>({
         newDraftHistory: createTestFeatureFlag(false),
         usfmFormat: createTestFeatureFlag(false),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -3,19 +3,18 @@ import { provideRouter } from '@angular/router';
 import { createTestUserProfile } from 'realtime-server/lib/esm/common/models/user-test-data';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
+import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { ParagraphBreakFormat, QuoteFormat } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { of } from 'rxjs';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
 import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
 import { SF_TYPE_REGISTRY } from '../../../../core/models/sf-type-registry';
-import { TrainingDataDoc } from '../../../../core/models/training-data-doc';
 import { PermissionsService } from '../../../../core/permissions.service';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { BuildDto } from '../../../../machine-api/build-dto';
@@ -72,17 +71,14 @@ describe('DraftHistoryEntryComponent', () => {
       })
     } as SFProjectProfileDoc;
     when(mockedActivatedProjectService.projectDoc).thenReturn(targetProjectDoc);
-    const trainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery<TrainingDataDoc>);
-    when(trainingDataQuery.docs).thenReturn([
-      { id: 'doc01', data: { dataId: 'file01', title: 'training-data.txt' } } as TrainingDataDoc
-    ]);
-    when(mockedTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
-      instance(trainingDataQuery)
-    );
     when(mockedDraftOptionsService.areFormattingOptionsAvailableButUnselected(anything())).thenReturn(true);
     when(mockedPermissionsService.isUserOnProject(anything())).thenResolve(true);
     const userDoc = { id: 'sf-user-id', data: { displayName: 'User 01' } } as UserProfileDoc;
     when(mockedUserService.getProfile(anything())).thenResolve(userDoc);
+    const activeTrainingData: TrainingData[] = [{ dataId: 'file01', title: 'training-data.txt' } as TrainingData];
+    when(mockedTrainingDataService.getTrainingData(anything(), anything(), anything())).thenReturn(
+      of(activeTrainingData)
+    );
     fixture = TestBed.createComponent(DraftHistoryEntryComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -144,6 +140,29 @@ describe('DraftHistoryEntryComponent', () => {
       expect(component.trainingConfigurationOpen).toBe(false);
       expect(fixture.nativeElement.querySelector('.scriptureRange')).toBeNull();
       expect(fixture.nativeElement.querySelector('.requested-label')).not.toBeNull();
+    }));
+
+    it('should show the title of deleted training data files used in the build', fakeAsync(() => {
+      const deletedFile: TrainingData = { dataId: 'file01', title: 'deleted-file.txt', deleted: true } as TrainingData;
+      when(mockedTrainingDataService.getTrainingData(anything(), anything(), anything())).thenReturn(of([deletedFile]));
+
+      const user = 'user-display-name';
+      const date = dateAfterFormattingSupported;
+      const entry = getStandardBuildDto({
+        user,
+        date,
+        trainingBooks: ['EXO'],
+        translateBooks: ['GEN'],
+        trainingDataFiles: ['file01']
+      });
+
+      // SUT
+      component.entry = entry;
+      tick();
+      fixture.detectChanges();
+
+      // The deleted file's title should still be shown, since this is historical data
+      expect(component.trainingDataFiles).toEqual(['deleted-file.txt']);
     }));
 
     it('should not get source project if user does not have permission', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -24,13 +24,13 @@ import {
 import { RouterLink } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
+import { Subject, takeUntil } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { UserService } from 'xforge-common/user.service';
+import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { SFProjectProfileDoc } from '../../../../core/models/sf-project-profile-doc';
-import { TrainingDataDoc } from '../../../../core/models/training-data-doc';
 import { PermissionsService } from '../../../../core/permissions.service';
 import { SFProjectService } from '../../../../core/sf-project.service';
 import { BuildDto } from '../../../../machine-api/build-dto';
@@ -102,8 +102,11 @@ interface SourceInfo {
 })
 export class DraftHistoryEntryComponent {
   private _entry?: BuildDto;
+  private entryChanged: Subject<void> = new Subject<void>();
+
   @Input() set entry(value: BuildDto | undefined) {
     this._entry = value;
+    this.entryChanged.next();
 
     // Only set if a draft can be downloaded if it is not set externally
     if (this._draftIsAvailable == null) {
@@ -170,17 +173,15 @@ export class DraftHistoryEntryComponent {
 
     const trainingDataFiles: string[] = this._entry?.additionalInfo?.trainingDataFileIds ?? [];
     if (this.activatedProjectService.projectId != null && trainingDataFiles.length > 0) {
-      this.dataFileQuery?.dispose();
-      void this.trainingDataService
-        .queryTrainingDataAsync(this.activatedProjectService.projectId, this.destroyRef)
-        .then(query => {
-          this.dataFileQuery = query;
-          this._trainingDataFiles = [
-            ...trainingDataFiles
-              .map(fileId => query.docs.find(f => f.data?.dataId === fileId))
-              .filter(file => file?.data != null)
-              .map(file => file!.data!.title)
-          ];
+      // Deleted training data is needed to show historical builds
+      this.trainingDataService
+        .getTrainingData(this.activatedProjectService.projectId, this.destroyRef, { includeDeleted: true })
+        .pipe(quietTakeUntilDestroyed(this.destroyRef), takeUntil(this.entryChanged))
+        .subscribe(allFiles => {
+          this._trainingDataFiles = trainingDataFiles
+            .map(fileId => allFiles.find(f => f.dataId === fileId))
+            .filter(file => file != null)
+            .map(file => file!.title);
         });
     }
 
@@ -320,7 +321,6 @@ export class DraftHistoryEntryComponent {
   readonly columnsToDisplay: string[] = ['scriptureRange', 'source', 'target'];
 
   private readonly showSelectFormatNoticeExpireDate = new Date('2025-12-01T12:00:00.000Z');
-  private dataFileQuery?: RealtimeQuery<TrainingDataDoc>;
 
   readonly timeframeForSelectFormatNotice: boolean = Date.now() < this.showSelectFormatNoticeExpireDate.getTime();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.spec.ts
@@ -8,7 +8,7 @@ import { createTestProject } from 'realtime-server/lib/esm/scriptureforge/models
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { TranslateSource } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { of, Subject } from 'rxjs';
-import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { anything, capture, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
@@ -17,7 +17,6 @@ import { ErrorReportingService } from 'xforge-common/error-reporting.service';
 import { FileService } from 'xforge-common/file.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { FileType } from 'xforge-common/models/file-offline-data';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
@@ -64,13 +63,6 @@ const mockedAuthService = mock(AuthService);
 const mockedDialogService = mock(DialogService);
 const mockTrainingDataService = mock(TrainingDataService);
 const mockedFileService = mock(FileService);
-
-const mockTrainingDataQuery: RealtimeQuery<TrainingDataDoc> = mock(RealtimeQuery);
-const trainingDataQueryLocalChanges$: Subject<void> = new Subject<void>();
-when(mockTrainingDataQuery.localChanges$).thenReturn(trainingDataQueryLocalChanges$);
-when(mockTrainingDataQuery.ready$).thenReturn(of(true));
-when(mockTrainingDataQuery.remoteChanges$).thenReturn(of());
-when(mockTrainingDataQuery.remoteDocChanges$).thenReturn(of());
 
 describe('DraftSourcesComponent', () => {
   configureTestingModule(() => ({
@@ -328,12 +320,7 @@ describe('DraftSourcesComponent', () => {
       env.clickLanguageCodesConfirmationCheckbox();
 
       const savedFile = {} as TrainingData;
-      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
-      when(mockTrainingDataQuery.docs).thenReturn([
-        { data: savedFile } as TrainingDataDoc,
-        { data: deletedFile } as TrainingDataDoc
-      ]);
-      trainingDataQueryLocalChanges$.next();
+      env.activeTrainingData$.next([savedFile]);
 
       expect(env.component.availableTrainingFiles.length).toEqual(1);
 
@@ -352,13 +339,7 @@ describe('DraftSourcesComponent', () => {
 
       const savedFile1 = { dataId: 'file1' } as TrainingData;
       const savedFile2 = { dataId: 'file2' } as TrainingData;
-      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
-      when(mockTrainingDataQuery.docs).thenReturn([
-        { data: savedFile1 } as TrainingDataDoc,
-        { data: savedFile2 } as TrainingDataDoc,
-        { data: deletedFile } as TrainingDataDoc
-      ]);
-      trainingDataQueryLocalChanges$.next();
+      env.activeTrainingData$.next([savedFile1, savedFile2]);
       tick();
 
       expect(env.component.availableTrainingFiles.length).toEqual(2);
@@ -380,12 +361,7 @@ describe('DraftSourcesComponent', () => {
       when(mockedDialogService.confirm(anything(), anything(), anything())).thenResolve(true);
 
       const savedFile = { dataId: 'saved_file', ownerRef: 'user01' } as TrainingData;
-      const deletedFile: TrainingData = { dataId: 'deleted', ownerRef: 'user01', deleted: true } as TrainingData;
-      when(mockTrainingDataQuery.docs).thenReturn([
-        { data: savedFile } as TrainingDataDoc,
-        { data: deletedFile } as TrainingDataDoc
-      ]);
-      trainingDataQueryLocalChanges$.next();
+      env.activeTrainingData$.next([savedFile]);
       tick();
 
       expect(env.component.availableTrainingFiles.length).toEqual(1);
@@ -428,13 +404,7 @@ describe('DraftSourcesComponent', () => {
 
       const initialFile1 = { dataId: 'file1' } as TrainingData;
       const initialFile2 = { dataId: 'file2' } as TrainingData;
-      const deletedFile: TrainingData = { dataId: 'deleted', deleted: true } as TrainingData;
-      when(mockTrainingDataQuery.docs).thenReturn([
-        { data: initialFile1 } as TrainingDataDoc,
-        { data: initialFile2 } as TrainingDataDoc,
-        { data: deletedFile } as TrainingDataDoc
-      ]);
-      trainingDataQueryLocalChanges$.next();
+      env.activeTrainingData$.next([initialFile1, initialFile2]);
       tick();
 
       expect(env.component.availableTrainingFiles).toEqual([initialFile1, initialFile2]);
@@ -449,14 +419,7 @@ describe('DraftSourcesComponent', () => {
 
       // Another client updates the query
       const remoteFile = { dataId: 'remote_file' } as TrainingData;
-      const remoteDeletedFile: TrainingData = { dataId: 'remote_deleted', deleted: true } as TrainingData;
-      when(mockTrainingDataQuery.docs).thenReturn([
-        { data: initialFile1 } as TrainingDataDoc,
-        { data: initialFile2 } as TrainingDataDoc,
-        { data: remoteFile } as TrainingDataDoc,
-        { data: remoteDeletedFile } as TrainingDataDoc
-      ]);
-      trainingDataQueryLocalChanges$.next();
+      env.activeTrainingData$.next([initialFile1, initialFile2, remoteFile]);
       tick();
 
       // The user's unsaved changes should be preserved
@@ -685,6 +648,7 @@ class TestEnvironment {
   readonly testOnlineStatusService: TestOnlineStatusService = TestBed.inject(
     OnlineStatusService
   ) as TestOnlineStatusService;
+  readonly activeTrainingData$: Subject<TrainingData[]> = new Subject<TrainingData[]>();
 
   private projectsLoaded$: Subject<void> = new Subject<void>();
 
@@ -839,10 +803,8 @@ class TestEnvironment {
     when(mockedActivatedProjectService.projectDoc).thenReturn(this.activatedProjectDoc);
     this.testOnlineStatusService.setIsOnline(!!args.isOnline);
 
-    when(mockTrainingDataService.queryTrainingDataAsync(anything(), anything())).thenResolve(
-      instance(mockTrainingDataQuery)
-    );
-    when(mockTrainingDataQuery.docs).thenReturn([]);
+    when(mockTrainingDataService.getTrainingData(anything(), anything())).thenReturn(this.activeTrainingData$);
+    this.activeTrainingData$.next([]);
 
     this.fixture = TestBed.createComponent(DraftSourcesComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-sources/draft-sources.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
-import { filter, merge, Subscription } from 'rxjs';
+import { filter, Subscription } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { isNetworkError } from 'xforge-common/command.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
@@ -20,7 +20,6 @@ import { FileService } from 'xforge-common/file.service';
 import { I18nKeyForComponent, I18nService } from 'xforge-common/i18n.service';
 import { ElementState } from 'xforge-common/models/element-state';
 import { FileType } from 'xforge-common/models/file-offline-data';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFUserProjectsService } from 'xforge-common/user-projects.service';
@@ -107,8 +106,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
   protected changesMade = false;
 
   private controlStates = new Map<string, ElementState>();
-  private trainingDataQuery?: RealtimeQuery<TrainingDataDoc>;
-  private trainingDataQuerySubscription?: Subscription;
+  private trainingDataSubscription?: Subscription;
   private savedTrainingFiles?: Readonly<TrainingData>[];
 
   constructor(
@@ -130,7 +128,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
   }
 
   ngOnInit(): void {
-    this.activatedProjectService.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async projectDoc => {
+    this.activatedProjectService.changes$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(projectDoc => {
       if (projectDoc?.data != null) {
         const { trainingSources, trainingTargets, draftingSources } = projectToDraftSources(projectDoc.data);
         if (trainingSources.length > 2) throw new Error('More than 2 training sources is not supported');
@@ -146,7 +144,7 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
         if (this.draftingSources.length < 1) this.draftingSources.push(undefined);
         if (this.trainingSources.length < 1) this.trainingSources.push(undefined);
 
-        await this.initializeTrainingFiles(projectDoc);
+        this.initializeTrainingFiles(projectDoc);
       }
     });
 
@@ -165,27 +163,18 @@ export class DraftSourcesComponent extends DataLoadingComponent implements OnIni
       .subscribe(() => this.loadProjects());
   }
 
-  private async initializeTrainingFiles(projectDoc: SFProjectProfileDoc): Promise<void> {
-    // Query for all training data files in the project
-    this.trainingDataQuery?.dispose();
-    this.trainingDataQuery = await this.trainingDataService.queryTrainingDataAsync(projectDoc.id, this.destroyRef);
-    this.trainingDataQuerySubscription?.unsubscribe();
-
-    // Subscribe to the training data query results changes
-    this.trainingDataQuerySubscription = merge(
-      this.trainingDataQuery.localChanges$,
-      this.trainingDataQuery.ready$,
-      this.trainingDataQuery.remoteChanges$,
-      this.trainingDataQuery.remoteDocChanges$
-    )
+  private initializeTrainingFiles(projectDoc: SFProjectProfileDoc): void {
+    // Subscribe to non-deleted training data files for the project
+    this.trainingDataSubscription?.unsubscribe();
+    this.trainingDataSubscription = this.trainingDataService
+      .getTrainingData(projectDoc.id, this.destroyRef)
       .pipe(quietTakeUntilDestroyed(this.destroyRef, { logWarnings: false }))
-      .subscribe(() => {
+      .subscribe(activeFiles => {
         const removedFiles =
           this.savedTrainingFiles?.filter(saved => !this.availableTrainingFiles.includes(saved)) ?? [];
         const addedFiles = this.availableTrainingFiles.filter(selected => !this.savedTrainingFiles?.includes(selected));
 
-        this.savedTrainingFiles =
-          this.trainingDataQuery?.docs.filter(d => d.data != null && d.data.deleted !== true).map(d => d.data!) ?? [];
+        this.savedTrainingFiles = activeFiles;
         this.availableTrainingFiles = this.savedTrainingFiles
           .filter(d => removedFiles.findIndex(f => f.dataId === d.dataId) === -1)
           .concat(addedFiles);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data-multi-select.component.spec.ts
@@ -8,8 +8,8 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { FileService } from 'xforge-common/file.service';
-import { FileType } from 'xforge-common/models/file-offline-data';
 import { I18nService } from 'xforge-common/i18n.service';
+import { FileType } from 'xforge-common/models/file-offline-data';
 import { Locale } from 'xforge-common/models/i18n-locale';
 import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
@@ -157,5 +157,6 @@ describe('TrainingDataMultiSelectComponent', () => {
     verify(
       mockFileService.onlineDownloadFile(FileType.TrainingData, mockTrainingData[0].fileUrl, mockTrainingData[0].title)
     ).once();
+    expect().nothing();
   }));
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.spec.ts
@@ -2,7 +2,6 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { getTrainingDataId, TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
 import { CommandService } from 'xforge-common/command.service';
-import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { Snapshot } from 'xforge-common/models/snapshot';
 import { noopDestroyRef } from 'xforge-common/realtime.service';
 import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
@@ -39,6 +38,19 @@ describe('TrainingDataService', () => {
         title: 'test2.csv',
         ownerRef: 'user01',
         deleted: false
+      }
+    },
+    {
+      id: getTrainingDataId('project01', 'deletedData'),
+      data: {
+        projectRef: 'project01',
+        dataId: 'deletedData',
+        fileUrl: 'project01/deleted.csv',
+        mimeType: 'text/csv',
+        skipRows: 0,
+        title: 'deleted.csv',
+        ownerRef: 'user01',
+        deleted: true
       }
     }
   ];
@@ -107,14 +119,48 @@ describe('TrainingDataService', () => {
     expect().nothing();
   }));
 
-  it('should query training data docs', fakeAsync(async () => {
-    const query: RealtimeQuery<TrainingDataDoc> = await trainingDataService.queryTrainingDataAsync(
-      'project01',
-      noopDestroyRef
-    );
-    tick();
+  describe('getTrainingData', () => {
+    it('should emit only non-deleted files for the specified project', fakeAsync(() => {
+      let emittedFiles: TrainingData[] | undefined;
+      const subscription = trainingDataService.getTrainingData('project01', noopDestroyRef).subscribe(files => {
+        emittedFiles = files;
+      });
+      tick();
 
-    expect(trainingData.length).toEqual(2);
-    expect(query.docs.length).toEqual(1);
-  }));
+      // Should include data01 (project01, not deleted) but exclude data02 (wrong project) and deletedData (deleted)
+      expect(emittedFiles).toBeDefined();
+      expect(emittedFiles!.map(f => f.dataId)).toEqual(['data01']);
+
+      subscription.unsubscribe();
+    }));
+
+    it('should not include files from other projects', fakeAsync(() => {
+      let emittedFiles: TrainingData[] | undefined;
+      const subscription = trainingDataService.getTrainingData('project02', noopDestroyRef).subscribe(files => {
+        emittedFiles = files;
+      });
+      tick();
+
+      expect(emittedFiles).toBeDefined();
+      expect(emittedFiles!.map(f => f.dataId)).toEqual(['data02']);
+
+      subscription.unsubscribe();
+    }));
+
+    it('should include deleted files when includeDeleted is true', fakeAsync(() => {
+      let emittedFiles: TrainingData[] | undefined;
+      const subscription = trainingDataService
+        .getTrainingData('project01', noopDestroyRef, { includeDeleted: true })
+        .subscribe(files => {
+          emittedFiles = files;
+        });
+      tick();
+
+      expect(emittedFiles).toBeDefined();
+      expect(emittedFiles!.map(f => f.dataId)).toEqual(['data01', 'deletedData']);
+      expect(emittedFiles!.length).toEqual(2);
+
+      subscription.unsubscribe();
+    }));
+  });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/training-data/training-data.service.ts
@@ -1,6 +1,7 @@
 import { DestroyRef, Injectable } from '@angular/core';
 import { obj } from 'realtime-server/lib/esm/common/utils/obj-path';
 import { getTrainingDataId, TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
+import { finalize, from, map, merge, Observable, switchMap } from 'rxjs';
 import { CommandService } from 'xforge-common/command.service';
 import { RealtimeQuery } from 'xforge-common/models/realtime-query';
 import { QueryParameters } from 'xforge-common/query-parameters';
@@ -29,10 +30,38 @@ export class TrainingDataService {
     });
   }
 
-  queryTrainingDataAsync(projectId: string, destroyRef: DestroyRef): Promise<RealtimeQuery<TrainingDataDoc>> {
-    const queryParams: QueryParameters = {
-      [obj<TrainingData>().pathStr(t => t.projectRef)]: projectId
-    };
+  /**
+   * Returns an observable of training data files for a project. The observable emits a new list whenever the
+   * underlying query results change (on ready, local changes, or remote changes). The query is disposed when the
+   * subscription is unsubscribed.
+   *
+   * By default, deleted files are excluded. Pass `{ includeDeleted: true }` to include them (useful when displaying
+   * historical information about past builds where files may have since been deleted).
+   */
+  getTrainingData(
+    projectId: string,
+    destroyRef: DestroyRef,
+    options?: { includeDeleted?: boolean }
+  ): Observable<TrainingData[]> {
+    return from(this.queryTrainingDataAsync(projectId, destroyRef, options)).pipe(
+      switchMap(query =>
+        merge(query.localChanges$, query.ready$, query.remoteChanges$, query.remoteDocChanges$).pipe(
+          map(() => query.docs.filter(d => d.data != null).map(d => d.data!)),
+          finalize(() => query.dispose())
+        )
+      )
+    );
+  }
+
+  private queryTrainingDataAsync(
+    projectId: string,
+    destroyRef: DestroyRef,
+    options?: { includeDeleted?: boolean }
+  ): Promise<RealtimeQuery<TrainingDataDoc>> {
+    const queryParams: QueryParameters = { [obj<TrainingData>().pathStr(t => t.projectRef)]: projectId };
+    if (options?.includeDeleted !== true) {
+      queryParams[obj<TrainingData>().pathStr(t => t.deleted)] = false;
+    }
     return this.realtimeService.subscribeQuery(TrainingDataDoc.COLLECTION, queryParams, destroyRef);
   }
 }


### PR DESCRIPTION
The option was present on the page but only worked for users that were also members of the project.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3818)
<!-- Reviewable:end -->
