### PR TITLE
Keep chapter input size consistent

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.scss
@@ -86,6 +86,7 @@ app-copyright-banner {
 
 .chapter-input {
   @include mat.form-field-density(-5);
+  width: 15em;
 }
 
 .chapter-error {


### PR DESCRIPTION
This PR fixes an issue where the chapter input grows when an error is visible.

Before
<img width="987" height="351" alt="Chapter Input Before" src="https://github.com/user-attachments/assets/5ca592d1-34dd-4882-8e9b-e4ed9adf7120" />

After
<img width="999" height="412" alt="Chapter Input After" src="https://github.com/user-attachments/assets/0e2ae712-1e6a-4843-aa2b-ed9286be6f49" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4006)
<!-- Reviewable:end -->
