### PR TITLE
serval-admin: serval-builds: support chapter-aware project book display

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -66,8 +66,8 @@ export interface DraftJob {
   duration: number | undefined;
   errorMessage?: string;
   userId?: string;
-  trainingBooks?: ProjectBooks[];
-  translationBooks?: ProjectBooks[];
+  trainingBooks?: DraftJobsProjectBooks[];
+  translationBooks?: DraftJobsProjectBooks[];
 }
 
 /** Data that makes up a row of information in the Draft Jobs table. */
@@ -81,9 +81,19 @@ export interface DraftJobsTableRow {
   durationTooltip?: string;
   status: string;
   userId?: string;
-  trainingBooks: ProjectBooks[];
-  translationBooks: ProjectBooks[];
+  trainingBooks: DraftJobsProjectBooks[];
+  translationBooks: DraftJobsProjectBooks[];
   clearmlUrl?: string;
+}
+
+/** Maps a project to the list of book identifiers involved in a build. */
+export interface DraftJobsProjectBooks {
+  sfProjectId: string;
+  /** Display string for the project, e.g. "ABC - My Project" or just "ABC". */
+  projectDisplayName: string;
+  /** Short name of the project if available. */
+  shortName?: string;
+  books: string[];
 }
 
 /** Names of events that are relevant for pre-translation draft generation requests and processing. */
@@ -133,6 +143,9 @@ const DRAFTING_EVENTS = [
   ]
 })
 export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
+  /** Help template access static methods. */
+  protected ServalBuildsComponent = ServalBuildsComponent;
+
   /** Time when draftGenerationRequestId began to be used, which was in SFv5.46.1 shortly before
    * 2025-12-18T17:48:57Z. */
   private static readonly requestIdIntroductionDate: Date = new Date('2025-12-18T17:48:57Z');
@@ -806,8 +819,8 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
   }
 
   private static extractBooksFromEvent(event: EventMetric): {
-    trainingBooks: ProjectBooks[];
-    translationBooks: ProjectBooks[];
+    trainingBooks: DraftJobsProjectBooks[];
+    translationBooks: DraftJobsProjectBooks[];
   } {
     const trainingProjects = new Map<string, string[]>();
     const translationProjects = new Map<string, string[]>();
@@ -857,18 +870,20 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
       // If there's an error parsing the data, return empty arrays
     }
 
-    // Convert maps to ProjectBooks arrays
-    const trainingBooks: ProjectBooks[] = Array.from(trainingProjects.entries()).map(([projectId, books]) => ({
+    // Convert maps to DraftJobsProjectBooks arrays
+    const trainingBooks: DraftJobsProjectBooks[] = Array.from(trainingProjects.entries()).map(([projectId, books]) => ({
       sfProjectId: projectId,
       projectDisplayName: '',
       books: books
     }));
 
-    const translationBooks: ProjectBooks[] = Array.from(translationProjects.entries()).map(([projectId, books]) => ({
-      sfProjectId: projectId,
-      projectDisplayName: '',
-      books: books
-    }));
+    const translationBooks: DraftJobsProjectBooks[] = Array.from(translationProjects.entries()).map(
+      ([projectId, books]) => ({
+        sfProjectId: projectId,
+        projectDisplayName: '',
+        books: books
+      })
+    );
 
     return { trainingBooks, translationBooks };
   }
@@ -909,8 +924,20 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
 
   private static createSpreadsheetRows(rows: DraftJobsTableRow[]): SpreadsheetRow[] {
     return rows.map<SpreadsheetRow>((row: DraftJobsTableRow) => {
-      const trainingBooksList = ServalBuildsComponent.formatProjectBooks(row.trainingBooks);
-      const translationBooksList = ServalBuildsComponent.formatProjectBooks(row.translationBooks);
+      const trainingBooksProjectBooks: ProjectBooks[] = row.trainingBooks.map(bookInfo => ({
+        sfProjectId: bookInfo.sfProjectId,
+        projectDisplayName: bookInfo.projectDisplayName,
+        shortName: bookInfo.shortName,
+        booksAndChapters: bookInfo.books.map(book => ({ bookId: book }))
+      }));
+      const translationBooksProjectBooks: ProjectBooks[] = row.translationBooks.map(bookInfo => ({
+        sfProjectId: bookInfo.sfProjectId,
+        projectDisplayName: bookInfo.projectDisplayName,
+        shortName: bookInfo.shortName,
+        booksAndChapters: bookInfo.books.map(book => ({ bookId: book }))
+      }));
+      const trainingBooksList = ServalBuildsComponent.formatProjectBooks(trainingBooksProjectBooks);
+      const translationBooksList = ServalBuildsComponent.formatProjectBooks(translationBooksProjectBooks);
 
       let durationMinutes: string = '';
       if (row.job.startTime != null && row.job.finishTime != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
@@ -17,7 +17,7 @@ describe('toProjectBooks', () => {
     expect(result[0].sfProjectId).toBe('p1');
     expect(result[0].projectDisplayName).toBe('ABC - Project ABC');
     expect(result[0].projectName).toBe('Project ABC');
-    expect(result[0].books).toEqual(['GEN', 'EXO']);
+    expect(result[0].booksAndChapters).toEqual([{ bookId: 'GEN' }, { bookId: 'EXO' }]);
   });
 
   it('handles a single-book range', () => {
@@ -28,7 +28,7 @@ describe('toProjectBooks', () => {
     const result: ProjectBooks[] = toProjectBooks(ranges);
 
     expect(result.length).toBe(1);
-    expect(result[0].books).toEqual(['MAT']);
+    expect(result[0].booksAndChapters).toEqual([{ bookId: 'MAT' }]);
   });
 
   it('handles multiple project ranges with different projects', () => {
@@ -43,11 +43,11 @@ describe('toProjectBooks', () => {
     expect(result[0].sfProjectId).toBe('p1');
     expect(result[0].projectDisplayName).toBe('SRC - Source');
     expect(result[0].projectName).toBe('Source');
-    expect(result[0].books).toEqual(['GEN', 'EXO']);
+    expect(result[0].booksAndChapters).toEqual([{ bookId: 'GEN' }, { bookId: 'EXO' }]);
     expect(result[1].sfProjectId).toBe('p2');
     expect(result[1].projectDisplayName).toBe('TRN - Training');
     expect(result[1].projectName).toBe('Training');
-    expect(result[1].books).toEqual(['MAT', 'MRK', 'LUK']);
+    expect(result[1].booksAndChapters).toEqual([{ bookId: 'MAT' }, { bookId: 'MRK' }, { bookId: 'LUK' }]);
   });
 
   it('returns empty array for undefined ranges', () => {
@@ -105,7 +105,7 @@ describe('toProjectBooks', () => {
 
     const result: ProjectBooks[] = toProjectBooks(ranges);
 
-    expect(result[0].books).toEqual(['GEN', 'EXO']);
+    expect(result[0].booksAndChapters).toEqual([{ bookId: 'GEN' }, { bookId: 'EXO' }]);
   });
 
   it('filters out invalid book identifiers after parsing', () => {
@@ -115,7 +115,7 @@ describe('toProjectBooks', () => {
 
     const result: ProjectBooks[] = toProjectBooks(ranges);
 
-    expect(result[0].books).toEqual(['GEN', 'EXO']);
+    expect(result[0].booksAndChapters).toEqual([{ bookId: 'GEN' }, { bookId: 'EXO' }]);
   });
 
   it('populates shortName from the range shortName', () => {
@@ -138,6 +138,19 @@ describe('toProjectBooks', () => {
     const result: ProjectBooks[] = toProjectBooks(ranges);
 
     expect(result[0].shortName).toBeUndefined();
+  });
+
+  it('parses chapter numbers from scripture range segments', () => {
+    const ranges: BuildReportProjectScriptureRange[] = [
+      { sfProjectId: 'p1', scriptureRange: 'GEN10,11,16-19;EXO', shortName: 'PRJ', name: undefined }
+    ];
+
+    const result: ProjectBooks[] = toProjectBooks(ranges);
+
+    expect(result[0].booksAndChapters).toEqual([
+      { bookId: 'GEN', chapters: [10, 11, 16, 17, 18, 19] },
+      { bookId: 'EXO' }
+    ]);
   });
 });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -1,6 +1,7 @@
 import { Canon } from '@sillsdev/scripture';
 import { BuildDto } from '../machine-api/build-dto';
-import { booksFromScriptureRange } from '../shared/utils';
+import { expandNumbers } from '../shared/utils';
+import { notNull } from '../../type-utils';
 
 /**
  * A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
@@ -136,6 +137,12 @@ export function isDraftGenerationBuildStatus(value: string): value is DraftGener
   return draftGenerationBuildStatusValues.has(value);
 }
 
+/** A book identifier with optional chapter numbers. */
+export interface BookAndChapters {
+  bookId: string;
+  chapters?: number[];
+}
+
 /** Maps a project to the list of book identifiers involved in a build. */
 export interface ProjectBooks {
   sfProjectId: string;
@@ -145,12 +152,12 @@ export interface ProjectBooks {
   shortName?: string;
   /** Project name if available. */
   projectName?: string;
-  books: string[];
+  booksAndChapters: BookAndChapters[];
 }
 
 /**
  * Parses BuildReportProjectScriptureRange entries into ProjectBooks records by parsing semicolon-delimited scripture
- * ranges into individual book identifiers.
+ * ranges into individual book identifiers with optional chapter numbers.
  */
 export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | undefined): ProjectBooks[] {
   if (ranges == null) {
@@ -168,17 +175,36 @@ export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | unde
     }
 
     const displayName: string = buildProjectDisplayName(range.shortName, range.name, sfProjectId);
-    const bookNumbers: number[] = booksFromScriptureRange(scriptureRange);
-    const books: string[] = bookNumbers.map(bookNum => Canon.bookNumberToId(bookNum));
+    const booksAndChapters: BookAndChapters[] = parseBooksAndChapters(scriptureRange);
     projectBooks.push({
       sfProjectId: sfProjectId,
       projectDisplayName: displayName,
       shortName: range.shortName,
       projectName: range.name,
-      books: books
+      booksAndChapters: booksAndChapters
     });
   }
   return projectBooks;
+}
+
+/**
+ * Parses a semicolon-delimited scripture range string into BookAndChapters entries.
+ * Format: "GEN10,11,16-19;EXO" → [{bookId: 'GEN', chapters: [10,11,16,17,18,19]}, {bookId: 'EXO'}]
+ */
+function parseBooksAndChapters(scriptureRange: string): BookAndChapters[] {
+  return scriptureRange
+    .split(';')
+    .map(segment => {
+      const bookId: string = Canon.bookIdToNumber(segment.slice(0, 3)) > 0 ? segment.slice(0, 3) : '';
+      if (bookId === '') return null;
+      const chapterPart: string = segment.slice(3);
+      if (chapterPart === '') {
+        return { bookId };
+      }
+      const chapters: number[] = expandNumbers(chapterPart);
+      return chapters.length > 0 ? { bookId, chapters } : { bookId };
+    })
+    .filter(notNull);
 }
 
 /** Builds a display name for a project from its short name, name, and ID, falling back gracefully. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -44,10 +44,25 @@ export function countUniqueBooks(projectBooks: ProjectBooks[]): number {
   const uniqueBookCodes: Set<string> = new Set();
   for (const projectBook of projectBooks) {
     for (const bookCode of projectBook.booksAndChapters.map((bncs: BookAndChapters) => bncs.bookId)) {
-      uniqueBookCodes.add(bookCode);
+      const normalizedBookCode: string = normalizeBookCode(bookCode);
+      if (normalizedBookCode !== '') {
+        uniqueBookCodes.add(normalizedBookCode);
+      }
     }
   }
   return uniqueBookCodes.size;
+}
+
+/**
+ * Normalizes a book identifier to the first three characters. This supports values containing chapter notation
+ * (e.g. "GEN1" -> "GEN") and other non-standard tokens (e.g. "1234" -> "123").
+ */
+function normalizeBookCode(bookCode: string): string {
+  const trimmedBookCode: string = bookCode.trim().toUpperCase();
+  if (trimmedBookCode === '') {
+    return '';
+  }
+  return trimmedBookCode.length <= 3 ? trimmedBookCode : trimmedBookCode.slice(0, 3);
 }
 
 /** Computes the arithmetic mean, returning undefined for an empty array. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -32,7 +32,10 @@ export function validDateMsFrom(date: Date | undefined): number | undefined {
 
 /** Counts the total number of books across all project-book entries. */
 export function countBooks(projectBooks: ProjectBooks[]): number {
-  return projectBooks.reduce((total: number, projectBook: ProjectBooks) => total + projectBook.books.length, 0);
+  return projectBooks.reduce(
+    (total: number, projectBook: ProjectBooks) => total + projectBook.booksAndChapters.length,
+    0
+  );
 }
 
 /** Counts unique book codes across all project-book entries. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -1,5 +1,6 @@
 import { notNull } from '../../type-utils';
 import {
+  BookAndChapters,
   BuildReportProject,
   DraftGenerationBuildStatus,
   ProjectBooks,
@@ -42,7 +43,7 @@ export function countBooks(projectBooks: ProjectBooks[]): number {
 export function countUniqueBooks(projectBooks: ProjectBooks[]): number {
   const uniqueBookCodes: Set<string> = new Set();
   for (const projectBook of projectBooks) {
-    for (const bookCode of projectBook.books) {
+    for (const bookCode of projectBook.booksAndChapters.map((bncs: BookAndChapters) => bncs.bookId)) {
       uniqueBookCodes.add(bookCode);
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -175,11 +175,14 @@
                   <span class="project-link" [matTooltip]="toolTip">{{ short }}</span>
                 }
                 :
-                @if (projectBook.books.length <= 2) {
-                  {{ projectBook.books.join(", ") }}
+                @if (projectBook.booksAndChapters.length <= 2) {
+                  {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
                 } @else {
-                  <span [matTooltip]="projectBook.books.join(', ')" class="book-count">
-                    {{ projectBook.books.length }} books
+                  <span
+                    [matTooltip]="ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters)"
+                    class="book-count"
+                  >
+                    {{ projectBook.booksAndChapters.length }} books
                   </span>
                 }
               </div>
@@ -317,7 +320,7 @@
                                 } @else {
                                   <span class="project-link">{{ projectBook.projectDisplayName }}</span>
                                 }
-                                : {{ projectBook.books.join(", ") }}
+                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
                               </div>
                             } @empty {
                               <span>None</span>
@@ -339,7 +342,7 @@
                                 } @else {
                                   <span class="project-link">{{ projectBook.projectDisplayName }}</span>
                                 }
-                                : {{ projectBook.books.join(", ") }}
+                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
                               </div>
                             } @empty {
                               <span>None</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -364,6 +364,37 @@ describe('ServalBuildsComponent', () => {
       expect(summary.totalUniqueTrainingBooks).toBe(3);
     });
 
+    it('counts unique books by first three characters even for non-standard tokens', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: ServalBuildRow[] = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['ABC1', 'ABC2']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-2',
+          trainingBooks: env.createProjectBooks('proj-b', ['1234', '1235']),
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      // Total books: [ABC, ABC, 123, 123] => 4
+      expect(summary.totalTrainingBooks).toBe(4);
+      // Unique books dedupe by first three characters: [ABC, 123] => 2
+      expect(summary.totalUniqueTrainingBooks).toBe(2);
+    });
+
     it('uses only completed builds for mean duration', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -315,6 +315,55 @@ describe('ServalBuildsComponent', () => {
       expect(summary.totalUniqueTrainingBooks).toBe(3);
     });
 
+    it('handles book counting despite chapter numbers present', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: ServalBuildRow[] = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN1', 'EXO1-10,14']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-2',
+          trainingBooks: env.createProjectBooks('proj-b', ['GEN1', 'EXO']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-c',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-3',
+          trainingBooks: env.createProjectBooks('proj-c', ['GEN2', 'LEV']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-d',
+          startDate: env.addHours(baseStart, 6),
+          finishDate: env.addHours(baseStart, 7),
+          requesterId: 'user-3',
+          trainingBooks: env.createProjectBooks('proj-c', ['GEN']),
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      // Total books includes duplicates and is not influenced by chapter
+      // indications: [GEN, EXO, GEN, EXO, GEN, LEV, GEN] => 7
+      expect(summary.totalTrainingBooks).toBe(7);
+      // Unique books dedupe by book code globally, and is not influenced
+      // by chapter indications: [GEN, EXO, LEV] => 3
+      expect(summary.totalUniqueTrainingBooks).toBe(3);
+    });
+
     it('uses only completed builds for mean duration', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -319,7 +319,7 @@ describe('ServalBuildsComponent', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');
       const rows: ServalBuildRow[] = [
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-a',
           startDate: env.addHours(baseStart, 0),
           finishDate: env.addHours(baseStart, 1),
@@ -327,7 +327,7 @@ describe('ServalBuildsComponent', () => {
           trainingBooks: env.createProjectBooks('proj-a', ['GEN1', 'EXO1-10,14']),
           status: DraftGenerationBuildStatus.Completed
         }),
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-b',
           startDate: env.addHours(baseStart, 2),
           finishDate: env.addHours(baseStart, 3),
@@ -335,7 +335,7 @@ describe('ServalBuildsComponent', () => {
           trainingBooks: env.createProjectBooks('proj-b', ['GEN1', 'EXO']),
           status: DraftGenerationBuildStatus.Completed
         }),
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-c',
           startDate: env.addHours(baseStart, 4),
           finishDate: env.addHours(baseStart, 5),
@@ -343,7 +343,7 @@ describe('ServalBuildsComponent', () => {
           trainingBooks: env.createProjectBooks('proj-c', ['GEN2', 'LEV']),
           status: DraftGenerationBuildStatus.Completed
         }),
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-d',
           startDate: env.addHours(baseStart, 6),
           finishDate: env.addHours(baseStart, 7),
@@ -368,7 +368,7 @@ describe('ServalBuildsComponent', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');
       const rows: ServalBuildRow[] = [
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-a',
           startDate: env.addHours(baseStart, 0),
           finishDate: env.addHours(baseStart, 1),
@@ -376,7 +376,7 @@ describe('ServalBuildsComponent', () => {
           trainingBooks: env.createProjectBooks('proj-a', ['ABC1', 'ABC2']),
           status: DraftGenerationBuildStatus.Completed
         }),
-        env.createRowWithDetails({
+        TestEnvironment.createRowWithDetails({
           projectId: 'proj-b',
           startDate: env.addHours(baseStart, 2),
           finishDate: env.addHours(baseStart, 3),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1190,13 +1190,13 @@ describe('ServalBuildsComponent', () => {
           sfProjectId: '112233',
           projectDisplayName: 'BSB - Berean Standard Bible',
           shortName: 'BSB',
-          books: ['GEN', 'EXO']
+          booksAndChapters: [{ bookId: 'GEN' }, { bookId: 'EXO' }]
         },
         {
           sfProjectId: '222333',
           projectDisplayName: 'ASV - American Standard Version',
           shortName: 'ASV',
-          books: ['EXO', 'LEV']
+          booksAndChapters: [{ bookId: 'EXO' }, { bookId: 'LEV' }]
         }
       ];
 
@@ -1212,7 +1212,7 @@ describe('ServalBuildsComponent', () => {
           sfProjectId: '112233',
           projectDisplayName: '112233',
           shortName: undefined,
-          books: ['GEN']
+          booksAndChapters: [{ bookId: 'GEN' }]
         }
       ];
 
@@ -1220,6 +1220,29 @@ describe('ServalBuildsComponent', () => {
       const result: string = ServalBuildsComponent.formatProjectBooks(projectBooks);
 
       expect(result).toBe('112233: GEN');
+    });
+
+    it('includes chapter numbers in compact range notation', () => {
+      const projectBooks: ProjectBooks[] = [
+        {
+          sfProjectId: '112233',
+          projectDisplayName: 'BSB',
+          shortName: 'BSB',
+          booksAndChapters: [{ bookId: 'GEN', chapters: [10, 11, 16, 17, 18, 19] }, { bookId: 'EXO' }]
+        }
+      ];
+
+      // SUT
+      const result: string = ServalBuildsComponent.formatProjectBooks(projectBooks);
+
+      expect(result).toBe('112233 BSB: GEN 10-11, 16-19; EXO');
+    });
+
+    it('compactRangeNotation de-duplicates duplicate chapter numbers', () => {
+      // SUT
+      const result: string = ServalBuildsComponent.compactRangeNotation([10, 10, 11, 10, 16, 16, 17]);
+
+      expect(result).toBe('10-11, 16-17');
     });
   });
 
@@ -1521,7 +1544,9 @@ class TestEnvironment {
 
   createProjectBooks(projectId: string, books: string[], projectDisplayName?: string): ProjectBooks[] {
     const displayName: string = projectDisplayName ?? projectId.toUpperCase();
-    return [{ sfProjectId: projectId, projectDisplayName: displayName, books: books }];
+    return [
+      { sfProjectId: projectId, projectDisplayName: displayName, booksAndChapters: books.map(b => ({ bookId: b })) }
+    ];
   }
 
   createReport({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -55,6 +55,7 @@ import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.serv
 import { JobDetailsDialogComponent } from './job-details-dialog.component';
 import { ServalAdministrationService } from './serval-administration.service';
 import {
+  BookAndChapters,
   buildProjectDisplayName,
   DraftGenerationBuildStatus,
   Phase,
@@ -826,9 +827,42 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return projectBooks
       .map((pb: ProjectBooks) => {
         const prefix: string = pb.shortName != null ? `${pb.sfProjectId} ${pb.shortName}` : pb.sfProjectId;
-        return `${prefix}: ${pb.books.join('; ')}`;
+        const bookEntries: string = ServalBuildsComponent.formatBookEntries(pb.booksAndChapters);
+        return `${prefix}: ${bookEntries}`;
       })
       .join('. ');
+  }
+
+  /** Formats a BookAndChapters array into a display string, e.g. "GEN 10-11, 16-19; EXO". */
+  static formatBookEntries(booksAndChapters: BookAndChapters[]): string {
+    return booksAndChapters
+      .map(entry => {
+        if (entry.chapters == null || entry.chapters.length === 0) {
+          return entry.bookId;
+        }
+        return `${entry.bookId} ${ServalBuildsComponent.compactRangeNotation(entry.chapters)}`;
+      })
+      .join('; ');
+  }
+
+  /** Formats a sorted array of numbers into compact range notation, e.g. [1,2,3,5,7,8,9] → "1-3, 5, 7-9". */
+  static compactRangeNotation(nums: number[]): string {
+    if (nums.length === 0) return '';
+    const sortedUnique: number[] = [...new Set(nums)].sort((a, b) => a - b);
+    const ranges: string[] = [];
+    let rangeStart: number = sortedUnique[0];
+    let rangeEnd: number = sortedUnique[0];
+    for (let i = 1; i < sortedUnique.length; i++) {
+      if (sortedUnique[i] === rangeEnd + 1) {
+        rangeEnd = sortedUnique[i];
+      } else {
+        ranges.push(rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`);
+        rangeStart = sortedUnique[i];
+        rangeEnd = sortedUnique[i];
+      }
+    }
+    ranges.push(rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`);
+    return ranges.join(', ');
   }
 
   protected servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {


### PR DESCRIPTION
Recently a change was made in the backend where Serval builds might be
reported with chapter numbers, indicating a partial book. This patch
modifies the Serval builds tab to display that chapter information.
Unfortunately, it may not be possible to actually test this behvaiour
very easily until we start to use partial book drafting. It is
possible to see the new frontend behaviour by modifying the backend to
re-write data with chapter lists.

In draft-jobs.component.ts there is a change to using a new
`DraftJobsProjectBooks` instead of `projectBooks`. This is so the new
feature doesn't need to also be implemented in the draft jobs
component.

Screenshot showing chapter numbers in table row: (note: I didn't try to make the chapter usage make sense in this example screenshot; this is just to show the information)
<img width="630" height="158" alt="Screenshot_20260505_163422" src="https://github.com/user-attachments/assets/fc255d53-fa0d-4996-8d5a-86535daabd45" />

Screenshot showing chapter numbers in expanded details:
<img width="315" height="304" alt="Screenshot_20260505_163446" src="https://github.com/user-attachments/assets/0be6a093-0112-4d89-aa12-cace6e24cb46" />







<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3847)
<!-- Reviewable:end -->
