### PR TITLE
SF-3796 Color remarks blue in the editor

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_text.scss
@@ -24,6 +24,7 @@
   --sf-quill-delete-segment-background: #{if($is-dark, #531c17, #e8cccc)};
   --sf-quill-delete-segment-color: #{mat.get-theme-color($theme, neutral, if($is-dark, 96, 10))};
 
+  --sf-usx-rem-color: #{if($is-dark, #5c8dff, #003380)};
   --sf-usx-toc1-color: #{if($is-dark, #4bb74b, #004000)};
   --sf-usx-toc2-color: #{if($is-dark, #4bb74b, #004000)};
   --sf-usx-toc3-color: #{if($is-dark, #cf2f2f, #800000)};

--- a/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/_usx.scss
@@ -131,6 +131,12 @@ usx-para {
     margin-bottom: 2pt;
   }
 
+  &[data-style='rem'],
+  &[data-style='rem'] > usx-para-contents,
+  &[data-style='rem'] > usx-para-contents > usx-segment {
+    color: var(--sf-usx-rem-color) !important;
+  }
+
   &[data-style='s'],
   &[data-style='s1'] {
     font-weight: bold;


### PR DESCRIPTION
This PR colors remarks blue in the editor. The default black wasn't such a problem, until I noticed when testing per-chapter remarks, it was hard to tell the remarks from the text.

Remarks will now look like Paratext:
<img width="685" height="379" alt="image" src="https://github.com/user-attachments/assets/62501822-bbd5-4f74-a545-f001271c7b6a" />

And in dark mode:

<img width="685" height="379" alt="image" src="https://github.com/user-attachments/assets/ed56be2d-f642-4581-b8d0-7e50f5f4bc4e" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3856)
<!-- Reviewable:end -->
