### PR TITLE
SF-3760 Disable the save draft formatting button on click

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
@@ -63,7 +63,7 @@
           <div class="progress" [class.saving]="saving">
             <mat-spinner diameter="24"></mat-spinner>
           </div>
-          <button mat-flat-button class="save" color="primary" (click)="saveChanges()">
+          <button mat-flat-button class="save" color="primary" [disabled]="saving" (click)="saveChanges()">
             <mat-icon>check</mat-icon> {{ t("save_changes") }}
           </button>
         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.html
@@ -58,7 +58,9 @@
       </form>
 
       <div class="actions">
-        <button mat-button class="back" (click)="close()"><mat-icon>close</mat-icon>{{ t("cancel") }}</button>
+        <button mat-button class="back" [disabled]="saving" (click)="close()">
+          <mat-icon>close</mat-icon>{{ t("cancel") }}
+        </button>
         <div class="save-container">
           <div class="progress" [class.saving]="saving">
             <mat-spinner diameter="24"></mat-spinner>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -291,7 +291,7 @@ describe('DraftUsfmFormatComponent', () => {
     env.saveButton.click();
     // detect immediate changes before the save operation is completed
     env.fixture.detectChanges();
-    expect(env.fixture.nativeElement.querySelector('.progress')).not.toBeNull();
+    expect(env.fixture.nativeElement.querySelector('.progress.saving')).not.toBeNull();
     expect(env.saveButton.disabled).toBe(true);
     tick();
     env.fixture.detectChanges();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -288,12 +288,16 @@ describe('DraftUsfmFormatComponent', () => {
     verify(mockedProjectService.onlineSetUsfmConfig(env.projectId, anything())).never();
     verify(mockedDraftHandlingService.getDraft(anything(), anything())).twice();
 
-    // redirect to generate draft
     env.saveButton.click();
+    // detect immediate changes before the save operation is completed
+    env.fixture.detectChanges();
+    expect(env.fixture.nativeElement.querySelector('.progress')).not.toBeNull();
+    expect(env.saveButton.disabled).toBe(true);
     tick();
     env.fixture.detectChanges();
     verify(mockedProjectService.onlineSetUsfmConfig(env.projectId, deepEqual(config))).once();
     verify(mockedServalAdministration.onlineRetrievePreTranslationStatus(env.projectId)).once();
+    // redirect to generate draft
     verify(mockedLocation.back()).once();
   }));
 
@@ -379,11 +383,11 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
-  get backButton(): HTMLElement {
+  get backButton(): HTMLButtonElement {
     return this.fixture.nativeElement.querySelector('.back');
   }
 
-  get saveButton(): HTMLElement {
+  get saveButton(): HTMLButtonElement {
     return this.fixture.nativeElement.querySelector('.save');
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -222,6 +222,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
   }
 
   close(): void {
+    // go back to the draft generation or edit and review page
     this.location.back();
   }
 


### PR DESCRIPTION
When the draft usfm component is in the saving state, the user was still able to click the save button a second time. This is more of a problem on slower connections. This PR disables the button while the component is in the saving state. The original issue mentioned that the component navigated to unexpected places when this happened.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3832)
<!-- Reviewable:end -->
