### PR TITLE
SF-3332 Prevent user from deleting footnotes

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -1036,6 +1036,59 @@ describe('TextComponent', () => {
     });
   }));
 
+  it('does not allow selecting a range that includes a footnote', fakeAsync(() => {
+    const chapterNum = 2;
+    const segmentRef: string = `verse_${chapterNum}_1`;
+    const textDocOps: RichText.DeltaOperation[] = [
+      { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
+      { insert: { verse: { number: '1', style: 'v' } } },
+      {
+        insert: `quick brown fox`,
+        attributes: {
+          segment: segmentRef
+        }
+      },
+      {
+        insert: {
+          note: {
+            content: 'footnote on text',
+            style: 'f'
+          }
+        }
+      },
+      {
+        insert: ' jumped over',
+        attributes: {
+          segment: segmentRef
+        }
+      }
+    ];
+
+    const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
+
+    env.waitForEditor();
+    env.component.setSegment(segmentRef);
+    tick();
+    const segmentRange: QuillRange | undefined = env.component.getSegmentRange(segmentRef);
+    if (segmentRange == null) {
+      fail('setup');
+      return;
+    }
+
+    const expectedRange: QuillRange = {
+      index: segmentRange.index,
+      length: 'quick brown fox'.length
+    };
+    const newSel = env.component.conformToValidSelectionForCurrentSegment(
+      {
+        index: segmentRange.index,
+        length: segmentRange.length
+      },
+      false
+    );
+    expect(newSel).toEqual(expectedRange);
+  }));
+
   it('does not cancel in beforeinput when valid selection', fakeAsync(() => {
     const { env }: { env: TestEnvironment; segmentRange: QuillRange } = basicSimpleText();
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.spec.ts
@@ -1038,31 +1038,8 @@ describe('TextComponent', () => {
 
   it('does not allow selecting a range that includes a footnote', fakeAsync(() => {
     const chapterNum = 2;
-    const segmentRef: string = `verse_${chapterNum}_1`;
-    const textDocOps: RichText.DeltaOperation[] = [
-      { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
-      { insert: { verse: { number: '1', style: 'v' } } },
-      {
-        insert: `quick brown fox`,
-        attributes: {
-          segment: segmentRef
-        }
-      },
-      {
-        insert: {
-          note: {
-            content: 'footnote on text',
-            style: 'f'
-          }
-        }
-      },
-      {
-        insert: ' jumped over',
-        attributes: {
-          segment: segmentRef
-        }
-      }
-    ];
+    const textDocOps: RichText.DeltaOperation[] = chapterTextOpsWithFootnote(chapterNum);
+    const segmentRef: string = textDocOps.find(op => op.attributes?.segment)?.attributes?.segment as string;
 
     const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
 
@@ -1087,6 +1064,32 @@ describe('TextComponent', () => {
       false
     );
     expect(newSel).toEqual(expectedRange);
+  }));
+
+  it('does not allow modifying a selection that includes a footnote', fakeAsync(() => {
+    const chapterNum = 2;
+    const textDocOps: RichText.DeltaOperation[] = chapterTextOpsWithFootnote(chapterNum);
+    const segmentRef: string = textDocOps.find(op => op.attributes?.segment)?.attributes?.segment as string;
+
+    const env = new TestEnvironment({ chapterNum, textDoc: textDocOps });
+
+    env.waitForEditor();
+    env.component.setSegment(segmentRef);
+    tick();
+    const segmentRange: QuillRange | undefined = env.component.getSegmentRange(segmentRef);
+    if (segmentRange == null) {
+      fail('setup');
+      return;
+    }
+
+    const selectionWithFootnote: QuillRange = {
+      index: segmentRange.index,
+      length: segmentRange.length
+    };
+    // edits are ignored if the selection contains an embed
+    expect(env.component.isValidSelectionForCurrentSegment(selectionWithFootnote)).toBeFalse();
+    expect(env.quillHandleBackspace(selectionWithFootnote)).toBeFalse();
+    expect(env.quillHandleDelete(selectionWithFootnote)).toBeFalse();
   }));
 
   it('does not cancel in beforeinput when valid selection', fakeAsync(() => {
@@ -2222,4 +2225,33 @@ function basicSimpleText(): { env: TestEnvironment; segmentRange: QuillRange } {
   env.fixture.detectChanges();
   tick();
   return { env, segmentRange };
+}
+
+function chapterTextOpsWithFootnote(chapterNum: number): RichText.DeltaOperation[] {
+  const segmentRef: string = `verse_${chapterNum}_1`;
+  const textDocOps: RichText.DeltaOperation[] = [
+    { insert: { chapter: { number: chapterNum.toString(), style: 'c' } } },
+    { insert: { verse: { number: '1', style: 'v' } } },
+    {
+      insert: `quick brown fox`,
+      attributes: {
+        segment: segmentRef
+      }
+    },
+    {
+      insert: {
+        note: {
+          content: 'footnote on text',
+          style: 'f'
+        }
+      }
+    },
+    {
+      insert: ' jumped over',
+      attributes: {
+        segment: segmentRef
+      }
+    }
+  ];
+  return textDocOps;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1893,7 +1893,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    const newSel: Range | null = this.conformToValidSelectionForCurrentSegment(sel);
+    const newSel: Range | null = this.conformToValidSelectionForCurrentSegment(sel, false);
     if (newSel != null && (sel.index !== newSel.index || sel.length !== newSel.length)) {
       this._editor.setSelection(newSel, 'user');
     }
@@ -1901,7 +1901,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
   /** Given a selection, return a possibly modified selection that is a valid for editing the current segment.
    * For example, a selection over a segment boundary is sometimes not valid. */
-  conformToValidSelectionForCurrentSegment(sel: Range): Range | null {
+  conformToValidSelectionForCurrentSegment(sel: Range, allowSelectingTextualNotes: boolean = true): Range | null {
     if (this._editor == null || this._segment == null) {
       return null;
     }
@@ -1921,7 +1921,18 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       if (newStart > segEnd) {
         newStart = segEnd;
       }
-      const newEnd: number = Math.min(oldEnd, segEnd);
+      let newEnd: number = Math.min(oldEnd, segEnd);
+      const selectionLength: number = newEnd - newStart;
+      if (!allowSelectingTextualNotes) {
+        // Get the content of the range.
+        const content: Delta = this._editor.getContents(newStart, selectionLength);
+        const lengthToTextualNote: number = this.calculateTextualNoteIndex(content);
+
+        if (lengthToTextualNote < selectionLength) {
+          // if the content includes a text note, cut the selection at the note
+          newEnd = newStart + lengthToTextualNote;
+        }
+      }
 
       const embedPositions: number[] = Array.from(this.embeddedElements.values()).sort();
       if (newStart === this._segment.range.index || embedPositions.includes(newStart - 1)) {
@@ -1951,6 +1962,22 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     if (!this.isValidSelectionForCurrentSegment(sel)) {
       ev.preventDefault();
     }
+  }
+
+  private calculateTextualNoteIndex(content: Delta): number {
+    if (content.ops == null) return 0;
+    let textualNoteIndex: number = 0;
+    for (const op of content.ops) {
+      // count the length from the start of the selection to the textual note if it exists
+      if (op.insert != null && typeof op.insert === 'string') {
+        textualNoteIndex += op.insert.length;
+      } else if (op.insert != null && typeof op.insert === 'object') {
+        if (op.insert['note'] != null) break;
+        // any object op counts as length 1
+        textualNoteIndex++;
+      }
+    }
+    return textualNoteIndex;
   }
 
   /** Returns the number of embedded elements that are located at or after editorStartPos, through length of editor

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1091,7 +1091,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
   /** Is a given selection range valid for editing the current segment? */
   isValidSelectionForCurrentSegment(sel: Range): boolean {
-    const newSel: Range | null = this.conformToValidSelectionForCurrentSegment(sel);
+    const newSel: Range | null = this.conformToValidSelectionForCurrentSegment(sel, false);
     return !(newSel == null || sel.index !== newSel.index || sel.length !== newSel.length);
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -1901,7 +1901,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
   /** Given a selection, return a possibly modified selection that is a valid for editing the current segment.
    * For example, a selection over a segment boundary is sometimes not valid. */
-  conformToValidSelectionForCurrentSegment(sel: Range, allowSelectingTextualNotes: boolean = true): Range | null {
+  conformToValidSelectionForCurrentSegment(sel: Range, allowEmbedSelection: boolean = true): Range | null {
     if (this._editor == null || this._segment == null) {
       return null;
     }
@@ -1923,14 +1923,14 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       }
       let newEnd: number = Math.min(oldEnd, segEnd);
       const selectionLength: number = newEnd - newStart;
-      if (!allowSelectingTextualNotes) {
+      if (!allowEmbedSelection) {
         // Get the content of the range.
         const content: Delta = this._editor.getContents(newStart, selectionLength);
-        const lengthToTextualNote: number = this.calculateTextualNoteIndex(content);
+        const lengthToEmbed: number = this.calculateNextEmbedIndex(content);
 
-        if (lengthToTextualNote < selectionLength) {
+        if (lengthToEmbed < selectionLength) {
           // if the content includes a text note, cut the selection at the note
-          newEnd = newStart + lengthToTextualNote;
+          newEnd = newStart + lengthToEmbed;
         }
       }
 
@@ -1964,17 +1964,16 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  private calculateTextualNoteIndex(content: Delta): number {
+  private calculateNextEmbedIndex(content: Delta): number {
     if (content.ops == null) return 0;
     let textualNoteIndex: number = 0;
     for (const op of content.ops) {
-      // count the length from the start of the selection to the textual note if it exists
+      // count the length from the start of the selection to the embed if it exists
       if (op.insert != null && typeof op.insert === 'string') {
         textualNoteIndex += op.insert.length;
       } else if (op.insert != null && typeof op.insert === 'object') {
-        if (op.insert['note'] != null) break;
-        // any object op counts as length 1
-        textualNoteIndex++;
+        // objects indicate an embed which we want to prevent the user from manipulating
+        break;
       }
     }
     return textualNoteIndex;


### PR DESCRIPTION
Users were previously allowed to make a selection that included a cross reference or footnote. We do not want to allow users to select these notes which they would then be able to overwrite or delete. This PR introduces logic to identify any embed in a selection and update the selection be come before the embed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3915)
<!-- Reviewable:end -->
