### PR TITLE
serval-admin: serval-builds: show requester email in build details

### DIFF
--- a/src/RealtimeServer/common/services/user-service.spec.ts
+++ b/src/RealtimeServer/common/services/user-service.spec.ts
@@ -19,6 +19,14 @@ describe('UserService', () => {
     await expect(fetchDoc(conn, USERS_COLLECTION, 'user02')).resolves.not.toThrow();
   });
 
+  it('allows serval admin to view others', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+
+    const conn = clientConnect(env.server, 'user02', SystemRole.ServalAdmin);
+    await expect(fetchDoc(conn, USERS_COLLECTION, 'user01')).resolves.not.toThrow();
+  });
+
   it('allows system admin to edit others', async () => {
     const env = new TestEnvironment();
     await env.createData();

--- a/src/RealtimeServer/common/services/user-service.ts
+++ b/src/RealtimeServer/common/services/user-service.ts
@@ -106,7 +106,11 @@ export class UserService extends JsonDocService<User> {
   }
 
   protected allowRead(docId: string, doc: User, session: ConnectSession): boolean {
-    if (session.isServer || session.roles.includes(SystemRole.SystemAdmin)) {
+    if (
+      session.isServer ||
+      session.roles.includes(SystemRole.SystemAdmin) ||
+      session.roles.includes(SystemRole.ServalAdmin)
+    ) {
       return true;
     }
     if (docId === session.userId) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -269,6 +269,21 @@
                         @let requesterName = requesterDisplayName(row.report.requesterSFUserId) | async;
                         <span class="detail-value">{{ requesterName ?? "Unknown" }}</span>
                       </div>
+
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Email address</span>
+                        @let requesterEmail = requesterEmailAddress(row.report.requesterSFUserId) | async;
+                        <span class="detail-value detail-value-with-copy code">
+                          @if (requesterEmail != null) {
+                            <a [href]="'mailto:' + requesterEmail">
+                              {{ requesterEmail }}
+                            </a>
+                            <app-copy [value]="requesterEmail"></app-copy>
+                          } @else {
+                            <span>-</span>
+                          }
+                        </span>
+                      </div>
                     </span>
                   </mat-card-content>
                 </mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -267,7 +267,7 @@
                       <div class="detail-keyvalue">
                         <span class="detail-key">Display name</span>
                         @let requesterName = requesterDisplayName(row.report.requesterSFUserId) | async;
-                        <span class="detail-value">{{ requesterName ?? "Unknown" }}</span>
+                        <span class="detail-value">{{ requesterName ?? "-" }}</span>
                       </div>
 
                       <div class="detail-keyvalue">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -1,3 +1,7 @@
+a {
+  text-decoration: none;
+}
+
 .preview-notice {
   margin-top: 1rem;
   margin-bottom: 1rem;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1495,29 +1495,6 @@ describe('ServalBuildsComponent', () => {
       expect(await updatedDisplayNamePromise).toBe('Changed User');
       expect(await updatedEmailAddressPromise).toBe('changed@example.com');
     });
-
-    it('updates requester details when remoteChanges$ emits', async () => {
-      const env = new TestEnvironment();
-      const displayName$: Observable<string | undefined> = env.component['requesterDisplayName']('user02');
-      const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
-
-      expect(await firstValueFrom(displayName$)).toBe('Test User');
-      expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
-
-      const updatedDisplayNamePromise: Promise<string | undefined> = firstValueFrom(
-        displayName$.pipe(skip(1), take(1))
-      );
-      const updatedEmailAddressPromise: Promise<string | undefined> = firstValueFrom(
-        emailAddress$.pipe(skip(1), take(1))
-      );
-
-      env.userData.displayName = 'Remote Changed User';
-      env.userData.email = 'remote.changed@example.com';
-      env.userRemoteChanges$.next();
-
-      expect(await updatedDisplayNamePromise).toBe('Remote Changed User');
-      expect(await updatedEmailAddressPromise).toBe('remote.changed@example.com');
-    });
   });
 
   describe('export', () => {
@@ -1555,7 +1532,6 @@ class TestEnvironment {
   >(undefined);
   readonly userData: { displayName: string; avatarUrl: string; email: string };
   readonly userChanges$: Subject<void> = new Subject<void>();
-  readonly userRemoteChanges$: Subject<void> = new Subject<void>();
 
   constructor() {
     this.userData = {
@@ -1565,8 +1541,7 @@ class TestEnvironment {
     };
     const userDoc = {
       data: this.userData,
-      changes$: this.userChanges$,
-      remoteChanges$: this.userRemoteChanges$
+      changes$: this.userChanges$
     } as unknown as UserDoc;
 
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable, skip, Subject, take } from 'rxjs';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { anything, mock, when } from 'ts-mockito';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
@@ -1473,6 +1473,48 @@ describe('ServalBuildsComponent', () => {
 
       expect(emailAddress).toBe('user02@example.com');
     });
+
+    it('updates requester details when changes$ emits', async () => {
+      const env = new TestEnvironment();
+      const displayName$: Observable<string> = env.component['requesterDisplayName']('user02');
+      const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
+
+      expect(await firstValueFrom(displayName$)).toBe('Test User');
+      expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
+
+      const updatedDisplayNamePromise: Promise<string> = firstValueFrom(displayName$.pipe(skip(1), take(1)));
+      const updatedEmailAddressPromise: Promise<string | undefined> = firstValueFrom(
+        emailAddress$.pipe(skip(1), take(1))
+      );
+
+      env.userData.displayName = 'Changed User';
+      env.userData.email = 'changed@example.com';
+      env.userChanges$.next();
+
+      expect(await updatedDisplayNamePromise).toBe('Changed User');
+      expect(await updatedEmailAddressPromise).toBe('changed@example.com');
+    });
+
+    it('updates requester details when remoteChanges$ emits', async () => {
+      const env = new TestEnvironment();
+      const displayName$: Observable<string> = env.component['requesterDisplayName']('user02');
+      const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
+
+      expect(await firstValueFrom(displayName$)).toBe('Test User');
+      expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
+
+      const updatedDisplayNamePromise: Promise<string> = firstValueFrom(displayName$.pipe(skip(1), take(1)));
+      const updatedEmailAddressPromise: Promise<string | undefined> = firstValueFrom(
+        emailAddress$.pipe(skip(1), take(1))
+      );
+
+      env.userData.displayName = 'Remote Changed User';
+      env.userData.email = 'remote.changed@example.com';
+      env.userRemoteChanges$.next();
+
+      expect(await updatedDisplayNamePromise).toBe('Remote Changed User');
+      expect(await updatedEmailAddressPromise).toBe('remote.changed@example.com');
+    });
   });
 
   
@@ -1509,16 +1551,21 @@ class TestEnvironment {
   readonly builds$: BehaviorSubject<ServalBuildReportDto[] | undefined> = new BehaviorSubject<
     ServalBuildReportDto[] | undefined
   >(undefined);
+  readonly userData: { displayName: string; avatarUrl: string; email: string };
+  readonly userChanges$: Subject<void> = new Subject<void>();
+  readonly userRemoteChanges$: Subject<void> = new Subject<void>();
 
   constructor() {
-    const userData = {
+    this.userData = {
       displayName: 'Test User',
       avatarUrl: '',
       email: 'user02@example.com'
     };
     const userDoc = {
-      data: userData
-    } as UserDoc;
+      data: this.userData,
+      changes$: this.userChanges$,
+      remoteChanges$: this.userRemoteChanges$
+    } as unknown as UserDoc;
 
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
     when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1460,7 +1460,7 @@ describe('ServalBuildsComponent', () => {
     it('loads requester display name from user data', async () => {
       const env = new TestEnvironment();
 
-      const displayName: string = await firstValueFrom(env.component['requesterDisplayName']('user02'));
+      const displayName: string | undefined = await firstValueFrom(env.component['requesterDisplayName']('user02'));
 
       expect(displayName).toBe('Test User');
     });
@@ -1475,13 +1475,15 @@ describe('ServalBuildsComponent', () => {
 
     it('updates requester details when changes$ emits', async () => {
       const env = new TestEnvironment();
-      const displayName$: Observable<string> = env.component['requesterDisplayName']('user02');
+      const displayName$: Observable<string | undefined> = env.component['requesterDisplayName']('user02');
       const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
 
       expect(await firstValueFrom(displayName$)).toBe('Test User');
       expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
 
-      const updatedDisplayNamePromise: Promise<string> = firstValueFrom(displayName$.pipe(skip(1), take(1)));
+      const updatedDisplayNamePromise: Promise<string | undefined> = firstValueFrom(
+        displayName$.pipe(skip(1), take(1))
+      );
       const updatedEmailAddressPromise: Promise<string | undefined> = firstValueFrom(
         emailAddress$.pipe(skip(1), take(1))
       );
@@ -1496,13 +1498,15 @@ describe('ServalBuildsComponent', () => {
 
     it('updates requester details when remoteChanges$ emits', async () => {
       const env = new TestEnvironment();
-      const displayName$: Observable<string> = env.component['requesterDisplayName']('user02');
+      const displayName$: Observable<string | undefined> = env.component['requesterDisplayName']('user02');
       const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
 
       expect(await firstValueFrom(displayName$)).toBe('Test User');
       expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
 
-      const updatedDisplayNamePromise: Promise<string> = firstValueFrom(displayName$.pipe(skip(1), take(1)));
+      const updatedDisplayNamePromise: Promise<string | undefined> = firstValueFrom(
+        displayName$.pipe(skip(1), take(1))
+      );
       const updatedEmailAddressPromise: Promise<string | undefined> = firstValueFrom(
         emailAddress$.pipe(skip(1), take(1))
       );

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { BehaviorSubject, firstValueFrom, Observable, skip, Subject, take } from 'rxjs';
 import { ActivatedRoute, provideRouter } from '@angular/router';
-import { anything, mock, when } from 'ts-mockito';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { BehaviorSubject, firstValueFrom, Observable, skip, Subject, take } from 'rxjs';
+import { anything, mock, verify, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { MockConsole } from 'xforge-common/mock-console';
@@ -1457,7 +1456,7 @@ describe('ServalBuildsComponent', () => {
     });
   });
 
-   describe('requesting user details', () => {
+  describe('requesting user details', () => {
     it('loads requester display name from user data', async () => {
       const env = new TestEnvironment();
 
@@ -1517,7 +1516,6 @@ describe('ServalBuildsComponent', () => {
     });
   });
 
-  
   describe('export', () => {
     it('exports tsv rows through DraftJobsExportService', () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,12 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { ActivatedRoute, provideRouter } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { anything, mock, when } from 'ts-mockito';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { MockConsole } from 'xforge-common/mock-console';
-import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { provideTestOnlineStatus } from 'xforge-common/test-online-status-providers';
@@ -1456,6 +1457,25 @@ describe('ServalBuildsComponent', () => {
     });
   });
 
+   describe('requesting user details', () => {
+    it('loads requester display name from user data', async () => {
+      const env = new TestEnvironment();
+
+      const displayName: string = await firstValueFrom(env.component['requesterDisplayName']('user02'));
+
+      expect(displayName).toBe('Test User');
+    });
+
+    it('loads requester email address from user data', async () => {
+      const env = new TestEnvironment();
+
+      const emailAddress: string | undefined = await firstValueFrom(env.component['requesterEmailAddress']('user02'));
+
+      expect(emailAddress).toBe('user02@example.com');
+    });
+  });
+
+  
   describe('export', () => {
     it('exports tsv rows through DraftJobsExportService', () => {
       const env = new TestEnvironment();
@@ -1491,14 +1511,15 @@ class TestEnvironment {
   >(undefined);
 
   constructor() {
-    const mockedUserProfileDoc = mock(UserProfileDoc);
-    const userProfileDoc: UserProfileDoc = instance(mockedUserProfileDoc);
-    const profileData: { displayName: string; avatarUrl: string } = {
+    const userData = {
       displayName: 'Test User',
-      avatarUrl: ''
+      avatarUrl: '',
+      email: 'user02@example.com'
     };
+    const userDoc = {
+      data: userData
+    } as UserDoc;
 
-    when(mockedUserProfileDoc.data).thenReturn(profileData);
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
     when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);
     when(mockDraftGenerationService.getBuildsSince(anything())).thenReturn(this.builds$);
@@ -1506,7 +1527,7 @@ class TestEnvironment {
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
-    when(mockUserService.getProfile(anything())).thenReturn(Promise.resolve(userProfileDoc));
+    when(mockUserService.get(anything())).thenResolve(userDoc);
     when(mockI18nService.localeCode).thenReturn('en');
     when(mockI18nService.getLanguageDisplayName(anything())).thenReturn(undefined);
     when(mockedActivatedRoute.queryParams).thenReturn(new BehaviorSubject({}));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -184,7 +184,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   /** Data rows, including those that are filtered out by the includeDeleted toggle. */
   private allRows: ServalBuildRow[] = [];
   private readonly dateRange$ = new BehaviorSubject<NormalizedDateRange | undefined>(undefined);
-  private readonly requesterIdentityCache: Map<string, Observable<{ displayName: string; emailAddress?: string }>> =
+  private readonly requesterIdentityCache: Map<string, Observable<{ displayName?: string; emailAddress?: string }>> =
     new Map();
 
   constructor(
@@ -416,7 +416,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return `${durationMinutes} m`;
   }
 
-  protected requesterDisplayName(requesterSFUserId: string | undefined): Observable<string> {
+  protected requesterDisplayName(requesterSFUserId: string | undefined): Observable<string | undefined> {
     return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.displayName));
   }
 
@@ -426,18 +426,18 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
   private requesterIdentity(
     requesterSFUserId: string | undefined
-  ): Observable<{ displayName: string; emailAddress?: string }> {
+  ): Observable<{ displayName?: string; emailAddress?: string }> {
     if (requesterSFUserId == null) {
-      return of({ displayName: 'Unknown' });
+      return of({});
     }
 
     const requesterKey: string = requesterSFUserId;
-    const cached$: Observable<{ displayName: string; emailAddress?: string }> | undefined =
+    const cached$: Observable<{ displayName?: string; emailAddress?: string }> | undefined =
       this.requesterIdentityCache.get(requesterKey);
     if (cached$ != null) return cached$;
 
     // Cache the lookups so multiple rows don't need to request the same thing.
-    const identity$: Observable<{ displayName: string; emailAddress?: string }> = from(
+    const identity$: Observable<{ displayName?: string; emailAddress?: string }> = from(
       this.userService.get(requesterSFUserId)
     ).pipe(
       // This switchMap to changes$ and remoteChanges$ lets us cache Observables with information that stays up-to-date.
@@ -445,17 +445,17 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
         merge(userDoc.changes$, userDoc.remoteChanges$).pipe(
           startWith(undefined),
           map(() => {
-            const displayName: string | undefined = userDoc.data?.displayName?.trim();
-            const emailAddress: string | undefined = userDoc.data?.email?.trim();
+            const displayName: string | undefined = userDoc.data?.displayName;
+            const emailAddress: string | undefined = userDoc.data?.email;
             return {
-              displayName: isPopulatedString(displayName) ? displayName : 'Unknown',
-              emailAddress: isPopulatedString(emailAddress) ? emailAddress : undefined
+              displayName: displayName,
+              emailAddress: emailAddress
             };
           })
         )
       ),
       shareReplay(1),
-      catchError(() => of({ displayName: 'Unknown' }))
+      catchError(() => of({}))
     );
 
     this.requesterIdentityCache.set(requesterKey, identity$);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -442,7 +442,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     ).pipe(
       // This switchMap to changes$ and remoteChanges$ lets us cache Observables with information that stays up-to-date.
       switchMap((userDoc: UserDoc) =>
-        merge([userDoc.changes$, userDoc.remoteChanges$]).pipe(
+        merge(userDoc.changes$, userDoc.remoteChanges$).pipe(
           startWith(undefined),
           map(() => {
             const displayName: string | undefined = userDoc.data?.displayName?.trim();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -30,6 +30,7 @@ import {
   firstValueFrom,
   from,
   map,
+  merge,
   Observable,
   of,
   shareReplay,
@@ -40,7 +41,7 @@ import { CopyComponent } from 'xforge-common/copy/copy.component';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
-import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
+import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
@@ -183,7 +184,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   /** Data rows, including those that are filtered out by the includeDeleted toggle. */
   private allRows: ServalBuildRow[] = [];
   private readonly dateRange$ = new BehaviorSubject<NormalizedDateRange | undefined>(undefined);
-  private readonly requesterDisplayNameCache: Map<string, Observable<string>> = new Map();
+  private readonly requesterIdentityCache: Map<string, Observable<{ displayName: string; emailAddress?: string }>> =
+    new Map();
 
   constructor(
     noticeService: NoticeService,
@@ -415,28 +417,49 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   protected requesterDisplayName(requesterSFUserId: string | undefined): Observable<string> {
-    if (requesterSFUserId == null) return of('Unknown');
+    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.displayName));
+  }
+
+  protected requesterEmailAddress(requesterSFUserId: string | undefined): Observable<string | undefined> {
+    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.emailAddress));
+  }
+
+  private requesterIdentity(
+    requesterSFUserId: string | undefined
+  ): Observable<{ displayName: string; emailAddress?: string }> {
+    if (requesterSFUserId == null) {
+      return of({ displayName: 'Unknown' });
+    }
 
     const requesterKey: string = requesterSFUserId;
-    const cached$: Observable<string> | undefined = this.requesterDisplayNameCache.get(requesterKey);
+    const cached$: Observable<{ displayName: string; emailAddress?: string }> | undefined =
+      this.requesterIdentityCache.get(requesterKey);
     if (cached$ != null) return cached$;
 
     // Cache the lookups so multiple rows don't need to request the same thing.
-    const displayName$: Observable<string> = from(this.userService.getProfile(requesterSFUserId)).pipe(
-      switchMap((userProfileDoc: UserProfileDoc) =>
-        userProfileDoc.changes$.pipe(
+    const identity$: Observable<{ displayName: string; emailAddress?: string }> = from(
+      this.userService.get(requesterSFUserId)
+    ).pipe(
+      // This switchMap to changes$ and remoteChanges$ lets us cache Observables with information that stays up-to-date.
+      switchMap((userDoc: UserDoc) =>
+        merge([userDoc.changes$, userDoc.remoteChanges$]).pipe(
           startWith(undefined),
           map(() => {
-            const displayName: string | undefined = userProfileDoc.data?.displayName?.trim();
-            return isPopulatedString(displayName) ? displayName : 'Unknown';
+            const displayName: string | undefined = userDoc.data?.displayName?.trim();
+            const emailAddress: string | undefined = userDoc.data?.email?.trim();
+            return {
+              displayName: isPopulatedString(displayName) ? displayName : 'Unknown',
+              emailAddress: isPopulatedString(emailAddress) ? emailAddress : undefined
+            };
           })
         )
       ),
       shareReplay(1),
-      catchError(() => of('Unknown'))
+      catchError(() => of({ displayName: 'Unknown' }))
     );
-    this.requesterDisplayNameCache.set(requesterKey, displayName$);
-    return displayName$;
+
+    this.requesterIdentityCache.set(requesterKey, identity$);
+    return identity$;
   }
 
   protected clearProjectFilter(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -30,7 +30,6 @@ import {
   firstValueFrom,
   from,
   map,
-  merge,
   Observable,
   of,
   shareReplay,
@@ -440,9 +439,9 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     const identity$: Observable<{ displayName?: string; emailAddress?: string }> = from(
       this.userService.get(requesterSFUserId)
     ).pipe(
-      // This switchMap to changes$ and remoteChanges$ lets us cache Observables with information that stays up-to-date.
+      // This switchMap to changes$ lets us cache Observables with information that stays up-to-date.
       switchMap((userDoc: UserDoc) =>
-        merge(userDoc.changes$, userDoc.remoteChanges$).pipe(
+        userDoc.changes$.pipe(
           startWith(undefined),
           map(() => {
             const displayName: string | undefined = userDoc.data?.displayName;


### PR DESCRIPTION
This patch modifies the Requesting user area in the expanded
information of a Serval build so it shows the user's email address.

I have further plans for this "Requesting user" card after this change.

Screenshot:
<img width="324" height="295" alt="Screenshot_20260507_135949" src="https://github.com/user-attachments/assets/690904fc-291f-468a-a1c8-8d01d90ef746" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3860)
<!-- Reviewable:end -->
