### PR TITLE
Fix crash when filtering historic builds with invalid scripture ranges

### DIFF
--- a/src/SIL.XForge.Scripture/Models/ScriptureRangeParserExtensions.cs
+++ b/src/SIL.XForge.Scripture/Models/ScriptureRangeParserExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SIL.XForge.Scripture.Models;
+
+public static class ScriptureRangeParserExtensions
+{
+    public static bool TryGetChapters(
+        this ScriptureRangeParser scriptureRangeParser,
+        string chapterSelections,
+        [NotNullWhen(true)] out Dictionary<string, List<int>>? chapters
+    )
+    {
+        try
+        {
+            chapters = scriptureRangeParser.GetChapters(chapterSelections);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            chapters = null;
+            return false;
+        }
+    }
+}

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -4037,10 +4037,12 @@ public partial class MachineApiService(
                 b.State == BuildStateCompleted
                 && (
                     b.AdditionalInfo?.TranslationScriptureRanges.Any(r =>
-                        scriptureRangeParser
-                            .GetChapters(r.ScriptureRange)
-                            .TryGetValue(Canon.BookNumberToId(bookNum), out List<int> chapters)
-                        && (chapters.Count == 0 || chapters.Contains(chapterNum) || chapterNum == 0)
+                        scriptureRangeParser.TryGetChapters(
+                            r.ScriptureRange,
+                            out Dictionary<string, List<int>> chapters
+                        )
+                        && chapters.TryGetValue(Canon.BookNumberToId(bookNum), out List<int> bookChapters)
+                        && (bookChapters.Count == 0 || bookChapters.Contains(chapterNum) || chapterNum == 0)
                     )
                     ?? false
                 )


### PR DESCRIPTION
I have some historic builds for a project that were created during versification experiments. As such, there are drafts for additional chapters that cause the `ScriptureRangeParser` to crash, as the current versification is more normal.

This PR fixes this crash, by just ignoring these historic builds when filtering by book and chapter. These use cases will only occur if partial books drafts were created for chapters that are now no longer in the project's versification. Really only the Apocrypha will trigger this scenario if the versification is changed from LXX or Vulgate to Original, or additional chapter customizations to the versification are removed.

I have not changed any other use of `ScriptureRangeParser.GetChapters()`, as we would want to know of a crash for any current build with versification, as that will highlight a serious problem. For historic builds, I think it is OK just to skip them when we are filtering by a book or chapter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4068)
<!-- Reviewable:end -->
