### PR TITLE
SF-3919 Inform user what email address to look for onboarding response

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.html
@@ -146,6 +146,14 @@
                   })
                 }}
               </p>
+              @if (onboardingRequest.contactEmail != null) {
+                <p class="signup-response-email">
+                  <transloco
+                    key="draft_generation.signup_response_will_be_emailed"
+                    [params]="{ email: onboardingRequest.contactEmail }"
+                  ></transloco>
+                </p>
+              }
               @if (onboardingRequestAged(onboardingRequest)) {
                 <p>
                   @for (

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.scss
@@ -56,6 +56,10 @@ app-notice {
   margin-top: 20px;
 }
 
+.signup-response-email ::ng-deep b {
+  font-weight: 500;
+}
+
 // Hide the tab headers
 mat-tab-group {
   ::ng-deep .mat-mdc-tab-header {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.spec.ts
@@ -9,6 +9,7 @@ import { SFProjectRole } from 'realtime-server/lib/esm/scriptureforge/models/sf-
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { TextInfoPermission } from 'realtime-server/lib/esm/scriptureforge/models/text-info-permission';
 import { ProjectType } from 'realtime-server/lib/esm/scriptureforge/models/translate-config';
+import { defaultTranslocoMarkupTranspilers } from 'ngx-transloco-markup';
 import { EMPTY, of, Subject, throwError } from 'rxjs';
 import { instance, mock, verify, when } from 'ts-mockito';
 import { ActivatedProjectService } from 'xforge-common/activated-project.service';
@@ -84,6 +85,7 @@ describe('DraftGenerationComponent', () => {
         providers: [
           provideRouter([]),
           provideTestOnlineStatus(),
+          defaultTranslocoMarkupTranspilers(),
           { provide: AuthService, useValue: mockAuthService },
           { provide: DraftGenerationService, useValue: mockDraftGenerationService },
           { provide: DraftSourcesService, useValue: mockDraftSourcesService },
@@ -231,6 +233,10 @@ describe('DraftGenerationComponent', () => {
 
     get preGenerationStepper(): HTMLElement | null {
       return (this.fixture.nativeElement as HTMLElement).querySelector('app-draft-generation-steps');
+    }
+
+    get signupResponseEmail(): HTMLElement | null {
+      return (this.fixture.nativeElement as HTMLElement).querySelector('.signup-response-email');
     }
 
     getElementByTestId(testId: string): HTMLElement | null {
@@ -792,6 +798,42 @@ describe('DraftGenerationComponent', () => {
       env.fixture.detectChanges();
       expect(env.component.isBackTranslation).toBe(false);
       expect(env.getElementByTestId('approval-needed')).toBeNull();
+    });
+
+    it('should tell the submitter which email address the response will be sent to', () => {
+      const env = new TestEnvironment();
+      env.component.isBackTranslation = false;
+      env.component.isTargetLanguageSupported = true;
+      env.component.isPreTranslationApproved = false;
+      env.component.onboardingRequest = {
+        submittedAt: new Date().toISOString(),
+        submittedBy: { name: 'User One', email: 'account@example.com' },
+        status: 'new',
+        contactEmail: 'contact@example.com'
+      };
+      env.fixture.detectChanges();
+      const responseEmail = env.signupResponseEmail;
+      expect(responseEmail).not.toBeNull();
+      expect(responseEmail!.textContent).toContain('contact@example.com');
+      const emailElement = responseEmail!.querySelector('b')!;
+      expect(emailElement.textContent).toBe('contact@example.com');
+      expect(getComputedStyle(emailElement).fontWeight).toBe('500');
+    });
+
+    it('should not show a response email address to users other than the submitter', () => {
+      const env = new TestEnvironment();
+      env.component.isBackTranslation = false;
+      env.component.isTargetLanguageSupported = true;
+      env.component.isPreTranslationApproved = false;
+      env.component.onboardingRequest = {
+        submittedAt: new Date().toISOString(),
+        submittedBy: { name: 'User One', email: 'account@example.com' },
+        status: 'new',
+        contactEmail: null
+      };
+      env.fixture.detectChanges();
+      expect(env.getElementByTestId('approval-needed')).not.toBeNull();
+      expect(env.signupResponseEmail).toBeNull();
     });
 
     it('should not show "approval needed" info alert when project is in back translation mode', () => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-generation.component.ts
@@ -54,7 +54,7 @@ import { DraftOptionsService } from './draft-options.service';
 import { DRAFT_SIGNUP_RESPONSE_DAYS } from './draft-signup-form/draft-onboarding-form.component';
 import { DraftSource } from './draft-source';
 import { DraftSourcesService } from './draft-sources.service';
-import { OnboardingRequest, OnboardingRequestService } from './onboarding-request.service';
+import { OnboardingRequestService, OpenOnboardingRequest } from './onboarding-request.service';
 import { SupportedBackTranslationLanguagesDialogComponent } from './supported-back-translation-languages-dialog/supported-back-translation-languages-dialog.component';
 
 @Component({
@@ -131,7 +131,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
   hasDraftBooksAvailable = false;
 
   isPreTranslationApproved = false;
-  onboardingRequest?: OnboardingRequest | null;
+  onboardingRequest?: OpenOnboardingRequest | null;
   responseDays = DRAFT_SIGNUP_RESPONSE_DAYS;
 
   cancelDialogRef?: MatDialogRef<any>;
@@ -192,7 +192,7 @@ export class DraftGenerationComponent extends DataLoadingComponent implements On
     return issuesEmailTemplate();
   }
 
-  onboardingRequestAged(onboardingRequest: OnboardingRequest): boolean {
+  onboardingRequestAged(onboardingRequest: OpenOnboardingRequest): boolean {
     const elapsedTime = new Date().getTime() - new Date(onboardingRequest.submittedAt).getTime();
     const elapsedDays = elapsedTime / (1000 * 60 * 60 * 24);
     return elapsedDays > this.responseDays.max;

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/onboarding-request.service.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/onboarding-request.service.ts
@@ -71,6 +71,21 @@ export interface OnboardingRequest extends OnboardingRequestSummary {
   comments: OnboardingRequestComment[];
 }
 
+/**
+ * The subset of an open onboarding request returned by getOpenOnboardingRequest. Only what the draft
+ * generation page needs to tell users a request has already been submitted for the project.
+ */
+export interface OpenOnboardingRequest {
+  submittedAt: string;
+  submittedBy: { name: string; email: string };
+  status: OnboardingRequestStatusOption;
+  /**
+   * The email address the team's response will be sent to (from the signup form). Only present when the
+   * current user is the one who submitted the request; null for other project members.
+   */
+  contactEmail: string | null;
+}
+
 /** Represents a comment on an onboarding request. */
 export interface OnboardingRequestComment {
   id: string;
@@ -137,8 +152,8 @@ export class OnboardingRequestService {
   }
 
   /** Gets the existing onboarding request for the specified project, if any. */
-  async getOpenOnboardingRequest(projectId: string): Promise<OnboardingRequest | null> {
-    return (await this.onlineInvoke<OnboardingRequest | null>('getOpenOnboardingRequest', { projectId }))!;
+  async getOpenOnboardingRequest(projectId: string): Promise<OpenOnboardingRequest | null> {
+    return (await this.onlineInvoke<OpenOnboardingRequest | null>('getOpenOnboardingRequest', { projectId }))!;
   }
 
   async getRequestById(requestId: string): Promise<OnboardingRequest> {

--- a/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
+++ b/src/SIL.XForge.Scripture/ClientApp/src/assets/i18n/non_checking_en.json
@@ -223,6 +223,7 @@
     "quota_exceeded": "Generating drafts is temporarily unavailable for this project as its quota has been exceeded",
     "report_problem": "Report problem",
     "signup_already_submitted": "{{ name }} submitted a request to sign up for drafting on {{ date }}. A team member will contact you within {{ min }} to {{ max }} business days to discuss your project and next steps.",
+    "signup_response_will_be_emailed": "The response will be sent by email to [b]{{ email }}[/b].",
     "sign_up_for_drafting": "Sign up for drafting",
     "temporarily_unavailable": "Generating drafts is temporarily unavailable.",
     "problem_fetching_build_history": "There was a problem fetching build history.",

--- a/src/SIL.XForge.Scripture/Controllers/OnboardingRequestRpcController.cs
+++ b/src/SIL.XForge.Scripture/Controllers/OnboardingRequestRpcController.cs
@@ -93,7 +93,7 @@ public class OnboardingRequestRpcController(
                 return ForbiddenError();
             }
 
-            object result = await onboardingRequestService.GetOpenOnboardingRequestAsync(projectId);
+            object result = await onboardingRequestService.GetOpenOnboardingRequestAsync(projectId, UserId);
             return Ok(result);
         }
         catch (Exception)

--- a/src/SIL.XForge.Scripture/Services/IOnboardingRequestService.cs
+++ b/src/SIL.XForge.Scripture/Services/IOnboardingRequestService.cs
@@ -18,7 +18,7 @@ public interface IOnboardingRequestService
         Uri siteRoot
     );
 
-    Task<object> GetOpenOnboardingRequestAsync(string projectId);
+    Task<object> GetOpenOnboardingRequestAsync(string projectId, string userId);
 
     Task<List<OnboardingRequestSummary>> GetAllRequestsAsync();
 

--- a/src/SIL.XForge.Scripture/Services/OnboardingRequestService.cs
+++ b/src/SIL.XForge.Scripture/Services/OnboardingRequestService.cs
@@ -55,7 +55,7 @@ public class OnboardingRequestService(
         return request.Id;
     }
 
-    public async Task<object> GetOpenOnboardingRequestAsync(string projectId)
+    public async Task<object> GetOpenOnboardingRequestAsync(string projectId, string userId)
     {
         OnboardingRequest existingRequest = await onboardingRequestRepository
             .Query()
@@ -74,6 +74,11 @@ public class OnboardingRequestService(
             submittedAt = existingRequest.Submission.Timestamp,
             submittedBy = new { name = submittingUser.Name, email = submittingUser.Email },
             status = existingRequest.Status,
+            // The address the team's response will be sent to. Only disclosed to the user who submitted the
+            // request, so other project members are not shown someone else's email address.
+            contactEmail = existingRequest.Submission.UserId == userId
+                ? existingRequest.Submission.FormData.Email
+                : null,
         };
     }
 

--- a/test/SIL.XForge.Scripture.Tests/Services/OnboardingRequestServiceTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/OnboardingRequestServiceTests.cs
@@ -112,4 +112,61 @@ public class OnboardingRequestServiceTests
             .Received(1)
             .SendEmailAsync(AdminEmail, expectedSubject, expectedBody, CancellationToken.None);
     }
+
+    [Test]
+    public async Task GetOpenOnboardingRequestAsync_DisclosesContactEmailToSubmitter()
+    {
+        object result = await GetOpenOnboardingRequestAsync(callingUserId: UserId);
+
+        Assert.That(GetProperty(result, "contactEmail"), Is.EqualTo("contact@example.com"));
+    }
+
+    [Test]
+    public async Task GetOpenOnboardingRequestAsync_HidesContactEmailFromOtherUsers()
+    {
+        object result = await GetOpenOnboardingRequestAsync(callingUserId: "user02");
+
+        Assert.That(GetProperty(result, "contactEmail"), Is.Null);
+        // The rest of the response is still returned
+        Assert.That(GetProperty(result, "submittedBy"), Is.Not.Null);
+    }
+
+    private static async Task<object> GetOpenOnboardingRequestAsync(string callingUserId)
+    {
+        var repository = new MemoryRepository<OnboardingRequest>([
+            new OnboardingRequest
+            {
+                Id = "request01",
+                Submission = new OnboardingSubmission
+                {
+                    ProjectId = ProjectId,
+                    UserId = UserId,
+                    Timestamp = DateTime.UtcNow,
+                    FormData = new OnboardingRequestFormData { Email = "contact@example.com" },
+                },
+                Resolution = "unresolved",
+            },
+        ]);
+
+        var realtimeService = Substitute.For<IRealtimeService>();
+        realtimeService
+            .QuerySnapshots<User>()
+            .Returns(
+                new List<User>
+                {
+                    new User
+                    {
+                        Id = UserId,
+                        Name = "User One",
+                        Email = "account@example.com",
+                    },
+                }.AsQueryable()
+            );
+
+        var service = new OnboardingRequestService(repository, realtimeService, Substitute.For<IServiceScopeFactory>());
+        return await service.GetOpenOnboardingRequestAsync(ProjectId, callingUserId);
+    }
+
+    private static object? GetProperty(object obj, string propertyName) =>
+        obj.GetType().GetProperty(propertyName)!.GetValue(obj);
 }


### PR DESCRIPTION
This is to help address users not seeing responses.

<img width="891" height="141" alt="localhost_5000_projects_6a79f778c9349191952b2683_draft-generation (1)" src="https://github.com/user-attachments/assets/17c5fb07-06ee-4021-b111-c9832d1b9ffa" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4073)
<!-- Reviewable:end -->
