### PR TITLE
Fail e2e tests when browser fails to launch

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/e2e.mts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/e2e.mts
@@ -102,6 +102,7 @@ try {
   }
 } catch (error) {
   console.error(error);
+  failed = true;
 } finally {
   await logger.saveToFile();
 }


### PR DESCRIPTION
Our tests have been failing but the workflow silently passing, because the test runner only contemplated *test* failures, and missed *launch* failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3823)
<!-- Reviewable:end -->
