### PR TITLE
SF-3807 Store drafts in draft tab for speedy chapter navigation

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.service.ts
@@ -315,8 +315,8 @@ export class DraftGenerationService {
   getGeneratedDraftBookDeltaOperations(
     projectId: string,
     book: number,
-    timestamp?: Date,
-    usfmConfig?: DraftUsfmConfig
+    timestamp: Date | undefined,
+    usfmConfig: DraftUsfmConfig | undefined
   ): Observable<Map<string, DeltaOperation[]>> {
     if (!this.onlineStatusService.isOnline) {
       return of(new Map<string, DeltaOperation[]>());

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -5,7 +5,9 @@ import { ParagraphBreakFormat, QuoteFormat } from 'realtime-server/lib/esm/scrip
 import { DeltaOperation } from 'rich-text';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
+import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
@@ -15,19 +17,23 @@ import { DraftHandlingService } from './draft-handling.service';
 const mockedProjectService = mock(SFProjectService);
 const mockedTextDocService = mock(TextDocService);
 const mockedDraftGenerationService = mock(DraftGenerationService);
+const mockedActivatedProjectService = mock(ActivatedProjectService);
 
 describe('DraftHandlingService', () => {
   let service: DraftHandlingService;
+  const mockProject = mock(SFProjectProfileDoc);
 
   configureTestingModule(() => ({
     providers: [
       { provide: SFProjectService, useMock: mockedProjectService },
       { provide: TextDocService, useMock: mockedTextDocService },
-      { provide: DraftGenerationService, useMock: mockedDraftGenerationService }
+      { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
+      { provide: ActivatedProjectService, useMock: mockedActivatedProjectService }
     ]
   }));
 
   beforeEach(() => {
+    when(mockedActivatedProjectService.changes$).thenReturn(of(instance(mockProject)));
     service = TestBed.inject(DraftHandlingService);
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
+import { ParagraphBreakFormat, QuoteFormat } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
 import { of } from 'rxjs';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
@@ -30,23 +31,98 @@ describe('DraftHandlingService', () => {
     service = TestBed.inject(DraftHandlingService);
   });
 
-  describe('getDraft', () => {
-    it('should get a draft', () => {
+  describe('getBookDraft', () => {
+    it('should cache book drafts when timestamp provided and no config is undefined', () => {
       const textDocId = new TextDocId('project01', 1, 1);
-      const draftOps: DeltaOperation[] = [{ insert: 'In the beginning', attributes: { segment: 'verse_1_1' } }];
+      const timestamp = new Date('2025-03-25T01:02:03Z');
+      const bookDraftByChapter = new Map<string, DeltaOperation[]>([
+        ['1', [{ insert: 'In the beginning', attributes: { segment: 'verse_1_1' } }]]
+      ]);
+
       when(
-        mockedDraftGenerationService.getGeneratedDraftDeltaOperations(
-          anything(),
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations(
           anything(),
           anything(),
           anything(),
           anything()
         )
-      ).thenReturn(of(draftOps));
-      service.getDraft(textDocId, { timestamp: undefined }).subscribe(draftData => expect(draftData).toEqual(draftOps));
+      ).thenReturn(of(bookDraftByChapter));
+
+      let firstResult: Map<string, DeltaOperation[]> | undefined;
+      let secondResult: Map<string, DeltaOperation[]> | undefined;
+
+      service.getBookDraft(textDocId, { timestamp }).subscribe(draftData => (firstResult = draftData));
+      service.getBookDraft(textDocId, { timestamp }).subscribe(draftData => (secondResult = draftData));
+
+      expect(firstResult).toBe(bookDraftByChapter);
+      expect(secondResult).toBe(firstResult);
       verify(
-        mockedDraftGenerationService.getGeneratedDraftDeltaOperations('project01', 1, 1, undefined, undefined)
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations('project01', 1, timestamp, undefined)
       ).once();
+    });
+
+    it('should not cache book drafts when config is provided', () => {
+      const textDocId = new TextDocId('project01', 1, 1);
+      const timestamp = new Date('2025-03-25T01:02:03Z');
+      const config = { paragraphFormat: ParagraphBreakFormat.BestGuess, quoteFormat: QuoteFormat.Denormalized };
+      const firstDraft = new Map<string, DeltaOperation[]>([
+        ['1', [{ insert: 'First draft', attributes: { segment: 'verse_1_1' } }]]
+      ]);
+      const secondDraft = new Map<string, DeltaOperation[]>([
+        ['1', [{ insert: 'Second draft', attributes: { segment: 'verse_1_1' } }]]
+      ]);
+
+      when(
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations(
+          anything(),
+          anything(),
+          anything(),
+          anything()
+        )
+      ).thenReturn(of(firstDraft), of(secondDraft));
+
+      let firstResult: Map<string, DeltaOperation[]> | undefined;
+      let secondResult: Map<string, DeltaOperation[]> | undefined;
+
+      service.getBookDraft(textDocId, { timestamp, config }).subscribe(draftData => (firstResult = draftData));
+      service.getBookDraft(textDocId, { timestamp, config }).subscribe(draftData => (secondResult = draftData));
+
+      expect(firstResult).toBe(firstDraft);
+      expect(secondResult).toBe(secondDraft);
+      verify(
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations('project01', 1, timestamp, config)
+      ).twice();
+    });
+
+    it('should not cache book drafts when timestamp is undefined', () => {
+      const textDocId = new TextDocId('project01', 1, 1);
+      const firstDraft = new Map<string, DeltaOperation[]>([
+        ['1', [{ insert: 'First draft', attributes: { segment: 'verse_1_1' } }]]
+      ]);
+      const secondDraft = new Map<string, DeltaOperation[]>([
+        ['1', [{ insert: 'Second draft', attributes: { segment: 'verse_1_1' } }]]
+      ]);
+
+      when(
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations(
+          anything(),
+          anything(),
+          anything(),
+          anything()
+        )
+      ).thenReturn(of(firstDraft), of(secondDraft));
+
+      let firstResult: Map<string, DeltaOperation[]> | undefined;
+      let secondResult: Map<string, DeltaOperation[]> | undefined;
+
+      service.getBookDraft(textDocId, {}).subscribe(draftData => (firstResult = draftData));
+      service.getBookDraft(textDocId, {}).subscribe(draftData => (secondResult = draftData));
+
+      expect(firstResult).toBe(firstDraft);
+      expect(secondResult).toBe(secondDraft);
+      verify(
+        mockedDraftGenerationService.getGeneratedDraftBookDeltaOperations('project01', 1, undefined, undefined)
+      ).twice();
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -38,7 +38,7 @@ describe('DraftHandlingService', () => {
   });
 
   describe('getBookDraft', () => {
-    it('should cache book drafts when timestamp provided and no config is undefined', () => {
+    it('should cache book drafts when timestamp provided and no config is undefined', async () => {
       const textDocId = new TextDocId('project01', 1, 1);
       const timestamp = new Date('2025-03-25T01:02:03Z');
       const bookDraftByChapter = new Map<string, DeltaOperation[]>([
@@ -54,11 +54,8 @@ describe('DraftHandlingService', () => {
         )
       ).thenReturn(of(bookDraftByChapter));
 
-      let firstResult: Map<string, DeltaOperation[]> | undefined;
-      let secondResult: Map<string, DeltaOperation[]> | undefined;
-
-      service.getBookDraft(textDocId, { timestamp }).subscribe(draftData => (firstResult = draftData));
-      service.getBookDraft(textDocId, { timestamp }).subscribe(draftData => (secondResult = draftData));
+      const firstResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, { timestamp });
+      const secondResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, { timestamp });
 
       expect(firstResult).toBe(bookDraftByChapter);
       expect(secondResult).toBe(firstResult);
@@ -67,7 +64,7 @@ describe('DraftHandlingService', () => {
       ).once();
     });
 
-    it('should not cache book drafts when config is provided', () => {
+    it('should not cache book drafts when config is provided', async () => {
       const textDocId = new TextDocId('project01', 1, 1);
       const timestamp = new Date('2025-03-25T01:02:03Z');
       const config = { paragraphFormat: ParagraphBreakFormat.BestGuess, quoteFormat: QuoteFormat.Denormalized };
@@ -87,11 +84,8 @@ describe('DraftHandlingService', () => {
         )
       ).thenReturn(of(firstDraft), of(secondDraft));
 
-      let firstResult: Map<string, DeltaOperation[]> | undefined;
-      let secondResult: Map<string, DeltaOperation[]> | undefined;
-
-      service.getBookDraft(textDocId, { timestamp, config }).subscribe(draftData => (firstResult = draftData));
-      service.getBookDraft(textDocId, { timestamp, config }).subscribe(draftData => (secondResult = draftData));
+      const firstResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, { timestamp, config });
+      const secondResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, { timestamp, config });
 
       expect(firstResult).toBe(firstDraft);
       expect(secondResult).toBe(secondDraft);
@@ -100,7 +94,7 @@ describe('DraftHandlingService', () => {
       ).twice();
     });
 
-    it('should not cache book drafts when timestamp is undefined', () => {
+    it('should not cache book drafts when timestamp is undefined', async () => {
       const textDocId = new TextDocId('project01', 1, 1);
       const firstDraft = new Map<string, DeltaOperation[]>([
         ['1', [{ insert: 'First draft', attributes: { segment: 'verse_1_1' } }]]
@@ -118,11 +112,8 @@ describe('DraftHandlingService', () => {
         )
       ).thenReturn(of(firstDraft), of(secondDraft));
 
-      let firstResult: Map<string, DeltaOperation[]> | undefined;
-      let secondResult: Map<string, DeltaOperation[]> | undefined;
-
-      service.getBookDraft(textDocId, {}).subscribe(draftData => (firstResult = draftData));
-      service.getBookDraft(textDocId, {}).subscribe(draftData => (secondResult = draftData));
+      const firstResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, {});
+      const secondResult: Map<string, DeltaOperation[]> = await service.getBookDraft(textDocId, {});
 
       expect(firstResult).toBe(firstDraft);
       expect(secondResult).toBe(secondDraft);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -127,8 +127,14 @@ export class DraftHandlingService {
     this.bookDraftCache.clear();
   }
 
+  /**
+   * Gets a key to use for caching the draft of a book.
+   * @param textDocId The text doc identifier.
+   * @param timestamp The timestamp of the draft.
+   * @returns The string key to use for caching the draft of a book.
+   */
   private getBookDraftKey(textDocId: TextDocId, timestamp: Date): string {
-    const timestampKey = timestamp?.toISOString();
+    const timestampKey: string = timestamp.toISOString();
     return `${textDocId.projectId}:${textDocId.bookNum}:${timestampKey}`;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -3,7 +3,7 @@ import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
-import { Observable, of, tap } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../core/models/text-doc';
@@ -41,27 +41,32 @@ export class DraftHandlingService {
    * @param config The format configuration to access the draft. Providing this will return a draft from serval.
    * @returns The draft data as a map of chapter number to delta operation array.
    */
-  getBookDraft(
+  async getBookDraft(
     textDocId: TextDocId,
     { timestamp, config }: { timestamp?: Date; config?: DraftUsfmConfig }
-  ): Observable<Map<string, DeltaOperation[]>> {
+  ): Promise<Map<string, DeltaOperation[]>> {
     if (config == null && timestamp != null) {
       const cachedDraft: Map<string, DeltaOperation[]> | undefined = this.bookDraftCache.get(
         this.getBookDraftKey(textDocId, timestamp)
       );
       if (cachedDraft != null) {
-        return of(cachedDraft);
+        return cachedDraft;
       }
     }
 
-    return this.draftGenerationService
-      .getGeneratedDraftBookDeltaOperations(textDocId.projectId, textDocId.bookNum, timestamp, config)
-      .pipe(
-        tap(chapterDrafts => {
-          if (config != null || timestamp == null) return;
-          this.bookDraftCache.set(this.getBookDraftKey(textDocId, timestamp), chapterDrafts);
-        })
-      );
+    const chapterDrafts = await firstValueFrom(
+      this.draftGenerationService.getGeneratedDraftBookDeltaOperations(
+        textDocId.projectId,
+        textDocId.bookNum,
+        timestamp,
+        config
+      )
+    );
+    if (config == null && timestamp != null) {
+      this.bookDraftCache.set(this.getBookDraftKey(textDocId, timestamp), chapterDrafts);
+    }
+
+    return chapterDrafts;
   }
 
   canApplyDraft(

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -3,7 +3,7 @@ import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
-import { Observable } from 'rxjs';
+import { Observable, of, tap } from 'rxjs';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
@@ -16,6 +16,8 @@ const VERSE_NUM_REGEX = /(\d+)\w?$/;
   providedIn: 'root'
 })
 export class DraftHandlingService {
+  private readonly bookDraftCache = new Map<string, Map<string, DeltaOperation[]>>();
+
   constructor(
     private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
@@ -23,35 +25,33 @@ export class DraftHandlingService {
   ) {}
 
   /**
-   * Gets the generated draft of a chapter for a book.
+   * Gets the generated drafts for every chapter of the book.
    * @param textDocId The text document identifier.
    * @param timestamp A timestamp indicating what version of the doc to fetch. Returns latest version if omitted.
    * @param config The format configuration to access the draft. Providing this will return a draft from serval.
-   * @returns The draft data in the current delta operation format.
+   * @returns The draft data as a map of chapter number to delta operation array.
    */
-  getDraft(
-    textDocId: TextDocId,
-    { timestamp, config }: { timestamp?: Date; config?: DraftUsfmConfig }
-  ): Observable<DeltaOperation[]> {
-    return this.draftGenerationService.getGeneratedDraftDeltaOperations(
-      textDocId.projectId,
-      textDocId.bookNum,
-      textDocId.chapterNum,
-      timestamp,
-      config
-    );
-  }
-
   getBookDraft(
     textDocId: TextDocId,
     { timestamp, config }: { timestamp?: Date; config?: DraftUsfmConfig }
   ): Observable<Map<string, DeltaOperation[]>> {
-    return this.draftGenerationService.getGeneratedDraftBookDeltaOperations(
-      textDocId.projectId,
-      textDocId.bookNum,
-      timestamp,
-      config
-    );
+    if (config == null && timestamp != null) {
+      const cachedDraft: Map<string, DeltaOperation[]> | undefined = this.bookDraftCache.get(
+        this.getBookDraftKey(textDocId, timestamp)
+      );
+      if (cachedDraft != null) {
+        return of(cachedDraft);
+      }
+    }
+
+    return this.draftGenerationService
+      .getGeneratedDraftBookDeltaOperations(textDocId.projectId, textDocId.bookNum, timestamp, config)
+      .pipe(
+        tap(chapterDrafts => {
+          if (config != null || timestamp == null) return;
+          this.bookDraftCache.set(this.getBookDraftKey(textDocId, timestamp), chapterDrafts);
+        })
+      );
   }
 
   canApplyDraft(
@@ -111,5 +111,14 @@ export class DraftHandlingService {
     const onlyTextOpIsTrailingNewline = indexOfFirstText === ops.length - 1 && ops[indexOfFirstText]?.insert === '\n';
     const hasNoExistingText = indexOfFirstText === -1 || onlyTextOpIsTrailingNewline;
     return !hasNoExistingText;
+  }
+
+  clearBookDraftCache(): void {
+    this.bookDraftCache.clear();
+  }
+
+  private getBookDraftKey(textDocId: TextDocId, timestamp: Date): string {
+    const timestampKey = timestamp?.toISOString();
+    return `${textDocId.projectId}:${textDocId.bookNum}:${timestampKey}`;
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, Injectable } from '@angular/core';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
 import { Observable, of, tap } from 'rxjs';
+import { ActivatedProjectService } from 'xforge-common/activated-project.service';
+import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../core/models/text-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
@@ -21,8 +23,16 @@ export class DraftHandlingService {
   constructor(
     private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
-    private readonly draftGenerationService: DraftGenerationService
-  ) {}
+    private readonly activatedProjectService: ActivatedProjectService,
+    private readonly draftGenerationService: DraftGenerationService,
+    private readonly destroyRef: DestroyRef
+  ) {
+    this.activatedProjectService.changes$
+      .pipe(quietTakeUntilDestroyed(this.destroyRef), filterNullish())
+      // Clear the cache when a user navigates to a different project
+      // or there is a change in the current project (e.g. change to the formatting options)
+      .subscribe(() => this.clearBookDraftCache());
+  }
 
   /**
    * Gets the generated drafts for every chapter of the book.
@@ -113,7 +123,7 @@ export class DraftHandlingService {
     return !hasNoExistingText;
   }
 
-  clearBookDraftCache(): void {
+  private clearBookDraftCache(): void {
     this.bookDraftCache.clear();
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -398,7 +398,7 @@ class TestEnvironment {
       { insert: { verse: { number: 1 } }, attributes: { style: 'v' } },
       { insert: 'Verse 1 text.' }
     ]);
-    when(mockedDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(args.bookDraft ?? bookDraft));
+    when(mockedDraftHandlingService.getBookDraft(anything(), anything())).thenResolve(args.bookDraft ?? bookDraft);
     when(mockedActivatedProjectService.projectId$).thenReturn(of(this.projectId));
     this.onlineStatusService.setIsOnline(true);
     when(mockedNoticeService.show(anything())).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -18,17 +18,7 @@ import {
   QuoteFormat
 } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
-import {
-  BehaviorSubject,
-  combineLatest,
-  EMPTY,
-  first,
-  firstValueFrom,
-  map,
-  Observable,
-  Subject,
-  switchMap
-} from 'rxjs';
+import { BehaviorSubject, combineLatest, first, firstValueFrom, map, Observable, Subject, switchMap } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
@@ -189,14 +179,14 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
     this.updateDraftConfig$
       .pipe(
         quietTakeUntilDestroyed(this.destroyRef),
-        map(config => ({ config, textDocId: this.textDocId })),
-        switchMap(({ config, textDocId }) => {
-          // the textDocId would only be empty if a user unexpectedly navigates to formatting options by URL
-          if (textDocId == null) return EMPTY;
-          return this.draftHandlingService.getBookDraft(textDocId, { config });
-        })
+        map(config => ({ config, textDocId: this.textDocId }))
       )
-      .subscribe(chapterDeltas => {
+      .subscribe(async ({ config, textDocId }) => {
+        // the textDocId would only be empty if a user unexpectedly navigates to formatting options by URL
+        if (textDocId == null) return;
+        const chapterDeltas: Map<string, DeltaOperation[]> = await this.draftHandlingService.getBookDraft(textDocId, {
+          config
+        });
         this.chapterDeltas.clear();
         this.chaptersWithDrafts = [];
         for (const chapter of chapterDeltas.keys()) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -96,7 +96,7 @@ describe('EditorDraftComponent', () => {
     when(mockDraftGenerationService.getLastPreTranslationBuild(anything())).thenReturn(
       of({ state: BuildStates.Completed } as BuildDto)
     );
-    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(bookDraftByChapters));
+    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenResolve(bookDraftByChapters);
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(true);
     when(mockSFProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(true);
 
@@ -314,7 +314,7 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(emptyBookDraftByChapters));
+    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenResolve(emptyBookDraftByChapters);
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(false);
 
     // SUT

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -3,7 +3,6 @@ import { MatIcon } from '@angular/material/icon';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { MatTooltip } from '@angular/material/tooltip';
-import { cloneDeep } from 'lodash-es';
 import { QuillService } from 'ngx-quill';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { Delta } from 'quill';
@@ -97,6 +96,7 @@ describe('EditorDraftComponent', () => {
     when(mockDraftGenerationService.getLastPreTranslationBuild(anything())).thenReturn(
       of({ state: BuildStates.Completed } as BuildDto)
     );
+    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(bookDraftByChapters));
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(true);
     when(mockSFProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(true);
 
@@ -130,12 +130,11 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).never();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).never();
     expect(component.draftCheckState).toEqual('draft-unknown');
     expect(component.draftText).not.toBeUndefined();
 
@@ -143,7 +142,7 @@ describe('EditorDraftComponent', () => {
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText).not.toBeUndefined();
     flush();
@@ -158,7 +157,6 @@ describe('EditorDraftComponent', () => {
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
       of(draftHistory)
     );
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
 
     testOnlineStatus.setIsOnline(false);
@@ -195,14 +193,46 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
+    flush();
+  }));
+
+  it('should get book draft when changing chapter and book', fakeAsync(() => {
+    const testProjectDoc: SFProjectProfileDoc = {
+      data: createTestProjectProfile()
+    } as SFProjectProfileDoc;
+    when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(
+      of(draftHistory)
+    );
+    when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
+    spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
+
+    // Initial load fetches draft for current selection.
+    fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+    expect(component.bookNum).toBe(1);
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
+
+    // Changing chapter triggers another draft retrieval call.
+    component.chapter = 2;
+    component.ngOnChanges();
+    fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).twice();
+
+    // Changing book triggers one more draft retrieval call.
+    component.bookNum = 2;
+    component.chapter = 1;
+    component.ngOnChanges();
+    fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).thrice();
     flush();
   }));
 
@@ -215,7 +245,6 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     // Set the date to a time before the earliest draft
     fixture.componentInstance.timestamp = new Date('2024-03-22T03:02:01Z');
@@ -224,7 +253,7 @@ describe('EditorDraftComponent', () => {
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
     flush();
@@ -239,7 +268,6 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     // Set the date to a time just before the earliest draft
     // This will account for the delay in storing the draft
@@ -251,7 +279,7 @@ describe('EditorDraftComponent', () => {
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
     flush();
@@ -266,13 +294,12 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     // SUT
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
     flush();
@@ -287,14 +314,14 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(emptyDraftDelta.ops!)));
+    when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(emptyBookDraftByChapters));
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(false);
 
     // SUT
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-empty');
     expect(component.canApplyDraft).toBe(false);
     expect(component.canSelectDraft).toBe(true);
@@ -311,14 +338,13 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(emptyDraftDelta.ops!)));
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(false);
 
     // SUT
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).once();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).once();
     expect(component.draftCheckState).toEqual('draft-empty');
     expect(component.canApplyDraft).toBe(false);
     expect(component.canSelectDraft).toBe(false);
@@ -333,12 +359,11 @@ describe('EditorDraftComponent', () => {
     when(mockDraftGenerationService.getGeneratedDraftHistory(anything(), anything(), anything())).thenReturn(of([]));
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).never();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).never();
     expect(component.draftCheckState).toEqual('draft-empty');
     flush();
   }));
@@ -352,7 +377,6 @@ describe('EditorDraftComponent', () => {
     );
     when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
     spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops!));
-    when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(cloneDeep(draftDelta.ops!)));
 
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
@@ -363,7 +387,7 @@ describe('EditorDraftComponent', () => {
     fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
 
-    verify(mockDraftHandlingService.getDraft(anything(), anything())).twice();
+    verify(mockDraftHandlingService.getBookDraft(anything(), anything())).twice();
     expect(component.draftCheckState).toEqual('draft-present');
     expect(component.draftText.editor!.getContents().ops).toEqual(draftDelta.ops);
     flush();
@@ -393,7 +417,6 @@ describe('EditorDraftComponent', () => {
       when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
       when(mockDraftHandlingService.canApplyDraft(anything(), anything(), anything(), anything())).thenReturn(true);
       spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
 
       fixture.detectChanges();
       tick(EDITOR_READY_TIMEOUT);
@@ -412,7 +435,6 @@ describe('EditorDraftComponent', () => {
       when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
       when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
       spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
 
       fixture.detectChanges();
       tick(EDITOR_READY_TIMEOUT);
@@ -436,7 +458,6 @@ describe('EditorDraftComponent', () => {
       );
       when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
       spyOn<any>(component, 'getTargetOps').and.returnValue(of([]));
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
 
       fixture.detectChanges();
       tick(EDITOR_READY_TIMEOUT);
@@ -467,7 +488,6 @@ describe('EditorDraftComponent', () => {
       );
       when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
       when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
       spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
 
       fixture.detectChanges();
@@ -493,7 +513,6 @@ describe('EditorDraftComponent', () => {
       );
       when(mockActivatedProjectService.changes$).thenReturn(of(testProjectDoc));
       when(mockDialogService.confirm(anything(), anything())).thenResolve(true);
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
       spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
       fixture.detectChanges();
       tick(EDITOR_READY_TIMEOUT);
@@ -529,7 +548,6 @@ describe('EditorDraftComponent', () => {
         of(draftHistory)
       );
       spyOn<any>(component, 'getTargetOps').and.returnValue(of(targetDelta.ops));
-      when(mockDraftHandlingService.getDraft(anything(), anything())).thenReturn(of(draftDelta.ops!));
     });
 
     it('should be true when latest build has draft and selected revision is latest', fakeAsync(() => {
@@ -694,6 +712,11 @@ const draftDelta = new Delta([
   }
 ]);
 
+const bookDraftByChapters = new Map<string, any[]>([
+  ['1', draftDelta.ops],
+  ['2', draftDelta.ops]
+]);
+
 const emptyDraftDelta = new Delta([
   {
     attributes: {
@@ -734,6 +757,8 @@ const emptyDraftDelta = new Delta([
     }
   }
 ]);
+
+const emptyBookDraftByChapters = new Map<string, any[]>([['1', emptyDraftDelta.ops]]);
 
 const draftHistory: Revision[] = [
   { source: 'Draft', timestamp: '2025-03-25T01:02:03Z' },

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -158,9 +158,6 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       await projectNotificationService.stop();
       projectNotificationService.removeNotifyBuildProgressHandler(this.notifyBuildProgressHandler);
     });
-
-    // Clear the book draft cache in case formatting options have changed
-    this.draftHandlingService.clearBookDraftCache();
   }
 
   get bookId(): string {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -28,7 +28,6 @@ import {
   observeOn,
   of,
   startWith,
-  Subject,
   switchMap,
   take,
   tap,
@@ -91,7 +90,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
   @ViewChild(TextComponent) draftText!: TextComponent;
 
-  inputChanged$ = new Subject<void>();
+  inputChanged$ = new BehaviorSubject<TextDocId | undefined>(this.textDocId);
   draftCheckState: 'draft-unknown' | 'draft-present' | 'draft-empty' = 'draft-unknown';
   selectedRevision: Revision | undefined;
   generateDraftUrl?: string;
@@ -159,6 +158,9 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       await projectNotificationService.stop();
       projectNotificationService.removeNotifyBuildProgressHandler(this.notifyBuildProgressHandler);
     });
+
+    // Clear the book draft cache in case formatting options have changed
+    this.draftHandlingService.clearBookDraftCache();
   }
 
   get bookId(): string {
@@ -211,7 +213,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     }
 
     this.textDocId = new TextDocId(this.projectId, this.bookNum, this.chapter, 'target');
-    this.inputChanged$.next();
+    this.inputChanged$.next(this.textDocId);
   }
 
   ngAfterViewInit(): void {
@@ -228,17 +230,17 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     combineLatest([
       this.onlineStatusService.onlineStatus$,
       this.draftGenerationService.pollBuildProgress(this.textDocId!.projectId),
-      this.draftText.editorCreated as EventEmitter<any>,
-      this.inputChanged$.pipe(startWith(undefined))
+      this.inputChanged$.pipe(filterNullish()),
+      this.draftText.editorCreated as EventEmitter<any>
     ])
       .pipe(
         quietTakeUntilDestroyed(this.destroyRef),
         filter(([isOnline, build]) => isOnline && build != null && build.state !== BuildStates.Finishing),
         tap(() => this.setInitialState()),
-        switchMap(() =>
+        switchMap(([, , textDocId]) =>
           merge(
             this.draftGenerationService
-              .getGeneratedDraftHistory(this.textDocId!.projectId, this.textDocId!.bookNum, this.textDocId!.chapterNum)
+              .getGeneratedDraftHistory(textDocId.projectId, textDocId.bookNum, textDocId.chapterNum)
               .pipe(
                 map(revisions => {
                   if (revisions != null && revisions.length > 0) {
@@ -249,21 +251,21 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
                     const date = this.timestamp ?? new Date();
                     // Don't emit this.selectedRevision$, as the merge will handle this
                     this.selectedRevision = this.findClosestRevision(date, this.draftRevisions);
-                    return date;
+                    return { textDocId, timestamp: this.selectedRevision?.timestamp };
                   } else {
-                    return undefined;
+                    return { textDocId };
                   }
                 })
               ),
             this.selectedRevision$.pipe(
               filter((rev): rev is { timestamp: string } => rev != null),
-              map(revision => new Date(revision.timestamp))
+              map(revision => ({ textDocId, timestamp: revision.timestamp }))
             )
           )
         ),
-        switchMap(timestamp => {
-          // If an earlier draft exists, hide it if the draft history feature is not enabled
+        switchMap(({ textDocId, timestamp }) => {
           if (timestamp == null) {
+            // Unable to find a draft to display
             this.draftCheckState = 'draft-empty';
             return EMPTY;
           }
@@ -272,11 +274,11 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
           return this.activatedProjectService.changes$.pipe(
             filterNullish(),
             distinctUntilChanged(),
-            map(() => timestamp)
+            map(() => ({ textDocId, timestamp }))
           );
         }),
-        switchMap((timestamp: Date | undefined) =>
-          combineLatest([this.getTargetOps(), this.draftHandlingService.getDraft(this.textDocId!, { timestamp })])
+        switchMap(({ textDocId, timestamp }) =>
+          combineLatest([this.getTargetOps(), this.getChapterDraftOps(textDocId, timestamp)])
         ),
         switchMap(([targetOps, draftOps]) => {
           // Look for verses that contain text. If these are present, this is a non-empty draft
@@ -316,7 +318,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       this.onlineStatusService.onlineStatus$,
       this.activatedProjectService.projectDoc$,
       this.draftText.editorCreated as EventEmitter<any>,
-      this.inputChanged$.pipe(startWith(undefined))
+      this.inputChanged$
     ])
       .pipe(
         quietTakeUntilDestroyed(this.destroyRef),
@@ -434,5 +436,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
         else return of([] as DeltaOperation[]);
       })
     );
+  }
+
+  private getChapterDraftOps(textDocId: TextDocId, timestamp: string): Observable<DeltaOperation[]> {
+    const chapterNum: string = textDocId.chapterNum.toString();
+    const timestampAsDate = new Date(timestamp);
+    return this.draftHandlingService
+      .getBookDraft(textDocId, { timestamp: timestampAsDate })
+      .pipe(map(chapterDrafts => chapterDrafts.get(chapterNum) ?? []));
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -275,15 +275,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
           );
         }),
         switchMap(({ textDocId, timestamp }) =>
-          combineLatest([this.getTargetOps(), this.getChapterDraftOps(textDocId, timestamp)])
-        ),
-        switchMap(([targetOps, draftOps]) => {
-          // Look for verses that contain text. If these are present, this is a non-empty draft
-          if (this.draftHandlingService.opsHaveContent(draftOps)) {
-            this.draftCheckState = 'draft-present';
-            return of({ targetOps, draftOps });
-          }
-
+          this.getTargetOps().pipe(map(targetOps => ({ targetOps, textDocId, timestamp })))
+        )
+      )
+      .subscribe(async ({ targetOps, textDocId, timestamp }) => {
+        const draftOps: DeltaOperation[] = await this.getChapterDraftOps(textDocId, timestamp);
+        // Look for verses that contain text. If these are present, this is a non-empty draft
+        if (!this.draftHandlingService.opsHaveContent(draftOps)) {
           // If there are previous draft revisions, we should still show the selector to choose them
           this.canSelectDraft = this._draftRevisions.length > 1;
 
@@ -293,10 +291,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
 
           // No generated verse segments were found, return an empty draft
           this.draftCheckState = 'draft-empty';
-          return EMPTY;
-        })
-      )
-      .subscribe(({ targetOps, draftOps }) => {
+          return;
+        }
+        this.draftCheckState = 'draft-present';
+        this.canSelectDraft = true;
         this.draftDelta = new Delta(draftOps);
         this.targetDelta = new Delta(targetOps);
 
@@ -307,8 +305,6 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
         this.isDraftApplied =
           this.targetProject?.texts.find(t => t.bookNum === this.bookNum)?.chapters.find(c => c.number === this.chapter)
             ?.draftApplied ?? false;
-
-        this.canSelectDraft = this.draftCheckState === 'draft-present';
       });
 
     combineLatest([
@@ -435,11 +431,13 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     );
   }
 
-  private getChapterDraftOps(textDocId: TextDocId, timestamp: string): Observable<DeltaOperation[]> {
+  private async getChapterDraftOps(textDocId: TextDocId, timestamp: string): Promise<DeltaOperation[]> {
     const chapterNum: string = textDocId.chapterNum.toString();
     const timestampAsDate = new Date(timestamp);
-    return this.draftHandlingService
-      .getBookDraft(textDocId, { timestamp: timestampAsDate })
-      .pipe(map(chapterDrafts => chapterDrafts.get(chapterNum) ?? []));
+
+    const chapterDrafts: Map<string, DeltaOperation[]> = await this.draftHandlingService.getBookDraft(textDocId, {
+      timestamp: timestampAsDate
+    });
+    return chapterDrafts.get(chapterNum) ?? [];
   }
 }


### PR DESCRIPTION
This PR removes the getDraft method from draft handling service in favour of the getBookDraft. It also implements a cache so that getting drafts is speedier when accessing a book that is already cached. The draft tab component has been updated to use the getBookDraft method which allows navigating between chapters to require minimal load time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3899)
<!-- Reviewable:end -->
