### PR TITLE
serval-admin: serval-builds: reorder user items

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -267,16 +267,6 @@
                   <mat-card-content class="detail-card-content">
                     <span class="detail-area-stacked-keyvalues">
                       <div class="detail-keyvalue">
-                        <span class="detail-key">SF user ID</span>
-                        <span class="detail-value detail-value-with-copy code">
-                          <span>{{ row.report.requesterSFUserId ?? "-" }}</span>
-                          @if (row.report.requesterSFUserId != null) {
-                            <app-copy [value]="row.report.requesterSFUserId"></app-copy>
-                          }
-                        </span>
-                      </div>
-
-                      <div class="detail-keyvalue">
                         <span class="detail-key">Name</span>
                         @let requesterUserName = requesterName(row.report.requesterSFUserId) | async;
                         <span class="detail-value">{{ requesterUserName ?? "-" }}</span>
@@ -299,6 +289,16 @@
                             <app-copy [value]="requesterEmail"></app-copy>
                           } @else {
                             <span>-</span>
+                          }
+                        </span>
+                      </div>
+
+                      <div class="detail-keyvalue">
+                        <span class="detail-key">SF user ID</span>
+                        <span class="detail-value detail-value-with-copy code">
+                          <span>{{ row.report.requesterSFUserId ?? "-" }}</span>
+                          @if (row.report.requesterSFUserId != null) {
+                            <app-copy [value]="row.report.requesterSFUserId"></app-copy>
                           }
                         </span>
                       </div>


### PR DESCRIPTION
The SF user ID was moved to the bottom of the list.

Screenshot showing reordered card:

<img width="339" height="297" alt="image" src="https://github.com/user-attachments/assets/a462915b-0194-4a7f-95eb-ea394f3a87c5" />


<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3950)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3950)
<!-- Reviewable:end -->
