### PR TITLE
SF-3884 Fix error invoking deleteTrainingData

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/configure-sources/configure-sources.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/configure-sources/configure-sources.component.spec.ts
@@ -375,22 +375,10 @@ describe('ConfigureSourcesComponent', () => {
       tick();
 
       verify(
-        mockedFileService.deleteFile(
-          FileType.TrainingData,
-          env.activatedProjectDoc.id,
-          TrainingDataDoc.COLLECTION,
-          newFile.dataId,
-          newFile.ownerRef
-        )
+        mockedFileService.findOrUpdateCache(FileType.TrainingData, TrainingDataDoc.COLLECTION, newFile.dataId)
       ).once();
       verify(
-        mockedFileService.deleteFile(
-          FileType.TrainingData,
-          env.activatedProjectDoc.id,
-          TrainingDataDoc.COLLECTION,
-          savedFile.dataId,
-          savedFile.ownerRef
-        )
+        mockedFileService.findOrUpdateCache(FileType.TrainingData, TrainingDataDoc.COLLECTION, savedFile.dataId)
       ).never();
       verify(mockTrainingDataService.createTrainingDataAsync(anything())).never();
       verify(mockTrainingDataService.deleteTrainingDataAsync(anything())).never();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/configure-sources/configure-sources.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/configure-sources/configure-sources.component.ts
@@ -335,15 +335,11 @@ export class ConfigureSourcesComponent extends DataLoadingComponent implements O
         this.i18n.translate('draft_sources.stay_on_page')
       );
       if (confirmed) {
+        // Remove from the local cache any files that were not uploaded
         const addedFiles = this.availableTrainingFiles.filter(selected => !this.savedTrainingFiles?.includes(selected));
-        addedFiles.forEach(f =>
-          this.fileService.deleteFile(
-            FileType.TrainingData,
-            this.activatedProjectService.projectId!,
-            TrainingDataDoc.COLLECTION,
-            f.dataId,
-            f.ownerRef
-          )
+        addedFiles.forEach(
+          async f =>
+            await this.fileService.findOrUpdateCache(FileType.TrainingData, TrainingDataDoc.COLLECTION, f.dataId)
         );
       }
 


### PR DESCRIPTION
This PR fixes an error that is in bugsnag `"Error invoking deleteTrainingData: Http failure response for https://scriptureforge.org/command-api/projects: -32601 No methods matched request."` which can occur when a user adds a training data file, then cancels out of the configure sources page, then changes their online status to offline then online again.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4067)
<!-- Reviewable:end -->
