### PR TITLE
Initialize the onboarding request repository

### DIFF
--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
@@ -11,5 +11,6 @@ public static class SFDataAccessApplicationBuilderExtensions
         app.InitRepository<TranslateMetrics>();
         app.InitRepository<SFProjectSecret>();
         app.InitRepository<SyncMetrics>();
+        app.InitRepository<OnboardingRequest>();
     }
 }


### PR DESCRIPTION
I noticed that the onboarding request repository was not being initialized, which meant that its index on `Submission.ProjectId` was not being created. This PR fixes that by initializing the repository.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3820)
<!-- Reviewable:end -->
