### PR TITLE
serval-admin: onboarding-requests: add export spreadsheet

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { UserDoc } from 'xforge-common/models/user-doc';
+import { UserService } from 'xforge-common/user.service';
+import {
+  ONBOARDING_REQUEST_RESOLUTION_OPTIONS,
+  OnboardingRequest,
+  OnboardingRequestResolutionKey,
+  OnboardingRequestService
+} from '../../translate/draft-generation/onboarding-request.service';
+import { ServalAdministrationService } from '../serval-administration.service';
+import {
+  ONBOARDING_REQUESTS_EXPORT_HEADERS,
+  OnboardingRequestsExportService
+} from './onboarding-requests-export.service';
+
+const mockedOnboardingRequestService = mock(OnboardingRequestService);
+const mockedUserService = mock(UserService);
+const mockedServalAdministrationService = mock(ServalAdministrationService);
+
+const REQUEST_ID = 'req1';
+const PROJECT_ID = 'sfproj1';
+const PROJECT_SHORT_NAME = 'SHORT1';
+const UNKNOWN_PROJECT_ID = 'sfproj-unknown';
+const ASSIGNEE_ID = 'user2';
+const ASSIGNEE_NAME = 'Alice Assignee';
+const REQUEST_DATE_UTC = '2026-06-15T18:23:59.137';
+
+describe('OnboardingRequestsExportService', () => {
+  it('produces a header row with the requested columns in order', async () => {
+    const env = new TestEnvironment();
+
+    const tsv = await env.service.createTsv([]);
+
+    expect(env.lines(tsv)[0]).toEqual(ONBOARDING_REQUESTS_EXPORT_HEADERS.join('\t'));
+    expect(ONBOARDING_REQUESTS_EXPORT_HEADERS[0]).toEqual('request_date_utc');
+  });
+
+  it('maps a request to a tab-separated row in the correct column order', async () => {
+    const env = new TestEnvironment();
+
+    const tsv = await env.service.createTsv([env.createRequest()]);
+
+    expect(env.lines(tsv)[1]).toEqual(
+      [
+        REQUEST_DATE_UTC,
+        'Approved',
+        'Bob Requester',
+        'eo',
+        PROJECT_SHORT_NAME,
+        'Esperanto',
+        ASSIGNEE_NAME,
+        REQUEST_ID,
+        PROJECT_ID
+      ].join('\t')
+    );
+  });
+
+  it('leaves the request date empty when the timestamp is missing or invalid', async () => {
+    const env = new TestEnvironment();
+    const request = env.createRequest();
+    (request.submission as { timestamp: string }).timestamp = '';
+
+    const tsv = await env.service.createTsv([request]);
+
+    const cells = env.lines(tsv)[1].split('\t');
+    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('request_date_utc');
+    expect(cells[index]).toEqual('');
+  });
+
+  it('falls back to the project ID when the project document is unavailable', async () => {
+    const env = new TestEnvironment();
+    const request = env.createRequest();
+    request.submission.projectId = UNKNOWN_PROJECT_ID;
+
+    const tsv = await env.service.createTsv([request]);
+
+    const cells = env.lines(tsv)[1].split('\t');
+    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('project_shortname');
+    expect(cells[index]).toEqual(UNKNOWN_PROJECT_ID);
+  });
+
+  it('leaves the assignee column empty when there is no assignee', async () => {
+    const env = new TestEnvironment();
+
+    const tsv = await env.service.createTsv([env.createRequest({ assigneeId: '' })]);
+
+    const cells = env.lines(tsv)[1].split('\t');
+    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('assignee');
+    expect(cells[index]).toEqual('');
+  });
+
+  it('produces comma-separated values for CSV', async () => {
+    const env = new TestEnvironment();
+
+    const csv = await env.service.createCsv([env.createRequest()]);
+
+    expect(env.lines(csv)[0]).toEqual(ONBOARDING_REQUESTS_EXPORT_HEADERS.join(','));
+    expect(env.lines(csv)[1].split(',')[ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('request_id')]).toEqual(REQUEST_ID);
+  });
+
+  it('produces one data row per request', async () => {
+    const env = new TestEnvironment();
+
+    const tsv = await env.service.createTsv([env.createRequest({ id: 'req1' }), env.createRequest({ id: 'req2' })]);
+
+    const dataRows = env.lines(tsv).filter(line => line.trim().length > 0);
+    expect(dataRows.length).toEqual(3);
+  });
+
+  it('builds an export filename containing the UTC date and time with a trailing Z', () => {
+    const env = new TestEnvironment();
+    const date = new Date('2026-02-28T18:23:59.137Z');
+
+    expect(env.service.exportFilename('tsv', date)).toEqual('onboarding-requests_2026-02-28_182359Z.tsv');
+    expect(env.service.exportFilename('csv', date)).toEqual('onboarding-requests_2026-02-28_182359Z.csv');
+  });
+});
+
+class TestEnvironment {
+  readonly service: OnboardingRequestsExportService;
+
+  constructor() {
+    when(mockedOnboardingRequestService.getResolution(anything())).thenCall((key: OnboardingRequestResolutionKey) =>
+      ONBOARDING_REQUEST_RESOLUTION_OPTIONS.find(option => option.key === key)
+    );
+    when(mockedServalAdministrationService.get(PROJECT_ID)).thenResolve({
+      id: PROJECT_ID,
+      data: { shortName: PROJECT_SHORT_NAME }
+    } as any);
+    when(mockedServalAdministrationService.get(UNKNOWN_PROJECT_ID)).thenResolve(undefined as any);
+    when(mockedUserService.get(ASSIGNEE_ID)).thenResolve({
+      data: { displayName: ASSIGNEE_NAME }
+    } as unknown as UserDoc);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: OnboardingRequestService, useValue: instance(mockedOnboardingRequestService) },
+        { provide: UserService, useValue: instance(mockedUserService) },
+        { provide: ServalAdministrationService, useValue: instance(mockedServalAdministrationService) }
+      ]
+    });
+    this.service = TestBed.inject(OnboardingRequestsExportService);
+  }
+
+  createRequest(overrides: Partial<OnboardingRequest> = {}): OnboardingRequest {
+    return {
+      id: REQUEST_ID,
+      submittedAt: '2026-06-15T18:23:59.137Z',
+      submittedBy: { name: 'Bob Requester', email: 'bob@example.com' },
+      submission: {
+        projectId: PROJECT_ID,
+        userId: 'user1',
+        timestamp: '2026-06-15T18:23:59.137Z',
+        formData: {
+          name: 'Bob Requester',
+          email: 'bob@example.com',
+          organization: 'Org',
+          partnerOrganization: 'none',
+          translationLanguageName: 'Esperanto',
+          translationLanguageIsoCode: 'eo',
+          completedBooks: [],
+          nextBooksToDraft: [],
+          sourceProjectA: 'src',
+          draftingSourceProject: 'src',
+          backTranslationStage: 'None',
+          backTranslationProject: null
+        }
+      } as OnboardingRequest['submission'],
+      assigneeId: ASSIGNEE_ID,
+      status: 'in_progress',
+      resolution: 'approved',
+      comments: [],
+      ...overrides
+    } as OnboardingRequest;
+  }
+
+  lines(content: string): string[] {
+    return content.split('\n').map(line => line.replace(/\r$/, ''));
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@angular/core';
+import Papa from 'papaparse';
+import { UserService } from 'xforge-common/user.service';
+import { isPopulatedString } from '../../../type-utils';
+import { parseDate } from '../../shared/utils';
+import {
+  OnboardingRequest,
+  OnboardingRequestService
+} from '../../translate/draft-generation/onboarding-request.service';
+import { ServalAdministrationService } from '../serval-administration.service';
+
+/** Column headers for the onboarding requests export, in the order they appear in the exported file. */
+export const ONBOARDING_REQUESTS_EXPORT_HEADERS = [
+  'request_date_utc',
+  'resolution',
+  'requester',
+  'language_code',
+  'project_shortname',
+  'language_name',
+  'assignee',
+  'request_id',
+  'sf_project_id'
+] as const;
+
+/**
+ * Builds spreadsheet exports of onboarding requests.
+ */
+@Injectable({ providedIn: 'root' })
+export class OnboardingRequestsExportService {
+  constructor(
+    private readonly onboardingRequestService: OnboardingRequestService,
+    private readonly userService: UserService,
+    private readonly servalAdministrationService: ServalAdministrationService
+  ) {}
+
+  /** Builds a comma-separated values (CSV) string for the given onboarding requests. */
+  createCsv(requests: OnboardingRequest[]): Promise<string> {
+    return this.createSeparatedValues(requests, ',');
+  }
+
+  /** Builds a tab-separated values (TSV) string for the given onboarding requests. */
+  createTsv(requests: OnboardingRequest[]): Promise<string> {
+    return this.createSeparatedValues(requests, '\t');
+  }
+
+  /**
+   * Builds the export filename, e.g. onboarding-requests_2026-02-28_182359Z.tsv. The date and
+   * time are in UTC; the trailing 'Z' indicates this is UTC rather than the user's local time. The time is included
+   * because the exportable data will change during the day, and UTC is used both because the files can be shared across
+   * timezones and because the records in the file also have UTC timestamps.
+   */
+  exportFilename(extension: string, date: Date = new Date()): string {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const hours = String(date.getUTCHours()).padStart(2, '0');
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+    const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+    return `onboarding-requests_${year}-${month}-${day}_${hours}${minutes}${seconds}Z.${extension}`;
+  }
+
+  private async createSeparatedValues(requests: OnboardingRequest[], delimiter: string): Promise<string> {
+    const assigneeNames = await this.lookupAssigneeNames(requests);
+
+    const data: string[][] = await Promise.all(
+      requests.map(async request => {
+        const sfProjectId = request.submission.projectId;
+        const projectDoc = await this.servalAdministrationService.get(sfProjectId);
+        const projectShortName = projectDoc?.data?.shortName ?? sfProjectId;
+        return [
+          this.formatRequestDateUtc(request.submission.timestamp) ?? '',
+          this.onboardingRequestService.getResolution(request.resolution).label,
+          request.submission.formData.name,
+          request.submission.formData.translationLanguageIsoCode,
+          projectShortName,
+          request.submission.formData.translationLanguageName,
+          assigneeNames.get(request.assigneeId) ?? '',
+          request.id,
+          sfProjectId
+        ];
+      })
+    );
+
+    return Papa.unparse({ fields: [...ONBOARDING_REQUESTS_EXPORT_HEADERS], data }, { delimiter });
+  }
+
+  /** Resolves the display name for each unique populated SF assignee user ID. */
+  private async lookupAssigneeNames(requests: OnboardingRequest[]): Promise<Map<string, string>> {
+    const assigneeIds = [...new Set(requests.map(request => request.assigneeId).filter(isPopulatedString))];
+    const entries = await Promise.all(
+      assigneeIds.map(async assigneeId => {
+        const userDoc = await this.userService.get(assigneeId);
+        return [assigneeId, userDoc?.data?.displayName ?? ''] as const;
+      })
+    );
+    return new Map(entries);
+  }
+
+  /** Formats a request timestamp as an ISO 8601 UTC string with no timezone marker, if valid. The
+   * timezone marker ('Z') is removed so spreadsheet software can interpret the value as a date rather than as a string.
+   * */
+  private formatRequestDateUtc(timestamp: string | undefined): string | undefined {
+    const date: Date | undefined = parseDate(timestamp);
+    return date == null ? undefined : date.toISOString().replace(/Z$/, '');
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
@@ -81,7 +81,10 @@ export class OnboardingRequestsExportService {
       })
     );
 
-    return Papa.unparse({ fields: [...ONBOARDING_REQUESTS_EXPORT_HEADERS], data }, { delimiter });
+    return Papa.unparse(
+      { fields: [...ONBOARDING_REQUESTS_EXPORT_HEADERS], data },
+      { delimiter: delimiter, escapeFormulae: true }
+    );
   }
 
   /** Resolves the display name for each unique populated SF assignee user ID. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.html
@@ -10,13 +10,34 @@
       as resolved does not automatically enable drafting on the project.
     </app-notice>
 
-    <p>
+    <div class="filter-bar">
       <mat-button-toggle-group [(ngModel)]="activeFilter" class="status-filter">
         @for (option of filterOptions | keyvalue: null; track option.key) {
           <mat-button-toggle [value]="option.key">{{ option.value.name }}</mat-button-toggle>
         }
       </mat-button-toggle-group>
-    </p>
+      <div class="export-button-group">
+        <button mat-raised-button color="primary" class="export-csv-button" (click)="exportCsv()">
+          <mat-icon>download</mat-icon>
+          <span class="export-item-label">
+            Export CSV
+            <app-info text="Download a .csv (comma-separated values) spreadsheet of the table data"></app-info>
+          </span>
+        </button>
+        <button mat-raised-button color="primary" class="export-menu-button" [matMenuTriggerFor]="exportMenu">
+          <mat-icon>arrow_drop_down</mat-icon>
+        </button>
+      </div>
+      <mat-menu #exportMenu="matMenu" xPosition="before">
+        <button mat-menu-item (click)="exportTsv()">
+          <mat-icon>download</mat-icon>
+          <span class="export-item-label">
+            Export TSV
+            <app-info text="Download a .tsv (tab-separated values) spreadsheet of the table data"></app-info>
+          </span>
+        </button>
+      </mat-menu>
+    </div>
 
     @if (filteredRequests.length === 0) {
       <p class="no-requests">No requests are in the "{{ currentFilterName }}" category.</p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.scss
@@ -16,6 +16,43 @@
   padding: 40px;
 }
 
+.filter-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.export-button-group {
+  display: flex;
+
+  .export-csv-button {
+    // Be flush with the drop-down arrow
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+  }
+
+  .export-menu-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    min-width: 40px;
+    padding: 0 8px;
+
+    mat-icon {
+      margin: 0;
+    }
+  }
+}
+
+.export-item-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .requests-table {
   width: 100%;
   margin-top: 20px;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests.component.ts
@@ -4,16 +4,20 @@ import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { TranslocoModule } from '@ngneat/transloco';
+import { saveAs } from 'file-saver';
 import { DataLoadingComponent } from 'xforge-common/data-loading-component';
 import { NoticeService } from 'xforge-common/notice.service';
 import { OwnerComponent } from 'xforge-common/owner/owner.component';
 import { RouterLinkDirective } from 'xforge-common/router-link.directive';
 import { UserService } from 'xforge-common/user.service';
+import { InfoComponent } from '../../shared/info/info.component';
 import { NoticeComponent } from '../../shared/notice/notice.component';
 import { projectLabel } from '../../shared/utils';
 import {
@@ -24,6 +28,7 @@ import {
 } from '../../translate/draft-generation/onboarding-request.service';
 import { OnboardingRequestAssigneeSelectComponent } from '../onboarding-request-assignee-select/onboarding-request-assignee-select.component';
 import { ServalAdministrationService } from '../serval-administration.service';
+import { OnboardingRequestsExportService } from './onboarding-requests-export.service';
 
 type RequestFilterFunction = (request: OnboardingRequest, currentUserId: string | undefined) => boolean;
 
@@ -89,7 +94,10 @@ type FilterName = keyof typeof filterOptions;
     MatProgressSpinnerModule,
     MatButtonToggleModule,
     RouterLinkDirective,
-    MatInputModule
+    MatIconModule,
+    MatInputModule,
+    MatMenuModule,
+    InfoComponent
   ]
 })
 export class OnboardingRequestsComponent extends DataLoadingComponent implements OnInit {
@@ -98,7 +106,6 @@ export class OnboardingRequestsComponent extends DataLoadingComponent implements
   displayedColumns: string[] = ['status', 'project', 'languageCode', 'user', 'email', 'assignee', 'resolution'];
   currentUserId?: string;
   assignedUserIds: Set<string> = new Set();
-  userDisplayNames: Map<string, string> = new Map();
   projectNames: Map<string, string> = new Map();
   filterOptions = filterOptions;
 
@@ -111,7 +118,8 @@ export class OnboardingRequestsComponent extends DataLoadingComponent implements
     readonly userService: UserService,
     noticeService: NoticeService,
     private readonly servalAdministrationService: ServalAdministrationService,
-    readonly onboardingRequestService: OnboardingRequestService
+    readonly onboardingRequestService: OnboardingRequestService,
+    private readonly exportService: OnboardingRequestsExportService
   ) {
     super(noticeService, 'OnboardingRequestsComponent');
   }
@@ -153,6 +161,30 @@ export class OnboardingRequestsComponent extends DataLoadingComponent implements
         this.projectNames.set(projectId, projectId);
       }
     }
+  }
+
+  /** Exports the currently filtered requests as a CSV file. */
+  exportCsv(): Promise<void> {
+    return this.export('csv');
+  }
+
+  /** Exports the currently filtered requests as a TSV file. */
+  exportTsv(): Promise<void> {
+    return this.export('tsv');
+  }
+
+  private async export(extension: 'csv' | 'tsv'): Promise<void> {
+    const requests = this.filteredRequests;
+    if (requests.length === 0) {
+      this.noticeService.show('No data to export.');
+      return;
+    }
+
+    const content =
+      extension === 'csv' ? await this.exportService.createCsv(requests) : await this.exportService.createTsv(requests);
+    const mimeType = extension === 'csv' ? 'text/csv;charset=utf-8;' : 'text/tab-separated-values;charset=utf-8;';
+    const blob = new Blob([content], { type: mimeType });
+    saveAs(blob, this.exportService.exportFilename(extension));
   }
 
   /** Gets the project name for display, or falls back to project ID if not loaded yet. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-build-report.ts
@@ -1,7 +1,7 @@
 import { Canon } from '@sillsdev/scripture';
-import { BuildDto } from '../machine-api/build-dto';
-import { expandNumbers } from '../shared/utils';
 import { notNull } from '../../type-utils';
+import { BuildDto } from '../machine-api/build-dto';
+import { expandNumbers, parseDate } from '../shared/utils';
 
 /**
  * A report of a Serval build, combining Serval-native data with SF project information and event metrics information.
@@ -87,16 +87,6 @@ export interface BuildReportProjectScriptureRange {
 /** Takes a ServalBuildReportDto with JSON-typed values (date strings, status strings) and converts them to proper
  * TypeScript types. */
 export function interpretTypes(report: ServalBuildReportDto): ServalBuildReportDto {
-  const parseDate = (value: unknown): Date | undefined => {
-    if (value instanceof Date) return value;
-    if (value == null) return undefined;
-    if (typeof value !== 'string' && typeof value !== 'number') return undefined;
-
-    const parsed: Date = new Date(value);
-    if (Number.isNaN(parsed.getTime())) return undefined;
-    return parsed;
-  };
-
   const status: string = report.status;
   if (!isDraftGenerationBuildStatus(status)) {
     // Noisily handle invalid data.

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   getBookFileNameDigits,
   getUnsupportedTags,
   isBadDelta,
+  parseDate,
   projectLabel,
   XmlUtils
 } from './utils';
@@ -270,6 +271,38 @@ describe('shared utils', () => {
           insert: { note: { contents: { ops: [{ attributes: { 'invalid-inline': true, char: { style: 'bad' } } }] } } }
         })
       ).toEqual(['bad']);
+    });
+  });
+
+  describe('parseDate', () => {
+    it('returns the same Date instance when given a Date', () => {
+      const date = new Date('2026-06-15T12:00:00.000Z');
+      expect(parseDate(date)).toBe(date);
+    });
+
+    it('parses an ISO date string', () => {
+      const result = parseDate('2026-06-15T12:00:00.000Z');
+      expect(result).toEqual(new Date('2026-06-15T12:00:00.000Z'));
+    });
+
+    it('parses a numeric timestamp', () => {
+      const ms = Date.UTC(2026, 5, 15, 12, 0, 0);
+      expect(parseDate(ms)).toEqual(new Date(ms));
+    });
+
+    it('returns undefined for null or undefined', () => {
+      expect(parseDate(null)).toBeUndefined();
+      expect(parseDate(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for an invalid date string', () => {
+      expect(parseDate('not a date')).toBeUndefined();
+      expect(parseDate('')).toBeUndefined();
+    });
+
+    it('returns undefined for values that are not strings, numbers, or Dates', () => {
+      expect(parseDate({})).toBeUndefined();
+      expect(parseDate(true)).toBeUndefined();
     });
   });
 });

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -299,3 +299,16 @@ export function formatDateForFilename(date: Date): string {
   const minutes = String(date.getMinutes()).padStart(2, '0');
   return `${year}-${month}-${day}_${hours}${minutes}`;
 }
+
+/**
+ * Parses a value into a Date, returning undefined if the value is null, not a string/number, or not a valid date.
+ */
+export function parseDate(value: unknown): Date | undefined {
+  if (value instanceof Date) return value;
+  if (value == null) return undefined;
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+
+  const parsed: Date = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed;
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/utils.ts
@@ -301,7 +301,7 @@ export function formatDateForFilename(date: Date): string {
 }
 
 /**
- * Parses a value into a Date, returning undefined if the value is null, not a string/number, or not a valid date.
+ * Parses a Date, string, or number into a Date, if possible. Or returns undefined.
  */
 export function parseDate(value: unknown): Date | undefined {
   if (value instanceof Date) return value;


### PR DESCRIPTION
This patch adds an "Export CSV" button to the Serval Administration,
Onboarding Requests tab. A similar button and feature can be found on
the Serval Builds tab.

The parseDate function was moved out into app/shared/utils.ts to be
reused.

Exporting the Onboarding Request data is helpful for our internal analyses.

Screenshot showing the "Export CSV" button, with "Export TSV" as an alternate option in the drop-down:
<img width="230" height="132" alt="image" src="https://github.com/user-attachments/assets/0aa76454-8c02-4614-b367-33601464298c" />

Screenshot showing Export button in context, on the Onboarding Requests tab:
<img width="1061" height="234" alt="image" src="https://github.com/user-attachments/assets/d6245f68-2338-409d-81c6-466d4ac4329f" />



<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3954)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3954)
<!-- Reviewable:end -->
