### PR TITLE
SF-3608b Fix infinite editor updating when lynx enabled

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -143,8 +143,8 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
   private readonly _segments: Map<string, Range> = new Map<string, Range>();
   private readonly segments$ = new BehaviorSubject<ReadonlyMap<string, Range>>(this._segments);
 
-  private readonly _embedPositionsChanged$ = new Subject<void>();
-  readonly embedPositionsChanged$ = this._embedPositionsChanged$.asObservable();
+  private readonly _numberEmbedsChanged$ = new Subject<void>();
+  readonly numberEmbedsChanged$ = this._numberEmbedsChanged$.asObservable();
 
   get segments(): IterableIterator<[string, Range]> {
     return this._segments.entries();
@@ -658,6 +658,7 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
     let fixDelta = new Delta();
     let fixOffset = 0;
     const delta = editor.getContents();
+    const prevEmbedCount: number = this._embeddedElements.size;
     this._segments.clear();
     this._embeddedElements.clear();
     if (delta.ops == null) {
@@ -785,7 +786,9 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
     }
 
     this.segments$.next(this._segments);
-    this._embedPositionsChanged$.next();
+    if (this._embeddedElements.size !== prevEmbedCount) {
+      this._numberEmbedsChanged$.next();
+    }
 
     return convertDelta.compose(fixDelta).chop();
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-editor.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-editor.ts
@@ -45,9 +45,9 @@ export interface LynxTextModelConverter {
   getEmbedCountsToOffsetFunc(): LynxCountToOffsetFunc;
 
   /**
-   * Observable that emits when embedded element positions change.
+   * Observable that emits when the number of embedded elements changes.
    * This is useful for detecting when note embeds are added/removed (including remotely),
    * which affect the mapping between data model positions and editor positions.
    */
-  readonly embedPositionsChanged$: Observable<void>;
+  readonly numberEmbedsChanged$: Observable<void>;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
@@ -529,7 +529,7 @@ class TestEnvironment {
     when(mockOverlayService.isOpen).thenReturn(false);
     when(mockLynxWorkspaceService.getOnTypeEdits(anything(), anything())).thenResolve([]);
     when(mockTextModelConverter.dataDeltaToEditorDelta(anything())).thenCall((delta: Delta) => delta);
-    when(mockTextModelConverter.embedPositionsChanged$).thenReturn(this.embedPositionsChangedSubject);
+    when(mockTextModelConverter.numberEmbedsChanged$).thenReturn(this.embedPositionsChangedSubject);
 
     // Setup text model converter to return ranges as-is (prevents null range issues)
     when(mockTextModelConverter.dataRangeToEditorRange(anything())).thenCall((range: LynxInsightRange) => range);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.spec.ts
@@ -347,8 +347,8 @@ describe('LynxInsightEditorObjectsComponent', () => {
     }));
   });
 
-  describe('embed position changes', () => {
-    it('should re-render insights when embed positions change', fakeAsync(() => {
+  describe('number of embeds changes', () => {
+    it('should re-render insights when number of embeds change', fakeAsync(() => {
       // Start with editor not ready
       const env = new TestEnvironment({ initialEditorReady: false });
       const testInsight = env.createTestInsight();
@@ -368,15 +368,15 @@ describe('LynxInsightEditorObjectsComponent', () => {
       verify(mockInsightRenderService.render(anything(), anything())).once();
       verify(mockInsightRenderService.renderActionOverlay(anything(), anything(), anything(), anything())).once();
 
-      // Embed position change should trigger second insights render, but not action overlay render
-      env.triggerEmbedPositionChange();
-      tick(env.component.embedPositionsChangedDebounceTime);
+      // Number of embeds change should trigger second insights render, but not action overlay render
+      env.triggerNumberEmbedsChanged();
+      tick(env.component.numberEmbedsChangedDebounceTime);
       flush();
       verify(mockInsightRenderService.render(anything(), anything())).twice();
       verify(mockInsightRenderService.renderActionOverlay(anything(), anything(), anything(), anything())).once();
     }));
 
-    it('should not reset overlay state when embed positions change', fakeAsync(() => {
+    it('should not reset overlay state when number of embeds change', fakeAsync(() => {
       // Start with editor not ready
       const env = new TestEnvironment({ initialEditorReady: false });
       const testInsight = env.createTestInsight();
@@ -408,9 +408,9 @@ describe('LynxInsightEditorObjectsComponent', () => {
       verify(mockInsightRenderService.render(anything(), anything())).once(); // No new insight render
       verify(mockInsightRenderService.renderActionOverlay(anything(), anything(), anything(), anything())).twice();
 
-      // Embed position change should trigger second insights render, but not action overlay render
-      env.triggerEmbedPositionChange();
-      tick(env.component.embedPositionsChangedDebounceTime);
+      // Number of embeds change should trigger second insights render, but not action overlay render
+      env.triggerNumberEmbedsChanged();
+      tick(env.component.numberEmbedsChangedDebounceTime);
       flush();
       verify(mockInsightRenderService.render(anything(), anything())).twice();
       verify(mockInsightRenderService.renderActionOverlay(anything(), anything(), anything(), anything())).twice();
@@ -456,7 +456,7 @@ class TestEnvironment {
   private filterSubject: BehaviorSubject<LynxInsightFilter>;
   private filteredInsightCountsByTypeSubject: BehaviorSubject<Record<LynxInsightType, number>>;
   private taskRunningStatusSubject: BehaviorSubject<boolean>;
-  private embedPositionsChangedSubject: Subject<void>;
+  private numberEmbedsChangedSubject: Subject<void>;
 
   constructor(args: TestEnvArgs = {}) {
     const textModelConverter = instance(mockTextModelConverter);
@@ -482,7 +482,7 @@ class TestEnvironment {
     this.filteredInsightCountsByTypeSubject = new BehaviorSubject<any>({ info: 0, warning: 0, error: 0 });
     this.taskRunningStatusSubject = new BehaviorSubject<boolean>(false);
 
-    this.embedPositionsChangedSubject = new Subject<void>();
+    this.numberEmbedsChangedSubject = new Subject<void>();
 
     // Create mock editor
     const mockRoot = document.createElement('div');
@@ -529,7 +529,7 @@ class TestEnvironment {
     when(mockOverlayService.isOpen).thenReturn(false);
     when(mockLynxWorkspaceService.getOnTypeEdits(anything(), anything())).thenResolve([]);
     when(mockTextModelConverter.dataDeltaToEditorDelta(anything())).thenCall((delta: Delta) => delta);
-    when(mockTextModelConverter.numberEmbedsChanged$).thenReturn(this.embedPositionsChangedSubject);
+    when(mockTextModelConverter.numberEmbedsChanged$).thenReturn(this.numberEmbedsChangedSubject);
 
     // Setup text model converter to return ranges as-is (prevents null range issues)
     when(mockTextModelConverter.dataRangeToEditorRange(anything())).thenCall((range: LynxInsightRange) => range);
@@ -588,8 +588,8 @@ class TestEnvironment {
     }
   }
 
-  triggerEmbedPositionChange(): void {
-    this.embedPositionsChangedSubject.next();
+  triggerNumberEmbedsChanged(): void {
+    this.numberEmbedsChangedSubject.next();
   }
 
   createTestInsight(props: Partial<LynxInsight> = {}): LynxInsight {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
@@ -1,13 +1,13 @@
 import {
   Component,
   DestroyRef,
+  DOCUMENT,
   Inject,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
-  SimpleChanges,
-  DOCUMENT
+  SimpleChanges
 } from '@angular/core';
 import { isEqual } from 'lodash-es';
 import { Delta } from 'quill';
@@ -30,13 +30,13 @@ import { EditorReadyService } from '../base-services/editor-ready.service';
 import { InsightRenderService } from '../base-services/insight-render.service';
 import { LynxableEditor, LynxTextModelConverter } from '../lynx-editor';
 import { LynxInsight, LynxInsightDisplayState, LynxInsightRange } from '../lynx-insight';
+import { LynxInsightActionPromptComponent } from '../lynx-insight-action-prompt/lynx-insight-action-prompt.component';
 import { LynxInsightOverlayService } from '../lynx-insight-overlay.service';
+import { LynxInsightScrollPositionIndicatorComponent } from '../lynx-insight-scroll-position-indicator/lynx-insight-scroll-position-indicator.component';
 import { LynxInsightStateService } from '../lynx-insight-state.service';
+import { LynxInsightStatusIndicatorComponent } from '../lynx-insight-status-indicator/lynx-insight-status-indicator.component';
 import { LynxWorkspaceService } from '../lynx-workspace.service';
 import { LynxInsightBlot } from '../quill-services/blots/lynx-insight-blot';
-import { LynxInsightStatusIndicatorComponent } from '../lynx-insight-status-indicator/lynx-insight-status-indicator.component';
-import { LynxInsightScrollPositionIndicatorComponent } from '../lynx-insight-scroll-position-indicator/lynx-insight-scroll-position-indicator.component';
-import { LynxInsightActionPromptComponent } from '../lynx-insight-action-prompt/lynx-insight-action-prompt.component';
 
 @Component({
   selector: 'app-lynx-insight-editor-objects',
@@ -178,7 +178,7 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
                     ).pipe(tap(() => chapterInsightsRendered$.next(true)));
                   })
                 ),
-                (this.lynxTextModelConverter?.embedPositionsChanged$ ?? EMPTY).pipe(
+                (this.lynxTextModelConverter?.numberEmbedsChanged$ ?? EMPTY).pipe(
                   debounceTime(this.embedPositionsChangedDebounceTime),
                   withLatestFrom(this.insightState.filteredChapterInsights$),
                   switchMap(([_, insights]) => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/lynx/insights/lynx-insight-editor-objects/lynx-insight-editor-objects.component.ts
@@ -53,7 +53,7 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
   @Input() autoCorrectionsEnabled: boolean = false;
   @Input() insightsEnabled: boolean = false;
 
-  readonly embedPositionsChangedDebounceTime = 100;
+  readonly numberEmbedsChangedDebounceTime = 100;
 
   readonly insightSelector = `.${LynxInsightBlot.superClassName}`;
   private readonly dataIdProp = LynxInsightBlot.idDatasetPropName;
@@ -179,7 +179,7 @@ export class LynxInsightEditorObjectsComponent implements OnChanges, OnInit, OnD
                   })
                 ),
                 (this.lynxTextModelConverter?.numberEmbedsChanged$ ?? EMPTY).pipe(
-                  debounceTime(this.embedPositionsChangedDebounceTime),
+                  debounceTime(this.numberEmbedsChangedDebounceTime),
                   withLatestFrom(this.insightState.filteredChapterInsights$),
                   switchMap(([_, insights]) => {
                     return from(


### PR DESCRIPTION
I discovered this bug when I had lynx enabled and I saw infinite console logs appearing on dev tools. It turns out that lynx insights triggers an update to the editor which recalculates the number of embedded elements which triggers lynx insights to render in an infinite loop. This was introduced when PR #3549  was introduced. This PR breaks the loop by having lynx render only when the number of embedded elements changes.

You can see this issue if you add a console log to the update method in text.component.ts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3913)
<!-- Reviewable:end -->
