### PR TITLE
dev: eslint exclude dist to not JavaScript heap out of memory

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/eslint.config.mjs
+++ b/src/SIL.XForge.Scripture/ClientApp/eslint.config.mjs
@@ -10,7 +10,7 @@ import prettierPlugin from 'eslint-plugin-prettier';
 
 export default [
   {
-    ignores: ['projects/**/*']
+    ignores: ['projects/**/*', 'dist/**/*']
   },
   // TypeScript files
   {

--- a/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
+++ b/src/SIL.XForge.Scripture/ClientApp/tsconfig.json
@@ -32,5 +32,6 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
`npm run lint` includes processing files in ClientApp/dist. If lots of
files build up in there over time, then `npm run lint` can hit
"JavaScript heap out of memory" and fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3870)
<!-- Reviewable:end -->
