### PR TITLE
ci: monitor npm install scripts

### DIFF
--- a/.github/workflows/monitor-npm-hasInstallScript.yml
+++ b/.github/workflows/monitor-npm-hasInstallScript.yml
@@ -59,7 +59,9 @@ jobs:
           echo "comment_path=${COMMENT_FILE}" >> "${GITHUB_OUTPUT}"
 
       - name: Add result to workflow summary
-        run: cat "${{ steps.detect.outputs.comment_path }}" >> "${GITHUB_STEP_SUMMARY}"
+        run: cat "${COMMENT_PATH}" >> "${GITHUB_STEP_SUMMARY}"
+        env:
+          COMMENT_PATH: ${{ steps.detect.outputs.comment_path }}
 
       - name: Create or update PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/monitor-npm-hasInstallScript.yml
+++ b/.github/workflows/monitor-npm-hasInstallScript.yml
@@ -1,0 +1,100 @@
+name: Monitor npm hasInstallScript
+permissions: {}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: monitor-npm-hasinstallscript-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  monitor-install-scripts:
+    name: "Monitor npm install scripts"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Detect newly introduced npm install scripts
+        id: detect
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          BASE_SHA=$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")
+          HEAD_SHA="${PR_HEAD_SHA}"
+
+          echo "merge_base_sha=${BASE_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+
+          FINDINGS_FILE="${RUNNER_TEMP}/monitor-npm-has-install-script-findings.tsv"
+          COMMENT_FILE="${RUNNER_TEMP}/monitor-npm-has-install-script-comment.md"
+
+          deno run --allow-run=git --allow-write="${RUNNER_TEMP}" scripts/monitor-npm-has-install-script.mts \
+            --base-sha "${BASE_SHA}" \
+            --head-sha "${HEAD_SHA}" \
+            --findings-path "${FINDINGS_FILE}" \
+            --comment-path "${COMMENT_FILE}"
+
+          if [[ -s "${FINDINGS_FILE}" ]]; then
+            echo "has_findings=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_findings=false" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "comment_path=${COMMENT_FILE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Add result to workflow summary
+        run: cat "${{ steps.detect.outputs.comment_path }}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Create or update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_PATH: ${{ steps.detect.outputs.comment_path }}
+        with:
+          script: |
+            const fs = require('node:fs');
+
+            const marker = '<!-- monitor-npm-hasInstallScript -->';
+            const commentBody = fs.readFileSync(process.env.COMMENT_PATH, 'utf8').trim();
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.pull_request.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find(comment => comment.body?.includes(marker));
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: commentBody,
+              });
+            }

--- a/scripts/monitor-npm-has-install-script.mts
+++ b/scripts/monitor-npm-has-install-script.mts
@@ -1,0 +1,431 @@
+#!/usr/bin/env -S deno run --allow-run=git --allow-write
+
+interface CliOptions {
+  baseSha: string;
+  headSha: string;
+  findingsPath: string;
+  commentPath: string;
+}
+
+type FindingCategory = 'introduced' | 'existing_new_script';
+
+interface Finding {
+  lockfilePath: string;
+  category: FindingCategory;
+  packageName: string;
+  versions: string[];
+  packageKeys: string[];
+}
+
+interface LockfilePackage {
+  name?: unknown;
+  version?: unknown;
+  hasInstallScript?: unknown;
+}
+
+interface LockfileJson {
+  name?: unknown;
+  packages?: Record<string, LockfilePackage>;
+}
+
+interface ScriptInfo {
+  versions: Set<string>;
+  packageKeys: Set<string>;
+}
+
+interface Snapshot {
+  allNames: Set<string>;
+  hasScriptByName: Map<string, ScriptInfo>;
+}
+
+const MARKER: string = '<!-- monitor-npm-hasInstallScript -->';
+const MAX_DIFF_LINES: number = 200;
+
+function fail(message: string): never {
+  console.error(message);
+  Deno.exit(1);
+}
+
+function parseArgs(args: string[]): CliOptions {
+  if (args.includes('--help')) {
+    console.log(
+      'Usage: monitor-npm-has-install-script.mts --base-sha SHA --head-sha SHA --findings-path PATH --comment-path PATH'
+    );
+    Deno.exit(0);
+  }
+
+  const values: Record<string, string> = {};
+  const allowed: Set<string> = new Set(['base-sha', 'head-sha', 'findings-path', 'comment-path']);
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg: string = args[i];
+    if (arg.startsWith('--') === false) {
+      fail(`Unexpected argument: ${arg}`);
+    }
+
+    const key: string = arg.slice(2);
+    if (allowed.has(key) === false) {
+      fail(`Unsupported argument: --${key}`);
+    }
+
+    const value: string | undefined = args[i + 1];
+    if (value == null || value.startsWith('--')) {
+      fail(`Missing value for --${key}`);
+    }
+
+    values[key] = value;
+    i += 1;
+  }
+
+  const requiredKeys: string[] = ['base-sha', 'head-sha', 'findings-path', 'comment-path'];
+  for (const requiredKey of requiredKeys) {
+    if (values[requiredKey] == null || values[requiredKey] === '') {
+      fail(`Missing required argument: --${requiredKey}`);
+    }
+  }
+
+  const result: CliOptions = {
+    baseSha: values['base-sha'],
+    headSha: values['head-sha'],
+    findingsPath: values['findings-path'],
+    commentPath: values['comment-path']
+  };
+  return result;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null;
+}
+
+function normalizePackageName(packageKey: string, pkg: LockfilePackage, rootName: string): string {
+  // Prefer explicit package metadata when available.
+  if (typeof pkg.name === 'string' && pkg.name.trim() !== '') {
+    return pkg.name;
+  }
+
+  // The empty key represents the root package entry in lockfile "packages".
+  if (packageKey === '') {
+    return rootName;
+  }
+
+  // For entries like ".../node_modules/<name>", keep only "<name>".
+  const marker: string = 'node_modules/';
+  const markerIndex: number = packageKey.lastIndexOf(marker);
+  if (markerIndex >= 0) {
+    return packageKey.slice(markerIndex + marker.length);
+  }
+
+  // Fallback for any other path-like key shape.
+  // In well-formed npm lockfiles this should still produce a name segment, but malformed or odd keys
+  // (for example "/" or "node_modules/" with nothing after it) can resolve to an empty string.
+  // Returning "" results in being skipped by the caller.
+  const segments: string[] = packageKey.split('/');
+  // The nullish-coalescing fallback is defensive in case array indexing yields undefined.
+  return segments[segments.length - 1] ?? '';
+}
+
+function categorySortWeight(category: FindingCategory): number {
+  if (category === 'introduced') {
+    return 0;
+  }
+  return 1;
+}
+
+function categoryLabel(category: FindingCategory): string {
+  if (category === 'introduced') {
+    return 'Introduced package with install script';
+  }
+  return 'Existing package now has install script';
+}
+
+function toPackageJsonPath(lockfilePath: string): string | undefined {
+  if (lockfilePath.endsWith('package-lock.json') === false) {
+    return undefined;
+  }
+  return `${lockfilePath.slice(0, -'package-lock.json'.length)}package.json`;
+}
+
+function toLines(text: string): string[] {
+  const normalized: string = text.endsWith('\n') ? text.slice(0, -1) : text;
+  if (normalized === '') {
+    return [];
+  }
+  return normalized.split('\n');
+}
+
+async function runGit(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const output = await new Deno.Command('git', {
+    args,
+    stdout: 'piped',
+    stderr: 'piped'
+  }).output();
+
+  const decoder: TextDecoder = new TextDecoder();
+  return {
+    code: output.code,
+    stdout: decoder.decode(output.stdout),
+    stderr: decoder.decode(output.stderr)
+  };
+}
+
+async function runGitOrThrow(args: string[]): Promise<string> {
+  const result = await runGit(args);
+  if (result.code !== 0) {
+    const stderr: string = result.stderr.trim();
+    throw new Error(`git ${args.join(' ')} failed${stderr === '' ? '' : `: ${stderr}`}`);
+  }
+  return result.stdout;
+}
+
+async function gitPathExists(sha: string, path: string): Promise<boolean> {
+  const result = await runGit(['cat-file', '-e', `${sha}:${path}`]);
+  return result.code === 0;
+}
+
+async function listLockfilesAtSha(sha: string): Promise<string[]> {
+  const output: string = await runGitOrThrow(['ls-tree', '--name-only', '--full-tree', '-r', sha]);
+  return (
+    output
+      .split('\n')
+      .map(line => line.trim())
+      // Match package-lock.json at repo root or any subdirectory, and only that exact filename.
+      // `(^|\/)` matches either the start of a string or a forward slash character.
+      .filter(line => line !== '' && /(^|\/)package-lock\.json$/.test(line))
+  );
+}
+
+async function readGitFile(sha: string, path: string): Promise<string | undefined> {
+  if ((await gitPathExists(sha, path)) === false) {
+    return undefined;
+  }
+  return await runGitOrThrow(['show', `${sha}:${path}`]);
+}
+
+function parseSnapshot(lockfileText: string, lockfilePath: string, sha: string): Snapshot {
+  let parsed: LockfileJson;
+  try {
+    parsed = JSON.parse(lockfileText) as LockfileJson;
+  } catch (error) {
+    throw new Error(`Failed to parse JSON for ${lockfilePath} at ${sha}: ${(error as Error).message}`);
+  }
+
+  const rootName: string = typeof parsed.name === 'string' ? parsed.name : '';
+  const packages: Record<string, LockfilePackage> =
+    isObject(parsed.packages) === true ? (parsed.packages as Record<string, LockfilePackage>) : {};
+
+  const allNames: Set<string> = new Set<string>();
+  // For each package name with hasInstallScript=true, collect all seen versions and lockfile keys.
+  // This lets us merge repeated occurrences of the same package name in different lockfile paths.
+  const hasScriptByName: Map<string, ScriptInfo> = new Map<string, ScriptInfo>();
+
+  for (const [packageKey, pkg] of Object.entries(packages)) {
+    if (isObject(pkg) === false) {
+      continue;
+    }
+
+    const packageName: string = normalizePackageName(packageKey, pkg as LockfilePackage, rootName);
+    if (packageName !== '') {
+      allNames.add(packageName);
+    }
+
+    if (pkg.hasInstallScript === true && packageName !== '') {
+      // Multiple entries can share the same package name. Reuse the existing accumulator when present,
+      // otherwise start a new one.
+      const existing: ScriptInfo | undefined = hasScriptByName.get(packageName);
+      const scriptInfo: ScriptInfo =
+        existing == null
+          ? {
+              versions: new Set<string>(),
+              packageKeys: new Set<string>()
+            }
+          : existing;
+
+      // Keep growing the same record for this package name as we encounter additional entries.
+      // Set handles de-duplication for repeated versions/keys.
+      if (typeof pkg.version === 'string' && pkg.version !== '') {
+        scriptInfo.versions.add(pkg.version);
+      }
+      scriptInfo.packageKeys.add(packageKey);
+
+      hasScriptByName.set(packageName, scriptInfo);
+    }
+  }
+
+  return { allNames, hasScriptByName };
+}
+
+function findNewInstallScriptUsage(baseSnapshot: Snapshot, headSnapshot: Snapshot, lockfilePath: string): Finding[] {
+  const findings: Finding[] = [];
+  const packageNames: string[] = [...headSnapshot.hasScriptByName.keys()].sort();
+
+  for (const packageName of packageNames) {
+    const scriptInfo: ScriptInfo | undefined = headSnapshot.hasScriptByName.get(packageName);
+    if (scriptInfo == null) {
+      continue;
+    }
+
+    let category: FindingCategory | undefined;
+    if (baseSnapshot.allNames.has(packageName) === false) {
+      category = 'introduced';
+    } else if (baseSnapshot.hasScriptByName.has(packageName) === false) {
+      category = 'existing_new_script';
+    }
+
+    if (category != null) {
+      findings.push({
+        lockfilePath,
+        category,
+        packageName,
+        versions: [...scriptInfo.versions].sort(),
+        packageKeys: [...scriptInfo.packageKeys].sort()
+      });
+    }
+  }
+
+  return findings;
+}
+
+function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((left: Finding, right: Finding) => {
+    if (left.lockfilePath !== right.lockfilePath) {
+      return left.lockfilePath.localeCompare(right.lockfilePath);
+    }
+
+    const categoryWeightDiff: number = categorySortWeight(left.category) - categorySortWeight(right.category);
+    if (categoryWeightDiff !== 0) {
+      return categoryWeightDiff;
+    }
+
+    return left.packageName.localeCompare(right.packageName);
+  });
+}
+
+async function appendPackageJsonDiffs(
+  lines: string[],
+  findings: Finding[],
+  baseSha: string,
+  headSha: string
+): Promise<void> {
+  const lockfiles: string[] = [...new Set(findings.map(finding => finding.lockfilePath))].sort();
+
+  let headingAdded: boolean = false;
+  for (const lockfilePath of lockfiles) {
+    const packageJsonPath: string | undefined = toPackageJsonPath(lockfilePath);
+    if (packageJsonPath == null) {
+      continue;
+    }
+
+    const existsInEitherSha: boolean =
+      (await gitPathExists(baseSha, packageJsonPath)) || (await gitPathExists(headSha, packageJsonPath));
+    if (existsInEitherSha === false) {
+      continue;
+    }
+
+    const diffText: string = await runGitOrThrow(['diff', '--unified=3', baseSha, headSha, '--', packageJsonPath]);
+    const diffLines: string[] = toLines(diffText);
+    if (diffLines.length === 0) {
+      continue;
+    }
+
+    if (headingAdded === false) {
+      lines.push('');
+      lines.push('Relevant package.json diff snippets:');
+      headingAdded = true;
+    }
+
+    lines.push('');
+    lines.push(`<details><summary>${packageJsonPath}</summary>`);
+    lines.push('');
+    lines.push('```diff');
+    const displayedLines: string[] = diffLines.slice(0, MAX_DIFF_LINES);
+    lines.push(...displayedLines);
+    if (diffLines.length > MAX_DIFF_LINES) {
+      lines.push('... (truncated)');
+    }
+    lines.push('```');
+    lines.push('');
+    lines.push('</details>');
+  }
+}
+
+async function buildComment(findings: Finding[], baseSha: string, headSha: string): Promise<string> {
+  const sortedFindings: Finding[] = sortFindings(findings);
+  const lines: string[] = [MARKER];
+
+  if (sortedFindings.length === 0) {
+    lines.push('No new npm install scripts detected.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push('**Warning:** New npm install script detected.');
+  lines.push('');
+  lines.push('Detected packages:');
+
+  let previousLockfile: string | undefined;
+  let previousCategory: FindingCategory | undefined;
+
+  for (const finding of sortedFindings) {
+    if (finding.lockfilePath !== previousLockfile) {
+      if (previousLockfile != null) {
+        lines.push('');
+      }
+      lines.push(`- **${finding.lockfilePath}**`);
+      previousLockfile = finding.lockfilePath;
+      previousCategory = undefined;
+    }
+
+    if (finding.category !== previousCategory) {
+      lines.push(`  - ${categoryLabel(finding.category)}:`);
+      previousCategory = finding.category;
+    }
+
+    const versionsText: string = finding.versions.length > 0 ? finding.versions.join(', ') : 'unknown version';
+    const packageKeysText: string = finding.packageKeys.length > 0 ? ` (${finding.packageKeys.join(', ')})` : '';
+    lines.push(`    - ${finding.packageName} (${versionsText})${packageKeysText}`);
+  }
+
+  await appendPackageJsonDiffs(lines, sortedFindings, baseSha, headSha);
+  return `${lines.join('\n')}\n`;
+}
+
+async function main(): Promise<void> {
+  const options: CliOptions = parseArgs(Deno.args);
+
+  const baseLockfiles: string[] = await listLockfilesAtSha(options.baseSha);
+  const headLockfiles: string[] = await listLockfilesAtSha(options.headSha);
+  const lockfilePaths: string[] = [...new Set([...baseLockfiles, ...headLockfiles])].sort();
+
+  const findings: Finding[] = [];
+
+  for (const lockfilePath of lockfilePaths) {
+    const baseLockfile: string = (await readGitFile(options.baseSha, lockfilePath)) ?? '{"packages":{}}\n';
+    const headLockfile: string | undefined = await readGitFile(options.headSha, lockfilePath);
+
+    if (headLockfile == null) {
+      continue;
+    }
+
+    const baseSnapshot: Snapshot = parseSnapshot(baseLockfile, lockfilePath, options.baseSha);
+    const headSnapshot: Snapshot = parseSnapshot(headLockfile, lockfilePath, options.headSha);
+
+    findings.push(...findNewInstallScriptUsage(baseSnapshot, headSnapshot, lockfilePath));
+  }
+
+  const sortedFindings: Finding[] = sortFindings(findings);
+  const findingsContent: string =
+    sortedFindings.length === 0
+      ? ''
+      : `${sortedFindings
+          .map(
+            finding =>
+              `${finding.lockfilePath}\t${finding.category}\t${finding.packageName}\t${finding.versions.join(', ')}\t${finding.packageKeys.join(', ')}`
+          )
+          .join('\n')}\n`;
+
+  await Deno.writeTextFile(options.findingsPath, findingsContent);
+
+  const comment: string = await buildComment(sortedFindings, options.baseSha, options.headSha);
+  await Deno.writeTextFile(options.commentPath, comment);
+}
+
+await main();

--- a/scripts/monitor-npm-has-install-script.mts
+++ b/scripts/monitor-npm-has-install-script.mts
@@ -39,7 +39,7 @@ interface Snapshot {
 }
 
 const MARKER: string = '<!-- monitor-npm-hasInstallScript -->';
-const MAX_DIFF_LINES: number = 200;
+const MAX_DIFF_LINES: number = 30;
 
 function fail(message: string): never {
   console.error(message);


### PR DESCRIPTION
This patch adds a workflow which looks to see if a PR changes package-lock.json files such that a dependency newly has an install script that didn't before. Or if there is a new dependency added that has an install script. I read that this can be a suspicious sign of possible trouble to pay attention to.

I apologize that the script is so long. 

I suggest that the workflow just comment on our PRs for now without blocking them.

Some example findings can be seen below, as run from repo root.

No finding:
````
$ FINDINGS_PATH=$(mktemp) && COMMENT_PATH=$(mktemp) && deno run --allow-run=git --allow-write="$FINDINGS_PATH" --allow-write="$COMMENT_PATH" "$SF_REPO"/scripts/monitor-npm-has-install-script.mts --base-sha HEAD --head-sha HEAD --findings-path "$FINDINGS_PATH" --comment-path "$COMMENT_PATH" && wc --lines "$FINDINGS_PATH" && cat "$COMMENT_PATH"
0 /tmp/tmp.SntKHNuqUN
<!-- monitor-npm-hasInstallScript -->
No new npm install scripts detected.
````

Introduced package with install script:
````
$ INTRO_SHA=b0021d233a5768c2b2f8b7fc008b15156e2a4232 && BASE_SHA=$(git rev-parse "${INTRO_SHA}^")  && FINDINGS_PATH=$(mktemp) && COMMENT_PATH=$(mktemp) && deno run --allow-run=git --allow-write="$FINDINGS_PATH" --allow-write="$COMMENT_PATH"  "$SF_REPO"/scripts/monitor-npm-has-install-script.mts --base-sha "$BASE_SHA" --head-sha "$INTRO_SHA" --findings-path "$FINDINGS_PATH" --comment-path "$COMMENT_PATH" && wc --lines "$FINDINGS_PATH" &&cat "$FINDINGS_PATH" && cat "$COMMENT_PATH"1 /tmp/tmp.iobKPeNNAo
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      fsevents   1.2.13   node_modules/watchpack-chokidar2/node_modules/fsevents, node_modules/webpack-dev-server/node_modules/fsevents
<!-- monitor-npm-hasInstallScript -->
**Warning:** New npm install script detected.

Detected packages:
- **src/SIL.XForge.Scripture/ClientApp/package-lock.json**
  - Introduced package with install script:
    - fsevents (1.2.13) (node_modules/watchpack-chokidar2/node_modules/fsevents, node_modules/webpack-dev-server/node_modules/fsevents)
````

Existing package starts to have an install script:
````
$ BASE_SHA=539d963a5e0cee1362f6a87f493515c28cb910d1 && HEAD_SHA=d09db8e106215e3905fd81c9f893d14dceb61eef && FINDINGS_PATH=$(mktemp) && COMMENT_PATH=$(mktemp) && deno run --allow-run=git --allow-write="$FINDINGS_PATH" --allow-write="$COMMENT_PATH" "$SF_REPO/scripts/monitor-npm-has-install-script.mts" --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" --findings-path "$FINDINGS_PATH" --comment-path "$COMMENT_PATH" && cat "$FINDINGS_PATH" && cat "$COMMENT_PATH"src/SIL.XForge.Scripture/ClientApp/package-lock.json    existing_new_script     @angular/cli        10.2.3  node_modules/@angular/cli
<!-- monitor-npm-hasInstallScript -->
**Warning:** New npm install script detected.

Detected packages:
- **src/SIL.XForge.Scripture/ClientApp/package-lock.json**
  - Existing package now has install script:
    - @angular/cli (10.2.3) (node_modules/@angular/cli)

Relevant package.json diff snippets:

<details><summary>src/SIL.XForge.Scripture/ClientApp/package.json</summary>

```diff
diff --git a/src/SIL.XForge.Scripture/ClientApp/package.json b/src/SIL.XForge.Scripture/ClientApp/package.json
index dc083037c..3ae756d5e 100644
--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -24,21 +24,21 @@
   "private": true,
   "dependencies": {
     "@angular-mdc/web": "^5.1.1",
-    "@angular/animations": "^10.2.4",
+    "@angular/animations": "^10.2.5",
     "@angular/cdk": "^10.2.7",
-    "@angular/common": "^10.2.4",
-    "@angular/core": "^10.2.4",
+    "@angular/common": "^10.2.5",
+    "@angular/core": "^10.2.5",
     "@angular/flex-layout": "^10.0.0-beta.32",
-    "@angular/forms": "^10.2.4",
+    "@angular/forms": "^10.2.5",
     "@angular/material": "^10.2.7",
-    "@angular/platform-browser": "^10.2.4",
-    "@angular/platform-browser-dynamic": "^10.2.4",
-    "@angular/pwa": "^0.1002.2",
-    "@angular/router": "^10.2.4",
-    "@angular/service-worker": "^10.2.4",
+    "@angular/platform-browser": "^10.2.5",
+    "@angular/platform-browser-dynamic": "^10.2.5",
+    "@angular/pwa": "^0.1002.3",
+    "@angular/router": "^10.2.5",
+    "@angular/service-worker": "^10.2.5",
     "@bugsnag/js": "^7.8.0",
... (truncated)
```

</details>
````

A finding where there are RTS existing dependencies that now have an install script, and ClientApp existing packages that now have an insall script, and ClientApp has new dependencies that have install scripts. This example was made by using a large range of commits, which would presumably not be the normal situation.
````
$ BASE_SHA=d09db8e106215e3905fd81c9f893d14dceb61eef~1 && HEAD_SHA=0b0bae61df40d1fe68bb820d892da7ddd1bf0581 && FINDINGS_PATH=$(mktemp) && COMMENT_PATH=$(mktemp) && deno run --allow-run=git --allow-write="$FINDINGS_PATH" --allow-write="$COMMENT_PATH" "$SF_REPO/scripts/monitor-npm-has-install-script.mts" --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" --findings-path "$FINDINGS_PATH" --comment-path "$COMMENT_PATH" && cat "$FINDINGS_PATH" && cat "$COMMENT_PATH"                            src/RealtimeServer/package-lock.json    existing_new_script     fsevents        2.3.3       node_modules/fsevents
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      @compodoc/compodoc  1.1.25  node_modules/@compodoc/compodoc
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      @parcel/watcher     2.5.1   node_modules/@parcel/watcher
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      @swc/core  1.7.35   node_modules/@swc/core
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      esbuild 0.25.4      node_modules/esbuild
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      lmdb    3.2.6       node_modules/lmdb
src/SIL.XForge.Scripture/ClientApp/package-lock.json    introduced      msgpackr-extract    3.0.3   node_modules/msgpackr-extract
src/SIL.XForge.Scripture/ClientApp/package-lock.json    existing_new_script     sil.xforge.scripture        4.7.1
<!-- monitor-npm-hasInstallScript -->
**Warning:** New npm install script detected.

Detected packages:
- **src/RealtimeServer/package-lock.json**
  - Existing package now has install script:
    - fsevents (2.3.3) (node_modules/fsevents)

- **src/SIL.XForge.Scripture/ClientApp/package-lock.json**
  - Introduced package with install script:
    - @compodoc/compodoc (1.1.25) (node_modules/@compodoc/compodoc)
    - @parcel/watcher (2.5.1) (node_modules/@parcel/watcher)
    - @swc/core (1.7.35) (node_modules/@swc/core)
    - esbuild (0.25.4) (node_modules/esbuild)
    - lmdb (3.2.6) (node_modules/lmdb)
    - msgpackr-extract (3.0.3) (node_modules/msgpackr-extract)
  - Existing package now has install script:
    - sil.xforge.scripture (4.7.1) ()

Relevant package.json diff snippets:

<details><summary>src/RealtimeServer/package.json</summary>

```diff
diff --git a/src/RealtimeServer/package.json b/src/RealtimeServer/package.json
index 55b14fa39..5b5696c56 100644
--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -1,47 +1,71 @@
 {
   "name": "realtime-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Real-time Server",
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "tsc -b tsconfig.build.json",
-    "clean": "tsc -b tsconfig.build.json --clean",
-    "prepare": "npm run build"
+    "test:tc": "npm run test:ci",
+    "test:ci": "jest --ci --coverage --reporters=jest-junit",
+    "build": "tsc -b tsconfig.build.json && tsc -b tsconfig.build-esm.json",
+    "clean": "tsc -b tsconfig.build.json --clean && tsc -b tsconfig.build-esm.json --clean",
+    "lint": "eslint .",
+    "prepare": "npm run build",
+    "prettier": "prettier --write \"**/*.{ts,js,json,css,scss,less,html,md,yml}\"",
+    "prettier:tc": "npm run prettier:ci",
+    "prettier:ci": "prettier --list-different \"**/*.{ts,js,json,css,scss,less,html,md,yml}\""
   },
   "author": "SIL",
   "repository": "github:sillsdev/web-xforge",
-  "main": "lib/common/index.js",
-  "types": "lib/common/index.d.ts",
... (truncated)
```

</details>

<details><summary>src/SIL.XForge.Scripture/ClientApp/package.json</summary>

```diff
diff --git a/src/SIL.XForge.Scripture/ClientApp/package.json b/src/SIL.XForge.Scripture/ClientApp/package.json
index dc083037c..e31f91ed2 100644
--- a/src/SIL.XForge.Scripture/ClientApp/package.json
+++ b/src/SIL.XForge.Scripture/ClientApp/package.json
@@ -1,122 +1,167 @@
 {
   "name": "sil.xforge.scripture",
-  "version": "2.0.0",
+  "version": "4.7.1",
   "description": "SIL.XForge.Scripture - Scripture Forge",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "startBeta": "ng serve --configuration=developmentBeta",
-    "start:no-progress": "ng serve --progress=false",
+    "start": "echo \"open your browser on http://localhost:4200/ \" && ng serve",
     "start:no-reload": "ng serve --liveReload=false",
     "build": "ng build",
-    "test": "ng test --sourceMap=true",
-    "test:tc": "ng test --browsers xForgeChromiumHeadless --watch false --code-coverage",
+    "test": "ng test --source-map",
+    "test:firefox": "mkdir tmp & ng test --browsers xForgeFirefox --source-map",
+    "test:firefox-headless": "mkdir tmp & echo;export KARMA_REPORTERS=mocha && set KARMA_REPORTERS=mocha&& ng test --browsers xForgeFirefoxHeadless --source-map",
+    "test:safari": "ng test --browsers Safari --source-map",
+    "test:parallel": "echo;export KARMA_PARALLEL=true && set KARMA_PARALLEL=true&& npm test ",
+    "test:tc": "ng test --browsers xForgeChromiumHeadless --watch false --code-coverage --source-map",
+    "test:gha": "KARMA_REPORTERS=mocha,coverage-istanbul,junit ng test --browsers xForgeChromiumHeadless --watch false --code-coverage --source-map",
+    "//": "The environment variable is set in a way compatible with both sh and cmd. There is no space before '&& ng'.",
+    "test:headless": "echo;export KARMA_REPORTERS=mocha && set KARMA_REPORTERS=mocha&& ng test --browsers xForgeChromiumHeadless --source-map",
... (truncated)
```

</details>
````

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3882)
<!-- Reviewable:end -->
