### PR TITLE
Update SharpCompress dependency of MongoDB.Driver to 0.48

### DIFF
--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -874,8 +874,8 @@
       },
       "SharpCompress": {
         "type": "Transitive",
-        "resolved": "0.30.1",
-        "contentHash": "XqD4TpfyYGa7QTPzaGlMVbcecKnXy4YmYLDWrU+JIj7IuRNl7DH2END+Ll7ekWIY8o3dAMWLFDE1xdhfIWD1nw=="
+        "resolved": "0.48.0",
+        "contentHash": "6k0Sa9gf85Sz9Npy7jnn5UPerejrAa3FxU9Gq5T6PwFWHUhUIdF903TjPiJtrYjXFJsXbnccaWSNMHzEg27DwQ=="
       },
       "SharpZipLib": {
         "type": "Transitive",
@@ -1244,6 +1244,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "SharpCompress": "[0.48.0, )",
           "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -26,5 +26,7 @@
     <PackageReference Include="SIL.Core" Version="17.0.0" />
     <!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-pggp-6c3x-2xmx -->
     <PackageReference Include="Snappier" Version="1.3.1" />
+    <!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-6c8g-7p36-r338 -->
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
 </Project>

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -159,6 +159,12 @@
           "ZstdSharp.Port": "0.7.3"
         }
       },
+      "SharpCompress": {
+        "type": "Direct",
+        "requested": "[0.48.0, )",
+        "resolved": "0.48.0",
+        "contentHash": "6k0Sa9gf85Sz9Npy7jnn5UPerejrAa3FxU9Gq5T6PwFWHUhUIdF903TjPiJtrYjXFJsXbnccaWSNMHzEg27DwQ=="
+      },
       "SIL.Core": {
         "type": "Direct",
         "requested": "[17.0.0, )",
@@ -465,11 +471,6 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
-      },
-      "SharpCompress": {
-        "type": "Transitive",
-        "resolved": "0.30.1",
-        "contentHash": "XqD4TpfyYGa7QTPzaGlMVbcecKnXy4YmYLDWrU+JIj7IuRNl7DH2END+Ll7ekWIY8o3dAMWLFDE1xdhfIWD1nw=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1258,8 +1258,8 @@
       },
       "SharpCompress": {
         "type": "Transitive",
-        "resolved": "0.30.1",
-        "contentHash": "XqD4TpfyYGa7QTPzaGlMVbcecKnXy4YmYLDWrU+JIj7IuRNl7DH2END+Ll7ekWIY8o3dAMWLFDE1xdhfIWD1nw=="
+        "resolved": "0.48.0",
+        "contentHash": "6k0Sa9gf85Sz9Npy7jnn5UPerejrAa3FxU9Gq5T6PwFWHUhUIdF903TjPiJtrYjXFJsXbnccaWSNMHzEg27DwQ=="
       },
       "SharpZipLib": {
         "type": "Transitive",
@@ -1677,6 +1677,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "SharpCompress": "[0.48.0, )",
           "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }

--- a/test/SIL.XForge.Tests/packages.lock.json
+++ b/test/SIL.XForge.Tests/packages.lock.json
@@ -545,8 +545,8 @@
       },
       "SharpCompress": {
         "type": "Transitive",
-        "resolved": "0.30.1",
-        "contentHash": "XqD4TpfyYGa7QTPzaGlMVbcecKnXy4YmYLDWrU+JIj7IuRNl7DH2END+Ll7ekWIY8o3dAMWLFDE1xdhfIWD1nw=="
+        "resolved": "0.48.0",
+        "contentHash": "6k0Sa9gf85Sz9Npy7jnn5UPerejrAa3FxU9Gq5T6PwFWHUhUIdF903TjPiJtrYjXFJsXbnccaWSNMHzEg27DwQ=="
       },
       "SIL.Core": {
         "type": "Transitive",
@@ -619,6 +619,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.6, )",
           "MongoDB.Driver": "[3.7.1, )",
           "SIL.Core": "[17.0.0, )",
+          "SharpCompress": "[0.48.0, )",
           "Snappier": "[1.3.1, )",
           "idunno.Authentication.Basic": "[2.4.0, )"
         }


### PR DESCRIPTION
Currently builds are failing with the following error:

```
error NU1902: Warning As Error: Package 'SharpCompress' 0.30.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-6c8g-7p36-r338
```

This PR fixes that error by updating the vulnerable dependency of MongoDB.Driver (which does not yet have a version with the updated dependency reference).

See: 

 - https://github.com/advisories/GHSA-6c8g-7p36-r338

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3873)
<!-- Reviewable:end -->
