### PR TITLE
SF-3818 Allow Serval admins to configure sources

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/onboarding-flow.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/onboarding-flow.ts
@@ -205,7 +205,7 @@ export async function onboardingFlow(
   await screenshot(adminBrowser.page, { pageName: 'admin_comment_added', ...context });
 
   // Approve the request
-  await adminUser.click(adminBrowser.page.getByRole('button', { name: 'Approve & Enable' }));
+  await adminUser.click(adminBrowser.page.getByRole('button', { name: 'Approve & Configure Sources' }));
   await adminUser.click(adminBrowser.page.getByRole('button', { name: 'Approve', exact: true })); // Confirm in dialog
 
   // Verify the user now sees drafting enabled

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.html
@@ -1,0 +1,61 @@
+<h1 mat-dialog-title>Approve &amp; enable drafting</h1>
+<mat-dialog-content>
+  <p class="dialog-subtitle">Configure sources for {{ data.projectName }}</p>
+  <form [formGroup]="form">
+    <h3>Drafting source</h3>
+    <mat-radio-group formControlName="draftingSource" class="source-options">
+      @for (id of data.draftingSourceOptions; track id) {
+        <mat-radio-button [value]="id">
+          @if (data.projectInfo.get(id); as info) {
+            {{ info.name }} <span class="language-code">{{ info.languageCode }}</span>
+          } @else {
+            {{ id }}
+          }
+        </mat-radio-button>
+      }
+    </mat-radio-group>
+
+    <h3>Training sources</h3>
+    <p class="hint">Select 1 or 2 training sources.</p>
+    <div class="source-options">
+      @for (id of data.trainingSourceOptions; track id) {
+        <div class="training-source-option">
+          <mat-checkbox [checked]="isTrainingSourceSelected(id)" (change)="toggleTrainingSource(id, $event.checked)">
+            @if (data.projectInfo.get(id); as info) {
+              {{ info.name }} <span class="language-code">{{ info.languageCode }}</span>
+            } @else {
+              {{ id }}
+            }
+          </mat-checkbox>
+          @if (trainingSourceOrder(id); as order) {
+            <span
+              [class]="'order-label order-label--' + order.toLowerCase()"
+              [matTooltip]="
+                order === 'Primary'
+                  ? 'This project will be saved as the first training source'
+                  : 'This project will be saved as the second training source'
+              "
+              >{{ order }}</span
+            >
+          }
+        </div>
+      }
+    </div>
+    @if (form.hasError("languageCodesDiffer")) {
+      <app-notice type="error">All source projects must be in the same language.</app-notice>
+    }
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" mat-dialog-close id="cancel-button"><mat-icon>close</mat-icon> Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    (click)="approve()"
+    [disabled]="form.invalid"
+    id="approve-button"
+  >
+    <mat-icon>check_circle</mat-icon> Approve
+  </button>
+</mat-dialog-actions>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.scss
@@ -1,0 +1,53 @@
+.dialog-subtitle {
+  margin: 0 0 16px;
+  font-size: 1rem;
+  color: #3c3c3c;
+}
+
+.source-options {
+  display: flex;
+  flex-direction: column;
+}
+
+// Suppresses a phantom scrollbar; remove if this dialog ever needs real scrolling.
+mat-dialog-content {
+  overflow-y: hidden;
+}
+
+h3 {
+  margin-top: 0;
+}
+
+.language-code {
+  margin-left: 4px;
+  font-size: 0.875rem;
+  color: #616161;
+  font-family: monospace;
+}
+
+.hint {
+  margin-top: 0;
+}
+
+.training-source-option {
+  display: flex;
+  align-items: center;
+}
+
+.order-label {
+  margin-left: 8px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 12px;
+
+  &--primary {
+    background-color: #e8f0fe;
+    color: #1967d2;
+  }
+
+  &--secondary {
+    background-color: #f1f3f4;
+    color: #5f6368;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.spec.ts
@@ -1,0 +1,158 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import {
+  ApproveRequestDialogComponent,
+  ApproveRequestDialogData,
+  ApproveRequestDialogResult
+} from './approve-request-dialog.component';
+
+const TEST_DATA: ApproveRequestDialogData = {
+  projectInfo: new Map([
+    ['ptid-draft', { name: 'English Drafting Project', shortName: 'DRAFT', languageCode: 'eng' }],
+    ['ptid-A', { name: 'English Source Alpha', shortName: 'ALPHA', languageCode: 'eng' }],
+    ['ptid-B', { name: 'English Source Beta', shortName: 'BETA', languageCode: 'eng' }],
+    ['ptid-bt', { name: 'English Back Translation', shortName: 'BT', languageCode: 'eng' }]
+  ]),
+  projectName: 'MYPROJ - My Project',
+  draftingSourceOptions: ['ptid-draft', 'ptid-A', 'ptid-B'],
+  trainingSourceOptions: ['ptid-draft', 'ptid-A', 'ptid-B', 'ptid-bt'],
+  defaultDraftingSource: 'ptid-draft',
+  defaultTrainingSources: ['ptid-A']
+};
+
+describe('ApproveRequestDialogComponent', () => {
+  let fixture: ComponentFixture<ApproveRequestDialogComponent>;
+  let component: ApproveRequestDialogComponent;
+  let closeSpy: jasmine.Spy;
+
+  function setup(data: ApproveRequestDialogData = TEST_DATA): void {
+    closeSpy = jasmine.createSpy('close');
+    TestBed.configureTestingModule({
+      imports: [ApproveRequestDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: closeSpy } }
+      ]
+    });
+    fixture = TestBed.createComponent(ApproveRequestDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('pre-fills defaults', () => {
+    setup();
+    expect(component.draftingSource.value).toBe('ptid-draft');
+    expect(component.trainingSources.value).toEqual(['ptid-A']);
+  });
+
+  it('form is valid with default selections', () => {
+    setup();
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('form is invalid when no training source is selected', () => {
+    setup();
+    component.trainingSources.setValue([]);
+    expect(component.form.invalid).toBeTrue();
+  });
+
+  it('form is invalid when 3 training sources are selected', () => {
+    setup();
+    component.trainingSources.setValue(['ptid-draft', 'ptid-A', 'ptid-B']);
+    expect(component.form.invalid).toBeTrue();
+  });
+
+  it('form is invalid when source projects have different language codes', () => {
+    const mixedData: ApproveRequestDialogData = {
+      ...TEST_DATA,
+      projectInfo: new Map([
+        ...TEST_DATA.projectInfo,
+        ['ptid-draft', { name: 'French Drafting Project', shortName: 'DRAFT', languageCode: 'fra' }]
+      ])
+    };
+    setup(mixedData);
+    // Default: draftingSource=ptid-draft (fra), trainingSources=['ptid-A'] (eng) → differ
+    expect(component.form.hasError('languageCodesDiffer')).toBeTrue();
+  });
+
+  it('form is valid with 2 training sources selected', () => {
+    setup();
+    component.trainingSources.setValue(['ptid-A', 'ptid-B']);
+    expect(component.form.valid).toBeTrue();
+  });
+
+  it('approve() closes with correct result', () => {
+    setup();
+    component.draftingSource.setValue('ptid-A');
+    component.trainingSources.setValue(['ptid-B', 'ptid-bt']);
+    component.approve();
+    expect(closeSpy).toHaveBeenCalledOnceWith({
+      draftingSourceParatextId: 'ptid-A',
+      trainingSourceParatextIds: ['ptid-B', 'ptid-bt']
+    } satisfies ApproveRequestDialogResult);
+  });
+
+  it('approve() does not close when form is invalid', () => {
+    setup();
+    component.trainingSources.setValue([]);
+    component.approve();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('toggleTrainingSource adds and removes entries', () => {
+    setup();
+    component.toggleTrainingSource('ptid-B', true);
+    expect(component.trainingSources.value).toContain('ptid-B');
+    component.toggleTrainingSource('ptid-A', false);
+    expect(component.trainingSources.value).not.toContain('ptid-A');
+  });
+
+  it('trainingSourceOrder returns null when fewer than 2 sources selected', () => {
+    setup();
+    expect(component.trainingSourceOrder('ptid-A')).toBeNull();
+  });
+
+  it('trainingSourceOrder labels first-selected as Primary, second as Secondary', () => {
+    setup();
+    component.trainingSources.setValue(['ptid-A', 'ptid-B']);
+    expect(component.trainingSourceOrder('ptid-A')).toBe('Primary');
+    expect(component.trainingSourceOrder('ptid-B')).toBe('Secondary');
+  });
+
+  it('trainingSourceOrder updates when order changes via toggle', () => {
+    setup();
+    component.toggleTrainingSource('ptid-B', true); // A then B → A=primary
+    expect(component.trainingSourceOrder('ptid-A')).toBe('Primary');
+    expect(component.trainingSourceOrder('ptid-B')).toBe('Secondary');
+
+    component.toggleTrainingSource('ptid-A', false); // deselect A → only B
+    component.toggleTrainingSource('ptid-A', true); // re-select A → B=primary, A=secondary
+    expect(component.trainingSourceOrder('ptid-B')).toBe('Primary');
+    expect(component.trainingSourceOrder('ptid-A')).toBe('Secondary');
+  });
+
+  it('approve() emits training sources in primary-first order', () => {
+    setup();
+    component.trainingSources.setValue(['ptid-B', 'ptid-A']);
+    component.approve();
+    const result: ApproveRequestDialogResult = closeSpy.calls.mostRecent().args[0];
+    expect(result.trainingSourceParatextIds).toEqual(['ptid-B', 'ptid-A']);
+  });
+
+  it('approve button is disabled when form invalid', () => {
+    setup();
+    component.trainingSources.setValue([]);
+    fixture.detectChanges();
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('#approve-button');
+    expect(btn.disabled).toBeTrue();
+  });
+
+  it('approve button is enabled when form valid', () => {
+    setup();
+    fixture.detectChanges();
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('#approve-button');
+    expect(btn.disabled).toBeFalse();
+  });
+});

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/approve-request-dialog/approve-request-dialog.component.ts
@@ -1,0 +1,131 @@
+import { Component, Inject } from '@angular/core';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatIcon } from '@angular/material/icon';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
+import { MatTooltip } from '@angular/material/tooltip';
+import { NoticeComponent } from '../../../shared/notice/notice.component';
+import { normalizeLanguageCodeToISO639_3 } from '../../../translate/draft-generation/draft-utils';
+
+export interface ProjectInfo {
+  name: string;
+  shortName: string;
+  languageCode: string;
+}
+
+export interface ApproveRequestDialogData {
+  projectInfo: Map<string, ProjectInfo>;
+  projectName: string;
+  draftingSourceOptions: string[];
+  trainingSourceOptions: string[];
+  defaultDraftingSource: string;
+  defaultTrainingSources: string[];
+}
+
+export interface ApproveRequestDialogResult {
+  draftingSourceParatextId: string;
+  trainingSourceParatextIds: string[];
+}
+
+function trainingSourcesValidator(control: AbstractControl): ValidationErrors | null {
+  const value: string[] = control.value ?? [];
+  return value.length >= 1 && value.length <= 2 ? null : { trainingSourceCount: true };
+}
+
+function languageCodesValidator(projectInfo: Map<string, ProjectInfo>) {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const draftingSourceId: string = control.get('draftingSource')?.value;
+    const trainingSourceIds: string[] = control.get('trainingSources')?.value ?? [];
+    const allIds = [draftingSourceId, ...trainingSourceIds].filter((id): id is string => id != null);
+    const codes = allIds.map(id => projectInfo.get(id)?.languageCode).filter((c): c is string => c != null && c !== '');
+    const uniqueNormalized = new Set(codes.map(normalizeLanguageCodeToISO639_3));
+    return uniqueNormalized.size > 1 ? { languageCodesDiffer: true } : null;
+  };
+}
+
+@Component({
+  selector: 'app-approve-request-dialog',
+  templateUrl: './approve-request-dialog.component.html',
+  styleUrl: './approve-request-dialog.component.scss',
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton,
+    MatIcon,
+    MatRadioGroup,
+    MatRadioButton,
+    MatCheckbox,
+    MatTooltip,
+    NoticeComponent
+  ]
+})
+export class ApproveRequestDialogComponent {
+  readonly draftingSource: FormControl<string>;
+  readonly trainingSources: FormControl<string[]>;
+  readonly form: FormGroup;
+
+  constructor(
+    readonly dialogRef: MatDialogRef<ApproveRequestDialogComponent, ApproveRequestDialogResult>,
+    @Inject(MAT_DIALOG_DATA) readonly data: ApproveRequestDialogData
+  ) {
+    this.draftingSource = new FormControl<string>(data.defaultDraftingSource, {
+      validators: [Validators.required],
+      nonNullable: true
+    });
+    this.trainingSources = new FormControl<string[]>(data.defaultTrainingSources, {
+      validators: [trainingSourcesValidator],
+      nonNullable: true
+    });
+    this.form = new FormGroup(
+      { draftingSource: this.draftingSource, trainingSources: this.trainingSources },
+      { validators: languageCodesValidator(data.projectInfo) }
+    );
+  }
+
+  isTrainingSourceSelected(id: string): boolean {
+    return this.trainingSources.value.includes(id);
+  }
+
+  /** Returns 'Primary' or 'Secondary' when exactly 2 sources are selected, null otherwise. */
+  trainingSourceOrder(id: string): 'Primary' | 'Secondary' | null {
+    const sources = this.trainingSources.value;
+    if (sources.length !== 2) return null;
+    if (sources[0] === id) return 'Primary';
+    if (sources[1] === id) return 'Secondary';
+    return null;
+  }
+
+  toggleTrainingSource(id: string, checked: boolean): void {
+    const current = this.trainingSources.value;
+    this.trainingSources.setValue(checked ? [...current, id] : current.filter(s => s !== id));
+    this.trainingSources.markAsTouched();
+  }
+
+  approve(): void {
+    if (this.form.valid) {
+      this.dialogRef.close({
+        draftingSourceParatextId: this.draftingSource.value,
+        trainingSourceParatextIds: this.trainingSources.value
+      });
+    }
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.html
@@ -74,7 +74,7 @@
           </button>
           @if (!isResolved) {
             <button mat-button color="primary" (click)="approveRequest()">
-              <mat-icon>check_circle</mat-icon> Approve & Enable
+              <mat-icon>check_circle</mat-icon> Approve & Configure Sources
             </button>
           }
           <button mat-button color="warn" (click)="deleteRequest()"><mat-icon>delete</mat-icon> Delete Request</button>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-request-detail/onboarding-request-detail.component.ts
@@ -13,6 +13,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatDialogRef } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { ActivatedRoute, Router } from '@angular/router';
 import { saveAs } from 'file-saver';
@@ -27,6 +28,7 @@ import { RouterLinkDirective } from 'xforge-common/router-link.directive';
 import { isPopulatedString } from '../../../type-utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { ParatextService } from '../../core/paratext.service';
+import { SFProjectService } from '../../core/sf-project.service';
 import { DevOnlyComponent } from '../../shared/dev-only/dev-only.component';
 import { JsonViewerComponent } from '../../shared/json-viewer/json-viewer.component';
 import { MobileNotSupportedComponent } from '../../shared/mobile-not-supported/mobile-not-supported.component';
@@ -41,6 +43,12 @@ import {
   OnboardingRequestService
 } from '../../translate/draft-generation/onboarding-request.service';
 import { ServalAdministrationService } from '../serval-administration.service';
+import {
+  ApproveRequestDialogComponent,
+  ApproveRequestDialogData,
+  ApproveRequestDialogResult,
+  ProjectInfo
+} from './approve-request-dialog/approve-request-dialog.component';
 import { formatBookListForSILNLP } from './draft-request-detail-utils';
 
 /**
@@ -93,6 +101,7 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
     private readonly servalAdministrationService: ServalAdministrationService,
     private readonly onboardingRequestService: OnboardingRequestService,
     private readonly dialogService: DialogService,
+    private readonly projectService: SFProjectService,
     protected readonly noticeService: NoticeService
   ) {
     super(noticeService, 'OnboardingRequestDetailComponent');
@@ -381,24 +390,70 @@ export class OnboardingRequestDetailComponent extends DataLoadingComponent imple
   }
 
   async approveRequest(): Promise<void> {
-    const shortName = this.projectShortNames.get(this.request?.submission.projectId ?? '');
-    const result = await this.dialogService.confirm(
-      of(`Mark request as approved and enable drafting on the ${shortName} project?`),
-      of('Approve')
-    );
-    if (result && this.request != null) {
-      this.loadingStarted();
-      try {
-        const request = await this.onboardingRequestService.approveRequest({
-          requestId: this.request.id,
-          sfProjectId: this.request.submission.projectId
+    if (this.request == null) return;
+
+    const dialogData = this.buildApproveDialogData();
+    const dialogRef = this.dialogService.openMatDialog(ApproveRequestDialogComponent, {
+      data: dialogData
+    }) as MatDialogRef<ApproveRequestDialogComponent, ApproveRequestDialogResult>;
+    const result = await lastValueFrom(dialogRef.afterClosed());
+    if (result == null || this.request == null) return;
+
+    this.loadingStarted();
+    try {
+      await this.projectService.onlineUpdateSettings(this.request.submission.projectId, {
+        draftingSourcesParatextIds: [result.draftingSourceParatextId],
+        trainingSourcesParatextIds: result.trainingSourceParatextIds
+      });
+      const request = await this.onboardingRequestService.approveRequest({
+        requestId: this.request.id,
+        sfProjectId: this.request.submission.projectId
+      });
+      this.request = request;
+      this.noticeService.show('Onboarding request approved successfully');
+    } catch {
+      this.noticeService.showError('Failed to approve onboarding request');
+    } finally {
+      this.loadingFinished();
+    }
+  }
+
+  private buildApproveDialogData(): ApproveRequestDialogData {
+    const formData = this.formData;
+    const draftingSourceOptions = [
+      ...new Set(
+        [
+          formData.draftingSourceProject,
+          formData.sourceProjectA,
+          formData.sourceProjectB,
+          formData.sourceProjectC
+        ].filter((id): id is string => id != null)
+      )
+    ];
+    const trainingSourceOptions = [
+      ...new Set([...draftingSourceOptions, formData.backTranslationProject].filter((id): id is string => id != null))
+    ];
+
+    const projectInfo = new Map<string, ProjectInfo>();
+    for (const paratextId of new Set([...draftingSourceOptions, ...trainingSourceOptions])) {
+      const doc = this.projectDocs.get(paratextId);
+      if (doc?.data != null) {
+        projectInfo.set(paratextId, {
+          name: projectLabel(doc.data),
+          shortName: doc.data.shortName,
+          languageCode: doc.data.writingSystem.tag
         });
-        this.request = request;
-        this.noticeService.show('Onboarding request approved successfully');
-      } finally {
-        this.loadingFinished();
       }
     }
+
+    return {
+      projectInfo,
+      projectName: this.projectName ?? '',
+      draftingSourceOptions,
+      trainingSourceOptions,
+      defaultDraftingSource: draftingSourceOptions[0],
+      defaultTrainingSources: [formData.sourceProjectA].filter((id): id is string => id != null)
+    };
   }
 
   downloadProjects(): void {


### PR DESCRIPTION
Allow Serval admins to configure sources when enabling a project for drafting.

<img width="468" height="571" alt="localhost_5000_serval-administration_onboarding-requests_6a19d36bc462645c3f266aaa" src="https://github.com/user-attachments/assets/f4bb7772-e377-468b-b585-4126ef04aa23" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3916)
<!-- Reviewable:end -->
