### PR TITLE
SF-3905 Use new apply draft logic in the editor draft tab

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.spec.ts
@@ -137,15 +137,6 @@ describe('SFProjectService', () => {
     }));
   });
 
-  describe('onlineSetDraftApplied', () => {
-    it('should invoke the command service', fakeAsync(async () => {
-      const env = new TestEnvironment();
-      await env.service.onlineSetDraftApplied('project01', 1, 1, true, 25);
-      verify(mockedCommandService.onlineInvoke(anything(), 'setDraftApplied', anything())).once();
-      expect().nothing();
-    }));
-  });
-
   describe('onlineEventMetrics', () => {
     it('should invoke the command service', fakeAsync(async () => {
       const env = new TestEnvironment();

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/sf-project.service.ts
@@ -404,22 +404,6 @@ export class SFProjectService extends ProjectService<SFProject, SFProjectDoc> {
     });
   }
 
-  async onlineSetDraftApplied(
-    projectId: string,
-    book: number,
-    chapter: number,
-    draftApplied: boolean,
-    lastVerse: number
-  ): Promise<void> {
-    return await this.onlineInvoke('setDraftApplied', {
-      projectId,
-      book,
-      chapter,
-      draftApplied,
-      lastVerse
-    });
-  }
-
   async onlineSetIsValid(projectId: string, book: number, chapter: number, isValid: boolean): Promise<void> {
     return await this.onlineInvoke('setIsValid', {
       projectId,

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
@@ -326,7 +326,7 @@ describe('TextDocService', () => {
       expect(actual).toBe(false);
     });
 
-    it('should return false if the user not have the permission', () => {
+    it('should return false if the user does not have permission', () => {
       const env = new TestEnvironment();
       const project = createTestProjectProfile({ userRoles: { user01: SFProjectRole.ParatextObserver } });
 
@@ -355,7 +355,7 @@ describe('TextDocService', () => {
       expect(actual).toBeUndefined();
     });
 
-    it('should return false if the user not have the permission', () => {
+    it('should return false if the user does not have permission', () => {
       const env = new TestEnvironment();
       const project = createTestProjectProfile({ texts: [{ bookNum: 1, chapters: [{ number: 1 }] }] });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.spec.ts
@@ -46,7 +46,7 @@ describe('TextDocService', () => {
     const diff: Delta = origDelta.diff(newDelta);
 
     env.textDocService.getLocalSystemChanges$(env.textDocId).subscribe(emittedDiff => {
-      expect(emittedDiff.ops).toEqual(diff.ops);
+      expect(emittedDiff?.ops).toEqual(diff.ops);
     });
 
     env.textDocService.overwrite(env.textDocId, newDelta, 'Editor');
@@ -346,13 +346,13 @@ describe('TextDocService', () => {
   });
 
   describe('hasChapterEditPermission', () => {
-    it('should return false if the project not have the book', () => {
+    it('should return undefined if the project does not have the book', () => {
       const env = new TestEnvironment();
       const project = createTestProjectProfile({ texts: [] });
 
       // SUT
-      const actual: boolean = env.textDocService.hasChapterEditPermission(project, 1, 1);
-      expect(actual).toBe(false);
+      const actual: boolean | undefined = env.textDocService.hasChapterEditPermission(project, 1, 1);
+      expect(actual).toBeUndefined();
     });
 
     it('should return false if the user not have the permission', () => {
@@ -360,8 +360,8 @@ describe('TextDocService', () => {
       const project = createTestProjectProfile({ texts: [{ bookNum: 1, chapters: [{ number: 1 }] }] });
 
       // SUT
-      const actual: boolean = env.textDocService.hasChapterEditPermission(project, 1, 1);
-      expect(actual).toBe(false);
+      const actual: boolean | undefined = env.textDocService.hasChapterEditPermission(project, 1, 1);
+      expect(actual).toBeFalse();
     });
 
     it('should return true if the user has the write permission', () => {
@@ -376,8 +376,8 @@ describe('TextDocService', () => {
       });
 
       // SUT
-      const actual: boolean = env.textDocService.hasChapterEditPermission(project, 1, 1);
-      expect(actual).toBe(true);
+      const actual: boolean | undefined = env.textDocService.hasChapterEditPermission(project, 1, 1);
+      expect(actual).toBeTrue();
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/core/text-doc.service.ts
@@ -15,7 +15,7 @@ import { SFProjectService } from './sf-project.service';
   providedIn: 'root'
 })
 export class TextDocService {
-  private localSystemTextDocChangesMap = new Map<string, Subject<TextData>>();
+  private localSystemTextDocChangesMap = new Map<string, Subject<TextData | undefined>>();
 
   constructor(
     private readonly projectService: SFProjectService,
@@ -46,6 +46,17 @@ export class TextDocService {
   }
 
   /**
+   * Notifies any TextViewModels that the document has undergone major changes.
+   *
+   * @param {TextDocId} textDocId The id for text doc.
+   */
+  async notifyChanges(textDocId: TextDocId): Promise<void> {
+    const textDoc = await this.projectService.getText(textDocId);
+    if (textDoc.data?.ops == null) return;
+    this.getLocalSystemChangesInternal$(textDocId).next(undefined);
+  }
+
+  /**
    * Determines if the current user can edit the specified chapter.
    *
    * @param {SFProjectProfile | undefined} project The project.
@@ -72,7 +83,7 @@ export class TextDocService {
   ): boolean {
     return (
       this.userHasGeneralEditRight(project) &&
-      this.hasChapterEditPermission(project, bookNum, chapterNum) &&
+      this.hasChapterEditPermission(project, bookNum, chapterNum) === true &&
       this.isDataInSync(project) &&
       !this.isEditingDisabled(project)
     );
@@ -151,15 +162,16 @@ export class TextDocService {
    * @param {SFProjectProfile | undefined} project The project.
    * @param {number | undefined} bookNum The book number.
    * @param {number | undefined} chapterNum The chapter number.
-   * @returns {boolean} A value indicating whether the user can edit the chapter.
+   * @returns {boolean | undefined} A value indicating whether the user can edit the chapter.
+   *                                An undefined value means that the chapter is not in IndexedDB yet.
    */
   hasChapterEditPermission(
     project: SFProjectProfile | undefined,
     bookNum: number | undefined,
     chapterNum: number | undefined
-  ): boolean {
+  ): boolean | undefined {
     const text: TextInfo | undefined = project?.texts.find(t => t.bookNum === bookNum);
-    return this.hasChapterEditPermissionForText(text, chapterNum) ?? false;
+    return this.hasChapterEditPermissionForText(text, chapterNum);
   }
 
   /**
@@ -188,16 +200,16 @@ export class TextDocService {
    * @param {TextDocId} textDocId The id for text doc to listen to.
    * @returns {Observable<TextData>} An observable that emits the diff ops.
    */
-  getLocalSystemChanges$(textDocId: TextDocId): Observable<TextData> {
+  getLocalSystemChanges$(textDocId: TextDocId): Observable<TextData | undefined> {
     return this.getLocalSystemChangesInternal$(textDocId).asObservable();
   }
 
-  private getLocalSystemChangesInternal$(textDocId: TextDocId): Subject<TextData> {
+  private getLocalSystemChangesInternal$(textDocId: TextDocId): Subject<TextData | undefined> {
     const key: string = textDocId.toString();
-    let subject: Subject<TextData> | undefined = this.localSystemTextDocChangesMap.get(key);
+    let subject: Subject<TextData | undefined> | undefined = this.localSystemTextDocChangesMap.get(key);
 
     if (subject == null) {
-      subject = new Subject<TextData>();
+      subject = new Subject<TextData | undefined>();
       this.localSystemTextDocChangesMap.set(key, subject);
     }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -152,6 +152,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
   private _isReadOnly: boolean = true;
   private _editorStyles: any = { fontSize: '1rem' };
   private activePresenceSubscription?: Subscription;
+  private onCreateSub?: Subscription;
   private onDeleteSub?: Subscription;
   private localSystemChangesSub?: Subscription;
   private readonly DEFAULT_MODULES: any = {
@@ -575,11 +576,18 @@ export class TextComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(isOnline => {
+    this.onlineStatusService.onlineStatus$.pipe(quietTakeUntilDestroyed(this.destroyRef)).subscribe(async isOnline => {
       this.changeDetector.detectChanges();
 
       if (!isOnline && this._editor != null) {
         this.clearCursors(false); // Don't clear the local cursor
+      }
+
+      // If we have come online, watch for the creation of the text document
+      if (isOnline && this._id != null && this._editor != null) {
+        const textDoc = await this.projectService.getText(this._id);
+        this.onCreateSub?.unsubscribe();
+        this.onCreateSub = textDoc.create$.subscribe(() => this.bindQuill());
       }
     });
 
@@ -674,6 +682,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     this.viewModel?.unbind();
     this.loadingState = 'unloaded';
     void this.dismissPresences();
+    this.onCreateSub?.unsubscribe();
     this.onDeleteSub?.unsubscribe();
     this.localSystemChangesSub?.unsubscribe();
   }
@@ -1204,6 +1213,13 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     }
 
     if (!(await this.projectHasText())) {
+      // If we are online, watch for the creation of the text document
+      if (this.onlineStatusService.isOnline) {
+        const textDoc = await this.projectService.getText(this._id);
+        this.onCreateSub?.unsubscribe();
+        this.onCreateSub = textDoc.create$.subscribe(() => this.bindQuill());
+      }
+
       this.loaded.emit();
       return;
     }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/text/text.component.ts
@@ -584,11 +584,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
       }
 
       // If we have come online, watch for the creation of the text document
-      if (isOnline && this._id != null && this._editor != null) {
-        const textDoc = await this.projectService.getText(this._id);
-        this.onCreateSub?.unsubscribe();
-        this.onCreateSub = textDoc.create$.subscribe(() => this.bindQuill());
-      }
+      await this.subscribeToTextDocumentCreationAsync(isOnline);
     });
 
     // Listening to document 'selectionchange' event allows local cursor to change position on mousedown,
@@ -1214,12 +1210,7 @@ export class TextComponent implements AfterViewInit, OnDestroy {
 
     if (!(await this.projectHasText())) {
       // If we are online, watch for the creation of the text document
-      if (this.onlineStatusService.isOnline) {
-        const textDoc = await this.projectService.getText(this._id);
-        this.onCreateSub?.unsubscribe();
-        this.onCreateSub = textDoc.create$.subscribe(() => this.bindQuill());
-      }
-
+      await this.subscribeToTextDocumentCreationAsync(this.onlineStatusService.isOnline);
       this.loaded.emit();
       return;
     }
@@ -2008,6 +1999,15 @@ export class TextComponent implements AfterViewInit, OnDestroy {
     this.highlightMarkerHeight = bounds.height;
     this.highlightMarker.style.top = this._selectionBoundsTop + 'px';
     this.updateHighlightMarkerVisibility();
+  }
+
+  private async subscribeToTextDocumentCreationAsync(isOnline: boolean): Promise<void> {
+    // If we are online, watch for the creation of the text document
+    if (isOnline && this._id != null && this._editor != null) {
+      const textDoc = await this.projectService.getText(this._id);
+      this.onCreateSub?.unsubscribe();
+      this.onCreateSub = textDoc.create$.subscribe(() => this.bindQuill());
+    }
   }
 
   private updateHighlightMarkerVisibility(): void {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.spec.ts
@@ -1,5 +1,4 @@
 import { TestBed } from '@angular/core/testing';
-import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { ParagraphBreakFormat, QuoteFormat } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
@@ -9,12 +8,10 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { configureTestingModule } from 'xforge-common/test-utils';
 import { SFProjectProfileDoc } from '../../core/models/sf-project-profile-doc';
 import { TextDocId } from '../../core/models/text-doc';
-import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
 import { DraftGenerationService } from './draft-generation.service';
 import { DraftHandlingService } from './draft-handling.service';
 
-const mockedProjectService = mock(SFProjectService);
 const mockedTextDocService = mock(TextDocService);
 const mockedDraftGenerationService = mock(DraftGenerationService);
 const mockedActivatedProjectService = mock(ActivatedProjectService);
@@ -25,7 +22,6 @@ describe('DraftHandlingService', () => {
 
   configureTestingModule(() => ({
     providers: [
-      { provide: SFProjectService, useMock: mockedProjectService },
       { provide: TextDocService, useMock: mockedTextDocService },
       { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
       { provide: ActivatedProjectService, useMock: mockedActivatedProjectService }
@@ -224,71 +220,6 @@ describe('DraftHandlingService', () => {
       when(mockedTextDocService.isEditingDisabled(projectProfile)).thenReturn(false);
 
       expect(service.canApplyDraft(projectProfile, book, chapter, badOps)).toBe(false);
-    });
-  });
-
-  describe('applyChapterDraftAsync', () => {
-    it('should apply draft to text doc', async () => {
-      const textDocId = new TextDocId('project01', 1, 1);
-      const draftOps: DeltaOperation[] = [
-        { insert: { verse: { number: 1 } } },
-        { insert: 'In the beginning', attributes: { segment: 'verse_1_1' } }
-      ];
-      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
-      await service.applyChapterDraftAsync(textDocId, new Delta(draftOps));
-      verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).once();
-      verify(
-        mockedProjectService.onlineSetDraftApplied(
-          textDocId.projectId,
-          textDocId.bookNum,
-          textDocId.chapterNum,
-          true,
-          1
-        )
-      ).once();
-      expect().nothing();
-    });
-
-    it('should apply draft to text doc with verse letter', async () => {
-      const textDocId = new TextDocId('project01', 1, 1);
-      const draftOps: DeltaOperation[] = [
-        { insert: { verse: { number: '1a' } } },
-        { insert: 'In the beginning', attributes: { segment: 'verse_1_1a' } }
-      ];
-      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
-      await service.applyChapterDraftAsync(textDocId, new Delta(draftOps));
-      verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).once();
-      verify(
-        mockedProjectService.onlineSetDraftApplied(
-          textDocId.projectId,
-          textDocId.bookNum,
-          textDocId.chapterNum,
-          true,
-          1
-        )
-      ).once();
-      expect().nothing();
-    });
-
-    it('should apply draft to text doc with verse range', async () => {
-      const textDocId = new TextDocId('project01', 1, 1);
-      const draftOps: DeltaOperation[] = [
-        { insert: { verse: { number: '1-2' } } },
-        { insert: 'In the beginning', attributes: { segment: 'verse_1_1-2' } }
-      ];
-      when(mockedTextDocService.canRestore(anything(), 1, 1)).thenReturn(true);
-      await service.applyChapterDraftAsync(textDocId, new Delta(draftOps));
-      verify(mockedTextDocService.overwrite(textDocId, anything(), 'Draft')).once();
-      verify(
-        mockedProjectService.onlineSetDraftApplied(
-          textDocId.projectId,
-          textDocId.bookNum,
-          textDocId.chapterNum,
-          true,
-          2
-        )
-      ).once();
-      expect().nothing();
     });
   });
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-handling.service.ts
@@ -1,5 +1,4 @@
 import { DestroyRef, Injectable } from '@angular/core';
-import { Delta } from 'quill';
 import { SFProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project';
 import { DraftUsfmConfig } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
 import { DeltaOperation } from 'rich-text';
@@ -7,12 +6,9 @@ import { firstValueFrom } from 'rxjs';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
 import { filterNullish, quietTakeUntilDestroyed } from 'xforge-common/util/rxjs-util';
 import { TextDocId } from '../../core/models/text-doc';
-import { SFProjectService } from '../../core/sf-project.service';
 import { TextDocService } from '../../core/text-doc.service';
 import { isBadDelta } from '../../shared/utils';
 import { DraftGenerationService } from './draft-generation.service';
-
-const VERSE_NUM_REGEX = /(\d+)\w?$/;
 
 @Injectable({
   providedIn: 'root'
@@ -21,7 +17,6 @@ export class DraftHandlingService {
   private readonly bookDraftCache = new Map<string, Map<string, DeltaOperation[]>>();
 
   constructor(
-    private readonly projectService: SFProjectService,
     private readonly textDocService: TextDocService,
     private readonly activatedProjectService: ActivatedProjectService,
     private readonly draftGenerationService: DraftGenerationService,
@@ -77,41 +72,11 @@ export class DraftHandlingService {
   ): boolean {
     return (
       this.textDocService.userHasGeneralEditRight(targetProject) &&
-      this.textDocService.hasChapterEditPermission(targetProject, bookNum, chapterNum) &&
+      this.textDocService.hasChapterEditPermission(targetProject, bookNum, chapterNum) !== false &&
       this.textDocService.isDataInSync(targetProject) &&
       !this.textDocService.isEditingDisabled(targetProject) &&
       !isBadDelta(draftOps)
     );
-  }
-
-  /**
-   * Applies the draft to the text document.
-   * @param textDocId The text doc identifier.
-   * @param draftDelta The draft delta to overwrite the current text document with.
-   */
-  async applyChapterDraftAsync(textDocId: TextDocId, draftDelta: Delta): Promise<void> {
-    const verseOps: DeltaOperation[] = draftDelta.ops.filter(
-      op => typeof op.insert === 'object' && op.insert.verse != null
-    );
-
-    let lastVerse: number = 0;
-    if (verseOps.length > 0 && verseOps[verseOps.length - 1].insert!['verse']['number'] != null) {
-      let lastVerseStr: string = verseOps[verseOps.length - 1].insert!['verse']['number'].toString();
-      const match: RegExpExecArray | null = VERSE_NUM_REGEX.exec(lastVerseStr);
-      if (match != null) {
-        lastVerseStr = match[1];
-      }
-      lastVerse = parseInt(lastVerseStr, 10);
-    }
-    await this.projectService.onlineSetDraftApplied(
-      textDocId.projectId,
-      textDocId.bookNum,
-      textDocId.chapterNum,
-      true,
-      lastVerse
-    );
-    await this.projectService.onlineSetIsValid(textDocId.projectId, textDocId.bookNum, textDocId.chapterNum, true);
-    await this.textDocService.overwrite(textDocId, draftDelta, 'Draft');
   }
 
   /**

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.html
@@ -1,6 +1,6 @@
 <ng-container *transloco="let t; read: 'editor_draft_tab'">
   @if (onlineStatusService.onlineStatus$ | async) {
-    @if (draftCheckState === "draft-unknown") {
+    @if (draftCheckState === "draft-unknown" || draftCheckState === "draft-applying") {
       <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
     }
 
@@ -43,7 +43,12 @@
             </span>
           }
           @if (canApplyDraft) {
-            <button mat-flat-button color="primary" (click)="applyDraft()">
+            <button
+              mat-flat-button
+              color="primary"
+              (click)="applyDraft()"
+              [disabled]="draftCheckState === 'draft-applying'"
+            >
               <mat-icon>auto_awesome</mat-icon>
               @if (isDraftApplied) {
                 {{ t("reapply_to_project") }}

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.spec.ts
@@ -3,6 +3,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatSelect, MatSelectChange } from '@angular/material/select';
 import { MatTooltip } from '@angular/material/tooltip';
+import { Canon } from '@sillsdev/scripture';
 import { QuillService } from 'ngx-quill';
 import { TranslocoMarkupModule } from 'ngx-transloco-markup';
 import { Delta } from 'quill';
@@ -28,25 +29,30 @@ import { SF_TYPE_REGISTRY } from '../../../core/models/sf-type-registry';
 import { Revision } from '../../../core/paratext.service';
 import { ProjectNotificationService } from '../../../core/project-notification.service';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDocService } from '../../../core/text-doc.service';
 import { BuildDto } from '../../../machine-api/build-dto';
 import { BuildStates } from '../../../machine-api/build-states';
 import { provideQuillRegistrations } from '../../../shared/text/quill-editor-registration/quill-providers';
 import { EDITOR_READY_TIMEOUT } from '../../../shared/text/text.component';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { DraftHandlingService } from '../../draft-generation/draft-handling.service';
+import { DraftApplyStatus } from '../../draft-generation/draft-import-wizard/draft-import-wizard.component';
+import { DraftNotificationService } from '../../draft-generation/draft-notification.service';
 import { HistoryRevisionFormatPipe } from '../editor-history/history-chooser/history-revision-format.pipe';
 import { EditorDraftComponent } from './editor-draft.component';
 
-const mockDraftGenerationService = mock(DraftGenerationService);
 const mockActivatedProjectService = mock(ActivatedProjectService);
 const mockAuthService = mock(AuthService);
-const mockDraftHandlingService = mock(DraftHandlingService);
-const mockI18nService = mock(I18nService);
 const mockDialogService = mock(DialogService);
-const mockNoticeService = mock(NoticeService);
+const mockDraftGenerationService = mock(DraftGenerationService);
+const mockDraftHandlingService = mock(DraftHandlingService);
+const mockDraftNotificationService = mock(DraftNotificationService);
 const mockErrorReportingService = mock(ErrorReportingService);
-const mockSFProjectService = mock(SFProjectService);
+const mockI18nService = mock(I18nService);
+const mockNoticeService = mock(NoticeService);
 const mockProjectNotificationService = mock(ProjectNotificationService);
+const mockSFProjectService = mock(SFProjectService);
+const mockTextDocService = mock(TextDocService);
 
 describe('EditorDraftComponent', () => {
   let fixture: ComponentFixture<EditorDraftComponent>;
@@ -71,15 +77,17 @@ describe('EditorDraftComponent', () => {
       provideTestRealtime(SF_TYPE_REGISTRY),
       { provide: ActivatedProjectService, useMock: mockActivatedProjectService },
       { provide: AuthService, useMock: mockAuthService },
+      { provide: DialogService, useMock: mockDialogService },
       { provide: DraftGenerationService, useMock: mockDraftGenerationService },
       { provide: DraftHandlingService, useMock: mockDraftHandlingService },
+      { provide: DraftNotificationService, useMock: mockDraftNotificationService },
+      { provide: ErrorReportingService, useMock: mockErrorReportingService },
       { provide: I18nService, useMock: mockI18nService },
       { provide: OnlineStatusService, useClass: TestOnlineStatusService },
-      { provide: DialogService, useMock: mockDialogService },
+      { provide: ProjectNotificationService, useMock: mockProjectNotificationService },
       { provide: NoticeService, useMock: mockNoticeService },
-      { provide: ErrorReportingService, useMock: mockErrorReportingService },
       { provide: SFProjectService, useMock: mockSFProjectService },
-      { provide: ProjectNotificationService, useMock: mockProjectNotificationService }
+      { provide: TextDocService, useMock: mockTextDocService }
     ]
   }));
 
@@ -90,21 +98,41 @@ describe('EditorDraftComponent', () => {
   });
 
   beforeEach(() => {
-    when(mockDraftGenerationService.pollBuildProgress(anything())).thenReturn(buildProgress$.asObservable());
     buildProgress$.next({ state: BuildStates.Completed } as BuildDto);
-    when(mockActivatedProjectService.projectId$).thenReturn(of('targetProjectId'));
-    when(mockDraftGenerationService.getLastCompletedBuild(anything())).thenReturn(of(undefined));
     const defaultProjectDoc: SFProjectProfileDoc = { data: createTestProjectProfile() } as SFProjectProfileDoc;
     when(mockActivatedProjectService.projectDoc$).thenReturn(of(defaultProjectDoc));
+    when(mockActivatedProjectService.projectId$).thenReturn(of('targetProjectId'));
+    when(mockDraftGenerationService.getLastCompletedBuild(anything())).thenReturn(of(undefined));
     when(mockDraftGenerationService.getLastPreTranslationBuild(anything())).thenReturn(
       of({ state: BuildStates.Completed } as BuildDto)
     );
+    when(mockDraftGenerationService.pollBuildProgress(anything())).thenReturn(buildProgress$.asObservable());
     when(mockDraftHandlingService.getBookDraft(anything(), anything())).thenResolve(bookDraftByChapters);
     when(mockDraftHandlingService.opsHaveContent(anything())).thenReturn(true);
     when(mockSFProjectService.hasDraft(anything(), anything(), anything(), anything())).thenReturn(true);
 
     fixture = TestBed.createComponent(EditorDraftComponent);
     component = fixture.componentInstance;
+
+    when(
+      mockSFProjectService.onlineApplyPreTranslationToProject(anything(), anything(), anything(), anything())
+    ).thenCall(projectId => {
+      // Simulate the SignalR service emitting that the draft is being applied then successful
+      tick();
+      component.updateDraftApplyState(projectId, {
+        bookNum: 0,
+        chapterNum: 0,
+        totalChapters: 0,
+        status: DraftApplyStatus.InProgress
+      });
+      tick();
+      component.updateDraftApplyState(projectId, {
+        bookNum: 0,
+        chapterNum: 0,
+        totalChapters: 0,
+        status: DraftApplyStatus.Successful
+      });
+    });
 
     testOnlineStatus = TestBed.inject(OnlineStatusService) as TestOnlineStatusService;
 
@@ -477,7 +505,7 @@ describe('EditorDraftComponent', () => {
 
     it('should throw error if there is no draft', fakeAsync(() => {
       component.applyDraft().catch(e => {
-        expect(e).toEqual(new Error('No draft ops to apply.'));
+        expect(e).toEqual(new Error('No draft to apply.'));
       });
       flush();
     }));
@@ -502,7 +530,14 @@ describe('EditorDraftComponent', () => {
       tick();
 
       expect(draftDelta.ops).toEqual(component['draftDelta']!.ops);
-      verify(mockDraftHandlingService.applyChapterDraftAsync(component.textDocId!, component['draftDelta']!)).once();
+      verify(
+        mockSFProjectService.onlineApplyPreTranslationToProject(
+          component.textDocId!.projectId,
+          Canon.bookNumberToId(component.textDocId!.bookNum) + ' ' + component.textDocId!.chapterNum,
+          component.textDocId!.projectId,
+          anything()
+        )
+      ).once();
       expect(component.isDraftApplied).toBe(true);
       flush();
     }));
@@ -521,23 +556,37 @@ describe('EditorDraftComponent', () => {
       tick(EDITOR_READY_TIMEOUT);
 
       // Does not report network related issues to bugsnag
-      when(mockDraftHandlingService.applyChapterDraftAsync(anything(), anything())).thenReject(
-        new CommandError(CommandErrorCode.Other, '504 Gateway Timeout')
-      );
+      when(
+        mockSFProjectService.onlineApplyPreTranslationToProject(anything(), anything(), anything(), anything())
+      ).thenReject(new CommandError(CommandErrorCode.Other, '504 Gateway Timeout'));
       component.applyDraft();
       tick();
-      verify(mockDraftHandlingService.applyChapterDraftAsync(component.textDocId!, anything())).once();
+      verify(
+        mockSFProjectService.onlineApplyPreTranslationToProject(
+          component.textDocId!.projectId,
+          Canon.bookNumberToId(component.textDocId!.bookNum) + ' ' + component.textDocId!.chapterNum,
+          component.textDocId!.projectId,
+          anything()
+        )
+      ).once();
       verify(mockNoticeService.showError(anything())).once();
       verify(mockErrorReportingService.silentError(anything())).never();
       expect(component.isDraftApplied).toBe(false);
 
       // Reports to bugsnag if error is not network related
-      when(mockDraftHandlingService.applyChapterDraftAsync(anything(), anything())).thenReject(
-        new CommandError(CommandErrorCode.Other, 'Unknown error')
-      );
+      when(
+        mockSFProjectService.onlineApplyPreTranslationToProject(anything(), anything(), anything(), anything())
+      ).thenReject(new CommandError(CommandErrorCode.Other, 'Unknown error'));
       component.applyDraft();
       tick();
-      verify(mockDraftHandlingService.applyChapterDraftAsync(component.textDocId!, anything())).twice();
+      verify(
+        mockSFProjectService.onlineApplyPreTranslationToProject(
+          component.textDocId!.projectId,
+          Canon.bookNumberToId(component.textDocId!.bookNum) + ' ' + component.textDocId!.chapterNum,
+          component.textDocId!.projectId,
+          anything()
+        )
+      ).twice();
       verify(mockNoticeService.showError(anything())).twice();
       verify(mockErrorReportingService.silentError(anything(), anything())).once();
       expect(component.isDraftApplied).toBe(false);

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -411,8 +411,8 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       draftApplyState.chapterNum === 0
     ) {
       this.draftCheckState = 'draft-present';
-      this.isDraftApplied = true;
-      this.userAppliedDraft = true;
+      this.isDraftApplied = draftApplyState.status === DraftApplyStatus.Successful;
+      this.userAppliedDraft = this.isDraftApplied;
       void this.textDocService.notifyChanges(this.textDocId);
     } else {
       // Ensure that the UI reflects that a draft is being applied

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor-draft/editor-draft.component.ts
@@ -36,7 +36,6 @@ import { ActivatedProjectService } from 'xforge-common/activated-project.service
 import { isNetworkError } from 'xforge-common/command.service';
 import { DialogService } from 'xforge-common/dialog.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
-import { FontService } from 'xforge-common/font.service';
 import { I18nService } from 'xforge-common/i18n.service';
 import { Locale } from 'xforge-common/models/i18n-locale';
 import { NoticeService } from 'xforge-common/notice.service';
@@ -47,12 +46,18 @@ import { TextDocId } from '../../../core/models/text-doc';
 import { Revision } from '../../../core/paratext.service';
 import { ProjectNotificationService } from '../../../core/project-notification.service';
 import { SFProjectService } from '../../../core/sf-project.service';
+import { TextDocService } from '../../../core/text-doc.service';
 import { BuildDto } from '../../../machine-api/build-dto';
 import { BuildStates } from '../../../machine-api/build-states';
 import { NoticeComponent } from '../../../shared/notice/notice.component';
 import { TextComponent } from '../../../shared/text/text.component';
 import { DraftGenerationService } from '../../draft-generation/draft-generation.service';
 import { DraftHandlingService } from '../../draft-generation/draft-handling.service';
+import {
+  DraftApplyState,
+  DraftApplyStatus
+} from '../../draft-generation/draft-import-wizard/draft-import-wizard.component';
+import { DraftNotificationService } from '../../draft-generation/draft-notification.service';
 import { DraftOptionsService } from '../../draft-generation/draft-options.service';
 import { DraftPreviewBooksComponent } from '../../draft-generation/draft-preview-books/draft-preview-books.component';
 import { HistoryRevisionFormatPipe } from '../editor-history/history-chooser/history-revision-format.pipe';
@@ -90,7 +95,7 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   @ViewChild(TextComponent) draftText!: TextComponent;
 
   inputChanged$ = new BehaviorSubject<TextDocId | undefined>(this.textDocId);
-  draftCheckState: 'draft-unknown' | 'draft-present' | 'draft-empty' = 'draft-unknown';
+  draftCheckState: 'draft-unknown' | 'draft-present' | 'draft-empty' | 'draft-applying' = 'draft-unknown';
   selectedRevision: Revision | undefined;
   generateDraftUrl?: string;
   targetProject?: SFProjectProfile;
@@ -98,6 +103,10 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   canSelectDraft = false;
   isDraftApplied = false;
   userAppliedDraft = false;
+
+  private readonly notifyDraftApplyProgressHandler = (projectId: string, draftApplyState: DraftApplyState): void => {
+    this.updateDraftApplyState(projectId, draftApplyState);
+  };
 
   private selectedRevisionSubject = new BehaviorSubject<Revision | undefined>(undefined);
   private selectedRevision$ = this.selectedRevisionSubject.asObservable();
@@ -133,14 +142,15 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
     private readonly dialogService: DialogService,
     private readonly draftGenerationService: DraftGenerationService,
     private readonly draftHandlingService: DraftHandlingService,
-    readonly fontService: FontService,
+    private readonly draftNotificationService: DraftNotificationService,
+    private readonly draftOptionsService: DraftOptionsService,
+    private readonly errorReportingService: ErrorReportingService,
     private readonly i18n: I18nService,
     private readonly projectService: SFProjectService,
     readonly onlineStatusService: OnlineStatusService,
     private readonly noticeService: NoticeService,
-    private errorReportingService: ErrorReportingService,
     private readonly router: Router,
-    private readonly draftOptionsService: DraftOptionsService,
+    private readonly textDocService: TextDocService,
     projectNotificationService: ProjectNotificationService
   ) {
     this.activatedProjectService.projectId$
@@ -154,10 +164,15 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
         projectNotificationService.setNotifyBuildProgressHandler(this.notifyBuildProgressHandler);
       });
 
+    this.draftNotificationService.setNotifyDraftApplyProgressHandler(this.notifyDraftApplyProgressHandler);
     destroyRef.onDestroy(async () => {
-      // Stop the SignalR connection when the component is destroyed
+      // Stop the Project SignalR connection when the component is destroyed
       await projectNotificationService.stop();
       projectNotificationService.removeNotifyBuildProgressHandler(this.notifyBuildProgressHandler);
+
+      // Stop the Draft SignalR connection when the component is destroyed
+      await draftNotificationService.stop();
+      this.draftNotificationService.removeNotifyDraftApplyProgressHandler(this.notifyDraftApplyProgressHandler);
     });
   }
 
@@ -347,8 +362,8 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
   }
 
   async applyDraft(): Promise<void> {
-    if (this.draftDelta == null) {
-      throw new Error('No draft ops to apply.');
+    if (this.draftDelta == null || this.textDocId == null || this.selectedRevision == null) {
+      throw new Error('No draft to apply.');
     }
 
     // Warn before overwriting existing text
@@ -359,10 +374,18 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
       }
     }
 
+    // Subscribe to SignalR updates
+    await this.draftNotificationService.start();
+    await this.draftNotificationService.subscribeToProject(this.textDocId.projectId);
+
     try {
-      await this.draftHandlingService.applyChapterDraftAsync(this.textDocId!, this.draftDelta);
-      this.isDraftApplied = true;
-      this.userAppliedDraft = true;
+      await this.projectService.onlineApplyPreTranslationToProject(
+        this.textDocId.projectId,
+        Canon.bookNumberToId(this.textDocId.bookNum) + ' ' + this.textDocId.chapterNum,
+        this.textDocId.projectId,
+        new Date(this.selectedRevision.timestamp)
+      );
+      this.draftCheckState = 'draft-applying';
     } catch (err) {
       this.noticeService.showError(this.i18n.translateStatic('editor_draft_tab.error_applying_draft'));
       if (!isNetworkError(err)) {
@@ -371,6 +394,29 @@ export class EditorDraftComponent implements AfterViewInit, OnChanges {
           ErrorReportingService.normalizeError(err)
         );
       }
+    }
+  }
+
+  /**
+   * Handler for SignalR notifications when applying a draft.
+   *
+   * @param projectId The project identifier.
+   * @param draftApplyState The draft apply state from the backend.
+   */
+  updateDraftApplyState(projectId: string, draftApplyState: DraftApplyState): void {
+    if (projectId !== this.textDocId?.projectId) return;
+    if (
+      (draftApplyState.status === DraftApplyStatus.Failed || draftApplyState.status === DraftApplyStatus.Successful) &&
+      draftApplyState.bookNum === 0 &&
+      draftApplyState.chapterNum === 0
+    ) {
+      this.draftCheckState = 'draft-present';
+      this.isDraftApplied = true;
+      this.userAppliedDraft = true;
+      void this.textDocService.notifyChanges(this.textDocId);
+    } else {
+      // Ensure that the UI reflects that a draft is being applied
+      this.draftCheckState = 'draft-applying';
     }
   }
 

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -116,6 +116,7 @@ import { PRESENCE_EDITOR_ACTIVE_TIMEOUT } from '../../shared/text/text.component
 import { XmlUtils } from '../../shared/utils';
 import { BiblicalTermsComponent } from '../biblical-terms/biblical-terms.component';
 import { DraftGenerationService } from '../draft-generation/draft-generation.service';
+import { DraftNotificationService } from '../draft-generation/draft-notification.service';
 import { DraftOptionsService } from '../draft-generation/draft-options.service';
 import { DraftPreviewBooksComponent } from '../draft-generation/draft-preview-books/draft-preview-books.component';
 import { TrainingProgressComponent } from '../training-progress/training-progress.component';
@@ -144,6 +145,7 @@ const mockedTranslationEngineService = mock(TranslationEngineService);
 const mockedMatDialog = mock(MatDialog);
 const mockedHttpClient = mock(HttpClient);
 const mockedDraftGenerationService = mock(DraftGenerationService);
+const mockedDraftNotificationService = mock(DraftNotificationService);
 const mockedDraftOptionsService = mock(DraftOptionsService);
 const mockedParatextService = mock(ParatextService);
 const mockedPermissionsService = mock(PermissionsService);
@@ -213,6 +215,7 @@ describe('EditorComponent', () => {
       { provide: BreakpointObserver, useClass: TestBreakpointObserver },
       { provide: HttpClient, useMock: mockedHttpClient },
       { provide: DraftGenerationService, useMock: mockedDraftGenerationService },
+      { provide: DraftNotificationService, useMock: mockedDraftNotificationService },
       { provide: DraftOptionsService, useMock: mockedDraftOptionsService },
       { provide: ParatextService, useMock: mockedParatextService },
       { provide: ProjectNotificationService, useMock: mockedProjectNotificationService },

--- a/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/SFProjectsRpcController.cs
@@ -543,7 +543,7 @@ public class SFProjectsRpcController(
     }
 
     [Obsolete(
-        "New endpoints require the share link type. Old clients would only ever request a recipient link for email"
+        "New endpoints require the share link type. Old clients would only ever request a recipient link for email. Deprecated 2023-04"
     )]
     public async Task<IRpcMethodResult> LinkSharingKey(string projectId, string role) =>
         await LinkSharingKey(projectId, role, ShareLinkType.Recipient, 14);
@@ -885,7 +885,7 @@ public class SFProjectsRpcController(
     }
 
     [Obsolete(
-        "Use OnboardingRequestRpcController.GetProjectMetadata with either paratextId or scriptureForgeId instead for more flexible querying"
+        "Use OnboardingRequestRpcController.GetProjectMetadata with either paratextId or scriptureForgeId instead for more flexible querying. Deprecated 2026-02"
     )]
     public async Task<IRpcMethodResult> GetProjectIdByParatextId(string paratextId)
     {
@@ -1211,7 +1211,7 @@ public class SFProjectsRpcController(
         }
     }
 
-    [Obsolete("Use ApplyPreTranslationToProject instead. Deprecated 2025-12")]
+    [Obsolete("Use ApplyPreTranslationToProject instead. Deprecated 2026-03")]
     public async Task<IRpcMethodResult> AddChapters(string projectId, int book, int[] chapters)
     {
         try
@@ -1242,7 +1242,7 @@ public class SFProjectsRpcController(
         }
     }
 
-    [Obsolete("New endpoints require lastVerse. Old clients do not provide lastVerse")]
+    [Obsolete("New endpoints require lastVerse. Old clients do not provide lastVerse. Deprecated 2025-03")]
     public async Task<IRpcMethodResult> SetDraftApplied(string projectId, int book, int chapter, bool draftApplied)
     {
         try
@@ -1274,6 +1274,7 @@ public class SFProjectsRpcController(
         }
     }
 
+    [Obsolete("Use ApplyPreTranslationToProject instead. Deprecated 2026-08")]
     public async Task<IRpcMethodResult> SetDraftApplied(
         string projectId,
         int book,

--- a/src/SIL.XForge.Scripture/Services/MachineApiService.cs
+++ b/src/SIL.XForge.Scripture/Services/MachineApiService.cs
@@ -231,10 +231,19 @@ public partial class MachineApiService(
                     IUsj usj;
                     if (textDocument.IsLoaded)
                     {
+                        DateTime latestTimestampForRevision = await LatestTimestampForRevisionAsync(
+                            curUserId,
+                            project,
+                            bookNum,
+                            chapterNum,
+                            isServalAdmin: false,
+                            timestamp,
+                            cancellationToken
+                        );
                         // Retrieve the snapshot if it exists, or use the latest available if none
                         Snapshot<TextDocument> snapshot = await connection.FetchSnapshotAsync<TextDocument>(
                             id,
-                            timestamp
+                            latestTimestampForRevision
                         );
                         usj = snapshot.Data ?? textDocument.Data;
                     }
@@ -2751,7 +2760,7 @@ public partial class MachineApiService(
 
         DateTime latestTimestampForRevision = await LatestTimestampForRevisionAsync(
             curUserId,
-            sfProjectId,
+            project,
             bookNum,
             chapterNum,
             isServalAdmin,
@@ -3950,7 +3959,7 @@ public partial class MachineApiService(
     /// Retrieves the latest timestamp for the revision corresponding to the specified timestamp.
     /// </summary>
     /// <param name="curUserId">The current user identifier.</param>
-    /// <param name="sfProjectId">The Scripture Forge project identifier.</param>
+    /// <param name="project">The Scripture Forge project.</param>
     /// <param name="bookNum">The book number.</param>
     /// <param name="chapterNum">The chapter number.</param>
     /// <param name="isServalAdmin">If <c>true</c>, the current user is a Serval Administrator.</param>
@@ -3960,7 +3969,7 @@ public partial class MachineApiService(
     /// <remarks>This function is internal so it can be unit tests.</remarks>
     internal async Task<DateTime> LatestTimestampForRevisionAsync(
         string curUserId,
-        string sfProjectId,
+        SFProject project,
         int bookNum,
         int chapterNum,
         bool isServalAdmin,
@@ -3968,17 +3977,9 @@ public partial class MachineApiService(
         CancellationToken cancellationToken
     )
     {
-        // Ensure that the user has permission
-        SFProject project = await EnsureProjectPermissionAsync(
-            curUserId,
-            sfProjectId,
-            isServalAdmin,
-            cancellationToken
-        );
-
         IReadOnlyList<ServalBuildDto> builds = await GetBuildsAsync(
             curUserId,
-            sfProjectId,
+            project.Id,
             preTranslate: true,
             isServalAdmin,
             cancellationToken

--- a/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/MachineApiControllerTests.cs
@@ -1634,8 +1634,8 @@ public class MachineApiControllerTests
         Assert.IsTrue(revisionsExist);
     }
 
-#pragma warning disable CS0618 // GetPreTranslationUsfmAsync is deprecated, but tested until it is removed
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_MachineApiDown()
     {
         // Set up test environment
@@ -1667,6 +1667,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_NoPermission()
     {
         // Set up test environment
@@ -1696,6 +1697,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_NoProject()
     {
         // Set up test environment
@@ -1725,6 +1727,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_NotBuilt()
     {
         // Set up test environment
@@ -1754,6 +1757,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_NotSupported()
     {
         // Set up test environment
@@ -1784,6 +1788,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_ServalAdmin()
     {
         // Set up test environment
@@ -1827,6 +1832,7 @@ public class MachineApiControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task GetPreTranslationUsfmAsync_Success()
     {
         // Set up test environment
@@ -1868,7 +1874,6 @@ public class MachineApiControllerTests
             );
     }
 
-#pragma warning restore CS0618
     [Test]
     public async Task GetPreTranslationUsjAsync_MachineApiDown()
     {

--- a/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Controllers/SFProjectsRpcControllerTests.cs
@@ -715,6 +715,7 @@ public class SFProjectsRpcControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task SetDraftApplied_Success()
     {
         var env = new TestEnvironment();
@@ -732,6 +733,7 @@ public class SFProjectsRpcControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task SetDraftApplied_Forbidden()
     {
         var env = new TestEnvironment();
@@ -749,6 +751,7 @@ public class SFProjectsRpcControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public async Task SetDraftApplied_NotFound()
     {
         var env = new TestEnvironment();
@@ -768,6 +771,7 @@ public class SFProjectsRpcControllerTests
     }
 
     [Test]
+    [Obsolete("Tests legacy method")]
     public void SetDraftApplied_UnknownError()
     {
         var env = new TestEnvironment();

--- a/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/MachineApiServiceTests.cs
@@ -4762,6 +4762,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         DateTime timestamp = DateTime.UtcNow;
         DateTime buildRequested = timestamp.AddHours(1);
+        var project = env.Projects.Get(Project01);
         var build = new ServalBuildDto
         {
             State = MachineApiService.BuildStateCompleted,
@@ -4776,7 +4777,7 @@ public class MachineApiServiceTests
         // SUT
         DateTime actual = await env.Service.LatestTimestampForRevisionAsync(
             User01,
-            Project01,
+            project,
             bookNum: 2,
             chapterNum: 1,
             isServalAdmin: true,
@@ -4792,6 +4793,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         DateTime timestamp = DateTime.UtcNow;
         DateTime buildRequested = timestamp.AddHours(-1);
+        var project = env.Projects.Get(Project01);
         var build = new ServalBuildDto
         {
             State = MachineApiService.BuildStateCompleted,
@@ -4806,7 +4808,7 @@ public class MachineApiServiceTests
         // SUT
         DateTime actual = await env.Service.LatestTimestampForRevisionAsync(
             User01,
-            Project01,
+            project,
             bookNum: 2,
             chapterNum: 1,
             isServalAdmin: true,
@@ -4822,6 +4824,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         DateTime timestamp = DateTime.UtcNow;
         DateTime buildRequested = timestamp.AddHours(-1);
+        var project = env.Projects.Get(Project01);
         var build = new ServalBuildDto
         {
             State = MachineApiService.BuildStateFinishing,
@@ -4836,7 +4839,7 @@ public class MachineApiServiceTests
         // SUT
         DateTime actual = await env.Service.LatestTimestampForRevisionAsync(
             User01,
-            Project01,
+            project,
             bookNum: 2,
             chapterNum: 1,
             isServalAdmin: true,
@@ -4852,6 +4855,7 @@ public class MachineApiServiceTests
         var env = new TestEnvironment();
         DateTime timestamp = DateTime.UtcNow;
         DateTime buildRequested = timestamp.AddHours(-1);
+        var project = env.Projects.Get(Project01);
         var build = new ServalBuildDto
         {
             State = MachineApiService.BuildStateFinishing,
@@ -4866,7 +4870,7 @@ public class MachineApiServiceTests
         // SUT
         DateTime actual = await env.Service.LatestTimestampForRevisionAsync(
             User01,
-            Project01,
+            project,
             bookNum: 2,
             chapterNum: 1,
             isServalAdmin: true,
@@ -4881,6 +4885,7 @@ public class MachineApiServiceTests
     {
         var env = new TestEnvironment();
         DateTime timestamp = DateTime.UtcNow;
+        var project = env.Projects.Get(Project01);
         env.Service.Configure()
             .GetBuildsAsync(User01, Project01, preTranslate: true, isServalAdmin: true, CancellationToken.None)
             .Returns(Task.FromResult<IReadOnlyList<ServalBuildDto>>([]));
@@ -4888,7 +4893,7 @@ public class MachineApiServiceTests
         // SUT
         DateTime actual = await env.Service.LatestTimestampForRevisionAsync(
             User01,
-            Project01,
+            project,
             bookNum: 2,
             chapterNum: 1,
             isServalAdmin: true,


### PR DESCRIPTION
This PR updates the editor draft tab to use the new draft application logic, but retaining the same interface as the draft tab had previously. This resolves in particular an issue that prevented the old editor draft tab form adding a draft to a chapter of a book that was not in the project already.

I also took the opportunity to add/correct some dates in `[Obsolete]` attributes, so we can make a decision on when to remove these obsolete functions in future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4072)
<!-- Reviewable:end -->
