### PR TITLE
serval-admin: serval-builds: add TSV export option

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.spec.ts
@@ -136,6 +136,38 @@ describe('DraftJobsExportService', () => {
       expect(rsvRows[1][0]).toBeNull();
     });
   });
+
+  describe('exportTsv', () => {
+    it('exports as a tab-delimited .tsv file', () => {
+      const env = new TestEnvironment();
+      const exportSeparatedValuesSpy = spyOn<any>(env.service, 'exportSeparatedValues').and.stub();
+      const dateRange = { start: new Date(2025, 0, 15), end: new Date(2025, 1, 28) };
+      const rows: SpreadsheetRow[] = [
+        {
+          draftGenerationRequestId: 'req-1',
+          servalBuildId: 'build-1',
+          status: 'Completed',
+          sfProjectId: 'project-1',
+          trainingBooks: 'GEN; EXO',
+          translationBooks: 'MAT'
+        }
+      ];
+
+      // SUT
+      env.service.exportTsv(rows, dateRange, 60000, 120000, 'serval_builds');
+
+      expect(exportSeparatedValuesSpy).toHaveBeenCalledWith(
+        rows,
+        dateRange,
+        60000,
+        120000,
+        'serval_builds',
+        'tsv',
+        '\t',
+        'text/tab-separated-values'
+      );
+    });
+  });
 });
 
 class TestEnvironment {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
@@ -46,11 +46,38 @@ export class DraftJobsExportService {
     maxDuration: number,
     filenamePrefix: string
   ): void {
-    const spreadsheetRows = this.addStatistics(rows, meanDuration, maxDuration);
-    const csv: string = Papa.unparse(spreadsheetRows);
-    const filename: string = this.getExportFilename(dateRangeForFilename, 'csv', filenamePrefix);
-    const blob: Blob = new Blob([csv], { type: 'text/csv' });
-    saveAs(blob, filename);
+    this.exportSeparatedValues(
+      rows,
+      dateRangeForFilename,
+      meanDuration,
+      maxDuration,
+      filenamePrefix,
+      'csv',
+      ',',
+      'text/csv'
+    );
+  }
+
+  /**
+   * Export the draft jobs data to a TSV file.
+   */
+  exportTsv(
+    rows: SpreadsheetRow[],
+    dateRangeForFilename: NormalizedDateRange,
+    meanDuration: number,
+    maxDuration: number,
+    filenamePrefix: string
+  ): void {
+    this.exportSeparatedValues(
+      rows,
+      dateRangeForFilename,
+      meanDuration,
+      maxDuration,
+      filenamePrefix,
+      'tsv',
+      '\t',
+      'text/tab-separated-values'
+    );
   }
 
   /**
@@ -171,5 +198,22 @@ export class DraftJobsExportService {
    */
   private msToMinutes(milliseconds: number): number {
     return milliseconds / 1000 / 60;
+  }
+
+  private exportSeparatedValues(
+    rows: SpreadsheetRow[],
+    dateRangeForFilename: NormalizedDateRange,
+    meanDuration: number,
+    maxDuration: number,
+    filenamePrefix: string,
+    extension: string,
+    delimiter: string,
+    mimeType: string
+  ): void {
+    const spreadsheetRows = this.addStatistics(rows, meanDuration, maxDuration);
+    const separatedValues: string = Papa.unparse(spreadsheetRows, { delimiter: delimiter });
+    const filename: string = this.getExportFilename(dateRangeForFilename, extension, filenamePrefix);
+    const blob: Blob = new Blob([separatedValues], { type: mimeType });
+    saveAs(blob, filename);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -9,7 +9,7 @@
       <button mat-raised-button color="primary" class="export-csv-button" (click)="exportCsv()">
         <mat-icon>download</mat-icon>
         <span class="export-item-label">
-          Export CSV <app-info text="Download a .csv spreadsheet of the table data"></app-info>
+          Export CSV <app-info text="Download a .csv (comma-separated values) spreadsheet of the table data"></app-info>
         </span>
       </button>
       <button mat-raised-button color="primary" class="export-menu-button" [matMenuTriggerFor]="exportMenu">
@@ -17,12 +17,18 @@
       </button>
     </div>
     <mat-menu #exportMenu="matMenu" xPosition="before">
+      <button mat-menu-item (click)="exportTsv()">
+        <mat-icon>download</mat-icon>
+        <span class="export-item-label">
+          Export TSV <app-info text="Download a .tsv (tab-separated values) spreadsheet of the table data"></app-info>
+        </span>
+      </button>
       <button mat-menu-item (click)="exportRsv()">
         <mat-icon>download</mat-icon>
         <span class="export-item-label">
           Export RSV
           <app-info
-            text="Download an .rsv Rows of String Values spreadsheet of the table data (https://github.com/Stenway/RSV-Specification)"
+            text="Download an .rsv (Rows of String Values) spreadsheet of the table data (https://github.com/Stenway/RSV-Specification)"
           >
           </app-info>
         </span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
-import { anything, instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { DialogService } from 'xforge-common/dialog.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { MockConsole } from 'xforge-common/mock-console';
@@ -1214,6 +1214,30 @@ describe('ServalBuildsComponent', () => {
       expect(formatted).toBe('es (Spanish)');
     });
   });
+
+  describe('export', () => {
+    it('exports tsv rows through DraftJobsExportService', () => {
+      const env = new TestEnvironment();
+      const range: NormalizedDateRange = {
+        start: new Date('2024-01-01T00:00:00Z'),
+        end: new Date('2024-01-31T23:59:59Z')
+      };
+      env.component['dateRange$'].next(range);
+      env.component['rows'] = [
+        env.createRowWithDetails({
+          projectId: 'proj-a',
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN']),
+          translationBooks: env.createProjectBooks('proj-a', ['MAT'])
+        })
+      ];
+
+      // SUT
+      env.component['exportTsv']();
+
+      verify(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).once();
+    });
+  });
 });
 
 /** Provides helpers for constructing test data for ServalBuildsComponent tests. */
@@ -1239,6 +1263,7 @@ class TestEnvironment {
     when(mockDialogService.openMatDialog(anything(), anything(), anything())).thenReturn(undefined as never);
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
+    when(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockUserService.getProfile(anything())).thenReturn(Promise.resolve(userProfileDoc));
     when(mockI18nService.localeCode).thenReturn('en');
     when(mockI18nService.getLanguageDisplayName(anything())).thenReturn(undefined);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -239,6 +239,15 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     this.exportService.exportRsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
   }
 
+  protected exportTsv(): void {
+    const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
+    if (dateRange == null) throw new Error('Date range is not set');
+    const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
+    const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
+    const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
+    this.exportService.exportTsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  }
+
   protected clearMLUrl(servalBuildId: string): string {
     return `https://app.sil.hosted.allegro.ai/projects?gq=${servalBuildId}&tab=tasks`;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -222,30 +222,32 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   protected exportCsv(): void {
-    const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
-    if (dateRange == null) throw new Error('Date range is not set');
-    const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
-    const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
-    const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
+    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
     this.exportService.exportCsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
   }
 
   protected exportRsv(): void {
-    const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
-    if (dateRange == null) throw new Error('Date range is not set');
-    const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
-    const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
-    const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
+    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
     this.exportService.exportRsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
   }
 
   protected exportTsv(): void {
+    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
+    this.exportService.exportTsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  }
+
+  private createSpreadsheetData(): {
+    spreadsheetRows: SpreadsheetRow[];
+    dateRange: NormalizedDateRange;
+    meanDurationMs: number;
+    maxDurationMs: number;
+  } {
     const dateRange: NormalizedDateRange | undefined = this.dateRange$.value;
     if (dateRange == null) throw new Error('Date range is not set');
     const spreadsheetRows: SpreadsheetRow[] = ServalBuildsComponent.createSpreadsheetRows(this.rows);
     const meanDurationMs: number = this.summaryStats?.meanDurationMs ?? 0;
     const maxDurationMs: number = this.summaryStats?.maxDurationMs ?? 0;
-    this.exportService.exportTsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+    return { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs };
   }
 
   protected clearMLUrl(servalBuildId: string): string {


### PR DESCRIPTION
This patch adds an "Export TSV" option to export Serval build records using Tab-separated values.

@Nateowami and I were discussing whether .tsv might be preferable to .csv for our downloads, and I planned to add it as an option on the Serval builds tab.

The `createSpreadsheetData` helper could have gone a step further and called `exportCsv`, `exportTsv`, `exportRsv` but I chose to have it return data that then the caller can use to subsequently call `exportCsv` so that there is more flexibility with what to do with the prepared data.

Screenshot:
<img width="700" height="298" alt="image" src="https://github.com/user-attachments/assets/6a6ea43a-3325-4d76-ac95-cbbd5265af24" />


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3868)
<!-- Reviewable:end -->
