### PR TITLE
SF-3812 Inform user when no training books are available

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -126,20 +126,22 @@
           {{ t("choose_books_for_training_header") }}
         </ng-template>
         <h1>{{ t("choose_books_for_training_title") }}</h1>
-        <h2>{{ t("translated_books") }}</h2>
-        @if (trainingBooksWereAutoSelected) {
-          <app-notice icon="info" mode="basic" type="info">{{
-            t("books_were_automatically_selected_for_training")
-          }}</app-notice>
+        @if (selectableTrainingBooksByProj(activatedProject.projectId).length > 0) {
+          <h2>{{ t("translated_books") }}</h2>
+          @if (trainingBooksWereAutoSelected) {
+            <app-notice icon="info" mode="basic" type="info">{{
+              t("books_were_automatically_selected_for_training")
+            }}</app-notice>
+          }
+          <app-book-multi-select
+            [availableBooks]="selectableTrainingBooksByProj(activatedProject.projectId)"
+            [selectedBooks]="selectedTrainingBooksByProj(activatedProject.projectId)"
+            [projectName]="targetProjectName"
+            [projectId]="activatedProject.projectId"
+            (bookSelect)="onTranslatedBookSelect($event)"
+            data-test-id="draft-stepper-training-books"
+          ></app-book-multi-select>
         }
-        <app-book-multi-select
-          [availableBooks]="selectableTrainingBooksByProj(activatedProject.projectId)"
-          [selectedBooks]="selectedTrainingBooksByProj(activatedProject.projectId)"
-          [projectName]="targetProjectName"
-          [projectId]="activatedProject.projectId"
-          (bookSelect)="onTranslatedBookSelect($event)"
-          data-test-id="draft-stepper-training-books"
-        ></app-book-multi-select>
         @if (unusableTrainingSourceBooks.length > 0 || trainingBooksExcludingTranslatedWithoutEnoughData.length > 0) {
           <app-notice icon="info" mode="basic" type="light" class="unusable-training-books">
             <div class="notice-container">
@@ -182,33 +184,39 @@
             </div>
           </app-notice>
         }
-        <h2>{{ t("reference_books") }}</h2>
-        @for (source of trainingSources; track source) {
-          <p class="reference-project-label">{{ projectLabel(source) }}</p>
-          @if (selectableTrainingBooksByProj(source.projectRef).length === 0) {
-            <app-notice mode="basic" type="light" class="books-appear-notice">{{
-              t("training_books_will_appear")
-            }}</app-notice>
-          } @else {
-            <app-book-multi-select
-              [availableBooks]="selectableTrainingBooksByProj(source.projectRef)"
-              [selectedBooks]="selectedTrainingBooksByProj(source.projectRef)"
-              [basicMode]="true"
-              (bookSelect)="onSourceTrainingBookSelect($event, source)"
-            ></app-book-multi-select>
+        @if (selectableTrainingBooksByProj(activatedProject.projectId).length > 0) {
+          <h2>{{ t("reference_books") }}</h2>
+          @for (source of trainingSources; track source) {
+            <p class="reference-project-label">{{ projectLabel(source) }}</p>
+            @if (selectableTrainingBooksByProj(source.projectRef).length === 0) {
+              <app-notice mode="basic" type="light" class="books-appear-notice">{{
+                t("training_books_will_appear")
+              }}</app-notice>
+            } @else {
+              <app-book-multi-select
+                [availableBooks]="selectableTrainingBooksByProj(source.projectRef)"
+                [selectedBooks]="selectedTrainingBooksByProj(source.projectRef)"
+                [basicMode]="true"
+                (bookSelect)="onSourceTrainingBookSelect($event, source)"
+              ></app-book-multi-select>
+            }
           }
-        }
-        @if (!isTrainingOptional && selectableTrainingBooksByProj(activatedProject.projectId).length === 0) {
-          <app-notice class="error-no-translated-books" type="error">
+          @if (!translatedBooksSelectedInTrainingSources) {
+            <app-notice class="error-translated-books-unselected" type="error">
+              {{ t("translated_book_selected_no_training_pair") }}
+            </app-notice>
+          } @else if (showBookSelectionError) {
+            <app-notice class="error-choose-training-books" type="error">
+              {{ t("choose_books_for_training_error") }}
+            </app-notice>
+          }
+        } @else if (!isTrainingOptional) {
+          <app-notice class="error-no-translated-books" type="error" icon="error">
             {{ t("choose_books_for_training_no_books_error") }}
           </app-notice>
-        } @else if (!translatedBooksSelectedInTrainingSources) {
-          <app-notice class="error-translated-books-unselected" type="error">
-            {{ t("translated_book_selected_no_training_pair") }}
-          </app-notice>
-        } @else if (showBookSelectionError) {
-          <app-notice class="error-choose-training-books" type="error">
-            {{ t("choose_books_for_training_error") }}
+        } @else {
+          <app-notice class="info-no-translated-books" type="info" icon="info">
+            {{ t("choose_books_for_training_no_books_info") }}
           </app-notice>
         }
         <div class="button-strip">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -184,8 +184,8 @@
             </div>
           </app-notice>
         }
+        <h2>{{ t("reference_books") }}</h2>
         @if (selectableTrainingBooksByProj(activatedProject.projectId).length > 0) {
-          <h2>{{ t("reference_books") }}</h2>
           @for (source of trainingSources; track source) {
             <p class="reference-project-label">{{ projectLabel(source) }}</p>
             @if (selectableTrainingBooksByProj(source.projectRef).length === 0) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -316,7 +316,6 @@ describe('DraftGenerationStepsComponent', () => {
         emptyBookNums
       );
       when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
-      when(mockNllbLanguageService.isNllbLanguageAsync('xyz')).thenResolve(false);
       when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
 
       fixture = TestBed.createComponent(DraftGenerationStepsComponent);
@@ -533,6 +532,34 @@ describe('DraftGenerationStepsComponent', () => {
       ]);
       expect(component.selectedTrainingBooksByProj('sourceProject')).toEqual([{ number: 1, selected: true }]);
       expect(component.selectedTrainingBooksByProj('project01')).toEqual([{ number: 1, selected: true }]);
+    });
+
+    it('shows notice when project has no translated books', () => {
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      // all books
+      component.onTranslateBookSelect([1, 2, 3], config.draftingSources[0]);
+      fixture.detectChanges();
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      expect(component.selectedTrainingBooksByProj('project01').length).toBe(0);
+      expect(fixture.nativeElement.querySelector('.info-no-translated-books')).not.toBeNull();
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      expect(component.showBookSelectionError).toBe(false);
+      component.stepper.selectedIndex = 1;
+      fixture.detectChanges();
+      // deselect Genesis and Exodus
+      component.onTranslateBookSelect([3], config.draftingSources[0]);
+      component.tryAdvanceStep();
+      fixture.detectChanges();
+      // Genesis and Exodus becomes a selectable training book
+      expect(component.selectableTrainingBooksByProj('project01')).toEqual([
+        { number: 1, selected: false },
+        { number: 2, selected: false }
+      ]);
+      expect(fixture.nativeElement.querySelector('.info-no-translated-books')).toBeNull();
+      expect(component.showBookSelectionError).toBe(false);
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -238,7 +238,7 @@
     "choose_books_for_training_error": "No books selected. Select training books to continue.",
     "choose_books_for_training_header": "Training",
     "choose_books_for_training_no_books_error": "No books are available for training. Your project must have at least one translated book to use for training.",
-    "choose_books_for_training_no_books_info": "No books are available for training. You may proceed with drafting, or go back and select fewer books for drafting if you wish to select books for training.",
+    "choose_books_for_training_no_books_info": "No books have enough translations for training. Training books are optional. Go back and ensure translated books are not selected to draft if you want to use them for training.",
     "choose_books_for_training_title": "Select books to train on",
     "choose_books_to_translate_error": "No books selected. Select books to translate to continue.",
     "choose_books_to_translate_header": "Drafting",

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -238,6 +238,7 @@
     "choose_books_for_training_error": "No books selected. Select training books to continue.",
     "choose_books_for_training_header": "Training",
     "choose_books_for_training_no_books_error": "No books are available for training. Your project must have at least one translated book to use for training.",
+    "choose_books_for_training_no_books_info": "No books are available for training. You may proceed with drafting, or go back and select fewer books for drafting if you wish to select books for training.",
     "choose_books_for_training_title": "Select books to train on",
     "choose_books_to_translate_error": "No books selected. Select books to translate to continue.",
     "choose_books_to_translate_header": "Drafting",


### PR DESCRIPTION
This PR fixes the draft wizard UI to show a notice if no books are available for training (and that is OK), or an error if no books are available and books for training are required (i.e. because one of the languages is not in the NLLB).

I am not sure on the wording for the notice, as the issue did not contain any wording example.

**The notice when all books were selected for drafting, and both languages are in the NLLB:**
<img width="834" height="539" alt="Screenshot 2026-06-10 143329" src="https://github.com/user-attachments/assets/37d838fd-a55e-43af-ac83-290f5167e100" />

**The notice when the only books left over for training are not suitable for training, and both languages are in the NLLB:**
<img width="817" height="642" alt="Screenshot 2026-06-10 144303" src="https://github.com/user-attachments/assets/b070f319-92bd-42b3-9777-110435944425" />

**The notice when all books were selected for drafting, and one language is not in the NLLB (The next button does not proceed):**
<img width="819" height="563" alt="Screenshot 2026-06-10 143503" src="https://github.com/user-attachments/assets/bbba3b10-ee60-4a89-bb1e-b3f3cb504190" />

**The notice when the only books left over for training are not suitable for training, and one language is not in the NLLB (The next button does not proceed):**
<img width="827" height="638" alt="Screenshot 2026-06-10 144308" src="https://github.com/user-attachments/assets/7c837dbf-5b1d-47bc-958a-38c45a3b1957" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3936)
<!-- Reviewable:end -->
