### PR TITLE
SF-3789 Fix the access token cache expiring every minute

### DIFF
--- a/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineServiceCollectionExtensions.cs
@@ -30,7 +30,14 @@ public static class MachineServiceCollectionExtensions
         var servalOptions = configuration.GetOptions<ServalOptions>();
         services.AddDistributedMemoryCache();
         services
-            .AddClientCredentialsTokenManagement()
+            .AddClientCredentialsTokenManagement(options =>
+            {
+                // 10 hours is the token duration specified in Auth0
+                const int cacheLifetimeBuffer = 60;
+                options.CacheLifetimeBuffer = cacheLifetimeBuffer;
+                options.DefaultCacheLifetime = TimeSpan.FromSeconds(36000 - cacheLifetimeBuffer);
+                options.LocalCacheExpiration = null;
+            })
             .AddClient(
                 MachineApi.TokenClientName,
                 client =>
@@ -45,7 +52,7 @@ public static class MachineServiceCollectionExtensions
             .AddClientCredentialsHttpClient(
                 MachineApi.HttpClientName,
                 ClientCredentialsClientName.Parse(MachineApi.TokenClientName),
-                configureClient: client => client.BaseAddress = new Uri(servalOptions.ApiServer)
+                configureClient: client => client.BaseAddress = new Uri(servalOptions.ApiServer, UriKind.Absolute)
             )
             .ConfigurePrimaryHttpMessageHandler(() =>
             {


### PR DESCRIPTION
This PR fixes an issue where the Serval access token refreshes every minute after updating to Duende.AccessTokenManagement to version 4.2. I also wrote #3833 in case we want an immediate downgrade fix.

I have marked this as will require testing, but I think it is OK for a developer to test this, as enabling logging to view when the tokens are refresh requires a minor configuration change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/web-xforge/pull/3834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3834)
<!-- Reviewable:end -->
