### PR TITLE
SF-3426 Auto focus note dialog input when it opens

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.html
@@ -80,7 +80,7 @@
         <form [formGroup]="noteDialogForm">
           <mat-form-field class="full-width" appearance="outline">
             <mat-label>{{ t("your_comment") }}</mat-label>
-            <textarea matInput formControlName="comment"></textarea>
+            <textarea matInput formControlName="comment" cdkFocusInitial></textarea>
             <mat-error>{{ t("required") }}</mat-error>
           </mat-form-field>
         </form>

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/note-dialog/note-dialog.component.spec.ts
@@ -330,6 +330,12 @@ describe('NoteDialogComponent', () => {
     expect(env.flagIcon).toEqual('/assets/icons/TagIcons/' + SF_TAG_ICON + '.png');
   }));
 
+  it('focuses the comment textarea when the thread already has notes', fakeAsync(() => {
+    env = new TestEnvironment({ noteThread: TestEnvironment.getNoteThread() });
+    expect(env.notes.length).toBeGreaterThan(0);
+    expect(document.activeElement).toBe(env.noteInputElement.nativeElement);
+  }));
+
   it('does not save note if textarea is empty', fakeAsync(() => {
     env = new TestEnvironment({ verseRef: new VerseRef('MAT 1:1') });
     expect(env.noteInputElement).toBeTruthy();


### PR DESCRIPTION
This additionally steals focus from the editor, and I'm hoping that fixes the issues where the user can accidentally edit behind the dialog (but this change can also stand without that).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4059)
<!-- Reviewable:end -->
