### PR TITLE
serval-admin: serval-builds: add search

### DIFF
--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -22,7 +22,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
 ## Frontend testing
 
 - Write unit tests for new components and services
-- Do not put helper functions outside of TestEnvironment classes; helper functions or setup functions should be in the TestEnvironment class.
+- Do not put helper functions outside of TestEnvironment classes; helper functions or setup functions should be in the TestEnvironment class. For example, do not put a helper function, like `createRows()` as a top-level function in a .spec.ts file, or as a function in a `describe()` block. Instead, make the helper function as a method in the TestEnvironment class, like `TestEnvironment.createRows()`.
 - Test both online and offline scenarios
 - Test permission boundaries
 - When a TestEnvironment class is being given many optional arguments, prefer using object destructuring with default values, and the argument type definition specified inline rather than as an interface. For example,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -9,7 +9,7 @@
   $is-dark: mat.get-theme-type($theme) == dark;
 
   // Search box. The populated search box has a background colour different than the
-  // application palaette colours to make it stand out that not all the records are
+  // application palette colours to make it stand out that not all the records are
   // being shown.
   --sf-serval-builds-search-background-populated: #{if($is-dark, #453e00, #fff27c)};
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -8,10 +8,10 @@
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
-  // Search box. The populated search box has a background colour different than the
-  // application palette colours to make it stand out that not all the records are
-  // being shown.
-  --sf-serval-builds-search-background-populated: #{if($is-dark, #453e00, #fff27c)};
+  // Search box. When populated, the search box has a fill colour to make it stand out that
+  // the records are being limited by the search.
+  --sf-serval-builds-search-text-populated: var(--mat-sys-on-primary-container);
+  --sf-serval-builds-search-background-populated: var(--mat-sys-primary-container);
 
   // Status icon colors
   --sf-serval-builds-status-userrequested: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/_serval-builds-theme.scss
@@ -8,6 +8,11 @@
 @mixin color($theme) {
   $is-dark: mat.get-theme-type($theme) == dark;
 
+  // Search box. The populated search box has a background colour different than the
+  // application palaette colours to make it stand out that not all the records are
+  // being shown.
+  --sf-serval-builds-search-background-populated: #{if($is-dark, #453e00, #fff27c)};
+
   // Status icon colors
   --sf-serval-builds-status-userrequested: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};
   --sf-serval-builds-status-submittedtoserval: #{mat.get-theme-color($theme, neutral, if($is-dark, 40, 60))};

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -42,21 +42,32 @@
         text="Include builds in the list that do not correspond to any projects that are currently in this site database."
       ></app-info>
     </div>
-  </div>
 
-  @if (currentProjectFilter != null) {
-    <app-notice icon="filter_alt" mode="fill-dark">
-      <div class="filter-notice-content">
-        <span>
-          Showing builds for project <strong>{{ filteredProjectName ?? currentProjectFilter }}</strong>
-        </span>
-        <button mat-button class="clear-filter-btn" (click)="clearProjectFilter()">
-          <mat-icon>filter_alt_off</mat-icon>
-          <span>Show all projects</span>
-        </button>
-      </div>
-    </app-notice>
-  }
+    <div class="identifier-search-group">
+      <mat-form-field
+        appearance="outline"
+        subscriptSizing="dynamic"
+        class="identifier-search-field"
+        [class.identifier-search-field-active]="searchControl.value.length > 0"
+      >
+        <mat-label>Search</mat-label>
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput type="text" [formControl]="searchControl" />
+
+        @if (searchControl.value.length > 0) {
+          <button mat-icon-button matSuffix type="button" (click)="clearSearch()" aria-label="Clear search">
+            <mat-icon>close</mat-icon>
+          </button>
+        } @else {
+          <app-info
+            matSuffix
+            class="identifier-search-info"
+            text="Search builds by project ID, name, books, user ID, name, email."
+          ></app-info>
+        }
+      </mat-form-field>
+    </div>
+  </div>
 
   @if (summaryDisplayItems.length > 0) {
     <div class="summary-area">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -75,6 +75,7 @@ a {
 
 :host ::ng-deep .identifier-search-field.identifier-search-field-active .mat-mdc-text-field-wrapper {
   background-color: var(--sf-serval-builds-search-background-populated);
+  color: var(--sf-serval-builds-search-text-populated);
   transition: background-color 150ms ease-in;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -61,7 +61,7 @@ a {
 }
 
 .identifier-search-field {
-  width: min(14rem);
+  width: 14rem;
 
   &.identifier-search-field-active {
     border-radius: 12px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -7,13 +7,6 @@ a {
   margin-bottom: 1rem;
 }
 
-.filter-notice-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-}
-
 .filter-controls {
   display: flex;
   flex-wrap: wrap;
@@ -60,6 +53,29 @@ a {
     vertical-align: middle;
     margin-inline-start: 0.25em;
   }
+}
+
+.identifier-search-group {
+  display: inline-flex;
+  align-items: center;
+}
+
+.identifier-search-field {
+  width: min(14rem);
+
+  &.identifier-search-field-active {
+    border-radius: 12px;
+  }
+}
+
+/** Make the app-info icon in the same place as the close button. */
+.identifier-search-info {
+  margin-right: 0.6rem;
+}
+
+:host ::ng-deep .identifier-search-field.identifier-search-field-active .mat-mdc-text-field-wrapper {
+  background-color: var(--sf-serval-builds-search-background-populated);
+  transition: background-color 150ms ease-in;
 }
 
 .summary-area {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -30,7 +30,13 @@ import {
   ServalBuildReportDto
 } from './serval-build-report';
 import { buildSummary, gapsBetweenBuildsMs } from './serval-builds-statistics';
-import { BuildInputItem, RequesterInfo, ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
+import {
+  BuildInputItem,
+  RequesterInfo,
+  ServalBuildRow,
+  ServalBuildsComponent,
+  ServalBuildSummary
+} from './serval-builds.component';
 
 const mockNoticeService = mock(NoticeService);
 const mockDraftGenerationService = mock(DraftGenerationService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -118,6 +118,9 @@ describe('ServalBuildsComponent', () => {
     }));
 
     it('filters rows by Serval build ID', fakeAsync(() => {
+      // Suppose a user searches for a Serval build ID. It should match. And the matching
+      // for this and any other searchable fields is both case insensitive and partial,
+      // as a substring.
       const env = new TestEnvironment();
       const matchingRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-777' });
       const otherRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-888' });
@@ -151,19 +154,6 @@ describe('ServalBuildsComponent', () => {
 
       // SUT
       env.component['searchControl'].setValue('req-555');
-      env.waitForRowUpdate();
-
-      expect(env.component['rows']).toEqual([matchingRow]);
-    }));
-
-    it('matches search terms using case-insensitive partial matching', fakeAsync(() => {
-      const env = new TestEnvironment();
-      const matchingRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-777' });
-      const otherRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-888' });
-      env.component['allRows'] = [matchingRow, otherRow];
-
-      // SUT
-      env.component['searchControl'].setValue('serval-builD-7');
       env.waitForRowUpdate();
 
       expect(env.component['rows']).toEqual([matchingRow]);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { BehaviorSubject, firstValueFrom, Observable, skip, Subject, take } from 'rxjs';
@@ -20,7 +20,6 @@ import { BuildStates } from '../machine-api/build-states';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { NormalizedDateRange } from './date-range-picker.component';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
-import { ServalAdministrationService } from './serval-administration.service';
 import { ServalBuildProblemsDialog } from './serval-build-problems-dialog.component';
 import {
   buildProjectDisplayName,
@@ -31,7 +30,7 @@ import {
   ServalBuildReportDto
 } from './serval-build-report';
 import { buildSummary, gapsBetweenBuildsMs } from './serval-builds-statistics';
-import { BuildInputItem, ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
+import { BuildInputItem, RequesterInfo, ServalBuildRow, ServalBuildsComponent, ServalBuildSummary } from './serval-builds.component';
 
 const mockNoticeService = mock(NoticeService);
 const mockDraftGenerationService = mock(DraftGenerationService);
@@ -39,7 +38,6 @@ const mockDialogService = mock(DialogService);
 const mockExportService = mock(DraftJobsExportService);
 const mockUserService = mock(UserService);
 const mockI18nService = mock(I18nService);
-const mockServalAdministrationService = mock(ServalAdministrationService);
 const mockedActivatedRoute = mock(ActivatedRoute);
 const mockedConsole: MockConsole = MockConsole.install();
 
@@ -57,14 +55,13 @@ describe('ServalBuildsComponent', () => {
       { provide: DraftJobsExportService, useMock: mockExportService },
       { provide: UserService, useMock: mockUserService },
       { provide: I18nService, useMock: mockI18nService },
-      { provide: ServalAdministrationService, useMock: mockServalAdministrationService },
       { provide: ActivatedRoute, useMock: mockedActivatedRoute },
       provideNoopAnimations()
     ]
   }));
 
   describe('include deleted toggle', () => {
-    it('excludes deleted projects when toggle is off', () => {
+    it('excludes deleted projects when toggle is off', fakeAsync(() => {
       const env = new TestEnvironment();
       const activeRow = env.createRow(false, 1000);
       const deletedRow = env.createRow(true, 3000);
@@ -72,12 +69,13 @@ describe('ServalBuildsComponent', () => {
 
       // SUT
       env.component['onIncludeDeletedChange'](false);
+      env.waitForRowUpdate();
 
       expect(env.component['rows'].length).toBe(1);
       expect(env.component['rows'][0].report.project?.sfProjectId).toBeDefined();
-    });
+    }));
 
-    it('includes deleted projects when toggle is on', () => {
+    it('includes deleted projects when toggle is on', fakeAsync(() => {
       const env = new TestEnvironment();
       const activeRow = env.createRow(false, 1000);
       const deletedRow = env.createRow(true, 3000);
@@ -85,63 +83,324 @@ describe('ServalBuildsComponent', () => {
 
       // SUT
       env.component['onIncludeDeletedChange'](true);
+      env.waitForRowUpdate();
 
       expect(env.component['rows'].length).toBe(2);
       expect(env.component['rows'][1].report.project?.sfProjectId).toBeUndefined();
-    });
+    }));
   });
 
-  describe('sfProjectId filter', () => {
-    let rowA: any;
-    let rowB: any;
-    let rowC: any;
-    beforeEach(() => {
-      rowA = TestEnvironment.createRowWithDetails({
-        projectId: 'project-a',
-        startDate: new Date('2024-01-03T00:00:00Z')
-      });
-      rowB = TestEnvironment.createRowWithDetails({
-        projectId: 'project-b',
-        startDate: new Date('2024-01-02T00:00:00Z')
-      });
-      rowC = TestEnvironment.createRowWithDetails({
-        projectId: 'project-a',
-        startDate: new Date('2024-01-01T00:00:00Z')
-      });
-    });
-
-    it('filters rows to only the matching project when sfProjectId is set', () => {
+  describe('search', () => {
+    it('filters rows by SF project ID', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.component['allRows'] = [rowA, rowB, rowC];
-      env.component['currentProjectFilter'] = 'project-a';
+      const matchingRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-123' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-999' });
+      env.component['allRows'] = [matchingRow, otherRow];
 
       // SUT
-      env.component['applyFiltersAndStats']();
+      env.component['searchControl'].setValue('project-123');
+      env.waitForRowUpdate();
 
-      expect(env.component['rows'].length).toBe(2);
-      expect(env.component['rows'].every(r => r.report.project?.sfProjectId === 'project-a')).toBeTrue();
-    });
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
 
-    it('shows all rows when sfProjectId filter is cleared', () => {
+    it('filters rows by PT project ID', fakeAsync(() => {
       const env = new TestEnvironment();
-      env.component['allRows'] = [rowA, rowB, rowC];
-      env.component['currentProjectFilter'] = 'project-a';
-
-      // First confirm filtering is active.
-      env.component['applyFiltersAndStats']();
-
-      expect(env.component['rows'].length).toBe(2);
-      expect(env.component['rows'].every(r => r.report.project?.sfProjectId === 'project-a')).toBeTrue();
-
-      // Then clear and confirm all rows are shown.
-      env.component['currentProjectFilter'] = undefined;
+      const matchingRow: ServalBuildRow = env.createSearchRow({ ptProjectId: 'PT-PROJ-XYZ' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ ptProjectId: 'PT-PROJ-OTHER' });
+      env.component['allRows'] = [matchingRow, otherRow];
 
       // SUT
-      env.component['applyFiltersAndStats']();
+      env.component['searchControl'].setValue('proj-xyz');
+      env.waitForRowUpdate();
 
-      expect(env.component['rows'].length).toBe(3);
-    });
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by Serval build ID', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-777' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-888' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component['searchControl'].setValue('build-777');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by SF user ID', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-alpha' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-beta' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component['searchControl'].setValue('user-alpha');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by draft generation request ID', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ draftGenerationRequestId: 'DRAFT-REQ-555' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ draftGenerationRequestId: 'DRAFT-REQ-111' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component['searchControl'].setValue('req-555');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('matches search terms using case-insensitive partial matching', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-777' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ servalBuildId: 'SERVAL-BUILD-888' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component['searchControl'].setValue('serval-builD-7');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by requester display name', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const firstRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-alpha' });
+      const secondRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-beta' });
+      env.component['allRows'] = [firstRow, secondRow];
+      env.setRequesterData('user-alpha', {
+        displayName: 'Alpha Display User',
+        name: 'Alpha Name User',
+        email: 'alpha@example.com'
+      });
+      env.setRequesterData('user-beta', {
+        displayName: 'Beta Display User',
+        name: 'Beta Name User',
+        email: 'beta@example.com'
+      });
+
+      // SUT
+      env.component['searchControl'].setValue('alpha display');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([firstRow]);
+    }));
+
+    it('filters rows by requester name', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const firstRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-alpha' });
+      const secondRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-beta' });
+      env.component['allRows'] = [firstRow, secondRow];
+      env.setRequesterData('user-alpha', {
+        displayName: 'Alpha Display User',
+        name: 'Alpha Name User',
+        email: 'alpha@example.com'
+      });
+      env.setRequesterData('user-beta', {
+        displayName: 'Beta Display User',
+        name: 'Beta Name User',
+        email: 'beta@example.com'
+      });
+
+      // SUT
+      env.component['searchControl'].setValue('alpha name');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([firstRow]);
+    }));
+
+    it('filters rows by requester email address', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const firstRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-alpha' });
+      const secondRow: ServalBuildRow = env.createSearchRow({ requesterId: 'user-beta' });
+      env.component['allRows'] = [firstRow, secondRow];
+      env.setRequesterData('user-alpha', {
+        displayName: 'Alpha Display User',
+        name: 'Alpha Name User',
+        email: 'alpha@example.com'
+      });
+      env.setRequesterData('user-beta', {
+        displayName: 'Beta Display User',
+        name: 'Beta Name User',
+        email: 'beta@example.com'
+      });
+
+      // SUT
+      env.component['searchControl'].setValue('alpha@example.com');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([firstRow]);
+    }));
+
+    it('filters rows by project short name and project name', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({
+        projectShortName: 'ABC',
+        projectName: 'Alpha Build Project'
+      });
+      const otherRow: ServalBuildRow = env.createSearchRow({
+        projectShortName: 'XYZ',
+        projectName: 'Other Build Project'
+      });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      env.component['searchControl'].setValue('abc');
+      env.waitForRowUpdate();
+      const rowsByShortName: ServalBuildRow[] = [...env.component['rows']];
+
+      env.component['searchControl'].setValue('alpha build project');
+      env.waitForRowUpdate();
+      const rowsByName: ServalBuildRow[] = [...env.component['rows']];
+
+      expect(rowsByShortName).toEqual([matchingRow]);
+      expect(rowsByName).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by training or translation reference project short/name', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingTrainingReference: ProjectBooks[] = [
+        {
+          sfProjectId: 'train-1',
+          projectDisplayName: 'TRN - Training Reference Project',
+          shortName: 'TRN',
+          projectName: 'Training Reference Project',
+          booksAndChapters: [{ bookId: 'GEN' }, { bookId: 'EXO' }]
+        }
+      ];
+      const matchingTranslationReference: ProjectBooks[] = [
+        {
+          sfProjectId: 'trans-1',
+          projectDisplayName: 'TLR - Translation Reference Project',
+          shortName: 'TLR',
+          projectName: 'Translation Reference Project',
+          booksAndChapters: [{ bookId: 'MRK' }]
+        }
+      ];
+      const matchingRow: ServalBuildRow = env.createSearchRow({
+        trainingBooks: matchingTrainingReference,
+        translationBooks: matchingTranslationReference
+      });
+      const otherRow: ServalBuildRow = env.createSearchRow({
+        trainingBooks: [
+          {
+            sfProjectId: 'train-2',
+            projectDisplayName: 'OTR - Other Training Project',
+            shortName: 'OTR',
+            projectName: 'Other Training Project',
+            booksAndChapters: [{ bookId: 'LUK' }]
+          }
+        ],
+        translationBooks: []
+      });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      env.component['searchControl'].setValue('trn');
+      env.waitForRowUpdate();
+      const rowsByTrainingShortName: ServalBuildRow[] = [...env.component['rows']];
+
+      env.component['searchControl'].setValue('translation reference project');
+      env.waitForRowUpdate();
+      const rowsByTranslationName: ServalBuildRow[] = [...env.component['rows']];
+
+      expect(rowsByTrainingShortName).toEqual([matchingRow]);
+      expect(rowsByTranslationName).toEqual([matchingRow]);
+    }));
+
+    it('filters rows by referenced book code', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({
+        trainingBooks: env.createProjectBooks('train-1', ['GEN'])
+      });
+      const otherRow: ServalBuildRow = env.createSearchRow({
+        trainingBooks: env.createProjectBooks('train-2', ['LUK'])
+      });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component['searchControl'].setValue('gen');
+      env.waitForRowUpdate();
+
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('clearSearch clears search text and resets filtered rows', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-123' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-999' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      env.component['searchControl'].setValue('project-123');
+      env.waitForRowUpdate();
+      expect(env.component['rows']).toEqual([matchingRow]);
+
+      // SUT
+      env.component['clearSearch']();
+      env.waitForRowUpdate();
+
+      expect(env.component['searchControl'].value).toBe('');
+      expect(env.component['rows']).toEqual([matchingRow, otherRow]);
+    }));
+
+    it('uses query param q to set search text and filter rows', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const matchingRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-123' });
+      const otherRow: ServalBuildRow = env.createSearchRow({ projectId: 'sf-project-999' });
+      env.component['allRows'] = [matchingRow, otherRow];
+
+      // SUT
+      env.component.ngOnInit();
+      env.queryParams$.next({ q: 'project-123' });
+      env.waitForRowUpdate();
+
+      expect(env.component['searchControl'].value).toBe('project-123');
+      expect(env.component['rows']).toEqual([matchingRow]);
+    }));
+
+    it('updates query param q when search text changes', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const navigateSpy = spyOn(env.component['router'], 'navigate').and.resolveTo(true);
+
+      // SUT
+      env.component['searchControl'].setValue('project-123');
+      env.waitForRowUpdate();
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        [],
+        jasmine.objectContaining({
+          queryParams: { q: 'project-123' },
+          queryParamsHandling: 'merge'
+        })
+      );
+    }));
+
+    it('clears query param q when search text is cleared', fakeAsync(() => {
+      const env = new TestEnvironment();
+      const navigateSpy = spyOn(env.component['router'], 'navigate').and.resolveTo(true);
+
+      env.component['searchControl'].setValue('project-123');
+      env.waitForRowUpdate();
+      navigateSpy.calls.reset();
+
+      // SUT
+      env.component['searchControl'].setValue('');
+      env.waitForRowUpdate();
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        [],
+        jasmine.objectContaining({
+          queryParams: { q: null },
+          queryParamsHandling: 'merge'
+        })
+      );
+    }));
   });
+
   describe('summary stats', () => {
     it('returns undefined average requesters when a requester is missing', () => {
       // Suppose some builds for a project have a record of who requested them, and some builds for that or another
@@ -1512,7 +1771,7 @@ describe('ServalBuildsComponent', () => {
 
       const name: string | undefined = await firstValueFrom(env.component['requesterName']('user02'));
 
-      expect(name).toBe('Test Name');
+      expect(name).toBe('Test User Name');
     });
 
     it('loads requester display name from user data', async () => {
@@ -1533,11 +1792,15 @@ describe('ServalBuildsComponent', () => {
 
     it('updates requester details when changes$ emits', async () => {
       const env = new TestEnvironment();
+      const name$: Observable<string | undefined> = env.component['requesterName']('user02');
       const displayName$: Observable<string | undefined> = env.component['requesterDisplayName']('user02');
       const emailAddress$: Observable<string | undefined> = env.component['requesterEmailAddress']('user02');
 
+      expect(await firstValueFrom(name$)).toBe('Test User Name');
       expect(await firstValueFrom(displayName$)).toBe('Test User');
       expect(await firstValueFrom(emailAddress$)).toBe('user02@example.com');
+
+      const updatedNamePromise: Promise<string | undefined> = firstValueFrom(name$.pipe(skip(1), take(1)));
 
       const updatedDisplayNamePromise: Promise<string | undefined> = firstValueFrom(
         displayName$.pipe(skip(1), take(1))
@@ -1546,10 +1809,12 @@ describe('ServalBuildsComponent', () => {
         emailAddress$.pipe(skip(1), take(1))
       );
 
-      env.userData.displayName = 'Changed User';
-      env.userData.email = 'changed@example.com';
-      env.userChanges$.next();
+      env.requesterDataById.get('user02')!.name = 'Changed User Name';
+      env.requesterDataById.get('user02')!.displayName = 'Changed User';
+      env.requesterDataById.get('user02')!.email = 'changed@example.com';
+      env.requesterChangesById.get('user02')!.next();
 
+      expect(await updatedNamePromise).toBe('Changed User Name');
       expect(await updatedDisplayNamePromise).toBe('Changed User');
       expect(await updatedEmailAddressPromise).toBe('changed@example.com');
     });
@@ -1739,23 +2004,16 @@ describe('ServalBuildsComponent', () => {
 class TestEnvironment {
   readonly component: ServalBuildsComponent;
   readonly fixture: ComponentFixture<ServalBuildsComponent>;
+  private searchRowIndex: number = 0;
+  readonly requesterDataById: Map<string, RequesterInfo> = new Map<string, RequesterInfo>();
+  readonly requesterChangesById: Map<string, Subject<void>> = new Map<string, Subject<void>>();
   readonly builds$: BehaviorSubject<ServalBuildReportDto[] | undefined> = new BehaviorSubject<
     ServalBuildReportDto[] | undefined
   >(undefined);
-  readonly userData: { name: string; displayName: string; avatarUrl: string; email: string };
-  readonly userChanges$: Subject<void> = new Subject<void>();
+  readonly queryParams$: BehaviorSubject<Record<string, unknown>> = new BehaviorSubject<Record<string, unknown>>({});
 
   constructor() {
-    this.userData = {
-      name: 'Test Name',
-      displayName: 'Test User',
-      avatarUrl: '',
-      email: 'user02@example.com'
-    };
-    const userDoc = {
-      data: this.userData,
-      changes$: this.userChanges$
-    } as unknown as UserDoc;
+    this.setRequesterData('user02', { name: 'Test User Name', displayName: 'Test User', email: 'user02@example.com' });
 
     when(mockNoticeService.loadingStarted(anything())).thenReturn(undefined);
     when(mockNoticeService.loadingFinished(anything())).thenReturn(undefined);
@@ -1768,18 +2026,84 @@ class TestEnvironment {
     when(mockExportService.exportCsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportRsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
     when(mockExportService.exportTsv(anything(), anything(), anything(), anything(), anything())).thenReturn(undefined);
-    when(mockUserService.get(anything())).thenResolve(userDoc);
+    when(mockUserService.get(anything())).thenCall((requesterSFUserId: string) => {
+      const userData: RequesterInfo | undefined = this.requesterDataById.get(requesterSFUserId);
+      const changes$: Subject<void> | undefined = this.requesterChangesById.get(requesterSFUserId);
+      const userDoc = {
+        data: userData,
+        changes$: changes$
+      } as unknown as UserDoc;
+      return Promise.resolve(userDoc);
+    });
     when(mockI18nService.localeCode).thenReturn('en');
     when(mockI18nService.getLanguageDisplayName(anything())).thenReturn(undefined);
-    when(mockedActivatedRoute.queryParams).thenReturn(new BehaviorSubject({}));
+    when(mockedActivatedRoute.queryParams).thenReturn(this.queryParams$);
 
     this.fixture = TestBed.createComponent(ServalBuildsComponent);
     this.component = this.fixture.componentInstance;
   }
 
+  /** Adequate wait for rows to update in response to any changes in filtering/searching. */
+  waitForRowUpdate(): void {
+    flush();
+  }
+
+  setRequesterData(requesterSFUserId: string, userData: RequesterInfo): void {
+    const defaultUserData: RequesterInfo = {
+      name: `${requesterSFUserId} Name`,
+      displayName: `${requesterSFUserId} Display`,
+      email: `${requesterSFUserId}@example.com`
+    };
+    this.requesterDataById.set(requesterSFUserId, { ...defaultUserData, ...userData });
+    this.requesterChangesById.set(requesterSFUserId, new Subject<void>());
+  }
+
+  createSearchRow({
+    projectId = undefined,
+    ptProjectId = undefined,
+    projectShortName = 'PRJ',
+    projectName = 'Project Name',
+    requesterId = 'user-alpha',
+    servalBuildId = undefined,
+    draftGenerationRequestId = undefined,
+    startDate = undefined,
+    trainingBooks = [],
+    translationBooks = []
+  }: {
+    projectId?: string;
+    ptProjectId?: string;
+    projectShortName?: string;
+    projectName?: string;
+    requesterId?: string;
+    servalBuildId?: string;
+    draftGenerationRequestId?: string;
+    startDate?: Date;
+    trainingBooks?: ProjectBooks[];
+    translationBooks?: ProjectBooks[];
+  } = {}): ServalBuildRow {
+    const rowIndex: number = ++this.searchRowIndex;
+    const generatedProjectId: string = `sf-project-${rowIndex}`;
+    const generatedBuildId: string = `build-${rowIndex}`;
+    const generatedDraftGenerationRequestId: string = `draft-request-${rowIndex}`;
+    const generatedStartDate: Date = new Date(Date.UTC(2024, 0, 1 + rowIndex));
+
+    return TestEnvironment.createRowWithDetails({
+      projectId: projectId ?? generatedProjectId,
+      ptProjectId: ptProjectId,
+      projectShortName: projectShortName,
+      projectName: projectName,
+      requesterId: requesterId,
+      servalBuildId: servalBuildId ?? generatedBuildId,
+      draftGenerationRequestId: draftGenerationRequestId ?? generatedDraftGenerationRequestId,
+      startDate: startDate ?? generatedStartDate,
+      trainingBooks: trainingBooks,
+      translationBooks: translationBooks
+    });
+  }
+
   /** Creates a default BuildReportTimeline with optional overrides. */
   static makeTimeline(overrides: Partial<BuildReportTimeline> = {}): BuildReportTimeline {
-    return {
+    const result = {
       servalCreated: undefined,
       servalStarted: undefined,
       servalCompleted: undefined,
@@ -1792,11 +2116,12 @@ class TestEnvironment {
       phases: undefined,
       ...overrides
     };
+    return result;
   }
 
   /** Creates a default ServalBuildReportDto with optional timeline overrides. */
   makeReport(timelineOverrides: Partial<BuildReportTimeline> = {}): ServalBuildReportDto {
-    return {
+    const result = {
       build: undefined,
       project: undefined,
       timeline: TestEnvironment.makeTimeline(timelineOverrides),
@@ -1810,6 +2135,7 @@ class TestEnvironment {
       requesterSFUserId: undefined,
       status: DraftGenerationBuildStatus.Completed
     };
+    return result;
   }
 
   createRow(projectDeleted: boolean, durationMs: number): any {
@@ -1869,9 +2195,12 @@ class TestEnvironment {
   static createRowWithDetails({
     durationMs = 1000,
     projectId = undefined,
+    ptProjectId = undefined,
     projectShortName = 'PRJ',
     projectName = 'Project Name',
     requesterId = undefined,
+    servalBuildId = 'build-id',
+    draftGenerationRequestId = undefined,
     startDate = new Date(0),
     finishDate,
     trainingBooks = [],
@@ -1885,9 +2214,12 @@ class TestEnvironment {
   }: {
     durationMs?: number;
     projectId?: string;
+    ptProjectId?: string;
     projectShortName?: string;
     projectName?: string;
     requesterId?: string;
+    servalBuildId?: string;
+    draftGenerationRequestId?: string;
     /** null can be given for no start date, but be careful not to generate errors about overlapping builds. */
     startDate: Date | null;
     finishDate?: Date;
@@ -1914,7 +2246,7 @@ class TestEnvironment {
           state: status.toUpperCase() as BuildStates,
           queueDepth: 0,
           additionalInfo: {
-            buildId: 'build-id',
+            buildId: servalBuildId,
             step: 0,
             trainingScriptureRanges: [],
             translationEngineId: 'translation-engine-id',
@@ -1929,7 +2261,9 @@ class TestEnvironment {
     const report: ServalBuildReportDto = {
       build: servalBuild,
       project:
-        projectId != null ? { sfProjectId: projectId, shortName: projectShortName, name: projectName } : undefined,
+        projectId != null
+          ? { sfProjectId: projectId, ptProjectId: ptProjectId, shortName: projectShortName, name: projectName }
+          : undefined,
       timeline: TestEnvironment.makeTimeline({
         servalCreated: hasServalBuild ? start : undefined,
         servalFinished: hasServalBuild ? computedFinish : undefined,
@@ -1943,7 +2277,7 @@ class TestEnvironment {
         trainingDataFileIds: []
       },
       problems: problems,
-      draftGenerationRequestId: undefined,
+      draftGenerationRequestId: draftGenerationRequestId,
       requesterSFUserId: requesterId,
       status: status
     };

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -281,7 +281,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { q: queryParam },
-      queryParamsHandling: 'merge'
+      queryParamsHandling: 'merge',
+      replaceUrl: true
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -1,10 +1,13 @@
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { Component, DestroyRef, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatCard, MatCardContent, MatCardHeader, MatCardTitle, MatCardTitleGroup } from '@angular/material/card';
 import { provideNativeDateAdapter } from '@angular/material/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import {
@@ -45,15 +48,13 @@ import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { UserService } from 'xforge-common/user.service';
-import { isPopulatedString, notNull } from '../../type-utils';
+import { isPopulatedString, isString, notNull } from '../../type-utils';
 import { InfoComponent } from '../shared/info/info.component';
 import { NoticeComponent } from '../shared/notice/notice.component';
-import { projectLabel } from '../shared/utils';
 import { DraftGenerationService } from '../translate/draft-generation/draft-generation.service';
 import { DateRangePickerComponent, NormalizedDateRange } from './date-range-picker.component';
 import { DraftJobsExportService, SpreadsheetRow } from './draft-jobs-export.service';
 import { JobDetailsDialogComponent } from './job-details-dialog.component';
-import { ServalAdministrationService } from './serval-administration.service';
 import { ServalBuildProblemsDialog, ServalBuildProblemsDialogSection } from './serval-build-problems-dialog.component';
 import {
   BookAndChapters,
@@ -80,6 +81,13 @@ export interface ServalBuildRow {
   projectServalAdminUrl?: string;
   /** True if the build is not associable with any SF project currently in the database. */
   projectDeleted: boolean;
+}
+
+/** Pertinent information about the requester of a Serval build. */
+export interface RequesterInfo {
+  name?: string;
+  displayName?: string;
+  email?: string;
 }
 
 /** Aggregated statistics for the currently visible Serval build rows. */
@@ -172,7 +180,10 @@ export interface BuildInputItem {
     MatCardContent,
     MatCardTitleGroup,
     CopyComponent,
-    MatSlideToggle
+    MatSlideToggle,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule
   ]
 })
 export class ServalBuildsComponent extends DataLoadingComponent implements OnInit {
@@ -195,17 +206,15 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
    * and was deleted. Maybe another SF installation has that project and requested a Serval build. */
   protected includeDeleted: boolean = false;
   protected summaryIsExpanded: boolean = false;
-  /** Current project ID filter from query params, if any. */
-  protected currentProjectFilter: string | undefined = undefined;
-  /** Display name for the active project filter. */
-  protected filteredProjectName: string | undefined = undefined;
   /** Data rows, including those that are filtered out by the includeDeleted toggle. */
   private allRows: ServalBuildRow[] = [];
+  protected readonly searchControl: FormControl<string> = new FormControl('', { nonNullable: true });
+  /** The URL parameter. */
+  private currentSearchQueryParam: string | null = null;
   private readonly dateRange$ = new BehaviorSubject<NormalizedDateRange | undefined>(undefined);
-  private readonly requesterIdentityCache: Map<
-    string,
-    Observable<{ name?: string; displayName?: string; emailAddress?: string }>
-  > = new Map();
+  private readonly requesterIdentityCache: Map<string, Observable<RequesterInfo>> = new Map();
+  /** Sequence ID of searching records. Later initiated searches have higher IDs. */
+  private searchId: number = 0;
 
   constructor(
     noticeService: NoticeService,
@@ -217,10 +226,14 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     private readonly userService: UserService,
     private readonly destroyRef: DestroyRef,
     private readonly route: ActivatedRoute,
-    private readonly router: Router,
-    private readonly servalAdministrationService: ServalAdministrationService
+    private readonly router: Router
   ) {
     super(noticeService, 'ServalBuildsComponent');
+
+    this.searchControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((searchTerm: string) => {
+      this.updateUrlSearchQueryParam(searchTerm);
+      this.applyFiltersAndStats();
+    });
   }
 
   protected get isOnline(): boolean {
@@ -228,23 +241,48 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   ngOnInit(): void {
-    combineLatest([
-      this.route.queryParams.pipe(
-        map(params => params['sfProjectId']),
-        distinctUntilChanged()
-      ),
-      this.onlineStatusService.onlineStatus$,
-      this.dateRange$.pipe(filter(notNull))
-    ])
+    this.route.queryParams
+      .pipe(
+        map(params => params['q']),
+        map((queryParam: unknown) => (isString(queryParam) ? queryParam : null)),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((searchText: string | null) => {
+        this.currentSearchQueryParam = searchText;
+        const searchTextValue: string = searchText ?? '';
+        if (this.searchControl.value !== searchTextValue) {
+          this.searchControl.setValue(searchTextValue, { emitEvent: false });
+        }
+        this.applyFiltersAndStats();
+      });
+
+    combineLatest([this.onlineStatusService.onlineStatus$, this.dateRange$.pipe(filter(notNull))])
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(([projectFilterId, isOnline, range]) => {
+      .subscribe(([isOnline, range]) => {
         this.loadingStarted();
-        void this.loadBuilds(range, isOnline, projectFilterId);
+        void this.loadBuilds(range, isOnline);
       });
   }
 
   protected onDateRangeChange(range: NormalizedDateRange): void {
     this.dateRange$.next(range);
+  }
+
+  protected clearSearch(): void {
+    this.searchControl.setValue('');
+  }
+
+  /** Updating the URL with the search query allows searches to be bookmarked or shared by URL. */
+  private updateUrlSearchQueryParam(query: string): void {
+    const queryParam: string | null = isPopulatedString(query) ? query : null;
+    if (this.currentSearchQueryParam === queryParam) return;
+    this.currentSearchQueryParam = queryParam;
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { q: queryParam },
+      queryParamsHandling: 'merge'
+    });
   }
 
   /** Toggle whether a row is expanded. */
@@ -445,25 +483,20 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   protected requesterEmailAddress(requesterSFUserId: string | undefined): Observable<string | undefined> {
-    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.emailAddress));
+    return this.requesterIdentity(requesterSFUserId).pipe(map(identity => identity.email));
   }
 
-  private requesterIdentity(
-    requesterSFUserId: string | undefined
-  ): Observable<{ name?: string; displayName?: string; emailAddress?: string }> {
+  private requesterIdentity(requesterSFUserId: string | undefined): Observable<RequesterInfo> {
     if (requesterSFUserId == null) {
       return of({});
     }
 
     const requesterKey: string = requesterSFUserId;
-    const cached$: Observable<{ name?: string; displayName?: string; emailAddress?: string }> | undefined =
-      this.requesterIdentityCache.get(requesterKey);
+    const cached$: Observable<RequesterInfo> | undefined = this.requesterIdentityCache.get(requesterKey);
     if (cached$ != null) return cached$;
 
     // Cache the lookups so multiple rows don't need to request the same thing.
-    const identity$: Observable<{ name?: string; displayName?: string; emailAddress?: string }> = from(
-      this.userService.get(requesterSFUserId)
-    ).pipe(
+    const identity$: Observable<RequesterInfo> = from(this.userService.get(requesterSFUserId)).pipe(
       // This switchMap to changes$ lets us cache Observables with information that stays up-to-date.
       switchMap((userDoc: UserDoc) =>
         userDoc.changes$.pipe(
@@ -471,11 +504,11 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
           map(() => {
             const name: string | undefined = userDoc.data?.name;
             const displayName: string | undefined = userDoc.data?.displayName;
-            const emailAddress: string | undefined = userDoc.data?.email;
+            const email: string | undefined = userDoc.data?.email;
             return {
               name: name,
               displayName: displayName,
-              emailAddress: emailAddress
+              email: email
             };
           })
         )
@@ -488,36 +521,8 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
     return identity$;
   }
 
-  protected clearProjectFilter(): void {
-    void this.router.navigate([], {
-      relativeTo: this.route,
-      queryParams: { sfProjectId: null },
-      queryParamsHandling: 'merge'
-    });
-  }
-
-  private async loadBuilds(
-    range: NormalizedDateRange,
-    isOnline: boolean,
-    projectFilterId: string | undefined
-  ): Promise<void> {
+  private async loadBuilds(range: NormalizedDateRange, isOnline: boolean): Promise<void> {
     try {
-      // Resolve project filter display name
-      if (isPopulatedString(projectFilterId)) {
-        let displayName: string = projectFilterId;
-        try {
-          const projectDoc = await this.servalAdministrationService.get(projectFilterId);
-          displayName = projectDoc?.data != null ? projectLabel(projectDoc.data) : projectFilterId;
-        } catch {
-          // Filter can reference a deleted project; fall back to the raw ID
-        }
-        this.currentProjectFilter = projectFilterId;
-        this.filteredProjectName = displayName;
-      } else {
-        this.currentProjectFilter = undefined;
-        this.filteredProjectName = undefined;
-      }
-
       if (!isOnline) {
         this.allRows = [];
         this.rows = [];
@@ -589,19 +594,85 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
   }
 
   private applyFiltersAndStats(): void {
-    this.rows = this.filteredRows();
+    const searchId: number = ++this.searchId;
+    void this.applyFilteredRowsAndStats(searchId);
+  }
+
+  private async applyFilteredRowsAndStats(searchId: number): Promise<void> {
+    const rows: ServalBuildRow[] = await this.filteredRows();
+    if (searchId !== this.searchId) {
+      // Discard preempted search.
+      return;
+    }
+
+    this.rows = rows;
     this.updateSummaryStats();
   }
 
-  private filteredRows(): ServalBuildRow[] {
-    let rows: ServalBuildRow[] = this.allRows;
-    if (this.includeDeleted !== true) {
-      rows = rows.filter((row: ServalBuildRow) => !row.projectDeleted);
+  private async filteredRows(): Promise<ServalBuildRow[]> {
+    const rows: ServalBuildRow[] =
+      this.includeDeleted === true
+        ? [...this.allRows]
+        : this.allRows.filter((row: ServalBuildRow) => !row.projectDeleted);
+
+    const normalizedSearchTerm: string = this.normalizeSearchTerm(this.searchControl.value);
+    if (!isPopulatedString(normalizedSearchTerm)) {
+      return rows;
     }
-    if (this.currentProjectFilter !== undefined) {
-      rows = rows.filter((row: ServalBuildRow) => row.report.project?.sfProjectId === this.currentProjectFilter);
-    }
-    return rows;
+
+    const matchedRows: ServalBuildRow[] = (
+      await Promise.all(
+        rows.map(async (row: ServalBuildRow) => {
+          if (await this.matchesSearch(row, normalizedSearchTerm)) return row;
+          return undefined;
+        })
+      )
+    ).filter(notNull);
+    return matchedRows;
+  }
+
+  /** Does a row match a search? */
+  private async matchesSearch(row: ServalBuildRow, normalizedSearchTerm: string): Promise<boolean> {
+    const data: string[] = await this.searchableData(row);
+    return data.some((data: string) => data.includes(normalizedSearchTerm));
+  }
+
+  /** Returns the tokens of a row that can be searched. */
+  private async searchableData(row: ServalBuildRow): Promise<string[]> {
+    const requesterId: string | undefined = row.report.requesterSFUserId;
+    const requesterIdentity: RequesterInfo = await firstValueFrom(this.requesterIdentity(requesterId));
+    const result: string[] = [
+      row.report.build?.additionalInfo?.buildId,
+      row.report.draftGenerationRequestId,
+      row.report.project?.sfProjectId,
+      row.report.project?.shortName,
+      row.report.project?.name,
+      row.report.project?.ptProjectId,
+      requesterId,
+      requesterIdentity?.name,
+      requesterIdentity?.displayName,
+      requesterIdentity?.email,
+      ...this.referenceProjectSearchTerms(row.trainingBooks),
+      ...this.referenceProjectSearchTerms(row.translationBooks)
+    ]
+      .filter(isPopulatedString)
+      .map((data: string) => this.normalizeSearchTerm(data));
+    return result;
+  }
+
+  /** Returns the tokens of a translation source or training project that can be searched. */
+  private referenceProjectSearchTerms(references: ProjectBooks[]): string[] {
+    return references.flatMap((reference: ProjectBooks) => {
+      const bookIds: string[] = reference.booksAndChapters.map(
+        (bookAndChapters: BookAndChapters) => bookAndChapters.bookId
+      );
+      const terms: Array<string | undefined> = [reference.shortName, reference.projectName, ...bookIds];
+      return terms.filter(isPopulatedString);
+    });
+  }
+
+  private normalizeSearchTerm(value: string): string {
+    return value.trim().toLowerCase();
   }
 
   private updateSummaryStats(): void {


### PR DESCRIPTION
This patch extends the search/filter capability of the Serval build
records. Previously it would filter by SF project ID, but now it
allows searching by project name, requesting user ID, reference
project name, etc.

Showing projects by SF project ID was changed to use the search control. (Although the Projects tab isn't hooked up to direct you to the Serval builds tab at this time to see it in action.)

I used the term "search" rather than "filter". "Search" is familiar
language. We are also checking the search term in many data fields
rather than having the user specify that they want to only show
records where a particular field contains a particular value.

Requester name etc. is included in what is searched. I chose to fetch
this from RealtimeServer, not include it in the backend
ServalBuildReportDto, mainly to keep the DTO from becoming
increasingly un-reusable in other parts of the application.
I also chose to query the requester information using the current
fetch and cache mechanism in requesterIdentity(), and at search time,
rather than pre-fetching values. I like that the proposed
implementation for searching user metadata is not as complex as some
other options.

This PR creates a serval-builds.copmonent.spec.ts helper method, `createSearchRow()`. I have a followup commit prepared that unifies the various row creation helper methods, that I did not include in this PR.

Screenshot showing search control:
<img width="792" height="83" alt="image" src="https://github.com/user-attachments/assets/081495c4-06e4-4036-9251-e7363f64a43e" />

[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3907)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3907)
<!-- Reviewable:end -->
