### PR TITLE
Update REVIEW.md instructions for localization update PRs

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,7 +18,8 @@ Code should follow the rules outlined in [Code rules](doc/code-rules.md).
 
 - Front-end strings that can be seen by community checkers should be put in `checking_en.json`, even if non community checkers might see them.
 - Front-end strings that can never be seen by community checkers should be put in `non_checking_en.json`.
-- New strings only need to be added to the English localization files. A separate process will update the translation files, and fallback to English will be used in the meantime. Unnecessary changes should be avoided.
+- New strings only need to be added to the English localization files; other localization files shouldn't be updated.
+- Localization files are updated from Crowdin by a script that opens a PR with the title "Update all translation files from Crowdin". When reviewing a PR with this title, pay particular attention to the variables and tags in the source string, and the translated string, to make sure they are correctly preserved from the source string.
 - Updates to strings while keeping the same localization key are allowed, but significant changes to a string should use a new key, otherwise existing translations will continue to show the old string.
 - Strings that use variables should not be changed to different variables, otherwise errors will occur when the existing translations use the old variables. Instead, create a new localization key.
 


### PR DESCRIPTION
Devin has been commenting on the "update from Crowdin" PRs saying the localization strings shouldn't be updated due to instructions in this file (before the instruction I think it was complaining about developers *not* updating them). This attempts to steer it away from that, while also telling it what we *do* care about (that variables and such match in the translations).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3842)
<!-- Reviewable:end -->
