### PR TITLE
SF-3805 Allow installation of two resources with the same name

### DIFF
--- a/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
+++ b/src/SIL.XForge.Scripture/Services/SFInstallableDblResource.cs
@@ -179,6 +179,13 @@ public class SFInstallableDblResource : InstallableResource
                     {
                         _existingScrText = resourceScrText;
                     }
+                    else if (!ScrTextCollection.IsPresent(resourceScrText))
+                    {
+                        // In this case, we have a duplicate resource name, so to ensure that the resource about to be
+                        // installed does not overwrite the wrong p8z file, we will add this resource to ParatextData's
+                        // internal collection, if it is not already present in it.
+                        ScrTextCollection.Add(resourceScrText);
+                    }
                 }
             }
 

--- a/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
+++ b/src/SIL.XForge.Scripture/Services/SFScrTextCollection.cs
@@ -22,13 +22,6 @@ public class SFScrTextCollection : ScrTextCollection
     /// </summary>
     public static string ResourcesByIdDirectory => Path.Join(SettingsDirectory, "_resourcesById");
 
-    /// <summary>
-    /// Adds a ScrText to the internal index. This should only be used for testing purposes!
-    /// </summary>
-    /// <param name="scrText">The scripture text to add to the index.</param>
-    public void AddToInternalIndex(ScrText scrText) =>
-        AddInternal(scrText, skipChangeNotify: false, checkAlreadyExists: false);
-
     protected override string DictionariesDirectoryInternal => null;
 
     protected override void InitializeInternal(string settingsDir, bool allowMigration)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextServiceTests.cs
@@ -7555,7 +7555,7 @@ public class ParatextServiceTests
         {
             string ptProjectId = PTProjectIds[baseId].Id;
             ProjectScrText = GetScrText(associatedPtUser, ptProjectId, hasEditPermission);
-            ProjectScrTextCollection.AddToInternalIndex(ProjectScrText);
+            ScrTextCollection.Add(ProjectScrText);
 
             // We set the file manager here so we can track file manager operations after
             // the ScrText object has been disposed in ParatextService.


### PR DESCRIPTION
This PR fixes an issue where installing two resources with the same name will not work if the Scripture Forge process is restarted between the two installations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3893)
<!-- Reviewable:end -->
