### PR TITLE
serval-admin: serval-builds: Show Paratext project ID

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -20,6 +20,7 @@ export interface ServalBuildReportDto {
 /** SF project information for a build report entry.*/
 export interface BuildReportProject {
   sfProjectId: string;
+  ptProjectId?: string;
   shortName: string | undefined;
   name: string | undefined;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -243,6 +243,17 @@
                       </div>
 
                       <div class="detail-keyvalue">
+                        <span class="detail-key">Paratext project ID</span>
+                        @let ptProjectId = row.report.project?.ptProjectId;
+                        <span class="detail-value detail-value-with-copy code">
+                          <span class="pt-project-id">{{ ptProjectId ?? "-" }}</span>
+                          @if (ptProjectId != null) {
+                            <app-copy [value]="ptProjectId"></app-copy>
+                          }
+                        </span>
+                      </div>
+
+                      <div class="detail-keyvalue">
                         <span class="detail-key">Serval version</span>
                         <span class="detail-value">{{ row.report.build?.deploymentVersion ?? "Unknown" }}</span>
                       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -363,6 +363,10 @@
   font-family: monospace;
 }
 
+.pt-project-id {
+  max-width: 21ch;
+}
+
 .detail-area-stacked-keyvalues {
   word-break: break-word;
   display: flex;

--- a/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
@@ -61,6 +61,7 @@ public class ServalBuildReportDto
 public class BuildReportProject
 {
     public string SFProjectId { get; init; } = string.Empty;
+    public string? PTProjectId { get; init; }
     public string? ShortName { get; init; }
     public string? Name { get; init; }
 }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1350,6 +1350,7 @@ public class MachineApiService(
             projectInfo = new BuildReportProject
             {
                 SFProjectId = sfProjectId,
+                PTProjectId = sfProject?.ParatextId,
                 ShortName = sfProject?.ShortName,
                 Name = sfProject?.Name,
             };

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -1274,6 +1274,7 @@ public class MachineApiServiceTests
         Assert.IsNotNull(report.Build);
         Assert.IsNotNull(report.Project);
         Assert.AreEqual(Project01, report.Project!.SFProjectId);
+        Assert.AreEqual(project01.ParatextId, report.Project.PTProjectId);
         Assert.AreEqual(project01.ShortName, report.Project.ShortName);
         Assert.AreEqual(project01.Name, report.Project.Name);
         Assert.AreEqual(dateCreated, report.Timeline.ServalCreated);


### PR DESCRIPTION
This patch shows the Paratext project ID on the Identifiers card. Note that the PT project ID is wrapped at about 20 characters to make it look nice when wrapped on the card. 

Screenshot:
<img width="323" height="365" alt="image" src="https://github.com/user-attachments/assets/161b6b9e-f9a3-4ce4-aaa2-b2db57d4335a" />

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3861)
<!-- Reviewable:end -->
