### PR TITLE
Only specify chapters in draft build config when a chapter input was offered

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft-logic-handler.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft-logic-handler.spec.ts
@@ -388,6 +388,52 @@ describe('NewDraftLogicHandler', () => {
     });
   });
 
+  describe('scripture ranges for the build request', () => {
+    it('enumerates drafting chapters only for books the UI offered a chapter input for', async () => {
+      const env = new TestEnvironment(teamStartingToTranslateGenesis);
+      await env.waitForInit();
+
+      // GEN is offered a chapter input (defaulting to the untranslated chapters 6-50); EXO has no target progress,
+      // so it was only selectable whole
+      env.logicHandler.selectDraftingBooks(['GEN', 'EXO']);
+
+      expect(env.logicHandler.draftingScriptureRangeForBuild()).toBe('GEN6-50;EXO');
+    });
+
+    it('keeps explicit chapters even when they cover every chapter the source currently has', async () => {
+      const env = new TestEnvironment(teamStartingToTranslateGenesis);
+      await env.waitForInit();
+
+      env.logicHandler.selectDraftingBooks(['GEN']);
+      env.logicHandler.selectDraftingChapters('GEN', '1-50');
+
+      // A bare "GEN" would extend the draft to any chapters a pre-build sync brings in; the chapter-specific
+      // selection must be preserved exactly
+      expect(env.logicHandler.draftingScriptureRangeForBuild()).toBe('GEN1-50');
+    });
+
+    it('enumerates target training chapters only for books the UI offered a chapter input for', async () => {
+      const env = new TestEnvironment(teamStartingToTranslateGenesis);
+      await env.waitForInit();
+
+      env.logicHandler.selectDraftingBooks(['GEN']);
+      env.logicHandler.setInputMode('training_books');
+      env.logicHandler.selectTargetTrainingBooks(['GEN', 'MAT']);
+
+      // GEN is partially drafted, so its training chapters have an input and are spelled out; MAT was only
+      // selectable whole
+      expect(env.logicHandler.targetTrainingScriptureRangeForBuild()).toBe('GEN1-5;MAT');
+    });
+
+    it('serializes empty selections as empty strings', async () => {
+      const env = new TestEnvironment(teamStartingToTranslateGenesis);
+      await env.waitForInit();
+
+      expect(env.logicHandler.draftingScriptureRangeForBuild()).toBe('');
+      expect(env.logicHandler.targetTrainingScriptureRangeForBuild()).toBe('');
+    });
+  });
+
   describe('partial-training offering tracks the drafting selection', () => {
     // A book is only offered for partial target training while it is itself being drafted; otherwise the whole book
     // is available for training with no per-chapter restriction. This must still hold after the drafting selection

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft-logic-handler.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft-logic-handler.ts
@@ -511,6 +511,19 @@ export class NewDraftLogicHandler {
     this.selectedTargetTrainingScriptureRange = newTargetTrainingScriptureRange;
   }
 
+  /** The drafting selection serialized for the build request (see rangeStringForBuild). */
+  draftingScriptureRangeForBuild(): string {
+    return this.rangeStringForBuild(this.selectedDraftingScriptureRange, this.booksOfferedForPartialDrafting);
+  }
+
+  /** The target training selection serialized for the build request (see rangeStringForBuild). */
+  targetTrainingScriptureRangeForBuild(): string {
+    return this.rangeStringForBuild(
+      this.selectedTargetTrainingScriptureRange,
+      this.booksOfferedForPartialTargetTraining
+    );
+  }
+
   /**
    * A stable fingerprint of which projects are configured as drafting/training sources, used to detect mid-flow
    * reconfiguration. Only the set of project refs matters (order-independent); the target is excluded since it is
@@ -604,6 +617,20 @@ export class NewDraftLogicHandler {
     if (this.trainingBooksWereAutoSelected && this.selectedTargetTrainingScriptureRange.books.size === 0) {
       this.trainingBooksWereAutoSelected = false;
     }
+  }
+
+  /**
+   * Serializes a selection in the canonical scripture range format. A book the UI offered a chapter input for
+   * (`booksWithChapterInput`) carries a chapter-specific selection, so its chapters are enumerated — even when they
+   * happen to cover every chapter currently available. Enumerating in that case still matters: a sync runs when the
+   * build starts, and if it brings in chapters the book did not have when the user chose, a whole-book token would
+   * silently extend the build to chapters the user never saw. Every other book was only ever selectable whole, so it
+   * is written as a bare book token (meaning the whole book).
+   */
+  private rangeStringForBuild(selection: VerboseScriptureRange, booksWithChapterInput: string[]): string {
+    return Array.from(selection.books.entries())
+      .map(([bookId, chapters]) => (booksWithChapterInput.includes(bookId) ? bookId + chapters.toString() : bookId))
+      .join(VerboseScriptureRange.bookSeparator);
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.spec.ts
@@ -628,6 +628,42 @@ describe('NewDraftComponent', () => {
       expect().nothing();
     }));
 
+    it('enumerates chapters only for books with a chapter input, sending other books as bare tokens', fakeAsync(() => {
+      const env = new TestEnvironment(testState);
+      tick();
+      // Both books get a drafting chapter input (source has 12+ chapters, target has content), so both enumerate
+      // their chapters: GEN defaults to the untranslated 6-50, fully-translated MAT falls back to all 28
+      env.component.logicHandler.selectDraftingBooks(['GEN', 'MAT']);
+      env.component.logicHandler.setInputMode('training_books');
+      // JHN is not being drafted, so it has no training chapter input -> bare token; GEN is partially drafted, so
+      // its training chapter list must survive
+      env.component.logicHandler.selectTargetTrainingBooks(['GEN', 'JHN']);
+      env.component.logicHandler.selectTrainingSourceBooks('training-source-1-id', ['GEN', 'JHN']);
+
+      // SUT
+      env.component.generateDraftClicked();
+      tick();
+
+      verify(
+        mockedDraftGenerationService.startBuildOrGetActiveBuild(
+          deepEqual({
+            projectId: 'testProjectId',
+            translationScriptureRanges: [{ projectId: 'draft-source-1-id', scriptureRange: 'GEN6-50;MAT1-28' }],
+            trainingScriptureRanges: [
+              { projectId: 'training-source-1-id', scriptureRange: 'GEN;JHN' },
+              { projectId: 'testProjectId', scriptureRange: 'GEN1-5;JHN' }
+            ],
+            trainingDataFiles: [],
+            availableTrainingDataFiles: [],
+            fastTraining: false,
+            useEcho: false,
+            sendEmailOnBuildFinished: false
+          })
+        )
+      ).once();
+      expect().nothing();
+    }));
+
     it('navigates to draft-generation after submitting the build', fakeAsync(() => {
       const env = new TestEnvironment(testState);
       tick();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.ts
@@ -500,7 +500,7 @@ export class NewDraftComponent {
       const translationScriptureRanges: ProjectScriptureRange[] = [
         {
           projectId: draftingSource.projectRef,
-          scriptureRange: this.logicHandler.selectedDraftingScriptureRange.toString()
+          scriptureRange: this.logicHandler.draftingScriptureRangeForBuild()
         }
       ];
 
@@ -512,10 +512,11 @@ export class NewDraftComponent {
           trainingScriptureRanges.push({ projectId: source.projectRef, scriptureRange: bookIds.join(';') });
         }
       }
-      // Include target project entry at chapter-level: persists training selection and drives backend filter
+      // Include target project entry: persists training selection and drives backend filter. Chapters are only
+      // enumerated where the enumeration means something (see targetTrainingScriptureRangeForBuild).
       trainingScriptureRanges.push({
         projectId,
-        scriptureRange: this.logicHandler.selectedTargetTrainingScriptureRange.toString()
+        scriptureRange: this.logicHandler.targetTrainingScriptureRangeForBuild()
       });
 
       // Record available files alongside the selection so later builds can distinguish new files from deliberately deselected ones.


### PR DESCRIPTION
Before this change, a BuildProjectAsync event shows the scripture ranges that are specified being overly verbose:

``` json
{
  "curUserId": "5ea207780695620600a2f7ae",
  "buildConfig": {
    "AvailableTrainingDataFiles": [],
    "TrainingScriptureRanges": [
      {
        "ProjectId": "6a5905a01723aa447b2c2866",
        "ScriptureRange": "MRK;JHN;DEU"
      },
      {
        "ProjectId": "6a5f98e4671e6d7de2525b26",
        "ScriptureRange": "DEU1-9;MRK1-15;JHN1-21"
      }
    ],
    "TranslationScriptureRanges": [
      {
        "ProjectId": "6a5905a01723aa447b2c2866",
        "ScriptureRange": "DEU10-34;JOS1-24"
      }
    ],
    "FastTraining": true,
    "ProjectId": "6a5f98e4671e6d7de2525b26"
  },
  "preTranslate": true,
  "draftGenerationRequestId": "6a70c5fb786c16f3db594c32"
}
```
Notice:
- `JOS1-24` is specified for translation, even though the user selected the book, not a chapter range
- The training scripture range for the target project fully lists chapters: `DEU1-9;MRK1-15;JHN1-21`, which is at best unnecessary

Desired behavior is to specify chapters only when the user actually made a chapter selection. I'm not sure if specifying chapters currently causes buggy behavior or not, but it seems likely that it would, since it makes it harder to later determine which books a user selected.

Marked as will require testing, but it should be done by a developer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4018)
<!-- Reviewable:end -->
