### PR TITLE
SF-3825 Allow parallel editor view even when a source isn't set

### DIFF
--- a/src/RealtimeServer/scriptureforge/models/editor-tab.ts
+++ b/src/RealtimeServer/scriptureforge/models/editor-tab.ts
@@ -1,5 +1,7 @@
+// Editor tab types
 export const editorTabTypes = [
   'biblical-terms',
+  'blank-tab',
   'history',
   'draft',
   'project-source',
@@ -8,4 +10,8 @@ export const editorTabTypes = [
 ] as const;
 type EditorTabTypes = typeof editorTabTypes;
 export type EditorTabType = EditorTabTypes[number];
-export type EditorTabGroupType = 'source' | 'target';
+
+// Editor tab group types
+export const editorTabGroupTypes = ['source', 'target'] as const;
+type EditorTabGroupTypes = typeof editorTabGroupTypes;
+export type EditorTabGroupType = EditorTabGroupTypes[number];

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -190,6 +190,8 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
           toGroup.selectedIndex = toIndex;
         }
       }
+
+      this.tabGroupsSource$.next(this.groups);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/sf-tab-group/tab-state/tab-state.service.ts
@@ -288,10 +288,12 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
 
   /**
    * Restores tabs moved from last consolidation into their original groups.
+   *
+   * @returns `true` if the tabs were deconsolidated, `false` if there was no need to.
    */
-  deconsolidateTabGroups(): void {
+  deconsolidateTabGroups(): boolean {
     if (this.tabsToDeconsolidate == null || this.lastConsolidationGroupId == null) {
-      return;
+      return false;
     }
 
     const groupFrom: TabGroup<TGroupId, T> | undefined = this.groups.get(this.lastConsolidationGroupId);
@@ -315,6 +317,7 @@ export class TabStateService<TGroupId extends string, T extends TabInfo<string>>
 
     this.tabsConsolidatedSource$.next(false);
     this.tabGroupsSource$.next(this.groups);
+    return true;
   }
 
   private flattenTabGroups(tabGroups: Map<TGroupId, TabGroup<TGroupId, T>>): FlatTabInfo<TGroupId, T>[] {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -2,7 +2,7 @@
   @if (translationSuggestionsEnabled && userHasGeneralEditRight) {
     <app-smt-retirement-notice></app-smt-retirement-notice>
   }
-  <div class="content" [class.reverse-columns]="!isTargetTextRight">
+  <div class="content" [class.reverse-columns]="!isTargetTextRight" [class.target-only]="!showSourceTab">
     <div class="toolbar">
       <div class="toolbar-options">
         <app-book-chapter-chooser
@@ -12,28 +12,32 @@
           [(chapter)]="chapter"
           [chapters]="chapters"
         ></app-book-chapter-chooser>
-        <div class="toolbar-separator" [ngClass]="{ 'hide-lt-sm': !translatorSettingsEnabled }">&nbsp;</div>
-        <button
-          mat-icon-button
-          appBlurOnClick
-          type="button"
-          (click)="isTargetTextRight = !isTargetTextRight"
-          [matTooltip]="t('swap_source_and_target')"
-          class="hide-lt-sm"
-        >
-          <mat-icon>swap_horiz</mat-icon>
-        </button>
-        @if (translatorSettingsEnabled) {
-          <button
-            mat-icon-button
-            appBlurOnClick
-            type="button"
-            id="settings-btn"
-            (click)="openTranslatorSettings()"
-            [matTooltip]="t('configure_translator_settings')"
-          >
-            <mat-icon>settings</mat-icon>
-          </button>
+        @if (showSourceTab || translatorSettingsEnabled) {
+          <div class="toolbar-separator" [ngClass]="{ 'hide-lt-sm': !translatorSettingsEnabled }">&nbsp;</div>
+          @if (showSourceTab) {
+            <button
+              mat-icon-button
+              appBlurOnClick
+              type="button"
+              (click)="isTargetTextRight = !isTargetTextRight"
+              [matTooltip]="t('swap_source_and_target')"
+              class="hide-lt-sm"
+            >
+              <mat-icon>swap_horiz</mat-icon>
+            </button>
+          }
+          @if (translatorSettingsEnabled) {
+            <button
+              mat-icon-button
+              appBlurOnClick
+              type="button"
+              id="settings-btn"
+              (click)="openTranslatorSettings()"
+              [matTooltip]="t('configure_translator_settings')"
+            >
+              <mat-icon>settings</mat-icon>
+            </button>
+          }
         }
         @if (canShare) {
           <div class="toolbar-separator">&nbsp;</div>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -2,11 +2,7 @@
   @if (translationSuggestionsEnabled && userHasGeneralEditRight) {
     <app-smt-retirement-notice></app-smt-retirement-notice>
   }
-  <div
-    class="content"
-    [class.reverse-columns]="!isTargetTextRight"
-    [class.target-only]="!showSource && !showPersistedTabsOnSource"
-  >
+  <div class="content" [class.reverse-columns]="!isTargetTextRight">
     <div class="toolbar">
       <div class="toolbar-options">
         <app-book-chapter-chooser
@@ -16,32 +12,28 @@
           [(chapter)]="chapter"
           [chapters]="chapters"
         ></app-book-chapter-chooser>
-        @if (showSource || translatorSettingsEnabled) {
-          <div class="toolbar-separator" [ngClass]="{ 'hide-lt-sm': !translatorSettingsEnabled }">&nbsp;</div>
-          @if (showSource) {
-            <button
-              mat-icon-button
-              appBlurOnClick
-              type="button"
-              (click)="isTargetTextRight = !isTargetTextRight"
-              [matTooltip]="t('swap_source_and_target')"
-              class="hide-lt-sm"
-            >
-              <mat-icon>swap_horiz</mat-icon>
-            </button>
-          }
-          @if (translatorSettingsEnabled) {
-            <button
-              mat-icon-button
-              appBlurOnClick
-              type="button"
-              id="settings-btn"
-              (click)="openTranslatorSettings()"
-              [matTooltip]="t('configure_translator_settings')"
-            >
-              <mat-icon>settings</mat-icon>
-            </button>
-          }
+        <div class="toolbar-separator" [ngClass]="{ 'hide-lt-sm': !translatorSettingsEnabled }">&nbsp;</div>
+        <button
+          mat-icon-button
+          appBlurOnClick
+          type="button"
+          (click)="isTargetTextRight = !isTargetTextRight"
+          [matTooltip]="t('swap_source_and_target')"
+          class="hide-lt-sm"
+        >
+          <mat-icon>swap_horiz</mat-icon>
+        </button>
+        @if (translatorSettingsEnabled) {
+          <button
+            mat-icon-button
+            appBlurOnClick
+            type="button"
+            id="settings-btn"
+            (click)="openTranslatorSettings()"
+            [matTooltip]="t('configure_translator_settings')"
+          >
+            <mat-icon>settings</mat-icon>
+          </button>
         }
         @if (canShare) {
           <div class="toolbar-separator">&nbsp;</div>
@@ -82,6 +74,13 @@
                   [verse]="verse"
                   [projectId]="projectId"
                 ></app-biblical-terms>
+              }
+              @case ("blank-tab") {
+                <div class="blank-tab-container">
+                  <app-notice icon="help_outline" type="info" mode="outline">
+                    {{ t("blank_tab_notice") }}
+                  </app-notice>
+                </div>
               }
               @case ("project-resource") {
                 <app-editor-resource

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.scss
@@ -155,6 +155,15 @@ app-copyright-banner,
   overflow: hidden;
 }
 
+.blank-tab-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 0 10%;
+  box-sizing: border-box;
+}
+
 .container-for-split {
   flex-grow: 1;
   height: 100%;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -1228,17 +1228,6 @@ describe('EditorComponent', () => {
       env.dispose();
     }));
 
-    it('user cannot edit a chapter source text visible', fakeAsync(() => {
-      const env = new TestEnvironment();
-      env.setCurrentUser('user03');
-      env.setProjectUserConfig();
-      env.wait();
-      expect(env.bookName).toEqual('Matthew');
-      expect(env.component.canEdit).toBe(false);
-      expect(env.component.showSource).toBe(true);
-      env.dispose();
-    }));
-
     it('user cannot edit a chapter with permission', fakeAsync(() => {
       const env = new TestEnvironment();
       env.setCurrentUser('user03');
@@ -3980,11 +3969,82 @@ describe('EditorComponent', () => {
   }));
 
   describe('tabs', () => {
+    describe('blank tab', () => {
+      it('should add a blank tab when no source', fakeAsync(() => {
+        const env = new TestEnvironment();
+        delete env.testProjectProfile.translateConfig.source;
+        env.setupProject();
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        const tabGroup = env.component.tabState.getTabGroup('source');
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('blank-tab');
+
+        env.dispose();
+      }));
+
+      it('should not add a blank tab when there is a source', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        const tabGroup = env.component.tabState.getTabGroup('source');
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('project-source');
+
+        env.dispose();
+      }));
+
+      it('should not add a blank tab when there is a tab in the source pane', fakeAsync(() => {
+        const env = new TestEnvironment();
+        delete env.testProjectProfile.translateConfig.source;
+        env.setupProject();
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
+        when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        const tabGroup = env.component.tabState.getTabGroup('source');
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('draft');
+
+        env.dispose();
+      }));
+
+      it('should add a blank tab when the last tab in the source pane is closed', fakeAsync(() => {
+        const env = new TestEnvironment();
+        delete env.testProjectProfile.translateConfig.source;
+        env.setupProject();
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
+        when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
+        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
+        env.wait();
+
+        // Verify draft tab visible
+        const tabGroup = env.component.tabState.getTabGroup('source');
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('draft');
+
+        // Remove draft tab, ensure that only the blank tab is visible
+        env.component.tabState.removeTab('source', 0);
+        env.wait();
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('blank-tab');
+
+        // Re-open the draft tab, ensure that only the draft tab is visible
+        env.component.tabState.addTab('source', env.tabFactory.createTab('draft'));
+        env.wait();
+        expect(tabGroup?.tabs.length).toBe(1);
+        expect(tabGroup?.tabs[0].type).toEqual('draft');
+
+        env.dispose();
+      }));
+    });
+
     describe('tab group consolidation', () => {
       it('should call consolidateTabGroups for small screen widths once editor is loaded and tab state is initialized', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         const spyConsolidate = spyOn(env.component.tabState, 'consolidateTabGroups');
 
         expect(spyConsolidate).not.toHaveBeenCalled();
@@ -3999,9 +4059,7 @@ describe('EditorComponent', () => {
       }));
 
       it('should call deconsolidateTabGroups for large screen widths once editor is loaded and tab state is initialized', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         const spyDeconsolidate = spyOn(env.component.tabState, 'deconsolidateTabGroups');
         expect(spyDeconsolidate).not.toHaveBeenCalled();
         env.breakpointObserver.emitObserveValue(false);
@@ -4033,22 +4091,8 @@ describe('EditorComponent', () => {
         discardPeriodicTasks();
       }));
 
-      it('should not consolidate if showSource is false', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => false });
-        });
-        const spyConsolidate = spyOn(env.component.tabState, 'consolidateTabGroups');
-
-        env.component['tabStateInitialized$'].next(true);
-        env.component['targetEditorLoaded$'].next();
-        expect(spyConsolidate).not.toHaveBeenCalled();
-        flush();
-      }));
-
       it('should not consolidate on second editor load', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
 
         env.component['tabStateInitialized$'].next(true);
         env.component['targetEditorLoaded$'].next();
@@ -4164,10 +4208,8 @@ describe('EditorComponent', () => {
     });
 
     describe('updateDraftTabVisibility', () => {
-      it('should add the draft preview tab to source when available and "showSource" is true', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+      it('should add the draft preview tab to source side', fakeAsync(() => {
+        const env = new TestEnvironment();
         when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
         env.wait();
@@ -4183,29 +4225,8 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should add draft preview tab to target when available and "showSource" is false', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => false });
-        });
-        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
-        when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
-        env.wait();
-        env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
-        env.wait();
-
-        const targetTabGroup = env.component.tabState.getTabGroup('target');
-        expect(targetTabGroup?.tabs[1].type).toEqual('draft');
-
-        const sourceTabGroup = env.component.tabState.getTabGroup('source');
-        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
-
-        env.dispose();
-      }));
-
       it('should not add draft preview tab when draft formatting (usfmConfig) is not set', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         env.setupProject({ translateConfig: { draftConfig: {} } });
         // Formatting options not selected, so draft tab should be blocked
         when(mockedDraftOptionsService.areFormattingOptionsAvailableButUnselected(anything())).thenReturn(true);
@@ -4223,9 +4244,7 @@ describe('EditorComponent', () => {
       }));
 
       it('should hide source draft preview tab when switching to chapter with no draft', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
@@ -4246,9 +4265,7 @@ describe('EditorComponent', () => {
       }));
 
       it('should hide the draft preview tab when user is commenter', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         env.setCommenterUser();
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
@@ -4261,23 +4278,21 @@ describe('EditorComponent', () => {
       }));
 
       it('should hide the target draft preview tab when switching to chapter with no draft', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => false });
-        });
+        const env = new TestEnvironment();
         when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
         env.routeWithParams({ projectId: 'project01', bookId: 'LUK', chapter: '1' });
         env.wait();
 
-        const targetTabGroup = env.component.tabState.getTabGroup('target');
-        expect(targetTabGroup?.tabs[1].type).toEqual('draft');
+        const sourceTabGroup = env.component.tabState.getTabGroup('source');
+        expect(sourceTabGroup?.tabs[1].type).toEqual('draft');
         expect(env.component.chapter).toBe(1);
 
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(false);
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
         env.wait();
 
-        expect(targetTabGroup?.tabs[1]).toBeUndefined();
+        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
         expect(env.component.chapter).toBe(2);
 
         env.dispose();
@@ -4342,10 +4357,8 @@ describe('EditorComponent', () => {
     });
 
     describe('updateBiblicalTermsTabVisibility', () => {
-      it('should add biblical terms tab to source when enabled and "showSource" is true', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+      it('should add biblical terms tab to source when enabled', fakeAsync(() => {
+        const env = new TestEnvironment();
         env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
         env.setProjectUserConfig({ biblicalTermsEnabled: true });
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
@@ -4360,28 +4373,8 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should add biblical terms tab to target when available and "showSource" is false', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => false });
-        });
-        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
-        env.setProjectUserConfig({ biblicalTermsEnabled: true });
-        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
-        env.wait();
-
-        const targetTabGroup = env.component.tabState.getTabGroup('target');
-        expect(targetTabGroup?.tabs[1].type).toEqual('biblical-terms');
-
-        const sourceTabGroup = env.component.tabState.getTabGroup('source');
-        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
-
-        env.dispose();
-      }));
-
       it('should not add the biblical terms tab when opening project with biblical terms disabled', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: false } });
         env.setProjectUserConfig({ biblicalTermsEnabled: true });
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
@@ -4395,9 +4388,7 @@ describe('EditorComponent', () => {
       }));
 
       it('should not add the biblical terms tab if the user had biblical terms disabled', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => true });
-        });
+        const env = new TestEnvironment();
         env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
         env.setProjectUserConfig({ biblicalTermsEnabled: false });
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
@@ -4406,25 +4397,6 @@ describe('EditorComponent', () => {
         const sourceTabGroup = env.component.tabState.getTabGroup('source');
         expect(sourceTabGroup?.tabs[1]).toBeUndefined();
         expect(env.component.chapter).toBe(1);
-
-        env.dispose();
-      }));
-
-      it('should keep source pane open if biblical tab has been opened in it', fakeAsync(() => {
-        const env = new TestEnvironment(env => {
-          Object.defineProperty(env.component, 'showSource', { get: () => false });
-        });
-        env.setupProject({ biblicalTermsConfig: { biblicalTermsEnabled: true } });
-        env.setProjectUserConfig({
-          biblicalTermsEnabled: true,
-          editorTabsOpen: [{ tabType: 'biblical-terms', groupId: 'source' }]
-        });
-        env.routeWithParams({ projectId: 'project01', bookId: 'GEN', chapter: '1' });
-        env.wait();
-
-        expect(env.component.showSource).toBe(false);
-        expect(env.component.showPersistedTabsOnSource).toBe(true);
-        expect(env.fixture.debugElement.query(By.css('.biblical-terms'))).not.toBeNull();
 
         env.dispose();
       }));

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -41,7 +41,7 @@ import { isEqual } from 'lodash-es';
 import Quill, { Bounds, Delta, Range } from 'quill';
 import { Operation } from 'realtime-server/lib/esm/common/models/project-rights';
 import { User } from 'realtime-server/lib/esm/common/models/user';
-import { EditorTabGroupType } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
+import { EditorTabGroupType, editorTabGroupTypes } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab';
 import { EditorTabPersistData } from 'realtime-server/lib/esm/scriptureforge/models/editor-tab-persist-data';
 import { Note } from 'realtime-server/lib/esm/scriptureforge/models/note';
 import { BIBLICAL_TERM_TAG_ICON, NoteTag } from 'realtime-server/lib/esm/scriptureforge/models/note-tag';
@@ -127,6 +127,7 @@ import { CopyrightBannerComponent } from '../../shared/copyright-banner/copyrigh
 import { NoticeComponent } from '../../shared/notice/notice.component';
 import { expectedBookChapters } from '../../shared/progress-service/progress.service';
 import {
+  FlatTabInfo,
   TabAddRequestService,
   TabFactoryService,
   TabGroup,
@@ -347,6 +348,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
   private resizeObserver?: ResizeObserver;
   private scrollSubscription?: Subscription;
   private tabStateInitialized$ = new BehaviorSubject<boolean>(false);
+  private visibleTabGroups: EditorTabGroupType[] = editorTabGroupTypes.slice();
   private readonly fabDiameter = 40;
   readonly fabVerticalCushion = 5;
 
@@ -489,14 +491,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   get defaultShareRole(): SFProjectRole {
     return SF_DEFAULT_TRANSLATE_SHARE_ROLE;
-  }
-
-  get showSource(): boolean {
-    return this.hasSource && this.hasSourceViewRight;
-  }
-
-  get showPersistedTabsOnSource(): boolean {
-    return this.tabState.getTabGroup('source')?.tabs.some(tab => tab.persist) ?? false;
   }
 
   get hasEditRight(): boolean {
@@ -923,10 +917,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     ])
       .pipe(quietTakeUntilDestroyed(this.destroyRef))
       .subscribe(([breakpointState]) => {
-        if (breakpointState.matches && this.showSource) {
+        if (breakpointState.matches) {
+          this.visibleTabGroups = ['target'];
           this.tabState.consolidateTabGroups('target');
         } else {
-          this.tabState.deconsolidateTabGroups();
+          this.visibleTabGroups = editorTabGroupTypes.slice();
+          if (this.tabState.deconsolidateTabGroups()) {
+            this.addBlankTab();
+          }
         }
       });
   }
@@ -1317,7 +1315,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
   /**
    * Initializes the tab state from persisted tabs plus non-persisted tabs (source and target projects),
-   * then listens for tab state changes to update the persisted tabs.
+   * then listens for tab state changes to update the persisted tabs or add the blank tab.
    * Returns an observable that can be piped from projectDoc changes, allowing a single call to `subscribe`,
    * avoiding potential NG0911 error 'View has already been destroyed'.
    */
@@ -1393,7 +1391,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             tooltip: tabData.projectDoc?.data?.name
           });
 
-          if (tabData.groupId === 'source' && canViewSource) {
+          if (tabData.groupId === 'source') {
             sourceTabGroup.addTab(tab, tabData.isSelected);
           } else {
             targetTabGroup.addTab(tab, tabData.isSelected);
@@ -1430,6 +1428,11 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
           }
         });
 
+        // Handle the showing/hiding of the blank tab
+        setTimeout(() => {
+          this.addBlankTab(tabs);
+        }, 0);
+
         return tabsToPersist;
       }),
       tap((tabs: EditorTabPersistData[]) => {
@@ -1439,6 +1442,24 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
 
     // Combine so both observables are triggered with single subscription
     return merge(storeToState$, stateToStore$);
+  }
+
+  private addBlankTab(tabs: FlatTabInfo<EditorTabGroupType, EditorTabInfo>[] | undefined = undefined): void {
+    for (const groupId of this.visibleTabGroups) {
+      // For each tab group (i.e. source and target)
+      const blankTab = this.tabState.getFirstTabOfTypeIndex('blank-tab', groupId);
+      const groupTabs: EditorTabInfo[] =
+        tabs == null
+          ? (this.tabState.getTabGroup(groupId)?.tabs ?? []).slice()
+          : tabs.filter(t => t.groupId === groupId);
+      if (groupTabs.length === 0 && blankTab == null) {
+        // Add the blank tab, if there are no in tabs the tab group
+        this.tabState.addTab(groupId, this.editorTabFactory.createTab('blank-tab'));
+      } else if (groupTabs.length > 1 && blankTab != null) {
+        // Remove the blank tab if the tab group has a non-blank tab
+        this.tabState.removeTab(groupId, blankTab.index);
+      }
+    }
   }
 
   private async saveNote(params: SaveNoteParameters): Promise<void> {
@@ -1548,13 +1569,10 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.draftOptionsService.areFormattingOptionsAvailableButUnselected(draftBuild);
 
     if (draftShouldBeVisible && canViewDrafts && draftBuild != null && !isBlockedByFormattingOptions) {
-      // URL may indicate to select the 'draft' tab (such as when coming from generate draft page)
-      const groupIdToAddTo: EditorTabGroupType = this.showSource ? 'source' : 'target';
-
-      // Add to 'source' (or 'target' if showSource is false) tab group if no existing draft tab
+      // Add to 'source' tab group if no existing draft tab
       if (existingDraftTab == null) {
         this.tabState.addTab(
-          groupIdToAddTo,
+          'source',
           this.editorTabFactory.createTab('draft', {
             tooltip: `Draft - ${this.editorHistoryService.formatTimestamp(
               draftBuild?.additionalInfo?.dateFinished,
@@ -1569,7 +1587,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         // Remove 'draft-active' and 'draft-timestamp' query string from url when another tab from group is selected
         this.tabState.tabs$
           .pipe(
-            filter(tabs => tabs.some(tab => tab.groupId === groupIdToAddTo && tab.type !== 'draft' && tab.isSelected)),
+            filter(tabs => tabs.some(tab => tab.groupId === 'source' && tab.type !== 'draft' && tab.isSelected)),
             take(1)
           )
           .subscribe(() => {
@@ -1596,8 +1614,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       this.projectDoc?.data?.biblicalTermsConfig?.biblicalTermsEnabled === true &&
       this.projectUserConfigDoc?.data?.biblicalTermsEnabled === true
     ) {
-      const groupIdToAddTo: EditorTabGroupType = this.showSource ? 'source' : 'target';
-      this.tabState.addTab(groupIdToAddTo, this.editorTabFactory.createTab('biblical-terms'), false);
+      this.tabState.addTab('source', this.editorTabFactory.createTab('biblical-terms'), false);
       await this.projectUserConfigDoc?.submitJson0Op(op => op.unset(p => p.biblicalTermsEnabled));
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -493,6 +493,14 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     return SF_DEFAULT_TRANSLATE_SHARE_ROLE;
   }
 
+  get showSourceTab(): boolean {
+    return (
+      (this.hasSource && this.hasSourceViewRight) ||
+      this.isParatextUserRole ||
+      (this.tabState.getTabGroup('source')?.tabs.some(tab => tab.persist) ?? false)
+    );
+  }
+
   get hasEditRight(): boolean {
     return this.userHasGeneralEditRight && this.hasChapterEditPermission === true;
   }
@@ -835,7 +843,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         if (this.projectDoc.id !== prevProjectId) {
           this.setupTranslationEngine();
           this.projectDataChangesSub?.unsubscribe();
-          this.projectDataChangesSub = this.projectDoc.remoteChanges$.subscribe(() => {
+          this.projectDataChangesSub = this.projectDoc.remoteChanges$.subscribe(async () => {
             let sourceId: TextDocId | undefined;
             if (this.hasSource && this.chapter != null) {
               sourceId = new TextDocId(
@@ -856,6 +864,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             if (this.translationEngine == null || !this.translationSuggestionsProjectEnabled || !this.hasEditRight) {
               this.setupTranslationEngine();
             }
+
+            await this.addRemoveSourceTabAsync(this.projectDoc!);
           });
 
           if (this.metricsSession != null) {
@@ -1342,24 +1352,6 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
       tap(async (persistedTabs: (EditorTabPersistData & { projectDoc?: SFProjectProfileDoc })[]) => {
         const sourceTabGroup = new TabGroup<EditorTabGroupType, EditorTabInfo>('source');
         const targetTabGroup = new TabGroup<EditorTabGroupType, EditorTabInfo>('target');
-        const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
-        let canViewSource = false;
-        if (projectSource != null) {
-          canViewSource =
-            (await this.permissionsService.isUserOnProject(projectSource?.projectRef)) ||
-            (await this.permissionsService.userHasParatextRoleOnProject(projectDoc.id));
-        }
-
-        if (projectSource != null && canViewSource) {
-          sourceTabGroup.addTab(
-            this.editorTabFactory.createTab('project-source', {
-              projectId: projectSource.projectRef,
-              headerText$: of(projectSource.shortName),
-              tooltip: projectSource.name
-            })
-          );
-        }
-
         targetTabGroup.addTab(
           this.editorTabFactory.createTab('project-target', {
             projectId: projectDoc.id,
@@ -1367,6 +1359,8 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
             tooltip: projectDoc?.data?.name
           })
         );
+
+        await this.addRemoveSourceTabAsync(projectDoc, sourceTabGroup);
 
         for (const tabData of persistedTabs) {
           // Do not display the Biblical Terms tab if the user has lost permission
@@ -1459,6 +1453,38 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
         // Remove the blank tab if the tab group has a non-blank tab
         this.tabState.removeTab(groupId, blankTab.index);
       }
+    }
+  }
+
+  private async addRemoveSourceTabAsync(
+    projectDoc: SFProjectProfileDoc,
+    sourceTabGroup?: TabGroup<EditorTabGroupType, EditorTabInfo>
+  ): Promise<void> {
+    const projectSource: TranslateSource | undefined = projectDoc.data?.translateConfig.source;
+    let canViewSource = false;
+    if (projectSource != null) {
+      canViewSource =
+        (await this.permissionsService.isUserOnProject(projectSource?.projectRef)) ||
+        (await this.permissionsService.userHasParatextRoleOnProject(projectDoc.id));
+    }
+
+    const existingSourceTab: { groupId: EditorTabGroupType; index: number } | undefined =
+      this.tabState.getFirstTabOfTypeIndex('project-source');
+    if (projectSource != null && canViewSource) {
+      if (sourceTabGroup != null || existingSourceTab == null) {
+        const tab = this.editorTabFactory.createTab('project-source', {
+          projectId: projectSource.projectRef,
+          headerText$: of(projectSource.shortName),
+          tooltip: projectSource.name
+        });
+        if (sourceTabGroup != null) {
+          sourceTabGroup?.addTab(tab);
+        } else if (existingSourceTab == null) {
+          this.tabState.addTab('source', tab);
+        }
+      }
+    } else if (existingSourceTab != null) {
+      this.tabState.removeTab('source', existingSourceTab.index);
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-factory.service.ts
@@ -33,6 +33,20 @@ export class EditorTabFactoryService implements TabFactoryService<EditorTabType,
           },
           tabOptions
         );
+      case 'blank-tab':
+        return Object.assign(
+          {
+            id,
+            type: 'blank-tab',
+            icon: 'tab',
+            headerText$: this.i18n.translate('editor_tab_factory.blank_tab_header'),
+            closeable: false,
+            movable: false,
+            persist: false,
+            unique: true
+          },
+          tabOptions
+        );
       case 'history':
         return Object.assign(
           {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.spec.ts
@@ -130,6 +130,7 @@ describe('EditorTabMenuService', () => {
     when(mockPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(false);
     env.setExistingTabs([]);
     service['canShowHistory'] = () => true;
+    service['canShowResource'] = () => false;
 
     const items = await firstValueFrom(service.getMenuItems());
     expect(items.map(i => i.type)).toEqual(['history']);
@@ -210,11 +211,13 @@ describe('EditorTabMenuService', () => {
   });
 
   describe('canShowResource', () => {
-    it('should call permissions service canSync', () => {
+    it('should return true only if the user is a paratext user', () => {
       const env = new TestEnvironment();
-      const spy = spyOn(service['permissionsService'], 'canSync');
-      service['canShowResource'](env.projectDoc);
-      expect(spy).toHaveBeenCalledTimes(1);
+
+      Object.values(SFProjectRole).forEach(role => {
+        env.setUserByRole(role);
+        expect(service['canShowResource'](env.projectDoc)).toBe(isParatextRole(role));
+      });
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/tabs/editor-tab-menu.service.ts
@@ -173,6 +173,7 @@ export class EditorTabMenuService implements TabMenuService<EditorTabGroupType> 
   }
 
   private canShowResource(projectDoc: SFProjectProfileDoc): boolean {
-    return this.permissionsService.canSync(projectDoc, this.userService.currentUserId);
+    if (projectDoc.data == null) return false;
+    return isParatextRole(projectDoc.data.userRoles[this.userService.currentUserId]);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -448,6 +448,7 @@
   "editor": {
     "add_comment": "Add Comment",
     "anonymous": "Anonymous",
+    "blank_tab_notice": "Click the Add button above and select Resource to open a Paratext Project or Resource beside your current project.",
     "browser_warning_banner": "The editor is not compatible with the current browser for the project language. We recommend editing this project in {{ firefoxLink }} or {{ safari }}.",
     "cancel": "Cancel",
     "cannot_edit_chapter_formatting_invalid": "This chapter cannot be edited because the formatting is invalid. Please fix the formatting in Paratext.",
@@ -492,6 +493,7 @@
     "project_resource_menu_item": "Resource..."
   },
   "editor_tab_factory": {
+    "blank_tab_header": "New Tab",
     "default_biblical_terms_tab_header": "Biblical Terms",
     "default_history_tab_header": "History",
     "default_project_tab_header": "Project",


### PR DESCRIPTION
This PR adds an "always on" left hand tab pane, which when empty will show an "new tab" tab (I'm not sure on the wording/layout of this tab, so am really open to suggestions):

<img width="844" height="616" alt="image" src="https://github.com/user-attachments/assets/7d0cac9a-6b50-4d88-8b95-46965cbed158" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3952)
<!-- Reviewable:end -->
