### PR TITLE
serval-admin: show notice on 403 getting serval builds

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -14,6 +14,7 @@ import { DeltaOperation } from 'rich-text';
 import { of } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { anything, mock, verify } from 'ts-mockito';
+import { MockConsole } from 'xforge-common/mock-console';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
@@ -32,6 +33,7 @@ describe('DraftGenerationService', () => {
   let service: DraftGenerationService;
   let httpTestingController: HttpTestingController;
   const mockNoticeService = mock(NoticeService);
+  const mockedConsole: MockConsole = MockConsole.install();
   let testOnlineStatusService: TestOnlineStatusService;
 
   configureTestingModule(() => ({
@@ -379,6 +381,48 @@ describe('DraftGenerationService', () => {
       service.getBuildsSince(sinceDate).subscribe(result => {
         expect(result).toBeUndefined();
       });
+      tick();
+    }));
+
+    it('should show error notice and return undefined for a 403 error', fakeAsync(() => {
+      const sinceDate = new Date('2025-01-01T00:00:00.000Z');
+      mockedConsole.reset();
+      mockedConsole.expectAndHide(/403 Forbidden/);
+
+      // SUT
+      service.getBuildsSince(sinceDate).subscribe(result => {
+        expect(result).toBeUndefined();
+        verify(mockNoticeService.showError(anything())).once();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/since:${sinceDate.toISOString()}`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.Forbidden, statusText: 'Forbidden' });
+      tick();
+      mockedConsole.verify();
+      mockedConsole.reset();
+    }));
+
+    it('should return undefined and not show error notice for a 404 error', fakeAsync(() => {
+      const sinceDate = new Date('2025-01-01T00:00:00.000Z');
+
+      // SUT
+      service.getBuildsSince(sinceDate).subscribe(result => {
+        expect(result).toBeUndefined();
+        verify(mockNoticeService.showError(anything())).never();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/since:${sinceDate.toISOString()}`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.NotFound, statusText: 'Not Found' });
       tick();
     }));
   });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -125,11 +125,10 @@ export class DraftGenerationService {
     return this.httpClient.get<ServalBuildReportDto[]>(`translation/builds/since:${sinceIso}`).pipe(
       map(res => this.interpretTypesMany(res.data)),
       catchError(err => {
-        if (err.status === 403 || err.status === 404) {
+        if (err.status === 404) {
           return of(undefined);
         }
-
-        console.error(err);
+        console.error(err?.message ?? err);
         this.noticeService.showError(this.i18n.translateStatic('draft_generation.problem_fetching_build_history'));
         return of(undefined);
       })


### PR DESCRIPTION
Errors fetching from Serval, that looked like they may have been 403,
were looking like an empty list of records on the frontend without
even indication of a problem.

With this change, there can at least be a snackbar saying there was a
problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3844)
<!-- Reviewable:end -->
