### PR TITLE
SF-3823 Fix disabled state for previous/next buttons on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking/checking.component.scss
@@ -264,6 +264,12 @@ header {
         .mat-icon {
           color: var(--mat-button-text-label-text-color, var(--mat-sys-primary));
         }
+
+        &:disabled {
+          .mat-icon {
+            color: var(--mat-icon-button-disabled-icon-color);
+          }
+        }
       }
 
       // Switch to icon-only prev/next buttons on small screens


### PR DESCRIPTION
Regression from #3641 / SF-3678.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3982)
<!-- Reviewable:end -->
