### PR TITLE
serval-admin: serval-builds: add training column before source

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -153,42 +153,53 @@
           </td>
         </ng-container>
 
+        <ng-template #projectBooksCell let-projectBooks="projectBooks">
+          @for (projectBook of projectBooks; track projectBook.sfProjectId) {
+            <div>
+              @let link = servalAdminProjectLinkFor(projectBook.sfProjectId);
+              @let short = projectBook.shortName ?? projectBook.sfProjectId;
+              @let toolTip = projectBook.projectName ?? projectBook.sfProjectId;
+              @if (link != null) {
+                <a [href]="link" target="_blank" rel="noopener" class="project-link" [matTooltip]="toolTip">
+                  {{ short }}
+                </a>
+              } @else {
+                <span class="project-link" [matTooltip]="toolTip">{{ short }}</span>
+              }
+              :
+              @if (projectBook.booksAndChapters.length <= 2) {
+                {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
+              } @else {
+                <span
+                  [matTooltip]="ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters)"
+                  class="book-count"
+                >
+                  {{ projectBook.booksAndChapters.length }} books
+                </span>
+              }
+            </div>
+          } @empty {
+            None
+          }
+        </ng-template>
+
+        <ng-container matColumnDef="training">
+          <th mat-header-cell *matHeaderCellDef>Training</th>
+          <td mat-cell *matCellDef="let row">
+            <ng-container
+              [ngTemplateOutlet]="projectBooksCell"
+              [ngTemplateOutletContext]="{ projectBooks: row.trainingBooks }"
+            ></ng-container>
+          </td>
+        </ng-container>
+
         <ng-container matColumnDef="source">
           <th mat-header-cell *matHeaderCellDef>Source</th>
           <td mat-cell *matCellDef="let row">
-            @for (projectBook of row.translationBooks; track projectBook.sfProjectId) {
-              <div>
-                @let translationLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
-                @let short = projectBook.shortName ?? projectBook.sfProjectId;
-                @let toolTip = projectBook.projectName ?? projectBook.sfProjectId;
-                @if (translationLink != null) {
-                  <a
-                    [href]="translationLink"
-                    target="_blank"
-                    rel="noopener"
-                    class="project-link"
-                    [matTooltip]="toolTip"
-                  >
-                    {{ short }}
-                  </a>
-                } @else {
-                  <span class="project-link" [matTooltip]="toolTip">{{ short }}</span>
-                }
-                :
-                @if (projectBook.booksAndChapters.length <= 2) {
-                  {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
-                } @else {
-                  <span
-                    [matTooltip]="ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters)"
-                    class="book-count"
-                  >
-                    {{ projectBook.booksAndChapters.length }} books
-                  </span>
-                }
-              </div>
-            } @empty {
-              None
-            }
+            <ng-container
+              [ngTemplateOutlet]="projectBooksCell"
+              [ngTemplateOutletContext]="{ projectBooks: row.translationBooks }"
+            ></ng-container>
           </td>
         </ng-container>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -161,7 +161,7 @@ interface SummaryDisplayItem {
 export class ServalBuildsComponent extends DataLoadingComponent implements OnInit {
   /** Help template access static methods. */
   protected ServalBuildsComponent = ServalBuildsComponent;
-  protected columnsToDisplay: string[] = ['status', 'project', 'source', 'language', 'requested', 'expand'];
+  protected columnsToDisplay: string[] = ['status', 'project', 'training', 'source', 'language', 'requested', 'expand'];
   /** Tracks which rows are currently expanded (by Serval build ID). */
   private expandedRows: Set<string> = new Set();
   /** Data rows, excluding those that might be filtered out by the includeDeleted toggle. */


### PR DESCRIPTION
The Serval builds area has a "Source" column which lists the project
and books that a build translated from. This patch inserts a Training
column that lists the project and books used for Training.

As part of this change, the Source column was changed to an
ng-template, which is then reused for the Training column.

Screenshot showing columns:
<img width="564" height="170" alt="image" src="https://github.com/user-attachments/assets/b56072cd-da60-4f6c-87d9-c4408ebeb543" />

Screenshot showing more detailed information in Input card:
<img width="338" height="465" alt="image" src="https://github.com/user-attachments/assets/f768bbb7-cc07-4247-8133-6fdd4292bc52" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3887)
<!-- Reviewable:end -->
