### PR TITLE
Fix text color on offline notice

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/notice/notice.component.scss
@@ -94,10 +94,12 @@ $colors: (
   &.mode-fill-light {
     border-color: var(--notice-color-outline);
     background-color: var(--notice-color-light);
+    color: var(--notice-color-text);
   }
   &.mode-fill-dark {
     border-color: var(--notice-color);
     background-color: var(--notice-color);
+    color: var(--notice-color-text);
   }
   &.mode-fill-extra-dark {
     border-color: var(--notice-color-extra-dark);


### PR DESCRIPTION
This PR fixes an issue where the notice text color was getting overridden because the error notice was assigned the error class with a designated color and overriding the text color.

Before
<img width="910" height="423" alt="Share dialog offline before" src="https://github.com/user-attachments/assets/3f3b1817-b79f-4a5d-9fc9-5eb0539a36d7" />


After
<img width="920" height="466" alt="Share dialog offline after" src="https://github.com/user-attachments/assets/8b592e67-7744-426d-aaf9-3ae6ff3a1903" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4076)
<!-- Reviewable:end -->
