### PR TITLE
rts: clarify connect method

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -183,7 +183,7 @@ export = {
       callback(new Error('Server not started.'));
       return;
     }
-    const connection = server.connect(userId);
+    const connection = server.connectAsServer(userId);
     connection.on('error', err => console.log(err));
     const index = connectionIndex++;
     connections.set(index, connection);

--- a/src/RealtimeServer/common/realtime-server.spec.ts
+++ b/src/RealtimeServer/common/realtime-server.spec.ts
@@ -525,7 +525,7 @@ describe('RealtimeServer', () => {
     const env = new TestEnvironment();
     await env.createData();
 
-    const userConn = env.server.connect('user01');
+    const userConn = env.server.connectAsServer('user01');
     await submitOp(userConn, USERS_COLLECTION, 'user01', [
       {
         p: ['this_property_does_not_exist'],

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -394,7 +394,7 @@ export class RealtimeServer extends ShareDB {
       done();
     });
 
-    this.defaultConnection = this.connect();
+    this.defaultConnection = this.connectAsServer();
 
     if (!this.dataValidationDisabled) {
       ResourceMonitor.instance.setPubSub((this as any).pubsub);
@@ -418,26 +418,37 @@ export class RealtimeServer extends ShareDB {
     }
   }
 
-  connect(userId?: string): Connection;
-  connect(connection?: Connection, req?: any): Connection;
-  connect(connectionOrUserId?: Connection | string, req?: any): Connection {
-    let connection: Connection;
-    if (connectionOrUserId instanceof Connection) {
-      connection = connectionOrUserId;
-    } else {
-      // Temporary socket that is used in constructing the Connection, but quickly replaced with a new socket in ShareDB
-      // backend.js connect().
-      const tmpSocket = {
-        close: () => {
-          // do nothing
-        }
-      } as WebSocket;
-      connection = new MigrationConnection(tmpSocket);
-      if (connectionOrUserId != null) {
-        req = { userId: connectionOrUserId };
-      }
+  /**
+   * Creates a connection, described by `req`. `req` is later examined by `setConnectSession`, to produce a trusted
+   * server session with or without user ID, or a user session limited by JWT claims (for unit tests).
+   */
+  connect(connection?: Connection, req?: any): Connection {
+    if (connection != null) {
+      // Our application does not make any calls to this method with a defined Connection.
+      console.log(`Warning: realtime-server.ts RealtimeServer.connect unexpectedly received a connection argument.`);
+      return super.connect(connection, req);
     }
-    return super.connect(connection, req);
+
+    // Temporary socket that is used in constructing the Connection, but quickly replaced with a new socket in ShareDB
+    // backend.js connect().
+    const tmpSocket = {
+      close: () => {
+        // do nothing
+      }
+    } as WebSocket;
+    const migrationConnection = new MigrationConnection(tmpSocket);
+    return super.connect(migrationConnection, req);
+  }
+
+  /**
+   * Creates a connection that is trusted as the server, optionally acting for a user (but not limited by their
+   * permissions).
+   *
+   * Dotnet requests, this.defaultConnection, and other places in RealtimeServer reach this.
+   */
+  connectAsServer(onBehalfOfUserId?: string): Connection {
+    if (onBehalfOfUserId == null) return this.connect();
+    else return this.connect(undefined, { userId: onBehalfOfUserId });
   }
 
   listen(stream: any, req?: any): ShareDB.Agent {

--- a/src/RealtimeServer/common/utils/test-utils.ts
+++ b/src/RealtimeServer/common/utils/test-utils.ts
@@ -4,6 +4,9 @@ import { RealtimeServer, XF_ROLE_CLAIM, XF_USER_ID_CLAIM } from '../realtime-ser
 import { Json0OpBuilder } from './json0-op-builder';
 import { docCreate, docDelete, docFetch, docSubmitJson0Op, docSubmitOp } from './sharedb-utils';
 
+/**
+ * Connects with a user's own session, somewhat like a frontend client. For unit tests.
+ */
 export function clientConnect(server: RealtimeServer, userId: string, role: SystemRole = SystemRole.User): Connection {
   return server.connect(undefined, { user: { [XF_USER_ID_CLAIM]: userId, [XF_ROLE_CLAIM]: role } });
 }

--- a/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/note-thread-service.ts
@@ -251,7 +251,7 @@ export class NoteThreadService extends SFProjectDataService<NoteThread> {
     }
     const parts: string[] = docId.split(':');
     const projectId: string = parts[0];
-    const conn: Connection = this.server.connect(userId);
+    const conn: Connection = this.server.connectAsServer(userId);
     const pucDocs: Doc[] = (await createFetchQuery(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, { projectRef: projectId }))
       .results;
     const promises: Promise<boolean>[] = [];

--- a/src/RealtimeServer/scriptureforge/services/question-service.ts
+++ b/src/RealtimeServer/scriptureforge/services/question-service.ts
@@ -260,7 +260,7 @@ export class QuestionService extends SFProjectDataService<Question> {
   ): Promise<void> {
     const parts = docId.split(':');
     const projectId = parts[0];
-    const conn = this.server!.connect(userId);
+    const conn = this.server!.connectAsServer(userId);
     const query = await createFetchQuery(conn, SF_PROJECT_USER_CONFIGS_COLLECTION, { projectRef: projectId });
     const promises: Promise<boolean>[] = [];
     for (const doc of query.results) {


### PR DESCRIPTION
RealtimeServer.connect is overloaded and used for different things.

This patch changes the overloads to add clarity to how connect is
used, not used, and the implications.

---

- **I want to modify the `connect` method in a followup change. This patch makes our `connect` overloads more plain, and the followup change should be less confusing as a result.** 
- This patch should not be changing behaviour, but just adding clarity. (Except there is an added Warning.)
- You may notice unpleasant things as you review this. The patch here isn't trying to improve the behaviour, but preserve it.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/4060)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4060)
<!-- Reviewable:end -->
