### PR TITLE
serval-admin: serval-builds: stats: add translation book totals

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds-statistics.ts
@@ -200,6 +200,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
       averageTranslationBooksPerBuild: undefined,
       totalUniqueTrainingBooks: 0,
       totalTrainingBooks: 0,
+      totalUniqueTranslationBooks: 0,
+      totalTranslationBooks: 0,
       completedBuilds: 0,
       inProgressBuilds: 0,
       buildsWithProblems: 0,
@@ -277,6 +279,9 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
   const totalUniqueTrainingBooks: number = countUniqueBooks(
     rowsWithServalData.flatMap((row: KnowableBuildRow) => row.trainingBooks)
   );
+  const totalUniqueTranslationBooks: number = countUniqueBooks(
+    rowsWithServalData.flatMap((row: KnowableBuildRow) => row.translationBooks)
+  );
 
   const averageTrainingBooksPerBuild: number | undefined =
     servalBuildCount > 0 ? totalTrainingBooks / servalBuildCount : undefined;
@@ -306,6 +311,8 @@ export function buildSummary(rows: ServalBuildRow[]): ServalBuildSummary {
     averageTranslationBooksPerBuild: averageTranslationBooksPerBuild,
     totalUniqueTrainingBooks: totalUniqueTrainingBooks,
     totalTrainingBooks: totalTrainingBooks,
+    totalUniqueTranslationBooks: totalUniqueTranslationBooks,
+    totalTranslationBooks: totalTranslationBooks,
     completedBuilds: completedBuilds,
     inProgressBuilds: inProgressBuilds,
     buildsWithProblems: buildsWithProblems,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -265,6 +265,8 @@ describe('ServalBuildsComponent', () => {
       expect(summary.averageTranslationBooksPerBuild).toBeCloseTo(1);
       expect(summary.totalUniqueTrainingBooks).toBe(7);
       expect(summary.totalTrainingBooks).toBe(7);
+      expect(summary.totalUniqueTranslationBooks).toBe(6);
+      expect(summary.totalTranslationBooks).toBe(6);
       expect(summary.completedBuilds).toBe(3);
       expect(summary.inProgressBuilds).toBe(2);
       expect(summary.buildsWithProblems).toBe(1);
@@ -315,7 +317,7 @@ describe('ServalBuildsComponent', () => {
       expect(summary.totalUniqueTrainingBooks).toBe(3);
     });
 
-    it('excludes unconsidered builds from listed training book totals', () => {
+    it('excludes unconsidered builds from book totals', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');
       const rows: ServalBuildRow[] = [
@@ -325,6 +327,7 @@ describe('ServalBuildsComponent', () => {
           finishDate: env.addHours(baseStart, 1),
           requesterId: 'user-1',
           trainingBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          translationBooks: env.createProjectBooks('proj-a', ['PSA']),
           status: DraftGenerationBuildStatus.Completed
         }),
         TestEnvironment.createRowWithDetails({
@@ -333,6 +336,7 @@ describe('ServalBuildsComponent', () => {
           finishDate: env.addHours(baseStart, 3),
           requesterId: undefined,
           trainingBooks: env.createProjectBooks('proj-orphan', ['LEV', 'NUM']),
+          translationBooks: env.createProjectBooks('proj-orphan', ['ROM', 'ACT']),
           status: DraftGenerationBuildStatus.Completed
         })
       ];
@@ -345,6 +349,8 @@ describe('ServalBuildsComponent', () => {
       // The unconsidered build's books should not contribute to listed totals.
       expect(summary.totalTrainingBooks).toBe(2);
       expect(summary.totalUniqueTrainingBooks).toBe(2);
+      expect(summary.totalTranslationBooks).toBe(1);
+      expect(summary.totalUniqueTranslationBooks).toBe(1);
     });
 
     it('handles book counting despite chapter numbers present', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -278,7 +278,7 @@ describe('ServalBuildsComponent', () => {
       expect(summary.buildsSfDidNotKnowAbout).toBe(6);
     });
 
-    it('counts total and unique training books across listed builds', () => {
+    it('counts total and unique training books', () => {
       const env = new TestEnvironment();
       const baseStart: Date = new Date('2024-01-01T00:00:00Z');
       const rows: ServalBuildRow[] = [
@@ -315,6 +315,45 @@ describe('ServalBuildsComponent', () => {
       expect(summary.totalTrainingBooks).toBe(4);
       // Unique books dedupe by book code globally: [GEN, EXO, LEV] => 3
       expect(summary.totalUniqueTrainingBooks).toBe(3);
+    });
+
+    it('counts total and unique translation books', () => {
+      const env = new TestEnvironment();
+      const baseStart: Date = new Date('2024-01-01T00:00:00Z');
+      const rows: ServalBuildRow[] = [
+        TestEnvironment.createRowWithDetails({
+          projectId: 'proj-a',
+          startDate: env.addHours(baseStart, 0),
+          finishDate: env.addHours(baseStart, 1),
+          requesterId: 'user-1',
+          translationBooks: env.createProjectBooks('proj-a', ['GEN', 'EXO']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        TestEnvironment.createRowWithDetails({
+          projectId: 'proj-b',
+          startDate: env.addHours(baseStart, 2),
+          finishDate: env.addHours(baseStart, 3),
+          requesterId: 'user-2',
+          translationBooks: env.createProjectBooks('proj-b', ['GEN']),
+          status: DraftGenerationBuildStatus.Completed
+        }),
+        TestEnvironment.createRowWithDetails({
+          projectId: 'proj-c',
+          startDate: env.addHours(baseStart, 4),
+          finishDate: env.addHours(baseStart, 5),
+          requesterId: 'user-3',
+          translationBooks: env.createProjectBooks('proj-c', ['LEV']),
+          status: DraftGenerationBuildStatus.Completed
+        })
+      ];
+
+      // SUT
+      const summary: ServalBuildSummary = buildSummary(rows);
+
+      // Total books includes duplicates: [GEN, EXO, GEN, LEV] => 4
+      expect(summary.totalTranslationBooks).toBe(4);
+      // Unique books dedupe by book code globally: [GEN, EXO, LEV] => 3
+      expect(summary.totalUniqueTranslationBooks).toBe(3);
     });
 
     it('excludes unconsidered builds from book totals', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -90,6 +90,8 @@ export interface ServalBuildSummary {
   averageTranslationBooksPerBuild?: number;
   totalUniqueTrainingBooks: number;
   totalTrainingBooks: number;
+  totalUniqueTranslationBooks: number;
+  totalTranslationBooks: number;
   completedBuilds: number;
   inProgressBuilds: number;
   buildsWithProblems: number;
@@ -694,6 +696,23 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       prominence: 'hidden'
     };
     items.push(averageTranslationBooksItem);
+
+    const totalUniqueTranslationBooksItem: SummaryDisplayItem = {
+      label: 'Total unique translation books',
+      explanation:
+        'A book is only counted once even if used in multiple projects. For example, if two projects use GEN, and one project uses EXO, that is 2 unique books: GEN and EXO.',
+      value: this.formatCount(summary.totalUniqueTranslationBooks),
+      prominence: 'hidden'
+    };
+    items.push(totalUniqueTranslationBooksItem);
+
+    const totalTranslationBooksItem: SummaryDisplayItem = {
+      label: 'Total translation books',
+      explanation: 'Including counting the same book again when used in more than one project.',
+      value: this.formatCount(summary.totalTranslationBooks),
+      prominence: 'hidden'
+    };
+    items.push(totalTranslationBooksItem);
 
     const buildsServalDidNotKnowAboutItem: SummaryDisplayItem = {
       label: 'Builds Serval did not know about',

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -683,7 +683,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
     const totalTrainingBooksItem: SummaryDisplayItem = {
       label: 'Total training books',
-      explanation: 'Including counting the same book again when used in more than one project.',
+      explanation:
+        'The same book used in multiple projects is counted multiple times. For example, if two projects use GEN, and one project uses EXO, that is 3 total books: GEN, GEN, and EXO.',
       value: this.formatCount(summary.totalTrainingBooks),
       prominence: 'hidden'
     };
@@ -708,7 +709,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
 
     const totalTranslationBooksItem: SummaryDisplayItem = {
       label: 'Total translation books',
-      explanation: 'Including counting the same book again when used in more than one project.',
+      explanation:
+        'The same book used in multiple projects is counted multiple times. For example, if two projects use GEN, and one project uses EXO, that is 3 total books: GEN, GEN, and EXO.',
       value: this.formatCount(summary.totalTranslationBooks),
       prominence: 'hidden'
     };


### PR DESCRIPTION
This patch adds Serval builds summary stats for
"Total unique translation books" and
"Total translation books", mimicing the existing
"Total unique training books" and
"Total training books".

Screenshot of summary stat items:
<img width="630" height="84" alt="image" src="https://github.com/user-attachments/assets/e6f1c4e2-b7ba-492e-a054-40706de49168" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3890)
<!-- Reviewable:end -->
