### PR TITLE
serval-admin: serval-builds: use translation shortName, project name tooltip

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.spec.ts
@@ -16,6 +16,7 @@ describe('toProjectBooks', () => {
     expect(result.length).toBe(1);
     expect(result[0].sfProjectId).toBe('p1');
     expect(result[0].projectDisplayName).toBe('ABC - Project ABC');
+    expect(result[0].projectName).toBe('Project ABC');
     expect(result[0].books).toEqual(['GEN', 'EXO']);
   });
 
@@ -41,9 +42,11 @@ describe('toProjectBooks', () => {
     expect(result.length).toBe(2);
     expect(result[0].sfProjectId).toBe('p1');
     expect(result[0].projectDisplayName).toBe('SRC - Source');
+    expect(result[0].projectName).toBe('Source');
     expect(result[0].books).toEqual(['GEN', 'EXO']);
     expect(result[1].sfProjectId).toBe('p2');
     expect(result[1].projectDisplayName).toBe('TRN - Training');
+    expect(result[1].projectName).toBe('Training');
     expect(result[1].books).toEqual(['MAT', 'MRK', 'LUK']);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -143,6 +143,8 @@ export interface ProjectBooks {
   projectDisplayName: string;
   /** Short name of the project if available. */
   shortName?: string;
+  /** Project name if available */
+  projectName?: string;
   books: string[];
 }
 
@@ -172,6 +174,7 @@ export function toProjectBooks(ranges: BuildReportProjectScriptureRange[] | unde
       sfProjectId: sfProjectId,
       projectDisplayName: displayName,
       shortName: range.shortName,
+      projectName: range.name,
       books: books
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -143,7 +143,7 @@ export interface ProjectBooks {
   projectDisplayName: string;
   /** Short name of the project if available. */
   shortName?: string;
-  /** Project name if available */
+  /** Project name if available. */
   projectName?: string;
   books: string[];
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -139,12 +139,20 @@
             @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
               <div>
                 @let translationLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
+                @let short = projectBook.shortName ?? projectBook.sfProjectId;
+                @let toolTip = projectBook.projectName ?? projectBook.sfProjectId;
                 @if (translationLink != null) {
-                  <a [href]="translationLink" target="_blank" rel="noopener" class="project-link">
-                    {{ projectBook.projectDisplayName }}
+                  <a
+                    [href]="translationLink"
+                    target="_blank"
+                    rel="noopener"
+                    class="project-link"
+                    [matTooltip]="toolTip"
+                  >
+                    {{ short }}
                   </a>
                 } @else {
-                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                  <span class="project-link" [matTooltip]="toolTip">{{ short }}</span>
                 }
                 :
                 @if (projectBook.books.length <= 2) {


### PR DESCRIPTION
The Serval builds tab showed both the short name and project name of
the translation source. After feedback, this patch changes the display
to only show the short name. Pointing to the short name makes the
project name display in a tool tip. The "SHORT - Project Name" display
is retained in the expansion area on the Input card.

Screenshot showing short name in table row, with tooltip with project name:
<img width="261" height="144" alt="image" src="https://github.com/user-attachments/assets/684b21a1-2f6b-46d3-bea2-d7f2368bc797" />

Screenshot showing a more detailed display in Input card in expansion area:
<img width="319" height="299" alt="image" src="https://github.com/user-attachments/assets/deddb75d-3282-42af-a0a7-667e1a6a1565" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3849)
<!-- Reviewable:end -->
