### PR TITLE
SF-3357 Remove references to draft history and usfm format feature flags

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -144,14 +144,10 @@
     } @else {
       @if (!draftEnabled) {
         <section data-test-id="approval-needed">
-          @if (featureFlags.inAppDraftSignupForm.enabled && !onboardingRequest) {
+          @if (!onboardingRequest) {
             <button mat-flat-button color="primary" [routerLink]="['signup']">
               {{ t("sign_up_for_drafting") }}
             </button>
-          } @else if (!onboardingRequest) {
-            <a [href]="signupFormUrl" mat-flat-button color="primary" target="_blank" rel="noopener noreferrer">
-              {{ t("sign_up_for_drafting") }}
-            </a>
           } @else {
             <app-notice type="primary" icon="checkmark" mode="fill-dark">
               <p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -14,7 +14,6 @@ import { instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { AuthService } from 'xforge-common/auth.service';
 import { DialogService } from 'xforge-common/dialog.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -47,7 +46,6 @@ describe('DraftGenerationComponent', () => {
   let mockNoticeService: jasmine.SpyObj<NoticeService>;
   let mockNllbLanguageService: jasmine.SpyObj<NllbLanguageService>;
   let mockTrainingDataService: jasmine.SpyObj<TrainingDataService>;
-  let mockFeatureFlagService: jasmine.SpyObj<FeatureFlagService>;
   let mockSFProjectService: jasmine.SpyObj<SFProjectService>;
   let mockProjectNotificationService: jasmine.SpyObj<ProjectNotificationService>;
 
@@ -99,7 +97,6 @@ describe('DraftGenerationComponent', () => {
           { provide: OnlineStatusService, useClass: TestOnlineStatusService },
           { provide: TrainingDataService, useValue: mockTrainingDataService },
           { provide: ProgressService, useValue: undefined },
-          { provide: FeatureFlagService, useValue: mockFeatureFlagService },
           { provide: ProjectNotificationService, useValue: mockProjectNotificationService }
         ]
       });
@@ -154,11 +151,6 @@ describe('DraftGenerationComponent', () => {
 
       mockTrainingDataService = jasmine.createSpyObj<TrainingDataService>(['getTrainingData']);
       mockTrainingDataService.getTrainingData.and.returnValue(of([]));
-      mockFeatureFlagService = jasmine.createSpyObj<FeatureFlagService>({
-        newDraftHistory: createTestFeatureFlag(false),
-        usfmFormat: createTestFeatureFlag(false),
-        inAppDraftSignupForm: createTestFeatureFlag(true)
-      });
     }
 
     static initProject(currentUserId: string, preTranslate: boolean = true): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -23,7 +23,6 @@ import { AuthService } from 'xforge-common/auth.service';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ExternalUrlService } from 'xforge-common/external-url.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { L10nNumberPipe } from 'xforge-common/l10n-number.pipe';
 import { L10nPercentPipe } from 'xforge-common/l10n-percent.pipe';
@@ -54,7 +53,6 @@ import { DRAFT_SIGNUP_RESPONSE_DAYS } from './draft-signup-form/draft-onboarding
 import { DraftSource } from './draft-source';
 import { DraftSourcesService } from './draft-sources.service';
 import { OnboardingRequest, OnboardingRequestService } from './onboarding-request.service';
-import { PreTranslationSignupUrlService } from './pretranslation-signup-url.service';
 import { SupportedBackTranslationLanguagesDialogComponent } from './supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component';
 
 @Component({
@@ -134,7 +132,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   hasDraftBooksAvailable = false;
 
   isPreTranslationApproved = false;
-  signupFormUrl?: string;
   onboardingRequest?: OnboardingRequest | null;
   responseDays = DRAFT_SIGNUP_RESPONSE_DAYS;
 
@@ -159,11 +156,9 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     private readonly nllbService: NllbLanguageService,
     protected readonly i18n: I18nService,
     private readonly onlineStatusService: OnlineStatusService,
-    private readonly preTranslationSignupUrlService: PreTranslationSignupUrlService,
     private readonly draftingSignupService: OnboardingRequestService,
     protected readonly noticeService: NoticeService,
     protected readonly urlService: ExternalUrlService,
-    protected readonly featureFlags: FeatureFlagService,
     protected readonly draftOptionsService: DraftOptionsService,
     private readonly projectService: SFProjectService,
     private destroyRef: DestroyRef
@@ -268,10 +263,6 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
       .subscribe(async () => {
         this.isTargetLanguageSupported =
           !this.isBackTranslation || (await this.nllbService.isNllbLanguageAsync(this.targetLanguage));
-
-        if (!this.draftEnabled) {
-          this.signupFormUrl = await this.preTranslationSignupUrlService.generateSignupUrl();
-        }
 
         // Check if user has already submitted a signup for this project
         if (this.activatedProject.projectId != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.spec.ts
@@ -8,7 +8,7 @@ import { ParagraphBreakFormat, QuoteFormat } from 'realtime-server/lib/esm/scrip
 import { of } from 'rxjs';
 import { anything, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
+import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { UserProfileDoc } from 'xforge-common/models/user-profile-doc';
 import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
 import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
@@ -58,7 +58,6 @@ describe('DraftHistoryEntryComponent', () => {
   }));
 
   beforeEach(() => {
-    when(mockedFeatureFlagsService.usfmFormat).thenReturn(createTestFeatureFlag(true));
     when(mockedActivatedProjectService.projectId).thenReturn('project01');
     const targetProjectDoc = {
       id: 'project01',
@@ -410,26 +409,6 @@ describe('DraftHistoryEntryComponent', () => {
       tick();
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('.require-formatting-options')).not.toBeNull();
-    }));
-
-    it('should hide draft format UI when feature not enabled', fakeAsync(() => {
-      when(mockedFeatureFlagsService.usfmFormat).thenReturn(createTestFeatureFlag(false));
-      component.entry = {
-        id: 'build01',
-        engine: { id: 'project01' },
-        state: BuildStates.Completed,
-        message: 'Completed',
-        additionalInfo: {
-          dateGenerated: dateAfterFormattingSupported,
-          dateFinished: dateAfterFormattingSupported,
-          translationScriptureRanges: [{ projectId: 'source01', scriptureRange: 'EXO' }]
-        }
-      } as BuildDto;
-      component.isLatestBuild = true;
-      component.draftIsAvailable = true;
-      tick();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('.require-formatting-options')).toBeNull();
     }));
 
     it('should hide draft format UI if not the latest build', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -26,7 +26,6 @@ import { TranslocoModule } from '@ngneat/transloco';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { Subject, takeUntil } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { UserService } from 'xforge-common/user.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
@@ -330,7 +329,6 @@ export class DraftHistoryEntryComponent {
     private readonly userService: UserService,
     private readonly trainingDataService: TrainingDataService,
     private readonly activatedProjectService: ActivatedProjectService,
-    readonly featureFlags: FeatureFlagService,
     protected readonly draftOptionsService: DraftOptionsService,
     private readonly permissionsService: PermissionsService,
     private readonly destroyRef: DestroyRef,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
@@ -5,7 +5,6 @@ import { provideRouter } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 import { anything, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { provideTestRealtime } from 'xforge-common/test-realtime-providers';
 import { configureTestingModule, getTestTranslocoModule } from 'xforge-common/test-utils';
@@ -24,7 +23,6 @@ const mockedI18nService = mock(I18nService);
 const mockedProjectNotificationService = mock(ProjectNotificationService);
 const mockedSFProjectService = mock(SFProjectService);
 const mockedUserService = mock(UserService);
-const mockedFeatureFlagsService = mock(FeatureFlagService);
 
 describe('DraftHistoryListComponent', () => {
   configureTestingModule(() => ({
@@ -39,8 +37,7 @@ describe('DraftHistoryListComponent', () => {
       { provide: I18nService, useMock: mockedI18nService },
       { provide: ProjectNotificationService, useMock: mockedProjectNotificationService },
       { provide: SFProjectService, useMock: mockedSFProjectService },
-      { provide: UserService, useMock: mockedUserService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagsService }
+      { provide: UserService, useMock: mockedUserService }
     ]
   }));
 
@@ -229,7 +226,6 @@ describe('DraftHistoryListComponent', () => {
       when(mockedDraftGenerationService.getBuildHistory(projectId)).thenReturn(new BehaviorSubject(buildHistory));
       when(mockedDraftGenerationService.draftHistoryCutOffDate).thenReturn(new Date('2025-06-04T00:00:00.000Z'));
       when(mockedI18nService.formatDate(anything())).thenCall(date => date.toLocaleString(['en']));
-      when(mockedFeatureFlagsService.usfmFormat).thenReturn(createTestFeatureFlag(true));
 
       this.fixture = TestBed.createComponent(DraftHistoryListComponent);
       this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.spec.ts
@@ -6,27 +6,20 @@ import {
 } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { instance, mock, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { BuildDto } from '../../machine-api/build-dto';
 import { BuildStates } from '../../machine-api/build-states';
 import { DraftOptionsService, FORMATTING_OPTIONS_SUPPORTED_DATE } from './draft-options.service';
 
 const mockedActivatedProject = mock(ActivatedProjectService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 
 describe('DraftOptionsService', () => {
   let service: DraftOptionsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        DraftOptionsService,
-        { provide: ActivatedProjectService, useValue: instance(mockedActivatedProject) },
-        { provide: FeatureFlagService, useValue: instance(mockedFeatureFlagService) }
-      ]
+      providers: [DraftOptionsService, { provide: ActivatedProjectService, useValue: instance(mockedActivatedProject) }]
     });
-    when(mockedFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(true));
     service = TestBed.inject(DraftOptionsService);
   });
 
@@ -84,47 +77,35 @@ describe('DraftOptionsService', () => {
   const PROJECT_DOC_EMPTY_USFM: SFProjectProfileDoc = buildProjectDoc({});
 
   describe('areFormattingOptionsSelected', () => {
-    it('returns true when flag enabled and both options set', () => {
+    it('returns true when both options set', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_BOTH_FORMATS);
       expect(service.areFormattingOptionsSelected()).toBe(true);
     });
 
-    it('returns false when flag enabled and one option missing', () => {
+    it('returns false when one option missing', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_PARAGRAPH_ONLY);
       expect(service.areFormattingOptionsSelected()).toBe(false);
     });
 
-    it('returns false when flag enabled and both options missing', () => {
+    it('returns false when both options missing', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_EMPTY_USFM);
-      expect(service.areFormattingOptionsSelected()).toBe(false);
-    });
-
-    it('returns false when flag disabled even if both options set', () => {
-      when(mockedFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(false));
-      when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_BOTH_FORMATS);
       expect(service.areFormattingOptionsSelected()).toBe(false);
     });
   });
 
   describe('areFormattingOptionsAvailableButUnselected', () => {
-    it('returns true when flag enabled and both options missing', () => {
+    it('returns true when both options missing', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_EMPTY_USFM);
       expect(service.areFormattingOptionsAvailableButUnselected(SUPPORTED_BUILD_ENTRY)).toBe(true);
     });
 
-    it('returns true when flag enabled and one option missing', () => {
+    it('returns true when one option missing', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_QUOTE_ONLY);
       expect(service.areFormattingOptionsAvailableButUnselected(SUPPORTED_BUILD_ENTRY)).toBe(true);
     });
 
-    it('returns false when flag enabled and both options set', () => {
+    it('returns false when both options set', () => {
       when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_BOTH_FORMATS);
-      expect(service.areFormattingOptionsAvailableButUnselected(SUPPORTED_BUILD_ENTRY)).toBe(false);
-    });
-
-    it('returns false when flag disabled', () => {
-      when(mockedFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(false));
-      when(mockedActivatedProject.projectDoc).thenReturn(PROJECT_DOC_EMPTY_USFM);
       expect(service.areFormattingOptionsAvailableButUnselected(SUPPORTED_BUILD_ENTRY)).toBe(false);
     });
 
@@ -135,8 +116,7 @@ describe('DraftOptionsService', () => {
   });
 
   describe('areFormattingOptionsSupportedForBuild', () => {
-    function buildWith(date: Date | undefined, flagEnabled: boolean = true): BuildDto | undefined {
-      when(mockedFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(flagEnabled));
+    function buildWith(date: Date | undefined): BuildDto | undefined {
       if (date == null) {
         return {
           id: 'build-id',
@@ -152,14 +132,9 @@ describe('DraftOptionsService', () => {
       return buildDtoWithDate(date);
     }
 
-    it('returns true when flag enabled and date after supported date', () => {
+    it('returns true when date after supported date', () => {
       const entry = buildWith(new Date(FORMATTING_OPTIONS_SUPPORTED_DATE.getTime() + 1));
       expect(service.areFormattingOptionsSupportedForBuild(entry)).toBe(true);
-    });
-
-    it('returns false when flag disabled even if date after supported date', () => {
-      const entry = buildWith(new Date(FORMATTING_OPTIONS_SUPPORTED_DATE.getTime() + 1), false);
-      expect(service.areFormattingOptionsSupportedForBuild(entry)).toBe(false);
     });
 
     it('returns false when date before supported date', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-options.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { BuildDto } from '../../machine-api/build-dto';
 
 // Corresponds to Serval 1.11.0 release
@@ -10,14 +9,10 @@ export const FORMATTING_OPTIONS_SUPPORTED_DATE: Date = new Date('2025-09-25T00:0
   providedIn: 'root'
 })
 export class DraftOptionsService {
-  constructor(
-    private readonly activatedProjectService: ActivatedProjectService,
-    private readonly featureFlags: FeatureFlagService
-  ) {}
+  constructor(private readonly activatedProjectService: ActivatedProjectService) {}
 
   areFormattingOptionsSelected(): boolean {
     return (
-      this.featureFlags.usfmFormat.enabled &&
       this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig?.paragraphFormat != null &&
       this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig?.quoteFormat != null
     );
@@ -27,12 +22,12 @@ export class DraftOptionsService {
     const usfmConfig = this.activatedProjectService.projectDoc?.data?.translateConfig.draftConfig.usfmConfig;
     const optionsSelected = usfmConfig?.paragraphFormat != null && usfmConfig?.quoteFormat != null;
 
-    const available = this.featureFlags.usfmFormat.enabled && this.areFormattingOptionsSupportedForBuild(draftBuild);
+    const available = this.areFormattingOptionsSupportedForBuild(draftBuild);
     return available && !optionsSelected;
   }
 
   areFormattingOptionsSupportedForBuild(entry: BuildDto | undefined): boolean {
-    return this.featureFlags.usfmFormat.enabled && entry?.additionalInfo?.dateFinished != null
+    return entry?.additionalInfo?.dateFinished != null
       ? new Date(entry.additionalInfo.dateFinished) > FORMATTING_OPTIONS_SUPPORTED_DATE
       : false;
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -16,7 +16,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { CommandError, CommandErrorCode } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
@@ -45,7 +44,6 @@ const mockI18nService = mock(I18nService);
 const mockDialogService = mock(DialogService);
 const mockNoticeService = mock(NoticeService);
 const mockErrorReportingService = mock(ErrorReportingService);
-const mockFeatureFlagService = mock(FeatureFlagService);
 const mockSFProjectService = mock(SFProjectService);
 const mockProjectNotificationService = mock(ProjectNotificationService);
 
@@ -78,7 +76,6 @@ describe('EditorDraftComponent', () => {
       { provide: DialogService, useMock: mockDialogService },
       { provide: NoticeService, useMock: mockNoticeService },
       { provide: ErrorReportingService, useMock: mockErrorReportingService },
-      { provide: FeatureFlagService, useMock: mockFeatureFlagService },
       { provide: SFProjectService, useMock: mockSFProjectService },
       { provide: ProjectNotificationService, useMock: mockProjectNotificationService }
     ]
@@ -91,7 +88,6 @@ describe('EditorDraftComponent', () => {
   });
 
   beforeEach(() => {
-    when(mockFeatureFlagService.usfmFormat).thenReturn(createTestFeatureFlag(true));
     when(mockDraftGenerationService.pollBuildProgress(anything())).thenReturn(buildProgress$.asObservable());
     buildProgress$.next({ state: BuildStates.Completed } as BuildDto);
     when(mockActivatedProjectService.projectId$).thenReturn(of('targetProjectId'));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -38,7 +38,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { isNetworkError } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
-import { FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -134,7 +133,6 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     private readonly dialogService: DialogService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly draftHandlingService: DraftHandlingService,
-    readonly featureFlags: FeatureFlagService,
     readonly fontService: FontService,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -69,7 +69,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { AuthService } from 'xforge-common/auth.service';
 import { CONSOLE } from 'xforge-common/browser-globals';
 import { BugsnagService } from 'xforge-common/bugsnag.service';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { GenericDialogComponent, GenericDialogOptions } from 'xforge-common/generic-dialog/generic-dialog.component';
 import { UserDoc } from 'xforge-common/models/user-doc';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -149,7 +148,6 @@ const mockedDraftOptionsService = mock(DraftOptionsService);
 const mockedParatextService = mock(ParatextService);
 const mockedPermissionsService = mock(PermissionsService);
 const mockedLynxWorkspaceService = mock(LynxWorkspaceService);
-const mockedFeatureFlagService = mock(FeatureFlagService);
 const mockedProjectNotificationService = mock(ProjectNotificationService);
 
 class MockComponent {}
@@ -222,7 +220,6 @@ describe('EditorComponent', () => {
       { provide: TabMenuService, useValue: EditorTabMenuService },
       { provide: PermissionsService, useMock: mockedPermissionsService },
       { provide: LynxWorkspaceService, useMock: mockedLynxWorkspaceService },
-      { provide: FeatureFlagService, useMock: mockedFeatureFlagService },
       provideNoopAnimations()
     ]
   }));
@@ -5007,7 +5004,6 @@ class TestEnvironment {
     when(mockedDraftOptionsService.areFormattingOptionsAvailableButUnselected(anything())).thenReturn(false);
     when(mockedPermissionsService.isUserOnProject(anything())).thenResolve(true);
     when(mockedPermissionsService.canAccessText(anything(), anything())).thenReturn(true);
-    when(mockedFeatureFlagService.newDraftHistory).thenReturn(createTestFeatureFlag(false));
     when(mockedLynxWorkspaceService.rawInsightSource$).thenReturn(of([]));
 
     this.realtimeService = TestBed.inject(TestRealtimeService);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/feature-flags/feature-flag.service.ts
@@ -349,19 +349,14 @@ export class FeatureFlagService {
     this.featureFlagStore
   );
 
-  readonly newDraftHistory: FeatureFlag = new FeatureFlagFromStorage(
+  readonly newDraftHistory: FeatureFlag = new ServerOnlyFeatureFlag(
     'NewDraftHistory',
     'Preview new draft history interface',
     17,
-    new StaticFeatureFlagStore(true)
+    this.featureFlagStore
   );
 
-  readonly usfmFormat: ObservableFeatureFlag = new FeatureFlagFromStorage(
-    'UsfmFormat',
-    'USFM Format',
-    18,
-    new StaticFeatureFlagStore(true)
-  );
+  readonly usfmFormat: FeatureFlag = new ServerOnlyFeatureFlag('UsfmFormat', 'USFM Format', 18, this.featureFlagStore);
 
   readonly inAppDraftSignupForm: ObservableFeatureFlag = new FeatureFlagFromStorage(
     'InAppDraftSignupForm',


### PR DESCRIPTION
This PR removes references to the draft history and usfm format feature flags since these are now stable features within SF. I marked this as testing not required since there are no behavioural changes to test other than the feature flags not being visible in the feature flags dialog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3909)
<!-- Reviewable:end -->
