### PR TITLE
SF-3749 Show name of training source project without access

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -162,7 +162,9 @@ describe('DraftHistoryEntryComponent', () => {
 
       verify(mockedPermissionsService.isUserOnProject('project02')).twice();
       verify(mockedSFProjectService.getProfile('project02')).never();
-      expect(component.translationSource).toEqual('');
+      expect(component.translationSource).toEqual('src \u2022');
+      expect(component.sourceLanguage).toBe('fr');
+      expect(component.trainingConfiguration).toEqual([{ target: 'tar', source: 'src', scriptureRange: 'GEN' }]);
     }));
 
     it('should state that the model did not have training configuration', fakeAsync(() => {
@@ -499,7 +501,16 @@ describe('DraftHistoryEntryComponent', () => {
     when(mockedUserService.getProfile('sf-user-id')).thenResolve(userDoc);
     const targetProjectDoc = {
       id: 'project01',
-      data: createTestProjectProfile({ shortName: 'tar', writingSystem: { tag: 'en' } })
+      data: createTestProjectProfile({
+        shortName: 'tar',
+        writingSystem: { tag: 'en' },
+        translateConfig: {
+          draftConfig: {
+            draftingSources: [{ projectRef: 'project02', shortName: 'src', writingSystem: { tag: 'fr' } }],
+            trainingSources: [{ projectRef: 'project02', shortName: 'src', writingSystem: { tag: 'fr' } }]
+          }
+        }
+      })
     } as SFProjectProfileDoc;
     when(mockedSFProjectService.getProfile('project01')).thenResolve(targetProjectDoc);
     when(mockedActivatedProjectService.changes$).thenReturn(of(targetProjectDoc));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -266,6 +266,7 @@ describe('DraftHistoryEntryComponent', () => {
       when(mockedSFProjectService.getProfile('project01')).thenResolve(targetProjectDoc);
       when(mockedActivatedProjectService.changes$).thenReturn(of(targetProjectDoc));
       const entry = {
+        engine: { id: 'project01' },
         additionalInfo: {
           dateGenerated: dateAfterFormattingSupported,
           dateRequested: dateAfterFormattingSupported,
@@ -396,6 +397,7 @@ describe('DraftHistoryEntryComponent', () => {
       when(mockedFeatureFlagsService.usfmFormat).thenReturn(createTestFeatureFlag(false));
       component.entry = {
         id: 'build01',
+        engine: { id: 'project01' },
         state: BuildStates.Completed,
         message: 'Completed',
         additionalInfo: {
@@ -414,6 +416,7 @@ describe('DraftHistoryEntryComponent', () => {
     it('should hide draft format UI if not the latest build', fakeAsync(() => {
       component.entry = {
         id: 'build01',
+        engine: { id: 'project01' },
         state: BuildStates.Completed,
         message: 'Completed',
         additionalInfo: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -124,36 +124,16 @@ export class DraftHistoryEntryComponent {
     this._sourceLanguage = undefined;
     this._targetLanguage = undefined;
     this._trainingConfiguration = [];
-    let draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
 
     // Get the books used in the training configuration
     const trainingScriptureRanges = this._entry?.additionalInfo?.trainingScriptureRanges ?? [];
     void Promise.all(
       trainingScriptureRanges.map(async r => {
         // The engine ID is the target project ID
-        let target: SFProjectProfileDoc | undefined = undefined;
-        if (this._entry?.engine.id != null) {
-          target = await this.projectService.getProfile(this._entry.engine.id);
-          if (target?.data != null) {
-            draftSources = projectToDraftSources(target.data);
-          }
-        }
+        const { target, source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId);
 
         // Get the target language, if it is not already set
         this._targetLanguage ??= target?.data?.writingSystem?.tag;
-
-        let source: SourceInfo | undefined;
-        // Get the source project, if it is configured and the user has access
-        if (await this.permissionsService.isUserOnProject(r.projectId)) {
-          const trainingSource: SFProjectProfileDoc | undefined = await this.projectService.getProfile(r.projectId);
-          source = {
-            projectRef: r.projectId,
-            shortName: trainingSource?.data?.shortName,
-            writingSystem: trainingSource?.data?.writingSystem
-          };
-        } else {
-          source = draftSources?.trainingSources.find(s => s.projectRef === r.projectId);
-        }
 
         // Get the source language, if it is not already set
         this._sourceLanguage ??= source?.writingSystem?.tag;
@@ -181,20 +161,8 @@ export class DraftHistoryEntryComponent {
     this._translationSources = [];
     void Promise.all(
       translationScriptureRanges.map(async r => {
-        let source: SourceInfo | undefined;
-        if (await this.permissionsService.isUserOnProject(r.projectId)) {
-          const translationSource: SFProjectProfileDoc | undefined = await this.projectService.getProfile(r.projectId);
-          source =
-            r.projectId === value?.engine?.id
-              ? undefined
-              : {
-                  projectRef: r.projectId,
-                  shortName: translationSource?.data?.shortName,
-                  writingSystem: translationSource?.data?.writingSystem
-                };
-        } else {
-          source = draftSources?.draftingSources.find(s => s.projectRef === r.projectId);
-        }
+        // The engine ID is the target project ID
+        const { source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId);
         const sourceShortName = source?.shortName;
         if (sourceShortName != null) this._translationSources.push(sourceShortName);
       })
@@ -396,5 +364,31 @@ export class DraftHistoryEntryComponent {
       disableClose: false,
       panelClass: 'use-application-text-color'
     });
+  }
+
+  private async getProjectSourceInfo(
+    targetId: string | undefined,
+    sourceId: string
+  ): Promise<{ target: SFProjectProfileDoc | undefined; source: SourceInfo | undefined }> {
+    let target: SFProjectProfileDoc | undefined = undefined;
+    let draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
+    if (targetId != null) {
+      target = await this.projectService.getProfile(targetId);
+      if (target?.data != null) {
+        draftSources = projectToDraftSources(target.data);
+      }
+    }
+    let source: SourceInfo | undefined;
+    if (await this.permissionsService.isUserOnProject(sourceId)) {
+      const translationSource: SFProjectProfileDoc | undefined = await this.projectService.getProfile(sourceId);
+      source = {
+        projectRef: sourceId,
+        shortName: translationSource?.data?.shortName,
+        writingSystem: translationSource?.data?.writingSystem
+      };
+    } else {
+      source = draftSources?.draftingSources.find(s => s.projectRef === sourceId);
+    }
+    return { target, source };
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -41,6 +41,7 @@ import { DraftDownloadButtonComponent } from '../../draft-download-button/draft-
 import { DraftImportWizardComponent } from '../../draft-import-wizard/draft-import-wizard.component';
 import { DraftOptionsService } from '../../draft-options.service';
 import { DraftPreviewBooksComponent } from '../../draft-preview-books/draft-preview-books.component';
+import { DraftSourcesAsTranslateSourceArrays, projectToDraftSources } from '../../draft-utils';
 import { TrainingDataService } from '../../training-data/training-data.service';
 
 const STATUS_INFO: Record<BuildStates, { icons: string; text: string; color: string }> = {
@@ -62,6 +63,12 @@ interface TrainingConfigurationRow {
   scriptureRange: string;
   source: string;
   target: string;
+}
+
+interface SourceInfo {
+  projectRef: string;
+  shortName?: string;
+  writingSystem?: { tag: string };
 }
 
 @Component({
@@ -117,6 +124,7 @@ export class DraftHistoryEntryComponent {
     this._sourceLanguage = undefined;
     this._targetLanguage = undefined;
     this._trainingConfiguration = [];
+    let draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
 
     // Get the books used in the training configuration
     const trainingScriptureRanges = this._entry?.additionalInfo?.trainingScriptureRanges ?? [];
@@ -126,24 +134,34 @@ export class DraftHistoryEntryComponent {
         let target: SFProjectProfileDoc | undefined = undefined;
         if (this._entry?.engine.id != null) {
           target = await this.projectService.getProfile(this._entry.engine.id);
+          if (target?.data != null) {
+            draftSources = projectToDraftSources(target.data);
+          }
         }
 
         // Get the target language, if it is not already set
-        this._targetLanguage ??= target?.data?.writingSystem.tag;
+        this._targetLanguage ??= target?.data?.writingSystem?.tag;
 
-        let source: SFProjectProfileDoc | undefined;
+        let source: SourceInfo | undefined;
         // Get the source project, if it is configured and the user has access
         if (await this.permissionsService.isUserOnProject(r.projectId)) {
-          source = r.projectId === '' ? undefined : await this.projectService.getProfile(r.projectId);
+          const trainingSource: SFProjectProfileDoc | undefined = await this.projectService.getProfile(r.projectId);
+          source = {
+            projectRef: r.projectId,
+            shortName: trainingSource?.data?.shortName,
+            writingSystem: trainingSource?.data?.writingSystem
+          };
+        } else {
+          source = draftSources?.trainingSources.find(s => s.projectRef === r.projectId);
         }
 
         // Get the source language, if it is not already set
-        this._sourceLanguage ??= source?.data?.writingSystem.tag;
+        this._sourceLanguage ??= source?.writingSystem?.tag;
 
         // Return the data for this training range
         return {
           scriptureRange: r.scriptureRange,
-          source: source?.data?.shortName ?? this.i18n.translateStatic('draft_history_entry.draft_unknown'),
+          source: source?.shortName ?? this.i18n.translateStatic('draft_history_entry.draft_unknown'),
           target: target?.data?.shortName ?? this.i18n.translateStatic('draft_history_entry.draft_unknown')
         } as TrainingConfigurationRow;
       })
@@ -163,14 +181,21 @@ export class DraftHistoryEntryComponent {
     this._translationSources = [];
     void Promise.all(
       translationScriptureRanges.map(async r => {
-        let source: SFProjectProfileDoc | undefined;
+        let source: SourceInfo | undefined;
         if (await this.permissionsService.isUserOnProject(r.projectId)) {
+          const translationSource: SFProjectProfileDoc | undefined = await this.projectService.getProfile(r.projectId);
           source =
-            r.projectId === '' || r.projectId === value?.engine?.id
+            r.projectId === value?.engine?.id
               ? undefined
-              : await this.projectService.getProfile(r.projectId);
+              : {
+                  projectRef: r.projectId,
+                  shortName: translationSource?.data?.shortName,
+                  writingSystem: translationSource?.data?.writingSystem
+                };
+        } else {
+          source = draftSources?.draftingSources.find(s => s.projectRef === r.projectId);
         }
-        const sourceShortName = source?.data?.shortName;
+        const sourceShortName = source?.shortName;
         if (sourceShortName != null) this._translationSources.push(sourceShortName);
       })
     );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -130,7 +130,7 @@ export class DraftHistoryEntryComponent {
     void Promise.all(
       trainingScriptureRanges.map(async r => {
         // The engine ID is the target project ID
-        const { target, source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId);
+        const { target, source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId, 'training');
 
         // Get the target language, if it is not already set
         this._targetLanguage ??= target?.data?.writingSystem?.tag;
@@ -162,7 +162,7 @@ export class DraftHistoryEntryComponent {
     void Promise.all(
       translationScriptureRanges.map(async r => {
         // The engine ID is the target project ID
-        const { source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId);
+        const { source } = await this.getProjectSourceInfo(value?.engine.id, r.projectId, 'drafting');
         const sourceShortName = source?.shortName;
         if (sourceShortName != null) this._translationSources.push(sourceShortName);
       })
@@ -368,7 +368,8 @@ export class DraftHistoryEntryComponent {
 
   private async getProjectSourceInfo(
     targetId: string | undefined,
-    sourceId: string
+    sourceId: string,
+    type: 'training' | 'drafting'
   ): Promise<{ target: SFProjectProfileDoc | undefined; source: SourceInfo | undefined }> {
     let target: SFProjectProfileDoc | undefined = undefined;
     let draftSources: DraftSourcesAsTranslateSourceArrays | undefined;
@@ -387,7 +388,11 @@ export class DraftHistoryEntryComponent {
         writingSystem: translationSource?.data?.writingSystem
       };
     } else {
-      source = draftSources?.draftingSources.find(s => s.projectRef === sourceId);
+      if (type === 'drafting') {
+        source = draftSources?.draftingSources.find(s => s.projectRef === sourceId);
+      } else {
+        source = draftSources?.trainingSources.find(s => s.projectRef === sourceId);
+      }
     }
     return { target, source };
   }


### PR DESCRIPTION
This PR accesses the names and languages of the translation source and training sources so that they can be displayed to the user. Previously these labels were left blank or unknown since the user did not have permission on the project, but warnings on the same page showed the source project names.

<img width="1428" height="719" alt="User no source permission" src="https://github.com/user-attachments/assets/e3df347a-9767-4ca1-a362-3e6785bf183f" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3829)
<!-- Reviewable:end -->
