### PR TITLE
SF-3822 Allow drafting any book that is present in the source

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/generate-draft.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/generate-draft.ts
@@ -92,7 +92,7 @@ export async function generateDraft(
   await screenshot(page, { pageName: 'generate_draft_confirm_sources', ...context });
 
   await goToNextStepExpectingHeading('Select books to draft');
-  await expect(getStep().getByRole('option')).toHaveCount(3);
+  await expect(getStep().getByRole('option')).toHaveCount(66);
   const options = await getStep().getByRole('option').all();
 
   let previousBookWasSelected = false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -247,6 +247,7 @@ describe('DraftGenerationStepsComponent', () => {
     const availableBooks = [{ bookNum: 1 }, { bookNum: 2 }, { bookNum: 3 }, { bookNum: 5 }];
     const allBooks = [...availableBooks, { bookNum: 6 }, { bookNum: 7 }, { bookNum: 8 }];
     const sourceBooks = allBooks.filter(b => b.bookNum !== 6);
+    const emptyDraftSourceBooks = [5];
     const config: DraftSourcesAsArrays = {
       trainingSources: [
         {
@@ -305,7 +306,6 @@ describe('DraftGenerationStepsComponent', () => {
       const progress = new ProjectProgress(books);
       when(mockProgressService.getProgress('project01', anything())).thenResolve(progress);
 
-      const emptyBookNums = [5];
       when(mockActivatedProjectService.projectDoc).thenReturn(mockTargetProjectDoc);
       when(mockActivatedProjectService.projectDoc$).thenReturn(targetProjectDoc$);
       when(mockActivatedProjectService.changes$).thenReturn(targetProjectDoc$);
@@ -313,7 +313,7 @@ describe('DraftGenerationStepsComponent', () => {
       setupProjectProfileMock(
         sourceProjectId,
         sourceBooks.map(b => b.bookNum),
-        emptyBookNums
+        emptyDraftSourceBooks
       );
       when(mockNllbLanguageService.isNllbLanguageAsync(anything())).thenResolve(true);
       when(mockFeatureFlagService.showDeveloperTools).thenReturn(createTestFeatureFlag(false));
@@ -326,24 +326,24 @@ describe('DraftGenerationStepsComponent', () => {
     }));
 
     it('should set "allAvailableTranslateBooks" correctly', fakeAsync(() => {
-      expect(component.allAvailableTranslateBooks).toEqual([
-        { number: 1, selected: false },
-        { number: 2, selected: false },
-        { number: 3, selected: false },
-        { number: 5, selected: false },
-        { number: 8, selected: false }
-      ]);
+      expect(component.allAvailableTranslateBooks).toEqual(
+        sourceBooks.map(b => ({ number: b.bookNum, selected: false }))
+      );
     }));
 
     it('should set "availableTranslateBooks" correctly', fakeAsync(() => {
       expect(component.availableTranslateBooks).toEqual({
-        sourceProject: [
-          { number: 1, selected: false },
-          { number: 2, selected: false },
-          { number: 3, selected: false },
-          { number: 8, selected: false }
-        ]
+        sourceProject: sourceBooks
+          .map(b => ({ number: b.bookNum, selected: false }))
+          .filter(b => !emptyDraftSourceBooks.includes(b.number))
       });
+    }));
+
+    it('should set "selectableTranslateBooksByProj" correctly', fakeAsync(() => {
+      // all non-empty books in the drafting source are available
+      expect(component.selectableTranslateBooksByProj(config.draftingSources[0].projectRef).map(b => b.number)).toEqual(
+        sourceBooks.map(b => b.bookNum).filter(b => !emptyDraftSourceBooks.includes(b))
+      );
     }));
 
     it('should set "availableTrainingBooks" correctly', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -215,7 +215,7 @@ export class DraftGenerationStepsComponent implements OnInit {
           this.setProjectDisplayNames(trainingTargets[0], draftingSources[0]);
 
           // The null values will have been filtered above
-          const target = trainingTargets[0]!;
+          const target: DraftSource = trainingTargets[0]!;
           const draftingSource: DraftSource = draftingSources[0]!;
           // If both source and target project languages are in the NLLB,
           // training book selection is optional (and discouraged).
@@ -273,34 +273,41 @@ export class DraftGenerationStepsComponent implements OnInit {
           // Reset the field that toggles a notice that books were automatically selected
           this.trainingBooksWereAutoSelected = false;
 
-          // If book exists in both target and source, add to available books.
-          // Otherwise, add to unusable books.
-          // Ensure books are displayed in ascending canonical order.
-          const targetBooks = new Set<number>();
           const projectProgress = await this.progressService.getProgress(projectId, {
             maxStalenessMs: 30_000
           });
+
+          const sortedDraftingSourceBooks = Array.from(draftingSourceBooks).sort((a, b) => a - b);
+          // Iterate through books in the drafting source (sorted by book number)
+          // TODO: When implementing multiple drafting sources, this should be updated to handle multiple sources
+          for (const bookNum of sortedDraftingSourceBooks) {
+            // exclude non-canonical books
+            if (Canon.isExtraMaterial(bookNum)) {
+              continue;
+            }
+            // Translate books: Add all books with content from the source
+            const book: Book = { number: bookNum, selected: false };
+            this.allAvailableTranslateBooks.push(book);
+            if (this.bookHasVerseContent(draftingSource.projectRef, bookNum)) {
+              this.availableTranslateBooks[draftingSource.projectRef].push(book);
+            } else {
+              this.emptyTranslateSourceBooks.push(bookNum);
+            }
+          }
+          // Set books in target that do not exist in the drafting source
+          this.unusableTranslateSourceBooks = target.texts
+            .map(t => t.bookNum)
+            .filter(bookNum => !this.allAvailableTranslateBooks.some(b => b.number === bookNum));
+
+          const targetBooks = new Set<number>();
+          // Now handle training books - iterate through target books
           for (const text of target.texts.slice().sort((a, b) => a.bookNum - b.bookNum)) {
-            const bookNum = text.bookNum;
+            const bookNum: number = text.bookNum;
             targetBooks.add(bookNum);
 
             // Exclude non-canonical books
             if (Canon.isExtraMaterial(bookNum)) {
               continue;
-            }
-
-            // Translate books
-            // TODO: When implementing multiple drafting sources, this should be updated to handle multiple sources
-            if (draftingSourceBooks.has(bookNum)) {
-              const book: Book = { number: bookNum, selected: false };
-              this.allAvailableTranslateBooks.push(book);
-              if (this.bookHasVerseContent(draftingSource.projectRef, bookNum)) {
-                this.availableTranslateBooks[draftingSource.projectRef].push(book);
-              } else {
-                this.emptyTranslateSourceBooks.push(bookNum);
-              }
-            } else {
-              this.unusableTranslateSourceBooks.push(bookNum);
             }
 
             // See if there is an existing training scripture range


### PR DESCRIPTION
This PR allows users to select any book for drafting that is present in the drafting source. Previous work has enabled books not currently present in the target project to be visible to previous formatting and view in the editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3965)
<!-- Reviewable:end -->
