### PR TITLE
SF-3918 Keep generated draft tab open when navigating chapters

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.spec.ts
@@ -4353,7 +4353,7 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should hide source draft preview tab when switching to chapter with no draft', fakeAsync(() => {
+      it('should not hide source draft preview tab when switching to chapter with no draft', fakeAsync(() => {
         const env = new TestEnvironment();
         when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
@@ -4368,7 +4368,7 @@ describe('EditorComponent', () => {
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
         env.wait();
 
-        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
+        expect(sourceTabGroup?.tabs[1]).toBeDefined();
         expect(env.component.chapter).toBe(2);
 
         env.dispose();
@@ -4387,7 +4387,7 @@ describe('EditorComponent', () => {
         env.dispose();
       }));
 
-      it('should hide the target draft preview tab when switching to chapter with no draft', fakeAsync(() => {
+      it('should not hide the target draft preview tab when switching to chapter with no draft', fakeAsync(() => {
         const env = new TestEnvironment();
         when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
         when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
@@ -4402,7 +4402,7 @@ describe('EditorComponent', () => {
         env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
         env.wait();
 
-        expect(sourceTabGroup?.tabs[1]).toBeUndefined();
+        expect(sourceTabGroup?.tabs[1]).toBeDefined();
         expect(env.component.chapter).toBe(2);
 
         env.dispose();
@@ -4451,6 +4451,43 @@ describe('EditorComponent', () => {
           expect(tabs.find(tab => tab.type === 'draft')?.isSelected).toBe(false);
           env.dispose();
         });
+      }));
+
+      it('should keep the draft tab open when switching chapters', fakeAsync(() => {
+        const env = new TestEnvironment();
+        env.setupProject({
+          texts: [
+            {
+              bookNum: 40,
+              chapters: [
+                { number: 1, draftApplied: false },
+                { number: 2, draftApplied: true }
+              ]
+            }
+          ]
+        });
+        env.wait();
+        when(mockedPermissionsService.canAccessDrafts(anything(), anything())).thenReturn(true);
+        when(mockedSFProjectService.hasDraft(anything(), anything(), anything())).thenReturn(true);
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '1' });
+        env.wait();
+
+        let sourceTabGroup = env.component.tabState.getTabGroup('source');
+        const draftTab = sourceTabGroup?.tabs.find(tab => tab.type === 'draft');
+        expect(draftTab).toBeDefined();
+        const draftTabIndexBefore = sourceTabGroup?.tabs.indexOf(draftTab!);
+
+        // Matthew 2 has the draft applied but the tab should remain open
+        env.routeWithParams({ projectId: 'project01', bookId: 'MAT', chapter: '2' });
+        env.wait();
+
+        sourceTabGroup = env.component.tabState.getTabGroup('source');
+        const draftTabAfter = sourceTabGroup?.tabs.find(tab => tab.type === 'draft');
+        expect(draftTabAfter).toBeDefined();
+        const draftTabIndexAfter = sourceTabGroup?.tabs.indexOf(draftTabAfter!);
+        expect(draftTabIndexBefore).toBe(draftTabIndexAfter);
+
+        env.dispose();
       }));
 
       it('should not throw exception on remote change when source is undefined', fakeAsync(() => {

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/editor/editor.component.ts
@@ -1610,7 +1610,7 @@ export class EditorComponent extends DataLoadingComponent implements OnDestroy, 
     );
 
     const hasUnappliedDraft: boolean = hasDraft && !draftApplied;
-    const draftShouldBeVisible: boolean = hasUnappliedDraft || urlDraftActive;
+    const draftShouldBeVisible: boolean = hasUnappliedDraft || urlDraftActive || existingDraftTab != null;
 
     let draftBuild: BuildDto | undefined;
     // Only try to fetch the draft build if existing information indicates we should show the draft


### PR DESCRIPTION
This PR keeps the draft tab open even when navigating between chapters when the draft is already applied. It goes one step further and always keeps the tab open until a user chooses to close it. This makes sense since I do not see why automatically closing tabs is helpful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4077)
<!-- Reviewable:end -->
