### PR TITLE
SF-3887 Fix layout of generate draft summary page on mobile

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/new-draft.component.scss
@@ -117,6 +117,9 @@ app-copyright-banner {
 
 .card-header {
   display: flex;
+  // On narrow screens the heading and the action button don't fit side by side, so let the button drop onto its
+  // own line instead of being pushed outside the card.
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
   gap: 1em;
@@ -126,8 +129,16 @@ app-copyright-banner {
   }
 }
 
+.card-header-text {
+  // The heading needs this much room before it's worth keeping the action button beside it.
+  flex-basis: 20em;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
 .card-header-action {
-  flex-shrink: 0;
+  // Once on its own line the button is free to wrap its label, so even a long translation stays inside the card.
+  max-width: 100%;
 }
 
 .draft-books-list {


### PR DESCRIPTION
(both screenshots have the bottom truncated because I screenshotted a node that wasn't fully in the viewport, but you can see the layout difference).

Before | After
-------|------
<img width="1372" height="4134" alt="summary_page_before" src="https://github.com/user-attachments/assets/4865701e-69d4-40f5-97c9-0da4b6f733a4" /> | <img width="1372" height="3574" alt="summary_page_after" src="https://github.com/user-attachments/assets/eec67c46-7c53-4281-be8c-78cb878dc9f2" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4048)
<!-- Reviewable:end -->
