### PR TITLE
dev: correct and improve instruction on object literal type enforcement

### DIFF
--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -85,7 +85,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   7. ngOnInit
   8. public static and instance methods
   9. non-public static and instance methods
-- If an object literal is intended to match a specific type, don't rely on later return or assignment checks which may not flag extra fields that are no longer in the intended type. Instead, enforce the type at the point the object literal is created by using one of these patterns on the object literal itself: (1) assign it to a typed variable (`const x: TheType = { ... }`); (2) apply `satisfies` to it (`const x = { ... } satisfies TheType`); or (3) return it from a function or callback with an explicit return type (without first assigning it to an untyped variable).
+- If an object literal is intended to match a specific type, enforce the type at the point the object literal is created by using one of these patterns: (1) assign it to a typed variable (`const x: SomeType = { ... }`); (2) apply `satisfies` (`const x = { ... } satisfies SomeType`); or (3) return it from a function or callback with an explicit return type (without first assigning it to an untyped variable). This helps flag extra properties that are no longer in the intended type.
 
 ## Angular templates
 

--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -85,25 +85,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   7. ngOnInit
   8. public static and instance methods
   9. non-public static and instance methods
-- When making an object literal to return from a method, do not create and return the object literal in one statement. Instead, set a variable's value to the object literal and return the variable. This way, the type system can check whether the return value conforms to the declared return type of the method. For example, don't write this:
-  ```
-  getThing(id: string): Thing {
-    return {
-      thingId: id,
-      color: 7
-    };
-  }
-  ```
-  Instead, write this:
-  ```
-  getThing(id: string): Thing {
-    const thing: Thing = {
-      thingId: id,
-      color: 7
-    };
-    return thing;
-  }
-  ```
+- If an object literal is intended to match a specific type, don't rely on later return or assignment checks which may not flag extra fields that are no longer in the intended type. Instead, enforce the type at the point the object literal is created by using one of these patterns on the object literal itself: (1) assign it to a typed variable (`const x: TheType = { ... }`); (2) apply `satisfies` to it (`const x = { ... } satisfies TheType`); or (3) return it from a function or callback with an explicit return type (without first assigning it to an untyped variable).
 
 ## Angular templates
 


### PR DESCRIPTION
Consider the following code. Both assignments to B and C mistakenly
set a property that does not exist in the intended type. But one of them
raises an error, while the other does not.
```
interface Thing {
  id: number;
  color?: string;
}

const A = { id: 1, colour: 'red' };
const B: Thing = A; // No error.
const C: Thing = { id: 1, colour: 'red' }; // Error.
```

And consider that the fields on Thing could change over time. Removing
field `color` may be a good time for an error to be raised on code elsewhere in the application such as
```
const A2 = { id: 1, color: 'red' };
const B2: Thing = A2;
```

This patch prescribes syntax to bring to light such situations.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3923)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3923)
<!-- Reviewable:end -->
