### PR TITLE
SF-3907 Fix note dialog being incorrectly closed

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation-steps/draft-generation-steps.component.ts
@@ -204,7 +204,7 @@ export class DraftGenerationStepsComponent implements OnInit {
             await this.dialogService.message(
               'draft_generation_steps.remote_changes',
               'draft_generation_steps.remote_changes_start_over',
-              true
+              { disableClose: true }
             );
             this.cancel.emit();
           }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-signup-form/draft-onboarding-form.component.ts
@@ -347,7 +347,7 @@ export class DraftOnboardingFormComponent extends DataLoadingComponent implement
     if ((await this.onboardingRequestService.getOpenOnboardingRequest(this.activatedProject.projectId)) == null) {
       return false;
     } else {
-      await this.dialogService.message('draft_sources.request_already_submitted', undefined, true);
+      await this.dialogService.message('draft_sources.request_already_submitted', undefined, { disableClose: true });
       this.cancel();
       return true;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.spec.ts
@@ -1,0 +1,69 @@
+import { Component } from '@angular/core';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { anything, capture, instance, mock, when } from 'ts-mockito';
+import { DialogService } from './dialog.service';
+import { I18nService } from './i18n.service';
+
+@Component({ template: '' })
+class TestDialogComponent {}
+
+describe('DialogService', () => {
+  it('uses the disableClose from the config', () => {
+    const env = new TestEnvironment();
+    env.service.openMatDialog(TestDialogComponent, { disableClose: true });
+    expect(env.lastConfig.disableClose).toBe(true);
+  });
+
+  it('defaults disableClose to false when the config does not specify it', () => {
+    const env = new TestEnvironment();
+    env.service.openMatDialog(TestDialogComponent, { width: '600px' });
+    expect(env.lastConfig.disableClose).toBe(false);
+  });
+
+  it('lets a component default config set disableClose', () => {
+    const env = new TestEnvironment();
+    (TestDialogComponent as any).defaultMatDialogConfig = { disableClose: true };
+    env.service.openMatDialog(TestDialogComponent, { width: '600px' });
+    expect(env.lastConfig.disableClose).toBe(true);
+    delete (TestDialogComponent as any).defaultMatDialogConfig;
+  });
+
+  it('openGenericDialog uses disableClose from its dialogOptions', () => {
+    const env = new TestEnvironment();
+    env.service.openGenericDialog({ options: [] }, { disableClose: true });
+    expect(env.lastConfig.disableClose).toBe(true);
+  });
+
+  it('confirm passes disableClose through to the underlying dialog', () => {
+    const env = new TestEnvironment();
+    void env.service.confirm('dialog.cancel', 'dialog.cancel', undefined, { disableClose: true });
+    expect(env.lastConfig.disableClose).toBe(true);
+  });
+
+  it('message passes disableClose through to the underlying dialog', () => {
+    const env = new TestEnvironment();
+    void env.service.message('dialog.cancel', undefined, { disableClose: true });
+    expect(env.lastConfig.disableClose).toBe(true);
+  });
+});
+
+class TestEnvironment {
+  readonly mockedMatDialog = mock(MatDialog);
+  readonly mockedI18nService = mock(I18nService);
+  readonly service: DialogService;
+
+  constructor() {
+    when(this.mockedI18nService.direction).thenReturn('ltr');
+    when(this.mockedI18nService.translate(anything(), anything())).thenReturn(of(''));
+    when(this.mockedMatDialog.open(anything(), anything())).thenReturn({
+      afterClosed: () => of(undefined)
+    } as MatDialogRef<any>);
+    this.service = new DialogService(instance(this.mockedI18nService), instance(this.mockedMatDialog));
+  }
+
+  get lastConfig(): MatDialogConfig {
+    const [, config] = capture<any, MatDialogConfig>(this.mockedMatDialog.open).last();
+    return config;
+  }
+}

--- a/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/xforge-common/dialog.service.ts
@@ -22,19 +22,18 @@ export class DialogService {
 
   diagnosticOverlay: OverlayRef | undefined;
 
-  openMatDialog<T, D = any, R = any>(
-    component: ComponentType<T>,
-    config?: MatDialogConfig<D>,
-    disableClose: boolean = false
-  ): MatDialogRef<T, R> {
-    const defaults: MatDialogConfig = { direction: this.i18n.direction, autoFocus: false };
+  openMatDialog<T, D = any, R = any>(component: ComponentType<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R> {
+    const defaults: MatDialogConfig = { direction: this.i18n.direction, autoFocus: false, disableClose: false };
     const dialogDefaults: MatDialogConfig = hasObjectProp(component, 'defaultMatDialogConfig')
       ? component.defaultMatDialogConfig
       : {};
-    return this.matDialog.open(component, { ...defaults, ...dialogDefaults, ...(config ?? {}), disableClose });
+    return this.matDialog.open(component, { ...defaults, ...dialogDefaults, ...(config ?? {}) });
   }
 
-  openGenericDialog<T>(options: GenericDialogOptions<T>, disableClose: boolean = false): GenericDialogRef<T> {
+  openGenericDialog<T>(
+    options: GenericDialogOptions<T>,
+    dialogOptions?: { disableClose?: boolean }
+  ): GenericDialogRef<T> {
     const dialogRef: MatDialogRef<GenericDialogComponent<T>, T> = this.matDialog.open<
       GenericDialogComponent<T>,
       GenericDialogOptions<T>,
@@ -43,7 +42,7 @@ export class DialogService {
       direction: this.i18n.direction,
       autoFocus: false,
       data: options,
-      disableClose
+      disableClose: dialogOptions?.disableClose ?? false
     });
 
     return {
@@ -56,9 +55,9 @@ export class DialogService {
     question: I18nKey | Observable<string>,
     affirmative: I18nKey | Observable<string>,
     negative?: I18nKey | Observable<string>,
-    disableClose: boolean = false
+    options?: { disableClose?: boolean }
   ): Promise<boolean> {
-    return await this.confirmWithOptions({ title: question, affirmative, negative }, disableClose);
+    return await this.confirmWithOptions({ title: question, affirmative, negative }, options);
   }
 
   async confirmWithOptions(
@@ -68,7 +67,7 @@ export class DialogService {
       affirmative: I18nKey | Observable<string>;
       negative?: I18nKey | Observable<string>;
     },
-    disableClose: boolean = false
+    dialogOptions?: { disableClose?: boolean }
   ): Promise<boolean> {
     const result: boolean | undefined = await this.openGenericDialog(
       {
@@ -79,7 +78,7 @@ export class DialogService {
           { value: true, label: this.ensureLocalized(options.affirmative), highlight: true }
         ]
       },
-      disableClose
+      dialogOptions
     ).result;
     return result === true;
   }
@@ -91,19 +90,19 @@ export class DialogService {
    * key.
    * @param close (optional) May be an Observable<string>, or an I18nKey which will be used as a translation key. If not
    * provided the button will use a default label for the close button.
-   * @param disableClose (optional) When true, prevents clicking outside the dialog from closing it. Default is false.
+   * @param options (optional) disableClose: when true, prevents clicking outside the dialog from closing it.
    */
   async message(
     message: I18nKey | Observable<string>,
     close?: I18nKey | Observable<string>,
-    disableClose: boolean = false
+    options?: { disableClose?: boolean }
   ): Promise<void> {
     return await this.openGenericDialog(
       {
         title: this.ensureLocalized(message),
         options: [{ value: undefined, label: this.ensureLocalized(close ?? 'dialog.close'), highlight: true }]
       },
-      disableClose
+      options
     ).result;
   }
 


### PR DESCRIPTION
Supersedes #4045.

The bug was in the dialog service which in `openMatDialog` was not honoring `disableClosed` when passed in the options, because it would override the `disableClose` from the option with the positional argument.

I've eliminated the positional argument, since I think passing a boolean is very unclear. Meanwhile passing `{ disableClose: true }` is very clear what it means. Additionally, having two ways to set the same property naturally leads to situations where they might conflict, which is what was happening here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4053)
<!-- Reviewable:end -->
