### PR TITLE
Improve dense mat select SCSS imports to reduce bundle size

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_dense-mat-select.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_dense-mat-select.scss
@@ -1,0 +1,16 @@
+// Mixin for compact mat-select form fields used throughout toolbar areas.
+@mixin dense-mat-select() {
+  ::ng-deep {
+    height: 36px;
+    .mat-mdc-form-field-infix {
+      min-height: initial;
+      padding-top: 7px;
+      padding-bottom: 5px;
+      width: initial;
+      min-width: 25px; // prevent weird transparent gap between content and scrollbar in Chromium
+    }
+    .mat-mdc-select-arrow-wrapper {
+      margin-inline-start: 5px;
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -1,4 +1,4 @@
-@use 'src/styles';
+@use 'src/dense-mat-select';
 
 :host {
   display: flex;
@@ -9,7 +9,7 @@
 // These styles were written by inspecting the elements using developer and then adding rules until it looked right
 #chapter-select,
 #book-select {
-  @include styles.dense_mat_select();
+  @include dense-mat-select.dense-mat-select();
 
   ::ng-deep .mat-mdc-text-field-wrapper {
     padding-left: 12px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
@@ -1,4 +1,5 @@
 @use 'src/styles';
+@use 'src/dense-mat-select';
 
 /* We have two mat-icon actions buttons */
 .actions {
@@ -94,6 +95,6 @@ td.mat-column-renderings {
 }
 
 .biblical-terms-select {
-  @include styles.dense_mat_select();
+  @include dense-mat-select.dense-mat-select();
   width: 200px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.scss
@@ -1,4 +1,4 @@
-@use 'src/styles';
+@use 'src/dense-mat-select';
 
 :host {
   display: flex;
@@ -48,7 +48,7 @@ app-notice {
 }
 
 .draft-select {
-  @include styles.dense_mat_select();
+  @include dense-mat-select.dense-mat-select();
 }
 
 app-notice {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-chooser.component.scss
@@ -1,4 +1,4 @@
-@use 'src/styles';
+@use 'src/dense-mat-select';
 
 ::ng-deep .history-select-panel .mdc-list-item__primary-text {
   width: 100%;
@@ -29,5 +29,5 @@
 }
 
 .history-select {
-  @include styles.dense_mat_select();
+  @include dense-mat-select.dense-mat-select();
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/styles.scss
@@ -127,22 +127,6 @@ body[dir='rtl'] .mirror-rtl {
   }
 }
 
-@mixin dense_mat_select() {
-  ::ng-deep {
-    height: 36px;
-    .mat-mdc-form-field-infix {
-      min-height: initial;
-      padding-top: 7px;
-      padding-bottom: 5px;
-      width: initial;
-      min-width: 25px; // prevent weird transparent gap between content and scrollbar in Chromium
-    }
-    .mat-mdc-select-arrow-wrapper {
-      margin-inline-start: 5px;
-    }
-  }
-}
-
 // These breakpoints can be somewhat confusing, because a breakpoint can be thought of as a range, or as a specific
 // width. If they're fixed numbers, hide-lt-md and hide-gt-md would be mutually exclusive, but if you think of them as
 // ranges, you would need to use hide-lt-md and hide-gt-sm to make two elements mutually exclusive. For the purposes of


### PR DESCRIPTION
`@use` in SCSS duplicates CSS in the imported files. This change partially addresses it by moving dense-mat-select to its own file, so fewer files import `src/styles`.

### Before
```
Initial chunk files                  | Names                     |  Raw size | Estimated transfer size
main-3MEPFBXT.js                     | main                      |   4.27 MB |               760.86 kB
styles-FHKSEU3C.css                  | styles                    | 286.70 kB |                19.89 kB
chunk-2GO6OTLK.js                    | -                         | 218.81 kB |                56.44 kB
polyfills-C5CUGU4Y.js                | polyfills                 |  60.72 kB |                18.55 kB
chunk-7JRWTMVI.js                    | -                         |   2.40 kB |                 1.06 kB
```

### After
```
Initial chunk files                  | Names                     |  Raw size | Estimated transfer size
main-57N72EGX.js                     | main                      |   4.02 MB |               760.29 kB
styles-L3KQ44D2.css                  | styles                    | 286.70 kB |                19.88 kB
chunk-2GO6OTLK.js                    | -                         | 218.81 kB |                56.44 kB
polyfills-C5CUGU4Y.js                | polyfills                 |  60.72 kB |                18.55 kB
chunk-7JRWTMVI.js                    | -                         |   2.40 kB |                 1.06 kB
```

The raw size is reduced by 5.85%, while the estimated transfer size (with compression) is negligible.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3824)
<!-- Reviewable:end -->
