### PR TITLE
serval-admin: serval-builds: stats: exclude unconsidered rows from book totals

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -178,14 +178,6 @@ export function calculatePercentTimeOnSF(rows: ServalBuildRow[]): number | undef
  * containing counts, averages, and timing statistics.
  */
 export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
-  const listedTotalTrainingBooks: number = rows.reduce(
-    (sum: number, row: ServalBuildRow) => sum + countBooks(row.trainingBooks),
-    0
-  );
-  const listedTotalUniqueTrainingBooks: number = countUniqueBooks(
-    rows.flatMap((row: ServalBuildRow) => row.trainingBooks)
-  );
-
   // Type for a build row where the SF project is known.
   type KnowableBuildRow = ServalBuildRow & { report: ServalBuildReportDto & { project: BuildReportProject } };
   // Rows with a known SF project. Any build that is not associable with a project will not be included or
@@ -206,8 +198,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
       faultedBuilds: 0,
       averageTrainingBooksPerBuild: undefined,
       averageTranslationBooksPerBuild: undefined,
-      totalUniqueTrainingBooks: listedTotalUniqueTrainingBooks,
-      totalTrainingBooks: listedTotalTrainingBooks,
+      totalUniqueTrainingBooks: 0,
+      totalTrainingBooks: 0,
       completedBuilds: 0,
       inProgressBuilds: 0,
       buildsWithProblems: 0,
@@ -282,6 +274,9 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
     (sum: number, row: KnowableBuildRow) => sum + countBooks(row.translationBooks),
     0
   );
+  const totalUniqueTrainingBooks: number = countUniqueBooks(
+    rowsWithServalData.flatMap((row: KnowableBuildRow) => row.trainingBooks)
+  );
 
   const averageTrainingBooksPerBuild: number | undefined =
     servalBuildCount > 0 ? totalTrainingBooks / servalBuildCount : undefined;
@@ -309,8 +304,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
     faultedBuilds: faultedBuilds,
     averageTrainingBooksPerBuild: averageTrainingBooksPerBuild,
     averageTranslationBooksPerBuild: averageTranslationBooksPerBuild,
-    totalUniqueTrainingBooks: listedTotalUniqueTrainingBooks,
-    totalTrainingBooks: listedTotalTrainingBooks,
+    totalUniqueTrainingBooks: totalUniqueTrainingBooks,
+    totalTrainingBooks: totalTrainingBooks,
     completedBuilds: completedBuilds,
     inProgressBuilds: inProgressBuilds,
     buildsWithProblems: buildsWithProblems,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -315,6 +315,38 @@ describe('ServalBuildsComponent', () => {
       expect(summary.totalUniqueTrainingBooks).toBe(3);
     });
 
+    it('excludes unconsidered builds from listed training book totals', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: ServalBuildRow[] = [
+        TestEnvironment.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          trainingBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        TestEnvironment.createRowWithDetails({
+          projectId: undefined,
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: undefined,
+          trainingBooks: env.createProjectBooks('proj-orphan', ['LEV', 'NUM']),
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      expect(summary.totalBuilds).toBe(1);
+      expect(summary.unconsideredBuilds).toBe(1);
+      // The unconsidered build's books should not contribute to listed totals.
+      expect(summary.totalTrainingBooks).toBe(2);
+      expect(summary.totalUniqueTrainingBooks).toBe(2);
+    });
+
     it('handles book counting despite chapter numbers present', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');


### PR DESCRIPTION
The statistics regarding Total unique training books and Total
training books were incorrectly being computed from the full set of
input rows before buildSummary decided which rows to ignore. This
patch moves the computation below where the the `buildRows:
KnowableBuildRow[]` is determined (and further, considers only
`rowsWithServalData`). Some redundancy is also removed as
`totalTranslationBooks` was already being calculated for another
purpose.

Screenshot of stat area, containing
"Total unique training books" and 
"Total training books". (Unchanged display.)
<img width="638" height="85" alt="image" src="https://github.com/user-attachments/assets/63bef8f4-6b51-483e-a370-901c21702510" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3886)
<!-- Reviewable:end -->
