### PR TITLE
serval-admin: serval-builds: refactor: deduplicate input project book sections

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -305,51 +305,43 @@
                     </mat-card-title-group>
                   </mat-card-header>
                   <mat-card-content class="detail-card-content">
+                    <ng-template #projectBooksSection let-sectionLabel="sectionLabel" let-projectBooks="projectBooks">
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">{{ sectionLabel }}</span>
+                        <span class="detail-value">
+                          <div class="detail-books-list">
+                            @for (projectBook of projectBooks; track projectBook.sfProjectId) {
+                              <div>
+                                @let detailProjectLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
+                                @if (detailProjectLink != null) {
+                                  <a [href]="detailProjectLink" target="_blank" rel="noopener" class="project-link">
+                                    {{ projectBook.projectDisplayName }}
+                                  </a>
+                                } @else {
+                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                                }
+                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
+                              </div>
+                            } @empty {
+                              <span>None</span>
+                            }
+                          </div>
+                        </span>
+                      </div>
+                    </ng-template>
+
                     <span class="detail-area-stacked-keyvalues">
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Training books</span>
-                        <span class="detail-value">
-                          <div class="detail-books-list">
-                            @for (projectBook of row.trainingBooks; track projectBook.sfProjectId) {
-                              <div>
-                                @let detailTrainingLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
-                                @if (detailTrainingLink != null) {
-                                  <a [href]="detailTrainingLink" target="_blank" rel="noopener" class="project-link">
-                                    {{ projectBook.projectDisplayName }}
-                                  </a>
-                                } @else {
-                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
-                                }
-                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
-                              </div>
-                            } @empty {
-                              <span>None</span>
-                            }
-                          </div>
-                        </span>
-                      </div>
-                      <div class="detail-keyvalue">
-                        <span class="detail-key">Translation books</span>
-                        <span class="detail-value">
-                          <div class="detail-books-list">
-                            @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
-                              <div>
-                                @let detailTranslationLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
-                                @if (detailTranslationLink != null) {
-                                  <a [href]="detailTranslationLink" target="_blank" rel="noopener" class="project-link">
-                                    {{ projectBook.projectDisplayName }}
-                                  </a>
-                                } @else {
-                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
-                                }
-                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
-                              </div>
-                            } @empty {
-                              <span>None</span>
-                            }
-                          </div>
-                        </span>
-                      </div>
+                      <ng-container
+                        [ngTemplateOutlet]="projectBooksSection"
+                        [ngTemplateOutletContext]="{ sectionLabel: 'Training books', projectBooks: row.trainingBooks }"
+                      ></ng-container>
+                      <ng-container
+                        [ngTemplateOutlet]="projectBooksSection"
+                        [ngTemplateOutletContext]="{
+                          sectionLabel: 'Translation books',
+                          projectBooks: row.translationBooks
+                        }"
+                      ></ng-container>
                     </span>
                   </mat-card-content>
                 </mat-card>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton, MatIconButton } from '@angular/material/button';
@@ -127,6 +127,7 @@ interface SummaryDisplayItem {
   providers: [provideNativeDateAdapter()],
   imports: [
     AsyncPipe,
+    NgTemplateOutlet,
     MatButton,
     MatIconButton,
     MatIcon,


### PR DESCRIPTION
This patch just refactors the template in the Input card for the
Training books and Translation books sections. They now share an
ng-template for their display. This refactor is being done in
preparation for proposing a change to how these input projects are
displayed.

Screenshot of input card. (Unchanged display)
<img width="335" height="465" alt="Screenshot_20260515_101246" src="https://github.com/user-attachments/assets/e9cc7456-9321-47f5-83fd-1bd776555882" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3885)
<!-- Reviewable:end -->
