### PR TITLE
SF-3292 Re-pull auth profile if user not in SF

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.spec.ts
@@ -255,6 +255,18 @@ describe('AppComponent', () => {
     verify(mockedAuthService.updateInterfaceLanguage(anything())).never();
   }));
 
+  it('pulls the user profile from Auth0 if the user is not present in the realtime service', fakeAsync(() => {
+    const env = new TestEnvironment();
+    when(mockedAuthService.isNewlyLoggedIn).thenResolve(true);
+    env.setCurrentUser('missing_user_id');
+    env.navigate(['/projects', 'project01']);
+    env.init();
+
+    tick();
+    env.fixture.detectChanges();
+    verify(mockedAuthService.pullAuthUserProfile()).once();
+  }));
+
   it('sets user locale when stored locale does not match the browsing session', fakeAsync(() => {
     const env = new TestEnvironment();
     when(mockedAuthService.isNewlyLoggedIn).thenResolve(true);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/app.component.ts
@@ -311,8 +311,15 @@ export class AppComponent extends DataLoadingComponent implements OnInit, OnDest
       });
     }
 
+    // If the user is logged in, but they do not have user profile, pull it from Auth0
+    const isLoggedIn = await this.authService.isLoggedIn;
+    if (isLoggedIn && this.currentUserDoc.data == null) {
+      await this.authService.pullAuthUserProfile();
+      await this.currentUserDoc.onlineFetch();
+    }
+
     // Set the locale to the Auth0 user profile on first login
-    const languageTag: string | undefined = this.currentUserDoc.data!.interfaceLanguage;
+    const languageTag: string | undefined = this.currentUserDoc.data?.interfaceLanguage;
     if (
       isNewlyLoggedIn &&
       languageTag != null &&

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.component.ts
@@ -37,8 +37,9 @@ export const KNOWN_ERROR_CODES: ObjectPaths<typeof en.join>[] = [
   'key_already_used',
   'key_expired',
   'max_users_reached',
+  'project_link_is_invalid',
   'role_not_found',
-  'project_link_is_invalid'
+  'user_missing'
 ];
 
 @Component({

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/join/join.stories.ts
@@ -31,6 +31,7 @@ enum ShareKeys {
   InvalidShareKey = 'invalid_share_key',
   KeyAlreadyUsed = 'key_already_used',
   MaxUsersReached = 'max_users_reached',
+  UserMissing = 'user_missing',
   Valid = 'valid'
 }
 
@@ -114,6 +115,9 @@ const meta: Meta = {
       when(mockedSFProjectService.onlineJoinWithShareKey(ShareKeys.InvalidShareKey)).thenThrow(
         new CommandError(CommandErrorCode.Forbidden, 'project_link_is_invalid')
       );
+      when(mockedSFProjectService.onlineJoinWithShareKey(ShareKeys.UserMissing)).thenThrow(
+        new CommandError(CommandErrorCode.NotFound, 'user_missing')
+      );
       if (context.args.shareKey === ShareKeys.Valid) {
         when(mockedAuthService.tryTransparentAuthentication()).thenCall(() => {
           when(mockedAuthService.isLoggedIn).thenResolve(true);
@@ -177,6 +181,13 @@ export const DialogInvalidShareKey: Story = {
 export const DialogKeyAlreadyUsed: Story = {
   args: {
     shareKey: ShareKeys.KeyAlreadyUsed,
+    loggedIn: true
+  }
+};
+
+export const DialogUserMissing: Story = {
+  args: {
+    shareKey: ShareKeys.UserMissing,
     loggedIn: true
   }
 };

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -382,6 +382,7 @@
     "please_connect_to_use_link": "Please connect to the internet to join a project using a link.",
     "project_link_is_invalid": "The project link is invalid. Please contact the person who sent you the link and ask for a new one.",
     "role_not_found": "The role you were assigned on this project is no longer available. Please contact the person who sent you the link and ask for a new one.",
+    "user_missing": "Your user account could not be found. Please log out and join using the link again.",
     "your_name": "Name"
   },
   "dialog": {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -283,6 +283,10 @@ export class AuthService {
     }
   }
 
+  pullAuthUserProfile(): Promise<void> {
+    return this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
+  }
+
   requestParatextCredentialUpdate(cancelCallback?: () => void): void {
     void this.dialogService
       .confirm('warnings.paratext_credentials_expired', 'warnings.logout')
@@ -323,7 +327,7 @@ export class AuthService {
     this.localSettings.set(cacheKey.toKey(), cacheEntry);
     await this.localLogIn(authResponse.access_token, authResponse.id_token, authResponse.expires_in);
     await this.remoteStore.init(() => this.getAccessToken());
-    await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
+    await this.pullAuthUserProfile();
     this._loggedInState$.next({ loggedIn: true, newlyLoggedIn: true, anonymousUser: true });
     return true;
   }
@@ -483,7 +487,7 @@ export class AuthService {
     await this.localLogIn(authDetails.token.access_token, authDetails.token.id_token, authDetails.token.expires_in);
     await this.remoteStore.init(() => this.getAccessToken());
     try {
-      await this.commandService.onlineInvoke(USERS_URL, 'pullAuthUserProfile');
+      await this.pullAuthUserProfile();
     } catch (err) {
       // Display error dialog to pause login loop.
       // Error details will be sent to Bugsnag and logged to the console.

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/user-projects.service.ts
@@ -53,7 +53,7 @@ export class SFUserProjectsService {
   /** Updates our provided set of SF project docs for the current user based on the userdoc's list of SF projects the
    * user is on. */
   private async updateProjectList(userDoc: UserDoc): Promise<void> {
-    const currentProjectIds = userDoc.data!.sites[environment.siteId].projects;
+    const currentProjectIds: string[] = userDoc.data?.sites[environment.siteId].projects ?? [];
 
     let removedProjectsCount = 0;
     for (const [id, projectDoc] of this._projectDocs) {

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -474,9 +474,6 @@ public class SFProjectsRpcController(
         }
     }
 
-    [Obsolete("Only here for old clients that still call it. Removed 2023-04.")]
-    public async Task<IRpcMethodResult> CheckLinkSharing(string shareKey) => Ok(await JoinWithShareKey(shareKey));
-
     public async Task<IRpcMethodResult> JoinWithShareKey(string shareKey)
     {
         try
@@ -494,15 +491,11 @@ public class SFProjectsRpcController(
         catch (Exception)
         {
             _exceptionHandler.RecordEndpointInfoForException(
-                new Dictionary<string, string> { { "method", "CheckLinkSharing" }, { "shareKey", shareKey } }
+                new Dictionary<string, string> { { "method", "JoinWithShareKey" }, { "shareKey", shareKey } }
             );
             throw;
         }
     }
-
-    [Obsolete("New endpoints only require the share key. Old clients would still provide the projectId")]
-    public async Task<IRpcMethodResult> CheckLinkSharing(string projectId, string shareKey) =>
-        await CheckLinkSharing(shareKey);
 
     public IRpcMethodResult IsSourceProject(string projectId) => Ok(projectService.IsSourceProject(projectId));
 

--- a/src/SIL.XForge.Scripture/Services/SFProjectService.cs
+++ b/src/SIL.XForge.Scripture/Services/SFProjectService.cs
@@ -902,6 +902,11 @@ public class SFProjectService : ProjectService<SFProject, SFProjectSecret>, ISFP
         }
 
         IDocument<User> userDoc = await conn.FetchAsync<User>(curUserId);
+        if (!userDoc.IsLoaded)
+        {
+            throw new DataNotFoundException("user_missing");
+        }
+
         // Attempt to get the role for the user from the Paratext registry
         Attempt<string> attempt = await TryGetProjectRoleAsync(project, curUserId);
         if (attempt.TryResult(out string projectRole))

--- a/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/SFProjectServiceTests.cs
@@ -738,6 +738,13 @@ public class SFProjectServiceTests
     }
 
     [Test]
+    public void JoinWithShareKeyAsync_MissingUser()
+    {
+        var env = new TestEnvironment();
+        Assert.ThrowsAsync<DataNotFoundException>(() => env.Service.JoinWithShareKeyAsync("missing_user_id", "abcd"));
+    }
+
+    [Test]
     public void JoinWithShareKeyAsync_LinkSharingDisabledAndUserNotOnProject_Forbidden()
     {
         var env = new TestEnvironment();


### PR DESCRIPTION
I have marked this as testing not required, as it must be tested by a developer to recreate the breaking of the auth profile pulling that caused this bug to occur.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3979)
<!-- Reviewable:end -->
