### PR TITLE
Add lint rule to catch arrays passed to RxJS operators instead of args

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/eslint.config.mjs
+++ b/src/SIL.XForge.Scripture/ClientApp/eslint.config.mjs
@@ -121,7 +121,16 @@ export default [
       ],
       'no-underscore-dangle': 'off',
       'prefer-const': ['warn', { ignoreReadBeforeAssign: true }],
-      'no-var': 'warn'
+      'no-var': 'warn',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.name=/^(merge|concat)$/][arguments.length=1][arguments.0.type='ArrayExpression']",
+          message:
+            'You should probably pass separate arguments instead of an array to this RxJS operator. If you want to pass an array, disable this rule for the line with // eslint-disable-next-line no-restricted-syntax'
+        }
+      ]
     }
   },
   // HTML template files


### PR DESCRIPTION
This catches subtle issues like `merge([observableOne$, observableTwo$])` which should be `merge(observableOne$, observableTwo$)`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3867)
<!-- Reviewable:end -->
