### PR TITLE
Update SMT retirement notice to include a date

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.html
@@ -1,8 +1,6 @@
 <ng-container *transloco="let t; read: 'editor'">
   @if (translationSuggestionsEnabled && userHasGeneralEditRight) {
-    <app-notice icon="warning" type="warning" mode="fill-dark">
-      {{ i18n.translateStatic("translate_overview.translation_suggestions_retirement_notice", { email: issueEmail }) }}
-    </app-notice>
+    <app-smt-retirement-notice></app-smt-retirement-notice>
   }
   <div
     class="content"

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -164,6 +164,7 @@ import {
 import { BiblicalTermsComponent } from '../biblical-terms/biblical-terms.component';
 import { DraftGenerationService } from '../draft-generation/draft-generation.service';
 import { DraftOptionsService } from '../draft-generation/draft-options.service';
+import { SmtRetirementNoticeComponent } from '../smt-retirement-notice/smt-retirement-notice.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 import { EditorDraftComponent } from './editor-draft/editor-draft.component';
 import { EditorHistoryComponent } from './editor-history/editor-history.component';
@@ -275,7 +276,8 @@ const UNSUPPORTED_LANGUAGE_CODES = [
     LynxInsightsPanelComponent,
     SuggestionsComponent,
     TextDocIdPipe,
-    TrainingProgressComponent
+    TrainingProgressComponent,
+    SmtRetirementNoticeComponent
   ]
 })
 export class EditorComponent extends DataLoadingComponent implements OnDestroy, OnInit, AfterViewInit {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.html
@@ -1,0 +1,17 @@
+<app-notice icon="error" type="error" mode="fill-dark">
+  @for (
+    line of i18n.interpolateVariables("translate_overview.translation_suggestions_will_be_removed", {
+      email: issueEmail,
+      date: i18n.formatDate(smtRetirementDate, { showTime: false })
+    });
+    track $index
+  ) {
+    @if (line.id === "email") {
+      <a href="mailto:{{ issueEmail }}" target="_blank" rel="noreferrer">{{ line.text }}</a>
+    }
+    <!-- prettier-ignore -->
+    @else if (line.id === "date") {<strong>{{ line.text }}</strong>}
+    <!-- prettier-ignore -->
+    @else {{{ line.text }}}
+  }
+</app-notice>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { I18nService } from 'xforge-common/i18n.service';
+import { environment } from '../../../environments/environment';
+import { NoticeComponent } from '../../shared/notice/notice.component';
+
+@Component({
+  selector: 'app-smt-retirement-notice',
+  imports: [NoticeComponent],
+  templateUrl: './smt-retirement-notice.component.html'
+})
+export class SmtRetirementNoticeComponent {
+  readonly issueEmail = environment.issueEmail;
+  readonly smtRetirementDate = new Date('2026-08-04');
+
+  constructor(readonly i18n: I18nService) {}
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.html
@@ -6,9 +6,7 @@
   }
 
   @if (translationSuggestionsEnabled && canEditTexts) {
-    <app-notice icon="warning" type="warning" mode="fill-dark">{{
-      t("translation_suggestions_retirement_notice", { email: issueEmail })
-    }}</app-notice>
+    <app-smt-retirement-notice></app-smt-retirement-notice>
   }
 
   @if (isOnline) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/translate-overview/translate-overview.component.ts
@@ -36,7 +36,6 @@ import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { RouterLinkDirective } from 'xforge-common/router-link.directive';
 import { UserService } from 'xforge-common/user.service';
 import { quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
-import { environment } from '../../../environments/environment';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { SFProjectService } from '../../core/sf-project.service';
 import { TranslationEngineService } from '../../core/translation-engine.service';
@@ -44,6 +43,7 @@ import { RemoteTranslationEngine } from '../../machine-api/remote-translation-en
 import { NoticeComponent } from '../../shared/notice/notice.component';
 import { BookProgress, ProgressService, ProjectProgress } from '../../shared/progress-service/progress.service';
 import { FontUnsupportedMessageComponent } from '../font-unsupported-message/font-unsupported-message.component';
+import { SmtRetirementNoticeComponent } from '../smt-retirement-notice/smt-retirement-notice.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
 const ENGINE_QUALITY_STAR_COUNT = 3;
 const TEXT_PATH_TEMPLATE = obj<SFProject>().pathTemplate(p => p.texts[ANY_INDEX]);
@@ -74,6 +74,7 @@ const TEXT_PATH_TEMPLATE = obj<SFProject>().pathTemplate(p => p.texts[ANY_INDEX]
     MatCardActions,
     MatButton,
     TrainingProgressComponent,
+    SmtRetirementNoticeComponent,
     NoticeComponent,
     L10nNumberPipe,
     L10nPercentPipe
@@ -87,8 +88,6 @@ export class TranslateOverviewComponent extends DataLoadingComponent implements 
   engineConfidence: number = 0;
   trainedSegmentCount: number = 0;
   projectProgress?: ProjectProgress;
-  readonly issueEmail: string = environment.issueEmail;
-
   private trainingSub?: Subscription;
   private translationEngine?: RemoteTranslationEngine;
   private projectDoc?: SFProjectProfileDoc;

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -909,7 +909,7 @@
     "training_unavailable": "Training is temporarily unavailable",
     "translate_overview": "Translate Overview",
     "translated_segments": "{{ translatedSegments }} of {{ total }} segments",
-    "translation_suggestions_retirement_notice": "Your project appears to be using the translation suggestions feature. Translation suggestions will be retired soon. Please contact {{ email }} to discuss alternative ways to translate using Scripture Forge."
+    "translation_suggestions_will_be_removed": "Your project appears to be using the translation suggestions feature. Translation suggestions will be removed {{ date }}. Please contact {{ email }} to discuss alternative ways to translate using Scripture Forge."
   },
   "draft_signup": {
     "additional_comments_label": "Additional comments",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -327,7 +327,8 @@ export class I18nService {
     });
   }
 
-  formatDate(date: Date, options: { showTimeZone?: boolean } = {}): string {
+  formatDate(date: Date, options: { showTimeZone?: boolean; showTime?: boolean } = {}): string {
+    const showTime = 'showTime' in options ? options.showTime : true;
     // fall back to en in the event the language code isn't valid
     const format = I18nService.customDateFormats[this.localeCode] || {};
     return typeof format === 'function'
@@ -339,8 +340,7 @@ export class I18nService {
             month: 'numeric',
             year: 'numeric',
             day: 'numeric',
-            hour: 'numeric',
-            minute: 'numeric',
+            ...(showTime ? { hour: 'numeric', minute: 'numeric' } : {}),
             ...(options?.showTimeZone ? { timeZoneName: 'short' } : {}),
             ...format
           }


### PR DESCRIPTION
### Before
<img width="1788" height="148" alt="localhost_5000_projects_6a2068103a3af1fd8b2b22ec_translate_DEU_1 (2)" src="https://github.com/user-attachments/assets/6f709439-f614-40a1-96c9-d02145a144da" />

### After
<img width="1788" height="148" alt="localhost_5000_projects_6a2068103a3af1fd8b2b22ec_translate_DEU_1 (1)" src="https://github.com/user-attachments/assets/ce18d70c-3cf6-4f51-b687-4014c8d895c5" />

### Changes
- More scary (we haven't gotten messages as a result of the existing notice)
- Clearer message ("removed" instead of "retired")
- Email link
- Date specified

Disabling SMT can be done on a per-project basis, which will automatically make the message disappear.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3958)
<!-- Reviewable:end -->
