### PR TITLE
serval-admin: onboarding-requests: add structure to export

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.spec.ts
@@ -9,10 +9,7 @@ import {
   OnboardingRequestService
 } from '../../translate/draft-generation/onboarding-request.service';
 import { ServalAdministrationService } from '../serval-administration.service';
-import {
-  ONBOARDING_REQUESTS_EXPORT_HEADERS,
-  OnboardingRequestsExportService
-} from './onboarding-requests-export.service';
+import { OnboardingRequestsExportService } from './onboarding-requests-export.service';
 
 const mockedOnboardingRequestService = mock(OnboardingRequestService);
 const mockedUserService = mock(UserService);
@@ -32,8 +29,17 @@ describe('OnboardingRequestsExportService', () => {
 
     const tsv = await env.service.createTsv([]);
 
-    expect(env.lines(tsv)[0]).toEqual(ONBOARDING_REQUESTS_EXPORT_HEADERS.join('\t'));
-    expect(ONBOARDING_REQUESTS_EXPORT_HEADERS[0]).toEqual('request_date_utc');
+    expect(env.headers(tsv, '\t')).toEqual([
+      'request_date_utc',
+      'resolution',
+      'requester',
+      'language_code',
+      'project_shortname',
+      'language_name',
+      'assignee',
+      'request_id',
+      'sf_project_id'
+    ]);
   });
 
   it('maps a request to a tab-separated row in the correct column order', async () => {
@@ -64,7 +70,7 @@ describe('OnboardingRequestsExportService', () => {
     const tsv = await env.service.createTsv([request]);
 
     const cells = env.lines(tsv)[1].split('\t');
-    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('request_date_utc');
+    const index = env.headerIndex(tsv, '\t', 'request_date_utc');
     expect(cells[index]).toEqual('');
   });
 
@@ -76,7 +82,7 @@ describe('OnboardingRequestsExportService', () => {
     const tsv = await env.service.createTsv([request]);
 
     const cells = env.lines(tsv)[1].split('\t');
-    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('project_shortname');
+    const index = env.headerIndex(tsv, '\t', 'project_shortname');
     expect(cells[index]).toEqual(UNKNOWN_PROJECT_ID);
   });
 
@@ -86,7 +92,7 @@ describe('OnboardingRequestsExportService', () => {
     const tsv = await env.service.createTsv([env.createRequest({ assigneeId: '' })]);
 
     const cells = env.lines(tsv)[1].split('\t');
-    const index = ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('assignee');
+    const index = env.headerIndex(tsv, '\t', 'assignee');
     expect(cells[index]).toEqual('');
   });
 
@@ -95,8 +101,19 @@ describe('OnboardingRequestsExportService', () => {
 
     const csv = await env.service.createCsv([env.createRequest()]);
 
-    expect(env.lines(csv)[0]).toEqual(ONBOARDING_REQUESTS_EXPORT_HEADERS.join(','));
-    expect(env.lines(csv)[1].split(',')[ONBOARDING_REQUESTS_EXPORT_HEADERS.indexOf('request_id')]).toEqual(REQUEST_ID);
+    expect(env.headers(csv, ',')).toEqual([
+      'request_date_utc',
+      'resolution',
+      'requester',
+      'language_code',
+      'project_shortname',
+      'language_name',
+      'assignee',
+      'request_id',
+      'sf_project_id'
+    ]);
+    const requestIdIndex = env.headerIndex(csv, ',', 'request_id');
+    expect(env.lines(csv)[1].split(',')[requestIdIndex]).toEqual(REQUEST_ID);
   });
 
   it('produces one data row per request', async () => {
@@ -177,5 +194,13 @@ class TestEnvironment {
 
   lines(content: string): string[] {
     return content.split('\n').map(line => line.replace(/\r$/, ''));
+  }
+
+  headers(content: string, delimiter: string): string[] {
+    return this.lines(content)[0].split(delimiter);
+  }
+
+  headerIndex(content: string, delimiter: string, header: string): number {
+    return this.headers(content, delimiter).indexOf(header);
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
@@ -9,8 +9,7 @@ import {
 } from '../../translate/draft-generation/onboarding-request.service';
 import { ServalAdministrationService } from '../serval-administration.service';
 
-/** Column headers for the onboarding requests export, in the order they appear in the exported file. */
-export const ONBOARDING_REQUESTS_EXPORT_HEADERS = [
+const ONBOARDING_REQUESTS_SPREADSHEET_HEADINGS = [
   'request_date_utc',
   'resolution',
   'requester',
@@ -21,6 +20,13 @@ export const ONBOARDING_REQUESTS_EXPORT_HEADERS = [
   'request_id',
   'sf_project_id'
 ] as const;
+
+type OnboardingRequestSpreadsheetHeading = (typeof ONBOARDING_REQUESTS_SPREADSHEET_HEADINGS)[number];
+
+/**
+ * Represents a single onboarding request row to be exported to a spreadsheet.
+ */
+export type OnboardingRequestSpreadsheetRow = Record<OnboardingRequestSpreadsheetHeading, string>;
 
 /**
  * Builds spreadsheet exports of onboarding requests.
@@ -59,32 +65,46 @@ export class OnboardingRequestsExportService {
     return `onboarding-requests_${year}-${month}-${day}_${hours}${minutes}${seconds}Z.${extension}`;
   }
 
+  private transformSpreadsheetRowsForExport(rows: OnboardingRequestSpreadsheetRow[]): string[][] {
+    return rows.map(row => {
+      return ONBOARDING_REQUESTS_SPREADSHEET_HEADINGS.map(heading => row[heading] ?? '');
+    });
+  }
+
   private async createSeparatedValues(requests: OnboardingRequest[], delimiter: string): Promise<string> {
     const assigneeNames = await this.lookupAssigneeNames(requests);
 
-    const data: string[][] = await Promise.all(
-      requests.map(async request => {
-        const sfProjectId = request.submission.projectId;
-        const projectDoc = await this.servalAdministrationService.get(sfProjectId);
-        const projectShortName = projectDoc?.data?.shortName ?? sfProjectId;
-        return [
-          this.formatRequestDateUtc(request.submission.timestamp) ?? '',
-          this.onboardingRequestService.getResolution(request.resolution).label,
-          request.submission.formData.name,
-          request.submission.formData.translationLanguageIsoCode,
-          projectShortName,
-          request.submission.formData.translationLanguageName,
-          assigneeNames.get(request.assigneeId) ?? '',
-          request.id,
-          sfProjectId
-        ];
-      })
+    const spreadsheetRows: OnboardingRequestSpreadsheetRow[] = await Promise.all(
+      requests.map(async request => this.createSpreadsheetRow(request, assigneeNames))
     );
 
+    const dataRows: string[][] = this.transformSpreadsheetRowsForExport(spreadsheetRows);
+
     return Papa.unparse(
-      { fields: [...ONBOARDING_REQUESTS_EXPORT_HEADERS], data },
+      { fields: [...ONBOARDING_REQUESTS_SPREADSHEET_HEADINGS], data: dataRows },
       { delimiter: delimiter, escapeFormulae: true }
     );
+  }
+
+  private async createSpreadsheetRow(
+    request: OnboardingRequest,
+    assigneeNames: Map<string, string>
+  ): Promise<OnboardingRequestSpreadsheetRow> {
+    const sfProjectId = request.submission.projectId;
+    const projectDoc = await this.servalAdministrationService.get(sfProjectId);
+    const projectShortName = projectDoc?.data?.shortName ?? sfProjectId;
+
+    return {
+      request_date_utc: this.formatRequestDateUtc(request.submission.timestamp) ?? '',
+      resolution: this.onboardingRequestService.getResolution(request.resolution).label,
+      requester: request.submission.formData.name,
+      language_code: request.submission.formData.translationLanguageIsoCode,
+      project_shortname: projectShortName,
+      language_name: request.submission.formData.translationLanguageName,
+      assignee: assigneeNames.get(request.assigneeId) ?? '',
+      request_id: request.id,
+      sf_project_id: sfProjectId
+    };
   }
 
   /** Resolves the display name for each unique populated SF assignee user ID. */

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/onboarding-requests/onboarding-requests-export.service.ts
@@ -26,7 +26,7 @@ type OnboardingRequestSpreadsheetHeading = (typeof ONBOARDING_REQUESTS_SPREADSHE
 /**
  * Represents a single onboarding request row to be exported to a spreadsheet.
  */
-export type OnboardingRequestSpreadsheetRow = Record<OnboardingRequestSpreadsheetHeading, string>;
+type OnboardingRequestSpreadsheetRow = Record<OnboardingRequestSpreadsheetHeading, string>;
 
 /**
  * Builds spreadsheet exports of onboarding requests.


### PR DESCRIPTION
This patch adjusts the onboarding request exporter so that there is
more definition given to ordering output columns.

This PR is in response to a comment on #3954.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/3963)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3963)
<!-- Reviewable:end -->
