### PR TITLE
Fix localized screenshots e2e workflow

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/e2e/workflows/localized-screenshots.ts
@@ -486,17 +486,19 @@ export async function localizedScreenshots(
   await navLocator(page, 'generate_draft').click();
   await expect(page.getByText('The draft is ready')).toBeVisible();
 
+  const addToProject = page.locator('.draft-options').getByRole('button').first();
+
   await forEachLocale(async locale => {
-    await user.hover(page.getByRole('button', { name: 'Add to a project' }), defaultArrowLocation);
+    await user.hover(addToProject, defaultArrowLocation);
     await screenshot(page, { ...context, pageName: 'import_book', locale });
   });
 
   await forEachLocale(async locale => {
-    await user.click(page.getByRole('button', { name: 'Add to a project' }));
+    await user.click(addToProject);
 
     await page.getByRole('combobox').fill('seedsp2');
     await page.getByRole('option', { name: 'seedsp2 - ' }).click();
-    await user.hover(page.getByRole('button', { name: 'next' }), defaultArrowLocation);
+    await user.hover(page.locator('.button-strip').getByRole('button').last(), defaultArrowLocation);
     await screenshotElements(
       page,
       [page.locator('mat-dialog-container')],


### PR DESCRIPTION
The previous selectors only worked before localization strings for other locales were merged. The selectors have been updated to not use the button label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3988)
<!-- Reviewable:end -->
