### PR TITLE
dev: split up AGENTS.md into multiple files to improve review instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ This document contains information and instructions for AI.
 
 See the software [architecture](doc/architecture.md) overview.
 
-## Code rules
+## Rules for writing code
 
-Follow all rules in [Code rules](doc/code-rules.md) and [Code rules for AI](doc/code-rules-ai.md).
+When writing code, follow all rules in [Code rules](doc/code-rules.md) and [Code rules for AI](doc/code-rules-ai.md).
 
 ## Code review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,124 +1,24 @@
-# Architecture Overview
+# Instructions for AI
 
-This repository contains three interconnected applications:
+This document contains information and instructions for AI.
 
-1. Frontend (Angular) that runs in a browser, at src/SIL.XForge.Scripture/ClientApp
-2. Backend (dotnet) that runs on a server, at src/SIL.XForge and src/SIL.XForge.Scripture
-3. RealtimeServer (Node) that runs on a server, at src/RealtimeServer
+## Architecture
 
-# Data exchange between the three interconnected applications
+See the software [architecture](doc/architecture.md) overview.
 
-- Data models must be defined in all 3 applications and stay in sync.
-- An example Backend data model can be seen at src/SIL.XForge.Scripture/Models/SFProject.cs
-- Frontend and RealtimeServer both use the same data model files. An example can be seen at src/RealtimeServer/scriptureforge/models/sf-project.ts
-- Frontend uses src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts to read and write data. This Realtime document data is stored in IndexedDB and is also automatically kept up to date with the data in RealtimeServer when Frontend has an Internet connection. If Frontend is offline, it continues reading and writing realtime documents using realtime.service.ts, and later data is synced with RealtimeService when Frontend regains an Internet connection.
-- Realtime documents should not be modified directly. Instead, submit ops to modify the realtime documents.
-- RealtimeServer uses ShareDB to merge ops from multiple Frontend clients. Frontend clients synchronize with RealtimeServer and present a live view of the changes from other clients as they work.
-- Frontend also uses JSON-RPC to communicate with Backend, such as seen on Backend at src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs.
-- User permissions should be checked in all of Frontend, Backend, and RealtimeServer, using the rights service whenever possible, rather than checking the user role. See project-rights.ts, sf-project-rights.ts, and SFProjectRights.cs.
-- Follow existing patterns for validation schemas.
+## Code rules
 
-# Frontend
+Follow all rules in [Code rules](doc/code-rules.md) and [Code rules for AI](doc/code-rules-ai.md).
 
-- Most Frontend tasks should work on a mobile phone. In other words, on a device with a narrow and short screen.
-- Most editing and reviewing tasks should work while offline. Changing some settings may require being online.
-- Feature flags (feature-flag.service.ts) can control functionality rollout.
-- Error handling with ErrorReportingService
-- Keep related files together in feature folders
-- Follow existing naming conventions
-- Follow MVVM design, where domain objects and business logic are in Models, templates represent information to the user in Views, and ViewModels transform and bridge data between Models and Views.
-- Component templates should be in separate .html files, rather than specified inline in the component decorator.
-- Component template stylesheets should be in separate .scss files, rather than specified inline in the component decorator.
-- Avoid hard-coding colors in SCSS files when styling components. Instead, use existing CSS variables or create an Angular Material theme file and import it into src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+## Code review
 
-# Frontend localization
+Instructions for what to look for when performing a code review can be found in [REVIEW.md](REVIEW.md).
 
-- Use TranslocoModule for translations
-- Put UI strings in checking_en.json if ANY user might see them
-- Only put strings in non_checking_en.json if community checkers will NEVER see them
-- Localizations that a Community Checker user might see should be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json. Only localizations that a Community Checker user will not see can be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json.
-- Even if something is a system-wide feature that isn't specific to community checking functionality, it should still be placed in checking_en.json if a community checking user would POSSIBLY see it.
+## dev container
 
-# Frontend testing
+The software and a backing database can be run using the [dev container](.devcontainer).
 
-- Write unit tests for new components and services
-- Follow existing patterns for mocking dependencies
-- Use TestEnvironment pattern from existing tests. Use the TestEnvironment class pattern rather than using a `beforeEach`. Do not put helper functions outside of TestEnvironment classes; helper functions or setup functions should be in the TestEnvironment class.
-- Test both online and offline scenarios
-- Test permission boundaries
-- When a TestEnvironment class is being given many optional arguments, prefer using object destructuring with default values, and the argument type definition specified inline rather than as an interface. For example,
-  ```typescript
-  class TestEnvironment {
-    constructor({
-      someRequired,
-      someOptional = 'abc',
-    }: {
-      someRequired: string;
-      someOptional?: string;
-    }) {
-      ...
-    }
-  }
-  ```
-  Example using `= {}` when all items are optional:
-  ```typescript
-  class TestEnvironment {
-    constructor({
-      someOptional = 'abc',
-    }: {
-      someOptional?: string;
-    } = {}) {
-      ...
-    }
-  }
-  ```
-
-# Code comments
-
-- Do not remove comments already in the code if they are still relevant.
-- Do not insert new comments into the code where method calls already make it clear.
-- Do not add method comments unless the method would be unclear to an experienced developer.
-- Do put comments into the code to make it more clear what is going on if it would not be obvious to an experienced developer.
-- Do put comments into the code if the intent is not clear from the code.
-- All classes and interfaces should have a comment to briefly explain why it is there and what its purpose is in the overall system, even if it seems obvious.
-- Please do not fail to add a comment to any classes or interfaces that are created. All classes and interfaces should have a comment.
-- Use good argument and variable names that explain themselves without needing a comment. Well named arguments or variables are better than unclearly named arguments or variables with a comment.
-
-# TypeScript language
-
-- When doing null checks, prefer using `== null` or `!= null` rather than writing `if (value)` or `if (!value)` to better express intent. If guarding for empty strings or other falsy values is necessary, prefer to explicitly check for those as well, such as `if (value == null || value === '')` rather than just `if (!value)`.
-- Specify types when declaring variables, arguments, and for function return types, if it's not completely obvious. For example, don't write
-  `const projectId = this.determineProjectId();` or
-  `const buildEvents = eventsSorted.filter(...);` or
-  `const buildEvent = buildEvents[0];`. Instead, write
-  `const projectId: string | undefined = this.determineProjectId();` and
-  `const buildEvents: EventMetric[] = eventsSorted.filter(...);` and
-  `const buildEvent: EventMetric | undefined = buildEvents[0];`.
-- Prefer to use `null` to express a deliberate absence of a value, and `undefined` to express a value that has not been set yet.
-- Observables (including subclasses such as Subject or BehaviorSubject) should have names that end with a `$`.
-
-# Angular templates
-
-- Use `@if {}` syntax rather than `*ngIf` syntax.
-
-# Code
-
-- All code that you write should be able to pass eslint linting tests for TypeScript, or csharpier for C#.
-- Don't merely write code for the local context, but make changes that are good overall considering the architecture of the application and structure of the files and classes.
-- It is better to write code that is verbose and understandable than terse and concise.
-- It is better to explicitly check for and handle problems, or prevent problems from happening, than to assume problems will not happen.
-- Corner-cases happen. They should be handled in code.
-- Please don't change existing code without good justification. Existing code largely works and changing it will cause work for code review. Leave existing code as is when possible.
-
-# Frontend code
-
-- Pay attention to available types and type guards in src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts.
-
-# Tests
-
-- If a unit test is more than 20 lines long, then place a line with "// SUT" before the line that causes the code being tested to be exercised.
-
-# Running commands
+## Running commands
 
 - If you run frontend tests, run them in the `src/SIL.XForge.Scripture/ClientApp` directory with a command such as `npm run test:headless -- --watch=false --include '**/text.component.spec.ts' --include '**/settings.component.spec.ts'`
 - If you need to run all frontend tests, you can run them in the `src/SIL.XForge.Scripture/ClientApp` directory with command `npm run test:headless -- --watch=false`

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,4 +1,14 @@
-# Code review guidelines (mostly intended for AI agents, but also relevant for human reviewers)
+# Code review guidelines
+
+This document describes what to look for when performing a code review. It is mostly intended for AI agents, but is also relevant for human reviewers.
+
+## Architecture
+
+Code should be reviewed in context of the software [architecture](doc/architecture.md) and the new code's place in it.
+
+## Code rules
+
+Code should follow the rules outlined in [Code rules](doc/code-rules.md).
 
 ## Naming things
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,28 @@
+# Architecture
+
+This document contains descriptive information about the software architecture.
+
+## Architecture Overview
+
+This repository contains three interconnected applications:
+
+1. Frontend (Angular) that runs in a browser, at src/SIL.XForge.Scripture/ClientApp
+2. Backend (dotnet) that runs on a server, at src/SIL.XForge and src/SIL.XForge.Scripture
+3. RealtimeServer (Node) that runs on a server, at src/RealtimeServer
+
+## Data exchange between the three interconnected applications
+
+- An example Backend data model can be seen at src/SIL.XForge.Scripture/Models/SFProject.cs
+- Frontend and RealtimeServer both use the same data model files. An example can be seen at src/RealtimeServer/scriptureforge/models/sf-project.ts
+- Frontend uses src/SIL.XForge.Scripture/ClientApp/src/xforge-common/realtime.service.ts to read and write data. This Realtime document data is stored in IndexedDB and is also automatically kept up to date with the data in RealtimeServer when Frontend has an Internet connection. If Frontend is offline, it continues reading and writing realtime documents using realtime.service.ts, and later data is synced with RealtimeService when Frontend regains an Internet connection.
+- RealtimeServer uses ShareDB to merge ops from multiple Frontend clients. Frontend clients synchronize with RealtimeServer and present a live view of the changes from other clients as they work.
+- Frontend also uses JSON-RPC to communicate with Backend, such as seen on Backend at src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs.
+
+## Frontend
+
+- Feature flags (feature-flag.service.ts) can control functionality rollout.
+- Frontend has a global exception handler, ExceptionHandlingService. It catches and handles exceptions, showing a message to the user. If an exception occurs repeatedly or otherwise makes the UI unusable, it is preferable to handle it manually to allow the UI to continue to be usable.
+
+## Frontend localization
+
+- TranslocoModule is used for translations.

--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -1,0 +1,82 @@
+# Code rules for AI
+
+This document describes code rules that AI should follow.
+
+Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
+
+# Frontend
+
+- Follow MVVM design, where domain objects and business logic are in Models, templates represent information to the user in Views, and ViewModels transform and bridge data between Models and Views.
+- Component templates should be in separate .html files, rather than specified inline in the component decorator.
+- Component template stylesheets should be in separate .scss files, rather than specified inline in the component decorator.
+- Avoid hard-coding colors in SCSS files when styling components. Instead, use existing CSS variables or create an Angular Material theme file and import it into ../src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+
+# Frontend testing
+
+- Write unit tests for new components and services
+- Do not put helper functions outside of TestEnvironment classes; helper functions or setup functions should be in the TestEnvironment class.
+- Test both online and offline scenarios
+- Test permission boundaries
+- When a TestEnvironment class is being given many optional arguments, prefer using object destructuring with default values, and the argument type definition specified inline rather than as an interface. For example,
+  ```typescript
+  class TestEnvironment {
+    constructor({
+      someRequired,
+      someOptional = 'abc',
+    }: {
+      someRequired: string;
+      someOptional?: string;
+    }) {
+      ...
+    }
+  }
+  ```
+  Example using `= {}` when all items are optional:
+  ```typescript
+  class TestEnvironment {
+    constructor({
+      someOptional = 'abc',
+    }: {
+      someOptional?: string;
+    } = {}) {
+      ...
+    }
+  }
+  ```
+
+# Code comments
+
+- Do not remove comments already in the code if they are still relevant.
+- Do not insert new comments into the code where method calls already make it clear.
+- Do not add method comments unless the method would be unclear to an experienced developer.
+- Do put comments into the code to make it more clear what is going on if it would not be obvious to an experienced developer.
+- Do put comments into the code if the intent is not clear from the code.
+- Use good argument and variable names that explain themselves without needing a comment. Well named arguments or variables are better than unclearly named arguments or variables with a comment.
+
+# TypeScript language
+
+- When doing null checks, prefer using `== null` or `!= null` rather than writing `if (value)` or `if (!value)` to better express intent. If guarding for empty strings or other falsy values is necessary, prefer to explicitly check for those as well, such as `if (value == null || value === '')` rather than just `if (!value)`.
+- Specify types when declaring variables, arguments, and for function return types, if it's not completely obvious. For example, don't write
+  `const projectId = this.determineProjectId();` or
+  `const buildEvents = eventsSorted.filter(...);` or
+  `const buildEvent = buildEvents[0];`. Instead, write
+  `const projectId: string | undefined = this.determineProjectId();` and
+  `const buildEvents: EventMetric[] = eventsSorted.filter(...);` and
+  `const buildEvent: EventMetric | undefined = buildEvents[0];`.
+- Prefer to use `null` to express a deliberate absence of a value, and `undefined` to express a value that has not been set yet.
+
+# Angular templates
+
+- Use `@if {}` syntax rather than `*ngIf` syntax.
+
+# Code
+
+- All code that you write should be able to pass eslint linting tests for TypeScript, or csharpier for C#.
+- It is better to write code that is verbose and understandable than terse and concise.
+- It is better to explicitly check for and handle problems, or prevent problems from happening, than to assume problems will not happen.
+- Corner-cases happen. They should be handled in code.
+- Please don't change existing code without good justification. Existing code largely works and changing it will cause work for code review. Leave existing code as is when possible.
+
+# Tests
+
+- If a unit test is more than 20 lines long, then place a line with "// SUT" before the line that causes the code being tested to be exercised.

--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -1,6 +1,6 @@
 # Code rules for AI
 
-This document describes code rules that AI should follow.
+This document describes code rules that AI should follow when writing code. The rules in this file should _not_ be used when reviewing human-written code.
 
 Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 
@@ -49,7 +49,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 - Do not remove comments already in the code if they are still relevant.
 - Do not insert new comments into the code where method calls already make it clear.
 - Do not add method comments unless the method would be unclear to an experienced developer.
-- Do put comments into the code to make it more clear what is going on if it would not be obvious to an experienced developer.
+- Do put comments into the code to make it more clear, if the code would not be obvious to an experienced developer.
 - Do put comments into the code if the intent is not clear from the code.
 - Use good argument and variable names that explain themselves without needing a comment. Well named arguments or variables are better than unclearly named arguments or variables with a comment.
 

--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -4,14 +4,14 @@ This document describes code rules that AI should follow.
 
 Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 
-# Frontend
+## Frontend
 
 - Follow MVVM design, where domain objects and business logic are in Models, templates represent information to the user in Views, and ViewModels transform and bridge data between Models and Views.
 - Component templates should be in separate .html files, rather than specified inline in the component decorator.
 - Component template stylesheets should be in separate .scss files, rather than specified inline in the component decorator.
-- Avoid hard-coding colors in SCSS files when styling components. Instead, use existing CSS variables or create an Angular Material theme file and import it into ../src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+- Avoid hard-coding colors in SCSS files when styling components. Instead, use existing CSS variables or create an Angular Material theme file and import it into src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
 
-# Frontend testing
+## Frontend testing
 
 - Write unit tests for new components and services
 - Do not put helper functions outside of TestEnvironment classes; helper functions or setup functions should be in the TestEnvironment class.
@@ -44,7 +44,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   }
   ```
 
-# Code comments
+## Code comments
 
 - Do not remove comments already in the code if they are still relevant.
 - Do not insert new comments into the code where method calls already make it clear.
@@ -53,7 +53,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 - Do put comments into the code if the intent is not clear from the code.
 - Use good argument and variable names that explain themselves without needing a comment. Well named arguments or variables are better than unclearly named arguments or variables with a comment.
 
-# TypeScript language
+## TypeScript language
 
 - When doing null checks, prefer using `== null` or `!= null` rather than writing `if (value)` or `if (!value)` to better express intent. If guarding for empty strings or other falsy values is necessary, prefer to explicitly check for those as well, such as `if (value == null || value === '')` rather than just `if (!value)`.
 - Specify types when declaring variables, arguments, and for function return types, if it's not completely obvious. For example, don't write
@@ -65,11 +65,11 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   `const buildEvent: EventMetric | undefined = buildEvents[0];`.
 - Prefer to use `null` to express a deliberate absence of a value, and `undefined` to express a value that has not been set yet.
 
-# Angular templates
+## Angular templates
 
 - Use `@if {}` syntax rather than `*ngIf` syntax.
 
-# Code
+## Code
 
 - All code that you write should be able to pass eslint linting tests for TypeScript, or csharpier for C#.
 - It is better to write code that is verbose and understandable than terse and concise.
@@ -77,6 +77,6 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 - Corner-cases happen. They should be handled in code.
 - Please don't change existing code without good justification. Existing code largely works and changing it will cause work for code review. Leave existing code as is when possible.
 
-# Tests
+## Tests
 
 - If a unit test is more than 20 lines long, then place a line with "// SUT" before the line that causes the code being tested to be exercised.

--- a/doc/code-rules.md
+++ b/doc/code-rules.md
@@ -4,45 +4,45 @@ This document describes code rules that both humans and AI should follow.
 
 ## Data exchange between the three interconnected applications
 
-(For more information, see the [architecture](architecture.md) overview.)
+For more information, see the [architecture](architecture.md) overview.
 
 - Data models must be defined in all 3 applications and stay in sync.
 - Realtime documents should not be modified directly. Instead, submit ops to modify the realtime documents.
 - User permissions should be checked in all of Frontend, Backend, and RealtimeServer, using the rights service whenever possible, rather than checking the user role. See project-rights.ts, sf-project-rights.ts, and SFProjectRights.cs.
 - Follow existing patterns for validation schemas.
 
-# Frontend
+## Frontend
 
 - Most Frontend tasks should work on a mobile phone. In other words, on a device with a narrow and short screen.
 - Most editing and reviewing tasks should work while offline. Changing some settings may require being online.
 - Keep related files together in feature folders
 - Follow existing naming conventions
 
-# Frontend localization
+## Frontend localization
 
 - Put UI strings in checking_en.json if ANY user might see them.
 - Only put strings in non_checking_en.json if community checkers will NEVER see them.
 - Localizations that a Community Checker user might see should be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json. Only localizations that a Community Checker user will not see can be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json.
 - Even if something is a system-wide feature that isn't specific to community checking functionality, it should still be placed in checking_en.json if a community checking user would POSSIBLY see it.
 
-# Frontend testing
+## Frontend testing
 
 - Follow existing patterns for mocking dependencies
 - Use TestEnvironment pattern from existing tests. Use the TestEnvironment class pattern rather than using a `beforeEach`.
 
-# Code comments
+## Code comments
 
 - All classes and interfaces should have a comment to briefly explain why it is there and what its purpose is in the overall system, even if it seems obvious.
 - Please do not fail to add a comment to any classes or interfaces that are created. All classes and interfaces should have a comment.
 
-# TypeScript language
+## TypeScript language
 
 - Observables (including subclasses such as Subject or BehaviorSubject) should have names that end with a `$`.
 
-# Code
+## Code
 
 - Don't merely write code for the local context, but make changes that are good overall considering the architecture of the application and structure of the files and classes.
 
-# Frontend code
+## Frontend code
 
 - Pay attention to available types and type guards in src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts.

--- a/doc/code-rules.md
+++ b/doc/code-rules.md
@@ -1,0 +1,48 @@
+# Code rules for humans and AI
+
+This document describes code rules that both humans and AI should follow.
+
+## Data exchange between the three interconnected applications
+
+(For more information, see the [architecture](architecture.md) overview.)
+
+- Data models must be defined in all 3 applications and stay in sync.
+- Realtime documents should not be modified directly. Instead, submit ops to modify the realtime documents.
+- User permissions should be checked in all of Frontend, Backend, and RealtimeServer, using the rights service whenever possible, rather than checking the user role. See project-rights.ts, sf-project-rights.ts, and SFProjectRights.cs.
+- Follow existing patterns for validation schemas.
+
+# Frontend
+
+- Most Frontend tasks should work on a mobile phone. In other words, on a device with a narrow and short screen.
+- Most editing and reviewing tasks should work while offline. Changing some settings may require being online.
+- Keep related files together in feature folders
+- Follow existing naming conventions
+
+# Frontend localization
+
+- Put UI strings in checking_en.json if ANY user might see them.
+- Only put strings in non_checking_en.json if community checkers will NEVER see them.
+- Localizations that a Community Checker user might see should be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json. Only localizations that a Community Checker user will not see can be created or edited in src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json.
+- Even if something is a system-wide feature that isn't specific to community checking functionality, it should still be placed in checking_en.json if a community checking user would POSSIBLY see it.
+
+# Frontend testing
+
+- Follow existing patterns for mocking dependencies
+- Use TestEnvironment pattern from existing tests. Use the TestEnvironment class pattern rather than using a `beforeEach`.
+
+# Code comments
+
+- All classes and interfaces should have a comment to briefly explain why it is there and what its purpose is in the overall system, even if it seems obvious.
+- Please do not fail to add a comment to any classes or interfaces that are created. All classes and interfaces should have a comment.
+
+# TypeScript language
+
+- Observables (including subclasses such as Subject or BehaviorSubject) should have names that end with a `$`.
+
+# Code
+
+- Don't merely write code for the local context, but make changes that are good overall considering the architecture of the application and structure of the files and classes.
+
+# Frontend code
+
+- Pay attention to available types and type guards in src/SIL.XForge.Scripture/ClientApp/src/type-utils.ts.

--- a/doc/code-rules.md
+++ b/doc/code-rules.md
@@ -14,7 +14,7 @@ For more information, see the [architecture](architecture.md) overview.
 ## Frontend
 
 - Most Frontend tasks should work on a mobile phone. In other words, on a device with a narrow and short screen.
-- Most editing and reviewing tasks should work while offline. Changing some settings may require being online.
+- Most editing and reviewing tasks should work while offline. Although changing some settings may require being online; for example, making changes to a SFProjectDoc uses RPC calls.
 - Keep related files together in feature folders
 - Follow existing naming conventions
 


### PR DESCRIPTION
---

I sought to primarily move content around into different files and avoid editing or revising. A slight amount of revision did take place, as well as introduction of pointers to the different files, but hopefully the cut-and-paste parts of the change will be easy to review.

Marked as "do not merge" while I solicit feedback from multiple people.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3822)
<!-- Reviewable:end -->
