### PR TITLE
serval-admin: serval-builds: show Problems

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/machine-api/build-dto.ts
@@ -22,6 +22,7 @@ export interface BuildExecutionData {
   pretranslateCount: number;
   sourceLanguageTag?: string;
   targetLanguageTag?: string;
+  warnings: string[];
 }
 
 /** Additional information about a Serval build. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.html
@@ -1,0 +1,34 @@
+<h2 mat-dialog-title>Problems for Serval build ID {{ data.servalBuildId }}</h2>
+
+<div mat-dialog-content class="problems-dialog-content">
+  @if (nonEmptySections.length > 0) {
+    @for (section of nonEmptySections; track section.heading) {
+      <div class="problems-dialog-section">
+        <div class="problems-dialog-section-header-row">
+          <div class="problems-dialog-section-header">{{ section.heading }}</div>
+          <app-copy [value]="sectionCopyValue(section)" tooltip="Copy section"></app-copy>
+        </div>
+        <ul class="problems-dialog-list">
+          @for (problem of section.problems; track $index) {
+            <li>
+              <span class="problems-dialog-message">{{ problem.message }}</span>
+            </li>
+          }
+        </ul>
+      </div>
+    }
+  } @else {
+    <div class="problems-dialog-empty">No problems detected</div>
+  }
+</div>
+
+<div mat-dialog-actions align="end" class="problems-dialog-actions">
+  <button mat-button (click)="copyAllToClipboard()">
+    <mat-icon>content_copy</mat-icon>
+    Copy all
+  </button>
+  <button mat-flat-button color="primary" mat-dialog-close>
+    <mat-icon>close</mat-icon>
+    Close
+  </button>
+</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.scss
@@ -1,0 +1,51 @@
+.problems-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: min(65vh, 600px);
+  overflow: auto;
+}
+
+.problems-dialog-section-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.problems-dialog-section-header {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.problems-dialog-list {
+  margin: 0 0 0 1.5em;
+  padding: 0;
+  word-break: break-word;
+}
+
+.problems-dialog-message {
+  white-space: pre-wrap;
+}
+
+.problems-dialog-empty {
+  color: var(--sf-text-secondary-color);
+}
+
+.problems-dialog-actions button mat-icon {
+  margin-right: 8px;
+}
+
+app-copy ::ng-deep {
+  .copy-button,
+  .copied,
+  .copy {
+    width: 1em;
+    height: 1em;
+    font-size: 1em;
+  }
+
+  .copy-button {
+    padding: 0;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
@@ -1,0 +1,65 @@
+import {
+  ServalBuildProblemsDialog,
+  ServalBuildProblemsDialogData,
+  ServalBuildProblemsDialogSection
+} from './serval-build-problems-dialog.component';
+import { BuildReportProblem } from './serval-build-report';
+
+describe('ServalBuildProblemsDialog', () => {
+  function createSection(heading: string, problems: BuildReportProblem[]): ServalBuildProblemsDialogSection {
+    return { heading: heading, problems: problems };
+  }
+
+  function createDialog(data: ServalBuildProblemsDialogData): ServalBuildProblemsDialog {
+    return new ServalBuildProblemsDialog(data);
+  }
+
+  it('sectionCopyValue returns section list entries with dash prefix', () => {
+    const section: ServalBuildProblemsDialogSection = createSection('Serval warnings', [
+      { source: 'serval', severity: 'warning', message: 'Low confidence' },
+      { source: 'serval', severity: 'warning', message: 'Missing data' }
+    ]);
+
+    const dialog: ServalBuildProblemsDialog = createDialog({ servalBuildId: 'build-id', sections: [section] });
+
+    expect(dialog.sectionCopyValue(section)).toBe('- Low confidence\n- Missing data');
+  });
+
+  it('copyAllValue returns full markdown content with title and sections', () => {
+    const dialog: ServalBuildProblemsDialog = createDialog({
+      servalBuildId: 'build-id',
+      sections: [
+        createSection('SF errors', [{ source: 'local', severity: 'error', message: 'SF failure' }]),
+        createSection('Serval warnings', [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
+      ]
+    });
+
+    const result: string = dialog.copyAllValue;
+
+    expect(result).toContain('# Problems with Serval build ID build-id');
+    expect(result).toContain('## SF errors');
+    expect(result).toContain('- SF failure');
+    expect(result).toContain('## Serval warnings');
+    expect(result).toContain('- Low confidence');
+  });
+
+  it('copyAllValue omits sections that have no problems', () => {
+    const dialog: ServalBuildProblemsDialog = createDialog({
+      servalBuildId: 'build-id',
+      sections: [
+        createSection('SF errors', []),
+        createSection('SF warnings', [{ source: 'local', severity: 'warning', message: 'Minor issue' }]),
+        createSection('Serval errors', []),
+        createSection('Serval warnings', [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
+      ]
+    });
+
+    const result: string = dialog.copyAllValue;
+
+    expect(result).not.toContain('## SF errors');
+    expect(result).toContain('## SF warnings');
+    expect(result).not.toContain('## Serval errors');
+    expect(result).toContain('## Serval warnings');
+    expect(result).not.toContain('None reported');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
@@ -7,10 +7,14 @@ import { BuildReportProblem } from './serval-build-report';
 
 describe('ServalBuildProblemsDialog', () => {
   const problemsHeader: string = '# Problems with Serval build ID build-id';
+  const sfErrorsHeaderInput: string = 'SF errors';
   const sfErrorsHeader: string = '## SF errors';
   const sfFailureItem: string = '- SF failure';
+  const sfWarningsHeaderInput: string = 'SF warnings';
   const sfWarningsHeader: string = '## SF warnings';
+  const servalErrorsHeaderInput: string = 'Serval errors';
   const servalErrorsHeader: string = '## Serval errors';
+  const servalWarningsHeaderInput: string = 'Serval warnings';
   const servalWarningsHeader: string = '## Serval warnings';
   const servalWarningItem: string = '- Low confidence';
   const noneReportedIndication: string = 'None reported';
@@ -24,7 +28,7 @@ describe('ServalBuildProblemsDialog', () => {
   }
 
   it('sectionCopyValue returns section list entries with dash prefix', () => {
-    const section: ServalBuildProblemsDialogSection = createSection('Serval warnings', [
+    const section: ServalBuildProblemsDialogSection = createSection(servalWarningsHeaderInput, [
       { source: 'serval', severity: 'warning', message: 'Low confidence' },
       { source: 'serval', severity: 'warning', message: 'Missing data' }
     ]);
@@ -38,8 +42,8 @@ describe('ServalBuildProblemsDialog', () => {
     const dialog: ServalBuildProblemsDialog = createDialog({
       servalBuildId: 'build-id',
       sections: [
-        createSection('SF errors', [{ source: 'local', severity: 'error', message: 'SF failure' }]),
-        createSection('Serval warnings', [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
+        createSection(sfErrorsHeaderInput, [{ source: 'local', severity: 'error', message: 'SF failure' }]),
+        createSection(servalWarningsHeaderInput, [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
       ]
     });
 
@@ -56,10 +60,10 @@ describe('ServalBuildProblemsDialog', () => {
     const dialog: ServalBuildProblemsDialog = createDialog({
       servalBuildId: 'build-id',
       sections: [
-        createSection('SF errors', []),
-        createSection('SF warnings', [{ source: 'local', severity: 'warning', message: 'Minor issue' }]),
-        createSection('Serval errors', []),
-        createSection('Serval warnings', [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
+        createSection(sfErrorsHeaderInput, []),
+        createSection(sfWarningsHeaderInput, [{ source: 'local', severity: 'warning', message: 'Minor issue' }]),
+        createSection(servalErrorsHeaderInput, []),
+        createSection(servalWarningsHeaderInput, [{ source: 'serval', severity: 'warning', message: 'Low confidence' }])
       ]
     });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.spec.ts
@@ -6,6 +6,15 @@ import {
 import { BuildReportProblem } from './serval-build-report';
 
 describe('ServalBuildProblemsDialog', () => {
+  const problemsHeader: string = '# Problems with Serval build ID build-id';
+  const sfErrorsHeader: string = '## SF errors';
+  const sfFailureItem: string = '- SF failure';
+  const sfWarningsHeader: string = '## SF warnings';
+  const servalErrorsHeader: string = '## Serval errors';
+  const servalWarningsHeader: string = '## Serval warnings';
+  const servalWarningItem: string = '- Low confidence';
+  const noneReportedIndication: string = 'None reported';
+
   function createSection(heading: string, problems: BuildReportProblem[]): ServalBuildProblemsDialogSection {
     return { heading: heading, problems: problems };
   }
@@ -36,11 +45,11 @@ describe('ServalBuildProblemsDialog', () => {
 
     const result: string = dialog.copyAllValue;
 
-    expect(result).toContain('# Problems with Serval build ID build-id');
-    expect(result).toContain('## SF errors');
-    expect(result).toContain('- SF failure');
-    expect(result).toContain('## Serval warnings');
-    expect(result).toContain('- Low confidence');
+    expect(result).toContain(problemsHeader);
+    expect(result).toContain(sfErrorsHeader);
+    expect(result).toContain(sfFailureItem);
+    expect(result).toContain(servalWarningsHeader);
+    expect(result).toContain(servalWarningItem);
   });
 
   it('copyAllValue omits sections that have no problems', () => {
@@ -56,10 +65,10 @@ describe('ServalBuildProblemsDialog', () => {
 
     const result: string = dialog.copyAllValue;
 
-    expect(result).not.toContain('## SF errors');
-    expect(result).toContain('## SF warnings');
-    expect(result).not.toContain('## Serval errors');
-    expect(result).toContain('## Serval warnings');
-    expect(result).not.toContain('None reported');
+    expect(result).not.toContain(sfErrorsHeader);
+    expect(result).toContain(sfWarningsHeader);
+    expect(result).not.toContain(servalErrorsHeader);
+    expect(result).toContain(servalWarningsHeader);
+    expect(result).not.toContain(noneReportedIndication);
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.ts
@@ -1,0 +1,61 @@
+import { Component, Inject } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import { MatIcon } from '@angular/material/icon';
+import { CopyComponent } from 'xforge-common/copy/copy.component';
+import { BuildReportProblem } from './serval-build-report';
+
+/** A section in the Serval build problems dialog. */
+export interface ServalBuildProblemsDialogSection {
+  heading: string;
+  problems: BuildReportProblem[];
+}
+
+/** Data passed to the Serval build problems dialog. */
+export interface ServalBuildProblemsDialogData {
+  servalBuildId: string;
+  sections: ServalBuildProblemsDialogSection[];
+}
+
+/** Displays problems for a Serval build. */
+@Component({
+  selector: 'app-serval-build-problems-dialog',
+  templateUrl: './serval-build-problems-dialog.component.html',
+  styleUrls: ['./serval-build-problems-dialog.component.scss'],
+  imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatButton, MatDialogClose, MatIcon, CopyComponent]
+})
+export class ServalBuildProblemsDialog {
+  constructor(@Inject(MAT_DIALOG_DATA) readonly data: ServalBuildProblemsDialogData) {}
+
+  get nonEmptySections(): ServalBuildProblemsDialogSection[] {
+    return this.data.sections.filter((section: ServalBuildProblemsDialogSection) => section.problems.length > 0);
+  }
+
+  /** Returns the set of problems in text to be copied to the clipboard. */
+  get copyAllValue(): string {
+    let text: string = `# Problems with Serval build ID ${this.data.servalBuildId}\n`;
+
+    for (const section of this.nonEmptySections) {
+      text += `\n## ${section.heading}\n\n`;
+      text += `${this.sectionCopyValue(section)}\n`;
+    }
+
+    return text;
+  }
+
+  /** Returns the set of problems in a section in text to be copied to the clipboard. */
+  sectionCopyValue(section: ServalBuildProblemsDialogSection): string {
+    return section.problems.map((problem: BuildReportProblem) => `- ${problem.message}`).join('\n');
+  }
+
+  /** Copies all problems to the clipboard. */
+  copyAllToClipboard(): void {
+    void navigator.clipboard.writeText(this.copyAllValue);
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-problems-dialog.component.ts
@@ -37,7 +37,6 @@ export class ServalBuildProblemsDialog {
     return this.data.sections.filter((section: ServalBuildProblemsDialogSection) => section.problems.length > 0);
   }
 
-  /** Returns the set of problems in text to be copied to the clipboard. */
   get copyAllValue(): string {
     let text: string = `# Problems with Serval build ID ${this.data.servalBuildId}\n`;
 
@@ -49,12 +48,10 @@ export class ServalBuildProblemsDialog {
     return text;
   }
 
-  /** Returns the set of problems in a section in text to be copied to the clipboard. */
   sectionCopyValue(section: ServalBuildProblemsDialogSection): string {
     return section.problems.map((problem: BuildReportProblem) => `- ${problem.message}`).join('\n');
   }
 
-  /** Copies all problems to the clipboard. */
   copyAllToClipboard(): void {
     void navigator.clipboard.writeText(this.copyAllValue);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -12,10 +12,25 @@ export interface ServalBuildReportDto {
   project: BuildReportProject | undefined;
   timeline: BuildReportTimeline;
   config: BuildReportConfig;
-  problems: string[];
+  problems: BuildReportProblem[];
   draftGenerationRequestId: string | undefined;
   requesterSFUserId: string | undefined;
   status: DraftGenerationBuildStatus;
+}
+
+export type BuildReportProblemSource = 'local' | 'serval';
+function isBuildReportProblemSource(value: unknown): value is BuildReportProblemSource {
+  return value === 'local' || value === 'serval';
+}
+export type BuildReportProblemSeverity = 'warning' | 'error';
+function isBuildReportProblemSeverity(value: unknown): value is BuildReportProblemSeverity {
+  return value === 'warning' || value === 'error';
+}
+
+export interface BuildReportProblem {
+  source: BuildReportProblemSource;
+  severity: BuildReportProblemSeverity;
+  message: string;
 }
 
 /** SF project information for a build report entry.*/
@@ -93,6 +108,12 @@ export function interpretTypes(report: ServalBuildReportDto): ServalBuildReportD
     ...phase,
     started: parseDate(phase.started)
   }));
+  report.problems.forEach((problem: BuildReportProblem) => {
+    if (!isBuildReportProblemSource(problem.source))
+      throw Error(`Unknown BuildReportProblemSource when interpreting DTO: ${problem.source}`);
+    if (!isBuildReportProblemSeverity(problem.severity))
+      throw Error(`Unknown BuildReportProblemSeverity when interpreting DTO: ${problem.severity}`);
+  });
 
   return {
     ...report,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -114,8 +114,9 @@
                 >
                   {{ statusIcon(row.report.status) }}
                 </mat-icon>
-                @if (row.report.problems.length > 0) {
-                  <mat-icon class="problem-badge" [matTooltip]="row.report.problems.join('; ')">warning</mat-icon>
+                <!-- Don't also show the problem badge if already showing the faulted indication. -->
+                @if (row.report.problems.length > 0 && row.report.status !== DraftGenerationBuildStatus.Faulted) {
+                  <mat-icon class="problem-badge" [matTooltip]="problemsBadgeTooltip(row)">warning</mat-icon>
                 }
               </div>
             </div>
@@ -451,6 +452,84 @@
                         ></div>
                       }
                     </div>
+                  </mat-card-content>
+                </mat-card>
+
+                <mat-card appearance="filled" class="detail-card problems-card">
+                  <mat-card-header>
+                    <mat-card-title-group>
+                      <mat-icon>warning</mat-icon>
+                      <mat-card-title>Problems</mat-card-title>
+                    </mat-card-title-group>
+                  </mat-card-header>
+                  <mat-card-content class="detail-card-content">
+                    @let sfErrors = problems(row, "local", "error");
+                    @let sfWarnings = problems(row, "local", "warning");
+                    @let servalErrors = problems(row, "serval", "error");
+                    @let servalWarnings = problems(row, "serval", "warning");
+                    <div class="problems-sections">
+                      @if (!hasAnyProblems(row)) {
+                        <div class="problems-section">
+                          <span class="problems-none">No problems detected</span>
+                        </div>
+                      }
+                      @if (sfErrors.length > 0) {
+                        <div class="problems-section">
+                          <span class="problems-section-header">SF errors</span>
+                          <ul class="problems-list">
+                            @for (message of renderProblemMessagesForCard(sfErrors); track $index) {
+                              <li>
+                                <span class="problem-message">{{ message }}</span>
+                              </li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                      @if (sfWarnings.length > 0) {
+                        <div class="problems-section">
+                          <span class="problems-section-header">SF warnings</span>
+                          <ul class="problems-list">
+                            @for (message of renderProblemMessagesForCard(sfWarnings); track $index) {
+                              <li>
+                                <span class="problem-message">{{ message }}</span>
+                              </li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                      @if (servalErrors.length > 0) {
+                        <div class="problems-section">
+                          <span class="problems-section-header">Serval errors</span>
+                          <ul class="problems-list">
+                            @for (message of renderProblemMessagesForCard(servalErrors); track $index) {
+                              <li>
+                                <span class="problem-message">{{ message }}</span>
+                              </li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                      @if (servalWarnings.length > 0) {
+                        <div class="problems-section">
+                          <span class="problems-section-header">Serval warnings</span>
+                          <ul class="problems-list">
+                            @for (message of renderProblemMessagesForCard(servalWarnings); track $index) {
+                              <li>
+                                <span class="problem-message">{{ message }}</span>
+                              </li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                    </div>
+                    @if (hasAnyProblems(row)) {
+                      <div class="problems-actions">
+                        <button mat-button class="show-all-problems-button" (click)="showAllProblems(row)">
+                          <mat-icon>list</mat-icon>
+                          Show all
+                        </button>
+                      </div>
+                    }
                   </mat-card-content>
                 </mat-card>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -449,6 +449,49 @@ a {
   margin-top: 8px;
 }
 
+.problems-section {
+  margin-bottom: 0.5em;
+}
+
+.problems-section-header {
+  font-weight: 600;
+}
+
+.problems-list {
+  margin: 0.25em 0 0 1.5em;
+  padding: 0;
+}
+
+.problem-message {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.problems-card {
+  display: flex;
+  flex-direction: column;
+
+  .detail-card-content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+}
+
+.problems-sections {
+  display: flex;
+  flex-direction: column;
+}
+
+.problems-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: auto;
+}
+
 .details-dialog-button {
   mat-icon {
     margin-right: 8px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1545,7 +1545,7 @@ describe('ServalBuildsComponent', () => {
       expect(env.component['hasAnyProblems'](row)).toBeTrue();
     });
 
-    it('problemsBySource filters to origin', () => {
+    it('problems filters by origin and severity', () => {
       const env = new TestEnvironment();
       const problems: BuildReportProblem[] = [
         { source: 'local', severity: 'error', message: 'SF error' },
@@ -1627,7 +1627,7 @@ describe('ServalBuildsComponent', () => {
       expect(preview[limit]).toEqual('…');
     });
 
-    it('problemMessagesForCard returns all messages when not too many', () => {
+    it('renderProblemMessagesForCard returns all messages when not too many', () => {
       const env = new TestEnvironment();
       const problems: BuildReportProblem[] = [
         { source: 'local', severity: 'error', message: 'Message 1' },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -21,8 +21,10 @@ import { DraftGenerationService } from '../translate/draft-generation/draft-gene
 import { NormalizedDateRange } from './date-range-picker.component';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { ServalAdministrationService } from './serval-administration.service';
+import { ServalBuildProblemsDialog } from './serval-build-problems-dialog.component';
 import {
   buildProjectDisplayName,
+  BuildReportProblem,
   BuildReportTimeline,
   DraftGenerationBuildStatus,
   ProjectBooks,
@@ -209,7 +211,7 @@ describe('ServalBuildsComponent', () => {
           requesterId: 'user-2',
           trainingBooks: env.createProjectBooks('proj-a', ['ROM', '1CO', '2CO']),
           translationBooks: env.createProjectBooks('proj-a', ['MAT', 'LUK']),
-          problems: ['Low confidence'],
+          problems: [{ source: 'serval', severity: 'warning', message: 'Low confidence' }],
           status: DraftGenerationBuildStatus.Completed
         }),
         TestEnvironment.createRowWithDetails({
@@ -1521,6 +1523,148 @@ describe('ServalBuildsComponent', () => {
       verify(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).once();
     });
   });
+
+  describe('problems', () => {
+    function createRowWithProblems(problems: BuildReportProblem[]): ServalBuildRow {
+      return TestEnvironment.createRowWithDetails({ problems: problems, startDate: new Date('2026-01-01T00:00:00Z') });
+    }
+
+    it('hasAnyProblems returns false when no problems are present', () => {
+      const env = new TestEnvironment();
+      const row: ServalBuildRow = createRowWithProblems([]);
+
+      expect(env.component['hasAnyProblems'](row)).toBeFalse();
+    });
+
+    it('hasAnyProblems returns true when at least one problem is present', () => {
+      const env = new TestEnvironment();
+      const row: ServalBuildRow = createRowWithProblems([
+        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' }
+      ]);
+
+      expect(env.component['hasAnyProblems'](row)).toBeTrue();
+    });
+
+    it('problemsBySource filters to origin', () => {
+      const env = new TestEnvironment();
+      const problems: BuildReportProblem[] = [
+        { source: 'local', severity: 'error', message: 'SF error' },
+        { source: 'local', severity: 'warning', message: 'SF warning 2' },
+        { source: 'local', severity: 'warning', message: 'SF warning' },
+        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
+        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
+        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
+        { source: 'serval', severity: 'warning', message: 'Missing data' },
+        { source: 'serval', severity: 'warning', message: 'Serval warning' },
+        { source: 'serval', severity: 'warning', message: 'Serval warning' },
+        { source: 'serval', severity: 'warning', message: 'Serval warning' }
+      ];
+      const row: ServalBuildRow = createRowWithProblems(problems);
+
+      expect(env.component['problems'](row, 'local', 'error').length).toBe(1);
+      expect(env.component['problems'](row, 'local', 'warning').length).toBe(2);
+      expect(env.component['problems'](row, 'serval', 'error').length).toBe(3);
+      expect(env.component['problems'](row, 'serval', 'warning').length).toBe(4);
+    });
+
+    it('problemsBadgeTooltip joins all problem messages', () => {
+      const env = new TestEnvironment();
+      const problems: BuildReportProblem[] = [
+        { source: 'local', severity: 'error', message: 'No Serval build' },
+        { source: 'serval', severity: 'warning', message: 'Low confidence' }
+      ];
+      const row: ServalBuildRow = createRowWithProblems(problems);
+
+      const tooltip: string = env.component['problemsBadgeTooltip'](row);
+
+      expect(tooltip).toBe('No Serval build. Low confidence');
+    });
+
+    it('problemSections keeps full untruncated problem text', () => {
+      const env = new TestEnvironment();
+      const fullMessage = 'This is a very long Serval warning message that must not be truncated in the dialog.';
+      const problems: BuildReportProblem[] = [
+        { source: 'local', severity: 'error', message: 'SF build failed with unrecoverable error state' },
+        { source: 'serval', severity: 'warning', message: fullMessage }
+      ];
+      const row: ServalBuildRow = createRowWithProblems(problems);
+
+      const sections: { heading: string; problems: BuildReportProblem[] }[] = env.component['problemSections'](row);
+
+      expect(sections[0].heading).toBe('SF errors');
+      expect(sections[0].problems[0].message).toBe('SF build failed with unrecoverable error state');
+      expect(sections[1].heading).toBe('SF warnings');
+      // There are no SF warnings.
+      expect(sections[1].problems.length).toBe(0);
+      expect(sections[2].heading).toBe('Serval errors');
+      // There are no Serval errors.
+      expect(sections[2].problems.length).toBe(0);
+      expect(sections[3].heading).toBe('Serval warnings');
+      expect(sections[3].problems[0].message).toBe(fullMessage);
+    });
+
+    it('renderProblemMessagesForCard limits returned amount of problems', () => {
+      const env = new TestEnvironment();
+      const problems: BuildReportProblem[] = [
+        { source: 'serval', severity: 'warning', message: 'Message 1' },
+        { source: 'serval', severity: 'warning', message: 'Message 2' },
+        { source: 'serval', severity: 'warning', message: 'Message 3' },
+        { source: 'serval', severity: 'warning', message: 'Message 4' },
+        { source: 'serval', severity: 'warning', message: 'Message 5' },
+        { source: 'serval', severity: 'warning', message: 'Message 6' },
+        { source: 'serval', severity: 'warning', message: 'Message 7' },
+        { source: 'serval', severity: 'warning', message: 'Message 8' },
+        { source: 'serval', severity: 'warning', message: 'Message 9' },
+        { source: 'serval', severity: 'warning', message: 'Message 10' },
+        { source: 'serval', severity: 'warning', message: 'Message 11' },
+        { source: 'serval', severity: 'warning', message: 'Message 12' }
+      ];
+
+      const preview: string[] = env.component['renderProblemMessagesForCard'](problems);
+      const limit: number = env.component.problemPreviewLimit;
+      const ellipsisItem: number = 1;
+      expect(preview.length).toBe(limit + ellipsisItem);
+      expect(preview[limit]).toEqual('…');
+    });
+
+    it('problemMessagesForCard returns all messages when not too many', () => {
+      const env = new TestEnvironment();
+      const problems: BuildReportProblem[] = [
+        { source: 'local', severity: 'error', message: 'Message 1' },
+        { source: 'local', severity: 'error', message: 'Message 2' }
+      ];
+
+      const preview: string[] = env.component['renderProblemMessagesForCard'](problems);
+      expect(preview.length).toBe(2);
+      expect(preview).toEqual(['Message 1', 'Message 2']);
+    });
+
+    it('showAllProblems opens serval build problems dialog', () => {
+      const env = new TestEnvironment();
+      let componentArg: any;
+      let configArg: any;
+      when(mockDialogService.openMatDialog(anything(), anything())).thenCall((component: any, config: any) => {
+        componentArg = component;
+        configArg = config;
+        return undefined as never;
+      });
+      const problems: BuildReportProblem[] = [
+        { source: 'local', severity: 'warning', message: 'SF warning message' },
+        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' }
+      ];
+      const row: ServalBuildRow = createRowWithProblems(problems);
+
+      env.component['showAllProblems'](row);
+
+      verify(mockDialogService.openMatDialog(anything(), anything())).once();
+      expect(componentArg).toBe(ServalBuildProblemsDialog);
+      expect(configArg.data.sections.length).toBe(4);
+      expect(configArg.data.sections[0].heading).toBe('SF errors');
+      expect(configArg.data.sections[1].heading).toBe('SF warnings');
+      expect(configArg.data.sections[2].heading).toBe('Serval errors');
+      expect(configArg.data.sections[3].heading).toBe('Serval warnings');
+    });
+  });
 });
 
 /** Provides helpers for constructing test data for ServalBuildsComponent tests. */
@@ -1547,7 +1691,11 @@ class TestEnvironment {
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
     when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);
     when(mockDraftGenerationService.getBuildsSince(anything())).thenReturn(this.builds$);
-    when(mockDialogService.openMatDialog(anything(), anything(), anything())).thenReturn(undefined as never);
+    when(mockDialogService.openMatDialog(anything(), anything())).thenReturn(undefined as never);
+    when(mockDialogService.openGenericDialog(anything())).thenReturn({
+      dialogRef: undefined as never,
+      result: Promise.resolve(undefined)
+    } as never);
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
@@ -1677,7 +1825,7 @@ class TestEnvironment {
     trainingBooks?: ProjectBooks[];
     translationBooks?: ProjectBooks[];
     status?: DraftGenerationBuildStatus;
-    problems?: string[];
+    problems?: BuildReportProblem[];
     sfUserRequestTime?: Date;
     sfAcknowledgedTime?: Date;
     hasServalBuild?: boolean;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1533,7 +1533,7 @@ describe('ServalBuildsComponent', () => {
       const env = new TestEnvironment();
       const row: ServalBuildRow = createRowWithProblems([]);
 
-      expect(env.component['hasAnyProblems'](row)).toBeFalse();
+      expect(env.component.hasAnyProblems(row)).toBeFalse();
     });
 
     it('hasAnyProblems returns true when at least one problem is present', () => {
@@ -1542,7 +1542,7 @@ describe('ServalBuildsComponent', () => {
         { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' }
       ]);
 
-      expect(env.component['hasAnyProblems'](row)).toBeTrue();
+      expect(env.component.hasAnyProblems(row)).toBeTrue();
     });
 
     it('problems filters by origin and severity', () => {
@@ -1561,10 +1561,10 @@ describe('ServalBuildsComponent', () => {
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
-      expect(env.component['problems'](row, 'local', 'error').length).toBe(1);
-      expect(env.component['problems'](row, 'local', 'warning').length).toBe(2);
-      expect(env.component['problems'](row, 'serval', 'error').length).toBe(3);
-      expect(env.component['problems'](row, 'serval', 'warning').length).toBe(4);
+      expect(env.component.problems(row, 'local', 'error').length).toBe(1);
+      expect(env.component.problems(row, 'local', 'warning').length).toBe(2);
+      expect(env.component.problems(row, 'serval', 'error').length).toBe(3);
+      expect(env.component.problems(row, 'serval', 'warning').length).toBe(4);
     });
 
     it('problemsBadgeTooltip joins all problem messages', () => {
@@ -1575,7 +1575,7 @@ describe('ServalBuildsComponent', () => {
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
-      const tooltip: string = env.component['problemsBadgeTooltip'](row);
+      const tooltip: string = env.component.problemsBadgeTooltip(row);
 
       expect(tooltip).toBe('No Serval build. Low confidence');
     });
@@ -1589,7 +1589,7 @@ describe('ServalBuildsComponent', () => {
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
-      const sections: { heading: string; problems: BuildReportProblem[] }[] = env.component['problemSections'](row);
+      const sections: { heading: string; problems: BuildReportProblem[] }[] = env.component.problemSections(row);
 
       expect(sections[0].heading).toBe('SF errors');
       expect(sections[0].problems[0].message).toBe('SF build failed with unrecoverable error state');
@@ -1620,7 +1620,7 @@ describe('ServalBuildsComponent', () => {
         { source: 'serval', severity: 'warning', message: 'Message 12' }
       ];
 
-      const preview: string[] = env.component['renderProblemMessagesForCard'](problems);
+      const preview: string[] = env.component.renderProblemMessagesForCard(problems);
       const limit: number = env.component.problemPreviewLimit;
       const ellipsisItem: number = 1;
       expect(preview.length).toBe(limit + ellipsisItem);
@@ -1634,7 +1634,7 @@ describe('ServalBuildsComponent', () => {
         { source: 'local', severity: 'error', message: 'Message 2' }
       ];
 
-      const preview: string[] = env.component['renderProblemMessagesForCard'](problems);
+      const preview: string[] = env.component.renderProblemMessagesForCard(problems);
       expect(preview.length).toBe(2);
       expect(preview).toEqual(['Message 1', 'Message 2']);
     });
@@ -1654,7 +1654,7 @@ describe('ServalBuildsComponent', () => {
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
-      env.component['showAllProblems'](row);
+      env.component.showAllProblems(row);
 
       verify(mockDialogService.openMatDialog(anything(), anything())).once();
       expect(componentArg).toBe(ServalBuildProblemsDialog);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1525,6 +1525,20 @@ describe('ServalBuildsComponent', () => {
   });
 
   describe('problems', () => {
+    const headingSFErrors: string = 'SF errors';
+    const headingSFWarnings: string = 'SF warnings';
+    const headingServalErrors: string = 'Serval errors';
+    const headingServalWarnings: string = 'Serval warnings';
+
+    const msgSFError: string = 'SF error';
+    const msgSFWarning: string = 'SF warning';
+    const msgSFWarning2: string = 'SF warning 2';
+    const msgFaulted: string = 'Faulted: Engine crashed';
+    const msgMissingData: string = 'Missing data';
+    const msgServalWarning: string = 'Serval warning';
+    const msgMessage1: string = 'Message 1';
+    const msgMessage2: string = 'Message 2';
+
     function createRowWithProblems(problems: BuildReportProblem[]): ServalBuildRow {
       return TestEnvironment.createRowWithDetails({ problems: problems, startDate: new Date('2026-01-01T00:00:00Z') });
     }
@@ -1538,9 +1552,7 @@ describe('ServalBuildsComponent', () => {
 
     it('hasAnyProblems returns true when at least one problem is present', () => {
       const env = new TestEnvironment();
-      const row: ServalBuildRow = createRowWithProblems([
-        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' }
-      ]);
+      const row: ServalBuildRow = createRowWithProblems([{ source: 'serval', severity: 'error', message: msgFaulted }]);
 
       expect(env.component.hasAnyProblems(row)).toBeTrue();
     });
@@ -1548,16 +1560,16 @@ describe('ServalBuildsComponent', () => {
     it('problems filters by origin and severity', () => {
       const env = new TestEnvironment();
       const problems: BuildReportProblem[] = [
-        { source: 'local', severity: 'error', message: 'SF error' },
-        { source: 'local', severity: 'warning', message: 'SF warning 2' },
-        { source: 'local', severity: 'warning', message: 'SF warning' },
-        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
-        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
-        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' },
-        { source: 'serval', severity: 'warning', message: 'Missing data' },
-        { source: 'serval', severity: 'warning', message: 'Serval warning' },
-        { source: 'serval', severity: 'warning', message: 'Serval warning' },
-        { source: 'serval', severity: 'warning', message: 'Serval warning' }
+        { source: 'local', severity: 'error', message: msgSFError },
+        { source: 'local', severity: 'warning', message: msgSFWarning2 },
+        { source: 'local', severity: 'warning', message: msgSFWarning },
+        { source: 'serval', severity: 'error', message: msgFaulted },
+        { source: 'serval', severity: 'error', message: msgFaulted },
+        { source: 'serval', severity: 'error', message: msgFaulted },
+        { source: 'serval', severity: 'warning', message: msgMissingData },
+        { source: 'serval', severity: 'warning', message: msgServalWarning },
+        { source: 'serval', severity: 'warning', message: msgServalWarning },
+        { source: 'serval', severity: 'warning', message: msgServalWarning }
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
@@ -1570,36 +1582,36 @@ describe('ServalBuildsComponent', () => {
     it('problemsBadgeTooltip joins all problem messages', () => {
       const env = new TestEnvironment();
       const problems: BuildReportProblem[] = [
-        { source: 'local', severity: 'error', message: 'No Serval build' },
-        { source: 'serval', severity: 'warning', message: 'Low confidence' }
+        { source: 'local', severity: 'error', message: msgSFError },
+        { source: 'serval', severity: 'warning', message: msgServalWarning }
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
       const tooltip: string = env.component.problemsBadgeTooltip(row);
 
-      expect(tooltip).toBe('No Serval build. Low confidence');
+      expect(tooltip).toBe(`${msgSFError}. ${msgServalWarning}`);
     });
 
     it('problemSections keeps full untruncated problem text', () => {
       const env = new TestEnvironment();
       const fullMessage = 'This is a very long Serval warning message that must not be truncated in the dialog.';
       const problems: BuildReportProblem[] = [
-        { source: 'local', severity: 'error', message: 'SF build failed with unrecoverable error state' },
+        { source: 'local', severity: 'error', message: msgSFError },
         { source: 'serval', severity: 'warning', message: fullMessage }
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
       const sections: { heading: string; problems: BuildReportProblem[] }[] = env.component.problemSections(row);
 
-      expect(sections[0].heading).toBe('SF errors');
-      expect(sections[0].problems[0].message).toBe('SF build failed with unrecoverable error state');
-      expect(sections[1].heading).toBe('SF warnings');
+      expect(sections[0].heading).toBe(headingSFErrors);
+      expect(sections[0].problems[0].message).toBe(msgSFError);
+      expect(sections[1].heading).toBe(headingSFWarnings);
       // There are no SF warnings.
       expect(sections[1].problems.length).toBe(0);
-      expect(sections[2].heading).toBe('Serval errors');
+      expect(sections[2].heading).toBe(headingServalErrors);
       // There are no Serval errors.
       expect(sections[2].problems.length).toBe(0);
-      expect(sections[3].heading).toBe('Serval warnings');
+      expect(sections[3].heading).toBe(headingServalWarnings);
       expect(sections[3].problems[0].message).toBe(fullMessage);
     });
 
@@ -1630,13 +1642,13 @@ describe('ServalBuildsComponent', () => {
     it('renderProblemMessagesForCard returns all messages when not too many', () => {
       const env = new TestEnvironment();
       const problems: BuildReportProblem[] = [
-        { source: 'local', severity: 'error', message: 'Message 1' },
-        { source: 'local', severity: 'error', message: 'Message 2' }
+        { source: 'local', severity: 'error', message: msgMessage1 },
+        { source: 'local', severity: 'error', message: msgMessage2 }
       ];
 
       const preview: string[] = env.component.renderProblemMessagesForCard(problems);
       expect(preview.length).toBe(2);
-      expect(preview).toEqual(['Message 1', 'Message 2']);
+      expect(preview).toEqual([msgMessage1, msgMessage2]);
     });
 
     it('showAllProblems opens serval build problems dialog', () => {
@@ -1649,8 +1661,8 @@ describe('ServalBuildsComponent', () => {
         return undefined as never;
       });
       const problems: BuildReportProblem[] = [
-        { source: 'local', severity: 'warning', message: 'SF warning message' },
-        { source: 'serval', severity: 'error', message: 'Faulted: Engine crashed' }
+        { source: 'local', severity: 'warning', message: msgSFWarning },
+        { source: 'serval', severity: 'error', message: msgFaulted }
       ];
       const row: ServalBuildRow = createRowWithProblems(problems);
 
@@ -1659,10 +1671,10 @@ describe('ServalBuildsComponent', () => {
       verify(mockDialogService.openMatDialog(anything(), anything())).once();
       expect(componentArg).toBe(ServalBuildProblemsDialog);
       expect(configArg.data.sections.length).toBe(4);
-      expect(configArg.data.sections[0].heading).toBe('SF errors');
-      expect(configArg.data.sections[1].heading).toBe('SF warnings');
-      expect(configArg.data.sections[2].heading).toBe('Serval errors');
-      expect(configArg.data.sections[3].heading).toBe('Serval warnings');
+      expect(configArg.data.sections[0].heading).toBe(headingSFErrors);
+      expect(configArg.data.sections[1].heading).toBe(headingSFWarnings);
+      expect(configArg.data.sections[2].heading).toBe(headingServalErrors);
+      expect(configArg.data.sections[3].heading).toBe(headingServalWarnings);
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -54,9 +54,11 @@ import { DateRangePickerComponent, NormalizedDateRange } from './date-range-pick
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { JobDetailsDialogComponent } from './job-details-dialog.component';
 import { ServalAdministrationService } from './serval-administration.service';
+import { ServalBuildProblemsDialog, ServalBuildProblemsDialogSection } from './serval-build-problems-dialog.component';
 import {
   BookAndChapters,
   buildProjectDisplayName,
+  BuildReportProblem,
   DraftGenerationBuildStatus,
   Phase,
   ProjectBooks,
@@ -161,8 +163,12 @@ interface SummaryDisplayItem {
   ]
 })
 export class ServalBuildsComponent extends DataLoadingComponent implements OnInit {
+  /** Max problems to preview in problems card. */
+  public readonly problemPreviewLimit: number = 8;
+
   /** Help template access static methods. */
   protected ServalBuildsComponent = ServalBuildsComponent;
+  protected DraftGenerationBuildStatus = DraftGenerationBuildStatus;
   protected columnsToDisplay: string[] = ['status', 'project', 'training', 'source', 'language', 'requested', 'expand'];
   /** Tracks which rows are currently expanded (by Serval build ID). */
   private expandedRows: Set<string> = new Set();
@@ -922,5 +928,50 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       return `${langCode} (${languageName})`;
     }
     return langCode;
+  }
+
+  protected problems(
+    row: ServalBuildRow,
+    source: BuildReportProblem['source'],
+    severity: BuildReportProblem['severity']
+  ): BuildReportProblem[] {
+    return row.report.problems.filter((p: BuildReportProblem) => p.source === source && p.severity === severity);
+  }
+
+  protected hasAnyProblems(row: ServalBuildRow): boolean {
+    return row.report.problems.length > 0;
+  }
+
+  protected problemSections(row: ServalBuildRow): ServalBuildProblemsDialogSection[] {
+    const sections: ServalBuildProblemsDialogSection[] = [
+      { heading: 'SF errors', problems: this.problems(row, 'local', 'error') },
+      { heading: 'SF warnings', problems: this.problems(row, 'local', 'warning') },
+      { heading: 'Serval errors', problems: this.problems(row, 'serval', 'error') },
+      { heading: 'Serval warnings', problems: this.problems(row, 'serval', 'warning') }
+    ];
+    return sections;
+  }
+
+  protected renderProblemMessagesForCard(problems: BuildReportProblem[]): string[] {
+    const messages: string[] = problems.map((problem: BuildReportProblem) => problem.message);
+    // Limit the number of problems to show in the card.
+    if (messages.length <= this.problemPreviewLimit) {
+      return messages;
+    }
+
+    return [...messages.slice(0, this.problemPreviewLimit), '…'];
+  }
+
+  protected showAllProblems(row: ServalBuildRow): void {
+    const servalBuildId: string = row.report.build?.additionalInfo?.buildId ?? 'unknown';
+    const sections: ServalBuildProblemsDialogSection[] = this.problemSections(row);
+
+    this.dialogService.openMatDialog(ServalBuildProblemsDialog, {
+      data: { servalBuildId: servalBuildId, sections: sections }
+    });
+  }
+
+  protected problemsBadgeTooltip(row: ServalBuildRow): string {
+    return row.report.problems.map((p: BuildReportProblem) => p.message).join('. ');
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -59,6 +59,8 @@ import {
   BookAndChapters,
   buildProjectDisplayName,
   BuildReportProblem,
+  BuildReportProblemSeverity,
+  BuildReportProblemSource,
   DraftGenerationBuildStatus,
   Phase,
   ProjectBooks,
@@ -932,8 +934,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
   protected problems(
     row: ServalBuildRow,
-    source: BuildReportProblem['source'],
-    severity: BuildReportProblem['severity']
+    source: BuildReportProblemSource,
+    severity: BuildReportProblemSeverity
   ): BuildReportProblem[] {
     return row.report.problems.filter((p: BuildReportProblem) => p.source === source && p.severity === severity);
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -932,7 +932,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return langCode;
   }
 
-  protected problems(
+  problems(
     row: ServalBuildRow,
     source: BuildReportProblemSource,
     severity: BuildReportProblemSeverity
@@ -940,11 +940,11 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return row.report.problems.filter((p: BuildReportProblem) => p.source === source && p.severity === severity);
   }
 
-  protected hasAnyProblems(row: ServalBuildRow): boolean {
+  hasAnyProblems(row: ServalBuildRow): boolean {
     return row.report.problems.length > 0;
   }
 
-  protected problemSections(row: ServalBuildRow): ServalBuildProblemsDialogSection[] {
+  problemSections(row: ServalBuildRow): ServalBuildProblemsDialogSection[] {
     const sections: ServalBuildProblemsDialogSection[] = [
       { heading: 'SF errors', problems: this.problems(row, 'local', 'error') },
       { heading: 'SF warnings', problems: this.problems(row, 'local', 'warning') },
@@ -954,7 +954,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return sections;
   }
 
-  protected renderProblemMessagesForCard(problems: BuildReportProblem[]): string[] {
+  renderProblemMessagesForCard(problems: BuildReportProblem[]): string[] {
     const messages: string[] = problems.map((problem: BuildReportProblem) => problem.message);
     // Limit the number of problems to show in the card.
     if (messages.length <= this.problemPreviewLimit) {
@@ -964,7 +964,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return [...messages.slice(0, this.problemPreviewLimit), '…'];
   }
 
-  protected showAllProblems(row: ServalBuildRow): void {
+  showAllProblems(row: ServalBuildRow): void {
     const servalBuildId: string = row.report.build?.additionalInfo?.buildId ?? 'unknown';
     const sections: ServalBuildProblemsDialogSection[] = this.problemSections(row);
 
@@ -973,7 +973,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     });
   }
 
-  protected problemsBadgeTooltip(row: ServalBuildRow): string {
+  problemsBadgeTooltip(row: ServalBuildRow): string {
     return row.report.problems.map((p: BuildReportProblem) => p.message).join('. ');
   }
 }

--- a/src/SIL.XForge.Scripture/Models/BuildReportProblem.cs
+++ b/src/SIL.XForge.Scripture/Models/BuildReportProblem.cs
@@ -1,0 +1,58 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace SIL.XForge.Scripture.Models;
+
+/// <summary>
+/// A problem regarding a Serval build.
+/// </summary>
+public class BuildReportProblem
+{
+    /// <summary>
+    /// Where the problem occurred, or what system reported it.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public BuildReportProblemSource Source { get; init; }
+
+    /// <summary>
+    /// The severity of the problem.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public BuildReportProblemSeverity Severity { get; init; }
+
+    /// <summary>
+    /// A message describing the problem.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Origin of a problem.
+/// </summary>
+public enum BuildReportProblemSource
+{
+    /// <summary>
+    /// The problem occurred in the local application.
+    /// </summary>
+    [EnumMember(Value = "local")]
+    Local,
+
+    /// <summary>
+    /// The problem was reported by Serval.
+    /// </summary>
+    [EnumMember(Value = "serval")]
+    Serval,
+}
+
+/// <summary>
+/// Degree of significance of a problem.
+/// </summary>
+public enum BuildReportProblemSeverity
+{
+    [EnumMember(Value = "warning")]
+    Warning,
+
+    [EnumMember(Value = "error")]
+    Error,
+}

--- a/src/SIL.XForge.Scripture/Models/ServalBuildExecutionData.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildExecutionData.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SIL.XForge.Scripture.Models;
 
 /// <summary>
@@ -10,4 +12,5 @@ public class ServalBuildExecutionData
     public int PretranslateCount { get; set; }
     public string? SourceLanguageTag { get; set; }
     public string? TargetLanguageTag { get; set; }
+    public List<string> Warnings { get; set; } = [];
 }

--- a/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
+++ b/src/SIL.XForge.Scripture/Models/ServalBuildReportDto.cs
@@ -34,9 +34,9 @@ public class ServalBuildReportDto
     public BuildReportConfig Config { get; init; } = new();
 
     /// <summary>
-    /// Problems or warnings identified for this build.
+    /// Errors and warnings identified for this build.
     /// </summary>
-    public List<string> Problems { get; init; } = [];
+    public List<BuildReportProblem> Problems { get; init; } = [];
 
     /// <summary>
     /// The SF draft generation request identifier, if one was found.

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1376,8 +1376,8 @@ public class MachineApiService(
         // Build the timeline
         BuildReportTimeline timeline = BuildTimeline(translationBuild, projectEvents, draftGenerationRequestId);
 
-        // Collect problems
-        List<BuildReportProblem> problems = CollectProblems(translationBuild, projectEvents);
+        // Identify problems
+        List<BuildReportProblem> problems = ExtractProblems(translationBuild, projectEvents);
 
         return new ServalBuildReportDto
         {
@@ -1421,10 +1421,10 @@ public class MachineApiService(
     }
 
     /// <summary>
-    /// Collects problems for a build report by inspecting the Serval build state, message, warnings,
+    /// Gathers problems for a build report from the Serval build state, message, warnings,
     /// and any SF event exceptions.
     /// </summary>
-    private static List<BuildReportProblem> CollectProblems(
+    private static List<BuildReportProblem> ExtractProblems(
         TranslationBuild translationBuild,
         List<EventMetric> projectEvents
     )

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -1376,12 +1376,16 @@ public class MachineApiService(
         // Build the timeline
         BuildReportTimeline timeline = BuildTimeline(translationBuild, projectEvents, draftGenerationRequestId);
 
+        // Collect problems
+        List<BuildReportProblem> problems = CollectProblems(translationBuild, projectEvents);
+
         return new ServalBuildReportDto
         {
             Build = buildDto,
             Project = projectInfo,
             Timeline = timeline,
             Config = config,
+            Problems = problems,
             DraftGenerationRequestId = draftGenerationRequestId,
             RequesterSFUserId = requesterUserId,
             Status = ToDraftGenerationBuildStatus(translationBuild.State),
@@ -1414,6 +1418,66 @@ public class MachineApiService(
     {
         EventMetric? buildEvent = FindBuildProjectEvent(projectEvents, servalBuildId);
         return buildEvent?.UserId;
+    }
+
+    /// <summary>
+    /// Collects problems for a build report by inspecting the Serval build state, message, warnings,
+    /// and any SF event exceptions.
+    /// </summary>
+    private static List<BuildReportProblem> CollectProblems(
+        TranslationBuild translationBuild,
+        List<EventMetric> projectEvents
+    )
+    {
+        List<BuildReportProblem> problems = [];
+
+        // SF (local) problems: exceptions from BuildProjectAsync events
+        EventMetric? buildEvent = FindBuildProjectEvent(projectEvents, translationBuild.Id);
+        if (!string.IsNullOrEmpty(buildEvent?.Exception))
+        {
+            problems.Add(
+                new BuildReportProblem
+                {
+                    Source = BuildReportProblemSource.Local,
+                    Severity = BuildReportProblemSeverity.Error,
+                    Message = buildEvent.Exception,
+                }
+            );
+        }
+
+        // Serval problems: faulted build
+        if (translationBuild.State == JobState.Faulted)
+        {
+            string faultedMessage = !string.IsNullOrEmpty(translationBuild.Message)
+                ? $"Faulted: {translationBuild.Message}"
+                : "Serval faulted the build for an unknown reason.";
+            problems.Add(
+                new BuildReportProblem
+                {
+                    Source = BuildReportProblemSource.Serval,
+                    Severity = BuildReportProblemSeverity.Error,
+                    Message = faultedMessage,
+                }
+            );
+        }
+
+        // Serval problems: execution data warnings
+        if (translationBuild.ExecutionData?.Warnings is { Count: > 0 } warnings)
+        {
+            foreach (string warning in warnings)
+            {
+                problems.Add(
+                    new BuildReportProblem
+                    {
+                        Source = BuildReportProblemSource.Serval,
+                        Severity = BuildReportProblemSeverity.Warning,
+                        Message = warning,
+                    }
+                );
+            }
+        }
+
+        return problems;
     }
 
     /// <summary>
@@ -1666,7 +1730,15 @@ public class MachineApiService(
                                 RequestTime = sfUserRequested,
                             },
                             Config = new BuildReportConfig(),
-                            Problems = ["No Serval build was reported for this draft generation request."],
+                            Problems =
+                            [
+                                new BuildReportProblem
+                                {
+                                    Source = BuildReportProblemSource.Local,
+                                    Severity = BuildReportProblemSeverity.Error,
+                                    Message = "No Serval build was reported for this draft generation request.",
+                                },
+                            ],
                             DraftGenerationRequestId = requestId,
                             RequesterSFUserId = startEvent?.UserId,
                             Status = status,
@@ -1701,7 +1773,15 @@ public class MachineApiService(
                                     RequestTime = sfUserRequested,
                                 },
                                 Config = new BuildReportConfig(),
-                                Problems = ["No Serval build was reported for this draft generation request."],
+                                Problems =
+                                [
+                                    new BuildReportProblem
+                                    {
+                                        Source = BuildReportProblemSource.Local,
+                                        Severity = BuildReportProblemSeverity.Error,
+                                        Message = "No Serval build was reported for this draft generation request.",
+                                    },
+                                ],
                                 RequesterSFUserId = startEvent.UserId,
                                 Status = DraftGenerationBuildStatus.UserRequested,
                             }
@@ -3021,6 +3101,7 @@ public class MachineApiService(
                         PretranslateCount = executionData.PretranslateCount,
                         SourceLanguageTag = executionData.EngineSourceLanguageTag,
                         TargetLanguageTag = executionData.EngineTargetLanguageTag,
+                        Warnings = [.. executionData.Warnings],
                     },
         };
 


### PR DESCRIPTION
This patch adds a Problems card to the Serval build record. The card
displays an abbreviated list of various errors or warnings that were
associated with the build. A button opens a dialog with unabbreviated
information.

The ServalBuildReportDto class now carries a more descriptive Problems
field.

The ServalBuildExecutionData is modified to also include its Warnings.
This is redundant with a subset of ServalBuildReportDto.Problems but
seemed appropriate to add.

The GUI change is in Serval Administration > Serval Builds tab. Expand a build record to see cards.
Screenshot of Problems card with no problems:
<img width="324" height="456" alt="Screenshot_20260514_095651" src="https://github.com/user-attachments/assets/e3460cbc-9583-4fc9-bf31-9636217b61df" />

Screenshot of Problems card with mock problems:
<img width="318" height="458" alt="image" src="https://github.com/user-attachments/assets/3b47b3ab-83df-4ede-a0eb-0594b91fd808" />

Screenshot of resulting dialog after clicking Show all:
<img width="660" height="592" alt="image" src="https://github.com/user-attachments/assets/3e0d4120-5262-4b31-932f-65aa91d2672e" />


Clipboard contents after clicking Copy all:
```
# Problems with Serval build ID 69fa6fffbf2b2e708b149a13

## SF errors

- Big local problem! Build is 
12341232134
1234423141234123423
123442312341423412241423234412323412341
12342341234123412341

## Serval errors

- Big problem here at Serval! 432114231234234112341234123441234124123412

## Serval warnings

- Minor problem here at Serval. 12341234123412341234
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
- RUT 0:2 has bad versification in the verses and will not be formatted as verses.
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3880)
<!-- Reviewable:end -->
