### PR TITLE
SF-3777 Retrieve confidence data and calculate book level scores

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/translate-config.ts
+++ b/src/RealtimeServer/scriptureforge/models/translate-config.ts
@@ -60,11 +60,14 @@ export interface DraftUsfmConfig {
 
 /**
  * The configuration used for Quality Estimation.
+ *
+ * NOTE: dateUpdated is nullable here but not in the C# backend, as it will not be in the model sent to the backend.
  */
 export interface QualityEstimationConfig {
   version: string;
   slope: number;
   intercept: number;
+  dateUpdated?: Date;
 }
 
 export interface DraftConfig {

--- a/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/sf-project-service.ts
@@ -287,6 +287,9 @@ export class SFProjectService extends ProjectService<SFProject> {
                   },
                   intercept: {
                     bsonType: 'number'
+                  },
+                  dateUpdated: {
+                    bsonType: 'string'
                   }
                 },
                 additionalProperties: false

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/base-export-service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/base-export-service.ts
@@ -1,0 +1,25 @@
+import { NormalizedDateRange } from './date-range-picker.component';
+
+/**
+ * Base Service for exporting draft jobs data to CSV, TSV, and RSV formats.
+ */
+export abstract class BaseExportService {
+  /**
+   * Returns export filename using current date range, formatted as {prefix}_YYYY-MM-DD_YYYY-MM-DD.{ext}
+   */
+  protected getExportFilename(dateRange: NormalizedDateRange | undefined, ext: string, filenamePrefix: string): string {
+    const startStr = dateRange == null ? '' : '_' + this.formatDateForExport(dateRange.start);
+    const endStr = dateRange == null ? '' : '_' + this.formatDateForExport(dateRange.end);
+    return `${filenamePrefix}${startStr}${endStr}.${ext}`;
+  }
+
+  /**
+   * Formats a Date as YYYY-MM-DD (no time)
+   */
+  private formatDateForExport(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
@@ -79,7 +79,7 @@ export class BuildConfidencesExportService extends BaseExportService {
 
   private createRsvRows(rows: (BookConfidence | ChapterConfidence)[]): string[][] {
     if (this.isChapterConfidenceArray(rows)) {
-      const headers: string[] = ['Book', 'Chapter', 'Projected chrF3', 'Usability', 'Label'];
+      const headers: string[] = ['Book', 'Chapter', 'Projected chrF3', 'Usability', 'Label', 'Confidence'];
       const dataRows: string[][] = rows.map(row => [
         Canon.bookNumberToId(row.bookNum),
         row.chapterNum.toString(),
@@ -89,7 +89,7 @@ export class BuildConfidencesExportService extends BaseExportService {
       ]);
       return [headers, ...dataRows];
     } else {
-      const headers: string[] = ['Book', 'Projected chrF3', 'Usability', 'Label'];
+      const headers: string[] = ['Book', 'Projected chrF3', 'Usability', 'Label', 'Confidence'];
       const dataRows: string[][] = rows.map(row => [
         Canon.bookNumberToId(row.bookNum),
         row.projectedChrF3.toString(),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
@@ -1,0 +1,152 @@
+import { Injectable } from '@angular/core';
+import { Canon } from '@sillsdev/scripture';
+import { saveAs } from 'file-saver';
+import Papa from 'papaparse';
+import { BookConfidence, ChapterConfidence } from '../translate/draft-generation/build-confidences/build-confidences';
+import { BaseExportService } from './base-export-service';
+import { NormalizedDateRange } from './date-range-picker.component';
+import { encodeRsv } from './rsv';
+
+interface BookConfidenceRow {
+  Book: string;
+  'Projected chrF3': string;
+  Usability: string;
+  Label: string;
+  Confidence: string;
+}
+
+interface ChapterConfidenceRow {
+  Book: string;
+  Chapter: string;
+  'Projected chrF3': string;
+  Usability: string;
+  Label: string;
+  Confidence: string;
+}
+
+/**
+ * Service for exporting draft jobs data to CSV and RSV formats.
+ * Handles the transformation of table rows to spreadsheet format and file generation.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class BuildConfidencesExportService extends BaseExportService {
+  /**
+   * Export the build confidences data as a CSV file.
+   */
+  exportCsv(
+    rows: (BookConfidence | ChapterConfidence)[],
+    dateRangeForFilename: NormalizedDateRange | undefined,
+    filenamePrefix: string | undefined = undefined
+  ): void {
+    this.exportSeparatedValues(rows, dateRangeForFilename, filenamePrefix, 'csv', ',', 'text/csv');
+  }
+
+  /**
+   * Export the build confidences data as a TSV file.
+   */
+  exportTsv(
+    rows: BookConfidence[] | ChapterConfidence[],
+    dateRangeForFilename: NormalizedDateRange | undefined,
+    filenamePrefix: string | undefined = undefined
+  ): void {
+    this.exportSeparatedValues(rows, dateRangeForFilename, filenamePrefix, 'tsv', '\t', 'text/tab-separated-values');
+  }
+
+  /**
+   * Export the build confidences data as an RSV (Rows of String Values) file.
+   */
+  exportRsv(
+    rows: (BookConfidence | ChapterConfidence)[],
+    dateRangeForFilename: NormalizedDateRange | undefined,
+    filenamePrefix: string | undefined = undefined
+  ): void {
+    const allRows: (string | null)[][] = this.createRsvRows(rows);
+
+    // Encode to RSV format
+    const rsvData: Uint8Array = encodeRsv(allRows);
+
+    // Create filename and download
+    const filename: string = this.getExportFilename(
+      dateRangeForFilename,
+      'rsv',
+      this.getFileNamePrefix(rows, filenamePrefix)
+    );
+    const blob: Blob = new Blob([rsvData as BlobPart], { type: 'application/octet-stream' });
+    saveAs(blob, filename);
+  }
+
+  private createRsvRows(rows: (BookConfidence | ChapterConfidence)[]): string[][] {
+    if (this.isChapterConfidenceArray(rows)) {
+      const headers: string[] = ['Book', 'Chapter', 'Projected chrF5', 'Usability', 'Label'];
+      const dataRows: string[][] = rows.map(row => [
+        Canon.bookNumberToId(row.bookNum),
+        row.chapterNum.toString(),
+        row.projectedChrF3.toString(),
+        row.usability.toString(),
+        row.label ?? null
+      ]);
+      return [headers, ...dataRows];
+    } else {
+      const headers: string[] = ['Book', 'Projected chrF5', 'Usability', 'Label'];
+      const dataRows: string[][] = rows.map(row => [
+        Canon.bookNumberToId(row.bookNum),
+        row.projectedChrF3.toString(),
+        row.usability.toString(),
+        row.label ?? null
+      ]);
+      return [headers, ...dataRows];
+    }
+  }
+
+  private exportSeparatedValues(
+    rows: (BookConfidence | ChapterConfidence)[],
+    dateRangeForFilename: NormalizedDateRange | undefined,
+    filenamePrefix: string | undefined,
+    extension: string,
+    delimiter: string,
+    mimeType: string
+  ): void {
+    const spreadsheetRows: (BookConfidenceRow | ChapterConfidenceRow)[] = this.getSpreadsheetRows(rows);
+    const separatedValues: string = Papa.unparse(spreadsheetRows, { delimiter: delimiter });
+    const filename: string = this.getExportFilename(
+      dateRangeForFilename,
+      extension,
+      this.getFileNamePrefix(rows, filenamePrefix)
+    );
+    const blob: Blob = new Blob([separatedValues], { type: mimeType });
+    saveAs(blob, filename);
+  }
+
+  private getFileNamePrefix(rows: (BookConfidence | ChapterConfidence)[], filenamePrefix: string | undefined): string {
+    return (filenamePrefix ?? this.isChapterConfidenceArray(rows)) ? 'usability_chapters' : 'usability_books';
+  }
+
+  private getSpreadsheetRows(
+    rows: BookConfidence[] | ChapterConfidence[]
+  ): (BookConfidenceRow | ChapterConfidenceRow)[] {
+    if (this.isChapterConfidenceArray(rows)) {
+      return rows.map(row => ({
+        Book: Canon.bookNumberToId(row.bookNum),
+        Chapter: row.chapterNum.toString(),
+        'Projected chrF3': row.projectedChrF3.toFixed(3),
+        Usability: row.usability.toFixed(3),
+        Label: row.label,
+        Confidence: row.confidence.toFixed(3)
+      }));
+    } else {
+      return rows.map(row => ({
+        Book: Canon.bookNumberToId(row.bookNum),
+        'Projected chrF3': row.projectedChrF3.toFixed(3),
+        Usability: row.usability.toFixed(3),
+        Label: row.label,
+        Confidence: row.confidence.toFixed(3)
+      }));
+    }
+  }
+
+  private isChapterConfidenceArray(rows: (BookConfidence | ChapterConfidence)[]): rows is ChapterConfidence[] {
+    return rows.length > 0 && 'chapterNum' in rows[0];
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/build-confidences-export.service.ts
@@ -79,7 +79,7 @@ export class BuildConfidencesExportService extends BaseExportService {
 
   private createRsvRows(rows: (BookConfidence | ChapterConfidence)[]): string[][] {
     if (this.isChapterConfidenceArray(rows)) {
-      const headers: string[] = ['Book', 'Chapter', 'Projected chrF5', 'Usability', 'Label'];
+      const headers: string[] = ['Book', 'Chapter', 'Projected chrF3', 'Usability', 'Label'];
       const dataRows: string[][] = rows.map(row => [
         Canon.bookNumberToId(row.bookNum),
         row.chapterNum.toString(),
@@ -89,7 +89,7 @@ export class BuildConfidencesExportService extends BaseExportService {
       ]);
       return [headers, ...dataRows];
     } else {
-      const headers: string[] = ['Book', 'Projected chrF5', 'Usability', 'Label'];
+      const headers: string[] = ['Book', 'Projected chrF3', 'Usability', 'Label'];
       const dataRows: string[][] = rows.map(row => [
         Canon.bookNumberToId(row.bookNum),
         row.projectedChrF3.toString(),
@@ -120,7 +120,7 @@ export class BuildConfidencesExportService extends BaseExportService {
   }
 
   private getFileNamePrefix(rows: (BookConfidence | ChapterConfidence)[], filenamePrefix: string | undefined): string {
-    return (filenamePrefix ?? this.isChapterConfidenceArray(rows)) ? 'usability_chapters' : 'usability_books';
+    return filenamePrefix ?? (this.isChapterConfidenceArray(rows) ? 'usability_chapters' : 'usability_books');
   }
 
   private getSpreadsheetRows(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs-export.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
+import { BaseExportService } from './base-export-service';
 import { NormalizedDateRange } from './date-range-picker.component';
 import { encodeRsv } from './rsv';
 
@@ -35,7 +36,7 @@ export interface SpreadsheetRow {
 @Injectable({
   providedIn: 'root'
 })
-export class DraftJobsExportService {
+export class DraftJobsExportService extends BaseExportService {
   /**
    * Export the draft jobs data to a CSV file.
    */
@@ -172,25 +173,6 @@ export class DraftJobsExportService {
     result.push(maxRow);
 
     return result;
-  }
-
-  /**
-   * Returns export filename using current date range, formatted as {prefix}_YYYY-MM-DD_YYYY-MM-DD.{ext}
-   */
-  private getExportFilename(dateRange: NormalizedDateRange, ext: string, filenamePrefix: string): string {
-    const startStr = this.formatDateForExport(dateRange.start);
-    const endStr = this.formatDateForExport(dateRange.end);
-    return `${filenamePrefix}_${startStr}_${endStr}.${ext}`;
-  }
-
-  /**
-   * Formats a Date as YYYY-MM-DD (no time)
-   */
-  private formatDateForExport(date: Date): string {
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -2,6 +2,7 @@ import { Canon } from '@sillsdev/scripture';
 import { notNull } from '../../type-utils';
 import { BuildDto } from '../machine-api/build-dto';
 import { expandNumbers, parseDate } from '../shared/utils';
+import { BuildConfidences } from '../translate/draft-generation/build-confidences/build-confidences';
 
 /**
  * A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
@@ -16,6 +17,7 @@ export interface ServalBuildReportDto {
   draftGenerationRequestId: string | undefined;
   requesterSFUserId: string | undefined;
   status: DraftGenerationBuildStatus;
+  buildConfidences: BuildConfidences | undefined;
 }
 
 export type BuildReportProblemSource = 'local' | 'serval';

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -126,6 +126,10 @@
                   <mat-icon class="problem-badge" [matTooltip]="problemsBadgeTooltip(row)">warning</mat-icon>
                 }
               </div>
+              <app-display-confidence
+                [confidence]="row.report.buildConfidences?.lowestConfidence"
+                [showText]="false"
+              ></app-display-confidence>
             </div>
           </td>
         </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -648,13 +648,33 @@
                             bookConfidence of row.report.buildConfidences.bookConfidences;
                             track bookConfidence.bookNum
                           ) {
-                            <div class="detail-keyvalue">
-                              <span class="detail-key">
-                                {{ "canon.book_names." + getBookId(bookConfidence) | transloco }}
-                              </span>
-                              <span class="detail-value">
-                                <app-display-confidence [confidence]="bookConfidence"></app-display-confidence>
-                              </span>
+                            <div class="book-confidence">
+                              <div class="detail-keyvalue">
+                                <span class="detail-key">
+                                  {{ "canon.book_names." + getBookId(bookConfidence) | transloco }}
+                                </span>
+                                <span class="detail-value">
+                                  <app-display-confidence [confidence]="bookConfidence"></app-display-confidence>
+                                </span>
+                              </div>
+                              <div class="detail-keyvalue">
+                                <span class="detail-key">
+                                  {{ "canon.book_names." + getBookId(bookConfidence) | transloco }} - Projected ChrF3
+                                </span>
+                                <span class="detail-value">{{ bookConfidence.projectedChrF3.toFixed(3) }}</span>
+                              </div>
+                              <div class="detail-keyvalue">
+                                <span class="detail-key">
+                                  {{ "canon.book_names." + getBookId(bookConfidence) | transloco }} - Confidence
+                                </span>
+                                <span class="detail-value">{{ bookConfidence.confidence.toFixed(3) }}</span>
+                              </div>
+                              <div class="detail-keyvalue">
+                                <span class="detail-key">
+                                  {{ "canon.book_names." + getBookId(bookConfidence) | transloco }} - Usability
+                                </span>
+                                <span class="detail-value">{{ bookConfidence.usability.toFixed(3) }}</span>
+                              </div>
                             </div>
                           }
                         </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -628,6 +628,99 @@
                     </span>
                   </mat-card-content>
                 </mat-card>
+
+                <mat-card appearance="filled" class="detail-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>traffic</mat-icon>
+                      <mat-card-title>Quality Estimation</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    <span class="detail-area-stacked-keyvalues">
+                      @if (row.report.buildConfidences != null) {
+                        <div class="book-confidences">
+                          @for (
+                            bookConfidence of row.report.buildConfidences.bookConfidences;
+                            track bookConfidence.bookNum
+                          ) {
+                            <div class="detail-keyvalue">
+                              <span class="detail-key">
+                                {{ "canon.book_names." + getBookId(bookConfidence) | transloco }}
+                              </span>
+                              <span class="detail-value">
+                                <app-display-confidence [confidence]="bookConfidence"></app-display-confidence>
+                              </span>
+                            </div>
+                          }
+                        </div>
+                        <div class="export-button-group">
+                          <button
+                            mat-raised-button
+                            color="primary"
+                            class="export-csv-button"
+                            (click)="exportCsv(row.report.buildConfidences.bookConfidences)"
+                          >
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Book Usability CSV </span>
+                          </button>
+                          <button
+                            mat-raised-button
+                            color="primary"
+                            class="export-menu-button"
+                            [matMenuTriggerFor]="exportBookMenu"
+                          >
+                            <mat-icon>arrow_drop_down</mat-icon>
+                          </button>
+                        </div>
+                        <mat-menu #exportBookMenu="matMenu" xPosition="before">
+                          <button mat-menu-item (click)="exportTsv(row.report.buildConfidences.bookConfidences)">
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Book Usability TSV </span>
+                          </button>
+                          <button mat-menu-item (click)="exportRsv(row.report.buildConfidences.bookConfidences)">
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Book Usability RSV </span>
+                          </button>
+                        </mat-menu>
+                        <div class="export-button-group">
+                          <button
+                            mat-raised-button
+                            color="primary"
+                            class="export-csv-button"
+                            (click)="exportCsv(row.report.buildConfidences.chapterConfidences)"
+                          >
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Chapter Usability CSV </span>
+                          </button>
+                          <button
+                            mat-raised-button
+                            color="primary"
+                            class="export-menu-button"
+                            [matMenuTriggerFor]="exportChapterMenu"
+                          >
+                            <mat-icon>arrow_drop_down</mat-icon>
+                          </button>
+                        </div>
+                        <mat-menu #exportChapterMenu="matMenu" xPosition="before">
+                          <button mat-menu-item (click)="exportTsv(row.report.buildConfidences.chapterConfidences)">
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Chapter Usability TSV </span>
+                          </button>
+                          <button mat-menu-item (click)="exportRsv(row.report.buildConfidences.chapterConfidences)">
+                            <mat-icon>download</mat-icon>
+                            <span class="export-item-label"> Export Chapter Usability RSV </span>
+                          </button>
+                        </mat-menu>
+                      } @else {
+                        <div class="detail-keyvalue">
+                          <span class="detail-key">Configured</span>
+                          <span class="detail-value">No</span>
+                        </div>
+                      }
+                    </span>
+                  </mat-card-content>
+                </mat-card>
               </div>
 
               <div class="detail-actions">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -151,6 +151,7 @@ a {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
 }
 
 /* Ensure the mat-cell for the status column centers its content. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -552,4 +552,10 @@ a {
 .book-confidences {
   max-height: 13em;
   overflow-y: auto;
+  display: grid;
+  row-gap: 1em;
+  .book-confidence {
+    display: grid;
+    row-gap: 0;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -547,3 +547,8 @@ a {
     margin-right: 8px;
   }
 }
+
+.book-confidences {
+  max-height: 13em;
+  overflow-y: auto;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -18,7 +18,9 @@ import { notNull } from '../../type-utils';
 import { SF_TYPE_REGISTRY } from '../core/models/sf-type-registry';
 import { BuildDto } from '../machine-api/build-dto';
 import { BuildStates } from '../machine-api/build-states';
+import { BuildConfidences } from '../translate/draft-generation/build-confidences/build-confidences';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
+import { BuildConfidencesExportService } from './build-confidences-export.service';
 import { NormalizedDateRange } from './date-range-picker.component';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { ServalBuildProblemsDialog } from './serval-build-problems-dialog.component';
@@ -40,6 +42,7 @@ import {
 } from './serval-builds.component';
 
 const mockNoticeService = mock(NoticeService);
+const mockBuildConfidencesExportService = mock(BuildConfidencesExportService);
 const mockDraftGenerationService = mock(DraftGenerationService);
 const mockDialogService = mock(DialogService);
 const mockExportService = mock(DraftJobsExportService);
@@ -57,6 +60,7 @@ describe('ServalBuildsComponent', () => {
       provideRouter([]),
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
+      { provide: BuildConfidencesExportService, useMock: mockBuildConfidencesExportService },
       { provide: DraftGenerationService, useMock: mockDraftGenerationService },
       { provide: DialogService, useMock: mockDialogService },
       { provide: DraftJobsExportService, useMock: mockExportService },
@@ -1908,6 +1912,7 @@ describe('ServalBuildsComponent', () => {
       env.component['exportTsv']();
 
       verify(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).once();
+      expect().nothing();
     });
   });
 
@@ -2154,7 +2159,8 @@ class TestEnvironment {
       problems: [],
       draftGenerationRequestId: undefined,
       requesterSFUserId: undefined,
-      status: DraftGenerationBuildStatus.Completed
+      status: DraftGenerationBuildStatus.Completed,
+      buildConfidences: undefined
     };
     return result;
   }
@@ -2181,7 +2187,8 @@ class TestEnvironment {
     problems = [],
     projectDeleted = false,
     hasServalBuild = true,
-    hasEvents = true
+    hasEvents = true,
+    buildConfidences = undefined
   }: {
     projectId?: string | null;
     ptProjectId?: string;
@@ -2205,6 +2212,7 @@ class TestEnvironment {
     /** Whether or not there are any events from which this row is based on. Records that correspond to no events
      * aren't able to have certain kinds of data. */
     hasEvents?: boolean;
+    buildConfidences?: BuildConfidences;
   }): ServalBuildRow {
     if (!hasEvents) {
       // Check data consistency here rather than expect each caller to not make a mistake.
@@ -2281,7 +2289,8 @@ class TestEnvironment {
       problems: problems,
       draftGenerationRequestId: draftGenerationRequestId ?? undefined,
       requesterSFUserId: requesterId ?? undefined,
-      status: status
+      status: status,
+      buildConfidences: buildConfidences
     };
 
     const result: ServalBuildRow = {
@@ -2354,7 +2363,8 @@ class TestEnvironment {
       problems: [],
       draftGenerationRequestId: undefined,
       requesterSFUserId: undefined,
-      status: DraftGenerationBuildStatus.Completed
+      status: DraftGenerationBuildStatus.Completed,
+      buildConfidences: undefined
     };
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -24,6 +24,8 @@ import {
 } from '@angular/material/table';
 import { MatTooltip } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
+import { TranslocoModule } from '@ngneat/transloco';
+import { Canon } from '@sillsdev/scripture';
 import {
   BehaviorSubject,
   catchError,
@@ -51,7 +53,10 @@ import { UserService } from 'xforge-common/user.service';
 import { isPopulatedString, isString, notNull } from '../../type-utils';
 import { InfoComponent } from '../shared/info/info.component';
 import { NoticeComponent } from '../shared/notice/notice.component';
+import { BookConfidence, ChapterConfidence } from '../translate/draft-generation/build-confidences/build-confidences';
+import { DisplayConfidenceComponent } from '../translate/draft-generation/build-confidences/display-confidence.component';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
+import { BuildConfidencesExportService } from './build-confidences-export.service';
 import { DateRangePickerComponent, NormalizedDateRange } from './date-range-picker.component';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { JobDetailsDialogComponent } from './job-details-dialog.component';
@@ -181,6 +186,8 @@ export interface BuildInputItem {
     MatCardTitleGroup,
     CopyComponent,
     MatSlideToggle,
+    TranslocoModule,
+    DisplayConfidenceComponent,
     MatFormFieldModule,
     MatInputModule,
     ReactiveFormsModule
@@ -218,6 +225,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
   constructor(
     noticeService: NoticeService,
+    private readonly buildConfidencesExportService: BuildConfidencesExportService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly dialogService: DialogService,
     private readonly onlineStatusService: OnlineStatusService,
@@ -304,19 +312,31 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return this.expandedRows.has(id);
   }
 
-  protected exportCsv(): void {
-    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
-    this.exportService.exportCsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  protected exportCsv(rows: (BookConfidence | ChapterConfidence)[] | undefined = undefined): void {
+    if (rows == null) {
+      const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
+      this.exportService.exportCsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+    } else {
+      this.buildConfidencesExportService.exportCsv(rows, this.dateRange$.value);
+    }
   }
 
-  protected exportRsv(): void {
-    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
-    this.exportService.exportRsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  protected exportRsv(rows: (BookConfidence | ChapterConfidence)[] | undefined = undefined): void {
+    if (rows == null) {
+      const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
+      this.exportService.exportRsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+    } else {
+      this.buildConfidencesExportService.exportRsv(rows, this.dateRange$.value);
+    }
   }
 
-  protected exportTsv(): void {
-    const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
-    this.exportService.exportTsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+  protected exportTsv(rows: (BookConfidence | ChapterConfidence)[] | undefined = undefined): void {
+    if (rows == null) {
+      const { spreadsheetRows, dateRange, meanDurationMs, maxDurationMs } = this.createSpreadsheetData();
+      this.exportService.exportTsv(spreadsheetRows, dateRange, meanDurationMs, maxDurationMs, 'serval_builds');
+    } else {
+      this.buildConfidencesExportService.exportTsv(rows, this.dateRange$.value);
+    }
   }
 
   private createSpreadsheetData(): {
@@ -407,6 +427,10 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       return 'Submitted to Serval';
     }
     return status;
+  }
+
+  protected getBookId(bookConfidence: BookConfidence): string {
+    return Canon.bookNumberToId(bookConfidence.bookNum);
   }
 
   /** Returns the requested phase of the build.  */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular/material/table';
 import { Router } from '@angular/router';
 import { saveAs } from 'file-saver';
+import { cloneDeep } from 'lodash-es';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { TrainingData } from 'realtime-server/lib/esm/scriptureforge/models/training-data';
 import {
@@ -254,9 +255,14 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
 
           // Setup the serval config and quality estimation config values
           this.servalConfig.setValue(project.translateConfig.draftConfig.servalConfig);
-          this.qualityEstimationConfig.setValue(
-            JSON.stringify(project.translateConfig.draftConfig.qualityEstimationConfig)
+
+          // Clone the quality estimation config and remove the last saved date,
+          // as that is right now only used in the backend, and is not a part of the config entered by the user.
+          const qualityEstimationConfig: QualityEstimationConfig | undefined = cloneDeep(
+            project.translateConfig.draftConfig.qualityEstimationConfig
           );
+          delete qualityEstimationConfig?.dateUpdated;
+          this.qualityEstimationConfig.setValue(JSON.stringify(qualityEstimationConfig));
 
           // Get the last completed build
           if (this.isOnline && this.projectService.hasDraft(project)) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/_build-confidences-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/_build-confidences-theme.scss
@@ -1,0 +1,15 @@
+@use '@angular/material' as mat;
+
+@mixin color($theme) {
+  $is-dark: mat.get-theme-type($theme) == dark;
+
+  --sf-build-confidence-red-color: #{if($is-dark, red, darkRed)};
+  --sf-build-confidence-yellow-color: #{if($is-dark, #dbdb00, #ffcc00)};
+  --sf-build-confidence-green-color: #{if($is-dark, lightGreen, darkGreen)};
+}
+
+@mixin theme($theme) {
+  @if mat.theme-has($theme, color) {
+    @include color($theme);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/_build-confidences-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/_build-confidences-theme.scss
@@ -6,6 +6,7 @@
   --sf-build-confidence-red-color: #{if($is-dark, red, darkRed)};
   --sf-build-confidence-yellow-color: #{if($is-dark, #dbdb00, #ffcc00)};
   --sf-build-confidence-green-color: #{if($is-dark, lightGreen, darkGreen)};
+  --sf-build-confidence-grey-color: #{if($is-dark, hsl(0 0% 60%), hsl(0 0% 45%))};
 }
 
 @mixin theme($theme) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/build-confidences.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/build-confidences.ts
@@ -4,6 +4,7 @@ export interface BuildConfidences {
   buildId: string;
   bookConfidences: BookConfidence[];
   chapterConfidences: ChapterConfidence[];
+  lowestConfidence?: Confidence;
 }
 
 /** The confidence values */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/build-confidences.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/build-confidences.ts
@@ -1,0 +1,30 @@
+/** The build confidences DTO */
+export interface BuildConfidences {
+  projectId: string;
+  buildId: string;
+  bookConfidences: BookConfidence[];
+  chapterConfidences: ChapterConfidence[];
+}
+
+/** The confidence values */
+export interface Confidence {
+  confidence: number;
+  label: UsabilityLabel;
+  projectedChrF3: number;
+  usability: number;
+}
+
+export interface BookConfidence extends Confidence {
+  bookNum: number;
+}
+
+export interface ChapterConfidence extends BookConfidence {
+  chapterNum: number;
+}
+
+/** The usability label */
+export enum UsabilityLabel {
+  Red = 'Red',
+  Yellow = 'Yellow',
+  Green = 'Green'
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
@@ -1,13 +1,13 @@
 @switch (usabilityLabel) {
-  @case ("Green") {
+  @case (UsabilityLabel.Green) {
     <div class="confidence green">
       <mat-icon [matTooltip]="usabilityTooltip">check_circle</mat-icon>{{ usabilityText }}
     </div>
   }
-  @case ("Yellow") {
+  @case (UsabilityLabel.Yellow) {
     <div class="confidence yellow"><mat-icon [matTooltip]="usabilityTooltip">circle</mat-icon>{{ usabilityText }}</div>
   }
-  @case ("Red") {
+  @case (UsabilityLabel.Red) {
     <div class="confidence red"><mat-icon [matTooltip]="usabilityTooltip">error</mat-icon>{{ usabilityText }}</div>
   }
   @case (undefined) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
@@ -1,0 +1,11 @@
+@switch (usabilityLabel) {
+  @case ("Green") {
+    <div class="confidence green"><mat-icon>check</mat-icon> Likely good quality</div>
+  }
+  @case ("Yellow") {
+    <div class="confidence yellow"><mat-icon class="filled">circle</mat-icon> Likely moderate quality</div>
+  }
+  @case ("Red") {
+    <div class="confidence red"><mat-icon>warning</mat-icon> Likely poor quality</div>
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.html
@@ -1,11 +1,18 @@
 @switch (usabilityLabel) {
   @case ("Green") {
-    <div class="confidence green"><mat-icon>check</mat-icon> Likely good quality</div>
+    <div class="confidence green">
+      <mat-icon [matTooltip]="usabilityTooltip">check_circle</mat-icon>{{ usabilityText }}
+    </div>
   }
   @case ("Yellow") {
-    <div class="confidence yellow"><mat-icon class="filled">circle</mat-icon> Likely moderate quality</div>
+    <div class="confidence yellow"><mat-icon [matTooltip]="usabilityTooltip">circle</mat-icon>{{ usabilityText }}</div>
   }
   @case ("Red") {
-    <div class="confidence red"><mat-icon>warning</mat-icon> Likely poor quality</div>
+    <div class="confidence red"><mat-icon [matTooltip]="usabilityTooltip">error</mat-icon>{{ usabilityText }}</div>
+  }
+  @case (undefined) {
+    <div class="confidence grey">
+      <mat-icon class="material-icons-outlined" [matTooltip]="usabilityTooltip">circle</mat-icon>{{ usabilityText }}
+    </div>
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.scss
@@ -1,0 +1,17 @@
+.confidence {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  &.green {
+    color: var(--sf-build-confidence-green-color);
+  }
+
+  &.yellow {
+    color: var(--sf-build-confidence-yellow-color);
+  }
+
+  &.red {
+    color: var(--sf-build-confidence-red-color);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.scss
@@ -14,4 +14,8 @@
   &.red {
     color: var(--sf-build-confidence-red-color);
   }
+
+  &.grey {
+    color: var(--sf-build-confidence-grey-color);
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { configureTestingModule } from 'xforge-common/test-utils';
+import { Confidence, UsabilityLabel } from './build-confidences';
+import { DisplayConfidenceComponent } from './display-confidence.component';
+
+describe('DisplayConfidenceComponent', () => {
+  configureTestingModule(() => ({
+    imports: [DisplayConfidenceComponent]
+  }));
+
+  it('good quality', () => {
+    const env = new TestEnvironment({
+      label: UsabilityLabel.Green
+    });
+    expect(env.confidenceValueElement(UsabilityLabel.Green)).not.toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Yellow)).toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Red)).toBeNull();
+  });
+
+  it('moderate quality', () => {
+    const env = new TestEnvironment({
+      label: UsabilityLabel.Yellow
+    });
+    expect(env.confidenceValueElement(UsabilityLabel.Green)).toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Yellow)).not.toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Red)).toBeNull();
+  });
+
+  it('poor quality', () => {
+    const env = new TestEnvironment({
+      label: UsabilityLabel.Red
+    });
+    expect(env.confidenceValueElement(UsabilityLabel.Green)).toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Yellow)).toBeNull();
+    expect(env.confidenceValueElement(UsabilityLabel.Red)).not.toBeNull();
+  });
+
+  /** Provides helpers for constructing test data for DisplayConfidenceComponent tests. */
+  class TestEnvironment {
+    readonly component: DisplayConfidenceComponent;
+    readonly fixture: ComponentFixture<DisplayConfidenceComponent>;
+
+    constructor(confidence: Partial<Confidence>) {
+      this.fixture = TestBed.createComponent(DisplayConfidenceComponent);
+      this.component = this.fixture.componentInstance;
+      this.component.confidence = confidence as Confidence;
+      this.fixture.detectChanges();
+    }
+
+    confidenceValueElement(label: UsabilityLabel): DebugElement {
+      return this.fixture.debugElement.query(By.css(`.${label.toLowerCase()}`));
+    }
+  }
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
@@ -18,6 +18,8 @@ export class DisplayConfidenceComponent {
   @Input() confidence: Confidence | undefined;
   @Input() showText: boolean | undefined;
 
+  UsabilityLabel = UsabilityLabel;
+
   get usabilityLabel(): UsabilityLabel | undefined {
     return this.confidence?.label;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
@@ -31,11 +31,11 @@ export class DisplayConfidenceComponent {
   get usabilityTooltip(): string {
     switch (this.usabilityLabel) {
       case UsabilityLabel.Green:
-        return 'Likely good quality';
+        return 'Likely to be useful';
       case UsabilityLabel.Yellow:
-        return 'Likely moderate quality';
+        return 'Probably useful';
       case UsabilityLabel.Red:
-        return 'Likely poor quality';
+        return 'May not be useful';
       default:
         return 'Not configured';
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
 import { Confidence, UsabilityLabel } from './build-confidences';
 
 @Component({
   selector: 'app-display-confidence',
   templateUrl: './display-confidence.component.html',
   styleUrl: './display-confidence.component.scss',
-  imports: [MatIcon]
+  imports: [MatIcon, MatTooltip]
 })
 /**
  * Displays the confidence value in an human-friendly format.
@@ -15,8 +16,26 @@ import { Confidence, UsabilityLabel } from './build-confidences';
  */
 export class DisplayConfidenceComponent {
   @Input() confidence: Confidence | undefined;
+  @Input() showText: boolean | undefined;
 
   get usabilityLabel(): UsabilityLabel | undefined {
     return this.confidence?.label;
+  }
+
+  get usabilityText(): string {
+    return this.showText === false ? '' : this.usabilityTooltip;
+  }
+
+  get usabilityTooltip(): string {
+    switch (this.usabilityLabel) {
+      case UsabilityLabel.Green:
+        return 'Likely good quality';
+      case UsabilityLabel.Yellow:
+        return 'Likely moderate quality';
+      case UsabilityLabel.Red:
+        return 'Likely poor quality';
+      default:
+        return 'Not configured';
+    }
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+import { Confidence, UsabilityLabel } from './build-confidences';
+
+@Component({
+  selector: 'app-display-confidence',
+  templateUrl: './display-confidence.component.html',
+  styleUrl: './display-confidence.component.scss',
+  imports: [MatIcon]
+})
+/**
+ * Displays the confidence value in an human-friendly format.
+ *
+ * NOTE: This component is not yet localized as it is only used by the Serval Builds tab, and is not yet finalized.
+ */
+export class DisplayConfidenceComponent {
+  @Input() confidence: Confidence | undefined;
+
+  get usabilityLabel(): UsabilityLabel | undefined {
+    return this.confidence?.label;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.stories.ts
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { Confidence, UsabilityLabel } from './build-confidences';
+import { DisplayConfidenceComponent } from './display-confidence.component';
+
+const meta: Meta<DisplayConfidenceComponent> = {
+  title: 'Draft/Display Confidence Label',
+  component: DisplayConfidenceComponent
+};
+export default meta;
+
+type Story = StoryObj<DisplayConfidenceComponent>;
+
+export const GoodQuality: Story = {
+  args: { confidence: { label: UsabilityLabel.Green } as Confidence }
+};
+
+export const ModerateQuality: Story = {
+  args: { confidence: { label: UsabilityLabel.Yellow } as Confidence }
+};
+
+export const PoorQuality: Story = {
+  args: { confidence: { label: UsabilityLabel.Red } as Confidence }
+};
+
+export const NotDefined: Story = {
+  args: { confidence: undefined }
+};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/build-confidences/display-confidence.stories.ts
@@ -11,7 +11,7 @@ export default meta;
 type Story = StoryObj<DisplayConfidenceComponent>;
 
 export const GoodQuality: Story = {
-  args: { confidence: { label: UsabilityLabel.Green } as Confidence }
+  args: { confidence: { label: UsabilityLabel.Green } as Confidence, showText: true }
 };
 
 export const ModerateQuality: Story = {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.spec.ts
@@ -26,6 +26,7 @@ import { BuildDto, ServalBuildAdditionalInfo } from '../../machine-api/build-dto
 import { BuildStates } from '../../machine-api/build-states';
 import { MACHINE_API_BASE_URL } from '../../machine-api/http-client';
 import { DraftGenerationBuildStatus, ServalBuildReportDto } from '../../serval-administration/serval-build-report';
+import { BuildConfidences } from './build-confidences/build-confidences';
 import { BuildConfig } from './draft-generation';
 import { DraftGenerationService } from './draft-generation.service';
 
@@ -46,6 +47,13 @@ describe('DraftGenerationService', () => {
   }));
 
   const projectId = 'testProjectId';
+  const buildId = 'testBuildId';
+  const buildConfidences: BuildConfidences = {
+    projectId,
+    buildId,
+    bookConfidences: [],
+    chapterConfidences: []
+  };
   const buildConfig: BuildConfig = {
     projectId,
     trainingDataFiles: [],
@@ -56,7 +64,7 @@ describe('DraftGenerationService', () => {
     sendEmailOnBuildFinished: false
   };
   const buildDto: BuildDto = {
-    id: 'testId',
+    id: buildId,
     href: 'testHref',
     revision: 0,
     engine: {
@@ -139,6 +147,101 @@ describe('DraftGenerationService', () => {
         .subscribe(result => {
           expect(result).toBeUndefined();
         });
+      tick();
+    }));
+  });
+
+  describe('getBuildConfidences', () => {
+    it('should get build confidences and return an observable of BuildConfidences', fakeAsync(() => {
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toEqual(buildConfidences);
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/id:${projectId}.${buildId}/confidences`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(buildConfidences);
+      tick();
+    }));
+
+    it('should return undefined if no confidence values are available for the build', fakeAsync(() => {
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toBeUndefined();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/id:${projectId}.${buildId}/confidences`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.NoContent, statusText: 'No Content' });
+      tick();
+    }));
+
+    it('should return undefined if offline', fakeAsync(() => {
+      testOnlineStatusService.setIsOnline(false);
+
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toBeUndefined();
+      });
+      tick();
+    }));
+
+    it('should return undefined and not show error when server returns 403', fakeAsync(() => {
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toBeUndefined();
+        verify(mockNoticeService.showError(anything())).never();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/id:${projectId}.${buildId}/confidences`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.Forbidden, statusText: 'Forbidden' });
+      tick();
+    }));
+
+    it('should return undefined and not show error when server returns 404', fakeAsync(() => {
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toBeUndefined();
+        verify(mockNoticeService.showError(anything())).never();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/id:${projectId}.${buildId}/confidences`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.NotFound, statusText: 'Not Found' });
+      tick();
+    }));
+
+    it('should return undefined and show error when server returns 500', fakeAsync(() => {
+      // SUT
+      service.getBuildConfidences(projectId, buildId).subscribe(result => {
+        expect(result).toBeUndefined();
+        verify(mockNoticeService.showError(anything())).once();
+      });
+      tick();
+
+      // Setup the HTTP request
+      const req = httpTestingController.expectOne(
+        `${MACHINE_API_BASE_URL}translation/builds/id:${projectId}.${buildId}/confidences`
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(null, { status: HttpStatusCode.InternalServerError, statusText: 'Server Error' });
       tick();
     }));
   });
@@ -354,7 +457,8 @@ describe('DraftGenerationService', () => {
       problems: [],
       draftGenerationRequestId: undefined,
       requesterSFUserId: undefined,
-      status: DraftGenerationBuildStatus.UserRequested
+      status: DraftGenerationBuildStatus.UserRequested,
+      buildConfidences: undefined
     };
 
     it('should request builds', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -18,6 +18,7 @@ import { BuildDto } from '../../machine-api/build-dto';
 import { HttpClient } from '../../machine-api/http-client';
 import { interpretTypes, ServalBuildReportDto } from '../../serval-administration/serval-build-report';
 import { booksFromScriptureRange, formatDateForFilename, getBookFileNameDigits } from '../../shared/utils';
+import { BuildConfidences } from './build-confidences/build-confidences';
 import {
   activeBuildStates,
   BuildConfig,
@@ -72,6 +73,30 @@ export class DraftGenerationService {
       map(res => res.data),
       catchError(err => {
         // If no build has ever been started, return undefined
+        if (err.status === 403 || err.status === 404) {
+          return of(undefined);
+        }
+
+        this.noticeService.showError(this.i18n.translateStatic('draft_generation.temporarily_unavailable'));
+        return of(undefined);
+      })
+    );
+  }
+
+  /**
+   * Gets the build confidence scores for a build, if they are present.
+   * @param projectId The Scripture Forge project identifier.
+   * @param buildId The Serval build identifier.
+   * @returns The build confidences if present, otherwise undefined if they are not present or the user is offline.
+   */
+  getBuildConfidences(projectId: string, buildId: string): Observable<BuildConfidences | undefined> {
+    if (!this.onlineStatusService.isOnline) {
+      return of(undefined);
+    }
+    return this.httpClient.get<BuildConfidences>(`translation/builds/id:${projectId}.${buildId}/confidences`).pipe(
+      map(res => res.data),
+      catchError(err => {
+        // If build confidences do not exist or the user does not have permission, return undefined
         if (err.status === 403 || err.status === 404) {
           return of(undefined);
         }

--- a/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/material-styles.scss
@@ -18,6 +18,7 @@
 @use 'src/app/shared/json-viewer/json-viewer-theme' as sf-json-viewer;
 @use 'src/app/shared/audio-recorder-dialog/audio-recorder-dialog-theme' as sf-audio-recorder-dialog;
 @use 'src/app/sync/sync-theme' as sf-sync;
+@use 'src/app/translate/draft-generation/build-confidences/build-confidences-theme' as sf-build-confidences;
 @use 'src/app/translate/draft-generation/confirm-sources/confirm-sources-theme' as sf-confirm-sources;
 @use 'src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form-theme' as sf-draft-onboarding-form;
 @use 'src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry-theme' as
@@ -61,6 +62,7 @@
   @include sf-attach-audio.theme($theme);
   @include sf-single-button-audio-player.theme($theme);
   @include sf-info.theme($theme);
+  @include sf-build-confidences.theme($theme);
   @include sf-confirm-sources.theme($theme);
   @include sf-draft-history-entry.theme($theme);
   @include sf-draft-import-wizard.theme($theme);

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -319,11 +319,12 @@ public class MachineApiController : ControllerBase
     /// <param name="buildId">The build identifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <response code="200">The build is returned.</response>
-    /// <response code="403">You do not have permission to retrieve build confidence data for this project.</response>
-    /// <response code="404">
+    /// <response code="204">
     /// Confidence data is not available for this build. Either quality estimation is not configured for the project,
     /// or the build was created before quality estimation was configured for the project.
     /// </response>
+    /// <response code="403">You do not have permission to retrieve build confidence data for this project.</response>
+    /// <response code="404">The project does not exist.</response>
     [HttpGet(MachineApi.GetBuildConfidences)]
     public async Task<ActionResult<BuildConfidences>> GetBuildConfidencesAsync(
         string sfProjectId,

--- a/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/MachineApiController.cs
@@ -1,7 +1,5 @@
-#nullable disable warnings
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -199,7 +197,7 @@ public class MachineApiController : ControllerBase
         try
         {
             bool isServalAdmin = _userAccessor.SystemRoles.Contains(SystemRole.ServalAdmin);
-            TranslationBuild build = await _machineApiService.GetRawBuildAsync(
+            TranslationBuild? build = await _machineApiService.GetRawBuildAsync(
                 _userAccessor.UserId,
                 sfProjectId,
                 buildId,
@@ -315,6 +313,54 @@ public class MachineApiController : ControllerBase
     }
 
     /// <summary>
+    /// Gets the confidence scores for a build at book and chapter level.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildId">The build identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="200">The build is returned.</response>
+    /// <response code="403">You do not have permission to retrieve build confidence data for this project.</response>
+    /// <response code="404">
+    /// Confidence data is not available for this build. Either quality estimation is not configured for the project,
+    /// or the build was created before quality estimation was configured for the project.
+    /// </response>
+    [HttpGet(MachineApi.GetBuildConfidences)]
+    public async Task<ActionResult<BuildConfidences>> GetBuildConfidencesAsync(
+        string sfProjectId,
+        string buildId,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            bool isServalAdmin = _userAccessor.SystemRoles.Contains(SystemRole.ServalAdmin);
+            BuildConfidences? buildConfidences = await _machineApiService.GetBuildConfidencesAsync(
+                _userAccessor.UserId,
+                sfProjectId,
+                buildId,
+                isServalAdmin,
+                cancellationToken
+            );
+
+            // No confidence data exists for the build
+            if (buildConfidences is null)
+            {
+                return NoContent();
+            }
+
+            return Ok(buildConfidences);
+        }
+        catch (DataNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (ForbiddenException)
+        {
+            return Forbid();
+        }
+    }
+
+    /// <summary>
     /// Gets a translation engine.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
@@ -373,7 +419,7 @@ public class MachineApiController : ControllerBase
         try
         {
             bool isServalAdmin = _userAccessor.SystemRoles.Contains(SystemRole.ServalAdmin);
-            TranslationEngine engine = await _machineApiService.GetRawEngineAsync(
+            TranslationEngine? engine = await _machineApiService.GetRawEngineAsync(
                 _userAccessor.UserId,
                 sfProjectId,
                 preTranslate,
@@ -512,7 +558,7 @@ public class MachineApiController : ControllerBase
     /// <response code="409">The engine has not been built on the ML server.</response>
     /// <response code="503">The ML server is temporarily unavailable or unresponsive.</response>
     [HttpGet(MachineApi.GetPreTranslationDelta)]
-    public async Task<ActionResult<Snapshot<TextData>>> GetPreTranslationDeltaAsync(
+    public async Task<ActionResult<Snapshot<TextData>?>> GetPreTranslationDeltaAsync(
         string sfProjectId,
         int bookNum,
         int chapterNum,
@@ -536,7 +582,7 @@ public class MachineApiController : ControllerBase
                 config,
                 cancellationToken
             );
-            deltas.TryGetValue(chapterNum.ToString(), out Snapshot<TextData> chapterDelta);
+            deltas.TryGetValue(chapterNum.ToString(), out Snapshot<TextData>? chapterDelta);
             return Ok(chapterDelta);
         }
         catch (BrokenCircuitException e)

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessApplicationBuilderExtensions.cs
@@ -12,5 +12,6 @@ public static class SFDataAccessApplicationBuilderExtensions
         app.InitRepository<SFProjectSecret>();
         app.InitRepository<SyncMetrics>();
         app.InitRepository<OnboardingRequest>();
+        app.InitRepository<DraftMetrics>();
     }
 }

--- a/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
+++ b/src/SIL.XForge.Scripture/DataAccess/SFDataAccessServiceCollectionExtensions.cs
@@ -1,8 +1,7 @@
-#nullable disable warnings
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using MongoDB.Driver;
 using SIL.XForge.DataAccess;
-using SIL.XForge.Models;
 using SIL.XForge.Scripture.Models;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -24,14 +23,10 @@ public static class SFDataAccessServiceCollectionExtensions
             idx =>
                 idx.CreateMany([
                     new CreateIndexModel<SFProjectSecret>(
-                        Builders<SFProjectSecret>.IndexKeys.Ascending(ps => ps.ServalData.PreTranslationEngineId)
+                        Builders<SFProjectSecret>.IndexKeys.Ascending(ps => ps.ServalData!.PreTranslationEngineId)
                     ),
-                    // The C# Driver still does not support fluent syntax for multi-key indexes.
-                    // See https://jira.mongodb.org/browse/CSHARP-1309
                     new CreateIndexModel<SFProjectSecret>(
-                        Builders<SFProjectSecret>.IndexKeys.Ascending(
-                            $"{nameof(SFProjectSecret.ShareKeys)}.{nameof(ShareKey.Key)}"
-                        )
+                        Builders<SFProjectSecret>.IndexKeys.Ascending(ps => ps.ShareKeys.Select(sk => sk.Key))
                     ),
                 ])
         );
@@ -53,6 +48,7 @@ public static class SFDataAccessServiceCollectionExtensions
                     )
                 )
         );
+        services.AddMongoRepository<DraftMetrics>("draft_metrics", cm => cm.MapIdProperty(dm => dm.Id));
 
         return services;
     }

--- a/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using SIL.XForge.Models;
+
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// The metrics for a specific draft.
+/// </summary>
+public class DraftMetrics : IIdentifiable
+{
+    /// <summary>
+    /// Gets the document identifier for the draft metrics of a specific build.
+    /// </summary>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildId">The build identifier.</param>
+    /// <returns>An id in the format <c>projectId:buildId</c>.</returns>
+    public static string GetDocId(string sfProjectId, string buildId) => $"{sfProjectId}:{buildId}";
+
+    /// <summary>
+    /// Gets or sets the identifier.
+    /// </summary>
+    /// <remarks>This is in the format projectId:buildId.</remarks>
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the confidence scores for every book in the draft.
+    /// </summary>
+    public List<BookConfidence> BookConfidences { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the confidence scores for every chapter in the draft.
+    /// </summary>
+    public List<ChapterConfidence> ChapterConfidences { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the quality estimation configuration for this draft.
+    /// </summary>
+    public required QualityEstimationConfig QualityEstimationConfig { get; set; }
+
+    /// <summary>
+    /// The confidence scores for every verse in the draft.
+    /// </summary>
+    public List<VerseConfidence> VerseConfidences { get; set; } = [];
+}
+
+public class VerseConfidence : VerseRefData
+{
+    public VerseConfidence() { }
+
+    public VerseConfidence(int bookNum, int chapterNum, int verseNum, double confidence)
+        : base(bookNum, chapterNum, verseNum) => Confidence = confidence;
+
+    public VerseConfidence(int bookNum, int chapterNum, string verse, double confidence)
+        : base(bookNum, chapterNum, verse) => Confidence = confidence;
+
+    public double Confidence { get; set; }
+}
+
+public class BookConfidence
+{
+    public required int BookNum { get; set; }
+    public required double Confidence { get; set; }
+    public required string Label { get; set; }
+    public required double ProjectedChrF3 { get; set; }
+    public required double Usability { get; set; }
+}
+
+public class ChapterConfidence : BookConfidence
+{
+    public required int ChapterNum { get; set; }
+}
+
+/// <summary>
+/// The values that will be returned to the front end for build confidences.
+/// </summary>
+public class BuildConfidences
+{
+    /// <summary>
+    /// Gets or sets the project identifier.
+    /// </summary>
+    public required string ProjectId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the build identifier.
+    /// </summary>
+    public required string BuildId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the confidence scores for every book in the build.
+    /// </summary>
+    public required ICollection<BookConfidence> BookConfidences { get; init; }
+
+    /// <summary>
+    /// Gets or sets the confidence scores for every chapter in the build.
+    /// </summary>
+    public required List<ChapterConfidence> ChapterConfidences { get; init; }
+}

--- a/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
@@ -62,13 +62,17 @@ public class VerseConfidence : VerseRefData
     public double Confidence { get; set; }
 }
 
-public class BookConfidence
+public class ConfidenceScore
 {
-    public required int BookNum { get; set; }
     public required double Confidence { get; set; }
     public required string Label { get; set; }
     public required double ProjectedChrF3 { get; set; }
     public required double Usability { get; set; }
+}
+
+public class BookConfidence : ConfidenceScore
+{
+    public required int BookNum { get; set; }
 }
 
 public class ChapterConfidence : BookConfidence
@@ -100,4 +104,9 @@ public class BuildConfidences
     /// Gets or sets the confidence scores for every chapter in the build.
     /// </summary>
     public required List<ChapterConfidence> ChapterConfidences { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest confidence score.
+    /// </summary>
+    public ConfidenceScore? LowestConfidence { get; init; }
 }

--- a/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
+++ b/src/SIL.XForge.Scripture/Models/DraftMetrics.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using SIL.XForge.Models;
 
@@ -41,6 +42,11 @@ public class DraftMetrics : IIdentifiable
     /// The confidence scores for every verse in the draft.
     /// </summary>
     public List<VerseConfidence> VerseConfidences { get; set; } = [];
+
+    /// <summary>
+    /// The date and time in UTC when these metrics were last updated.
+    /// </summary>
+    public DateTime DateUpdated { get; set; }
 }
 
 public class VerseConfidence : VerseRefData

--- a/src/SIL.XForge.Scripture/Models/MachineApi.cs
+++ b/src/SIL.XForge.Scripture/Models/MachineApi.cs
@@ -13,6 +13,7 @@ public static class MachineApi
     public const string GetRawBuild = "translation/builds/id:{sfProjectId}.{buildId}/raw";
     public const string GetBuilds = "translation/builds/project:{sfProjectId}";
     public const string GetBuildsSince = "translation/builds/since:{dateTime}";
+    public const string GetBuildConfidences = "translation/builds/id:{sfProjectId}.{buildId}/confidences";
     public const string GetEngine = "translation/engines/project:{sfProjectId}";
     public const string GetRawEngine = "translation/engines/project:{sfProjectId}/raw";
     public const string GetWordGraph = "translation/engines/project:{sfProjectId}/actions/getWordGraph";

--- a/src/SIL.XForge.Scripture/Models/QualityEstimationConfig.cs
+++ b/src/SIL.XForge.Scripture/Models/QualityEstimationConfig.cs
@@ -1,11 +1,14 @@
+using System;
+
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>
 /// The configuration used for Quality Estimation.
 /// </summary>
-public class QualityEstimationConfig
+public record QualityEstimationConfig
 {
     public required string Version { get; set; }
     public double Slope { get; set; }
     public double Intercept { get; set; }
+    public DateTime DateUpdated { get; set; }
 }

--- a/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
@@ -53,6 +53,11 @@ public class ServalBuildReportDto
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public DraftGenerationBuildStatus Status { get; init; }
+
+    /// <summary>
+    /// The confidence values for the build.
+    /// </summary>
+    public BuildConfidences? BuildConfidences { get; init; }
 }
 
 /// <summary>

--- a/src/SIL.XForge.Scripture/Models/VerseRefData.cs
+++ b/src/SIL.XForge.Scripture/Models/VerseRefData.cs
@@ -1,47 +1,62 @@
-#nullable disable warnings
 using SIL.Scripture;
 
 namespace SIL.XForge.Scripture.Models;
 
-public class VerseRefData
+/// <summary>
+/// A verse reference that can be stored in Mongo or the RealtimeServer.
+/// </summary>
+public class VerseRefData()
 {
-    private static void ParseVerseNumber(string vNum, out int number, out string segment)
-    {
-        int j;
-        for (j = 0; j < vNum.Length && char.IsDigit(vNum[j]); ++j) { }
-
-        number = 0;
-        if (j > 0)
-        {
-            string num = vNum[..j];
-            int.TryParse(num, out number); // Can't fail, we have already validated digits
-        }
-
-        segment = vNum[j..];
-    }
-
-    public VerseRefData() { }
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VerseRefData"/> class with a verse as a number.
+    /// </summary>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="chapterNum">The chapter number.</param>
+    /// <param name="verseNum">The verse number.</param>
+    /// <remarks>This should only be used when you want <see cref="Verse"/> to by <c>null</c>.</remarks>
     public VerseRefData(int bookNum, int chapterNum, int verseNum)
+        : this()
     {
         BookNum = bookNum;
         ChapterNum = chapterNum;
         VerseNum = verseNum;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VerseRefData"/> class.
+    /// </summary>
+    /// <param name="bookNum">The book number.</param>
+    /// <param name="chapterNum">The chapter number.</param>
+    /// <param name="verse">The verse.</param>
     public VerseRefData(int bookNum, int chapterNum, string verse)
+        : this()
     {
         BookNum = bookNum;
         ChapterNum = chapterNum;
         Verse = verse;
-        ParseVerseNumber(verse, out int verseNum, out _);
-        VerseNum = verseNum;
+        VerseNum = ParseVerseNumber(verse);
     }
 
+    /// <summary>
+    /// Gets or sets the book number.
+    /// </summary>
     public int BookNum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the chapter number.
+    /// </summary>
     public int ChapterNum { get; set; }
+
+    /// <summary>
+    /// Gets or sets the verse number.
+    /// </summary>
     public int VerseNum { get; set; }
-    public string Verse { get; set; }
+
+    /// <summary>
+    /// Gets or sets the verse.
+    /// </summary>
+    /// <remarks>If <c>null</c>, the <see cref="VerseNum"/> should be used instead.</remarks>
+    public string? Verse { get; set; }
 
     public VerseRef ToVerseRef()
     {
@@ -52,4 +67,13 @@ public class VerseRefData
     }
 
     public override string ToString() => ToVerseRef().ToString();
+
+    private static int ParseVerseNumber(string verse)
+    {
+        int i;
+        for (i = 0; i < verse.Length && char.IsDigit(verse[i]); ++i) { }
+        if (i > 0 && int.TryParse(verse[..i], out int number))
+            return number;
+        return 0;
+    }
 }

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -47,8 +47,8 @@
         prior to testing on SF QA -->
     <PackageReference Include="Serval.Client" Version="1.18.0" />
     <PackageReference Include="SIL.Machine" Version="3.8.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
   </ItemGroup>
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -46,7 +46,7 @@
     <!-- When updating Serval.Client consider that API changes must be released to Serval Prod
         prior to testing on SF QA -->
     <PackageReference Include="Serval.Client" Version="1.18.0" />
-    <PackageReference Include="SIL.Machine" Version="3.8.2" />
+    <PackageReference Include="SIL.Machine" Version="3.8.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -46,7 +46,7 @@
     <!-- When updating Serval.Client consider that API changes must be released to Serval Prod
         prior to testing on SF QA -->
     <PackageReference Include="Serval.Client" Version="1.18.0" />
-    <PackageReference Include="SIL.Machine" Version="3.8.3" />
+    <PackageReference Include="SIL.Machine" Version="3.8.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/IMachineApiService.cs
@@ -49,7 +49,7 @@ public interface IMachineApiService
         bool isServalAdmin,
         CancellationToken cancellationToken
     );
-    Task<TranslationBuild> GetRawBuildAsync(
+    Task<TranslationBuild?> GetRawBuildAsync(
         string curUserId,
         string sfProjectId,
         string buildId,
@@ -76,6 +76,13 @@ public interface IMachineApiService
         string sfProjectId,
         long? minRevision,
         bool preTranslate,
+        bool isServalAdmin,
+        CancellationToken cancellationToken
+    );
+    Task<BuildConfidences?> GetBuildConfidencesAsync(
+        string curUserId,
+        string sfProjectId,
+        string buildId,
         bool isServalAdmin,
         CancellationToken cancellationToken
     );

--- a/src/SIL.XForge.Scripture/Services/IPreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/IPreTranslationService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using SIL.XForge.Scripture.Models;
@@ -6,6 +7,10 @@ namespace SIL.XForge.Scripture.Services;
 
 public interface IPreTranslationService
 {
+    Task<IEnumerable<VerseConfidence>> GetVerseConfidencesAsync(
+        string sfProjectId,
+        CancellationToken cancellationToken
+    );
     Task<string> GetPreTranslationUsfmAsync(
         string sfProjectId,
         int bookNum,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -17,7 +17,6 @@ using Serval.Client;
 using SIL.Converters.Usj;
 using SIL.Machine.Corpora;
 using SIL.Machine.QualityEstimation;
-using SIL.Machine.Statistics;
 using SIL.ObjectModel;
 using SIL.Scripture;
 using SIL.XForge.Configuration;
@@ -3022,8 +3021,12 @@ public class MachineApiService(
         }
 
         // Only calculate quality estimation if the project is configured for it, and we have not calculated it already
-        List<VerseConfidence> verseConfidences = [];
         bool calculateQualityEstimation = projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig != null;
+
+        // Retrieve the pre-translation verse confidences from Serval
+        List<VerseConfidence> verseConfidences = calculateQualityEstimation
+            ? [.. await preTranslationService.GetVerseConfidencesAsync(sfProjectId, cancellationToken)]
+            : [];
 
         // For every text we have a draft applied to, get the pre-translation
         foreach (
@@ -3069,28 +3072,6 @@ public class MachineApiService(
                     );
                     IDocument<TextDocument> textDocument = await conn.FetchAsync<TextDocument>(id);
                     await SaveTextDocumentAsync(textDocument, usj);
-
-                    // Get the verse confidences
-                    if (calculateQualityEstimation)
-                    {
-                        PreTranslation[] preTranslations = await preTranslationService.GetPreTranslationsAsync(
-                            sfProjectId,
-                            bookNum,
-                            chapterNum,
-                            cancellationToken
-                        );
-                        foreach (PreTranslation preTranslation in preTranslations)
-                        {
-                            string verse = preTranslation.Reference.Split('_').Last();
-                            var verseConfidence = new VerseConfidence(
-                                bookNum,
-                                chapterNum,
-                                verse,
-                                preTranslation.Confidence
-                            );
-                            verseConfidences.Add(verseConfidence);
-                        }
-                    }
                 }
             }
         }
@@ -3117,12 +3098,7 @@ public class MachineApiService(
                     .. usabilityBooks.Select(b => new BookConfidence
                     {
                         BookNum = Canon.BookIdToNumber(b.Book),
-                        // TODO: Update Machine to pass through this value, i.e. Confidence = b.Confidence,
-                        Confidence = StatisticalMethods.GeometricMean([
-                            .. verseConfidences
-                                .Where(vc => vc.BookNum == Canon.BookIdToNumber(b.Book))
-                                .Select(vc => vc.Confidence),
-                        ]),
+                        Confidence = b.Confidence,
                         Label = b.Label.ToString(),
                         ProjectedChrF3 = b.ProjectedChrF3,
                         Usability = b.Usability,
@@ -3134,12 +3110,7 @@ public class MachineApiService(
                     {
                         BookNum = Canon.BookIdToNumber(c.Book),
                         ChapterNum = c.Chapter,
-                        // TODO: Update Machine to pass through this value, i.e. Confidence = b.Confidence,
-                        Confidence = StatisticalMethods.GeometricMean([
-                            .. verseConfidences
-                                .Where(vc => vc.BookNum == Canon.BookIdToNumber(c.Book) && vc.ChapterNum == c.Chapter)
-                                .Select(vc => vc.Confidence),
-                        ]),
+                        Confidence = c.Confidence,
                         Label = c.Label.ToString(),
                         ProjectedChrF3 = c.ProjectedChrF3,
                         Usability = c.Usability,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -15,6 +15,9 @@ using MongoDB.Bson;
 using Newtonsoft.Json;
 using Serval.Client;
 using SIL.Converters.Usj;
+using SIL.Machine.Corpora;
+using SIL.Machine.QualityEstimation;
+using SIL.Machine.Statistics;
 using SIL.ObjectModel;
 using SIL.Scripture;
 using SIL.XForge.Configuration;
@@ -41,6 +44,7 @@ namespace SIL.XForge.Scripture.Services;
 public class MachineApiService(
     IBackgroundJobClient backgroundJobClient,
     IDeltaUsxMapper deltaUsxMapper,
+    IRepository<DraftMetrics> draftMetrics,
     IEventMetricService eventMetricService,
     IExceptionHandler exceptionHandler,
     IHubContext<NotificationHub, INotifier> hubContext,
@@ -1079,6 +1083,32 @@ public class MachineApiService(
             .Values.GroupBy(entry => entry.sfProjectId)
             .ToDictionary(group => group.Key, group => group.First().sfProject);
 
+        // Build a list of project ids and build ids for the draft metric ids
+        // for all projects with quality estimation configured.
+        List<string> draftMetricIds = [];
+        foreach (TranslationBuild translationBuild in translationBuilds)
+        {
+            if (
+                engineToProject.TryGetValue(
+                    translationBuild.Engine.Id,
+                    out (string sfProjectId, SFProject? sfProject) project
+                ) && project.sfProject?.TranslateConfig.DraftConfig.QualityEstimationConfig is not null
+            )
+            {
+                draftMetricIds.Add($"{project.sfProjectId}:{translationBuild.Id}");
+            }
+        }
+
+        // Get the draft metrics for the specified projects/builds
+        List<DraftMetrics> draftMetricsForBuilds = [];
+        if (draftMetricIds.Count > 0)
+        {
+            draftMetricsForBuilds = await draftMetrics
+                .Query()
+                .Where(dm => draftMetricIds.Contains(dm.Id))
+                .ToListAsync(cancellationToken);
+        }
+
         // Build reports from Serval builds
         HashSet<string> matchedRequestIds = [];
         List<ServalBuildReportDto> reports = [];
@@ -1089,6 +1119,7 @@ public class MachineApiService(
                 engineToProject,
                 eventsByProject,
                 projectSnapshots,
+                draftMetricsForBuilds,
                 cancellationToken
             );
             if (report.DraftGenerationRequestId != null)
@@ -1118,6 +1149,60 @@ public class MachineApiService(
         reports.AddRange(eventsOnlyReports);
 
         return reports;
+    }
+
+    /// <summary>
+    /// Gets the confidence values for the specified project and build.
+    /// </summary>
+    /// <param name="curUserId">The current user identifier.</param>
+    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildId">The build identifier.</param>
+    /// <param name="isServalAdmin">If <c>true</c>, the current user is a Serval Administrator.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// The confidence values for the books and chapters, and the quality estimation configuration used,
+    /// or <c>null</c> if the confidence data does not exist for the build.
+    /// </returns>
+    /// <exception cref="DataNotFoundException">The project does not exist.</exception>
+    public async Task<BuildConfidences?> GetBuildConfidencesAsync(
+        string curUserId,
+        string sfProjectId,
+        string buildId,
+        bool isServalAdmin,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure that the user has permission
+        await EnsureProjectPermissionAsync(curUserId, sfProjectId, isServalAdmin, cancellationToken);
+
+        // Retrieve the draft metrics, if they exist, or throw an error if they do not
+        Attempt<DraftMetrics> attempt = await draftMetrics.TryGetAsync(
+            DraftMetrics.GetDocId(sfProjectId, buildId),
+            cancellationToken
+        );
+        if (attempt.Success)
+        {
+            return MapBuildConfidences(attempt.Result);
+        }
+
+        return null;
+    }
+
+    private static BuildConfidences? MapBuildConfidences(DraftMetrics? draftMetrics)
+    {
+        if (draftMetrics is null)
+        {
+            return null;
+        }
+
+        string[] id = draftMetrics.Id.Split(':');
+        return new BuildConfidences
+        {
+            ProjectId = id[0],
+            BuildId = id[1],
+            BookConfidences = draftMetrics.BookConfidences,
+            ChapterConfidences = draftMetrics.ChapterConfidences,
+        };
     }
 
     /// <summary>
@@ -1233,6 +1318,7 @@ public class MachineApiService(
         Dictionary<string, (string sfProjectId, SFProject? sfProject)> engineToProject,
         Dictionary<string, List<EventMetric>> eventsByProject,
         Dictionary<string, SFProject?> projectSnapshots,
+        List<DraftMetrics> draftMetricsForBuilds,
         CancellationToken cancellationToken
     )
     {
@@ -1276,6 +1362,12 @@ public class MachineApiService(
         // Identify problems
         List<BuildReportProblem> problems = ExtractProblems(translationBuild, projectEvents);
 
+        // Get the draft metrics for the build
+        DraftMetrics buildDraftMetrics =
+            sfProjectId != null
+                ? draftMetricsForBuilds.SingleOrDefault(dm => dm.Id == $"{sfProjectId}:{buildDto.Id}")
+                : null;
+
         return new ServalBuildReportDto
         {
             Build = buildDto,
@@ -1286,6 +1378,7 @@ public class MachineApiService(
             DraftGenerationRequestId = draftGenerationRequestId,
             RequesterSFUserId = requesterUserId,
             Status = ToDraftGenerationBuildStatus(translationBuild.State),
+            BuildConfidences = MapBuildConfidences(buildDraftMetrics),
         };
     }
 
@@ -2546,7 +2639,8 @@ public class MachineApiService(
                 );
 
                 // Update the pre-translation text documents
-                await UpdatePreTranslationTextDocumentsAsync(sfProjectId, cancellationToken);
+                string? buildId = translationBuild.Id;
+                await UpdatePreTranslationTextDocumentsAsync(sfProjectId, buildId, cancellationToken);
 
                 // Update the drafted scripture range to include the current scripture range
                 string draftedScriptureRange =
@@ -2568,7 +2662,6 @@ public class MachineApiService(
                 );
 
                 // Notify any SignalR clients subscribed to the project
-                string? buildId = translationBuild.Id;
                 await hubContext.NotifyBuildProgress(
                     sfProjectId,
                     new ServalBuildState { BuildId = buildId, State = nameof(ServalData.PreTranslationsRetrieved) }
@@ -2869,12 +2962,14 @@ public class MachineApiService(
     /// Updates the text documents locally with the latest pre-translation drafts.
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="buildId">The Serval build identifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>An asynchronous task.</returns>
     /// <exception cref="DataNotFoundException">Required data could not be found.</exception>
     /// <remarks>This can be mocked in unit tests.</remarks>
     protected internal virtual async Task UpdatePreTranslationTextDocumentsAsync(
         string sfProjectId,
+        string buildId,
         CancellationToken cancellationToken
     )
     {
@@ -2926,6 +3021,10 @@ public class MachineApiService(
             throw new ForbiddenException();
         }
 
+        // Only calculate quality estimation if the project is configured for it, and we have not calculated it already
+        List<VerseConfidence> verseConfidences = [];
+        bool calculateQualityEstimation = projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig != null;
+
         // For every text we have a draft applied to, get the pre-translation
         foreach (
             (string bookId, List<int> chapters) in ScriptureRangeParser.GetChapters(
@@ -2970,8 +3069,86 @@ public class MachineApiService(
                     );
                     IDocument<TextDocument> textDocument = await conn.FetchAsync<TextDocument>(id);
                     await SaveTextDocumentAsync(textDocument, usj);
+
+                    // Get the verse confidences
+                    if (calculateQualityEstimation)
+                    {
+                        PreTranslation[] preTranslations = await preTranslationService.GetPreTranslationsAsync(
+                            sfProjectId,
+                            bookNum,
+                            chapterNum,
+                            cancellationToken
+                        );
+                        foreach (PreTranslation preTranslation in preTranslations)
+                        {
+                            string verse = preTranslation.Reference.Split('_').Last();
+                            var verseConfidence = new VerseConfidence(
+                                bookNum,
+                                chapterNum,
+                                verse,
+                                preTranslation.Confidence
+                            );
+                            verseConfidences.Add(verseConfidence);
+                        }
+                    }
                 }
             }
+        }
+
+        // Generate the draft metrics containing the confidence scores
+        if (calculateQualityEstimation)
+        {
+            ChrF3QualityEstimator estimator = new ChrF3QualityEstimator(
+                projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig.Slope,
+                projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig.Intercept
+            );
+            (
+                List<ScriptureSegmentUsability> _, // We do not require segment level confidence values
+                List<ScriptureChapterUsability> usabilityChapters,
+                List<ScriptureBookUsability> usabilityBooks
+            ) = estimator.EstimateQuality(
+                verseConfidences.Select(vc => (new ScriptureRef(vc.ToVerseRef()), vc.Confidence))
+            );
+            var entity = new DraftMetrics
+            {
+                Id = DraftMetrics.GetDocId(sfProjectId, buildId),
+                BookConfidences =
+                [
+                    .. usabilityBooks.Select(b => new BookConfidence
+                    {
+                        BookNum = Canon.BookIdToNumber(b.Book),
+                        // TODO: Update Machine to pass through this value, i.e. Confidence = b.Confidence,
+                        Confidence = StatisticalMethods.GeometricMean([
+                            .. verseConfidences
+                                .Where(vc => vc.BookNum == Canon.BookIdToNumber(b.Book))
+                                .Select(vc => vc.Confidence),
+                        ]),
+                        Label = b.Label.ToString(),
+                        ProjectedChrF3 = b.ProjectedChrF3,
+                        Usability = b.Usability,
+                    }),
+                ],
+                ChapterConfidences =
+                [
+                    .. usabilityChapters.Select(c => new ChapterConfidence
+                    {
+                        BookNum = Canon.BookIdToNumber(c.Book),
+                        ChapterNum = c.Chapter,
+                        // TODO: Update Machine to pass through this value, i.e. Confidence = b.Confidence,
+                        Confidence = StatisticalMethods.GeometricMean([
+                            .. verseConfidences
+                                .Where(vc => vc.BookNum == Canon.BookIdToNumber(c.Book) && vc.ChapterNum == c.Chapter)
+                                .Select(vc => vc.Confidence),
+                        ]),
+                        Label = c.Label.ToString(),
+                        ProjectedChrF3 = c.ProjectedChrF3,
+                        Usability = c.Usability,
+                    }),
+                ],
+                QualityEstimationConfig = projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig,
+                VerseConfidences = verseConfidences,
+            };
+            await draftMetrics.ReplaceAsync(entity, upsert: true, cancellationToken);
         }
     }
 

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -3118,6 +3118,7 @@ public class MachineApiService(
                 ],
                 QualityEstimationConfig = projectDoc.Data.TranslateConfig.DraftConfig.QualityEstimationConfig,
                 VerseConfidences = verseConfidences,
+                DateUpdated = DateTime.UtcNow,
             };
             await draftMetrics.ReplaceAsync(entity, upsert: true, cancellationToken);
         }

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1201,6 +1201,7 @@ public class MachineApiService(
             BuildId = id[1],
             BookConfidences = draftMetrics.BookConfidences,
             ChapterConfidences = draftMetrics.ChapterConfidences,
+            LowestConfidence = draftMetrics.BookConfidences.OrderBy(b => b.Usability).FirstOrDefault(),
         };
     }
 

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -17,9 +17,7 @@ public class PreTranslationService(
     ITranslationEnginesClient translationEnginesClient
 ) : IPreTranslationService
 {
-    public static string GetTextId(int bookNum, int chapterNum) => $"{bookNum}_{chapterNum}";
-
-    public static string GetTextId(int bookNum) => Canon.BookNumberToId(bookNum);
+    private static string GetTextId(int bookNum) => Canon.BookNumberToId(bookNum);
 
     /// <summary>
     /// Get the verse confidences for the pre-translations.
@@ -197,15 +195,15 @@ public class PreTranslationService(
     )> GetPreTranslationParametersAsync(string sfProjectId)
     {
         // Load the target project secrets, so we can get the translation engine ID and corpus ID
-        if (!(await projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret projectSecret))
+        if (!(await projectSecrets.TryGetAsync(sfProjectId)).TryResult(out SFProjectSecret? projectSecret))
         {
             throw new DataNotFoundException("The project secret cannot be found.");
         }
 
-        string? translationEngineId = projectSecret.ServalData?.PreTranslationEngineId;
+        string? translationEngineId = projectSecret?.ServalData?.PreTranslationEngineId;
         string? corpusId = null;
         string? parallelCorpusId = null;
-        if (!string.IsNullOrWhiteSpace(projectSecret.ServalData?.ParallelCorpusIdForPreTranslate))
+        if (!string.IsNullOrWhiteSpace(projectSecret?.ServalData?.ParallelCorpusIdForPreTranslate))
         {
             parallelCorpusId = projectSecret.ServalData.ParallelCorpusIdForPreTranslate;
         }
@@ -213,7 +211,9 @@ public class PreTranslationService(
         {
             // Legacy Serval Project
             corpusId = projectSecret
-                .ServalData?.Corpora?.FirstOrDefault(c => c.Value.PreTranslate && !c.Value.AlternateTrainingSource)
+                ?.ServalData?.Corpora?.FirstOrDefault(c =>
+                    c.Value is { PreTranslate: true, AlternateTrainingSource: false }
+                )
                 .Key;
         }
 

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -75,7 +75,7 @@ public class PreTranslationService(
                 continue;
             }
 
-            // Add the confidence value. HHowever, if the confidence value already exists, see if this pre-translation
+            // Add the confidence value. However, if the confidence value already exists, see if this pre-translation
             // is for the verse content, and if so, set the confidence value.
             if (!confidences.TryAdd(verseRef, pretranslationConfidence.Confidence) && !references.First().Contains('/'))
             {

--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -1,4 +1,4 @@
-#nullable disable warnings
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -22,14 +22,79 @@ public class PreTranslationService(
     public static string GetTextId(int bookNum) => Canon.BookNumberToId(bookNum);
 
     /// <summary>
+    /// Get the verse confidences for the pre-translations.
+    /// </summary>
+    /// <param name="sfProjectId">The SF project identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The verse confidences.</returns>
+    public async Task<IEnumerable<VerseConfidence>> GetVerseConfidencesAsync(
+        string sfProjectId,
+        CancellationToken cancellationToken
+    )
+    {
+        // Ensure we have the parameters to retrieve the pre-translation
+        (string translationEngineId, string? _, string? parallelCorpusId) = await GetPreTranslationParametersAsync(
+            sfProjectId
+        );
+
+        // If there is no parallel corpus id, there are no confidence values
+        if (parallelCorpusId is null)
+            return [];
+
+        // Iterate over every pre-translation confidence for the parallel corpus.
+        // Use a dictionary to stop duplication of verse references
+        Dictionary<VerseRef, double> confidences = [];
+        foreach (
+            PretranslationConfidence pretranslationConfidence in await translationEnginesClient.GetAllPretranslationConfidencesAsync(
+                translationEngineId,
+                parallelCorpusId,
+                cancellationToken
+            )
+        )
+        {
+            // Get the references - old builds will only have TargetRefs specified,
+            // newer builds will have TargetRefs and SourceRefs specified.
+            List<string> references = [.. pretranslationConfidence.SourceRefs, .. pretranslationConfidence.TargetRefs];
+
+            // A reference will be in the format: "MAT 1:2" or "MAT 1:2/1:p"
+            string? reference = references.FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(reference))
+            {
+                continue;
+            }
+
+            // If there is a forward slash, in the reference, the first half is the verse reference
+            if (reference.Contains('/', StringComparison.OrdinalIgnoreCase))
+            {
+                reference = reference.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            }
+
+            // Ensure we have a valid verse reference and it is for this chapter
+            if (!VerseRef.TryParse(reference, out VerseRef verseRef))
+            {
+                continue;
+            }
+
+            // Add the confidence value. HHowever, if the confidence value already exists, see if this pre-translation
+            // is for the verse content, and if so, set the confidence value.
+            if (!confidences.TryAdd(verseRef, pretranslationConfidence.Confidence) && !references.First().Contains('/'))
+            {
+                confidences[verseRef] = pretranslationConfidence.Confidence;
+            }
+        }
+
+        return confidences.Select(c => new VerseConfidence(c.Key.BookNum, c.Key.ChapterNum, c.Key.Verse, c.Value));
+    }
+
+    /// <summary>
     /// Gets the pre-translations as USFM.
     /// </summary>
     /// <param name="sfProjectId">The SF project identifier.</param>
     /// <param name="bookNum">The book number.</param>
     /// <param name="chapterNum">The chapter number. If 0, all chapters in the book are returned.</param>
-    /// <param name="config">The draft USFM configuration.</param>":
+    /// <param name="config">The draft USFM configuration.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns></returns>
+    /// <returns>The USFM.</returns>
     /// <exception cref="DataNotFoundException">
     /// The project secret or pre-translation configuration was not found.
     /// </exception>
@@ -42,7 +107,7 @@ public class PreTranslationService(
     )
     {
         // Ensure we have the parameters to retrieve the pre-translation
-        (string? translationEngineId, string? corpusId, string? parallelCorpusId, bool _) =
+        (string translationEngineId, string? corpusId, string? parallelCorpusId) =
             await GetPreTranslationParametersAsync(sfProjectId);
 
         // Generate the paragraph marker and quote normalization behaviors
@@ -61,7 +126,7 @@ public class PreTranslationService(
         };
 
         // Get the USFM
-        string usfm;
+        string usfm = string.Empty;
         if (parallelCorpusId is not null)
         {
             usfm = await translationEnginesClient.GetPretranslatedUsfmAsync(
@@ -77,7 +142,7 @@ public class PreTranslationService(
                 cancellationToken: cancellationToken
             );
         }
-        else
+        else if (corpusId is not null)
         {
             // Retrieve the USFM from a legacy corpus
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -121,15 +186,14 @@ public class PreTranslationService(
     /// </summary>
     /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
     /// <returns>
-    /// The translation engine identifier, the corpus identifier, and whether to use Paratext verse references.
+    /// The translation engine identifier, the corpus identifier, and the parallel corpus identifier.
     /// </returns>
     /// <remarks>This can be mocked in unit tests.</remarks>
     /// <exception cref="DataNotFoundException">The pre-translation engine is not configured, or the project secret cannot be found.</exception>
     protected internal virtual async Task<(
         string translationEngineId,
         string? corpusId,
-        string? parallelCorpusId,
-        bool useParatextVerseRef
+        string? parallelCorpusId
     )> GetPreTranslationParametersAsync(string sfProjectId)
     {
         // Load the target project secrets, so we can get the translation engine ID and corpus ID
@@ -138,14 +202,12 @@ public class PreTranslationService(
             throw new DataNotFoundException("The project secret cannot be found.");
         }
 
-        string translationEngineId = projectSecret.ServalData?.PreTranslationEngineId;
+        string? translationEngineId = projectSecret.ServalData?.PreTranslationEngineId;
         string? corpusId = null;
         string? parallelCorpusId = null;
-        bool useParatextVerseRef = false;
         if (!string.IsNullOrWhiteSpace(projectSecret.ServalData?.ParallelCorpusIdForPreTranslate))
         {
             parallelCorpusId = projectSecret.ServalData.ParallelCorpusIdForPreTranslate;
-            useParatextVerseRef = true;
         }
         else
         {
@@ -153,10 +215,6 @@ public class PreTranslationService(
             corpusId = projectSecret
                 .ServalData?.Corpora?.FirstOrDefault(c => c.Value.PreTranslate && !c.Value.AlternateTrainingSource)
                 .Key;
-            if (!string.IsNullOrWhiteSpace(corpusId))
-            {
-                useParatextVerseRef = projectSecret.ServalData.Corpora[corpusId].UploadParatextZipFile;
-            }
         }
 
         if (
@@ -167,6 +225,6 @@ public class PreTranslationService(
             throw new DataNotFoundException("The pre-translation engine is not configured.");
         }
 
-        return (translationEngineId, corpusId, parallelCorpusId, useParatextVerseRef);
+        return (translationEngineId, corpusId, parallelCorpusId);
     }
 }

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -1257,7 +1257,13 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         else
         {
             await projectDoc.SubmitJson0OpAsync(op =>
-                op.Set(p => p.TranslateConfig.DraftConfig.QualityEstimationConfig, qualityEstimationConfig)
+                op.Set(
+                    p => p.TranslateConfig.DraftConfig.QualityEstimationConfig,
+                    qualityEstimationConfig with
+                    {
+                        DateUpdated = DateTime.UtcNow,
+                    }
+                )
             );
         }
     }

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -143,24 +143,24 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "Direct",
-        "requested": "[10.1.7, )",
-        "resolved": "10.1.7",
-        "contentHash": "vgef8DPT411JU5JjHiDbr0WOxsIVuAvegPGtqmm4Na4JRl/264dfBJcGkiPHsAr5P+Vda+qN1rZKRtBl1rF9aA==",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "SDU6akgCV/H4jFMRfyJ0mgO5jWOuuAqekvEThXg8c/LjnfNz5Nkaz+RUpeTVJKWIRX4wDKC/6R3ogJ4AsRE32A==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "10.0.0",
-          "Swashbuckle.AspNetCore.Swagger": "10.1.7",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.1.7",
-          "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.1",
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.1"
         }
       },
       "Swashbuckle.AspNetCore.Newtonsoft": {
         "type": "Direct",
-        "requested": "[10.1.7, )",
-        "resolved": "10.1.7",
-        "contentHash": "5kOG8iV2LjNSAjaCBqKotkng3kQarSVaZeemUGRnv8selqx3qkJPO7j3cN36wFb5wzehNp0J2NTTkHFiUNFK0w==",
+        "requested": "[10.2.1, )",
+        "resolved": "10.2.1",
+        "contentHash": "zL4aMBs4UxYwakaEccD6dYhTi609LO3dOwrib4KqkQUol3WMxeYI31SKeQzMJwy5qAsnN7Z84sFO3I4uKbvdYw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "10.0.0",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.1.7"
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1"
         }
       },
       "AbrarJahin.DiffMatchPatch": {
@@ -523,8 +523,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "u7QhXCISMQuab3flasb1hoaiERmUqyWsW7tmQODyILoQ7mJV5IRGM+2KKZYo0QUfC13evEOcHAb6TPWgqEQtrw=="
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Microsoft.Win32.Registry.AccessControl": {
         "type": "Transitive",
@@ -931,24 +931,24 @@
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "EjLibt/d/QuRv170GoihTbcPUpgzSFm2WKHhnGJFZQ03JYzfuitsM79azaAR8NBwRunU7yScSX6HRE5JUlrEMQ==",
+        "resolved": "10.2.1",
+        "contentHash": "ej4inPhiWCq+0utG8yaKhIhE8M3k3R/qRaGhpgDZB+O/s+o62/zRMO1Cn2CtQccsrqPE9PYnzCp6hQGYGpJOyQ==",
         "dependencies": {
-          "Microsoft.OpenApi": "2.4.1"
+          "Microsoft.OpenApi": "2.7.5"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "PuubO9BjvNn6U3D9kLpuWKY1JtziWw7SsGBq0age1E50uQjQ8Fzl8s0EwzrLfANqYJNgDnJi9l7N1QxcGVB2Zw==",
+        "resolved": "10.2.1",
+        "contentHash": "JYX6i/y0xEtQWH/hZyfcage1/ldwww83ueD/gBc34uSnMwyvRLUsOpYcxlliFFxFbZMrY6t+R9ENqolE7zTEOg==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "10.1.7"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "iJo3ODyUb/M8Vm8AH1r9y9iAba0w95xsCn3zFVl96ISRHbTDWxi+l7oFVCZqUEdjd97B8VMDPnMliWAdomR8uw=="
+        "resolved": "10.2.1",
+        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -129,9 +129,9 @@
       },
       "SIL.Machine": {
         "type": "Direct",
-        "requested": "[3.8.2, )",
-        "resolved": "3.8.2",
-        "contentHash": "Uqv7nGmJZaubTI7VYibu6qEAQiDhoqAflGt6nA+pHOdLDhfZPWngCeJQeIWYVj/t+W1h6eFeyM7JbVoyHKgrZA==",
+        "requested": "[3.8.3, )",
+        "resolved": "3.8.3",
+        "contentHash": "Vn85jnwrs4HmwU44xZdKEzZsJ/7IOVKw4Gbv8uMYpaEJQ00UFmG6C0skMP3EBg9fZP5vxYT7jMRirSULCa2Xaw==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -129,9 +129,9 @@
       },
       "SIL.Machine": {
         "type": "Direct",
-        "requested": "[3.8.3, )",
-        "resolved": "3.8.3",
-        "contentHash": "Vn85jnwrs4HmwU44xZdKEzZsJ/7IOVKw4Gbv8uMYpaEJQ00UFmG6C0skMP3EBg9fZP5vxYT7jMRirSULCa2Xaw==",
+        "requested": "[3.8.4, )",
+        "resolved": "3.8.4",
+        "contentHash": "iyIGFWIneklLYaI856FuP7H097Gg8XsWgqaRrYTC6bd7YXjowrLzlK+oWqTiEQHdhWsA1M3A8wao800DDIrMVQ==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",

--- a/test/SIL.Converters.Usj.Tests/SIL.Converters.Usj.Tests.csproj
+++ b/test/SIL.Converters.Usj.Tests/SIL.Converters.Usj.Tests.csproj
@@ -15,13 +15,13 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/SIL.Converters.Usj.Tests/packages.lock.json
+++ b/test/SIL.Converters.Usj.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "kb5kBe1HioGuH+ZDKysv/oAO9cCUW2yxtrGrRBZp/dIij5f011OfC4XiNMayZ8bGfOv2+n2ocPkaJIGppAZDEg=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
@@ -16,19 +16,19 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.5.1, )",
-        "resolved": "18.5.1",
-        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.1",
-          "Microsoft.TestPlatform.TestHost": "18.5.1"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.6.0, )",
-        "resolved": "4.6.0",
-        "contentHash": "RsafbuYR+HzdDhgfdLYrDOSuFdv8IgGpbe5NIqXWAhZ7t6lXNj9yNcLcAk34lKVio6OusBQolKlboyl/9hObNA=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -48,8 +48,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
@@ -99,15 +99,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1,4 +1,3 @@
-#nullable disable warnings
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -93,7 +92,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.CancelPreTranslationBuildAsync(User01, Project01, CancellationToken.None)
-            .Returns(Task.FromResult(Build01));
+            .Returns(Task.FromResult<string?>(Build01));
 
         // SUT
         ActionResult actual = await env.Controller.CancelPreTranslationBuildAsync(Project01, CancellationToken.None);
@@ -149,7 +148,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
-            .Returns(Task.FromResult<ServalBuildDto>(null));
+            .Returns(Task.FromResult<ServalBuildDto?>(null));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -215,7 +214,9 @@ public class MachineApiControllerTests
                 isServalAdmin: false,
                 CancellationToken.None
             )
-            .Returns(Task.FromResult(new ServalBuildDto { State = MachineApiService.BuildStateQueued }));
+            .Returns(
+                Task.FromResult<ServalBuildDto?>(new ServalBuildDto { State = MachineApiService.BuildStateQueued })
+            );
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -246,9 +247,9 @@ public class MachineApiControllerTests
                 User01,
                 Project01,
                 Build01,
-                minRevision: default,
-                preTranslate: default,
-                isServalAdmin: default,
+                minRevision: null,
+                preTranslate: false,
+                isServalAdmin: false,
                 CancellationToken.None
             );
     }
@@ -265,7 +266,7 @@ public class MachineApiControllerTests
                 isServalAdmin: false,
                 CancellationToken.None
             )
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -294,7 +295,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, true, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -323,7 +324,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, true, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -352,7 +353,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, true, true, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
         env.UserAccessor.SystemRoles.Returns([SystemRole.ServalAdmin]);
 
         // SUT
@@ -376,7 +377,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetBuildAsync(User01, Project01, Build01, null, false, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -441,7 +442,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
-            .Returns(Task.FromResult<ServalBuildDto>(null));
+            .Returns(Task.FromResult<ServalBuildDto?>(null));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -501,7 +502,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetCurrentBuildAsync(User01, Project01, null, false, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetBuildAsync(
@@ -625,6 +626,112 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    public async Task GetBuildConfidencesAsync_NoContent()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetBuildConfidencesAsync(
+                User01,
+                Project01,
+                Build01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Returns(Task.FromResult<BuildConfidences?>(null));
+
+        // SUT
+        ActionResult<BuildConfidences> actual = await env.Controller.GetBuildConfidencesAsync(
+            Project01,
+            Build01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NoContentResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetBuildConfidencesAsync(
+                User01,
+                Project01,
+                Build01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<BuildConfidences> actual = await env.Controller.GetBuildConfidencesAsync(
+            Project01,
+            Build01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetBuildConfidencesAsync(
+                User01,
+                Project01,
+                Build01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<BuildConfidences> actual = await env.Controller.GetBuildConfidencesAsync(
+            Project01,
+            Build01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetBuildConfidencesAsync(
+                User01,
+                Project01,
+                Build01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Returns(
+                Task.FromResult<BuildConfidences?>(
+                    new BuildConfidences
+                    {
+                        ProjectId = Project01,
+                        BuildId = Build01,
+                        BookConfidences = [],
+                        ChapterConfidences = [],
+                    }
+                )
+            );
+
+        // SUT
+        ActionResult<BuildConfidences> actual = await env.Controller.GetBuildConfidencesAsync(
+            Project01,
+            Build01,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
     public async Task GetEngineAsync_MachineApiDown()
     {
         // Set up test environment
@@ -707,7 +814,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
-            .Returns(Task.FromResult<ServalBuildDto>(null));
+            .Returns(Task.FromResult<ServalBuildDto?>(null));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
@@ -758,7 +865,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, true, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
         env.UserAccessor.SystemRoles.Returns([SystemRole.ServalAdmin]);
 
         // SUT
@@ -780,7 +887,7 @@ public class MachineApiControllerTests
         // Set up test environment
         var env = new TestEnvironment();
         env.MachineApiService.GetLastCompletedPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         // SUT
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetLastCompletedPreTranslationBuildAsync(
@@ -800,7 +907,7 @@ public class MachineApiControllerTests
     {
         var env = new TestEnvironment();
         env.MachineApiService.GetLastPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
-            .Returns(Task.FromResult<ServalBuildDto>(null));
+            .Returns(Task.FromResult<ServalBuildDto?>(null));
 
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetLastPreTranslationBuildAsync(
             Project01,
@@ -830,7 +937,7 @@ public class MachineApiControllerTests
     {
         var env = new TestEnvironment();
         env.MachineApiService.GetLastPreTranslationBuildAsync(User01, Project01, false, CancellationToken.None)
-            .Returns(Task.FromResult(new ServalBuildDto()));
+            .Returns(Task.FromResult<ServalBuildDto?>(new ServalBuildDto()));
 
         ActionResult<ServalBuildDto?> actual = await env.Controller.GetLastPreTranslationBuildAsync(
             Project01,
@@ -861,7 +968,7 @@ public class MachineApiControllerTests
             .Throws(new BrokenCircuitException());
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -894,7 +1001,7 @@ public class MachineApiControllerTests
             .Throws(new ForbiddenException());
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -925,7 +1032,7 @@ public class MachineApiControllerTests
             .Throws(new DataNotFoundException(string.Empty));
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -956,7 +1063,7 @@ public class MachineApiControllerTests
             .Throws(new InvalidOperationException());
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -987,7 +1094,7 @@ public class MachineApiControllerTests
             .Throws(new NotSupportedException());
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -1024,7 +1131,7 @@ public class MachineApiControllerTests
             .Returns(Task.FromResult(new Dictionary<string, Snapshot<TextData>>()));
 
         // SUT
-        ActionResult<Snapshot<TextData>> actual = await env.Controller.GetPreTranslationDeltaAsync(
+        ActionResult<Snapshot<TextData>?> actual = await env.Controller.GetPreTranslationDeltaAsync(
             Project01,
             40,
             1,
@@ -1039,35 +1146,6 @@ public class MachineApiControllerTests
 
     [Test]
     public async Task GetPretranslationDeltaAsync_SuccessSpecificConfig()
-    {
-        var env = new TestEnvironment();
-        env.MachineApiService.GetPreTranslationDeltaAsync(
-                User01,
-                Project01,
-                40,
-                1,
-                false,
-                Arg.Any<DateTime>(),
-                Arg.Any<DraftUsfmConfig>(),
-                CancellationToken.None
-            )
-            .Returns(Task.FromResult(new Dictionary<string, Snapshot<TextData>>()));
-
-        // SUT
-        var result = await env.Controller.GetPreTranslationDeltaAsync(
-            Project01,
-            40,
-            1,
-            null,
-            paragraphFormat: ParagraphBreakFormatOptions.BestGuess,
-            quoteFormat: QuoteStyleOptions.Denormalized,
-            CancellationToken.None
-        );
-        Assert.IsInstanceOf<OkObjectResult>(result.Result);
-    }
-
-    [Test]
-    public async Task GetPretranslationDeltaAsync_MachineApiDown()
     {
         var env = new TestEnvironment();
         env.MachineApiService.GetPreTranslationDeltaAsync(
@@ -1956,6 +2034,272 @@ public class MachineApiControllerTests
             40,
             1,
             null,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawBuildAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawBuildAsync(
+                User01,
+                Project01,
+                Build01,
+                minRevision: null,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<TranslationBuild?> actual = await env.Controller.GetRawBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetRawBuildAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawBuildAsync(
+                User01,
+                Project01,
+                Build01,
+                minRevision: null,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<TranslationBuild?> actual = await env.Controller.GetRawBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawBuildAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawBuildAsync(
+                User01,
+                Project01,
+                Build01,
+                minRevision: null,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<TranslationBuild?> actual = await env.Controller.GetRawBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawBuildAsync_ServalAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawBuildAsync(
+                User01,
+                Project01,
+                Build01,
+                minRevision: null,
+                preTranslate: true,
+                isServalAdmin: true,
+                CancellationToken.None
+            )
+            .Returns(Task.FromResult<TranslationBuild?>(new TranslationBuild()));
+        env.UserAccessor.SystemRoles.Returns([SystemRole.ServalAdmin]);
+
+        // SUT
+        ActionResult<TranslationBuild?> actual = await env.Controller.GetRawBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawBuildAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawBuildAsync(
+                User01,
+                Project01,
+                Build01,
+                minRevision: null,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Returns(Task.FromResult<TranslationBuild?>(new TranslationBuild()));
+
+        // SUT
+        ActionResult<TranslationBuild?> actual = await env.Controller.GetRawBuildAsync(
+            Project01,
+            Build01,
+            minRevision: null,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawEngineAsync_MachineApiDown()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawEngineAsync(
+                User01,
+                Project01,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new BrokenCircuitException());
+
+        // SUT
+        ActionResult<TranslationEngine?> actual = await env.Controller.GetRawEngineAsync(
+            Project01,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        env.ExceptionHandler.Received(1).ReportException(Arg.Any<BrokenCircuitException>());
+        Assert.IsInstanceOf<ObjectResult>(actual.Result);
+        Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, (actual.Result as ObjectResult)?.StatusCode);
+    }
+
+    [Test]
+    public async Task GetRawEngineAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawEngineAsync(
+                User01,
+                Project01,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new ForbiddenException());
+
+        // SUT
+        ActionResult<TranslationEngine?> actual = await env.Controller.GetRawEngineAsync(
+            Project01,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<ForbidResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawEngineAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawEngineAsync(
+                User01,
+                Project01,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Throws(new DataNotFoundException(string.Empty));
+
+        // SUT
+        ActionResult<TranslationEngine?> actual = await env.Controller.GetRawEngineAsync(
+            Project01,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<NotFoundResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawEngineAsync_ServalAdmin()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawEngineAsync(
+                User01,
+                Project01,
+                preTranslate: true,
+                isServalAdmin: true,
+                CancellationToken.None
+            )
+            .Returns(Task.FromResult<TranslationEngine?>(new TranslationEngine()));
+        env.UserAccessor.SystemRoles.Returns([SystemRole.ServalAdmin]);
+
+        // SUT
+        ActionResult<TranslationEngine?> actual = await env.Controller.GetRawEngineAsync(
+            Project01,
+            preTranslate: true,
+            CancellationToken.None
+        );
+
+        Assert.IsInstanceOf<OkObjectResult>(actual.Result);
+    }
+
+    [Test]
+    public async Task GetRawEngineAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        env.MachineApiService.GetRawEngineAsync(
+                User01,
+                Project01,
+                preTranslate: true,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+            .Returns(Task.FromResult<TranslationEngine?>(new TranslationEngine()));
+
+        // SUT
+        ActionResult<TranslationEngine?> actual = await env.Controller.GetRawEngineAsync(
+            Project01,
+            preTranslate: true,
             CancellationToken.None
         );
 

--- a/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
+++ b/test/SIL.XForge.Scripture.Tests/SIL.XForge.Scripture.Tests.csproj
@@ -20,14 +20,14 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <!-- Fix a vulnerable dependency of ParatextData 9.5.0.24 -->
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -2207,6 +2207,7 @@ public class MachineApiServiceTests
             Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
             Assert.That(actual.BookConfidences, Is.Not.Empty);
             Assert.That(actual.ChapterConfidences, Is.Not.Empty);
+            Assert.That(actual.LowestConfidence, Is.Not.Null);
         }
     }
 
@@ -2232,6 +2233,7 @@ public class MachineApiServiceTests
             Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
             Assert.That(actual.BookConfidences, Is.Not.Empty);
             Assert.That(actual.ChapterConfidences, Is.Not.Empty);
+            Assert.That(actual.LowestConfidence, Is.Not.Null);
         }
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -58,8 +58,6 @@ public class MachineApiServiceTests
     private const string HangfireJobId = "jobId";
     private const string Data01 = "data01";
 
-    private const string TestPreTranslation =
-        "The book of the generations of Jesus Christ, the son of David, the son of Abraham.";
     private const string TestUsfm = "\\c 1 \\v 1 Verse 1";
     private const string TestUsx =
         "<usx version=\"3.0\"><book code=\"MAT\" style=\"id\"></book><chapter number=\"1\" style=\"c\" />"
@@ -5252,9 +5250,7 @@ public class MachineApiServiceTests
                 CancellationToken.None
             );
 
-        await env
-            .PreTranslationService.Received(1)
-            .GetPreTranslationsAsync(Project01, bookNum, chapterNum: 1, CancellationToken.None);
+        await env.PreTranslationService.Received(1).GetVerseConfidencesAsync(Project01, CancellationToken.None);
         env.ParatextService.Received(1).GetChaptersAsUsj(Arg.Any<UserSecret>(), Paratext01, bookNum, TestUsfm);
         DraftMetrics draftMetrics = env.DraftMetrics.Get(DraftMetrics.GetDocId(Project01, ServalBuildId01));
         using (Assert.EnterMultipleScope())
@@ -5974,19 +5970,16 @@ public class MachineApiServiceTests
                 .Returns(Task.FromResult(TestUsfm));
             int preTranslationChapterNum = chapterNum == 0 ? 1 : chapterNum;
             PreTranslationService
-                .GetPreTranslationsAsync(Project01, bookNum, preTranslationChapterNum, CancellationToken.None)
+                .GetVerseConfidencesAsync(Project01, CancellationToken.None)
                 .Returns(
-                    Task.FromResult(
-                        new[]
-                        {
-                            new PreTranslation
-                            {
-                                Reference = $"verse_{preTranslationChapterNum}_1",
-                                Translation = TestPreTranslation,
-                                Confidence = 0.6020749899712906,
-                            },
-                        }
-                    )
+                    Task.FromResult<IEnumerable<VerseConfidence>>([
+                        new VerseConfidence(
+                            bookNum,
+                            preTranslationChapterNum,
+                            verseNum: 1,
+                            confidence: 0.6020749899712906
+                        ),
+                    ])
                 );
             ParatextService.GetChaptersAsUsj(Arg.Any<UserSecret>(), Paratext01, bookNum, TestUsfm).Returns([TestUsj]);
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -2174,7 +2174,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
 
         // SUT
-        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+        BuildConfidences? actual = await env.Service.GetBuildConfidencesAsync(
             User01,
             Project01,
             ServalBuildId01,
@@ -2193,7 +2193,7 @@ public class MachineApiServiceTests
         await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
 
         // SUT
-        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+        BuildConfidences? actual = await env.Service.GetBuildConfidencesAsync(
             User02,
             Project01,
             ServalBuildId01,
@@ -2203,11 +2203,11 @@ public class MachineApiServiceTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.ProjectId, Is.EqualTo(Project01));
-            Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
-            Assert.That(actual.BookConfidences, Is.Not.Empty);
-            Assert.That(actual.ChapterConfidences, Is.Not.Empty);
-            Assert.That(actual.LowestConfidence, Is.Not.Null);
+            Assert.That(actual?.ProjectId, Is.EqualTo(Project01));
+            Assert.That(actual?.BuildId, Is.EqualTo(ServalBuildId01));
+            Assert.That(actual?.BookConfidences, Is.Not.Empty);
+            Assert.That(actual?.ChapterConfidences, Is.Not.Empty);
+            Assert.That(actual?.LowestConfidence, Is.Not.Null);
         }
     }
 
@@ -2219,7 +2219,7 @@ public class MachineApiServiceTests
         await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
 
         // SUT
-        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+        BuildConfidences? actual = await env.Service.GetBuildConfidencesAsync(
             User01,
             Project01,
             ServalBuildId01,
@@ -2229,11 +2229,11 @@ public class MachineApiServiceTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(actual.ProjectId, Is.EqualTo(Project01));
-            Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
-            Assert.That(actual.BookConfidences, Is.Not.Empty);
-            Assert.That(actual.ChapterConfidences, Is.Not.Empty);
-            Assert.That(actual.LowestConfidence, Is.Not.Null);
+            Assert.That(actual?.ProjectId, Is.EqualTo(Project01));
+            Assert.That(actual?.BuildId, Is.EqualTo(ServalBuildId01));
+            Assert.That(actual?.BookConfidences, Is.Not.Empty);
+            Assert.That(actual?.ChapterConfidences, Is.Not.Empty);
+            Assert.That(actual?.LowestConfidence, Is.Not.Null);
         }
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -58,6 +58,8 @@ public class MachineApiServiceTests
     private const string HangfireJobId = "jobId";
     private const string Data01 = "data01";
 
+    private const string TestPreTranslation =
+        "The book of the generations of Jesus Christ, the son of David, the son of Abraham.";
     private const string TestUsfm = "\\c 1 \\v 1 Verse 1";
     private const string TestUsx =
         "<usx version=\"3.0\"><book code=\"MAT\" style=\"id\"></book><chapter number=\"1\" style=\"c\" />"
@@ -106,6 +108,13 @@ public class MachineApiServiceTests
         Revision = 43,
         State = JobState.Completed,
         DateFinished = DateTimeOffset.UtcNow,
+    };
+
+    private static readonly QualityEstimationConfig QualityEstimationConfig = new QualityEstimationConfig
+    {
+        Version = "0.1",
+        Slope = 109.6145,
+        Intercept = -14.0633,
     };
 
     [Test]
@@ -1113,7 +1122,7 @@ public class MachineApiServiceTests
         DateTimeOffset dateCreated = DateTimeOffset.UtcNow.AddDays(-2);
         DateTimeOffset dateStarted = dateCreated.AddHours(6);
         DateTimeOffset dateFinished = dateCreated.AddDays(1);
-        DateTimeOffset dateCompleted = dateFinished;
+        DateTimeOffset dateCompleted = dateFinished.AddSeconds(1);
         TranslationBuild translationBuild = new TranslationBuild
         {
             Id = ServalBuildId01,
@@ -1131,6 +1140,7 @@ public class MachineApiServiceTests
             .Returns(Task.FromResult<IList<TranslationBuild>>([translationBuild]));
         const string draftGenerationRequestId = "draft-req";
         env.SetDraftGenerationMetricAssociation(draftGenerationRequestId);
+        await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
 
         // SUT
         IReadOnlyList<ServalBuildReportDto> reports = await env.Service.GetBuildsSinceAsync(
@@ -1153,6 +1163,8 @@ public class MachineApiServiceTests
         Assert.AreEqual(dateCompleted, report.Timeline.ServalCompleted);
         Assert.AreEqual(dateFinished, report.Timeline.ServalFinished);
         Assert.AreEqual(draftGenerationRequestId, report.DraftGenerationRequestId);
+        Assert.NotZero(report.BuildConfidences!.BookConfidences.Count);
+        Assert.NotZero(report.BuildConfidences!.ChapterConfidences.Count);
     }
 
     [Test]
@@ -2119,6 +2131,110 @@ public class MachineApiServiceTests
                 CancellationToken.None
             )
         );
+    }
+
+    [Test]
+    public void GetBuildConfidencesAsync_NoPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<ForbiddenException>(() =>
+            env.Service.GetBuildConfidencesAsync(
+                User02,
+                Project01,
+                ServalBuildId01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+        );
+    }
+
+    [Test]
+    public void GetBuildConfidencesAsync_NoProject()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        Assert.ThrowsAsync<DataNotFoundException>(() =>
+            env.Service.GetBuildConfidencesAsync(
+                User01,
+                "invalid_project_id",
+                ServalBuildId01,
+                isServalAdmin: false,
+                CancellationToken.None
+            )
+        );
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_NoContent()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+
+        // SUT
+        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+            User01,
+            Project01,
+            ServalBuildId01,
+            isServalAdmin: false,
+            CancellationToken.None
+        );
+
+        Assert.That(actual, Is.Null);
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_ServalAdminDoesNotNeedPermission()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
+
+        // SUT
+        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+            User02,
+            Project01,
+            ServalBuildId01,
+            isServalAdmin: true,
+            CancellationToken.None
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual.ProjectId, Is.EqualTo(Project01));
+            Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
+            Assert.That(actual.BookConfidences, Is.Not.Empty);
+            Assert.That(actual.ChapterConfidences, Is.Not.Empty);
+        }
+    }
+
+    [Test]
+    public async Task GetBuildConfidencesAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
+
+        // SUT
+        BuildConfidences actual = await env.Service.GetBuildConfidencesAsync(
+            User01,
+            Project01,
+            ServalBuildId01,
+            isServalAdmin: false,
+            CancellationToken.None
+        );
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual.ProjectId, Is.EqualTo(Project01));
+            Assert.That(actual.BuildId, Is.EqualTo(ServalBuildId01));
+            Assert.That(actual.BookConfidences, Is.Not.Empty);
+            Assert.That(actual.ChapterConfidences, Is.Not.Empty);
+        }
     }
 
     [Test]
@@ -3949,6 +4065,7 @@ public class MachineApiServiceTests
         env.ConfigureTranslationBuild(
             new TranslationBuild
             {
+                Id = ServalBuildId01,
                 State = JobState.Completed,
                 Pretranslate =
                 [
@@ -3957,7 +4074,7 @@ public class MachineApiServiceTests
             }
         );
         env.Service.Configure()
-            .UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
             .Throws(new TaskCanceledException());
 
         // SUT
@@ -3975,6 +4092,7 @@ public class MachineApiServiceTests
         env.ConfigureTranslationBuild(
             new TranslationBuild
             {
+                Id = ServalBuildId01,
                 State = JobState.Completed,
                 Pretranslate =
                 [
@@ -3983,14 +4101,16 @@ public class MachineApiServiceTests
             }
         );
         env.Service.Configure()
-            .UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
             .Returns(Task.CompletedTask);
         await env.ProjectSecrets.UpdateAsync(Project01, u => u.Set(p => p.ServalData!.PreTranslationsRetrieved, false));
 
         // SUT
         await env.Service.RetrievePreTranslationStatusAsync(Project01, CancellationToken.None);
 
-        await env.Service.DidNotReceive().UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env
+            .Service.DidNotReceive()
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
     }
 
     [Test]
@@ -4001,6 +4121,7 @@ public class MachineApiServiceTests
         env.ConfigureTranslationBuild(
             new TranslationBuild
             {
+                Id = ServalBuildId01,
                 State = JobState.Completed,
                 Pretranslate =
                 [
@@ -4009,7 +4130,9 @@ public class MachineApiServiceTests
             }
         );
         ServalApiException ex = ServalApiExceptions.Forbidden;
-        env.Service.Configure().UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None).Throws(ex);
+        env.Service.Configure()
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
+            .Throws(ex);
 
         // SUT
         Assert.ThrowsAsync<ServalApiException>(() =>
@@ -4066,6 +4189,7 @@ public class MachineApiServiceTests
         env.ConfigureTranslationBuild(
             new TranslationBuild
             {
+                Id = ServalBuildId01,
                 State = JobState.Completed,
                 Pretranslate =
                 [
@@ -4073,14 +4197,23 @@ public class MachineApiServiceTests
                 ],
             }
         );
+        env.EventMetricService.GetEventMetricsAsync(
+                Project01,
+                Arg.Any<EventScope[]?>(),
+                Arg.Any<string[]>(),
+                Arg.Any<DateTime>()
+            )
+            .Returns(Task.FromResult(env.GetEventMetricsForBuildCompleted(true)));
         env.Service.Configure()
-            .UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
             .Returns(Task.CompletedTask);
 
         // SUT
         await env.Service.RetrievePreTranslationStatusAsync(Project01, CancellationToken.None);
 
-        await env.Service.Received().UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env
+            .Service.Received()
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
     }
 
     [Test]
@@ -4091,6 +4224,7 @@ public class MachineApiServiceTests
         env.ConfigureTranslationBuild(
             new TranslationBuild
             {
+                Id = ServalBuildId01,
                 State = JobState.Completed,
                 Pretranslate =
                 [
@@ -4098,15 +4232,24 @@ public class MachineApiServiceTests
                 ],
             }
         );
+        env.EventMetricService.GetEventMetricsAsync(
+                Project01,
+                Arg.Any<EventScope[]?>(),
+                Arg.Any<string[]>(),
+                Arg.Any<DateTime>()
+            )
+            .Returns(Task.FromResult(env.GetEventMetricsForBuildCompleted(true)));
         env.Service.Configure()
-            .UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
             .Returns(Task.CompletedTask);
         await env.ProjectSecrets.UpdateAsync(Project01, u => u.Set(p => p.ServalData!.PreTranslationsRetrieved, true));
 
         // SUT
         await env.Service.RetrievePreTranslationStatusAsync(Project01, CancellationToken.None);
 
-        await env.Service.Received().UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env
+            .Service.Received()
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
     }
 
     [Test]
@@ -4162,7 +4305,7 @@ public class MachineApiServiceTests
             }
         );
         env.Service.Configure()
-            .UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            .UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
             .Returns(Task.CompletedTask);
         const string draftGenerationRequestId = "1234";
         env.SetDraftGenerationMetricAssociation(draftGenerationRequestId);
@@ -4994,7 +5137,7 @@ public class MachineApiServiceTests
         );
 
         // SUT
-        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
 
         await env
             .PreTranslationService.Received(1)
@@ -5019,7 +5162,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
         );
     }
 
@@ -5031,7 +5174,11 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync("invalid_project_id", CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(
+                "invalid_project_id",
+                ServalBuildId01,
+                CancellationToken.None
+            )
         );
     }
 
@@ -5043,7 +5190,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync(Project02, CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project02, ServalBuildId01, CancellationToken.None)
         );
     }
 
@@ -5055,7 +5202,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync(Project03, CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project03, ServalBuildId01, CancellationToken.None)
         );
     }
 
@@ -5071,8 +5218,57 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<DataNotFoundException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
         );
+    }
+
+    [Test]
+    public async Task UpdatePreTranslationTextDocumentsAsync_QualityEstimation()
+    {
+        // Set up test environment
+        var env = new TestEnvironment();
+        await env.SetupDraftMetricsAsync(Project01, ServalBuildId01, QualityEstimationConfig);
+        const int bookNum = 1;
+        const int chapterNum = 0;
+        string textDocumentId = TextDocument.GetDocId(Project01, bookNum, chapter: 1, TextDocument.Draft);
+        await env.SetupTextDocumentAsync(
+            textDocumentId,
+            bookNum,
+            chapterNum,
+            scriptureRange: "GEN",
+            alreadyExists: false
+        );
+
+        // SUT
+        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
+
+        await env
+            .PreTranslationService.Received(1)
+            .GetPreTranslationUsfmAsync(
+                Project01,
+                bookNum,
+                chapterNum,
+                Arg.Any<DraftUsfmConfig>(),
+                CancellationToken.None
+            );
+
+        await env
+            .PreTranslationService.Received(1)
+            .GetPreTranslationsAsync(Project01, bookNum, chapterNum: 1, CancellationToken.None);
+        env.ParatextService.Received(1).GetChaptersAsUsj(Arg.Any<UserSecret>(), Paratext01, bookNum, TestUsfm);
+        DraftMetrics draftMetrics = env.DraftMetrics.Get(DraftMetrics.GetDocId(Project01, ServalBuildId01));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await env.TextDocuments.CountDocumentsAsync(_ => true), Is.EqualTo(1));
+            Assert.That(env.TextDocuments.Get(textDocumentId).Content, Is.Not.Empty);
+            Assert.That(draftMetrics.BookConfidences, Has.Count.EqualTo(1));
+            Assert.That(draftMetrics.ChapterConfidences, Has.Count.EqualTo(1));
+            Assert.That(draftMetrics.VerseConfidences, Has.Count.EqualTo(1));
+            Assert.That(
+                draftMetrics.QualityEstimationConfig,
+                Is.EqualTo(QualityEstimationConfig).UsingPropertiesComparer()
+            );
+        }
     }
 
     [Test]
@@ -5091,7 +5287,7 @@ public class MachineApiServiceTests
         );
 
         // SUT
-        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
 
         await env
             .PreTranslationService.Received(1)
@@ -5115,7 +5311,7 @@ public class MachineApiServiceTests
 
         // SUT
         Assert.ThrowsAsync<ForbiddenException>(() =>
-            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None)
+            env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None)
         );
     }
 
@@ -5136,7 +5332,7 @@ public class MachineApiServiceTests
         );
 
         // SUT
-        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, CancellationToken.None);
+        await env.Service.UpdatePreTranslationTextDocumentsAsync(Project01, ServalBuildId01, CancellationToken.None);
 
         await env
             .PreTranslationService.Received(1)
@@ -5159,6 +5355,7 @@ public class MachineApiServiceTests
             BackgroundJobClient = Substitute.For<IBackgroundJobClient>();
             BackgroundJobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns(HangfireJobId);
             DeltaUsxMapper = Substitute.For<IDeltaUsxMapper>();
+            DraftMetrics = new MemoryRepository<DraftMetrics>();
             EventMetricService = Substitute.For<IEventMetricService>();
             ExceptionHandler = Substitute.For<IExceptionHandler>();
             var hubContext = Substitute.For<IHubContext<NotificationHub, INotifier>>();
@@ -5293,6 +5490,7 @@ public class MachineApiServiceTests
             Service = Substitute.ForPartsOf<MachineApiService>(
                 BackgroundJobClient,
                 DeltaUsxMapper,
+                DraftMetrics,
                 EventMetricService,
                 ExceptionHandler,
                 hubContext,
@@ -5322,6 +5520,7 @@ public class MachineApiServiceTests
         public MockLogger<MachineApiService> MockLogger { get; }
         public IParatextService ParatextService { get; }
         public IPreTranslationService PreTranslationService { get; }
+        public MemoryRepository<DraftMetrics> DraftMetrics { get; }
         public MemoryRepository<SFProject> Projects { get; }
         public MemoryRepository<SFProjectSecret> ProjectSecrets { get; }
         public MemoryRepository<TextDocument> TextDocuments { get; }
@@ -5773,6 +5972,22 @@ public class MachineApiServiceTests
                     CancellationToken.None
                 )
                 .Returns(Task.FromResult(TestUsfm));
+            int preTranslationChapterNum = chapterNum == 0 ? 1 : chapterNum;
+            PreTranslationService
+                .GetPreTranslationsAsync(Project01, bookNum, preTranslationChapterNum, CancellationToken.None)
+                .Returns(
+                    Task.FromResult(
+                        new[]
+                        {
+                            new PreTranslation
+                            {
+                                Reference = $"verse_{preTranslationChapterNum}_1",
+                                Translation = TestPreTranslation,
+                                Confidence = 0.6020749899712906,
+                            },
+                        }
+                    )
+                );
             ParatextService.GetChaptersAsUsj(Arg.Any<UserSecret>(), Paratext01, bookNum, TestUsfm).Returns([TestUsj]);
 
             if (alreadyExists)
@@ -5860,6 +6075,48 @@ public class MachineApiServiceTests
                 );
         }
 
+        public async Task SetupDraftMetricsAsync(
+            string sfProjectId,
+            string buildId,
+            QualityEstimationConfig qualityEstimationConfig
+        )
+        {
+            DraftMetrics.Add(
+                new DraftMetrics
+                {
+                    Id = Models.DraftMetrics.GetDocId(sfProjectId, buildId),
+                    QualityEstimationConfig = qualityEstimationConfig,
+                    BookConfidences =
+                    [
+                        new BookConfidence
+                        {
+                            BookNum = 1,
+                            Confidence = 0.6,
+                            Label = "Green",
+                            ProjectedChrF3 = 51.93,
+                            Usability = 0.765,
+                        },
+                    ],
+                    ChapterConfidences =
+                    [
+                        new ChapterConfidence
+                        {
+                            BookNum = 1,
+                            ChapterNum = 1,
+                            Confidence = 0.6,
+                            Label = "Green",
+                            ProjectedChrF3 = 51.93,
+                            Usability = 0.765,
+                        },
+                    ],
+                }
+            );
+            await Projects.UpdateAsync(
+                p => p.Id == sfProjectId,
+                u => u.Set(s => s.TranslateConfig.DraftConfig.QualityEstimationConfig, qualityEstimationConfig)
+            );
+        }
+
         public static void AssertCoreBuildProperties(TranslationBuild translationBuild, ServalBuildDto? actual)
         {
             string buildDtoId = $"{Project01}.{translationBuild.Id}";
@@ -5874,7 +6131,7 @@ public class MachineApiServiceTests
             Assert.AreEqual(MachineApi.GetEngineHref(Project01), actual.Engine.Href);
         }
 
-        /// <remarks>Either to test the empty situation, or because it is not important for the test.</remarks>
+        /// <summary>Used either to test the empty situation, or because it is not important for the test.</summary>
         public void SetEmptyDraftGenerationMetricAssociations()
         {
             // Mock for GetEventMetricsAsync in GetDraftGenerationRequestIdForBuildAsync

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -20,9 +20,8 @@ public class PreTranslationServiceTests
     private const string ParallelCorpus01 = "parallelCorpus01";
     private const string TranslationEngine01 = "translationEngine01";
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task GetPreTranslationParametersAsync_CompatibleWithLegacyCorpora(bool uploadParatextZipFile)
+    [Test]
+    public async Task GetPreTranslationParametersAsync_CompatibleWithLegacyCorpora()
     {
         // Set up test environment
         var env = new TestEnvironment();
@@ -38,19 +37,18 @@ public class PreTranslationServiceTests
                     },
                     {
                         Corpus01,
-                        new ServalCorpus { PreTranslate = true, UploadParatextZipFile = uploadParatextZipFile }
+                        new ServalCorpus { PreTranslate = true }
                     },
                 },
             }
         );
 
         // SUT
-        (string translationEngineId, string? corpusId, string? parallelCorpusId, bool useParatextVerseRef) =
+        (string translationEngineId, string? corpusId, string? parallelCorpusId) =
             await env.Service.GetPreTranslationParametersAsync(Project01);
         Assert.AreEqual(TranslationEngine01, translationEngineId);
         Assert.AreEqual(Corpus01, corpusId);
         Assert.IsNull(parallelCorpusId);
-        Assert.AreEqual(uploadParatextZipFile, useParatextVerseRef);
     }
 
     [Test]
@@ -67,12 +65,11 @@ public class PreTranslationServiceTests
         );
 
         // SUT
-        (string translationEngineId, string? corpusId, string? parallelCorpusId, bool useParatextVerseRef) =
+        (string translationEngineId, string? corpusId, string? parallelCorpusId) =
             await env.Service.GetPreTranslationParametersAsync(Project01);
         Assert.AreEqual(TranslationEngine01, translationEngineId);
         Assert.IsNull(corpusId);
         Assert.AreEqual(ParallelCorpus01, parallelCorpusId);
-        Assert.IsTrue(useParatextVerseRef);
     }
 
     [Test]
@@ -125,9 +122,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_LegacyCorpus()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true });
         env.TranslationEnginesClient.GetCorpusPretranslatedUsfmAsync(
                 id: Arg.Any<string>(),
                 corpusId: Arg.Any<string>(),
@@ -157,9 +152,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_ReturnsEntireBook()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         string usfm = await env.Service.GetPreTranslationUsfmAsync(
@@ -176,9 +169,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_ReturnsChapterOneWithIntroductoryMaterial()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         string usfm = await env.Service.GetPreTranslationUsfmAsync(
@@ -195,9 +186,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_ReturnsSpecificChapter()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         string usfm = await env.Service.GetPreTranslationUsfmAsync(
@@ -214,9 +203,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_ParagraphFormatSpecified()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         await env.Service.GetPreTranslationUsfmAsync(
@@ -292,9 +279,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_QuoteFormatSpecified()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         await env.Service.GetPreTranslationUsfmAsync(
@@ -347,9 +332,7 @@ public class PreTranslationServiceTests
     public async Task GetPreTranslationUsfmAsync_ReturnsEmptyStringForMissingChapter()
     {
         // Set up test environment
-        var env = new TestEnvironment(
-            new TestEnvironmentOptions { MockPreTranslationParameters = true, UseParatextZipFile = true }
-        );
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
 
         // SUT
         string usfm = await env.Service.GetPreTranslationUsfmAsync(
@@ -362,11 +345,41 @@ public class PreTranslationServiceTests
         Assert.IsEmpty(usfm);
     }
 
+    [Test]
+    public async Task GetVerseConfidencesAsync_LegacyCorpus()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockLegacyPreTranslationParameters = true });
+
+        // SUT
+        IEnumerable<VerseConfidence> actual = await env.Service.GetVerseConfidencesAsync(
+            Project01,
+            CancellationToken.None
+        );
+        Assert.IsEmpty(actual);
+    }
+
+    [Test]
+    public async Task GetVerseConfidencesAsync_Success()
+    {
+        // Set up test environment
+        var env = new TestEnvironment(new TestEnvironmentOptions { MockPreTranslationParameters = true });
+
+        // SUT
+        List<VerseConfidence> actual =
+        [
+            .. await env.Service.GetVerseConfidencesAsync(Project01, CancellationToken.None),
+        ];
+        Assert.That(actual, Has.Count.EqualTo(3));
+        Assert.That(actual[0], Is.EqualTo(new VerseConfidence(40, 1, "1", 0.2)).UsingPropertiesComparer());
+        Assert.That(actual[1], Is.EqualTo(new VerseConfidence(40, 1, "2", 0.4)).UsingPropertiesComparer());
+        Assert.That(actual[2], Is.EqualTo(new VerseConfidence(40, 1, "3", 0.7)).UsingPropertiesComparer());
+    }
+
     private class TestEnvironmentOptions
     {
         public bool MockLegacyPreTranslationParameters { get; init; }
         public bool MockPreTranslationParameters { get; init; }
-        public bool UseParatextZipFile { get; init; }
     }
 
     private class TestEnvironment
@@ -395,17 +408,72 @@ public class PreTranslationServiceTests
                     cancellationToken: CancellationToken.None
                 )
                 .Returns(MatthewBookUsfm);
+            TranslationEnginesClient
+                .GetAllPretranslationConfidencesAsync(
+                    id: Arg.Any<string>(),
+                    parallelCorpusId: Arg.Any<string>(),
+                    cancellationToken: CancellationToken.None
+                )
+                .Returns(
+                    Task.FromResult<IList<PretranslationConfidence>>([
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value with no references
+                            SourceRefs = [],
+                            TargetRefs = [],
+                            Confidence = 0.1,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value from a build of Serval before 1.18.0
+                            SourceRefs = [],
+                            TargetRefs = ["MAT 1:1"],
+                            Confidence = 0.2,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value with an invalid references
+                            SourceRefs = ["invalid_reference"],
+                            TargetRefs = ["invalid_reference"],
+                            Confidence = 0.3,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value from a segment
+                            SourceRefs = ["MAT 1:2/1:p"],
+                            TargetRefs = ["MAT 1:2/1:p"],
+                            Confidence = 0.4,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value from a segment that will be overridden by the verse
+                            SourceRefs = ["MAT 1:3/2:p"],
+                            TargetRefs = ["MAT 1:3/2:p"],
+                            Confidence = 0.5,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value from another  segment that will be overridden by the verse
+                            SourceRefs = ["MAT 1:3/3:p"],
+                            TargetRefs = ["MAT 1:3/3:p"],
+                            Confidence = 0.6,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value for a verse
+                            SourceRefs = ["MAT 1:3"],
+                            TargetRefs = ["MAT 1:3"],
+                            Confidence = 0.7,
+                        },
+                    ])
+                );
             Service = Substitute.ForPartsOf<PreTranslationService>(ProjectSecrets, TranslationEnginesClient);
             if (options.MockLegacyPreTranslationParameters)
             {
                 Service
                     .Configure()
                     .GetPreTranslationParametersAsync(Project01)
-                    .Returns(
-                        Task.FromResult<(string, string?, string?, bool)>(
-                            (TranslationEngine01, Corpus01, null, options.UseParatextZipFile)
-                        )
-                    );
+                    .Returns(Task.FromResult<(string, string?, string?)>((TranslationEngine01, Corpus01, null)));
             }
             else if (options.MockPreTranslationParameters)
             {
@@ -413,9 +481,7 @@ public class PreTranslationServiceTests
                     .Configure()
                     .GetPreTranslationParametersAsync(Project01)
                     .Returns(
-                        Task.FromResult<(string, string?, string?, bool)>(
-                            (TranslationEngine01, null, ParallelCorpus01, options.UseParatextZipFile)
-                        )
+                        Task.FromResult<(string, string?, string?)>((TranslationEngine01, null, ParallelCorpus01))
                     );
             }
         }

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -4090,7 +4090,8 @@ public class SFProjectServiceTests
         project = env.GetProject(Project01);
         Assert.That(
             project.TranslateConfig.DraftConfig.QualityEstimationConfig,
-            Is.EqualTo(qualityEstimationConfig).UsingPropertiesComparer()
+            Is.EqualTo(qualityEstimationConfig)
+                .UsingPropertiesComparer<QualityEstimationConfig>(c => c.Excluding(p => p.DateUpdated))
         );
     }
 

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "kb5kBe1HioGuH+ZDKysv/oAO9cCUW2yxtrGrRBZp/dIij5f011OfC4XiNMayZ8bGfOv2+n2ocPkaJIGppAZDEg=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
@@ -16,12 +16,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.5.1, )",
-        "resolved": "18.5.1",
-        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.1",
-          "Microsoft.TestPlatform.TestHost": "18.5.1"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "NSubstitute": {
@@ -35,9 +35,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.6.0, )",
-        "resolved": "4.6.0",
-        "contentHash": "RsafbuYR+HzdDhgfdLYrDOSuFdv8IgGpbe5NIqXWAhZ7t6lXNj9yNcLcAk34lKVio6OusBQolKlboyl/9hObNA=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -377,8 +377,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.DotNet.PlatformAbstractions": {
         "type": "Transitive",
@@ -784,8 +784,8 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "2.4.1",
-        "contentHash": "u7QhXCISMQuab3flasb1hoaiERmUqyWsW7tmQODyILoQ7mJV5IRGM+2KKZYo0QUfC13evEOcHAb6TPWgqEQtrw=="
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -830,15 +830,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -1328,44 +1328,44 @@
       },
       "Swashbuckle.AspNetCore": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "vgef8DPT411JU5JjHiDbr0WOxsIVuAvegPGtqmm4Na4JRl/264dfBJcGkiPHsAr5P+Vda+qN1rZKRtBl1rF9aA==",
+        "resolved": "10.2.1",
+        "contentHash": "SDU6akgCV/H4jFMRfyJ0mgO5jWOuuAqekvEThXg8c/LjnfNz5Nkaz+RUpeTVJKWIRX4wDKC/6R3ogJ4AsRE32A==",
         "dependencies": {
           "Microsoft.Extensions.ApiDescription.Server": "10.0.0",
-          "Swashbuckle.AspNetCore.Swagger": "10.1.7",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.1.7",
-          "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.1",
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1",
+          "Swashbuckle.AspNetCore.SwaggerUI": "10.2.1"
         }
       },
       "Swashbuckle.AspNetCore.Newtonsoft": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "5kOG8iV2LjNSAjaCBqKotkng3kQarSVaZeemUGRnv8selqx3qkJPO7j3cN36wFb5wzehNp0J2NTTkHFiUNFK0w==",
+        "resolved": "10.2.1",
+        "contentHash": "zL4aMBs4UxYwakaEccD6dYhTi609LO3dOwrib4KqkQUol3WMxeYI31SKeQzMJwy5qAsnN7Z84sFO3I4uKbvdYw==",
         "dependencies": {
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "10.0.0",
-          "Swashbuckle.AspNetCore.SwaggerGen": "10.1.7"
+          "Swashbuckle.AspNetCore.SwaggerGen": "10.2.1"
         }
       },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "EjLibt/d/QuRv170GoihTbcPUpgzSFm2WKHhnGJFZQ03JYzfuitsM79azaAR8NBwRunU7yScSX6HRE5JUlrEMQ==",
+        "resolved": "10.2.1",
+        "contentHash": "ej4inPhiWCq+0utG8yaKhIhE8M3k3R/qRaGhpgDZB+O/s+o62/zRMO1Cn2CtQccsrqPE9PYnzCp6hQGYGpJOyQ==",
         "dependencies": {
-          "Microsoft.OpenApi": "2.4.1"
+          "Microsoft.OpenApi": "2.7.5"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "PuubO9BjvNn6U3D9kLpuWKY1JtziWw7SsGBq0age1E50uQjQ8Fzl8s0EwzrLfANqYJNgDnJi9l7N1QxcGVB2Zw==",
+        "resolved": "10.2.1",
+        "contentHash": "JYX6i/y0xEtQWH/hZyfcage1/ldwww83ueD/gBc34uSnMwyvRLUsOpYcxlliFFxFbZMrY6t+R9ENqolE7zTEOg==",
         "dependencies": {
-          "Swashbuckle.AspNetCore.Swagger": "10.1.7"
+          "Swashbuckle.AspNetCore.Swagger": "10.2.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerUI": {
         "type": "Transitive",
-        "resolved": "10.1.7",
-        "contentHash": "iJo3ODyUb/M8Vm8AH1r9y9iAba0w95xsCn3zFVl96ISRHbTDWxi+l7oFVCZqUEdjd97B8VMDPnMliWAdomR8uw=="
+        "resolved": "10.2.1",
+        "contentHash": "vzB8ZAGqXus3fdareJ9GHctaRP9ZL+wW9x8U7s1Y+BWprInFvSg6rpD9VhANNpwXA8fUHqu5Agjl/+hHG1BCQA=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -1692,17 +1692,17 @@
           "SIL.Machine": "[3.8.3, )",
           "SIL.XForge": "[1.0.0, )",
           "Serval.Client": "[1.18.0, )",
-          "Swashbuckle.AspNetCore": "[10.1.7, )",
-          "Swashbuckle.AspNetCore.Newtonsoft": "[10.1.7, )"
+          "Swashbuckle.AspNetCore": "[10.2.1, )",
+          "Swashbuckle.AspNetCore.Newtonsoft": "[10.2.1, )"
         }
       },
       "sil.xforge.tests": {
         "type": "Project",
         "dependencies": {
           "JunitXml.TestLogger": "[8.0.0, )",
-          "Microsoft.NET.Test.Sdk": "[18.5.1, )",
+          "Microsoft.NET.Test.Sdk": "[18.6.0, )",
           "NSubstitute": "[5.3.0, )",
-          "NUnit": "[4.6.0, )",
+          "NUnit": "[4.6.1, )",
           "NUnit3TestAdapter": "[6.2.0, )",
           "SIL.XForge": "[1.0.0, )"
         }

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1275,8 +1275,8 @@
       },
       "SIL.Machine": {
         "type": "Transitive",
-        "resolved": "3.8.2",
-        "contentHash": "Uqv7nGmJZaubTI7VYibu6qEAQiDhoqAflGt6nA+pHOdLDhfZPWngCeJQeIWYVj/t+W1h6eFeyM7JbVoyHKgrZA==",
+        "resolved": "3.8.3",
+        "contentHash": "Vn85jnwrs4HmwU44xZdKEzZsJ/7IOVKw4Gbv8uMYpaEJQ00UFmG6C0skMP3EBg9fZP5vxYT7jMRirSULCa2Xaw==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",
@@ -1689,7 +1689,7 @@
           "ParatextData": "[9.5.0.24, )",
           "Polly": "[8.6.6, )",
           "SIL.Converters.Usj": "[1.0.0, )",
-          "SIL.Machine": "[3.8.2, )",
+          "SIL.Machine": "[3.8.3, )",
           "SIL.XForge": "[1.0.0, )",
           "Serval.Client": "[1.18.0, )",
           "Swashbuckle.AspNetCore": "[10.1.7, )",

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1275,8 +1275,8 @@
       },
       "SIL.Machine": {
         "type": "Transitive",
-        "resolved": "3.8.3",
-        "contentHash": "Vn85jnwrs4HmwU44xZdKEzZsJ/7IOVKw4Gbv8uMYpaEJQ00UFmG6C0skMP3EBg9fZP5vxYT7jMRirSULCa2Xaw==",
+        "resolved": "3.8.4",
+        "contentHash": "iyIGFWIneklLYaI856FuP7H097Gg8XsWgqaRrYTC6bd7YXjowrLzlK+oWqTiEQHdhWsA1M3A8wao800DDIrMVQ==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",
@@ -1689,7 +1689,7 @@
           "ParatextData": "[9.5.0.24, )",
           "Polly": "[8.6.6, )",
           "SIL.Converters.Usj": "[1.0.0, )",
-          "SIL.Machine": "[3.8.3, )",
+          "SIL.Machine": "[3.8.4, )",
           "SIL.XForge": "[1.0.0, )",
           "Serval.Client": "[1.18.0, )",
           "Swashbuckle.AspNetCore": "[10.2.1, )",

--- a/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
+++ b/test/SIL.XForge.Tests/SIL.XForge.Tests.csproj
@@ -21,14 +21,14 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JunitXml.TestLogger" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/SIL.XForge.Tests/packages.lock.json
+++ b/test/SIL.XForge.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "pmUxktztlMnsIvgHjzxG3fHRAXpqmZSA+W8dIsbVMfwI01SnBndrBIOE3Stg6987+o7HjBa62C4q5um3Ia6d9g=="
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "kb5kBe1HioGuH+ZDKysv/oAO9cCUW2yxtrGrRBZp/dIij5f011OfC4XiNMayZ8bGfOv2+n2ocPkaJIGppAZDEg=="
       },
       "JunitXml.TestLogger": {
         "type": "Direct",
@@ -16,12 +16,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.5.1, )",
-        "resolved": "18.5.1",
-        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "requested": "[18.6.0, )",
+        "resolved": "18.6.0",
+        "contentHash": "kAIBt0MsYR0o2RULmlW5BhQ1ha50aGEgLKG4f1p0kePBGLJCprqs3S+NxRrYN8UH7mSQRPKpeiH9mwPMEKUObQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.5.1",
-          "Microsoft.TestPlatform.TestHost": "18.5.1"
+          "Microsoft.CodeCoverage": "18.6.0",
+          "Microsoft.TestPlatform.TestHost": "18.6.0"
         }
       },
       "NSubstitute": {
@@ -35,9 +35,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.6.0, )",
-        "resolved": "4.6.0",
-        "contentHash": "RsafbuYR+HzdDhgfdLYrDOSuFdv8IgGpbe5NIqXWAhZ7t6lXNj9yNcLcAk34lKVio6OusBQolKlboyl/9hObNA=="
+        "requested": "[4.6.1, )",
+        "resolved": "4.6.1",
+        "contentHash": "xS4+YaBFUv1r8bcAbjitSfYaRZGfMwUiMdiaRziBXZpKgVxKDSHhjUn0mV5mObHGZRZq6eNa+WFWr3g8grj66A=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -268,8 +268,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+        "resolved": "18.6.0",
+        "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -489,15 +489,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+        "resolved": "18.6.0",
+        "contentHash": "gQTW4BIfM2ZLxixo9ITXoulLKjn20FiiHtqTsx9PENqTrX7368ZeJ5L0QZJyReXDWORPRV8jXwZR6Aar8JOyaA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.5.1",
-        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "resolved": "18.6.0",
+        "contentHash": "em1eLz5Q46+hsCtAXdXggWAPd9gQyT4ngdsQ7k1eWvQgpsjtS/wAOJ/5TteieFdiAvrEq1iVn00LtusAxRaVmQ==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Microsoft.TestPlatform.ObjectModel": "18.6.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },


### PR DESCRIPTION
This PR adds a card to the Serval Builds tab with Quality Estimation, allowing downloading of book and chapter data in a format very similar to SILNLP:

<img width="726" height="513" alt="image" src="https://github.com/user-attachments/assets/31656b3c-92c8-43ba-9cdb-24cfc7582efe" />


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3876)
<!-- Reviewable:end -->
