### PR TITLE
Reduce generated size of biblical terms CSS

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-terms.component.scss
@@ -1,4 +1,4 @@
-@use 'src/styles';
+@use 'src/breakpoints';
 @use 'src/dense-mat-select';
 
 /* We have two mat-icon actions buttons */
@@ -42,13 +42,17 @@
 
 /* Hide the category when the view is constrained */
 .mat-column-category {
-  @extend .hide-lt-xl;
+  @include breakpoints.media-breakpoint-down(lg) {
+    display: none !important;
+  }
 }
 
 /* Hide the gloss when the view is constrained */
 .mat-column-gloss {
-  @extend .hide-lt-md;
   overflow: hidden;
+  @include breakpoints.media-breakpoint-down(sm) {
+    display: none !important;
+  }
 }
 
 /* Show the term renderings in the project font */


### PR DESCRIPTION
### Before
```
Initial chunk files                  | Names                     |  Raw size | Estimated transfer size
main-3N5CUUMQ.js                     | main                      |   4.02 MB |               760.36 kB
styles-L3KQ44D2.css                  | styles                    | 286.70 kB |                19.88 kB
chunk-2GO6OTLK.js                    | -                         | 218.81 kB |                56.44 kB
polyfills-C5CUGU4Y.js                | polyfills                 |  60.72 kB |                18.55 kB
chunk-7JRWTMVI.js                    | -                         |   2.40 kB |                 1.06 kB
```

### After
```
Initial chunk files                  | Names                     |  Raw size | Estimated transfer size
main-G7SWIXO5.js                     | main                      |   3.94 MB |               754.78 kB
styles-L3KQ44D2.css                  | styles                    | 286.70 kB |                19.88 kB
chunk-2GO6OTLK.js                    | -                         | 218.81 kB |                56.44 kB
polyfills-C5CUGU4Y.js                | polyfills                 |  60.72 kB |                18.55 kB
chunk-7JRWTMVI.js                    | -                         |   2.40 kB |                 1.06 kB
```

This reduces the bundle size by about 2%, and the compressed size by about 0.73%.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3827)
<!-- Reviewable:end -->
