### PR TITLE
serval-admin: serval-builds: add training book total summary stats

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -35,6 +35,17 @@ export function countBooks(projectBooks: ProjectBooks[]): number {
   return projectBooks.reduce((total: number, projectBook: ProjectBooks) => total + projectBook.books.length, 0);
 }
 
+/** Counts unique book codes across all project-book entries. */
+export function countUniqueBooks(projectBooks: ProjectBooks[]): number {
+  const uniqueBookCodes: Set<string> = new Set();
+  for (const projectBook of projectBooks) {
+    for (const bookCode of projectBook.books) {
+      uniqueBookCodes.add(bookCode);
+    }
+  }
+  return uniqueBookCodes.size;
+}
+
 /** Computes the arithmetic mean, returning undefined for an empty array. */
 export function averageNumbers(values: number[]): number | undefined {
   if (values.length === 0) return undefined;
@@ -148,6 +159,14 @@ export function calculatePercentTimeOnSF(rows: ServalBuildRow[]): number | undef
  * containing counts, averages, and timing statistics.
  */
 export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
+  const listedTotalTrainingBooks: number = rows.reduce(
+    (sum: number, row: ServalBuildRow) => sum + countBooks(row.trainingBooks),
+    0
+  );
+  const listedTotalUniqueTrainingBooks: number = countUniqueBooks(
+    rows.flatMap((row: ServalBuildRow) => row.trainingBooks)
+  );
+
   // Type for a build row where the SF project is known.
   type KnowableBuildRow = ServalBuildRow & { report: ServalBuildReportDto & { project: BuildReportProject } };
   // Rows with a known SF project. Any build that is not associable with a project will not be included or
@@ -168,6 +187,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
       faultedBuilds: 0,
       averageTrainingBooksPerBuild: undefined,
       averageTranslationBooksPerBuild: undefined,
+      totalUniqueTrainingBooks: listedTotalUniqueTrainingBooks,
+      totalTrainingBooks: listedTotalTrainingBooks,
       completedBuilds: 0,
       inProgressBuilds: 0,
       buildsWithProblems: 0,
@@ -269,6 +290,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
     faultedBuilds: faultedBuilds,
     averageTrainingBooksPerBuild: averageTrainingBooksPerBuild,
     averageTranslationBooksPerBuild: averageTranslationBooksPerBuild,
+    totalUniqueTrainingBooks: listedTotalUniqueTrainingBooks,
+    totalTrainingBooks: listedTotalTrainingBooks,
     completedBuilds: completedBuilds,
     inProgressBuilds: inProgressBuilds,
     buildsWithProblems: buildsWithProblems,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -205,6 +205,8 @@ describe('ServalBuildsComponent', () => {
       expect(summary.faultedBuilds).toBe(1);
       expect(summary.averageTrainingBooksPerBuild).toBeCloseTo(1.1666666667);
       expect(summary.averageTranslationBooksPerBuild).toBeCloseTo(1);
+      expect(summary.totalUniqueTrainingBooks).toBe(7);
+      expect(summary.totalTrainingBooks).toBe(7);
       expect(summary.completedBuilds).toBe(3);
       expect(summary.inProgressBuilds).toBe(2);
       expect(summary.buildsWithProblems).toBe(1);
@@ -214,6 +216,45 @@ describe('ServalBuildsComponent', () => {
       // All rows created above with createRowWithDetails have a servalBuild and no events, so all are "SF did not know about"
       expect(summary.buildsServalDidNotKnowAbout).toBe(0);
       expect(summary.buildsSfDidNotKnowAbout).toBe(6);
+    });
+
+    it('counts total and unique training books across listed builds', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: ServalBuildRow[] = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-2',
+          trainingBooks: env.createProjectBooks('proj-b', ['GEN']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        env.createRowWithDetails({
+          projectId: 'proj-c',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-3',
+          trainingBooks: env.createProjectBooks('proj-c', ['LEV']),
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      // Total books includes duplicates: [GEN, EXO, GEN, LEV] => 4
+      expect(summary.totalTrainingBooks).toBe(4);
+      // Unique books dedupe by book code globally: [GEN, EXO, LEV] => 3
+      expect(summary.totalUniqueTrainingBooks).toBe(3);
     });
 
     it('uses only completed builds for mean duration', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -83,6 +83,8 @@ export interface ServalBuildSummary {
   faultedBuilds: number;
   averageTrainingBooksPerBuild?: number;
   averageTranslationBooksPerBuild?: number;
+  totalUniqueTrainingBooks: number;
+  totalTrainingBooks: number;
   completedBuilds: number;
   inProgressBuilds: number;
   buildsWithProblems: number;
@@ -604,6 +606,23 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       prominence: 'hidden'
     };
     items.push(averageTrainingBooksItem);
+
+    const totalUniqueTrainingBooksItem: SummaryDisplayItem = {
+      label: 'Total unique training books',
+      explanation:
+        'A book is only counted once even if used in multiple projects. For example, if two projects use GEN, and one project uses EXO, that is 2 unique books: GEN and EXO.',
+      value: this.formatCount(summary.totalUniqueTrainingBooks),
+      prominence: 'hidden'
+    };
+    items.push(totalUniqueTrainingBooksItem);
+
+    const totalTrainingBooksItem: SummaryDisplayItem = {
+      label: 'Total training books',
+      explanation: 'Including counting the same book again when used in more than one project.',
+      value: this.formatCount(summary.totalTrainingBooks),
+      prominence: 'hidden'
+    };
+    items.push(totalTrainingBooksItem);
 
     const averageTranslationBooksItem: SummaryDisplayItem = {
       label: 'Average translation books per build',


### PR DESCRIPTION
This adds information to the Serval builds tab in the summary area. The new items are
"Total unique training books" and 
"Total training books". I plan to do similar for translation books in followup.

Screenshot (you can ignore the numbers in this poor example):
<img width="632" height="88" alt="image" src="https://github.com/user-attachments/assets/c5b2cac0-358b-4a76-921e-80430f269954" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3866)
<!-- Reviewable:end -->
