### PR TITLE
SF-3800 Show white label tab label

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -51,6 +51,7 @@ import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { issuesEmailTemplate, supportedBrowser } from 'xforge-common/utils';
 import versionData from '../../../version.json';
 import { environment } from '../environments/environment';
+import { BrandingService } from './core/branding.service';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
 import { roleCanAccessTranslate } from './core/models/sf-project-role-info';
 import { SFProjectUserConfigDoc } from './core/models/sf-project-user-config-doc';
@@ -137,6 +138,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
     private readonly pwaService: PwaService,
     private readonly themeService: ThemeService,
     private readonly fontService: FontService,
+    private readonly brandingService: BrandingService,
     onlineStatusService: OnlineStatusService,
     private destroyRef: DestroyRef
   ) {
@@ -291,7 +293,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
 
   async ngOnInit(): Promise<void> {
     await this.authService.loggedIn;
-    this.document.title = environment.siteName;
+    this.document.title = this.brandingService.siteName;
     this.loadingStarted();
     this.currentUserDoc = await this.userService.getCurrentUser();
     const userData: User | undefined = cloneDeep(this.currentUserDoc.data);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/branding.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/branding.service.ts
@@ -9,4 +9,8 @@ export class BrandingService {
   get useScriptureForgeBranding(): boolean {
     return this.locationService.host === new URL(environment.masterUrl).host;
   }
+
+  get siteName(): string {
+    return this.useScriptureForgeBranding ? environment.siteName : this.locationService.hostname;
+  }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.spec.ts
@@ -19,6 +19,7 @@ import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
 import { TestRealtimeService } from 'xforge-common/test-realtime.service';
 import { ChildViewContainerComponent, configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
 import { UserService } from 'xforge-common/user.service';
+import { BrandingService } from '../../core/branding.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { SF_TYPE_REGISTRY } from '../../core/models/sf-type-registry';
@@ -30,6 +31,7 @@ const mockedProjectService = mock(SFProjectService);
 const mockedNavigator = mock(Navigator);
 const mockedNoticeService = mock(NoticeService);
 const mockedUserService = mock(UserService);
+const mockedBrandingService = mock(BrandingService);
 
 enum TestUsers {
   CommunityChecker = 'user01',
@@ -47,7 +49,8 @@ describe('ShareDialogComponent', () => {
       { provide: NAVIGATOR, useMock: mockedNavigator },
       { provide: NoticeService, useMock: mockedNoticeService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: UserService, useMock: mockedUserService }
+      { provide: UserService, useMock: mockedUserService },
+      { provide: BrandingService, useMock: mockedBrandingService }
     ]
   }));
 
@@ -419,6 +422,7 @@ class TestEnvironment {
         }`
     );
     when(mockedProjectService.isProjectAdmin(projectId, TestUsers.Admin)).thenResolve(true);
+    when(mockedBrandingService.siteName).thenReturn('Scripture Forge');
 
     const config: MatDialogConfig<ShareDialogData> = {
       data: {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/share/share-dialog.component.ts
@@ -27,7 +27,7 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { UserService } from 'xforge-common/user.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
-import { environment } from '../../../environments/environment';
+import { BrandingService } from '../../core/branding.service';
 import { SF_DEFAULT_SHARE_ROLE, SF_DEFAULT_TRANSLATE_SHARE_ROLE } from '../../core/models/sf-project-role-info';
 import { ShareLinkType } from '../../core/models/share-link-type';
 import { SFProjectService } from '../../core/sf-project.service';
@@ -91,6 +91,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     private readonly noticeService: NoticeService,
     private readonly projectService: SFProjectService,
     private readonly onlineStatusService: OnlineStatusService,
+    private readonly brandingService: BrandingService,
     userService: UserService,
     private destroyRef: DestroyRef
   ) {
@@ -217,7 +218,7 @@ export class ShareDialogComponent extends ShareBaseComponent {
     const params = {
       inviteName: currentUser.data.displayName,
       projectName: this.projectDoc.data.name,
-      siteName: environment.siteName
+      siteName: this.brandingService.siteName
     };
     this.navigator
       .share({


### PR DESCRIPTION
This change update our app use the white label site name when the user is on a white label site. The primary reason was that the Scripture Forge name was listed as the label on the browser tab. I also clean up another instance where our site name was used. I marked this as testing not required since a developer can confirm this change.

<img width="849" height="481" alt="image" src="https://github.com/user-attachments/assets/8225d148-d6e6-4554-80fe-dffb408d8ad7" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3877)
<!-- Reviewable:end -->
