### PR TITLE
Complete removal of Paratext account linking

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/paratext.service.ts
@@ -2,7 +2,6 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { firstValueFrom, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { AuthService } from 'xforge-common/auth.service';
 import { TextSnapshot } from 'xforge-common/models/textsnapshot';
 import { PARATEXT_API_NAMESPACE } from 'xforge-common/url-constants';
 import { compareProjectsForSorting } from '../shared/utils';
@@ -62,14 +61,7 @@ export class ParatextService {
     return paratextId.length === RESOURCE_IDENTIFIER_LENGTH;
   }
 
-  constructor(
-    private readonly http: HttpClient,
-    private readonly authService: AuthService
-  ) {}
-
-  linkParatext(returnUrl: string): void {
-    void this.authService.linkParatext(returnUrl);
-  }
+  constructor(private readonly http: HttpClient) {}
 
   getParatextUsername(): Observable<string | undefined> {
     return this.http

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.html
@@ -12,24 +12,7 @@
             <mat-card-title>{{ t("translate") }}</mat-card-title>
             <div class="tool-setting">
               @if (!isLoadingData && !isLoggedInToParatext && isAppOnline) {
-                <div class="paratext-login-container">
-                  <button
-                    class="action-button"
-                    mat-flat-button
-                    type="button"
-                    (click)="logInWithParatext()"
-                    id="btn-log-in-settings"
-                  >
-                    <mat-icon>
-                      <img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" />
-                    </mat-icon>
-                    {{ t("log_in_with_paratext") }}
-                  </button>
-                  <span
-                    class="more-options"
-                    [innerHTML]="i18n.translateAndInsertTags('settings.enable_translation_suggestions')"
-                  ></span>
-                </div>
+                <app-paratext-account-notice id="paratext-account-not-connected" />
               }
               @if (mainSettingsLoaded) {
                 <p class="helper-text">{{ t("select_project_or_resource") }}</p>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.scss
@@ -95,19 +95,6 @@ a {
   padding-left: 16px;
 }
 
-.paratext-login-container {
-  margin-top: 16px;
-  margin-left: 24px;
-
-  .paratext-logo {
-    width: 100%;
-  }
-
-  > .more-options {
-    margin-left: 16px;
-  }
-}
-
 .mat-mdc-checkbox {
   padding: 3px 0px;
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.spec.ts
@@ -190,12 +190,12 @@ describe('SettingsComponent', () => {
     }));
 
     describe('Translation Suggestions options', () => {
-      it('should see login button when Paratext account not connected', fakeAsync(() => {
+      it('should show the Paratext account notice when Paratext account not connected', fakeAsync(() => {
         const env = new TestEnvironment();
         env.setupProject({ translateConfig: { translationSuggestionsEnabled: true } });
         when(mockedParatextService.getParatextUsername()).thenReturn(of(undefined));
         env.wait();
-        expect(env.loginButton).not.toBeNull();
+        expect(env.paratextAccountNotice).not.toBeNull();
         expect(env.inputElement(env.translationSuggestionsCheckbox).disabled).toBe(false);
         expect(env.basedOnSelect).not.toBeNull();
       }));
@@ -847,8 +847,8 @@ class TestEnvironment {
     return this.fixture.debugElement.query(By.css('#based-on-status'));
   }
 
-  get loginButton(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#btn-log-in-settings'));
+  get paratextAccountNotice(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#paratext-account-not-connected'));
   }
 
   get checkingCheckbox(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/settings/settings.component.ts
@@ -41,6 +41,7 @@ import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { ProjectSelectComponent } from '../project-select/project-select.component';
 import { InfoComponent } from '../shared/info/info.component';
+import { ParatextAccountNoticeComponent } from '../shared/paratext-account-notice/paratext-account-notice.component';
 import { DeleteProjectDialogComponent } from './delete-project-dialog/delete-project-dialog.component';
 
 /** Allows user to configure high-level settings of how SF will use their Paratext project. */
@@ -67,7 +68,8 @@ import { DeleteProjectDialogComponent } from './delete-project-dialog/delete-pro
     MatRadioButton,
     TranslocoMarkupComponent,
     RouterLinkDirective,
-    MatCardActions
+    MatCardActions,
+    ParatextAccountNoticeComponent
   ]
 })
 export class SettingsComponent extends DataLoadingComponent implements OnInit {
@@ -270,15 +272,6 @@ export class SettingsComponent extends DataLoadingComponent implements OnInit {
           this.updateFormEnabled();
         }
       });
-  }
-
-  logInWithParatext(): void {
-    if (this.projectDoc == null) {
-      return;
-    }
-
-    const url = '/projects/' + this.projectDoc.id + '/settings';
-    this.paratextService.linkParatext(url);
   }
 
   openDeleteProjectDialog(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/paratext-account-notice/paratext-account-notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/paratext-account-notice/paratext-account-notice.component.html
@@ -1,0 +1,3 @@
+<ng-container *transloco="let t; read: 'paratext_account_notice'">
+  <app-notice type="warning" icon="info">{{ t("not_connected") }}</app-notice>
+</ng-container>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/paratext-account-notice/paratext-account-notice.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/paratext-account-notice/paratext-account-notice.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { TranslocoModule } from '@ngneat/transloco';
+import { NoticeComponent } from '../notice/notice.component';
+
+/**
+ * Shown in place of the old "Log in to Paratext" buttons for the edge case of a logged-in user whose account is not
+ * connected to a Paratext account.
+ */
+@Component({
+  selector: 'app-paratext-account-notice',
+  templateUrl: './paratext-account-notice.component.html',
+  imports: [TranslocoModule, NoticeComponent]
+})
+export class ParatextAccountNoticeComponent {}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.html
@@ -18,10 +18,7 @@
     <mat-card class="sync-card">
       <div class="card-content">
         @if (showParatextLogin && isAppOnline) {
-          <button mat-flat-button type="button" (click)="logInWithParatext()" id="btn-log-in">
-            <mat-icon><img src="/assets/images/logo-pt9.png" alt="Paratext Logo" class="paratext-logo" /></mat-icon>
-            {{ t("log_in_to_paratext") }}
-          </button>
+          <app-paratext-account-notice id="paratext-account-not-connected" />
         }
         @if (isLoggedIntoParatext || isLoadingData || !isAppOnline) {
           @if (!syncActive) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.scss
@@ -1,4 +1,3 @@
-@use 'src/variables';
 @use 'src/breakpoints';
 
 h1 {
@@ -61,16 +60,6 @@ h1 {
 }
 
 app-sync-progress {
-  width: 100%;
-}
-
-#btn-log-in {
-  background-color: variables.$pt-button-green;
-  color: white;
-  height: 2.5rem;
-}
-
-.paratext-logo {
   width: 100%;
 }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.spec.ts
@@ -58,37 +58,27 @@ describe('SyncComponent', () => {
     ]
   }));
 
-  it('should display Log In to Paratext', fakeAsync(() => {
+  it('should display the Paratext account notice when not connected to Paratext', fakeAsync(() => {
     const env = new TestEnvironment({ isParatextAccountConnected: false });
     expect(env.title.textContent).toContain('Synchronize Sync Test Project with Paratext');
-    expect(env.logInButton.nativeElement.textContent).toContain('Log in to Paratext');
+    expect(env.paratextAccountNotice.nativeElement.textContent).toContain('Paratext');
     expect(env.syncButton).toBeNull();
     expect(env.lastSyncDate).toBeNull();
-    expect(env.logInButton.nativeElement.disabled).toBe(false);
     env.onlineStatus = false;
-    expect(env.logInButton).toBeNull();
-  }));
-
-  it('should redirect the user to Log In to Paratext', fakeAsync(() => {
-    const env = new TestEnvironment({ isParatextAccountConnected: false });
-
-    env.clickElement(env.logInButton);
-
-    verify(mockedParatextService.linkParatext(anything())).once();
-    expect().nothing();
+    expect(env.paratextAccountNotice).toBeNull();
   }));
 
   it('should display sync project', fakeAsync(() => {
     const env = new TestEnvironment();
     expect(env.title.textContent).toContain('Synchronize Sync Test Project with Paratext');
-    expect(env.logInButton).toBeNull();
+    expect(env.paratextAccountNotice).toBeNull();
     expect(env.syncButton.nativeElement.textContent).toContain('Sync with Paratext');
     expect(env.lastSyncDate.textContent).toContain('Last synced on');
   }));
 
   it('should disable button when offline', fakeAsync(() => {
     const env = new TestEnvironment({ isParatextAccountConnected: true, isInProgress: false, isOnline: false });
-    expect(env.logInButton).toBeNull();
+    expect(env.paratextAccountNotice).toBeNull();
     expect(env.syncButton.nativeElement.disabled).toBe(true);
     expect(env.lastSyncDate.textContent).toContain('Last synced on');
     expect(env.offlineMessage).not.toBeNull();
@@ -110,7 +100,7 @@ describe('SyncComponent', () => {
     expect(env.component.syncActive).toBe(true);
     expect(env.progressBar).not.toBeNull();
     expect(env.cancelButton).not.toBeNull();
-    expect(env.logInButton).toBeNull();
+    expect(env.paratextAccountNotice).toBeNull();
     expect(env.syncButton).toBeNull();
     env.emitSyncComplete(true, env.projectId);
     expect(env.component.lastSyncDate!.getTime()).toBeGreaterThan(previousLastSyncDate!.getTime());
@@ -200,7 +190,7 @@ describe('SyncComponent', () => {
       isOnline: true,
       isSyncDisabled: true
     });
-    expect(env.logInButton).toBeNull();
+    expect(env.paratextAccountNotice).toBeNull();
     expect(env.syncButton.nativeElement.disabled).toBe(true);
     expect(env.lastSyncDate.textContent).toContain('Last synced on');
     expect(env.syncDisabledMessage).not.toBeNull();
@@ -319,8 +309,8 @@ class TestEnvironment {
     this.fixture.detectChanges();
   }
 
-  get logInButton(): DebugElement {
-    return this.fixture.debugElement.query(By.css('#btn-log-in'));
+  get paratextAccountNotice(): DebugElement {
+    return this.fixture.debugElement.query(By.css('#paratext-account-not-connected'));
   }
 
   get syncButton(): DebugElement {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -22,6 +22,7 @@ import { SFProjectDoc } from '../core/models/sf-project-doc';
 import { ParatextService } from '../core/paratext.service';
 import { SFProjectService } from '../core/sf-project.service';
 import { NoticeComponent } from '../shared/notice/notice.component';
+import { ParatextAccountNoticeComponent } from '../shared/paratext-account-notice/paratext-account-notice.component';
 import { SyncProgressComponent } from './sync-progress/sync-progress.component';
 /** Reports as to whether a given project is actively syncing right now. */
 export function isSFProjectSyncing(project: SFProjectProfile): boolean {
@@ -36,7 +37,17 @@ enum SyncErrorCodes {
   selector: 'app-sync',
   templateUrl: './sync.component.html',
   styleUrls: ['./sync.component.scss'],
-  imports: [TranslocoModule, NoticeComponent, MatCard, MatButton, MatIcon, SyncProgressComponent, MatHint, MatTooltip]
+  imports: [
+    TranslocoModule,
+    NoticeComponent,
+    ParatextAccountNoticeComponent,
+    MatCard,
+    MatButton,
+    MatIcon,
+    SyncProgressComponent,
+    MatHint,
+    MatTooltip
+  ]
 })
 export class SyncComponent extends DataLoadingComponent implements OnInit {
   isAppOnline: boolean = false;
@@ -188,14 +199,6 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
         }
       });
     });
-  }
-
-  logInWithParatext(): void {
-    if (this.projectDoc == null) {
-      return;
-    }
-    const url = '/projects/' + this.projectDoc.id + '/sync';
-    this.paratextService.linkParatext(url);
   }
 
   syncProject(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -123,7 +123,6 @@
     "enable_community_checking": "Enable Community Checking",
     "engage_the_wider_community_to_check_scripture": "Engage the wider community to ensure that the translation is clear, accurate, and natural. Select verses, ask targeted questions, allow discussion of answers.",
     "error_fetching_resources": "There was an error fetching the Digital Bible Library resources. You will only be able to select projects.",
-    "paratext_account_linked_to_another_user": "You have logged into a Paratext account that is already linked to a user with the email {{ email }}. You will be logged out of your current account and proceed as the Paratext user.",
     "problem_already_connected": "The project is already connected. Maybe another project administrator connected the project at the same time. Please try again. If it continues to be a problem, please report the issue so we can get it fixed.",
     "proceed": "Proceed",
     "project_settings": "Project Settings",
@@ -684,6 +683,9 @@
     "previous_page": "Previous page",
     "range_label": "{{ startIndex }} - {{ endIndex }} of {{ length }}"
   },
+  "paratext_account_notice": {
+    "not_connected": "Your account isn't connected to Paratext. To continue, log out and sign in with your Paratext account."
+  },
   "project_select": {
     "please_select_valid_project_or_resource": "Please select a valid project or resource",
     "projects": "Projects",
@@ -750,7 +752,6 @@
     "delete_this_project": "Delete this project",
     "email_invitations_only": "Email invitations only",
     "enable_community_checking": "Enable Community Checking",
-    "enable_translation_suggestions": "to enable {{ boldStart }}Translate Suggestions{{ boldEnd }} and see more options",
     "engage_the_wider_community": "Engage the wider community to ensure that the translation is clear, accurate, and natural. Select verses, ask questions, and discuss answers.",
     "error_fetching_projects_resources": "There was an error fetching projects and resources. You can't change what the project is based on.",
     "error_fetching_projects": "There was an error fetching projects. You will only be able to select resources from Digital Bible Library.",
@@ -760,7 +761,6 @@
     "export_marked_for_export": "Answers flagged for review",
     "export_none": "No answers",
     "exporting_answers": "Exporting Answers",
-    "log_in_with_paratext": "Log in to Paratext",
     "see_others_answers_and_comments": "Allow checkers to see each other's answers and comments",
     "select_project_or_resource": "Select the Paratext project or Digital Bible Library resource that your project is based on. If your project is based on a Paratext project, it's best to set it up as a daughter project in Paratext.",
     "settings": "Settings",
@@ -831,7 +831,6 @@
     "connect_network_to_synchronize": "Please connect to the internet to synchronize this project",
     "initialize_sync": "Initializing sync...",
     "last_synced_time_stamp": "Last synced on {{ timeStamp }}",
-    "log_in_to_paratext": "Log in to Paratext",
     "never_been_synced": "Never been synced",
     "phase_0": "Connecting to project",
     "phase_0_percent": "Checking SF books and notes {{progressPercent}}%",

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -27,7 +27,7 @@ import {
 } from './auth.service';
 import { Auth0Service, TransparentAuthenticationCookie } from './auth0.service';
 import { BugsnagService } from './bugsnag.service';
-import { CommandError, CommandErrorCode, CommandService } from './command.service';
+import { CommandService } from './command.service';
 import { DialogService } from './dialog.service';
 import { ErrorReportingService } from './error-reporting.service';
 import { LocalSettingsService } from './local-settings.service';
@@ -215,7 +215,6 @@ describe('AuthService', () => {
           expires_in: 720,
           token_type: 'Bearer'
         },
-        idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
         loginResult: {
           appState: JSON.stringify({ returnUrl: '' }),
           response_type: ResponseType.Code
@@ -242,7 +241,6 @@ describe('AuthService', () => {
           expires_in: 720,
           token_type: 'Bearer'
         },
-        idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
         loginResult: {
           appState: JSON.stringify({ returnUrl: '' }),
           response_type: ResponseType.Code
@@ -269,7 +267,6 @@ describe('AuthService', () => {
           expires_in: 720,
           token_type: 'Bearer'
         },
-        idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
         loginResult: {
           appState: JSON.stringify({ returnUrl: '' }),
           response_type: ResponseType.Code
@@ -427,29 +424,6 @@ describe('AuthService', () => {
     expect(authOptions!.authorizationParams!.logo).not.toEqual(sfLogoUrl);
   }));
 
-  it('should link with Paratext', fakeAsync(() => {
-    const env = new TestEnvironment({ isOnline: true, isLoggedIn: true });
-    const returnUrl = 'test-returnUrl';
-
-    env.service.linkParatext(returnUrl);
-    tick();
-
-    verify(mockedWebAuth.loginWithRedirect(anything())).once();
-    const authOptions: RedirectLoginOptions | undefined = capture<RedirectLoginOptions | undefined>(
-      mockedWebAuth.loginWithRedirect
-    ).last()[0];
-    expect(authOptions).toBeDefined();
-    if (authOptions != null) {
-      expect(authOptions.appState).toBeDefined();
-      const state = JSON.parse(authOptions.appState!);
-      expect(state.returnUrl).toEqual(returnUrl);
-      expect(state.linking).toBe(true);
-      expect(authOptions.authorizationParams!.ui_locales).toEqual(env.language);
-      expect(authOptions.authorizationParams!.login_hint).toEqual(env.language);
-    }
-    env.discardTokenExpiryTimer();
-  }));
-
   it('should update interface language if logged in', fakeAsync(() => {
     const env = new TestEnvironment({ isOnline: true, isLoggedIn: true });
     const interfaceLanguage = 'es';
@@ -544,41 +518,6 @@ describe('AuthService', () => {
     verify(mockedWebAuth.getTokenSilently(anything())).twice();
     verify(mockedDialogService.message(anything(), anything())).once();
     mockedConsole.verify();
-  }));
-
-  it('should link to paratext account on login', fakeAsync(() => {
-    const env = new TestEnvironment({
-      isOnline: true,
-      isNewlyLoggedIn: true,
-      loginState: {
-        returnUrl: '',
-        linking: true,
-        currentSub: 'user01'
-      }
-    });
-    expect(env.isAuthenticated).toBe(true);
-    expect(env.authLinkedId).toEqual(env.auth0Response!.idToken!.sub);
-    env.discardTokenExpiryTimer();
-  }));
-
-  it('should reload if an error occurred linking paratext user to another user', fakeAsync(() => {
-    const env = new TestEnvironment({
-      isOnline: true,
-      isNewlyLoggedIn: true,
-      loginState: {
-        returnUrl: '',
-        linking: true,
-        currentSub: 'user01'
-      },
-      accountLinkingResponse: new CommandError(CommandErrorCode.Other, 'paratext-linked-to-another-user')
-    });
-    expect(env.isAuthenticated).toBe(true);
-    verify(mockedLocationService.reload()).once();
-    verify(mockedDialogService.message(anything(), anything())).once();
-    // handleOnlineAuth gets called a second time after the dialog is closed
-    verify(mockedRouter.navigateByUrl('/projects', anything())).twice();
-
-    env.discardTokenExpiryTimer();
   }));
 
   it('should redirect to url after successful login', fakeAsync(() => {
@@ -795,7 +734,6 @@ interface TestEnvironmentConstructorArgs {
   isNewlyLoggedIn?: boolean;
   loginState?: AuthState;
   setTransparentAuthenticationCookie?: boolean;
-  accountLinkingResponse?: CommandError;
   auth0Response?: AuthDetails | undefined;
   callback?: (env: TestEnvironment) => void;
 }
@@ -816,7 +754,6 @@ interface LocalSettings {
 class TestEnvironment {
   static userId = 'user01';
   auth0Response: AuthDetails | undefined = {
-    idToken: undefined,
     loginResult: { appState: JSON.stringify({}), response_type: ResponseType.Code },
     token: { id_token: '', access_token: '', expires_in: 0, token_type: 'Bearer' }
   };
@@ -829,7 +766,6 @@ class TestEnvironment {
   private tokenExpiryTimer = 720; // 2 hours
   readonly localSettings = new Map<string, string[] | string | number>();
   private _localeSettingsRemoveChanges = new Subject<StorageEvent>();
-  private _loginLinkedAccountId: string | undefined;
   private readonly _authLoginState: string;
 
   static encodeAccessToken(token: Auth0AccessToken): string {
@@ -844,7 +780,6 @@ class TestEnvironment {
     isNewlyLoggedIn,
     loginState = { returnUrl: '' },
     setTransparentAuthenticationCookie,
-    accountLinkingResponse,
     auth0Response,
     callback
   }: TestEnvironmentConstructorArgs = {}) {
@@ -887,16 +822,6 @@ class TestEnvironment {
     when(mockedDialogService.message(anything(), anything())).thenResolve();
     when(mockedAuth0Service.init(anything())).thenReturn(instance(mockedWebAuth));
     when(mockedAuth0Service.changePassword(anything())).thenReturn(new Promise(r => r));
-    when(mockedCommandService.onlineInvoke(anything(), 'linkParatextAccount', anything())).thenCall(
-      (_url, _method, params) => {
-        if (accountLinkingResponse != null) {
-          throw accountLinkingResponse;
-        }
-        if (params?.secondaryId != null) {
-          this._loginLinkedAccountId = params.secondaryId;
-        }
-      }
-    );
     if (callback != null) {
       callback(this);
     }
@@ -913,10 +838,6 @@ class TestEnvironment {
     this.service.getAccessToken().then(token => (accessToken = token));
     tick();
     return accessToken;
-  }
-
-  get authLinkedId(): string | undefined {
-    return this._loginLinkedAccountId;
   }
 
   get isAuthenticated(): boolean {
@@ -996,7 +917,6 @@ class TestEnvironment {
   setLoginResponse(auth0Response?: AuthDetails | undefined): void {
     auth0Response ??= {
       token: this.validToken,
-      idToken: { __raw: '1', sub: '7890', email: 'test@example.com' },
       loginResult: {
         appState: this._authLoginState,
         response_type: ResponseType.Code
@@ -1005,7 +925,6 @@ class TestEnvironment {
     this.auth0Response = auth0Response;
     when(mockedWebAuth.getTokenSilently()).thenResolve(this.auth0Response!.token.access_token);
     when(mockedWebAuth.getTokenSilently(anything())).thenResolve(this.auth0Response!.token);
-    when(mockedWebAuth.getIdTokenClaims()).thenResolve(this.auth0Response!.idToken);
   }
 
   setLoginRequiredResponse(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -7,14 +7,12 @@ import {
   CacheKey,
   ConnectAccountRedirectResult,
   GetTokenSilentlyVerboseResponse,
-  IdToken,
   LogoutOptions,
   RedirectLoginOptions,
   RedirectLoginResult,
   WrappedCacheEntry
 } from '@auth0/auth0-spa-js';
 import jwtDecode from 'jwt-decode';
-import { clone } from 'lodash-es';
 import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { BehaviorSubject, firstValueFrom, Observable, of, Subscription, timer } from 'rxjs';
@@ -23,10 +21,9 @@ import { environment } from '../environments/environment';
 import { hasPropWithValue } from '../type-utils';
 import { Auth0Service, TransparentAuthenticationCookie } from './auth0.service';
 import { BugsnagService } from './bugsnag.service';
-import { CommandError, CommandService } from './command.service';
+import { CommandService } from './command.service';
 import { DialogService } from './dialog.service';
 import { ErrorReportingService } from './error-reporting.service';
-import { I18nService } from './i18n.service';
 import { LocalSettingsService } from './local-settings.service';
 import { LocationService } from './location.service';
 import { OfflineStore } from './offline-store';
@@ -52,12 +49,9 @@ export const ROLE_SETTING = 'role';
 
 export interface AuthState {
   returnUrl: string;
-  linking?: boolean;
-  currentSub?: string;
 }
 
 export interface AuthDetails {
-  idToken: IdToken | undefined;
   loginResult: RedirectLoginResult | ConnectAccountRedirectResult;
   token: GetTokenSilentlyVerboseResponse;
 }
@@ -86,7 +80,6 @@ interface xForgeAuth0Parameters extends AuthorizationParams {
   providedIn: 'root'
 })
 export class AuthService {
-  readonly ptLinkedToAnotherUserKey: string = 'paratext-linked-to-another-user';
   private _loggedInState$: BehaviorSubject<LoginResult | undefined> = new BehaviorSubject<LoginResult | undefined>(
     undefined
   );
@@ -117,8 +110,7 @@ export class AuthService {
     private readonly localSettings: LocalSettingsService,
     private readonly onlineStatusService: OnlineStatusService,
     private readonly dialogService: DialogService,
-    private readonly reportingService: ErrorReportingService,
-    private readonly i18n: I18nService
+    private readonly reportingService: ErrorReportingService
   ) {
     // Listen for changes to the auth state. If the user logs out in another tab/window, redirect to the home page.
     // When localStorage is cleared event.key is null. The logic below may be more specific than necessary, but we can't
@@ -269,21 +261,6 @@ export class AuthService {
     };
     this.unscheduleRenewal();
     await this.auth0.loginWithRedirect(authOptions);
-  }
-
-  async linkParatext(returnUrl: string): Promise<void> {
-    const idToken: IdToken | undefined = await this.auth0.getIdTokenClaims();
-    const state: AuthState = { returnUrl, linking: true, currentSub: idToken?.sub };
-    const language: string = getAspCultureCookieLanguage(this.cookieService.get(ASP_CULTURE_COOKIE_NAME));
-    const options: RedirectLoginOptions = {
-      authorizationParams: {
-        connection: 'paratext',
-        ui_locales: language,
-        login_hint: language
-      },
-      appState: JSON.stringify(state)
-    };
-    await this.auth0.loginWithRedirect(options);
   }
 
   async logOut(): Promise<void> {
@@ -469,8 +446,7 @@ export class AuthService {
         }
         const authDetails: AuthDetails = {
           loginResult,
-          token,
-          idToken: await this.auth0.getIdTokenClaims()
+          token
         };
         if (!(await this.handleOnlineAuth(authDetails))) {
           this.clearState();
@@ -501,57 +477,17 @@ export class AuthService {
       return false;
     }
 
-    let primaryId: string | undefined;
-    let secondaryId: string | undefined;
     const state: AuthState = JSON.parse(authDetails.loginResult.appState);
-    if (state.linking != null && state.linking) {
-      if (!(await this.isAuthenticated()) || authDetails.idToken == null) {
-        return false;
-      }
-      primaryId = state.currentSub;
-      secondaryId = authDetails.idToken.sub;
-    } else {
-      await this.localLogIn(authDetails.token.access_token, authDetails.token.id_token, authDetails.token.expires_in);
-    }
+    await this.localLogIn(authDetails.token.access_token, authDetails.token.id_token, authDetails.token.expires_in);
     await this.remoteStore.init(() => this.getAccessToken());
-    if (primaryId != null && secondaryId != null) {
-      try {
-        await this.commandService.onlineInvoke(USERS_URL, 'linkParatextAccount', { primaryId, secondaryId });
-        // Trigger a session check with auth0 so that tokens are reversed back to the primary account and not
-        // the Paratext account that was just merged into the primary - this causes a redirect back to auth0
-        await this.auth0.checkSession({ cacheMode: 'off' });
-      } catch (err) {
-        if (!(err instanceof CommandError) || !err.message.includes(this.ptLinkedToAnotherUserKey)) {
-          console.error(err);
-          return false;
-        }
-        void this.dialogService
-          .message(
-            this.i18n.translate('connect_project.paratext_account_linked_to_another_user', {
-              email: authDetails.idToken?.email
-            }),
-            'connect_project.proceed'
-          )
-          .then(async () => {
-            // Strip out the linking state so that we don't process linking again
-            const withoutLinkingState = clone(authDetails);
-            delete state.linking;
-            withoutLinkingState.loginResult.appState = JSON.stringify(state);
-            await this.handleOnlineAuth(withoutLinkingState);
-            // Reload the app for the new current user id to take effect
-            this.locationService.reload();
-          });
-      }
-    } else {
-      try {
-        await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
-      } catch (err) {
-        // Display error dialog to pause login loop.
-        // Error details will be sent to Bugsnag and logged to the console.
-        await this.handleLoginError('handleOnlineAuth', err);
+    try {
+      await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
+    } catch (err) {
+      // Display error dialog to pause login loop.
+      // Error details will be sent to Bugsnag and logged to the console.
+      await this.handleLoginError('handleOnlineAuth', err);
 
-        return false;
-      }
+      return false;
     }
     // Ensure the return URL is one we want to return the user to
     if (this.isValidReturnUrl(state.returnUrl)) {

--- a/src/SIL.XForge/Controllers/UsersRpcController.cs
+++ b/src/SIL.XForge/Controllers/UsersRpcController.cs
@@ -11,24 +11,6 @@ namespace SIL.XForge.Controllers;
 
 /// <summary>
 /// This is the controller for all JSON-RPC commands for users.
-///
-/// When a user logs into SF with a password account, and links that account to a PT account, the following appears to
-/// be the typical flow between frontend, backend .net app, and auth0:
-///
-/// Frontend: User goes to auth0 and logs in.
-/// Auth0: Calls SF backend RPC pushAuthUserProfile and sends user back to SF site.
-/// Backend: UserService.UpdateUserFromProfileAsync()
-/// Frontend: User is at SF and logged in.
-/// Frontend: User accesses Connect project, clicks "Log in with Paratext", and authenticates at PT Registry.
-/// Auth0: Decides not to immediately link original auth0 account and new PT auth0 account if they do not have the same,
-/// verified email address.
-/// Auth0: Calls SF backend RPC pushAuthUserProfile (which may not land quite yet?) and sends user back to SF site.
-/// Frontend: User is at SF and logged in with new PT auth0 account (if not already linked in auth0).
-/// Frontend: auth.service handleOnlineAuth() calls SF backend RPC linkParatextAccount if appropriate.
-/// Backend: If the PT auth0 account is new, UserService.LinkParatextAccount asks auth0 to link accounts.
-/// Auth0: Links (merges) new PT auth0 account as an identity on original  auth0 account.
-/// Frontend: Reloads page. User is at SF and logged in with original  auth0 account.
-/// Backend: UserService.UpdateUserFromProfileAsync() applies updates from original auth0 account.
 /// </summary>
 public class UsersRpcController : RpcControllerBase
 {
@@ -78,9 +60,6 @@ public class UsersRpcController : RpcControllerBase
         await _userService.UpdateUserFromProfileAsync(UserId, userProfile);
         return Ok();
     }
-
-    // Linking Paratext accounts is currently disabled
-    public async Task<IRpcMethodResult> LinkParatextAccount(string primaryId, string secondaryId) => ForbiddenError();
 
     public async Task<IRpcMethodResult> UpdateAvatarFromDisplayName()
     {

--- a/src/SIL.XForge/Services/AuthService.cs
+++ b/src/SIL.XForge/Services/AuthService.cs
@@ -93,12 +93,6 @@ public class AuthService : DisposableBase, IAuthService
         return CallApiAsync(HttpMethod.Post, "users", content);
     }
 
-    public Task LinkAccounts(string primaryAuthId, string secondaryAuthId)
-    {
-        var content = new JObject(new JProperty("provider", "oauth2"), new JProperty("user_id", secondaryAuthId));
-        return CallApiAsync(HttpMethod.Post, $"users/{primaryAuthId}/identities", content);
-    }
-
     public Task UpdateAvatar(string authId, string url)
     {
         var content = new JObject(new JProperty("user_metadata", new JObject(new JProperty("picture", url))));

--- a/src/SIL.XForge/Services/IAuthService.cs
+++ b/src/SIL.XForge/Services/IAuthService.cs
@@ -10,7 +10,6 @@ public interface IAuthService
     Task<Tokens?> GetParatextTokensAsync(string authId, CancellationToken token);
     Task<string> GetUserAsync(string authId);
     Task<string> GenerateAnonymousUser(string name, TransparentAuthenticationCredentials credentials, string language);
-    Task LinkAccounts(string primaryAuthId, string secondaryAuthId);
     Task UpdateAvatar(string authId, string url);
     Task UpdateInterfaceLanguage(string authId, string language);
 }

--- a/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
+++ b/test/SIL.XForge.Tests/Controllers/UsersRpcControllerTests.cs
@@ -16,7 +16,6 @@ public class UsersRpcControllerTests
     private static readonly string[] Roles = [SystemRole.User];
     private const string User01 = "user01";
     private const string User02 = "user02";
-    private const string AuthId01 = "auth0|user01";
 
     [Test]
     public async Task Delete_Forbidden()
@@ -57,7 +56,6 @@ public class UsersRpcControllerTests
         {
             var userAccessor = Substitute.For<IUserAccessor>();
             userAccessor.UserId.Returns(User01);
-            userAccessor.AuthId.Returns(AuthId01);
             userAccessor.SystemRoles.Returns(Roles);
             UserService = Substitute.For<IUserService>();
             var authService = Substitute.For<IAuthService>();


### PR DESCRIPTION
This finishes the work begun in #3938 

I have marked it `testing not required` because I'm not aware of any non-contrived way to reach it, *except* a system admin joining a project (and therefore not having a Paratext role).

In fact, I think the message could be completely ripped out, but I'm not confident enough to do it just yet.

<img width="623" height="240" alt="Screenshot from 2026-06-24 14-21-30" src="https://github.com/user-attachments/assets/64a281ac-c6a9-4771-bec0-1c3e7ad04b7f" />
<img width="880" height="431" alt="Screenshot from 2026-06-24 14-20-16" src="https://github.com/user-attachments/assets/287f605e-72e3-4b4c-9bae-de22bd534b51" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3968)
<!-- Reviewable:end -->
