### PR TITLE
SF-3816 Fix error being logged when a user has an invalid token

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/checking_en.json
@@ -334,6 +334,8 @@
     "error_occurred_login": "An error occurred during login.",
     "failed_to_retrieve_suggestions": "Couldn't get translation suggestions.",
     "failed_to_update_avatar": "Your avatar image could not be updated.",
+    "login": "Log in",
+    "login_expired": "Your log in has expired. Please log in again.",
     "suggestion_engine_requires_retrain": "Couldn't get translation suggestions. Please retrain the suggestions on the Overview page.",
     "go_to_retrain": "Go to Overview",
     "try_again": "Try Again"

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.spec.ts
@@ -524,6 +524,17 @@ describe('AuthService', () => {
     mockedConsole.verify();
   }));
 
+  it('should display prompt to log in again when the token grant is invalid', fakeAsync(() => {
+    const callback = (env: TestEnvironment): void => {
+      env.setInvalidGrantResponse();
+      mockedConsole.expectAndHide(/Unknown or invalid refresh token/);
+    };
+    const env = new TestEnvironment({ isOnline: true, isNewlyLoggedIn: true, callback });
+    expect(env.isLoggedIn).toBe(false);
+    verify(mockedWebAuth.getTokenSilently(anything())).once();
+    verify(mockedDialogService.message(anything(), anything())).once();
+  }));
+
   it('should redirect to url after successful login', fakeAsync(() => {
     const env = new TestEnvironment({
       isOnline: true,
@@ -943,18 +954,18 @@ class TestEnvironment {
     when(mockedWebAuth.getTokenSilently(anything())).thenResolve(this.auth0Response!.token);
   }
 
+  setInvalidGrantResponse(): void {
+    const grantError = new GenericError('invalid_grant', 'Unknown or invalid refresh token.');
+    when(mockedWebAuth.getTokenSilently()).thenThrow(grantError);
+    when(mockedWebAuth.getTokenSilently(anything())).thenThrow(grantError);
+    when(mockedWebAuth.getIdTokenClaims()).thenThrow(grantError);
+  }
+
   setLoginRequiredResponse(): void {
     const loginError = new GenericError('login_required', 'Not logged in');
     when(mockedWebAuth.getTokenSilently()).thenThrow(loginError);
     when(mockedWebAuth.getTokenSilently(anything())).thenThrow(loginError);
     when(mockedWebAuth.getIdTokenClaims()).thenThrow(loginError);
-  }
-
-  setMissingTokenResponse(): void {
-    const tokenError = new GenericError('missing_refresh_token', 'Invalid token');
-    when(mockedWebAuth.getTokenSilently()).thenThrow(tokenError);
-    when(mockedWebAuth.getTokenSilently(anything())).thenThrow(tokenError);
-    when(mockedWebAuth.getIdTokenClaims()).thenThrow(tokenError);
   }
 
   setOnline(isOnline: boolean = true): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/auth.service.ts
@@ -535,6 +535,14 @@ export class AuthService {
 
   private async handleLoginError(method: string, error: unknown): Promise<void> {
     console.error(error);
+
+    // Handle invalid_grant from Auth0
+    if (hasPropWithValue(error, 'error', 'invalid_grant')) {
+      await this.dialogService.message('error_messages.login_expired', 'error_messages.login');
+      return;
+    }
+
+    // Unknown log in error
     this.reportingService.silentError(`Error occurred in ${method}`, ErrorReportingService.normalizeError(error));
     await this.dialogService.message('error_messages.error_occurred_login', 'error_messages.try_again');
   }


### PR DESCRIPTION
I have marked this PR as not requiring testing, as it should be tested by a developer because it requires modifying your Auth0 profile (by clearing your device tokens in Auth0) to recreate the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3980)
<!-- Reviewable:end -->
