### PR TITLE
SF-3830 Remove PushAuthUserProfile and basic authentication

### DIFF
--- a/.github/workflows/release-live.yml
+++ b/.github/workflows/release-live.yml
@@ -102,7 +102,6 @@ jobs:
       paratext_client_id: ${{ secrets.paratext_client_id }}
       serval_client_id: ${{ secrets.serval_client_id }}
       auth_backend_secret: ${{ secrets.auth_backend_secret }}
-      auth_webhook_password: ${{ secrets.auth_webhook_password }}
       auth_health_check_api_key: ${{ secrets.auth_health_check_api_key }}
       paratext_api_token: ${{ secrets.paratext_api_token }}
       paratext_resource_password_base64: ${{ secrets.paratext_resource_password_base64 }}

--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -123,7 +123,6 @@ jobs:
       paratext_client_id: ${{ secrets.paratext_client_id }}
       serval_client_id: ${{ secrets.serval_client_id }}
       auth_backend_secret: ${{ secrets.auth_backend_secret }}
-      auth_webhook_password: ${{ secrets.auth_webhook_password }}
       auth_health_check_api_key: ${{ secrets.auth_health_check_api_key }}
       paratext_api_token: ${{ secrets.paratext_api_token }}
       paratext_resource_password_base64: ${{ secrets.paratext_resource_password_base64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,6 @@ on:
         required: true
       auth_backend_secret:
         required: true
-      auth_webhook_password:
-        required: true
       auth_health_check_api_key:
         required: true
       paratext_api_token:
@@ -174,7 +172,6 @@ jobs:
           PROJECT: ${{inputs.project}}
           SERVAL_CLIENT_ID: ${{secrets.serval_client_id}}
           AUTH_BACKEND_SECRET: ${{secrets.auth_backend_secret}}
-          AUTH_WEBHOOK_PASSWORD: ${{secrets.auth_webhook_password}}
           AUTH_HEALTH_CHECK_API_KEY: ${{secrets.auth_health_check_api_key}}
           PARATEXT_API_TOKEN: ${{secrets.paratext_api_token}}
           PARATEXT_RESOURCE_PASSWORD_BASE64: ${{secrets.paratext_resource_password_base64}}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,6 @@
     "flexbox",
     "gtag",
     "helphero",
-    "idunno",
     "indexeddb",
     "ldml",
     "listbox",

--- a/scripts/build-and-ship
+++ b/scripts/build-and-ship
@@ -31,7 +31,6 @@ cat <<EOF >"$BUILD_OUTPUT/app/secrets.json"
   },
   "Auth": {
     "BackendClientSecret": "${AUTH_BACKEND_SECRET}",
-    "WebhookPassword": "${AUTH_WEBHOOK_PASSWORD}",
     "HealthCheckApiKey": "${AUTH_HEALTH_CHECK_API_KEY}"
   },
   "Site": {

--- a/src/SIL.XForge.Scripture/appsettings.json
+++ b/src/SIL.XForge.Scripture/appsettings.json
@@ -45,7 +45,6 @@
     "Audience": "https://scriptureforge.org/",
     "ManagementAudience": "https://languagetechnology.auth0.com/api/v2/",
     "Scope": "sf_data",
-    "WebhookUsername": "auth0",
     "FrontendClientId": "tY2wXn40fsL5VsPM4uIHNtU6ZUEXGeFn",
     "BackendClientId": "4BVns47NmY3ksZsTHUI2FPdAvhwUaKyg"
   },

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -302,11 +302,6 @@
         "resolved": "59.1.7",
         "contentHash": "CnPSvu/V6nSP5KV2bJ0eMjsJ7lYr9qv03hdZTcIPoU9EAFV1+ZdZTKgd5rHud6WdB/Pwv++LghQB7V9KKJV02A=="
       },
-      "idunno.Authentication.Basic": {
-        "type": "Transitive",
-        "resolved": "2.4.0",
-        "contentHash": "h263h8GI/7xJrbz+ydEMhutpDmZ1EsLysPAqlaAqIf1D4xQBHTi94xeUlDQGD8R+Hl7a48bgD2bGCxQupfeCpg=="
-      },
       "Jering.Javascript.NodeJS": {
         "type": "Transitive",
         "resolved": "6.3.1",
@@ -1244,8 +1239,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.8, )",
           "MongoDB.Driver": "[3.8.1, )",
           "SIL.Core": "[17.0.0, )",
-          "SharpCompress": "[0.48.0, )",
-          "idunno.Authentication.Basic": "[2.4.0, )"
+          "SharpCompress": "[0.48.0, )"
         }
       }
     }

--- a/src/SIL.XForge/Configuration/AuthOptions.cs
+++ b/src/SIL.XForge/Configuration/AuthOptions.cs
@@ -9,6 +9,4 @@ public class AuthOptions : PublicAuthOptions
     public string BackendClientSecret { get; init; } = string.Empty;
     public string HealthCheckApiKey { get; init; } = string.Empty;
     public string ManagementAudience { get; init; } = string.Empty;
-    public string WebhookUsername { get; init; } = string.Empty;
-    public string WebhookPassword { get; init; } = string.Empty;
 }

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading.Tasks;
 using EdjCase.JsonRpc.Router.Abstractions;
-using idunno.Authentication.Basic;
-using Microsoft.AspNetCore.Authorization;
 using SIL.XForge.Services;
 
 namespace SIL.XForge.Controllers;
@@ -12,43 +9,14 @@ namespace SIL.XForge.Controllers;
 /// <summary>
 /// This is the controller for all JSON-RPC commands for users.
 /// </summary>
-public class UsersRpcController : RpcControllerBase
+public class UsersRpcController(
+    IUserAccessor userAccessor,
+    IUserService userService,
+    IAuthService authService,
+    IExceptionHandler exceptionHandler
+) : RpcControllerBase(userAccessor, exceptionHandler)
 {
-    private readonly IAuthService _authService;
-    private readonly IExceptionHandler _exceptionHandler;
-    private readonly IUserService _userService;
-
-    public UsersRpcController(
-        IUserAccessor userAccessor,
-        IUserService userService,
-        IAuthService authService,
-        IExceptionHandler exceptionHandler
-    )
-        : base(userAccessor, exceptionHandler)
-    {
-        _userService = userService;
-        _authService = authService;
-        _exceptionHandler = exceptionHandler;
-    }
-
-    /// <summary>
-    /// Updates the user entity from the specified Auth0 user profile. Auth0 calls this command from a rule.
-    /// </summary>
-    [Authorize(AuthenticationSchemes = BasicAuthenticationDefaults.AuthenticationScheme)]
-    public Task PushAuthUserProfile(string userId, JsonElement userProfile)
-    {
-        try
-        {
-            return _userService.UpdateUserFromProfileAsync(userId, userProfile.ToString());
-        }
-        catch (Exception)
-        {
-            _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "PushAuthUserProfile" }, { "userId", userId } }
-            );
-            throw;
-        }
-    }
+    private readonly IExceptionHandler _exceptionHandler = exceptionHandler;
 
     /// <summary>
     /// Updates the current user's entity from the user's corresponding Auth0 profile. Called by the front end after
@@ -56,8 +24,8 @@ public class UsersRpcController : RpcControllerBase
     /// </summary>
     public async Task<IRpcMethodResult> PullAuthUserProfile()
     {
-        string userProfile = await _authService.GetUserAsync(AuthId);
-        await _userService.UpdateUserFromProfileAsync(UserId, userProfile);
+        string userProfile = await authService.GetUserAsync(AuthId);
+        await userService.UpdateUserFromProfileAsync(UserId, userProfile);
         return Ok();
     }
 
@@ -65,7 +33,7 @@ public class UsersRpcController : RpcControllerBase
     {
         try
         {
-            await _userService.UpdateAvatarFromDisplayNameAsync(UserId, AuthId);
+            await userService.UpdateAvatarFromDisplayNameAsync(UserId, AuthId);
             return Ok();
         }
         catch (Exception)
@@ -81,7 +49,7 @@ public class UsersRpcController : RpcControllerBase
     {
         try
         {
-            await _userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
+            await userService.UpdateInterfaceLanguageAsync(UserId, AuthId, language);
             return Ok();
         }
         catch (Exception)
@@ -97,7 +65,7 @@ public class UsersRpcController : RpcControllerBase
     {
         try
         {
-            await _userService.DeleteAsync(UserId, SystemRoles, userId);
+            await userService.DeleteAsync(UserId, SystemRoles, userId);
             return Ok();
         }
         catch (ForbiddenException)

--- a/src/SIL.XForge/SIL.XForge.csproj
+++ b/src/SIL.XForge/SIL.XForge.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.8" />
     <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
     <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="idunno.Authentication.Basic" Version="2.4.0" />
     <PackageReference Include="AbrarJahin.DiffMatchPatch" Version="0.1.0" />
     <PackageReference Include="SIL.Core" Version="17.0.0" />
     <!-- Vulnerable dependency of MongoDB.Driver - see https://github.com/advisories/GHSA-6c8g-7p36-r338 -->

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -40,12 +40,6 @@ public class AuthService : DisposableBase, IAuthService
         _httpClient.BaseAddress = new Uri($"https://{_authOptions.Value.Domain}");
     }
 
-    public bool ValidateWebhookCredentials(string username, string password)
-    {
-        AuthOptions authOptions = _authOptions.Value;
-        return authOptions.WebhookUsername == username && authOptions.WebhookPassword == password;
-    }
-
     public async Task<Tokens?> GetParatextTokensAsync(string authId, CancellationToken token)
     {
         string userProfileJson;
@@ -149,7 +143,7 @@ public class AuthService : DisposableBase, IAuthService
                 new JProperty("grant_type", "client_credentials"),
                 new JProperty("client_id", options.BackendClientId),
                 new JProperty("client_secret", options.BackendClientSecret),
-                new JProperty("audience", _authOptions.Value.ManagementAudience)
+                new JProperty("audience", options.ManagementAudience)
             );
             request.Content = new StringContent(requestObj.ToString(), Encoding.UTF8, "application/json");
             if (string.IsNullOrEmpty(options.BackendClientSecret))

--- a/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
+++ b/src/SIL.XForge/Services/AuthServiceCollectionExtensions.cs
@@ -1,16 +1,11 @@
-#nullable disable warnings
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Duende.IdentityModel;
-using idunno.Authentication.Basic;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using SIL.XForge;
 using SIL.XForge.Configuration;
-using SIL.XForge.Services;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -51,42 +46,10 @@ public static class AuthServiceCollectionExtensions
                     },
                     OnTokenValidated = context =>
                     {
-                        string scopeClaim = context.Principal.FindFirst(c => c.Type == JwtClaimTypes.Scope)?.Value;
+                        string? scopeClaim = context.Principal?.FindFirst(c => c.Type == JwtClaimTypes.Scope)?.Value;
                         var scopes = new HashSet<string>(scopeClaim?.Split(' ') ?? Enumerable.Empty<string>());
                         if (!scopes.Contains(authOptions.Scope))
                             context.Fail("A required scope has not been granted.");
-                        return Task.CompletedTask;
-                    },
-                };
-            })
-            .AddBasic(options =>
-            {
-                options.Events = new BasicAuthenticationEvents
-                {
-                    OnValidateCredentials = context =>
-                    {
-                        var authService = context.HttpContext.RequestServices.GetService<IAuthService>();
-                        if (authService.ValidateWebhookCredentials(context.Username, context.Password))
-                        {
-                            Claim[] claims =
-                            [
-                                new Claim(
-                                    ClaimTypes.NameIdentifier,
-                                    context.Username,
-                                    ClaimValueTypes.String,
-                                    context.Options.ClaimsIssuer
-                                ),
-                                new Claim(
-                                    ClaimTypes.Name,
-                                    context.Username,
-                                    ClaimValueTypes.String,
-                                    context.Options.ClaimsIssuer
-                                ),
-                            ];
-
-                            context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
-                            context.Success();
-                        }
                         return Task.CompletedTask;
                     },
                 };

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -6,7 +6,6 @@ namespace SIL.XForge.Services;
 
 public interface IAuthService
 {
-    bool ValidateWebhookCredentials(string username, string password);
     Task<Tokens?> GetParatextTokensAsync(string authId, CancellationToken token);
     Task<string> GetUserAsync(string authId);
     Task<string> GenerateAnonymousUser(string name, TransparentAuthenticationCredentials credentials, string language);

--- a/src/SIL.XForge/packages.lock.json
+++ b/src/SIL.XForge/packages.lock.json
@@ -99,12 +99,6 @@
           "MongoDB.Driver": "3.7.1"
         }
       },
-      "idunno.Authentication.Basic": {
-        "type": "Direct",
-        "requested": "[2.4.0, )",
-        "resolved": "2.4.0",
-        "contentHash": "h263h8GI/7xJrbz+ydEMhutpDmZ1EsLysPAqlaAqIf1D4xQBHTi94xeUlDQGD8R+Hl7a48bgD2bGCxQupfeCpg=="
-      },
       "Jering.Javascript.NodeJS": {
         "type": "Direct",
         "requested": "[6.3.1, 6.3.1]",

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -227,11 +227,6 @@
         "resolved": "59.1.7",
         "contentHash": "CnPSvu/V6nSP5KV2bJ0eMjsJ7lYr9qv03hdZTcIPoU9EAFV1+ZdZTKgd5rHud6WdB/Pwv++LghQB7V9KKJV02A=="
       },
-      "idunno.Authentication.Basic": {
-        "type": "Transitive",
-        "resolved": "2.4.0",
-        "contentHash": "h263h8GI/7xJrbz+ydEMhutpDmZ1EsLysPAqlaAqIf1D4xQBHTi94xeUlDQGD8R+Hl7a48bgD2bGCxQupfeCpg=="
-      },
       "Jering.Javascript.NodeJS": {
         "type": "Transitive",
         "resolved": "6.3.1",
@@ -1677,8 +1672,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.8, )",
           "MongoDB.Driver": "[3.8.1, )",
           "SIL.Core": "[17.0.0, )",
-          "SharpCompress": "[0.48.0, )",
-          "idunno.Authentication.Basic": "[2.4.0, )"
+          "SharpCompress": "[0.48.0, )"
         }
       },
       "sil.xforge.scripture": {

--- a/test/SIL.XForge.Tests/Services/AuthServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/AuthServiceTests.cs
@@ -7,15 +7,13 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using SIL.XForge.Configuration;
+using Options = Microsoft.Extensions.Options.Options;
 
 namespace SIL.XForge.Services;
 
 [TestFixture]
 public class AuthServiceTests
 {
-    public const string ValidPassword = "password";
-    public const string ValidUsername = "username";
-
     [Test]
     public async Task GetParatextTokensAsync_NoParatextIdentity()
     {
@@ -128,43 +126,12 @@ public class AuthServiceTests
         Assert.IsNull(handler.LastInput);
     }
 
-    [TestCase(ValidUsername, "invalid_password")]
-    [TestCase("invalid_username", ValidPassword)]
-    [TestCase("invalid_username", "invalid_password")]
-    public void ValidateWebhookCredentials_Failure(string username, string password)
-    {
-        using var httpClient = new HttpClient();
-        var env = new TestEnvironment(httpClient);
-
-        // SUT
-        bool actual = env.Service.ValidateWebhookCredentials(username, password);
-        Assert.IsFalse(actual);
-    }
-
-    [Test]
-    public void ValidateWebhookCredentials_Success()
-    {
-        using var httpClient = new HttpClient();
-        var env = new TestEnvironment(httpClient);
-
-        // SUT
-        bool actual = env.Service.ValidateWebhookCredentials(ValidUsername, ValidPassword);
-        Assert.IsTrue(actual);
-    }
-
     private class TestEnvironment
     {
         public TestEnvironment(HttpClient httpClient)
         {
-            var authOptions = Substitute.For<IOptions<AuthOptions>>();
-            authOptions.Value.Returns(
-                new AuthOptions
-                {
-                    BackendClientSecret = "secret",
-                    Domain = "localhost",
-                    WebhookUsername = ValidUsername,
-                    WebhookPassword = ValidPassword,
-                }
+            IOptions<AuthOptions> authOptions = Options.Create(
+                new AuthOptions { BackendClientSecret = "secret", Domain = "localhost" }
             );
             ExceptionHandler = Substitute.For<IExceptionHandler>();
             var httpClientFactory = Substitute.For<IHttpClientFactory>();

--- a/test/SIL.XForge.Tests/Services/UserServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/UserServiceTests.cs
@@ -75,7 +75,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_NewUser_NickNameExtracted()
+    public async Task UpdateUserFromProfileAsync_NewUser_NickNameExtracted()
     {
         var env = new TestEnvironment();
 
@@ -90,7 +90,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_NewUser_NameExtracted()
+    public async Task UpdateUserFromProfileAsync_NewUser_NameExtracted()
     {
         var env = new TestEnvironment();
 
@@ -105,7 +105,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_AvatarSet()
+    public async Task UpdateUserFromProfileAsync_Metadata_AvatarSet()
     {
         var env = new TestEnvironment();
 
@@ -120,7 +120,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_AvatarNotSet()
+    public async Task UpdateUserFromProfileAsync_Metadata_AvatarNotSet()
     {
         var env = new TestEnvironment();
 
@@ -133,7 +133,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_NotSet()
+    public async Task UpdateUserFromProfileAsync_Metadata_NotSet()
     {
         var env = new TestEnvironment();
 
@@ -145,7 +145,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_RolesAreArray()
+    public async Task UpdateUserFromProfileAsync_Metadata_RolesAreArray()
     {
         var env = new TestEnvironment();
 
@@ -157,7 +157,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_RolesAreString()
+    public async Task UpdateUserFromProfileAsync_Metadata_RolesAreString()
     {
         var env = new TestEnvironment();
 
@@ -169,7 +169,7 @@ public class UserServiceTests
     }
 
     [Test]
-    public async Task PushAuthUserProfile_Metadata_RolesNotSet()
+    public async Task UpdateUserFromProfileAsync_Metadata_RolesNotSet()
     {
         var env = new TestEnvironment();
 

--- a/test/SIL.XForge.Tests/packages.lock.json
+++ b/test/SIL.XForge.Tests/packages.lock.json
@@ -170,11 +170,6 @@
           "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
         }
       },
-      "idunno.Authentication.Basic": {
-        "type": "Transitive",
-        "resolved": "2.4.0",
-        "contentHash": "h263h8GI/7xJrbz+ydEMhutpDmZ1EsLysPAqlaAqIf1D4xQBHTi94xeUlDQGD8R+Hl7a48bgD2bGCxQupfeCpg=="
-      },
       "Jering.Javascript.NodeJS": {
         "type": "Transitive",
         "resolved": "6.3.1",
@@ -619,8 +614,7 @@
           "Microsoft.AspNetCore.SpaServices.Extensions": "[10.0.8, )",
           "MongoDB.Driver": "[3.8.1, )",
           "SIL.Core": "[17.0.0, )",
-          "SharpCompress": "[0.48.0, )",
-          "idunno.Authentication.Basic": "[2.4.0, )"
+          "SharpCompress": "[0.48.0, )"
         }
       }
     }


### PR DESCRIPTION
This PR removes that `pushAuthUserProfile` JSON-RPC endpoint which was previously used by Auth0.

@Nateowami Can you please check whether this endpoint is still used by Auth0 on QA and Live? (I do not have access to do this, but I have checked the HTTP logs on live, and cannot see the User RPC controller being called by Auth0, as far as I can see). To do this:

1. Open Auth0
2. In the left hand menu, select Actions, then Triggers.
3. Click post-login.
4. Ensure that "Sync user profile with xForge backend" is not present in the flow diagram.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3961)
<!-- Reviewable:end -->
