### PR TITLE
serval-admin: serval-builds: add copyable SF IDs in Input card

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -343,17 +343,43 @@
                         <span class="detail-key">{{ sectionLabel }}</span>
                         <span class="detail-value">
                           <div class="detail-books-list">
-                            @for (projectBook of projectBooks; track projectBook.sfProjectId) {
-                              <div>
-                                @let detailProjectLink = servalAdminProjectLinkFor(projectBook.sfProjectId);
-                                @if (detailProjectLink != null) {
-                                  <a [href]="detailProjectLink" target="_blank" rel="noopener" class="project-link">
-                                    {{ projectBook.projectDisplayName }}
-                                  </a>
-                                } @else {
-                                  <span class="project-link">{{ projectBook.projectDisplayName }}</span>
+                            @for (projectBook of determineBuildInputs(projectBooks); track projectBook.sfProjectId) {
+                              <div class="detail-project-books-item">
+                                <div class="detail-project-books-meta detail-value-with-copy">
+                                  @if (projectBook.shortName != null) {
+                                    @if (projectBook.projectLink != null) {
+                                      <a
+                                        [href]="projectBook.projectLink"
+                                        target="_blank"
+                                        rel="noopener"
+                                        class="project-link"
+                                      >
+                                        {{ projectBook.shortName }}
+                                      </a>
+                                    } @else {
+                                      <span class="project-link">{{ projectBook.shortName }}</span>
+                                    }
+                                  }
+                                  <span class="detail-project-books-id">{{ projectBook.sfProjectId }}</span>
+                                  <app-copy [value]="projectBook.sfProjectId"></app-copy>
+                                </div>
+
+                                @if (projectBook.projectName != null) {
+                                  @if (projectBook.projectLink != null) {
+                                    <a
+                                      [href]="projectBook.projectLink"
+                                      target="_blank"
+                                      rel="noopener"
+                                      class="project-link"
+                                    >
+                                      {{ projectBook.projectName }}
+                                    </a>
+                                  } @else {
+                                    <span class="project-link">{{ projectBook.projectName }}</span>
+                                  }
                                 }
-                                : {{ ServalBuildsComponent.formatBookEntries(projectBook.booksAndChapters) }}
+
+                                <div>{{ projectBook.booksDisplay }}</div>
                               </div>
                             } @empty {
                               <span>None</span>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -157,7 +157,7 @@
         <ng-template #projectBooksCell let-projectBooks="projectBooks">
           @for (projectBook of projectBooks; track projectBook.sfProjectId) {
             <div>
-              @let link = servalAdminProjectLinkFor(projectBook.sfProjectId);
+              @let link = ServalBuildsComponent.servalAdminProjectLinkFor(projectBook.sfProjectId);
               @let short = projectBook.shortName ?? projectBook.sfProjectId;
               @let toolTip = projectBook.projectName ?? projectBook.sfProjectId;
               @if (link != null) {
@@ -343,7 +343,10 @@
                         <span class="detail-key">{{ sectionLabel }}</span>
                         <span class="detail-value">
                           <div class="detail-books-list">
-                            @for (projectBook of determineBuildInputs(projectBooks); track projectBook.sfProjectId) {
+                            @for (
+                              projectBook of projectBooks | transformWith: ServalBuildsComponent.determineBuildInputs;
+                              track projectBook.sfProjectId
+                            ) {
                               <div class="detail-project-books-item">
                                 <div class="detail-project-books-meta detail-value-with-copy">
                                   @if (projectBook.shortName != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -350,36 +350,28 @@
                               <div class="detail-project-books-item">
                                 <div class="detail-project-books-meta detail-value-with-copy">
                                   @if (projectBook.shortName != null) {
-                                    @if (projectBook.projectLink != null) {
-                                      <a
-                                        [href]="projectBook.projectLink"
-                                        target="_blank"
-                                        rel="noopener"
-                                        class="project-link"
-                                      >
-                                        {{ projectBook.shortName }}
-                                      </a>
-                                    } @else {
-                                      <span class="project-link">{{ projectBook.shortName }}</span>
-                                    }
-                                  }
-                                  <span class="detail-project-books-id">{{ projectBook.sfProjectId }}</span>
-                                  <app-copy [value]="projectBook.sfProjectId"></app-copy>
-                                </div>
-
-                                @if (projectBook.projectName != null) {
-                                  @if (projectBook.projectLink != null) {
                                     <a
                                       [href]="projectBook.projectLink"
                                       target="_blank"
                                       rel="noopener"
                                       class="project-link"
                                     >
-                                      {{ projectBook.projectName }}
+                                      {{ projectBook.shortName }}
                                     </a>
-                                  } @else {
-                                    <span class="project-link">{{ projectBook.projectName }}</span>
                                   }
+                                  <span class="detail-project-books-id">{{ projectBook.sfProjectId }}</span>
+                                  <app-copy [value]="projectBook.sfProjectId"></app-copy>
+                                </div>
+
+                                @if (projectBook.projectName != null) {
+                                  <a
+                                    [href]="projectBook.projectLink"
+                                    target="_blank"
+                                    rel="noopener"
+                                    class="project-link"
+                                  >
+                                    {{ projectBook.projectName }}
+                                  </a>
                                 }
 
                                 <div>{{ projectBook.booksDisplay }}</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -440,7 +440,21 @@ a {
 .detail-books-list {
   display: flex;
   flex-direction: column;
+  gap: 10px;
+}
+
+.detail-project-books-item {
+  display: flex;
+  flex-direction: column;
   gap: 2px;
+}
+
+.detail-project-books-meta {
+  align-self: flex-start;
+}
+
+.detail-project-books-id {
+  font-family: monospace;
 }
 
 .detail-actions {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1405,6 +1405,51 @@ describe('ServalBuildsComponent', () => {
     });
   });
 
+  describe('determineBuildInputs', () => {
+    it('builds result with desired info', () => {
+      const env = new TestEnvironment();
+      const input: ProjectBooks[] = [
+        {
+          sfProjectId: 'proj-b-id',
+          projectDisplayName: 'B - Project B',
+          shortName: 'B',
+          projectName: 'Project B',
+          booksAndChapters: [{ bookId: 'GEN' }, { bookId: 'EXO' }]
+        }
+      ];
+
+      const rows: any[] = env.component['determineBuildInputs'](input);
+
+      expect(rows.length).toBe(1);
+      expect(rows[0].projectName).toBe('Project B');
+      expect(rows[0].shortName).toBe('B');
+      expect(rows[0].sfProjectId).toBe('proj-b-id');
+      expect(rows[0].projectLink).toBe('/serval-administration/proj-b-id');
+      expect(rows[0].booksDisplay).toBe('GEN; EXO');
+    });
+
+    it('omits missing project name and short name values', () => {
+      const env = new TestEnvironment();
+      const input: ProjectBooks[] = [
+        {
+          sfProjectId: 'proj-c-id',
+          projectDisplayName: 'proj-c-id',
+          shortName: undefined,
+          projectName: undefined,
+          booksAndChapters: [{ bookId: 'LEV', chapters: [1, 2, 3] }, { bookId: 'NUM' }]
+        }
+      ];
+
+      const rows: any[] = env.component['determineBuildInputs'](input);
+
+      expect(rows.length).toBe(1);
+      expect(rows[0].projectName).toBeUndefined();
+      expect(rows[0].shortName).toBeUndefined();
+      expect(rows[0].sfProjectId).toBe('proj-c-id');
+      expect(rows[0].booksDisplay).toBe('LEV 1-3; NUM');
+    });
+  });
+
   describe('requested sorting', () => {
     it('sorts by user request time with serval created fallback', () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -31,7 +31,7 @@ import {
   ServalBuildReportDto
 } from './serval-build-report';
 import { buildSummary, gapsBetweenBuildsMs } from './serval-builds-statistics';
-import { ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
+import { BuildInputItem, ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
 
 const mockNoticeService = mock(NoticeService);
 const mockDraftGenerationService = mock(DraftGenerationService);
@@ -1407,7 +1407,6 @@ describe('ServalBuildsComponent', () => {
 
   describe('determineBuildInputs', () => {
     it('builds result with desired info', () => {
-      const env = new TestEnvironment();
       const input: ProjectBooks[] = [
         {
           sfProjectId: 'proj-b-id',
@@ -1418,18 +1417,17 @@ describe('ServalBuildsComponent', () => {
         }
       ];
 
-      const rows: any[] = env.component['determineBuildInputs'](input);
+      const results: BuildInputItem[] = ServalBuildsComponent.determineBuildInputs(input);
 
-      expect(rows.length).toBe(1);
-      expect(rows[0].projectName).toBe('Project B');
-      expect(rows[0].shortName).toBe('B');
-      expect(rows[0].sfProjectId).toBe('proj-b-id');
-      expect(rows[0].projectLink).toBe('/serval-administration/proj-b-id');
-      expect(rows[0].booksDisplay).toBe('GEN; EXO');
+      expect(results.length).toBe(1);
+      expect(results[0].projectName).toBe('Project B');
+      expect(results[0].shortName).toBe('B');
+      expect(results[0].sfProjectId).toBe('proj-b-id');
+      expect(results[0].projectLink).toBe('/serval-administration/proj-b-id');
+      expect(results[0].booksDisplay).toBe('GEN; EXO');
     });
 
     it('omits missing project name and short name values', () => {
-      const env = new TestEnvironment();
       const input: ProjectBooks[] = [
         {
           sfProjectId: 'proj-c-id',
@@ -1440,13 +1438,18 @@ describe('ServalBuildsComponent', () => {
         }
       ];
 
-      const rows: any[] = env.component['determineBuildInputs'](input);
+      const results: BuildInputItem[] = ServalBuildsComponent.determineBuildInputs(input);
 
-      expect(rows.length).toBe(1);
-      expect(rows[0].projectName).toBeUndefined();
-      expect(rows[0].shortName).toBeUndefined();
-      expect(rows[0].sfProjectId).toBe('proj-c-id');
-      expect(rows[0].booksDisplay).toBe('LEV 1-3; NUM');
+      expect(results.length).toBe(1);
+      expect(results[0].projectName).toBeUndefined();
+      expect(results[0].shortName).toBeUndefined();
+      expect(results[0].sfProjectId).toBe('proj-c-id');
+      expect(results[0].booksDisplay).toBe('LEV 1-3; NUM');
+    });
+
+    it('returns empty array for undefined or null input', () => {
+      expect(ServalBuildsComponent.determineBuildInputs(undefined)).toEqual([]);
+      expect(ServalBuildsComponent.determineBuildInputs(null)).toEqual([]);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -123,6 +123,15 @@ interface SummaryDisplayItem {
   prominence: 'top' | 'hidden';
 }
 
+/** View model for one project, and its set of books, shown in the Input card book lists. */
+interface BuildInputItem {
+  sfProjectId: string;
+  projectLink?: string;
+  projectName?: string;
+  shortName?: string;
+  booksDisplay: string;
+}
+
 /**
  * Displays Serval builds in the Serval Administration area.
  */
@@ -891,6 +900,25 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
         return `${prefix}: ${bookEntries}`;
       })
       .join('. ');
+  }
+
+  protected determineBuildInputs(projectBooks: ProjectBooks[]): BuildInputItem[] {
+    return projectBooks.map((projectBooksEntry: ProjectBooks) => {
+      const projectName: string | undefined = isPopulatedString(projectBooksEntry.projectName)
+        ? projectBooksEntry.projectName
+        : undefined;
+      const shortName: string | undefined = isPopulatedString(projectBooksEntry.shortName)
+        ? projectBooksEntry.shortName
+        : undefined;
+
+      return {
+        sfProjectId: projectBooksEntry.sfProjectId,
+        projectLink: this.servalAdminProjectLinkFor(projectBooksEntry.sfProjectId),
+        projectName: projectName,
+        shortName: shortName,
+        booksDisplay: ServalBuildsComponent.formatBookEntries(projectBooksEntry.booksAndChapters)
+      };
+    });
   }
 
   /** Formats a BookAndChapters array into a display string, e.g. "GEN 10-11, 16-19; EXO". */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -127,7 +127,7 @@ interface SummaryDisplayItem {
 /** View model for one project and its books, shown in Input card lists. */
 export interface BuildInputItem {
   sfProjectId: string;
-  projectLink?: string;
+  projectLink: string;
   projectName?: string;
   shortName?: string;
   booksDisplay: string;
@@ -909,7 +909,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       return [];
     }
 
-    return projectBooks.map((projectBooksEntry: ProjectBooks) => {
+    const result: BuildInputItem[] = projectBooks.map((projectBooksEntry: ProjectBooks) => {
       const projectName: string | undefined = isPopulatedString(projectBooksEntry.projectName)
         ? projectBooksEntry.projectName
         : undefined;
@@ -925,6 +925,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
         booksDisplay: ServalBuildsComponent.formatBookEntries(projectBooksEntry.booksAndChapters)
       };
     });
+    return result;
   }
 
   /** Formats a BookAndChapters array into a display string, e.g. "GEN 10-11, 16-19; EXO". */
@@ -959,9 +960,13 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return ranges.join(', ');
   }
 
-  static servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {
-    if (sfProjectId == null) return undefined;
-    return `/serval-administration/${sfProjectId}`;
+  /** (The return type is string if the input is a type string (at compile time), or undefined
+   * if the input is of type undefined (at compile time).) */
+  static servalAdminProjectLinkFor<T extends string | undefined>(
+    sfProjectId: T
+  ): T extends string ? string : undefined {
+    if (sfProjectId == null) return undefined as T extends string ? string : undefined;
+    return `/serval-administration/${sfProjectId}` as T extends string ? string : undefined;
   }
 
   /** Formats a language code with its display name, e.g. "es (Spanish)". Falls back to just the code. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -68,6 +68,7 @@ import {
   toProjectBooks
 } from './serval-build-report';
 import { buildSummary } from './serval-builds-statistics';
+import { TransformWithPipe } from './transform.pipe';
 
 /** Represents a row of Serval build data in the builds table. */
 export interface ServalBuildRow {
@@ -123,8 +124,8 @@ interface SummaryDisplayItem {
   prominence: 'top' | 'hidden';
 }
 
-/** View model for one project, and its set of books, shown in the Input card book lists. */
-interface BuildInputItem {
+/** View model for one project and its books, shown in Input card lists. */
+export interface BuildInputItem {
   sfProjectId: string;
   projectLink?: string;
   projectName?: string;
@@ -143,6 +144,7 @@ interface BuildInputItem {
   imports: [
     AsyncPipe,
     NgTemplateOutlet,
+    TransformWithPipe,
     MatButton,
     MatIconButton,
     MatIcon,
@@ -557,7 +559,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
         report.project?.name,
         sfProjectId
       );
-      const projectLink: string | undefined = this.servalAdminProjectLinkFor(sfProjectId);
+      const projectLink: string | undefined = ServalBuildsComponent.servalAdminProjectLinkFor(sfProjectId);
       const trainingBooks: ProjectBooks[] = toProjectBooks(report.config.trainingScriptureRanges);
       const translationBooks: ProjectBooks[] = toProjectBooks(report.config.translationScriptureRanges);
 
@@ -902,7 +904,11 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       .join('. ');
   }
 
-  protected determineBuildInputs(projectBooks: ProjectBooks[]): BuildInputItem[] {
+  static determineBuildInputs(projectBooks: ProjectBooks[] | null | undefined): BuildInputItem[] {
+    if (projectBooks == null) {
+      return [];
+    }
+
     return projectBooks.map((projectBooksEntry: ProjectBooks) => {
       const projectName: string | undefined = isPopulatedString(projectBooksEntry.projectName)
         ? projectBooksEntry.projectName
@@ -913,7 +919,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
       return {
         sfProjectId: projectBooksEntry.sfProjectId,
-        projectLink: this.servalAdminProjectLinkFor(projectBooksEntry.sfProjectId),
+        projectLink: ServalBuildsComponent.servalAdminProjectLinkFor(projectBooksEntry.sfProjectId),
         projectName: projectName,
         shortName: shortName,
         booksDisplay: ServalBuildsComponent.formatBookEntries(projectBooksEntry.booksAndChapters)
@@ -953,7 +959,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return ranges.join(', ');
   }
 
-  protected servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {
+  static servalAdminProjectLinkFor(sfProjectId: string | undefined): string | undefined {
     if (sfProjectId == null) return undefined;
     return `/serval-administration/${sfProjectId}`;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/transform.pipe.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/transform.pipe.spec.ts
@@ -1,0 +1,27 @@
+import { TransformWithPipe } from './transform.pipe';
+
+describe('TransformWithPipe', () => {
+  let pipe: TransformWithPipe;
+
+  beforeEach(() => {
+    pipe = new TransformWithPipe();
+  });
+
+  it('applies fn to a defined input', () => {
+    const result = pipe.transform(4, value => (value ?? 0) * 3);
+
+    expect(result).toBe(12);
+  });
+
+  it('passes undefined input through to fn', () => {
+    const result = pipe.transform(undefined, value => (value == null ? 'nullish' : 'non-nullish'));
+
+    expect(result).toBe('nullish');
+  });
+
+  it('passes null input through to fn', () => {
+    const result = pipe.transform<number, string>(null, value => (value == null ? 'nullish' : 'non-nullish'));
+
+    expect(result).toBe('nullish');
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/transform.pipe.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/transform.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/** This short pipe can be used in a template to only transform input when the input changes. Rather
+ * than calling a method from the template and transforming the input each change detection. For
+ * example, `{{ someValue | transformWith: someFunction }}` */
+@Pipe({
+  name: 'transformWith',
+  pure: true,
+  standalone: true
+})
+export class TransformWithPipe implements PipeTransform {
+  transform<TInput, TResult>(
+    input: TInput | null | undefined,
+    fn: (input: TInput | null | undefined) => TResult
+  ): TResult {
+    return fn(input);
+  }
+}


### PR DESCRIPTION
The Inputs card lists training books and translation books. It also
indicates the project they are from. This patch changes the display to
include the SF project ID with a copy icon, to make it easy to get the
ID for the referenced project.

Screenshot of previous display:
<img width="338" height="465" alt="image" src="https://github.com/user-attachments/assets/8649100e-dbbb-4af4-a4d2-d82371ecd4c6" />

Screenshot showing Input card, where you can see that there is now SF project IDs shown for the input projects, with a copy icon. 
<img width="338" height="465" alt="image" src="https://github.com/user-attachments/assets/6f3f95cd-6841-4c67-b83c-78e416833f00" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3888)
<!-- Reviewable:end -->
