### PR TITLE
SF-1119 Archive instead of delete questions when book is removed

### DIFF
--- a/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
+++ b/src/SIL.XForge.Scripture/Services/ParatextSyncRunner.cs
@@ -35,7 +35,7 @@ namespace SIL.XForge.Scripture.Services;
 /// 3. A note changelist is computed by diffing the real-time question docs and the notes in the local repo.
 /// 4. The local repo is updated using the note changelist.
 /// 5. PT send/receive is performed (remote and local repos are synced).
-/// 6. Docs associated with remotely deleted books are deleted.
+/// 6. Docs associated with remotely deleted books are deleted, except for question docs, which are archived.
 /// 7. Updated USX is retrieved from the local repo.
 /// 7. The returned USX is converted back to text deltas and diffed against the current deltas.
 /// 8. The diff is submitted as an operation to the real-time text docs (chapter docs are added and deleted as
@@ -301,7 +301,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
             if (targetBooksToDelete.Count > 0)
             {
                 LogMetric(
-                    $"RunAsync: Going to delete texts and questions,comments,answers for {targetBooksToDelete.Count} books."
+                    $"RunAsync: Going to delete texts, and archive questions, for {targetBooksToDelete.Count} books."
                 );
                 // delete target books
                 foreach (int bookNum in targetBooksToDelete)
@@ -312,7 +312,7 @@ public class ParatextSyncRunner : IParatextSyncRunner
                     await _projectDoc.SubmitJson0OpAsync(op => op.Remove(pd => pd.Texts, textIndex));
 
                     await DeleteAllTextDocsForBookAsync(text);
-                    await DeleteAllQuestionsDocsForBookAsync(text);
+                    await ArchiveAllQuestionsDocsForBookAsync(text);
                     await DeleteNoteThreadDocsInChapters(text.BookNum, text.Chapters);
                 }
 
@@ -1660,28 +1660,38 @@ public class ParatextSyncRunner : IParatextSyncRunner
     }
 
     /// <summary>
-    /// Deletes all real-time questions docs from the database for a book.
+    /// Archives all real-time question docs in the database for a book.
     /// </summary>
-    private async Task DeleteAllQuestionsDocsForBookAsync(TextInfo text)
+    /// <remarks>
+    /// The questions are archived rather than deleted so that they are not lost if the book was removed from Paratext
+    /// by accident.
+    /// </remarks>
+    private async Task ArchiveAllQuestionsDocsForBookAsync(TextInfo text)
     {
         List<string> questionDocIds = await _realtimeService
             .QuerySnapshots<Question>()
-            .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum)
+            .Where(q => q.ProjectRef == _projectDoc.Id && q.VerseRef.BookNum == text.BookNum && !q.IsArchived)
             .Select(q => q.Id)
             .ToListAsync();
         var tasks = new List<Task>();
         foreach (string questionId in questionDocIds)
         {
-            async Task deleteQuestion()
+            async Task archiveQuestion()
             {
                 IDocument<Question> questionDoc = await _conn.FetchAsync<Question>(questionId);
-                if (questionDoc.IsLoaded)
-                    await questionDoc.DeleteAsync();
+                if (questionDoc.IsLoaded && !questionDoc.Data.IsArchived)
+                {
+                    await questionDoc.SubmitJson0OpAsync(op =>
+                    {
+                        op.Set(q => q.IsArchived, true);
+                        op.Set(q => q.DateArchived, (DateTime?)DateTime.UtcNow);
+                    });
+                }
             }
-            tasks.Add(deleteQuestion());
+            tasks.Add(archiveQuestion());
         }
         await Task.WhenAll(tasks);
-        _syncMetrics.Questions.Deleted += questionDocIds.Count;
+        _syncMetrics.Questions.Updated += questionDocIds.Count;
     }
 
     private async Task<List<string>> DeleteNoteThreadDocsInChapters(int bookNum, IEnumerable<Chapter> chapters)

--- a/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/Services/ParatextSyncRunnerTests.cs
@@ -604,10 +604,18 @@ public class ParatextSyncRunnerTests
         Assert.That(env.ContainsText("project02", "LUK", 1), Is.True);
         Assert.That(env.ContainsText("project02", "LUK", 2), Is.True);
 
-        Assert.That(env.ContainsQuestion("MRK", 1), Is.False);
-        Assert.That(env.ContainsQuestion("MRK", 2), Is.False);
+        // The questions for the removed book are archived rather than deleted, so they are not lost if the book
+        // is restored in Paratext
+        Assert.That(env.ContainsQuestion("MRK", 1), Is.True);
+        Assert.That(env.ContainsQuestion("MRK", 2), Is.True);
+        Assert.That(env.GetQuestion("MRK", 1).IsArchived, Is.True);
+        Assert.That(env.GetQuestion("MRK", 1).DateArchived, Is.Not.Null);
+        Assert.That(env.GetQuestion("MRK", 2).IsArchived, Is.True);
+        Assert.That(env.GetQuestion("MRK", 2).DateArchived, Is.Not.Null);
         Assert.That(env.ContainsQuestion("MAT", 1), Is.True);
         Assert.That(env.ContainsQuestion("MAT", 2), Is.True);
+        Assert.That(env.GetQuestion("MAT", 1).IsArchived, Is.False);
+        Assert.That(env.GetQuestion("MAT", 2).IsArchived, Is.False);
 
         Assert.That(env.ContainsNote(2), Is.False);
         env.VerifyProjectSync(true);
@@ -621,7 +629,7 @@ public class ParatextSyncRunnerTests
             Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 1, updated: 0)));
-        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
         syncMetrics = env.GetSyncMetrics("project02");
         Assert.That(syncMetrics.Books, Is.EqualTo(new SyncMetricInfo(added: 1, deleted: 1, updated: 1)));
         Assert.That(syncMetrics.TextDocs, Is.EqualTo(new SyncMetricInfo(added: 2, deleted: 2, updated: 0)));
@@ -630,7 +638,7 @@ public class ParatextSyncRunnerTests
             Is.EqualTo(new NoteSyncMetricInfo(added: 0, deleted: 0, updated: 0, removed: 0))
         );
         Assert.That(syncMetrics.NoteThreads, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 0)));
-        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 2, updated: 0)));
+        Assert.That(syncMetrics.Questions, Is.EqualTo(new SyncMetricInfo(added: 0, deleted: 0, updated: 2)));
     }
 
     [Test]


### PR DESCRIPTION
The sync logic now looks a bit odd with questions being archived and notes being deleted, but I think that actually makes sense because questions are only present in SF, so their deletion is destructive, whereas notes are also present in PT. I'm assuming we're essentially removing the notes from SF, but PT still has them, while the deletion of questions was permanently deleting them from a user's perspective (though I'm guessing ShareDB still had the ops).

Long term it would be nice to have a "deleted" state in SF, in addition to the archive state, and it would make more sense to put them there. In the meantime though, this makes more sense than removing them entirely.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4075)
<!-- Reviewable:end -->
