### PR TITLE
Remove deprecated codecov/test-results-action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,13 +120,15 @@ jobs:
             -targetdir:coverage \
             "-reporttypes:HTML;TeamCitySummary"
       - name: "Coverage: Publish to Codecov"
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
+          report_type: coverage
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: "Test: Publish test results to Codecov"
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build-production:

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts
@@ -129,8 +129,8 @@ describe('ProgressService', () => {
     const project1Books: BookProgress[] = [{ bookId: 'GEN', verseSegments: 100, blankVerseSegments: 20 }];
     const project2Books: BookProgress[] = [{ bookId: 'MAT', verseSegments: 50, blankVerseSegments: 10 }];
 
-    when(mockedProjectService.getProjectProgress('project1')).thenReturn(Promise.resolve(project1Books));
-    when(mockedProjectService.getProjectProgress('project2')).thenReturn(Promise.resolve(project2Books));
+    when(mockedProjectService.getProjectProgress('project1')).thenResolve(project1Books);
+    when(mockedProjectService.getProjectProgress('project2')).thenResolve(project2Books);
 
     let result1: ProjectProgress | undefined;
     let result2: ProjectProgress | undefined;


### PR DESCRIPTION
This PR fixes the following warnings thrown by the Build and test (ubuntu-24.04, 10.0.x, 22.13.0, 11.11.0) GHA:

```
This action is being deprecated in favor of 'codecov-action'.
      Please update CI accordingly to use 'codecov-action@v5' with
      'report_type: test_results'.
      The 'codecov-action' should and can be run at least once for
      coverage and once for test results
```

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea, codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

I have also fixed the two grit_check warnings I noticed when reviewing the GHA grit-check: 

```
./src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts#L133
then_resolve
grit-check: ./src/SIL.XForge.Scripture/ClientApp/src/app/shared/progress-service/progress.service.spec.ts#L132
then_resolve
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3905)
<!-- Reviewable:end -->
