### PR TITLE
command-service: handle null or non-JSON-RPC response

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
@@ -199,8 +199,8 @@ describe('CommandService', () => {
         expect(errorInfo).toBeInstanceOf(CommandError);
         const commandError: CommandError = errorInfo as CommandError;
 
-        expect(commandError.message).toMatch(/Error invoking foo:/);
-        expect(commandError.message).toMatch(/Unexpected null JSON-RPC response from server/i);
+        expect(commandError.message).toContain('Error invoking foo:');
+        expect(commandError.message).toContain('Unexpected null JSON-RPC response from server');
         expect(commandError.code).toEqual(CommandErrorCode.Other);
       });
     tick();
@@ -227,7 +227,7 @@ describe('CommandService', () => {
         const commandError: CommandError = errorInfo as CommandError;
 
         expect(commandError.message).toContain('Error invoking foo:');
-        expect(commandError.message).toContain('Unexpected JSON-RPC response from server.');
+        expect(commandError.message).toContain('Unexpected JSON-RPC response from server');
         expect(commandError.code).toEqual(CommandErrorCode.Other);
       });
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
@@ -183,6 +183,60 @@ describe('CommandService', () => {
   // It would be nice to have a test that gets down to the fall-thru condition of a type of error that didn't match
   // what we expected. But the HttpTestingController isn't letting a request.error() be done that is not an
   // ErrorEvent. And if we request.flush(jsonRpcResponse), the jsonRpcResponse.error must be a JsonRpcError.
+
+  it('handles null response body without crashing when processing it', fakeAsync(() => {
+    // Suppose HttpClient.post returns null rather than a JSON-RPC response. CommandService
+    // should handle and process this rather than crash attempting to process the response.
+    const env = new TestEnvironment();
+
+    // SUT
+    env.service
+      .onlineInvoke<string>('place1', 'foo')
+      .then((_res: string | undefined) => {
+        fail('test setup error. should not have had a successful promise resolution');
+      })
+      .catch((errorInfo: unknown) => {
+        expect(errorInfo).toBeInstanceOf(CommandError);
+        const commandError: CommandError = errorInfo as CommandError;
+
+        expect(commandError.message).toMatch(/Error invoking foo:/);
+        expect(commandError.message).toMatch(/Unexpected null JSON-RPC response from server./i);
+        expect(commandError.code).toEqual(CommandErrorCode.Other);
+      });
+    tick();
+
+    const request = env.httpMock.expectOne({ url: 'command-api/place1', method: 'POST' });
+    request.flush(null);
+    tick();
+    env.httpMock.verify();
+  }));
+
+  it('throws CommandError when server returns non-null response not in JSON-RPC form', fakeAsync(() => {
+    // Suppose HttpClient.post returns a non-null response that is neither a JsonRpcFailure or
+    // a JsonRpcSuccess. onlineInvoke should throw with a message about it.
+    const env = new TestEnvironment();
+
+    // SUT
+    env.service
+      .onlineInvoke<string>('place1', 'foo')
+      .then((_res: string | undefined) => {
+        fail('test setup error. should not have had a successful promise resolution');
+      })
+      .catch((errorInfo: unknown) => {
+        expect(errorInfo).toBeInstanceOf(CommandError);
+        const commandError: CommandError = errorInfo as CommandError;
+
+        expect(commandError.message).toContain('Error invoking foo:');
+        expect(commandError.message).toContain('Unexpected JSON-RPC response from server.');
+        expect(commandError.code).toEqual(CommandErrorCode.Other);
+      });
+    tick();
+
+    const request = env.httpMock.expectOne({ url: 'command-api/place1', method: 'POST' });
+    request.flush({ jsonrpc: '2.0', id: '1' });
+    tick();
+    env.httpMock.verify();
+  }));
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.spec.ts
@@ -200,7 +200,7 @@ describe('CommandService', () => {
         const commandError: CommandError = errorInfo as CommandError;
 
         expect(commandError.message).toMatch(/Error invoking foo:/);
-        expect(commandError.message).toMatch(/Unexpected null JSON-RPC response from server./i);
+        expect(commandError.message).toMatch(/Unexpected null JSON-RPC response from server/i);
         expect(commandError.code).toEqual(CommandErrorCode.Other);
       });
     tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import { v1 as uuidv1 } from 'uuid';
-import { hasNumberProp, hasObjectProp, hasStringProp } from '../type-utils';
+import { hasNumberProp, hasObjectProp, hasProp, hasPropWithValue, hasStringProp } from '../type-utils';
 import { BugsnagService } from './bugsnag.service';
 import { COMMAND_API_NAMESPACE } from './url-constants';
 
@@ -45,8 +45,18 @@ export interface JsonRpcError {
   data?: any;
 }
 
-function isJsonRpcFailure<T>(response: JsonRpcResponse<T>): response is JsonRpcFailure {
-  return 'error' in response && response.error != null;
+function isJsonRpcFailure(value: unknown): value is JsonRpcFailure {
+  return (
+    hasPropWithValue(value, 'jsonrpc', '2.0') &&
+    hasStringProp(value, 'id') &&
+    hasObjectProp(value, 'error') &&
+    hasNumberProp(value.error, 'code') &&
+    hasStringProp(value.error, 'message')
+  );
+}
+
+function isJsonRpcSuccess(value: unknown): value is JsonRpcSuccess<unknown> {
+  return hasPropWithValue(value, 'jsonrpc', '2.0') && hasStringProp(value, 'id') && hasProp(value, 'result');
 }
 
 export function isNetworkError(error: any): boolean {
@@ -100,13 +110,19 @@ export class CommandService {
       'request'
     );
     try {
-      const response = await lastValueFrom(
-        this.http.post<JsonRpcResponse<T>>(url, request, { headers: { 'Content-Type': 'application/json' } })
+      const response: unknown = await lastValueFrom(
+        this.http.post(url, request, { headers: { 'Content-Type': 'application/json' } })
       );
+      if (response == null) {
+        throw new Error('Unexpected null JSON-RPC response from server.');
+      }
       if (isJsonRpcFailure(response)) {
         throw response.error;
       }
-      return response.result;
+      if (isJsonRpcSuccess(response)) {
+        return response.result as T; // optimistic type assertion
+      }
+      throw new Error('Unexpected JSON-RPC response from server.');
     } catch (error) {
       // Transform the various kinds of errors into a CommandError.
 
@@ -121,6 +137,8 @@ export class CommandService {
         if (Object.values(CommandErrorCode).includes(error.status)) {
           code = error.status as CommandErrorCode;
         }
+        moreInformation = error.message;
+      } else if (error instanceof Error) {
         moreInformation = error.message;
       } else if (
         // Does error implement interface JsonRpcError by having these properties?

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/command.service.ts
@@ -122,7 +122,8 @@ export class CommandService {
       if (isJsonRpcSuccess(response)) {
         return response.result as T; // optimistic type assertion
       }
-      throw new Error('Unexpected JSON-RPC response from server.');
+      const res: string = JSON.stringify(response);
+      throw new Error(`Unexpected JSON-RPC response from server: ${res}`);
     } catch (error) {
       // Transform the various kinds of errors into a CommandError.
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3843)
<!-- Reviewable:end -->
