### PR TITLE
SF-2573 Prevent Mutex from running multiple jobs at the same time

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
+++ b/src/SIL.XForge.Scripture/Services/MutexAttribute.cs
@@ -1,6 +1,8 @@
 #nullable disable warnings
 using System;
 using System.Globalization;
+using System.Linq;
+using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
@@ -8,19 +10,28 @@ using Hangfire.Storage;
 namespace SIL.XForge.Scripture.Services;
 
 /// <summary>
-/// Represents a background job filter that helps to disable concurrent execution
-/// without causing worker to wait as in <see cref="Hangfire.DisableConcurrentExecutionAttribute"/>.
+/// Represents a background job filter that helps to disable concurrent execution without causing the initial worker
+/// to wait as in <see cref="DisableConcurrentExecutionAttribute"/>.
+///
+/// When a job starts executing, it will acquire a distributed lock and add its job id to a resource set.
+/// If another job with the same resource starts executing (i.e. because the jobs were all restarted),
+/// it will be blocked and rescheduled until the first job finishes and releases the lock.
 ///
 /// Source: https://gist.github.com/odinserj/4a3bf40606c4da9183588a5a325dfb99
 /// </summary>
 /// <remarks>
-/// When <paramref name="resource"/> is not configured, the method name is used as the mutex key.
+/// When <paramref name="resource"/> is not configured, the method name is used as the mutex key,
+/// while the job type and method name are used as the distributed lock key.
 /// </remarks>
-public class MutexAttribute(string? resource = null) : JobFilterAttribute, IElectStateFilter, IApplyStateFilter
+public class MutexAttribute(string? resource = null, int timeoutSec = MutexAttribute.DefaultTimeOutSec)
+    : DisableConcurrentExecutionAttribute(resource, timeoutSec),
+        IElectStateFilter,
+        IApplyStateFilter
 {
+    private const int DefaultTimeOutSec = 60 * 60 * 24;
     private static readonly TimeSpan DistributedLockTimeout = TimeSpan.FromMinutes(1);
 
-    public int RetryInSeconds { get; set; } = 15;
+    public int RetryInSeconds { get; } = 15;
     public int MaxAttempts { get; set; }
 
     public void OnStateElection(ElectStateContext context)
@@ -142,12 +153,12 @@ public class MutexAttribute(string? resource = null) : JobFilterAttribute, IElec
     private IDisposable AcquireDistributedSetLock(IStorageConnection connection, Job job) =>
         connection.AcquireDistributedLock(GetDistributedLockKey(job), DistributedLockTimeout);
 
-    private string GetDistributedLockKey(Job job) => $"extension:job-mutex:lock:{GetKeyFormat(job, resource)}";
+    private string GetDistributedLockKey(Job job) => $"extension:job-mutex:lock:{GetKeyFormat(job, this.Resource)}";
 
-    private string GetResourceKey(Job job) => $"extension:job-mutex:set:{GetKeyFormat(job, resource)}";
+    private string GetResourceKey(Job job) => $"extension:job-mutex:set:{GetKeyFormat(job, this.Resource)}";
 
     private static string GetKeyFormat(Job job, string? keyFormat) =>
         string.IsNullOrWhiteSpace(keyFormat)
             ? job.Method.Name
-            : string.Format(CultureInfo.InvariantCulture, keyFormat, job.Args);
+            : string.Format(CultureInfo.InvariantCulture, keyFormat, job.Args.ToArray());
 }

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -247,16 +247,6 @@
         "resolved": "2025.1001.2.129",
         "contentHash": "+woGT1lsBtwkntOpx2EZbdbySv0aWPefE0vrfvclxVdbi4oa2bbtphFPWgMiQe+kRCPICbfFJwp6w1DuR7Ge2Q=="
       },
-      "Hangfire": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "WmVI9+aQDj0cUmCqNkkIz0WQaWcvviNTMtyUTTuIF6ci1eVHsmo+DEWRXqGApYRbmoiCzWNE40JuTjPaXbRePA==",
-        "dependencies": {
-          "Hangfire.AspNetCore": "[1.8.23]",
-          "Hangfire.Core": "[1.8.23]",
-          "Hangfire.SqlServer": "[1.8.23]"
-        }
-      },
       "Hangfire.AspNetCore": {
         "type": "Transitive",
         "resolved": "1.8.23",
@@ -295,14 +285,6 @@
         "type": "Transitive",
         "resolved": "1.8.23",
         "contentHash": "SmvUJF/u5MCP666R5Y1V+GntqBc4RCWJqn5ztMMN67d53Cx5cuaWR0YNLMrabjylwLarFYJ7EdR9RnGEZzp/dg==",
-        "dependencies": {
-          "Hangfire.Core": "[1.8.23]"
-        }
-      },
-      "Hangfire.SqlServer": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "HiRUbwveK0+wop8iY98Z5DrtfjP+1QCly6IO+21Bnolb5kTO5eCrtKbGErHfhSN0BzKk9ehmTLk9uDHQdAtfcQ==",
         "dependencies": {
           "Hangfire.Core": "[1.8.23]"
         }
@@ -1252,8 +1234,9 @@
           "Bugsnag.AspNet.Core": "[4.1.0, )",
           "Duende.IdentityModel": "[8.1.0, )",
           "EdjCase.JsonRpc.Router": "[6.1.0, )",
-          "Hangfire": "[1.8.23, )",
+          "Hangfire.AspNetCore": "[1.8.23, )",
           "Hangfire.Autofac": "[2.7.0, )",
+          "Hangfire.Core": "[1.8.23, )",
           "Hangfire.Mongo": "[1.14.1, )",
           "Jering.Javascript.NodeJS": "[6.3.1, )",
           "MailKit": "[4.16.0, )",

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -11,7 +11,8 @@
     <PackageReference Include="Autofac.Extras.DynamicProxy" Version="7.1.0" />
     <PackageReference Include="Bugsnag.AspNet.Core" Version="4.1.0" />
     <PackageReference Include="EdjCase.JsonRpc.Router" Version="6.1.0" />
-    <PackageReference Include="Hangfire" Version="1.8.23" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.23" />
     <PackageReference Include="Hangfire.Autofac" Version="2.7.0" />
     <PackageReference Include="Hangfire.Mongo" Version="1.14.1" />
     <PackageReference Include="Duende.IdentityModel" Version="8.1.0" />

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -61,15 +61,13 @@
           "Microsoft.Extensions.DependencyModel": "8.0.1"
         }
       },
-      "Hangfire": {
+      "Hangfire.AspNetCore": {
         "type": "Direct",
         "requested": "[1.8.23, )",
         "resolved": "1.8.23",
-        "contentHash": "WmVI9+aQDj0cUmCqNkkIz0WQaWcvviNTMtyUTTuIF6ci1eVHsmo+DEWRXqGApYRbmoiCzWNE40JuTjPaXbRePA==",
+        "contentHash": "TXpOl7kX4xXq5bLEqqWCpt9zh3TaouDwtb3GDtzGHX5uSC2RaAqZzn2swevivx3Uki16slXIigiPtgr4TPKpsg==",
         "dependencies": {
-          "Hangfire.AspNetCore": "[1.8.23]",
-          "Hangfire.Core": "[1.8.23]",
-          "Hangfire.SqlServer": "[1.8.23]"
+          "Hangfire.NetCore": "[1.8.23]"
         }
       },
       "Hangfire.Autofac": {
@@ -80,6 +78,15 @@
         "dependencies": {
           "Autofac": "5.0.0",
           "Hangfire.Core": "1.6.0"
+        }
+      },
+      "Hangfire.Core": {
+        "type": "Direct",
+        "requested": "[1.8.23, )",
+        "resolved": "1.8.23",
+        "contentHash": "YCOTtF3NNOQI83PlfjeNDDBkofJDfdET2CwhfQsiVBwmsU6lP19QW9NVTIH9epl+MnOsyFC2G1RnlPSGV8F1FQ==",
+        "dependencies": {
+          "Newtonsoft.Json": "11.0.1"
         }
       },
       "Hangfire.Mongo": {
@@ -188,22 +195,6 @@
         "resolved": "1.6.1",
         "contentHash": "4H/f2uYJOZ+YObZjpY9ABrKZI+JNw3uizp6oMzTXwDw6F+2qIPhpRl/1t68O/6e98+vqNiYGu+lswmwdYUy3gg=="
       },
-      "Hangfire.AspNetCore": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "TXpOl7kX4xXq5bLEqqWCpt9zh3TaouDwtb3GDtzGHX5uSC2RaAqZzn2swevivx3Uki16slXIigiPtgr4TPKpsg==",
-        "dependencies": {
-          "Hangfire.NetCore": "[1.8.23]"
-        }
-      },
-      "Hangfire.Core": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "YCOTtF3NNOQI83PlfjeNDDBkofJDfdET2CwhfQsiVBwmsU6lP19QW9NVTIH9epl+MnOsyFC2G1RnlPSGV8F1FQ==",
-        "dependencies": {
-          "Newtonsoft.Json": "11.0.1"
-        }
-      },
       "Hangfire.NetCore": {
         "type": "Transitive",
         "resolved": "1.8.23",
@@ -213,14 +204,6 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "3.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
-        }
-      },
-      "Hangfire.SqlServer": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "HiRUbwveK0+wop8iY98Z5DrtfjP+1QCly6IO+21Bnolb5kTO5eCrtKbGErHfhSN0BzKk9ehmTLk9uDHQdAtfcQ==",
-        "dependencies": {
-          "Hangfire.Core": "[1.8.23]"
         }
       },
       "Markdig.Signed": {

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -169,16 +169,6 @@
         "resolved": "2025.1001.2.129",
         "contentHash": "+woGT1lsBtwkntOpx2EZbdbySv0aWPefE0vrfvclxVdbi4oa2bbtphFPWgMiQe+kRCPICbfFJwp6w1DuR7Ge2Q=="
       },
-      "Hangfire": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "WmVI9+aQDj0cUmCqNkkIz0WQaWcvviNTMtyUTTuIF6ci1eVHsmo+DEWRXqGApYRbmoiCzWNE40JuTjPaXbRePA==",
-        "dependencies": {
-          "Hangfire.AspNetCore": "[1.8.23]",
-          "Hangfire.Core": "[1.8.23]",
-          "Hangfire.SqlServer": "[1.8.23]"
-        }
-      },
       "Hangfire.AspNetCore": {
         "type": "Transitive",
         "resolved": "1.8.23",
@@ -222,14 +212,6 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "3.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
-        }
-      },
-      "Hangfire.SqlServer": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "HiRUbwveK0+wop8iY98Z5DrtfjP+1QCly6IO+21Bnolb5kTO5eCrtKbGErHfhSN0BzKk9ehmTLk9uDHQdAtfcQ==",
-        "dependencies": {
-          "Hangfire.Core": "[1.8.23]"
         }
       },
       "icu.net": {
@@ -1685,8 +1667,9 @@
           "Bugsnag.AspNet.Core": "[4.1.0, )",
           "Duende.IdentityModel": "[8.1.0, )",
           "EdjCase.JsonRpc.Router": "[6.1.0, )",
-          "Hangfire": "[1.8.23, )",
+          "Hangfire.AspNetCore": "[1.8.23, )",
           "Hangfire.Autofac": "[2.7.0, )",
+          "Hangfire.Core": "[1.8.23, )",
           "Hangfire.Mongo": "[1.14.1, )",
           "Jering.Javascript.NodeJS": "[6.3.1, )",
           "MailKit": "[4.16.0, )",

--- a/test/SIL.XForge.Tests/packages.lock.json
+++ b/test/SIL.XForge.Tests/packages.lock.json
@@ -125,16 +125,6 @@
           "Microsoft.Extensions.DependencyModel": "8.0.1"
         }
       },
-      "Hangfire": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "WmVI9+aQDj0cUmCqNkkIz0WQaWcvviNTMtyUTTuIF6ci1eVHsmo+DEWRXqGApYRbmoiCzWNE40JuTjPaXbRePA==",
-        "dependencies": {
-          "Hangfire.AspNetCore": "[1.8.23]",
-          "Hangfire.Core": "[1.8.23]",
-          "Hangfire.SqlServer": "[1.8.23]"
-        }
-      },
       "Hangfire.AspNetCore": {
         "type": "Transitive",
         "resolved": "1.8.23",
@@ -178,14 +168,6 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "3.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
-        }
-      },
-      "Hangfire.SqlServer": {
-        "type": "Transitive",
-        "resolved": "1.8.23",
-        "contentHash": "HiRUbwveK0+wop8iY98Z5DrtfjP+1QCly6IO+21Bnolb5kTO5eCrtKbGErHfhSN0BzKk9ehmTLk9uDHQdAtfcQ==",
-        "dependencies": {
-          "Hangfire.Core": "[1.8.23]"
         }
       },
       "idunno.Authentication.Basic": {
@@ -627,8 +609,9 @@
           "Bugsnag.AspNet.Core": "[4.1.0, )",
           "Duende.IdentityModel": "[8.1.0, )",
           "EdjCase.JsonRpc.Router": "[6.1.0, )",
-          "Hangfire": "[1.8.23, )",
+          "Hangfire.AspNetCore": "[1.8.23, )",
           "Hangfire.Autofac": "[2.7.0, )",
+          "Hangfire.Core": "[1.8.23, )",
           "Hangfire.Mongo": "[1.14.1, )",
           "Jering.Javascript.NodeJS": "[6.3.1, )",
           "MailKit": "[4.16.0, )",


### PR DESCRIPTION
The `MutexAttribute` prevents jobs from changing from queued to running if another job is running. However, as the documentation states:

> ## Mutex doesn’t prevent simultaneous execution of the same background job
> As there are no reliable automatic failure detectors in distributed systems, it is possible that the same job is being processed on different workers in some corner cases. Unlike OS-based mutexes, mutexes in this package don’t protect from this behavior so develop accordingly.
>
> `DisableConcurrentExecution` filter may reduce the probability of violation of this safety property, but the only way to guarantee it is to use transactions or CAS-based operations in our background jobs to make them idempotent.
>
> If a background job protected by a mutex is unexpectedly terminated, it will simply re-enter the mutex. It will be held until background job is moved to the final state (Succeeded, Deleted, but not Failed).

**Source:** https://docs.hangfire.io/en/latest/background-processing/throttling.html#mutexes

And so this PR updates the `MutexAttribute` to inherit the `DisableConcurrentExecutionAttribute`, which means if for some reason two jobs do start, one will wait for the other to complete (up to 24 hours) before continuing the job. During this state both jobs will be in the "Processing" state, but only one will be executing at one time.

I also took the opportunity to remove an unnecessary dependency on `HangFire.SqlServer`, as we don't use SQL Server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3819)
<!-- Reviewable:end -->
