### PR TITLE
SF-3791 Create Settings.xml for resources when missing

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextDataHelper.cs
@@ -88,6 +88,7 @@ public class ParatextDataHelper(IFileSystemService fileSystemService) : IParatex
     ///  - MigrateLanguage
     ///  - MigrateStyleSheet
     ///  - MigrateVersification
+    ///  - MigrateProjectSettings
     /// </remarks>
     public async Task MigrateResourceIfRequiredAsync(
         ScrText scrText,
@@ -149,6 +150,30 @@ public class ParatextDataHelper(IFileSystemService fileSystemService) : IParatex
                 scrText.Settings.Versification = ScrVers.Original;
                 scrText.Settings.Save();
             }
+        }
+
+        // Perform migration of the project settings (SSF file) to Settings.xml,
+        // remove settings that have been made obsolete and unused in Paratext 8+,
+        // and remove the now unnecessary .SSF file used to Paratext 7 settings.
+        string oldSsfFile = Path.Join(scrText.FullPath, scrText.Name + ".ssf");
+        if (fileSystemService.FileExists(oldSsfFile))
+        {
+            scrText.Settings.RemoveSetting("AllowAdvancedMorphology");
+            scrText.Settings.RemoveSetting("ChapterMarker");
+            scrText.Settings.RemoveSetting("CreatedWithPTW6");
+            scrText.Settings.RemoveSetting("Directory");
+            scrText.Settings.RemoveSetting("EthnologueCode");
+            scrText.Settings.RemoveSetting("FileNameChapterNumberForm");
+            scrText.Settings.RemoveSetting("LastBackedUp");
+            scrText.Settings.RemoveSetting("ResourceText");
+            scrText.Settings.RemoveSetting("RunFromCD");
+            scrText.Settings.RemoveSetting("SpellCheckingOn");
+            scrText.Settings.RemoveSetting("StylesheetModificationDate");
+            scrText.Settings.RemoveSetting("TextHasChanged");
+            scrText.Settings.RemoveSetting("VerseMarker");
+            scrText.Settings.RemoveSetting("Zipped");
+            scrText.Settings.Save();
+            fileSystemService.DeleteFile(oldSsfFile);
         }
     }
 

--- a/src/SIL.XForge.Scripture/Services/ParatextService.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextService.cs
@@ -2836,8 +2836,10 @@ public class ParatextService : DisposableBase, IParatextService
                 // Extract to the resource directory
                 _fileSystemService.CreateDirectory(path);
                 await resource.InstallableResource.ExtractToDirectoryAsync(path);
-                await MigrateResourceIfRequiredAsync(username, targetParatextId, overrideLanguageId, token);
             }
+
+            // Perform migrations, as resources may not have had all migrations run on them
+            await MigrateResourceIfRequiredAsync(username, targetParatextId, overrideLanguageId, token);
         }
         else
         {

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextDataHelperTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextDataHelperTests.cs
@@ -13,7 +13,6 @@ using Paratext.Data.ProjectComments;
 using Paratext.Data.ProjectFileAccess;
 using Paratext.Data.ProjectSettingsAccess;
 using Paratext.Data.Repository;
-using PtxUtils;
 using SIL.WritingSystems;
 using SIL.XForge.Scripture.Models;
 using SIL.XForge.Services;
@@ -311,6 +310,36 @@ public class ParatextDataHelperTests
         Assert.AreEqual(versification.ToString(), scrText.Settings.GetSetting(Setting.Versification));
     }
 
+    [Test]
+    public async Task MigrateResourceIfRequiredAsync_MigrateProjectSettings()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        using MockScrText scrText = env.GetScrText(ResourceId01, paratext7: true);
+        const string settingName = "CreatedWithPTW6";
+        scrText.Settings.SetSetting(settingName, "T");
+
+        // SUT
+        await env.Service.MigrateResourceIfRequiredAsync(scrText, overrideLanguage: null, CancellationToken.None);
+
+        string actual = scrText.Settings.GetSetting(settingName);
+        Assert.That(actual, Is.Empty);
+        env.MockFileSystemService.Received().DeleteFile(Arg.Is<string>(s => s.EndsWith("Proj.ssf")));
+    }
+
+    [Test]
+    public async Task MigrateResourceIfRequiredAsync_MigrateProjectSettings_AlreadyMigrated()
+    {
+        // Setup
+        var env = new TestEnvironment();
+        using MockScrText scrText = env.GetScrText(ResourceId01, paratext7: false);
+
+        // SUT
+        await env.Service.MigrateResourceIfRequiredAsync(scrText, overrideLanguage: null, CancellationToken.None);
+
+        env.MockFileSystemService.DidNotReceive().DeleteFile(Arg.Is<string>(s => s.EndsWith("Proj.ssf")));
+    }
+
     private class TestEnvironment
     {
         private readonly string _syncDir = Path.GetTempPath();
@@ -384,7 +413,11 @@ public class ParatextDataHelperTests
             };
             scrText.Settings.LanguageID = LanguageId.English;
             scrText.Settings.FileNamePostPart = ".SFM";
-            if (!paratext7)
+            if (paratext7)
+            {
+                MockFileSystemService.FileExists(Arg.Is<string>(s => s.EndsWith("Proj.ssf"))).Returns(true);
+            }
+            else
             {
                 scrText.Settings.DefaultStylesheetFileName = DefaultStylesheetFileName;
             }


### PR DESCRIPTION
This PR ensures that a Settings.xml file is present for a resource when it is installed, and will perform any required resource migrations on sync.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3894)
<!-- Reviewable:end -->

<!-- gk-ai-analysis-start:e37556a36c05767b910a71a49ff7fd154d5dd3fe -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRW5zdXJlcyBhIFNldHRpbmdzLnhtbCBmaWxlIGlzIGNyZWF0ZWQgZm9yIHJlc291cmNlcyBieSBwZXJmb3JtaW5nIHJlc291cmNlIG1pZ3JhdGlvbnMgb24gc3luYyBhbmQgY2xlYW5pbmcgdXAgb2Jzb2xldGUgc2V0dGluZ3MuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUmVzb3VyY2UgbWlncmF0aW9uIGNsZWFudXAiLCJkZXNjcmlwdGlvbiI6IkFkZGVkIGxvZ2ljIHRvIGBNaWdyYXRlUmVzb3VyY2VJZlJlcXVpcmVkQXN5bmNgIHRoYXQgZGV0ZWN0cyBhbiBvbGQgYC5zc2ZgIGZpbGUsIHJlbW92ZXMgb2Jzb2xldGUgc2V0dGluZ3MsIHNhdmVzIHRoZSB1cGRhdGVkIHNldHRpbmdzIChjcmVhdGluZyB0aGUgc3RhbmRhcmQgU2V0dGluZ3MueG1sKSwgYW5kIGRlbGV0ZXMgdGhlIG9sZCBgLnNzZmAgZmlsZS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL1NJTC5YRm9yZ2UuU2NyaXB0dXJlL1NlcnZpY2VzL1BhcmF0ZXh0RGF0YUhlbHBlci5jcyIsImxpbmVTdGFydCI6MTU0fSx7InRpdGxlIjoiQWx3YXlzIHJ1biBtaWdyYXRpb25zIG9uIHJlc291cmNlcyIsImRlc2NyaXB0aW9uIjoiTW92ZWQgdGhlIGNhbGwgdG8gYE1pZ3JhdGVSZXNvdXJjZUlmUmVxdWlyZWRBc3luY2Agb3V0c2lkZSB0aGUgZXh0cmFjdGlvbiBibG9jayBzbyB0aGF0IG1pZ3JhdGlvbnMgYXJlIHBlcmZvcm1lZCBvbiBzeW5jIGZvciBleGlzdGluZyByZXNvdXJjZXMgYXMgd2VsbCBhcyBuZXdseSBpbnN0YWxsZWQgb25lcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL1NJTC5YRm9yZ2UuU2NyaXB0dXJlL1NlcnZpY2VzL1BhcmF0ZXh0U2VydmljZS5jcyIsImxpbmVTdGFydCI6MjgzOX1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:e37556a36c05767b910a71a49ff7fd154d5dd3fe -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/sillsdev/web-xforge/pull/3894?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->