### PR TITLE
system-admin: serval-builds: reorder card Language info to before Input

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -292,6 +292,41 @@
                 <mat-card appearance="filled" class="detail-card">
                   <mat-card-header>
                     <mat-card-title-group>
+                      <mat-icon>translate</mat-icon>
+                      <mat-card-title>Language info</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Source language</span>
+                        <span class="detail-value">{{
+                          formatLanguageWithName(row.report.build?.executionData?.sourceLanguageTag)
+                        }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Target language</span>
+                        <span class="detail-value">{{
+                          formatLanguageWithName(row.report.build?.executionData?.targetLanguageTag)
+                        }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Strings trained on</span>
+                        <span class="detail-value">{{ row.report.build?.executionData?.trainCount ?? "-" }}</span>
+                      </div>
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">Strings translated</span>
+                        <span class="detail-value">{{
+                          row.report.build?.executionData?.pretranslateCount ?? "-"
+                        }}</span>
+                      </div>
+                    </span>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
                       <mat-icon>merge</mat-icon>
                       <mat-card-title>Input</mat-card-title>
                     </mat-card-title-group>
@@ -341,41 +376,6 @@
                             }
                           </div>
                         </span>
-                      </div>
-                    </span>
-                  </mat-card-content>
-                </mat-card>
-
-                <mat-card appearance="filled" class="detail-card">
-                  <mat-card-header>
-                    <mat-card-title-group>
-                      <mat-icon>translate</mat-icon>
-                      <mat-card-title>Language info</mat-card-title>
-                    </mat-card-title-group>
-                  </mat-card-header>
-                  <mat-card-content class="detail-card-content">
-                    <span class="detail-area-stacked-keyvalues">
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Source language</span>
-                        <span class="detail-value">{{
-                          formatLanguageWithName(row.report.build?.executionData?.sourceLanguageTag)
-                        }}</span>
-                      </div>
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Target language</span>
-                        <span class="detail-value">{{
-                          formatLanguageWithName(row.report.build?.executionData?.targetLanguageTag)
-                        }}</span>
-                      </div>
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Strings trained on</span>
-                        <span class="detail-value">{{ row.report.build?.executionData?.trainCount ?? "-" }}</span>
-                      </div>
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Strings translated</span>
-                        <span class="detail-value">{{
-                          row.report.build?.executionData?.pretranslateCount ?? "-"
-                        }}</span>
                       </div>
                     </span>
                   </mat-card-content>


### PR DESCRIPTION
This change is just cutting and pasting the block of lines to a new position.

Screenshot:
<img width="628" height="74" alt="image" src="https://github.com/user-attachments/assets/50d142e9-2f29-4c06-abef-ba4e7fac2e4c" />


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3865)
<!-- Reviewable:end -->
