### PR TITLE
Update to Serval.Client 1.17.0

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -43,7 +43,7 @@
     <PackageReference Include="Polly" Version="8.6.6" />
     <!-- When updating Serval.Client consider that API changes must be released to Serval Prod
         prior to testing on SF QA -->
-    <PackageReference Include="Serval.Client" Version="1.15.0" />
+    <PackageReference Include="Serval.Client" Version="1.17.0" />
     <PackageReference Include="SIL.Machine" Version="3.8.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -119,9 +119,9 @@
       },
       "Serval.Client": {
         "type": "Direct",
-        "requested": "[1.15.0, )",
-        "resolved": "1.15.0",
-        "contentHash": "1cTt1aX2pZN2m018FeEMgwlxGtkXrjaEA7IDmfOFsJPctc/pmxXu/P/o/V+loYg4TgXQwvAof8csMh7Es0pVPg==",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "DcV/x/9DiSoBL8hpLo48iG4VAuUDDDd8dB/rlcbynf0899SX2NRLZe2YRBkrFmtR2Vqs02z6cJO+nWSGHFCMow==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "System.ComponentModel.Annotations": "5.0.0"

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1249,8 +1249,8 @@
       },
       "Serval.Client": {
         "type": "Transitive",
-        "resolved": "1.15.0",
-        "contentHash": "1cTt1aX2pZN2m018FeEMgwlxGtkXrjaEA7IDmfOFsJPctc/pmxXu/P/o/V+loYg4TgXQwvAof8csMh7Es0pVPg==",
+        "resolved": "1.17.0",
+        "contentHash": "DcV/x/9DiSoBL8hpLo48iG4VAuUDDDd8dB/rlcbynf0899SX2NRLZe2YRBkrFmtR2Vqs02z6cJO+nWSGHFCMow==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4",
           "System.ComponentModel.Annotations": "5.0.0"
@@ -1696,7 +1696,7 @@
           "SIL.Converters.Usj": "[1.0.0, )",
           "SIL.Machine": "[3.8.2, )",
           "SIL.XForge": "[1.0.0, )",
-          "Serval.Client": "[1.15.0, )",
+          "Serval.Client": "[1.17.0, )",
           "Swashbuckle.AspNetCore": "[10.1.7, )",
           "Swashbuckle.AspNetCore.Newtonsoft": "[10.1.7, )"
         }

--- a/tools/ServalBuildReport/ServalBuildReport.csproj
+++ b/tools/ServalBuildReport/ServalBuildReport.csproj
@@ -20,7 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="NPOI" Version="[2.7.6]" />
-    <PackageReference Include="Serval.Client" Version="1.15.0" />
+    <PackageReference Include="Serval.Client" Version="1.17.0" />
+    <!-- Fix a vulnerable dependency of NPOI -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
 </Project>

--- a/tools/ServalDownloader/ServalDownloader.csproj
+++ b/tools/ServalDownloader/ServalDownloader.csproj
@@ -16,10 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageReference Include="Serval.Client" Version="1.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Serval.Client" Version="1.17.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Serval.Client 1.17 fixes a datetime bug exposed #3719 where the date is not being passed as UTC to Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3845)
<!-- Reviewable:end -->
