### PR TITLE
serval-admin: link to Serval Builds rather than Draft Jobs

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
@@ -1,4 +1,4 @@
-<app-notice icon="warning" type="warning" mode="outline" class="draft-jobs-notice">
+<app-notice icon="warning" type="warning" mode="outline">
   This Draft Jobs tab will be removed soon and replaced with the Serval Builds tab. Feedback is encouraged.
 </app-notice>
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.html
@@ -1,3 +1,7 @@
+<app-notice icon="warning" type="warning" mode="outline" class="draft-jobs-notice">
+  This Draft Jobs tab will be removed soon and replaced with the Serval Builds tab. Feedback is encouraged.
+</app-notice>
+
 @if (isOnline) {
   <div class="filter-controls">
     <app-date-range-picker (dateRangeChange)="onDateRangeChange($event)"></app-date-range-picker>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.scss
@@ -1,6 +1,11 @@
 @use 'src/variables' as sfColors;
 @use 'src/xforge-common/media-breakpoints/breakpoints' as *;
 
+app-notice {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .table-wrapper {
   overflow-x: auto;
   display: block;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.html
@@ -1,7 +1,3 @@
-<app-notice icon="info" type="primary" mode="outline" class="preview-notice">
-  This is a preview of a new view of the Serval build information. When complete, it should replace the Draft jobs tab.
-</app-notice>
-
 @if (isOnline) {
   <div class="filter-controls">
     <app-date-range-picker [showReset]="true" (dateRangeChange)="onDateRangeChange($event)"></app-date-range-picker>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.scss
@@ -2,11 +2,6 @@ a {
   text-decoration: none;
 }
 
-.preview-notice {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-}
-
 .filter-controls {
   display: flex;
   flex-wrap: wrap;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.html
@@ -32,9 +32,9 @@
   </div>
   <div class="admin-tool-control">
     <button id="view-draft-jobs" mat-flat-button color="primary" (click)="navigateToDraftJobs()" [disabled]="!isOnline">
-      View Draft Jobs
+      View Serval Builds
     </button>
-    <app-info text="View all draft jobs for this project in the Serval Administration page."></app-info>
+    <app-info text="View all Serval builds for this project in the Serval Administration page."></app-info>
   </div>
   <div class="admin-tool-control">
     <button

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-project.component.ts
@@ -347,8 +347,8 @@ export class ServalProjectComponent extends DataLoadingComponent implements OnIn
   navigateToDraftJobs(): void {
     void this.router.navigate(['/serval-administration'], {
       queryParams: {
-        projectId: this.activatedProjectService.projectId!,
-        tab: 'draft-jobs'
+        tab: 'serval-builds',
+        q: this.activatedProjectService.projectId!
       }
     });
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.html
@@ -65,7 +65,7 @@
         <td mat-cell *matCellDef="let row">
           <button mat-stroked-button (click)="viewDraftJobs(row.id)" class="draft-jobs-button">
             <mat-icon>list</mat-icon>
-            Draft Jobs
+            Serval Builds
           </button>
         </td>
       </ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-projects.component.ts
@@ -173,8 +173,8 @@ export class ServalProjectsComponent extends DataLoadingComponent implements OnI
   viewDraftJobs(projectId: string): void {
     void this.router.navigate(['/serval-administration'], {
       queryParams: {
-        projectId,
-        tab: 'draft-jobs'
+        tab: 'serval-builds',
+        q: projectId
       }
     });
   }


### PR DESCRIPTION
On the Serval Administration - Projects tab, a button can be clicked
to see the list of draft jobs. Similarly, on the Serval admin page for
an indivdual project, a button can be clicked to view the list of
draft jobs.

This patch changes these places to go to the Serval Builds tab instead
of the Draft Jobs tab, and adjusts the notices to say that the Draft
Jobs tab is going away.

Opening a list of Serval Builds for a given project makes use of the Search feature. Screenshot showing Search control populated with a SF project ID:
<img width="257" height="91" alt="image" src="https://github.com/user-attachments/assets/ba16e51f-bdeb-48a2-bf5f-b71e57bc54e9" />

The "Coming soon" notice on the Serval Builds tab is removed. A "Going away" notice is added to the Draft Jobs tab. Screenshot showing "Going away" notice:
<img width="839" height="204" alt="image" src="https://github.com/user-attachments/assets/41d2dd32-8ec2-4c1a-889e-441844b28323" />


<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3962)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3962)
<!-- Reviewable:end -->
