### PR TITLE
SF-3920 Fix event metrics not being recorded for BuildCompletedAsync

### DIFF
--- a/src/SIL.XForge/EventMetrics/EventMetricLogger.cs
+++ b/src/SIL.XForge/EventMetrics/EventMetricLogger.cs
@@ -35,7 +35,11 @@ namespace SIL.XForge.EventMetrics;
 /// See https://autofac.readthedocs.io/en/latest/advanced/interceptors.html for information on interceptors.
 /// </para>
 /// </remarks>
-public class EventMetricLogger(IEventMetricService eventMetricService, ILogger<EventMetric> logger) : IInterceptor
+public class EventMetricLogger(
+    IEventMetricService eventMetricService,
+    IExceptionHandler exceptionHandler,
+    ILogger<EventMetric> logger
+) : IInterceptor
 {
     /// <summary>
     /// A task was started by the Interceptor.
@@ -201,6 +205,7 @@ public class EventMetricLogger(IEventMetricService eventMetricService, ILogger<E
                 {
                     // Just log any errors rather than throwing
                     logger.LogError(e, "Error logging event metric for {methodName}", methodName);
+                    exceptionHandler.ReportException(e);
                 }
                 finally
                 {

--- a/src/SIL.XForge/Services/EventMetricService.cs
+++ b/src/SIL.XForge/Services/EventMetricService.cs
@@ -130,7 +130,7 @@ public class EventMetricService(IRepository<EventMetric> eventMetrics) : IEventM
         }
 
         // Generate the event metric
-        EventMetric eventMetric = new()
+        EventMetric eventMetric = new EventMetric
         {
             Id = ObjectId.GenerateNewId().ToString(),
             EventType = eventType,
@@ -171,6 +171,7 @@ public class EventMetricService(IRepository<EventMetric> eventMetrics) : IEventM
             decimal value => new BsonDecimal128(value),
             DateTime value => new BsonDateTime(value),
             Uri value => new BsonString(value.ToString()),
+            Enum value => new BsonString(value.ToString()),
             null => BsonNull.Value,
             _ => BsonDocument.Parse(JsonConvert.SerializeObject(objectValue)),
         };

--- a/test/SIL.XForge.Tests/Models/TestComplexObject.cs
+++ b/test/SIL.XForge.Tests/Models/TestComplexObject.cs
@@ -12,5 +12,11 @@ public class TestComplexObject : TestSimpleObject
     public required int Integer { get; init; }
     public required long LongInteger { get; init; }
     public required float SingleFloat { get; init; }
+    public required TestEnum Enum { get; init; }
     // ReSharper restore UnusedAutoPropertyAccessor.Global
+}
+
+public enum TestEnum
+{
+    TestValue,
 }

--- a/test/SIL.XForge.Tests/Services/EventMetricLoggerTests.cs
+++ b/test/SIL.XForge.Tests/Services/EventMetricLoggerTests.cs
@@ -12,6 +12,7 @@ using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using SIL.XForge.EventMetrics;
 using SIL.XForge.Models;
+using SIL.XForge.Realtime;
 using SIL.XForge.Utils;
 
 namespace SIL.XForge.Services;
@@ -259,6 +260,7 @@ public class EventMetricLoggerTests
             DateAndTime = DateTime.UtcNow,
             DecimalNumber = 12.34M,
             DoubleFloat = 56.78,
+            Enum = TestEnum.TestValue,
             Integer = 1234,
             LongInteger = 5678L,
             ProjectId = Project01,
@@ -618,6 +620,7 @@ public class EventMetricLoggerTests
             var services = new ServiceCollection();
             services.AddSingleton<TestClass>();
             services.AddSingleton<EventMetricLogger>();
+            services.AddSingleton<IExceptionHandler, MemoryExceptionHandler>();
             var containerBuilder = new ContainerBuilder();
             containerBuilder.Populate(services);
             containerBuilder.RegisterEventMetrics();

--- a/test/SIL.XForge.Tests/Services/EventMetricServiceTests.cs
+++ b/test/SIL.XForge.Tests/Services/EventMetricServiceTests.cs
@@ -249,6 +249,7 @@ public class EventMetricServiceTests
             DateAndTime = DateTime.UtcNow,
             DecimalNumber = 12.34M,
             DoubleFloat = 56.78,
+            Enum = TestEnum.TestValue,
             Integer = 1234,
             LongInteger = 5678L,
             ProjectId = Project01,
@@ -307,6 +308,7 @@ public class EventMetricServiceTests
         const float singleFloat = 90.12F;
         string[] stringArray = ["string1", "string2"];
         Uri uri = new Uri("https://example.com", UriKind.Absolute);
+        const TestEnum enumValue = TestEnum.TestValue;
         Dictionary<string, object> argumentsWithNames = new Dictionary<string, object>
         {
             { "projectId", Project01 },
@@ -320,6 +322,7 @@ public class EventMetricServiceTests
             { "singleFloat", singleFloat },
             { "stringArray", stringArray },
             { "uri", uri },
+            { "enum", enumValue },
             { "nullValue", null },
         };
         Dictionary<string, BsonValue> expectedPayload = new Dictionary<string, BsonValue>
@@ -335,6 +338,7 @@ public class EventMetricServiceTests
             { "singleFloat", BsonDouble.Create(singleFloat) },
             { "stringArray", BsonArray.Create(stringArray) },
             { "uri", BsonValue.Create(uri.ToString()) },
+            { "enum", BsonValue.Create(enumValue.ToString()) },
             { "nullValue", BsonNull.Value },
         };
         const bool result = true;


### PR DESCRIPTION
This PR fixes a bug I noticed on live where the following error was being logged in the journal:

```
Error logging event metric for BuildCompletedAsync
System.FormatException: Cannot deserialize a 'BsonDocument' from BsonType 'Int32'.
   at MongoDB.Bson.Serialization.Serializers.BsonValueSerializerBase`1.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.BsonDocument.Parse(String json)
   at SIL.XForge.Services.EventMetricService.GetBsonValue(Object objectValue) in D:\Source\Repos\web-xforge\src\SIL.XForge\Services\EventMetricService.cs:line 175
   at SIL.XForge.Services.EventMetricService.SaveEventMetricAsync(String projectId, String userId, String eventType, EventScope scope, Dictionary`2 argumentsWithNames, Object result, Nullable`1 executionTime, Exception exception) in D:\Source\Repos\web-xforge\src\SIL.XForge\Services\EventMetricService.cs:line 108
   at SIL.XForge.EventMetrics.EventMetricLogger.<>c__DisplayClass7_0.<<Intercept>g__SaveEventMetricAsync|0>d.MoveNext() in D:\Source\Repos\web-xforge\src\SIL.XForge\EventMetrics\EventMetricLogger.cs:line 189
```

This error doesn't prevent builds from completing, but will prevent the recording of the BuildCompletedAsync event metric.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4079)
<!-- Reviewable:end -->
