### PR TITLE
SF-3459 Fix text overflow in note dialog

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.scss
@@ -38,6 +38,8 @@ h1 {
     font-family: var(--project-font);
     font-size: 0.9em;
     flex: 1;
+    // Break long unbreakable runs (URLs, or scripts without word spaces) rather than overflow
+    overflow-wrap: anywhere;
     .segment-text {
       padding-top: 6px;
       border-top: 2px solid var(--sf-note-dialog-reference-text-color);
@@ -53,6 +55,10 @@ h1 {
     flex-wrap: wrap;
     .content {
       flex: 1 1 100%;
+      // A URL (or a script without word spaces) has no break opportunity, so without this the note
+      // text is laid out wider than the dialog. The note is `row-reverse` in LTR, so the overflow
+      // spills past the start edge where it is clipped and cannot be scrolled to.
+      overflow-wrap: anywhere;
     }
     &:first-child {
       padding-top: 10px;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4043)
<!-- Reviewable:end -->
