### PR TITLE
serval-admin: serval-builds: highlight and reset non-default date range

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.html
@@ -1,9 +1,20 @@
-<mat-form-field class="date-range-field">
+<mat-form-field class="date-range-field" [class.date-range-field-active]="showReset && !isDefaultRange">
   <mat-label>Date range</mat-label>
   <mat-date-range-input [formGroup]="dateRangeForm" [rangePicker]="dateRangePicker" [dateFilter]="disableFutureDates">
     <input matStartDate matInput formControlName="start" [max]="maxSelectableDate" placeholder="Start date" />
     <input matEndDate matInput formControlName="end" [max]="maxSelectableDate" placeholder="End date" />
   </mat-date-range-input>
+  @if (showReset && !isDefaultRange) {
+    <button
+      matSuffix
+      type="button"
+      class="date-range-reset-button"
+      (click)="resetToDefaultDateRange()"
+      aria-label="Reset date range"
+    >
+      <span class="material-icons date-range-reset-icon" aria-hidden="true">close</span>
+    </button>
+  }
   <mat-datepicker-toggle matIconSuffix [for]="dateRangePicker"></mat-datepicker-toggle>
   <mat-date-range-picker #dateRangePicker></mat-date-range-picker>
   @if (dateRangeFormatHint != null) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.html
@@ -5,14 +5,8 @@
     <input matEndDate matInput formControlName="end" [max]="maxSelectableDate" placeholder="End date" />
   </mat-date-range-input>
   @if (showReset && !isDefaultRange) {
-    <button
-      matSuffix
-      type="button"
-      class="date-range-reset-button"
-      (click)="resetToDefaultDateRange()"
-      aria-label="Reset date range"
-    >
-      <span class="material-icons date-range-reset-icon" aria-hidden="true">close</span>
+    <button matIconButton matSuffix type="button" (click)="resetToDefaultDateRange()" aria-label="Reset date range">
+      <mat-icon>close</mat-icon>
     </button>
   }
   <mat-datepicker-toggle matIconSuffix [for]="dateRangePicker"></mat-datepicker-toggle>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.scss
@@ -1,3 +1,27 @@
 .date-range-field {
   min-width: 260px;
 }
+
+.date-range-reset-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-right: 0.125rem;
+}
+
+.date-range-reset-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+:host ::ng-deep .date-range-field.date-range-field-active .mat-mdc-text-field-wrapper {
+  background-color: var(--sf-serval-builds-search-background-populated);
+  color: var(--sf-serval-builds-search-text-populated);
+  transition: background-color 150ms ease-in;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.scss
@@ -2,24 +2,6 @@
   min-width: 260px;
 }
 
-.date-range-reset-button {
-  border: 0;
-  background: transparent;
-  padding: 0;
-  width: 24px;
-  height: 24px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  margin-right: 0.125rem;
-}
-
-.date-range-reset-icon {
-  font-size: 24px;
-  line-height: 1;
-}
-
 :host ::ng-deep .date-range-field.date-range-field-active .mat-mdc-text-field-wrapper {
   background-color: var(--sf-serval-builds-search-background-populated);
   color: var(--sf-serval-builds-search-text-populated);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import {
   AbstractControl,
   FormBuilder,
@@ -56,6 +56,9 @@ export interface NormalizedDateRange {
   ]
 })
 export class DateRangePickerComponent implements OnInit {
+  /** When the date range is not the default, highlight the control and show a reset button. */
+  @Input() showReset: boolean = false;
+
   /** Maximum selectable date (today) */
   readonly maxSelectableDate: Date;
 
@@ -72,6 +75,11 @@ export class DateRangePickerComponent implements OnInit {
 
   /** Event emitted when the date range changes with a valid normalized range */
   @Output() dateRangeChange = new EventEmitter<NormalizedDateRange>();
+
+  /** Whether current range is equal to the initial default range. */
+  isDefaultRange: boolean = true;
+
+  private defaultRange: NormalizedDateRange | undefined;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -109,11 +117,16 @@ export class DateRangePickerComponent implements OnInit {
     const normalizedEnd = this.endOfTheDayOf(initialEndDate);
 
     this.dateRangeForm.setValue({ start: normalizedStart, end: normalizedEnd }, { emitEvent: false });
+    this.defaultRange = {
+      start: new Date(normalizedStart),
+      end: new Date(normalizedEnd)
+    };
+    this.isDefaultRange = true;
 
     // Tell parent of the initial range.
     this.dateRangeChange.emit({
-      start: new Date(normalizedStart.getTime()),
-      end: new Date(normalizedEnd.getTime())
+      start: new Date(normalizedStart),
+      end: new Date(normalizedEnd)
     });
 
     // Update format hint based on current locale
@@ -140,6 +153,18 @@ export class DateRangePickerComponent implements OnInit {
       });
   }
 
+  protected resetToDefaultDateRange(): void {
+    if (this.defaultRange == null) return;
+
+    this.dateRangeForm.setValue(
+      {
+        start: new Date(this.defaultRange.start),
+        end: new Date(this.defaultRange.end)
+      },
+      { emitEvent: true }
+    );
+  }
+
   /**
    * Process form input. Emits a normalized and valid range if possible. This method will be called for each start and
    * end date selection when working with the popup calendar control. Sometimes it will be called twice when a start
@@ -164,7 +189,14 @@ export class DateRangePickerComponent implements OnInit {
 
     // Dates are a valid and normalized range. Emit.
     const normalizedRange: NormalizedDateRange = { start: normalizedStart, end: normalizedEnd };
+    this.isDefaultRange = this.areRangesEqual(normalizedRange, this.defaultRange);
     this.dateRangeChange.emit(normalizedRange);
+  }
+
+  private areRangesEqual(left: NormalizedDateRange | undefined, right: NormalizedDateRange | undefined): boolean {
+    if (left == null && right == null) return true;
+    if (left == null || right == null) return false;
+    return left.start.getTime() === right.start.getTime() && left.end.getTime() === right.end.getTime();
   }
 
   /** Get the beginning of the day for a date */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
@@ -8,6 +8,7 @@ import {
   ValidationErrors,
   ValidatorFn
 } from '@angular/forms';
+import { MatIconButton } from '@angular/material/button';
 import { DateAdapter } from '@angular/material/core';
 import {
   MatDatepickerToggle,
@@ -17,6 +18,7 @@ import {
   MatStartDate
 } from '@angular/material/datepicker';
 import { MatFormField, MatFormFieldModule, MatLabel } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { distinctUntilChanged, map } from 'rxjs';
 import { I18nService } from 'xforge-common/i18n.service';
@@ -52,7 +54,9 @@ export interface NormalizedDateRange {
     MatEndDate,
     MatStartDate,
     MatInput,
-    MatLabel
+    MatLabel,
+    MatIcon,
+    MatIconButton
   ]
 })
 export class DateRangePickerComponent implements OnInit {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -4,7 +4,7 @@
 
 @if (isOnline) {
   <div class="filter-controls">
-    <app-date-range-picker (dateRangeChange)="onDateRangeChange($event)"></app-date-range-picker>
+    <app-date-range-picker [showReset]="true" (dateRangeChange)="onDateRangeChange($event)"></app-date-range-picker>
     <div class="export-button-group">
       <button mat-raised-button color="primary" class="export-csv-button" (click)="exportCsv()">
         <mat-icon>download</mat-icon>


### PR DESCRIPTION
When the user visits the Serval Builds tab, they are shown a default
date range. If the user adjusts the date range, highlight the control
and show a reset button to set the default range back to the initial
default value. This is similar in behaviour to the Search control
(regarding highlighting and resetting/clearing).

Screenshot of date range picker when the default date range is being used:
<img width="275" height="99" alt="Screenshot_20260615_143314" src="https://github.com/user-attachments/assets/554d9001-fd40-4258-82e9-52bbf2bdc66f" />

Screenshot of date range picker when the date range is changed:
<img width="307" height="99" alt="Screenshot_20260615_143353" src="https://github.com/user-attachments/assets/dd8be8bd-616b-4530-bd82-b0b655b51511" />

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3951)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3951)
<!-- Reviewable:end -->
