### PR TITLE
rts: answer a snapshot request made on a connection that is gone

### DIFF
--- a/src/RealtimeServer/common/index.ts
+++ b/src/RealtimeServer/common/index.ts
@@ -283,7 +283,11 @@ export = {
       return;
     }
     const conn = connections.get(handle);
-    conn?.fetchSnapshotByTimestamp(collection, id, timestamp, (err, snapshot) => callback(err, snapshot));
+    if (conn == null) {
+      callback(new Error('Connection not found.'));
+      return;
+    }
+    conn.fetchSnapshotByTimestamp(collection, id, timestamp, (err, snapshot) => callback(err, snapshot));
   },
 
   fetchSnapshotsByTimestamp: (


### PR DESCRIPTION
fetchSnapshotByTimestamp called through optional chaining, so when the
handle no longer named a connection the call was skipped entirely and
the
callback was never invoked. The dotnet caller awaits that callback
until it is given up on.

Check for the missing connection and answer with an error, as the
neighbouring fetchSnapshotsByTimestamp already does.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/4062)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4062)
<!-- Reviewable:end -->
