### PR TITLE
Make it clear when project has no Serval build warnings

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -171,12 +171,16 @@
   }
 </div>
 
-@if (rawLastCompletedBuild?.executionData?.warnings?.length > 0) {
-  <h2>Serval warnings from last build</h2>
-  @for (warning of rawLastCompletedBuild.executionData.warnings; track $index) {
+<h2>Serval warnings from last build</h2>
+@if (rawLastCompletedBuild == null) {
+  <em>No completed builds</em>
+} @else {
+  @for (warning of rawLastCompletedBuild.executionData?.warnings ?? []; track $index) {
     <p>
       <app-notice icon="warning" mode="fill-dark" type="warning">{{ warning }}</app-notice>
     </p>
+  } @empty {
+    <em>No warnings on latest build</em>
   }
 }
 


### PR DESCRIPTION
I think when I originally added this section to the page, the warnings weren't being produced yet, so a lack of warnings in the data didn't really mean a lack of problems. However, now that the feature is working and something the team looks at, it's better to be clear whether when there are no warnings and why.

<img width="327" height="80" alt="Screenshot from 2026-05-07 10-44-09" src="https://github.com/user-attachments/assets/9ab73a98-22fa-4b18-b35b-e4d341eaa268" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3857)
<!-- Reviewable:end -->
