### PR TITLE
SF-3846 Prevent edits that modify text outside of the selected range

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -602,6 +602,18 @@ export class TextComponent implements AfterViewInit, OnDestroy {
         tap(event => (this.isShiftDown = event.shiftKey))
       )
       .subscribe(event => {
+        // Do not allow characters to overwrite outside of the current range
+        const range = this.editor?.getSelection();
+        if (
+          !this.readOnlyEnabled &&
+          !this.nonPrintableCursorMoveKeys.has(event.key) &&
+          range != null &&
+          !this.isValidSelectionForCurrentSegment(range)
+        ) {
+          event.preventDefault();
+          return;
+        }
+
         // Set flag to use system cursor when any key is down that would move the cursor (avoids cursor lag issue)
         if (this.nonPrintableCursorMoveKeys.has(event.key) || event.key?.length === 1) {
           this.pressedCursorMoveKeys.add(event.key);


### PR DESCRIPTION
This PR prevents overwriting of verse markers by restricting keyboard input when text is selected outside of the current segment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3986)
<!-- Reviewable:end -->
