### PR TITLE
Fix auth service timeout seconds vs ms bug

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -2,18 +2,22 @@ import { discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/te
 import { provideRouter, Router } from '@angular/router';
 import {
   Auth0Client,
+  CacheKey,
   GenericError,
   GetTokenSilentlyVerboseResponse,
   RedirectLoginOptions,
   ResponseType,
-  TimeoutError
+  TimeoutError,
+  WrappedCacheEntry
 } from '@auth0/auth0-spa-js';
 import { CookieService } from 'ngx-cookie-service';
 import { SystemRole } from 'realtime-server/lib/esm/common/models/system-role';
 import { Subject } from 'rxjs';
 import { anyString, anything, capture, instance, mock, resetCalls, spy, verify, when } from 'ts-mockito';
 import { MockConsole } from 'xforge-common/mock-console';
+import { environment } from '../environments/environment';
 import {
+  AUTH0_SCOPE,
   AuthDetails,
   AuthService,
   AuthState,
@@ -641,6 +645,18 @@ describe('AuthService', () => {
     verify(mockedWebAuth.getTokenSilently(anything())).never();
     verify(mockedWebAuth.loginWithRedirect(anything())).never();
     expect(env.isAuthenticated).toBeTrue();
+
+    // The auth0-spa-js cache entry seeded for transparent auth must store expiresAt as a Unix timestamp in seconds
+    const cacheKey = new CacheKey({
+      clientId: environment.authClientId,
+      audience: environment.audience,
+      scope: AUTH0_SCOPE
+    });
+    const cacheEntry = env.localSettings.get(cacheKey.toKey()) as unknown as WrappedCacheEntry;
+    const nowInSeconds = Math.floor(Date.now() / 1000);
+    expect(cacheEntry.expiresAt).toBeGreaterThanOrEqual(nowInSeconds);
+    expect(cacheEntry.expiresAt).toBeLessThanOrEqual(nowInSeconds + env.validToken.expires_in! + 5);
+
     env.discardTokenExpiryTimer();
   }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -39,6 +39,7 @@ export const XF_ROLE_CLAIM = 'http://xforge.org/role';
 export const ID_TOKEN_SETTING = 'id_token';
 export const USER_ID_SETTING = 'user_id';
 export const ROLES_SETTING = 'roles';
+/** Key for local storage of when the token expires (Unix epoch) in milliseconds */
 export const EXPIRES_AT_SETTING = 'expires_at';
 export const AUTH0_SCOPE = `openid profile email ${environment.scope} offline_access`;
 
@@ -155,6 +156,7 @@ export class AuthService {
     return this.localSettings.get(ID_TOKEN_SETTING);
   }
 
+  /** When the token expires (Unix epoch), in milliseconds */
   get expiresAt(): number | undefined {
     return this.localSettings.get(EXPIRES_AT_SETTING);
   }
@@ -316,7 +318,7 @@ export class AuthService {
     };
     const cacheEntry: WrappedCacheEntry = {
       body: { ...cacheBody, ...authResponse },
-      expiresAt: Date.now() + authResponse.expires_in
+      expiresAt: Math.floor(Date.now() / 1000) + authResponse.expires_in
     };
     this.localSettings.set(cacheKey.toKey(), cacheEntry);
     await this.localLogIn(authResponse.access_token, authResponse.id_token, authResponse.expires_in);


### PR DESCRIPTION
This fixes a line that confused milliseconds with seconds.

In order to verify this fix is correct two things have to be established:
1. `authResponse.expires_in` is in seconds, not ms
2. The `expiresAt` field we are writing will be interpreted as seconds when it is read

### Evidence for assertion 1:
The value `authResponse.expires_in` comes from `auth0Service.tryTransparentAuthentication()`, which calls `oauth/token`. If you look at [Auth0's docs](https://auth0.com/docs/api/authentication/authorization-code-flow/get-token#param-expires-in) you can see it says `The access token lifetime in seconds.`

Perhaps even more convincing (since it doesn't require assuming the Auth0 docs are talking about the same value we're working with): If you step through the debugger you'll see `expires_in` is `86400`, which if interpreted as milliseconds gives less than a minute and a half (1:26.4) vs 24 hours if interpreted as seconds.

### Evidence for assertion 2:
This is weaker, but if you look in the dependency at `src/SIL.XForge.Scripture/ClientApp/node_modules/@auth0/auth0-spa-js/dist/lib/auth0-spa-js.cjs.js` and go to line 1511, it has this:
``` js
if (wrappedEntry.expiresAt - expiryAdjustmentSeconds < nowSeconds) {
```
If you look a few lines higher, you'll see wrappedEntry comes from the cache, which I think in our case will mean it's looking in local storage.

### Additional change

We store a value called EXPIRES_AT_SETTING that is stored in milliseconds, and rather than try to change that, I added comments to clearly document it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3969)
<!-- Reviewable:end -->
