### PR TITLE
Stop pre-filling email address on onboarding form

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
@@ -163,12 +163,11 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
       .then(userDoc => {
         const user: Readonly<User | undefined> = userDoc.data;
         if (user != null) {
-          // Omit email if it's a noreply email
-          const userEmail = user.email?.includes('@users.noreply.scriptureforge.org') ? '' : (user.email ?? '');
-          this.signupForm.patchValue({
-            name: user.displayName || user.name || '',
-            email: userEmail
-          });
+          const defaultNameValue = user.displayName || user.name || '';
+          // In some rare cases the email address ends up inside the user's name field, so don't auto fill it
+          if (!defaultNameValue.includes('@')) {
+            this.signupForm.patchValue({ name: defaultNameValue });
+          }
         }
       })
       .catch(err => console.error('Error loading user:', err));


### PR DESCRIPTION
The rationale for this is that users often have a different email address on their account than they actually use, and therefore email messages don't actually reach them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4021)
<!-- Reviewable:end -->
