### PR TITLE
SF-3774 Do not list books to translate as not enough data to train

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -140,7 +140,7 @@
           (bookSelect)="onTranslatedBookSelect($event)"
           data-test-id="draft-stepper-training-books"
         ></app-book-multi-select>
-        @if (unusableTrainingSourceBooks.length > 0 || trainingBooksWithoutEnoughData.length > 0) {
+        @if (unusableTrainingSourceBooks.length > 0 || trainingBooksExcludingTranslatedWithoutEnoughData.length > 0) {
           <app-notice icon="info" mode="basic" type="light" class="unusable-training-books">
             <div class="notice-container">
               <span
@@ -149,23 +149,25 @@
                 [innerHtml]="
                   !expandUnusableTrainingBooks
                     ? i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_show_why', {
-                        numBooks: unusableTrainingSourceBooks.length + trainingBooksWithoutEnoughData.length
+                        numBooks:
+                          unusableTrainingSourceBooks.length + trainingBooksExcludingTranslatedWithoutEnoughData.length
                       })
                     : i18n.translateAndInsertTags('draft_generation_steps.books_are_hidden_hide_explanation', {
-                        numBooks: unusableTrainingSourceBooks.length + trainingBooksWithoutEnoughData.length
+                        numBooks:
+                          unusableTrainingSourceBooks.length + trainingBooksExcludingTranslatedWithoutEnoughData.length
                       })
                 "
               >
               </span>
               @if (expandUnusableTrainingBooks) {
-                @if (trainingBooksWithoutEnoughData.length > 0) {
+                @if (trainingBooksExcludingTranslatedWithoutEnoughData.length > 0) {
                   <h4 class="explanation">
                     <transloco
                       key="draft_generation_steps.these_training_source_books_are_blank"
                       [params]="{ firstTrainingSource }"
                     ></transloco>
                   </h4>
-                  <span class="book-names">{{ bookNames(trainingBooksWithoutEnoughData) }}</span>
+                  <span class="book-names">{{ bookNames(trainingBooksExcludingTranslatedWithoutEnoughData) }}</span>
                 }
                 @if (unusableTrainingSourceBooks.length > 0) {
                   <h4 class="explanation">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -391,6 +391,12 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.emptyTranslateSourceBooks).toEqual([5]);
     }));
 
+    it('should set "trainingBooksExcludingTranslatedWithoutEnoughData"', fakeAsync(() => {
+      expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([3, 5, 8]);
+      component.onTranslateBookSelect([3, 8], config.draftingSources[0]);
+      expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([5]);
+    }));
+
     it('should set "trainingBooksWithoutEnoughData"', fakeAsync(() => {
       expect(component.trainingBooksWithoutEnoughData).toEqual([3, 5, 8]);
     }));
@@ -754,6 +760,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.unusableTrainingSourceBooks).toEqual([5, 6]);
       expect(component.emptyTranslateSourceBooks).toEqual([6]);
       expect(component.trainingBooksWithoutEnoughData).toEqual([3]);
+      expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([3]);
 
       // interact with unusable books notice
       const unusableTranslateBooks = fixture.nativeElement.querySelector('.unusable-translate-books');

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -397,10 +397,6 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([5]);
     }));
 
-    it('should set "trainingBooksWithoutEnoughData"', fakeAsync(() => {
-      expect(component.trainingBooksWithoutEnoughData).toEqual([3, 5, 8]);
-    }));
-
     it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
       expect(component.unusableTranslateTargetBooks).toEqual([7]);
       expect(component.unusableTrainingTargetBooks).toEqual([7]);
@@ -759,7 +755,6 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.unusableTranslateSourceBooks).toEqual([4]);
       expect(component.unusableTrainingSourceBooks).toEqual([5, 6]);
       expect(component.emptyTranslateSourceBooks).toEqual([6]);
-      expect(component.trainingBooksWithoutEnoughData).toEqual([3]);
       expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([3]);
 
       // interact with unusable books notice

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -138,7 +138,6 @@ export class DraftGenerationStepsComponent implements OnInit {
   unusableTranslateSourceBooks: number[] = [];
   unusableTranslateTargetBooks: number[] = [];
   emptyTranslateSourceBooks: number[] = [];
-  trainingBooksWithoutEnoughData: number[] = [];
   trainingBooksExcludingTranslatedWithoutEnoughData: number[] = [];
   unusableTrainingSourceBooks: number[] = [];
   unusableTrainingTargetBooks: number[] = [];
@@ -170,6 +169,7 @@ export class DraftGenerationStepsComponent implements OnInit {
   private trainingDataSubscription?: Subscription;
   private currentUserDoc?: UserDoc;
   private projectProgress: Map<string, ProjectProgress> = new Map<string, ProjectProgress>();
+  private trainingBooksWithoutEnoughData: number[] = [];
 
   constructor(
     private readonly destroyRef: DestroyRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -139,6 +139,7 @@ export class DraftGenerationStepsComponent implements OnInit {
   unusableTranslateTargetBooks: number[] = [];
   emptyTranslateSourceBooks: number[] = [];
   trainingBooksWithoutEnoughData: number[] = [];
+  trainingBooksExcludingTranslatedWithoutEnoughData: number[] = [];
   unusableTrainingSourceBooks: number[] = [];
   unusableTrainingTargetBooks: number[] = [];
 
@@ -357,6 +358,7 @@ export class DraftGenerationStepsComponent implements OnInit {
               if (isBookEmptyInAllSources || !this.bookHasVerseContent(projectId!, bookNum)) {
                 // the books is present but is empty
                 this.trainingBooksWithoutEnoughData.push(bookNum);
+                this.trainingBooksExcludingTranslatedWithoutEnoughData.push(bookNum);
               } else {
                 this.availableTrainingBooks[projectId!].push({ number: bookNum, selected: selected });
               }
@@ -572,6 +574,11 @@ export class DraftGenerationStepsComponent implements OnInit {
     for (const book of this.availableTranslateBooks[source.projectRef]) {
       book.selected = selectedBooks.includes(book.number);
     }
+
+    this.trainingBooksExcludingTranslatedWithoutEnoughData = this.trainingBooksWithoutEnoughData.filter(
+      x => !selectedBooks.includes(x)
+    );
+
     this.clearErrorMessage();
   }
 


### PR DESCRIPTION
This PR fixes a bug where books selected for drafting were still being displayed under the list of hidden books.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3848)
<!-- Reviewable:end -->
