### PR TITLE
Update SIL.Machine to 3.9.0

### DIFF
--- a/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
+++ b/src/SIL.XForge.Scripture/SIL.XForge.Scripture.csproj
@@ -46,7 +46,7 @@
     <!-- When updating Serval.Client consider that API changes must be released to Serval Prod
         prior to testing on SF QA -->
     <PackageReference Include="Serval.Client" Version="1.18.0" />
-    <PackageReference Include="SIL.Machine" Version="3.8.4" />
+    <PackageReference Include="SIL.Machine" Version="3.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
   </ItemGroup>

--- a/src/SIL.XForge.Scripture/packages.lock.json
+++ b/src/SIL.XForge.Scripture/packages.lock.json
@@ -129,9 +129,9 @@
       },
       "SIL.Machine": {
         "type": "Direct",
-        "requested": "[3.8.4, )",
-        "resolved": "3.8.4",
-        "contentHash": "iyIGFWIneklLYaI856FuP7H097Gg8XsWgqaRrYTC6bd7YXjowrLzlK+oWqTiEQHdhWsA1M3A8wao800DDIrMVQ==",
+        "requested": "[3.9.0, )",
+        "resolved": "3.9.0",
+        "contentHash": "OdVAM9KLWZDcCS09XHmXG7LXW7388SRv0voZ+3ckrTL6e25+1g3GpTpDE3EbJG8hsOeLVRuadvBgFMsccvZM+w==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",

--- a/test/SIL.XForge.Scripture.Tests/packages.lock.json
+++ b/test/SIL.XForge.Scripture.Tests/packages.lock.json
@@ -1275,8 +1275,8 @@
       },
       "SIL.Machine": {
         "type": "Transitive",
-        "resolved": "3.8.4",
-        "contentHash": "iyIGFWIneklLYaI856FuP7H097Gg8XsWgqaRrYTC6bd7YXjowrLzlK+oWqTiEQHdhWsA1M3A8wao800DDIrMVQ==",
+        "resolved": "3.9.0",
+        "contentHash": "OdVAM9KLWZDcCS09XHmXG7LXW7388SRv0voZ+3ckrTL6e25+1g3GpTpDE3EbJG8hsOeLVRuadvBgFMsccvZM+w==",
         "dependencies": {
           "CaseExtensions": "1.1.0",
           "Newtonsoft.Json": "13.0.4",
@@ -1689,7 +1689,7 @@
           "ParatextData": "[9.5.0.24, )",
           "Polly": "[8.6.6, )",
           "SIL.Converters.Usj": "[1.0.0, )",
-          "SIL.Machine": "[3.8.4, )",
+          "SIL.Machine": "[3.9.0, )",
           "SIL.XForge": "[1.0.0, )",
           "Serval.Client": "[1.18.0, )",
           "Swashbuckle.AspNetCore": "[10.2.1, )",


### PR DESCRIPTION
The updated threshold values in SIL.Machine 3.9.0 are needed for the Quality Estimation feature currently on QA/live.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3976)
<!-- Reviewable:end -->
