### PR TITLE
SF-2902 Prevent error when user is removed from a project

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -54,7 +54,6 @@ import { environment } from '../environments/environment';
 import { BrandingService } from './core/branding.service';
 import { SFProjectProfileDoc } from './core/models/sf-project-profile-doc';
 import { roleCanAccessTranslate } from './core/models/sf-project-role-info';
-import { SFProjectUserConfigDoc } from './core/models/sf-project-user-config-doc';
 import { SFProjectService } from './core/sf-project.service';
 import { NavigationComponent } from './navigation/navigation.component';
 import { GlobalNoticesComponent } from './shared/global-notices/global-notices.component';
@@ -109,7 +108,6 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
   protected isScreenTiny = false;
 
   private currentUserDoc?: UserDoc;
-  private projectUserConfigDoc?: SFProjectUserConfigDoc;
   private isLoggedInUserAnonymous: boolean = false;
   private _selectedProjectDoc?: SFProjectProfileDoc;
   private selectedProjectDeleteSub?: Subscription;
@@ -334,10 +332,7 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
         }
         this.projectFont = this.fontService.getFontFamilyFromProject(this._selectedProjectDoc.data);
         void this.userService.setCurrentProjectId(this.currentUserDoc!, this._selectedProjectDoc.id);
-        this.projectUserConfigDoc = await this.projectService.getUserConfig(
-          this._selectedProjectDoc.id,
-          this.currentUserDoc!.id
-        );
+
         if (this.selectedProjectDeleteSub != null) {
           this.selectedProjectDeleteSub.unsubscribe();
         }
@@ -371,15 +366,12 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
               void this.projectService.localDelete(this._selectedProjectDoc.id);
             }
 
-            if (this.projectUserConfigDoc != null) {
-              checkAppAccess(
-                this._selectedProjectDoc,
-                this.currentUserDoc.id,
-                this.projectUserConfigDoc,
-                this.locationService.pathname,
-                this.router
-              );
-            }
+            checkAppAccess(
+              this._selectedProjectDoc,
+              this.currentUserDoc.id,
+              this.locationService.pathname,
+              this.router
+            );
           }
         });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -11,7 +11,6 @@ import { isObj } from '../../type-utils';
 import { SelectableProject } from '../core/models/selectable-project';
 import { SFProjectProfileDoc } from '../core/models/sf-project-profile-doc';
 import { roleCanAccessCommunityChecking, roleCanAccessTranslate } from '../core/models/sf-project-role-info';
-import { SFProjectUserConfigDoc } from '../core/models/sf-project-user-config-doc';
 import { DraftSource } from '../translate/draft-generation/draft-source';
 
 /**
@@ -70,23 +69,12 @@ export function attributeFromMouseEvent(event: MouseEvent, nodeName: string, att
 export function checkAppAccess(
   projectDoc: SFProjectProfileDoc,
   userId: string,
-  projectUserConfigDoc: SFProjectUserConfigDoc,
   pathname: string,
   router: Router
 ): void {
   if (projectDoc.data == null) return;
   const projectRole = projectDoc.data.userRoles[userId] as SFProjectRole;
   const route = '/projects/' + projectDoc.id;
-
-  // Do this in a timeout to allow time for the project user config doc to be deleted if the user was removed entirely
-  setTimeout(() => {
-    if (projectUserConfigDoc.data == null) return;
-    // Remove the record of the selected task so 'Project Home' will not redirect there
-    void projectUserConfigDoc.submitJson0Op(op => {
-      op.unset(puc => puc.selectedTask!);
-      op.unset(puc => puc.selectedQuestionRef!);
-    });
-  }, 1000);
 
   if (pathname.includes('translate') && !roleCanAccessTranslate(projectRole)) {
     void router.navigateByUrl(route, { replaceUrl: true });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -75,13 +75,18 @@ export function checkAppAccess(
   router: Router
 ): void {
   if (projectDoc.data == null) return;
-  // Remove the record of the selected task so 'Project Home' will not redirect there
-  void projectUserConfigDoc.submitJson0Op(op => {
-    op.unset(puc => puc.selectedTask!);
-    op.unset(puc => puc.selectedQuestionRef!);
-  });
   const projectRole = projectDoc.data.userRoles[userId] as SFProjectRole;
   const route = '/projects/' + projectDoc.id;
+
+  // Do this in a timeout to allow time for the project user config doc to be deleted if the user was removed entirely
+  setTimeout(() => {
+    if (projectUserConfigDoc.data == null) return;
+    // Remove the record of the selected task so 'Project Home' will not redirect there
+    void projectUserConfigDoc.submitJson0Op(op => {
+      op.unset(puc => puc.selectedTask!);
+      op.unset(puc => puc.selectedQuestionRef!);
+    });
+  }, 1000);
 
   if (pathname.includes('translate') && !roleCanAccessTranslate(projectRole)) {
     void router.navigateByUrl(route, { replaceUrl: true });


### PR DESCRIPTION
When a user is removed from a project, the project user config doc takes time to be deleted. The problem is that if the project user config doc is not deleted before we check the doc, we fire ops to it and this results in an error shown to the user. It turns out we already have a check if the user has access a part of the app and do not need to unset the selected task. Removing that code will now prevent document deleted errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3878)
<!-- Reviewable:end -->
