### PR TITLE
SF-3810 Fix draft chapters not shown on formatting page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -146,6 +146,12 @@ describe('DraftUsfmFormatComponent', () => {
   }));
 
   it('can navigate to book and chapter if first chapter has no draft', fakeAsync(() => {
+    const bookDraft: Map<string, DeltaOperation[]> = new Map<string, DeltaOperation[]>();
+    bookDraft.set('2', [
+      { insert: { chapter: { number: 2 } }, attributes: { style: 'c' } },
+      { insert: { verse: { number: 1 } }, attributes: { style: 'v' } },
+      { insert: 'Verse 1 text.' }
+    ]);
     const env = new TestEnvironment({
       project: {
         texts: [
@@ -157,19 +163,19 @@ describe('DraftUsfmFormatComponent', () => {
           }
         ],
         translateConfig: { draftConfig: { currentScriptureRange: 'LEV' } as DraftConfig } as TranslateConfig
-      }
+      },
+      bookDraft
     });
     tick(EDITOR_READY_TIMEOUT);
     env.fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
     expect(env.component.bookNum).toBe(3);
-    // book 3 on the source starts at chapter 2
     expect(env.component.chapterNum).toBe(2);
-    expect(env.component.chaptersWithDrafts).toEqual([2, 3]);
+    expect(env.component.chaptersWithDrafts).toEqual([2]);
     verify(mockedDraftHandlingService.getBookDraft(anything(), anything())).once();
   }));
 
-  it('determines chapters with drafts based on translation source chapters', fakeAsync(() => {
+  it('determines chapters with drafts based draft chapters', fakeAsync(() => {
     const env = new TestEnvironment({
       project: {
         texts: [
@@ -182,14 +188,13 @@ describe('DraftUsfmFormatComponent', () => {
         ]
       }
     });
-    when(mockedProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(true);
     tick(EDITOR_READY_TIMEOUT);
     env.fixture.detectChanges();
     tick(EDITOR_READY_TIMEOUT);
     expect(env.component.bookNum).toBe(1);
     expect(env.component.chapterNum).toBe(1);
     // source has 3 chapters on book 1
-    expect(env.component.chaptersWithDrafts).toEqual([1, 2, 3]);
+    expect(env.component.chaptersWithDrafts).toEqual([1, 2]);
     expect(env.component.showDraftSourceWarning).toBe(false);
     verify(mockedDraftHandlingService.getBookDraft(anything(), anything())).once();
   }));
@@ -208,7 +213,7 @@ describe('DraftUsfmFormatComponent', () => {
     });
 
     verify(mockedDraftHandlingService.getBookDraft(anything(), anything())).once();
-    expect(env.component.chaptersWithDrafts.length).toEqual(3);
+    expect(env.component.chaptersWithDrafts.length).toEqual(2);
     expect(env.component.booksWithDrafts.length).toEqual(3);
 
     env.component.bookChanged(2);
@@ -362,6 +367,7 @@ class TestEnvironment {
       project?: Partial<SFProjectProfile>;
       canDenormalizeQuotes?: boolean;
       userCanAccessDraftingSource?: boolean;
+      bookDraft?: Map<string, DeltaOperation[]>;
     } = {}
   ) {
     this.realtimeService.addSnapshot<User>(UserDoc.COLLECTION, {
@@ -387,7 +393,12 @@ class TestEnvironment {
       { insert: { verse: { number: 1 } }, attributes: { style: 'v' } },
       { insert: 'Verse 1 text.' }
     ]);
-    when(mockedDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(bookDraft));
+    bookDraft.set('2', [
+      { insert: { chapter: { number: 2 } }, attributes: { style: 'c' } },
+      { insert: { verse: { number: 1 } }, attributes: { style: 'v' } },
+      { insert: 'Verse 1 text.' }
+    ]);
+    when(mockedDraftHandlingService.getBookDraft(anything(), anything())).thenReturn(of(args.bookDraft ?? bookDraft));
     when(mockedActivatedProjectService.projectId$).thenReturn(of(this.projectId));
     this.onlineStatusService.setIsOnline(true);
     when(mockedNoticeService.show(anything())).thenResolve();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.spec.ts
@@ -175,7 +175,7 @@ describe('DraftUsfmFormatComponent', () => {
     verify(mockedDraftHandlingService.getBookDraft(anything(), anything())).once();
   }));
 
-  it('determines chapters with drafts based draft chapters', fakeAsync(() => {
+  it('determines chapters with drafts based on draft chapters', fakeAsync(() => {
     const env = new TestEnvironment({
       project: {
         texts: [
@@ -193,7 +193,7 @@ describe('DraftUsfmFormatComponent', () => {
     tick(EDITOR_READY_TIMEOUT);
     expect(env.component.bookNum).toBe(1);
     expect(env.component.chapterNum).toBe(1);
-    // source has 3 chapters on book 1
+    // draft has 2 chapters
     expect(env.component.chaptersWithDrafts).toEqual([1, 2]);
     expect(env.component.showDraftSourceWarning).toBe(false);
     verify(mockedDraftHandlingService.getBookDraft(anything(), anything())).once();
@@ -404,7 +404,6 @@ class TestEnvironment {
     when(mockedNoticeService.show(anything())).thenResolve();
     when(mockedDialogService.confirm(anything(), anything(), anything())).thenResolve(true);
     when(mockedServalAdministration.onlineRetrievePreTranslationStatus(anything())).thenResolve();
-    when(mockedProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(true);
     this.setupProject(args.project);
     this.fixture = TestBed.createComponent(DraftUsfmFormatComponent);
     this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -208,7 +208,7 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
         if (this.chapterNum != null) {
           this.chapterNum = this.chaptersWithDrafts.includes(this.chapterNum)
             ? this.chapterNum
-            : this.chaptersWithDrafts[0];
+            : (this.chaptersWithDrafts[0] ?? this.chapterNum);
           this.setChapterContents(this.chapterNum);
         }
         this.draftText.applyEditorStyles();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-usfm-format/draft-usfm-format.component.ts
@@ -182,7 +182,8 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
         if (params['chapter'] !== undefined) {
           initialChapterNum = Number(params['chapter']);
         }
-        await this.subscribeBookAndChapters(initialBookNum, initialChapterNum);
+        this.chapterNum = initialChapterNum;
+        await this.subscribeBookAndChapters(initialBookNum);
       });
 
     this.updateDraftConfig$
@@ -197,11 +198,17 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
       )
       .subscribe(chapterDeltas => {
         this.chapterDeltas.clear();
+        this.chaptersWithDrafts = [];
         for (const chapter of chapterDeltas.keys()) {
           const draftDelta: Delta = new Delta(chapterDeltas.get(chapter));
           this.chapterDeltas.set(+chapter, draftDelta.ops);
+          this.chaptersWithDrafts.push(+chapter);
         }
+
         if (this.chapterNum != null) {
+          this.chapterNum = this.chaptersWithDrafts.includes(this.chapterNum)
+            ? this.chapterNum
+            : this.chaptersWithDrafts[0];
           this.setChapterContents(this.chapterNum);
         }
         this.draftText.applyEditorStyles();
@@ -230,11 +237,6 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
   close(): void {
     // go back to the draft generation or edit and review page
     this.location.back();
-  }
-
-  reloadText(): void {
-    this.loadingStarted();
-    this.updateDraftConfig$.next(this.currentFormat);
   }
 
   async saveChanges(): Promise<void> {
@@ -269,6 +271,11 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
     );
   }
 
+  reloadText(): void {
+    this.loadingStarted();
+    this.updateDraftConfig$.next(this.currentFormat);
+  }
+
   private setUsfmConfig(config?: DraftUsfmConfig): void {
     this.usfmFormatForm.setValue({
       paragraphFormat: config?.paragraphFormat ?? ParagraphBreakFormat.BestGuess,
@@ -294,30 +301,19 @@ export class DraftUsfmFormatComponent extends DataLoadingComponent implements Af
     }
   }
 
-  private async subscribeBookAndChapters(initialBookNum: number, initialChapterNum?: number): Promise<void> {
+  private async subscribeBookAndChapters(initialBookNum: number): Promise<void> {
     const currentUser = await this.userService.getCurrentUser();
     combineLatest([this.draftSources$, this.bookNum$.pipe(filterNullish())])
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
-      .subscribe(async ([source, bookNum]) => {
+      .subscribe(async ([source]) => {
         if (currentUser.data?.sites[environment.siteId].projects.includes(source.draftingSources[0].projectRef)) {
           this.translateSource ??= (await this.projectService.getProfile(source.draftingSources[0].projectRef)).data;
         }
 
         this.showDraftSourceWarning = this.translateSource == null;
         this.sourceProjectName = projectLabel(source.draftingSources[0]);
-
-        // Determine the chapter to navigate to, using the initial chapter if it exists and no chapter is defined yet
-        // If the user does not have access to the source project, just show the initial chapter, and if null, chapter 1
-        const chapters =
-          this.translateSource?.texts.find(t => t.bookNum === bookNum)?.chapters.map(c => c.number) ?? [];
-        if (chapters.length > 0) {
-          this.chaptersWithDrafts = chapters;
-        } else {
-          this.chaptersWithDrafts = [1];
-          initialChapterNum = 1;
-        }
-        this.chapterNum =
-          this.chapterNum == null ? (initialChapterNum ?? this.chaptersWithDrafts[0]) : this.chaptersWithDrafts[0];
+        // Default the chapter num to 1. This will be updated when we load the drafts and drafted chapters are known
+        if (this.chapterNum == null) this.chapterNum = 1;
         this.reloadText();
       });
 


### PR DESCRIPTION
The previous logic determined the number of drafted chapters based on the translation source project. This is unreliable since the translation source project can change. This PR updates the logic to determine the chapters with completed drafts based on the draft itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3912)
<!-- Reviewable:end -->
