### PR TITLE
SF-3840 Alert user that available drafting books reflect source text

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.html
@@ -98,11 +98,9 @@
             </div>
           </app-notice>
         }
-        @if (unusableTranslateTargetBooks.length) {
-          <app-notice>
-            <transloco key="draft_generation_steps.unusable_target_books"></transloco>
-          </app-notice>
-        }
+        <app-notice>
+          {{ t("draft_book_unavailable", { sourceProjectName: draftingSourceProjectName }) }}
+        </app-notice>
         @if (showBookSelectionError) {
           <app-notice type="error">
             {{ t("choose_books_to_translate_error") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.spec.ts
@@ -396,8 +396,7 @@ describe('DraftGenerationStepsComponent', () => {
       expect(component.trainingBooksExcludingTranslatedWithoutEnoughData).toEqual([5]);
     }));
 
-    it('should set "unusableTranslateTargetBooks" and "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
-      expect(component.unusableTranslateTargetBooks).toEqual([7]);
+    it('should set "unusableTrainingTargetBooks" correctly', fakeAsync(() => {
       expect(component.unusableTrainingTargetBooks).toEqual([7]);
     }));
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -136,7 +136,6 @@ export class DraftGenerationStepsComponent implements OnInit {
 
   // Unusable books do not exist in the target or corresponding drafting/training source project
   unusableTranslateSourceBooks: number[] = [];
-  unusableTranslateTargetBooks: number[] = [];
   emptyTranslateSourceBooks: number[] = [];
   trainingBooksExcludingTranslatedWithoutEnoughData: number[] = [];
   unusableTrainingSourceBooks: number[] = [];
@@ -376,9 +375,6 @@ export class DraftGenerationStepsComponent implements OnInit {
 
           // Store the books that are not in the target
           this.unusableTrainingTargetBooks = [...trainingSourceBooks].filter(
-            bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
-          );
-          this.unusableTranslateTargetBooks = [...draftingSourceBooks].filter(
             bookNum => !targetBooks.has(bookNum) && Canon.isCanonical(bookNum)
           );
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -247,6 +247,7 @@
     "configure_advanced_settings_title": "Advanced settings",
     "confirm_codes_correct_to_continue": "Please confirm the language codes are correct before continuing",
     "custom_configurations_apply": "Custom draft configurations have been applied by an administrator.",
+    "draft_book_unavailable": "Can't find the book you're looking for? Be sure the book exists in your drafting source text ({{ sourceProjectName }}).",
     "email_me": "Email me at {{ email }} when the draft is finished.",
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",
@@ -277,7 +278,6 @@
     "training_files": "Training files",
     "translated_book_selected_no_training_pair": "Some of the training books you selected have no matching reference books selected. Please select matching reference books.",
     "translated_books": "Translated books",
-    "unusable_target_books": "Can't find the book you're looking for? Be sure the book is created in Paratext, then sync your project.",
     "use_echo_warning": "Enabling this will echo your source text instead of translating it.",
     "use_echo": "Use Echo Translation Engine"
   },

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -247,7 +247,7 @@
     "configure_advanced_settings_title": "Advanced settings",
     "confirm_codes_correct_to_continue": "Please confirm the language codes are correct before continuing",
     "custom_configurations_apply": "Custom draft configurations have been applied by an administrator.",
-    "draft_book_unavailable": "Can't find the book you're looking for? Be sure the book exists in your drafting source text ({{ sourceProjectName }}).",
+    "draft_book_unavailable": "Can't find the book you're looking for? Be sure the book exists in your drafting source text ({{ sourceProjectName }}) and synchronize the project.",
     "email_me": "Email me at {{ email }} when the draft is finished.",
     "fast_training_warning": "Enabling this will save time but greatly reduce accuracy.",
     "fast_training": "Enable Fast Training",


### PR DESCRIPTION
This updates a notice to reflect the change to allow drafting any book available in the source project.
<img width="1264" height="625" alt="image" src="https://github.com/user-attachments/assets/75454a47-83d8-46d0-8920-cb7e66eb628e" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3977)
<!-- Reviewable:end -->
