### PR TITLE
SF-3806 Show all drafted books in formatting options book select

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -111,6 +111,18 @@ describe('DraftUsfmFormatComponent', () => {
     expect(isDisabled).toBe(true);
   }));
 
+  it('allows selecting any book with a completed draft', fakeAsync(() => {
+    const env = new TestEnvironment({
+      project: {
+        translateConfig: { draftConfig: { currentScriptureRange: 'GEN;EXO;NUM;' } as DraftConfig } as TranslateConfig
+      }
+    });
+    tick(EDITOR_READY_TIMEOUT);
+    env.fixture.detectChanges();
+    tick(EDITOR_READY_TIMEOUT);
+    expect(env.component.booksWithDrafts).toEqual([1, 2, 4]);
+  }));
+
   it('navigates to book and chapter from route params', fakeAsync(() => {
     when(mockedActivatedRoute.params).thenReturn(of({ bookId: 'EXO', chapter: '2' }));
     const env = new TestEnvironment();
@@ -143,10 +155,10 @@ describe('DraftUsfmFormatComponent', () => {
             hasSource: true,
             permissions: {}
           }
-        ]
+        ],
+        translateConfig: { draftConfig: { currentScriptureRange: 'LEV' } as DraftConfig } as TranslateConfig
       }
     });
-    when(mockedProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(false);
     tick(EDITOR_READY_TIMEOUT);
     env.fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
@@ -188,7 +200,8 @@ describe('DraftUsfmFormatComponent', () => {
       project: {
         translateConfig: {
           draftConfig: {
-            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized }
+            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized },
+            currentScriptureRange: 'GEN;EXO;LEV'
           } as DraftConfig
         } as TranslateConfig
       }
@@ -238,7 +251,8 @@ describe('DraftUsfmFormatComponent', () => {
       project: {
         translateConfig: {
           draftConfig: {
-            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized }
+            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized },
+            currentScriptureRange: 'GEN;EXO'
           } as DraftConfig
         } as TranslateConfig,
         texts: [
@@ -273,7 +287,8 @@ describe('DraftUsfmFormatComponent', () => {
       project: {
         translateConfig: {
           draftConfig: {
-            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized }
+            usfmConfig: { paragraphFormat: ParagraphBreakFormat.MoveToEnd, quoteFormat: QuoteFormat.Denormalized },
+            currentScriptureRange: 'GEN;EXO'
           } as DraftConfig
         } as TranslateConfig
       }
@@ -337,6 +352,10 @@ class TestEnvironment {
   readonly userId = 'user01';
   onlineStatusService: TestOnlineStatusService;
   private readonly realtimeService: TestRealtimeService = TestBed.inject<TestRealtimeService>(TestRealtimeService);
+
+  private translateConfig: Partial<TranslateConfig> = {
+    draftConfig: { currentScriptureRange: 'GEN;EXO' } as DraftConfig
+  };
 
   constructor(
     args: {
@@ -404,7 +423,7 @@ class TestEnvironment {
     return this.fixture.nativeElement.querySelector('.quote-format-warning');
   }
 
-  setupProject(project?: Partial<SFProjectProfile>): void {
+  private setupProject(project?: Partial<SFProjectProfile>): void {
     const texts: TextInfo[] = [
       {
         bookNum: 1,
@@ -437,7 +456,10 @@ class TestEnvironment {
     ];
     const projectDoc = {
       id: this.projectId,
-      data: createTestProjectProfile({ translateConfig: project?.translateConfig, texts: project?.texts ?? texts })
+      data: createTestProjectProfile({
+        translateConfig: project?.translateConfig ?? this.translateConfig,
+        texts: project?.texts ?? texts
+      })
     } as SFProjectProfileDoc;
     when(mockedActivatedProjectService.projectId).thenReturn(this.projectId);
     when(mockedActivatedProjectService.projectDoc$).thenReturn(of(projectDoc));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -12,7 +12,6 @@ import { Canon } from '@sillsdev/scripture';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
-import { TextInfo } from 'realtime-server/lib/esm/scriptureforge/models/text-info';
 import {
   DraftUsfmConfig,
   ParagraphBreakFormat,
@@ -46,7 +45,7 @@ import { BookChapterChooserComponent } from '../../../shared/book-chapter-choose
 import { NoticeComponent } from '../../../shared/notice/notice.component';
 import { ConfirmOnLeave } from '../../../shared/project-router.guard';
 import { TextComponent } from '../../../shared/text/text.component';
-import { projectLabel } from '../../../shared/utils';
+import { booksFromScriptureRange, projectLabel } from '../../../shared/utils';
 import { DraftGenerationService } from '../draft-generation.service';
 import { DraftHandlingService } from '../draft-handling.service';
 import { DraftSourcesAsArrays } from '../draft-source';
@@ -168,10 +167,9 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
         const projectDoc = this.activatedProjectService.projectDoc;
         if (projectDoc?.data == null) return;
         this.setUsfmConfig(projectDoc.data.translateConfig.draftConfig.usfmConfig);
-        const texts: TextInfo[] = projectDoc.data.texts;
-        this.booksWithDrafts = texts
-          .filter(t => this.projectService.hasDraft(projectDoc.data, t.bookNum, undefined, true))
-          .map(t => t.bookNum);
+        this.booksWithDrafts = booksFromScriptureRange(
+          projectDoc.data.translateConfig.draftConfig.currentScriptureRange
+        );
 
         if (this.booksWithDrafts.length === 0) return;
         this.loadingStarted();


### PR DESCRIPTION
The formatting options page previously calculated books with completed drafts based on the books that exist in the current project. This is no longer the best option since books can be used for drafting that may not exist in the target project. This PR updates the behaviour to show any books that were drafted in the current draft build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3902)
<!-- Reviewable:end -->
