### PR TITLE
Await fonts before taking Storybook screenshots

### DIFF
--- a/scripts/storybook-screenshots/take-screenshots.mts
+++ b/scripts/storybook-screenshots/take-screenshots.mts
@@ -185,6 +185,14 @@ async function screenshotStory(
         );
       });
 
+      // Wait for web fonts (Roboto and Material Icons, loaded from Google Fonts in
+      // preview-head.html) to finish loading, so the screenshot is not taken while text is
+      // still rendered in a fallback font. Note that fonts.ready also resolves when a font
+      // request fails, so this guards against slow loads, not against a font CDN outage.
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+      });
+
       // Check whether this story has opted out of snapshots (chromatic: { disableSnapshot: true }).
       if (storyParams?.chromatic?.disableSnapshot === true) {
         return { storyId, success: true, skipped: true, maxDiffPixels: null };


### PR DESCRIPTION
A recent PR had lots of screenshot "changes" that were just different fonts rendering the text. It can still happen after this PR since network requests for fonts can fail, but it should at least prevent the rendering from racing the fonts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4051)
<!-- Reviewable:end -->
