### PR TITLE
SF-2722 Send blank ops created when the user comes online to ShareDB

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text-view-model.ts
@@ -258,7 +258,12 @@ export class TextViewModel implements OnDestroy, LynxTextModelConverter {
       const updateDelta = this.updateSegments(editor, isOnline);
       if (updateDelta.ops != null && updateDelta.ops.length > 0) {
         // Clean up blanks in quill editor. This may result in re-entering the update() method.
-        editor.updateContents(updateDelta, source);
+        // We force the source to be user for blank ops so that any created when coming online are sent to ShareDB.
+        // (Blank ops created by user deletion of text already have the source of 'user'.)
+        const hasBlank = updateDelta.ops.some(
+          op => op.insert != null && typeof op.insert === 'object' && op.insert.blank === true
+        );
+        editor.updateContents(updateDelta, hasBlank ? 'user' : source);
       }
 
       const removeDuplicateDelta: Delta = this.fixDeltaForDuplicateEmbeds();


### PR DESCRIPTION
This PR where verse numbers disappear when coming online then editing a text by ensuring that an blank ops created by `fixSegments()` make their way to ShareDB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3935)
<!-- Reviewable:end -->
