### PR TITLE
serval-admin: serval-builds: adjust wrapping of values

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -472,7 +472,7 @@
                       }
                       <div class="detail-keyvalue">
                         <span class="detail-key">SF acknowledges Serval completion</span>
-                        <span class="detail-value">{{
+                        <span class="detail-value time-and-duration">{{
                           formatDateTime(row.report.timeline.sfAcknowledgedCompletion) ?? "-"
                         }}</span>
                       </div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -361,14 +361,16 @@
                               <div class="detail-project-books-item">
                                 <div class="detail-project-books-meta detail-value-with-copy">
                                   @if (projectBook.shortName != null) {
-                                    <a
-                                      [href]="projectBook.projectLink"
-                                      target="_blank"
-                                      rel="noopener"
-                                      class="project-link"
-                                    >
-                                      {{ projectBook.shortName }}
-                                    </a>
+                                    <span class="input-shortname">
+                                      <a
+                                        [href]="projectBook.projectLink"
+                                        target="_blank"
+                                        rel="noopener"
+                                        class="project-link"
+                                      >
+                                        {{ projectBook.shortName }}
+                                      </a>
+                                    </span>
                                   }
                                   <span class="detail-project-books-id">{{ projectBook.sfProjectId }}</span>
                                   <app-copy [value]="projectBook.sfProjectId"></app-copy>
@@ -422,48 +424,50 @@
                     <div class="detail-area-stacked-keyvalues timing-grid">
                       <div class="detail-keyvalue">
                         <span class="detail-key">User request</span>
-                        <span class="detail-value"
+                        <span class="detail-value time-and-duration"
                           >{{ formatDateTime(row.report.timeline.sfUserRequested) ?? "-" }} &nbsp;
                           {{ durationUserRequestToCompletionAcknowledged(row.report) }}</span
                         >
                       </div>
                       <div class="detail-keyvalue">
                         <span class="detail-key">SF build request</span>
-                        <span class="detail-value">{{
+                        <span class="detail-value time-and-duration">{{
                           formatDateTime(row.report.timeline.sfBuildProjectSubmitted) ?? "-"
                         }}</span>
                       </div>
                       <div class="detail-keyvalue">
                         <span class="detail-key">Serval creation</span>
-                        <span class="detail-value"
+                        <span class="detail-value time-and-duration"
                           >{{ formatDateTime(row.report.timeline.servalCreated) ?? "-" }} &nbsp;
                           {{ durationServalCreatedToFinish(row.report) }}</span
                         >
                       </div>
                       <div class="detail-keyvalue">
                         <span class="detail-key">Train phase</span>
-                        <span class="detail-value"
+                        <span class="detail-value time-and-duration"
                           >{{ formatDateTime(getPhase(row.report, "Train")?.started) ?? "-" }} &nbsp;
                           {{ durationPhaseTrain(row.report) }}</span
                         >
                       </div>
                       <div class="detail-keyvalue">
                         <span class="detail-key">Inference phase</span>
-                        <span class="detail-value"
+                        <span class="detail-value time-and-duration"
                           >{{ formatDateTime(getPhase(row.report, "Inference")?.started) ?? "-" }} &nbsp;
                           {{ durationPhaseInference(row.report) }}</span
                         >
                       </div>
                       <div class="detail-keyvalue">
                         <span class="detail-key">Serval finish</span>
-                        <span class="detail-value">{{
+                        <span class="detail-value time-and-duration">{{
                           formatDateTime(row.report.timeline.servalFinished) ?? "-"
                         }}</span>
                       </div>
                       @if (row.report.timeline.sfUserCancelled != null) {
                         <div class="detail-keyvalue">
                           <span class="detail-key">User cancel</span>
-                          <span class="detail-value">{{ formatDateTime(row.report.timeline.sfUserCancelled) }}</span>
+                          <span class="detail-value time-and-duration">{{
+                            formatDateTime(row.report.timeline.sfUserCancelled)
+                          }}</span>
                         </div>
                       }
                       <div class="detail-keyvalue">

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -326,7 +326,9 @@ a {
 
 .detail-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  // The min width of the columns should be big enough for the Timing card to show dates and
+  // durations without truncating.
+  grid-template-columns: repeat(auto-fill, minmax(285px, 1fr));
   gap: 12px 24px;
   margin-bottom: 16px;
 }
@@ -392,7 +394,8 @@ a {
 }
 
 .pt-project-id {
-  max-width: 21ch;
+  // Wrap the PT Project ID where it will align with the SF IDs.
+  max-width: 25ch;
 }
 
 .detail-area-stacked-keyvalues {
@@ -468,10 +471,31 @@ a {
 
 .detail-project-books-meta {
   align-self: flex-start;
+  // Help SF project ID truncate within the width.
+  max-width: 100%;
+}
+
+.input-shortname {
+  max-width: 100%;
+  white-space: nowrap;
+}
+
+.time-and-duration {
+  display: inline-block;
+  max-width: 100%;
+  // The Timing card should be given enough width to display its content without needing to
+  // overflow. But if it does need to overflow, truncate and use an ellipsis.
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .detail-project-books-id {
   font-family: monospace;
+  // Truncate the SF project ID, which may be needed if the shortname is long.
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .detail-actions {


### PR DESCRIPTION
On Input card:
- Prevent short name from wrapping.
- Truncate SF project ID if too long.

On timing card:
- Make sure the time + duration display has enough space. If
necessary, truncate rather than wrap.

On the Identifiers card:
- The PT project ID was confusing when wrapped at its midpoint.
Instead, wrap it at a length where the SF IDs end, aligning them.

Screenshots showing the Input, Timing, and Identifiers card when their content is squished about as far as the grid-template-columns value will allow:
<img width="301" height="320" alt="Screenshot_20260610_101747" src="https://github.com/user-attachments/assets/e76b3eb7-2ca0-42aa-a235-ebe26968abe9" /> <img width="309" height="461" alt="Screenshot_20260610_101806" src="https://github.com/user-attachments/assets/f084e7f8-8865-487d-aa09-4cd596bce03f" /> <img width="307" height="457" alt="Screenshot_20260610_101826-2" src="https://github.com/user-attachments/assets/07105157-8725-42d0-a92b-5e58e0dd184d" />



<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3937)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3937)
<!-- Reviewable:end -->
