### PR TITLE
SF-3025 Fix text overlapping input in Biblical term dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/biblical-terms/biblical-term-dialog.component.html
@@ -2,7 +2,7 @@
   <h1 mat-dialog-title>{{ t(canEdit() ? "edit_renderings" : "view_renderings") }}</h1>
   <mat-dialog-content>
     <div id="definition">{{ definition }}</div>
-    <mat-form-field [formGroup]="form" appearance="outline">
+    <mat-form-field [formGroup]="form" appearance="outline" subscriptSizing="dynamic">
       <mat-label>{{ t("renderings") }}</mat-label>
       <textarea
         appAutofocus


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4041)
<!-- Reviewable:end -->
