### PR TITLE
SF-3897 Fix inconsistent Biblical terms tab date format

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/checking/checking-overview/checking-overview.component.ts
@@ -333,7 +333,7 @@ export class CheckingOverviewComponent extends DataLoadingComponent implements O
       return '';
     }
     return this.i18n.translateStatic('checking_overview.time_archived_stamp', {
-      timeStamp: this.i18n.formatDate(new Date(date))
+      timeStamp: this.i18n.formatDate(new Date(date), { showTime: true, showTimeZone: false })
     });
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/draft-jobs.component.ts
@@ -270,7 +270,8 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
     const eventBasedDuration = job.duration != null ? this.formatDurationInHours(job.duration) : undefined;
 
     // Format start time if available
-    const startTime = job.startTime != null ? this.i18n.formatDate(job.startTime, { showTimeZone: true }) : undefined;
+    const startTime =
+      job.startTime != null ? this.i18n.formatDate(job.startTime, { showTime: true, showTimeZone: true }) : undefined;
 
     // Collect all events that were used to create this job
     const events = [job.startEvent, job.buildEvent, job.finishEvent, job.cancelEvent]
@@ -758,7 +759,7 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
 
       const duration = job.duration ? this.formatDurationInHours(job.duration) : undefined;
       const durationTooltip = job.finishTime
-        ? `Finished: ${this.i18n.formatDate(job.finishTime, { showTimeZone: true })}`
+        ? `Finished: ${this.i18n.formatDate(job.finishTime, { showTime: true, showTimeZone: true })}`
         : undefined;
 
       rows.push({
@@ -766,7 +767,9 @@ export class DraftJobsComponent extends DataLoadingComponent implements OnInit {
         projectId: job.projectId,
         projectName: projectDeleted ? `${job.projectId} [deleted]` : (projectName ?? job.projectId),
         projectDeleted,
-        startTimeStamp: job.startTime ? this.i18n.formatDate(job.startTime, { showTimeZone: true }) : 'N/A',
+        startTimeStamp: job.startTime
+          ? this.i18n.formatDate(job.startTime, { showTime: true, showTimeZone: true })
+          : 'N/A',
         duration,
         durationTooltip,
         status: this.getStatusDisplay(job.status),

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/job-details-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/job-details-dialog.component.ts
@@ -199,7 +199,7 @@ export class JobDetailsDialogComponent implements OnInit {
   }
 
   formatDate(timestamp: string): string {
-    return this.i18n.formatDate(new Date(timestamp), { showTimeZone: true });
+    return this.i18n.formatDate(new Date(timestamp), { showTime: true, showTimeZone: true });
   }
 
   hasPayload(payload: any): boolean {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/serval-builds.component.ts
@@ -372,7 +372,7 @@ export class ServalBuildsComponent extends DataLoadingComponent implements OnIni
       row.durationMs != null ? this.formatDurationHours(row.durationMs) : undefined;
     const servalCreated: Date | undefined = row.report.timeline.servalCreated;
     const createdDisplay: string | undefined =
-      servalCreated != null ? this.i18n.formatDate(servalCreated, { showTimeZone: true }) : undefined;
+      servalCreated != null ? this.i18n.formatDate(servalCreated, { showTime: true, showTimeZone: true }) : undefined;
 
     const buildsCreatedSince: number = this.rows.filter(other => {
       if (other.report.project?.sfProjectId !== sfProjectId) return false;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/global-notices/global-notices.component.html
@@ -6,7 +6,7 @@
           {{
             t("upcoming_maintenance", {
               duration,
-              startTime: i18n.formatDate(upcomingDowntime.start, { showTimeZone: true })
+              startTime: i18n.formatDate(upcomingDowntime.start, { showTime: true, showTimeZone: true })
             })
           }}
           <a [href]="upcomingDowntime.detailsUrl" target="_blank">{{ t("learn_more") }}</a>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-log/sync-log.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync-log/sync-log.component.spec.ts
@@ -60,7 +60,7 @@ describe('SyncLogComponent', () => {
     // A pre-formatted date would be re-parsed by the owner component, which swaps the day and month or yields an
     // invalid date in many locales
     expect(env.component.rows.map(row => row.dateTime)).toEqual([dateStarted, dateStarted, dateStarted]);
-    const expected = env.i18n.formatDate(new Date(dateStarted));
+    const expected = env.i18n.formatDate(new Date(dateStarted), { showTime: true, showTimeZone: false });
     expect(env.dateTimes).toEqual([expected, expected, expected]);
   }));
 
@@ -71,7 +71,7 @@ describe('SyncLogComponent', () => {
     env.wait();
 
     expect(env.component.rows[0].dateTime).toEqual(dateQueued);
-    expect(env.dateTimes).toEqual([env.i18n.formatDate(new Date(dateQueued))]);
+    expect(env.dateTimes).toEqual([env.i18n.formatDate(new Date(dateQueued), { showTime: true, showTimeZone: false })]);
   }));
 
   it('should show more entries when the show more button is clicked', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/sync/sync.component.ts
@@ -110,7 +110,7 @@ export class SyncComponent extends DataLoadingComponent implements OnInit {
       return this.i18n.translateStatic('sync.never_been_synced');
     } else {
       return this.i18n.translateStatic('sync.last_synced_time_stamp', {
-        timeStamp: this.i18n.formatDate(new Date(dateLastSynced))
+        timeStamp: this.i18n.formatDate(new Date(dateLastSynced), { showTime: true, showTimeZone: false })
       });
     }
   }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-entry/draft-history-entry.component.ts
@@ -346,7 +346,8 @@ export class DraftHistoryEntryComponent {
   ) {}
 
   formatDate(date?: string): string {
-    const formattedDate = date == null ? '' : this.i18n.formatDate(new Date(date));
+    const formattedDate =
+      date == null ? '' : this.i18n.formatDate(new Date(date), { showTime: true, showTimeZone: false });
     return formattedDate.indexOf(RIGHT_TO_LEFT_MARK) !== -1 ? RIGHT_TO_LEFT_MARK + formattedDate : formattedDate;
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.spec.ts
@@ -265,7 +265,7 @@ describe('DraftHistoryListComponent', () => {
       this.onlineStatusService = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
       if (isOnline === false) this.onlineStatusService.setIsOnline(false);
       when(mockedDraftGenerationService.draftHistoryCutOffDate).thenReturn(new Date('2025-06-04T00:00:00.000Z'));
-      when(mockedI18nService.formatDate(anything())).thenCall(date => date.toLocaleString(['en']));
+      when(mockedI18nService.formatDate(anything(), anything())).thenCall(date => date.toLocaleString(['en']));
 
       this.fixture = TestBed.createComponent(DraftHistoryListComponent);
       this.component = this.fixture.componentInstance;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-history-list/draft-history-list.component.ts
@@ -24,7 +24,8 @@ export class DraftHistoryListComponent {
   showOlderDraftsNotSupportedWarning: boolean = false;
   history: BuildDto[] = [];
   readonly draftHistoryCutOffDateFormatted: string = this.i18n.formatDate(
-    this.draftGenerationService.draftHistoryCutOffDate
+    this.draftGenerationService.draftHistoryCutOffDate,
+    { showTime: false, showTimeZone: false }
   );
   private readonly notifyBuildProgressHandler = (projectId: string): void => {
     this.loadHistory(projectId);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Delta } from 'quill';
-import { mock, when } from 'ts-mockito';
+import { anything, deepEqual, mock, verify, when } from 'ts-mockito';
 import { I18nService } from 'xforge-common/i18n.service';
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { EditorHistoryService } from './editor-history.service';
@@ -40,18 +40,33 @@ describe('EditorHistoryService', () => {
       expect(service.formatTimestamp('')).toBe('Invalid Date');
     });
 
-    it('should return abbrev month and day (like "Jan 5") if timestamp is within the last 26 weeks', () => {
-      const now = new Date();
-      const timestamp = new Date(now.getTime() - 7 * MILLISECONDS_IN_A_DAY).toISOString(); // 1 week ago
-      const result = service.formatTimestamp(timestamp);
-      expect(result).toMatch(/[a-z]{3} \d{1,2}/i);
+    it('should format the date with the I18nService', () => {
+      when(i18nMock.formatDate(anything(), anything())).thenReturn('Apr 22, 2026');
+      const timestamp = new Date().toISOString();
+      expect(service.formatTimestamp(timestamp)).toBe('Apr 22, 2026');
+      verify(
+        i18nMock.formatDate(deepEqual(new Date(timestamp)), deepEqual({ showTime: false, showTimeZone: false }))
+      ).once();
     });
 
-    it('should return mm/dd/yy if timestamp is more than 26 weeks ago', () => {
-      const now = new Date();
-      const timestamp = new Date(now.getTime() - 7 * MILLISECONDS_IN_A_DAY * 40).toISOString(); // 40 weeks ago
-      const result = service.formatTimestamp(timestamp);
-      expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{2}/);
+    it('should include the time when requested', () => {
+      when(i18nMock.formatDate(anything(), anything())).thenReturn('Apr 22, 2026, 3:04 PM');
+      const timestamp = new Date().toISOString();
+      expect(service.formatTimestamp(timestamp, true)).toBe('Apr 22, 2026, 3:04 PM');
+      verify(
+        i18nMock.formatDate(deepEqual(new Date(timestamp)), deepEqual({ showTime: true, showTimeZone: false }))
+      ).once();
+    });
+
+    it('should use the same format regardless of how old the timestamp is', () => {
+      // A project can have revisions spanning several years, so recent and old revisions must be formatted the same
+      // way. Formatting recent revisions differently (and without the year) made the dates ambiguous.
+      when(i18nMock.formatDate(anything(), anything())).thenReturn('formatted date');
+      const recent = new Date(Date.now() - MILLISECONDS_IN_A_DAY).toISOString(); // 1 day ago
+      const old = new Date(Date.now() - MILLISECONDS_IN_A_DAY * 700).toISOString(); // almost 2 years ago
+      expect(service.formatTimestamp(recent)).toBe('formatted date');
+      expect(service.formatTimestamp(old)).toBe('formatted date');
+      verify(i18nMock.formatDate(anything(), deepEqual({ showTime: false, showTimeZone: false }))).twice();
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/editor-history.service.ts
@@ -2,39 +2,24 @@ import { Injectable } from '@angular/core';
 import { Delta } from 'quill';
 import { I18nService } from 'xforge-common/i18n.service';
 
-const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
-
 @Injectable({
   providedIn: 'root'
 })
 export class EditorHistoryService {
   constructor(private readonly i18n: I18nService) {}
 
-  formatTimestamp(timestamp: string | null | undefined, forceLong: boolean = false): string {
-    if (timestamp != null) {
-      const date = new Date(timestamp);
-      const now = new Date();
-      const weeksAgo26 = new Date(now.getTime() - MILLISECONDS_IN_A_DAY * 7 * 26);
-
-      let options: Intl.DateTimeFormatOptions;
-
-      // If the date is within the last 26 weeks (6 months) show month and day like 'Jan 5'
-      if (!forceLong && date > weeksAgo26) {
-        options = {
-          month: 'short',
-          day: 'numeric'
-        };
-      } else {
-        // If the date is more than 26 weeks ago, or long date is forced, show month, day, and year (mm/dd/yy)
-        options = {
-          dateStyle: 'short'
-        };
-      }
-
-      return date.toLocaleString(this.i18n.locale.canonicalTag, options).replace(/,/g, '');
+  /**
+   * Formats a revision timestamp the same way as everywhere else revisions are shown (i.e. the history and draft
+   * selectors), so that dates always appear in the locale's format and always include the year.
+   * @param timestamp The timestamp to format.
+   * @param showTime Whether to include the time of day, as well as the date.
+   */
+  formatTimestamp(timestamp: string | null | undefined, showTime: boolean = false): string {
+    if (timestamp == null || timestamp === '') {
+      return 'Invalid Date';
     }
 
-    return 'Invalid Date';
+    return this.i18n.formatDate(new Date(timestamp), { showTime, showTimeZone: false });
   }
 
   processDiff(deltaA: Delta, deltaB: Delta): Delta {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-history/history-chooser/history-revision-format.pipe.ts
@@ -19,6 +19,6 @@ export class HistoryRevisionFormatPipe implements PipeTransform {
    */
   transform(revision: Revision | string, _locale: Locale | null): string {
     const revisionKey = typeof revision === 'string' ? revision : revision.timestamp;
-    return this.i18n.formatDate(new Date(revisionKey));
+    return this.i18n.formatDate(new Date(revisionKey), { showTime: true, showTimeZone: false });
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.ts
@@ -487,7 +487,7 @@ export class NoteDialogComponent implements OnInit {
    * @returns The formatted creation date as a string.
    */
   private getNoteDateCreated(note: Note): string {
-    return this.i18n.formatDate(new Date(note.dateCreated));
+    return this.i18n.formatDate(new Date(note.dateCreated), { showTime: true, showTimeZone: false });
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/smt-retirement-notice/smt-retirement-notice.component.html
@@ -2,7 +2,7 @@
   @for (
     line of i18n.interpolateVariables("translate_overview.translation_suggestions_will_be_removed", {
       email: issueEmail,
-      date: i18n.formatDate(smtRetirementDate, { showTime: false })
+      date: i18n.formatDate(smtRetirementDate, { showTime: false, showTimeZone: false })
     });
     track $index
   ) {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/experimental-features/experimental-features-dialog.component.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialogClose, MatDialogContent, MatDialogTitle } from '@angular/material/dialog';
-import { MatDivider } from '@angular/material/divider';
 import { MatIcon } from '@angular/material/icon';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ExperimentalFeature, ExperimentalFeaturesService } from './experimental-features.service';
@@ -21,7 +20,6 @@ import { ExperimentalFeature, ExperimentalFeaturesService } from './experimental
     MatDialogContent,
     MatDialogClose,
     MatCheckbox,
-    MatDivider,
     FormsModule
   ]
 })

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.spec.ts
@@ -87,31 +87,32 @@ describe('I18nService', () => {
     const service = getI18nService();
     // As of Chromium 110 the space between the minutes and AM/PM has been changed to U+202F (NARROW NO-BREAK SPACE)
     // Test for any white space character for maximum compatibility
+    const options = { showTime: true, showTimeZone: false };
     if (isSafari()) {
-      expect(service.formatDate(date)).toMatch(/Nov 25, 1991 at 5:28\sPM/);
+      expect(service.formatDate(date, options)).toMatch(/Nov 25, 1991 at 5:28\sPM/);
     } else {
       // Chrome, Firefox
-      expect(service.formatDate(date)).toMatch(/Nov 25, 1991, 5:28\sPM/);
+      expect(service.formatDate(date, options)).toMatch(/Nov 25, 1991, 5:28\sPM/);
     }
 
     service.setLocale('en-GB');
     if (isSafari()) {
-      expect(service.formatDate(date)).toMatch(/25 Nov 1991 at 5:28\spm/);
+      expect(service.formatDate(date, options)).toMatch(/25 Nov 1991 at 5:28\spm/);
     } else {
       // Chrome, Firefox
-      expect(service.formatDate(date)).toMatch(/25 Nov 1991, 5:28\spm/);
+      expect(service.formatDate(date, options)).toMatch(/25 Nov 1991, 5:28\spm/);
     }
 
     // As of Chromium 98 for zh-CN it's changed from using characters to indicate AM/PM, to using a 24 hour clock. It's
     // unclear whether the cause is Chromium itself or a localization library. The tests should pass with either version
     service.setLocale('zh-CN');
-    expect(['1991/11/25 17:28', '1991/11/25下午5:28']).toContain(service.formatDate(date));
+    expect(['1991/11/25 17:28', '1991/11/25下午5:28']).toContain(service.formatDate(date, options));
 
     service.setLocale('az');
-    expect(service.formatDate(date)).toEqual('25.11.1991 17:28');
+    expect(service.formatDate(date, options)).toEqual('25.11.1991 17:28');
 
     service.setLocale('npi');
-    expect(service.formatDate(date)).toEqual('१९९१-११-२५, १७:२८');
+    expect(service.formatDate(date, options)).toEqual('१९९१-११-२५ १७:२८');
   });
 
   it('should support including the timezone in the date', () => {
@@ -122,10 +123,10 @@ describe('I18nService', () => {
     const trailingTimezoneRegex = / ((GMT|UTC)[\-+−]\d{1,2}(:\d{2})?|[A-Z]+)$/;
 
     service.setLocale('fr');
-    expect(service.formatDate(date, { showTimeZone: true })).toMatch(trailingTimezoneRegex);
+    expect(service.formatDate(date, { showTime: true, showTimeZone: true })).toMatch(trailingTimezoneRegex);
 
     service.setLocale('az');
-    expect(service.formatDate(date, { showTimeZone: true })).toMatch(trailingTimezoneRegex);
+    expect(service.formatDate(date, { showTime: true, showTimeZone: true })).toMatch(trailingTimezoneRegex);
   });
 
   it('should interpolate translations around and within numbered template tags', done => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/i18n.service.ts
@@ -76,11 +76,10 @@ export class I18nService {
     'en-GB': { month: 'short', hour12: true },
     // Chrome formats az dates as en-US. This manual override is the format Firefox uses for az
     az: (d: Date, options) => {
-      let s = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-      if (options.showTimeZone) {
-        s += ` ${I18nService.getHumanReadableTimeZoneOffset('az', d)}`;
-      }
-      return s;
+      let result = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+      if (options.showTime) result += ` ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      if (options.showTimeZone) result += ` ${I18nService.getHumanReadableTimeZoneOffset('az', d)}`;
+      return result;
     },
     npi: (d: Date, options) => {
       const o = {
@@ -103,7 +102,10 @@ export class I18nService {
       const hour = parts.find(p => p.type === 'hour')?.value;
       const minute = parts.find(p => p.type === 'minute')?.value;
 
-      return `${year}-${month}-${day}, ${hour}:${minute}`;
+      let result = `${year}-${month}-${day}`;
+      if (options.showTime) result += ` ${hour}:${minute}`;
+      if (options.showTimeZone) result += ` ${I18nService.getHumanReadableTimeZoneOffset('npi', d)}`;
+      return result;
     },
     [PseudoLocalization.locale.canonicalTag]: PseudoLocalization.dateFormat
   };
@@ -331,7 +333,7 @@ export class I18nService {
     });
   }
 
-  formatDate(date: Date, options: { showTimeZone?: boolean; showTime?: boolean } = {}): string {
+  formatDate(date: Date, options: { showTimeZone: boolean; showTime: boolean }): string {
     const showTime = 'showTime' in options ? options.showTime : true;
     // fall back to en in the event the language code isn't valid
     const format = I18nService.customDateFormats[this.localeCode] || {};

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/date-format.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/models/date-format.ts
@@ -1,2 +1,3 @@
 /** Date format options for internationalization */
-export type DateFormat = Intl.DateTimeFormatOptions | ((date: Date, options: { showTimeZone?: boolean }) => string);
+export type DateFormat =
+  Intl.DateTimeFormatOptions | ((date: Date, options: { showTimeZone: boolean; showTime: boolean }) => string);

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/owner/owner.component.html
@@ -11,7 +11,7 @@
   <div class="owner-text">
     <div class="name">{{ name }}</div>
     @if (dateTime) {
-      <div class="date-time">{{ i18n.formatDate(date, { showTimeZone }) }}</div>
+      <div class="date-time">{{ i18n.formatDate(date, { showTime: true, showTimeZone }) }}</div>
     }
   </div>
 </div>


### PR DESCRIPTION
The original issue was caused by the editor not using the I18nService for date formats. Once that was fixed, the test team pointed out that two locales were showing the time where others were not. If fixed that and also made very use of the date format specify whether to include the time and timezone. This is perhaps more verbose than strictly necessary, but I thought it better to be verbose than let dates be formatted without the developer ever thinking through whether they want time and timezone.

(In general timezone is only included in logs for admins for troubleshooting)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4047)
<!-- Reviewable:end -->
