### PR TITLE
Update Snappier dependency of MongoDB.Driver to 1.3.1

### DIFF
--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -926,8 +926,8 @@
       },
       "Snappier": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "rFtK2KEI9hIe8gtx3a0YDXdHOpedIf9wYCEYtBEmtlyiWVX3XlCNV03JrmmAi/Cdfn7dxK+k0sjjcLv4fpHnqA=="
+        "resolved": "1.3.1",
+        "contentHash": "DOdDQiO8YZ5rBtVLY+6CmR1yp9WYoJRgEEktPBrR0tEj9QO2djA/zv0O3DX0OZpEAfosbY8pytQ9tQUogwQsEA=="
       },
       "Spart": {
         "type": "Transitive",
@@ -1244,6 +1244,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }
       }

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -24,5 +24,7 @@
     <PackageReference Include="idunno.Authentication.Basic" Version="2.4.0" />
     <PackageReference Include="AbrarJahin.DiffMatchPatch" Version="0.1.0" />
     <PackageReference Include="SIL.Core" Version="17.0.0" />
+    <!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 </Project>

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -172,6 +172,12 @@
           "TagLibSharp": "2.3.0"
         }
       },
+      "Snappier": {
+        "type": "Direct",
+        "requested": "[1.3.1, )",
+        "resolved": "1.3.1",
+        "contentHash": "DOdDQiO8YZ5rBtVLY+6CmR1yp9WYoJRgEEktPBrR0tEj9QO2djA/zv0O3DX0OZpEAfosbY8pytQ9tQUogwQsEA=="
+      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -464,11 +470,6 @@
         "type": "Transitive",
         "resolved": "0.30.1",
         "contentHash": "XqD4TpfyYGa7QTPzaGlMVbcecKnXy4YmYLDWrU+JIj7IuRNl7DH2END+Ll7ekWIY8o3dAMWLFDE1xdhfIWD1nw=="
-      },
-      "Snappier": {
-        "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "rFtK2KEI9hIe8gtx3a0YDXdHOpedIf9wYCEYtBEmtlyiWVX3XlCNV03JrmmAi/Cdfn7dxK+k0sjjcLv4fpHnqA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1323,8 +1323,8 @@
       },
       "Snappier": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "rFtK2KEI9hIe8gtx3a0YDXdHOpedIf9wYCEYtBEmtlyiWVX3XlCNV03JrmmAi/Cdfn7dxK+k0sjjcLv4fpHnqA=="
+        "resolved": "1.3.1",
+        "contentHash": "DOdDQiO8YZ5rBtVLY+6CmR1yp9WYoJRgEEktPBrR0tEj9QO2djA/zv0O3DX0OZpEAfosbY8pytQ9tQUogwQsEA=="
       },
       "Spart": {
         "type": "Transitive",
@@ -1677,6 +1677,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }
       },

--- a/test/SIL.XForge.Tests/packages.lock.json
+++ b/test/SIL.XForge.Tests/packages.lock.json
@@ -562,8 +562,8 @@
       },
       "Snappier": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "rFtK2KEI9hIe8gtx3a0YDXdHOpedIf9wYCEYtBEmtlyiWVX3XlCNV03JrmmAi/Cdfn7dxK+k0sjjcLv4fpHnqA=="
+        "resolved": "1.3.1",
+        "contentHash": "DOdDQiO8YZ5rBtVLY+6CmR1yp9WYoJRgEEktPBrR0tEj9QO2djA/zv0O3DX0OZpEAfosbY8pytQ9tQUogwQsEA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -619,6 +619,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }
       }


### PR DESCRIPTION
Currently builds are failing with the following error:

```
error NU1903: Warning As Error: Package 'Snappier' 1.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-pggp-6c3x-2xmx
```

This PR fixes that error by updating the vulnerable dependency of MongoDB.Driver (which does not yet have a version with the updated dependency reference).

See: 

 - https://github.com/advisories/GHSA-pggp-6c3x-2xmx

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3855)
<!-- Reviewable:end -->
