### PR TITLE
Fix headings and verse 0 being used in quality estimation

### DIFF
--- a/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
+++ b/src/SIL.XForge.Scripture/Services/PreTranslationService.cs
@@ -61,10 +61,10 @@ public class PreTranslationService(
                 continue;
             }
 
-            // If there is a forward slash, in the reference, the first half is the verse reference
+            // If there is a forward slash in the reference, do not use this confidence score, as it is a heading
             if (reference.Contains('/', StringComparison.OrdinalIgnoreCase))
             {
-                reference = reference.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                continue;
             }
 
             // Ensure we have a valid verse reference and it is for this chapter
@@ -73,12 +73,14 @@ public class PreTranslationService(
                 continue;
             }
 
-            // Add the confidence value. However, if the confidence value already exists, see if this pre-translation
-            // is for the verse content, and if so, set the confidence value.
-            if (!confidences.TryAdd(verseRef, pretranslationConfidence.Confidence) && !references.First().Contains('/'))
+            // Skip verse 0. This is usually the headings and introduction above chapter 1
+            if (verseRef.VerseNum == 0)
             {
-                confidences[verseRef] = pretranslationConfidence.Confidence;
+                continue;
             }
+
+            // Add the confidence value, if there is no confidence value already specified
+            confidences.TryAdd(verseRef, pretranslationConfidence.Confidence);
         }
 
         return confidences.Select(c => new VerseConfidence(c.Key.BookNum, c.Key.ChapterNum, c.Key.Verse, c.Value));

--- a/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/PreTranslationServiceTests.cs
@@ -370,10 +370,9 @@ public class PreTranslationServiceTests
         [
             .. await env.Service.GetVerseConfidencesAsync(Project01, CancellationToken.None),
         ];
-        Assert.That(actual, Has.Count.EqualTo(3));
+        Assert.That(actual, Has.Count.EqualTo(2));
         Assert.That(actual[0], Is.EqualTo(new VerseConfidence(40, 1, "1", 0.2)).UsingPropertiesComparer());
-        Assert.That(actual[1], Is.EqualTo(new VerseConfidence(40, 1, "2", 0.4)).UsingPropertiesComparer());
-        Assert.That(actual[2], Is.EqualTo(new VerseConfidence(40, 1, "3", 0.7)).UsingPropertiesComparer());
+        Assert.That(actual[1], Is.EqualTo(new VerseConfidence(40, 1, "3", 0.6)).UsingPropertiesComparer());
     }
 
     private class TestEnvironmentOptions
@@ -418,7 +417,7 @@ public class PreTranslationServiceTests
                     Task.FromResult<IList<PretranslationConfidence>>([
                         new PretranslationConfidence
                         {
-                            // A pre-translation confidence value with no references
+                            // A pre-translation confidence value with no references (ignored)
                             SourceRefs = [],
                             TargetRefs = [],
                             Confidence = 0.1,
@@ -432,37 +431,37 @@ public class PreTranslationServiceTests
                         },
                         new PretranslationConfidence
                         {
-                            // A pre-translation confidence value with an invalid references
+                            // A pre-translation confidence value with an invalid references (ignored)
                             SourceRefs = ["invalid_reference"],
                             TargetRefs = ["invalid_reference"],
                             Confidence = 0.3,
                         },
                         new PretranslationConfidence
                         {
-                            // A pre-translation confidence value from a segment
-                            SourceRefs = ["MAT 1:2/1:p"],
-                            TargetRefs = ["MAT 1:2/1:p"],
+                            // A pre-translation confidence value from verse that only has a segment (ignored)
+                            SourceRefs = ["MAT 1:2/1:s"],
+                            TargetRefs = ["MAT 1:2/1:s"],
                             Confidence = 0.4,
                         },
                         new PretranslationConfidence
                         {
-                            // A pre-translation confidence value from a segment that will be overridden by the verse
-                            SourceRefs = ["MAT 1:3/2:p"],
-                            TargetRefs = ["MAT 1:3/2:p"],
+                            // A pre-translation confidence value from a segment (ignored)
+                            SourceRefs = ["MAT 1:3/2:s"],
+                            TargetRefs = ["MAT 1:3/2:s"],
                             Confidence = 0.5,
-                        },
-                        new PretranslationConfidence
-                        {
-                            // A pre-translation confidence value from another  segment that will be overridden by the verse
-                            SourceRefs = ["MAT 1:3/3:p"],
-                            TargetRefs = ["MAT 1:3/3:p"],
-                            Confidence = 0.6,
                         },
                         new PretranslationConfidence
                         {
                             // A pre-translation confidence value for a verse
                             SourceRefs = ["MAT 1:3"],
                             TargetRefs = ["MAT 1:3"],
+                            Confidence = 0.6,
+                        },
+                        new PretranslationConfidence
+                        {
+                            // A pre-translation confidence value for verse zero (ignored)
+                            SourceRefs = ["MAT 1:0"],
+                            TargetRefs = ["MAT 1:0"],
                             Confidence = 0.7,
                         },
                     ])


### PR DESCRIPTION
This PR fixes a bug in quality estimation calculation where verses that only contained headings, and verse 0 was being included in the quality estimation calculation.

I have marked as testing not required, as the unit test covers the scope of the change, and it really can only be tested on production by an EITL.

I have verified the output of this as corresponding to the output from silnlp for the same confidence values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/3991)
<!-- Reviewable:end -->
