### PR TITLE
test: serval admin: clarify the non-null initial emit in date range picker

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.spec.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.spec.ts
@@ -22,13 +22,13 @@ describe('DateRangePickerComponent', () => {
   it('can initiate with an empty range when set', () => {
     const env = new TestEnvironment({ startWithEmptyRange: true });
     env.component.showReset = true;
-    const emitSpy = spyOn(env.component.dateRangeChange, 'emit');
     env.fixture.detectChanges();
 
     const initialFormValue = env.component.dateRangeForm.value;
     expect(initialFormValue.start).toBeNull();
     expect(initialFormValue.end).toBeNull();
-    expect(emitSpy).not.toHaveBeenCalled();
+    // Initialization with an empty range does not tell the parent about a range.
+    expect(env.emitSpy).not.toHaveBeenCalled();
     expect(env.component.isDefaultRange).toBe(true);
 
     const endDate = new Date(env.component.maxSelectableDate);
@@ -38,7 +38,7 @@ describe('DateRangePickerComponent', () => {
     env.component.dateRangeForm.setValue({ start: startDate, end: endDate });
     env.fixture.detectChanges();
     // The range has been updated
-    expect(emitSpy).toHaveBeenCalled();
+    expect(env.emitSpy).toHaveBeenCalled();
     expect(env.component.isDefaultRange).toBe(false);
 
     // Clear the range
@@ -46,6 +46,8 @@ describe('DateRangePickerComponent', () => {
     const clearButton = env.fixture.nativeElement.querySelector('[data-test-id="reset-button"]');
     clearButton.click();
     env.fixture.detectChanges();
+    // Clearing the range tells the parent that no range is in effect.
+    expect(env.emitSpy).toHaveBeenCalledWith(/* nothing */);
     expect(env.component.dateRangeForm.value).toEqual({ start: null, end: null });
     expect(env.component.isDefaultRange).toBe(true);
   });
@@ -53,18 +55,21 @@ describe('DateRangePickerComponent', () => {
   it('should not emit undefined for a range if the default is defined', () => {
     const env = new TestEnvironment({ startWithEmptyRange: false });
     env.component.showReset = true;
-    const emitSpy = spyOn(env.component.dateRangeChange, 'emit');
     env.fixture.detectChanges();
 
     const initialFormValue = env.component.dateRangeForm.value;
     expect(initialFormValue.start).not.toBeNull();
     expect(initialFormValue.end).not.toBeNull();
-    expect(emitSpy).not.toHaveBeenCalled();
+    // Initialization tells the parent about the default range.
+    expect(env.emitSpy).toHaveBeenCalledTimes(1);
+    expect(env.emitSpy).toHaveBeenCalledWith({ start: initialFormValue.start!, end: initialFormValue.end! });
     expect(env.component.isDefaultRange).toBe(true);
+
+    env.emitSpy.calls.reset();
     env.component.dateRangeForm.setValue({ start: null, end: null });
     env.fixture.detectChanges();
     // If the default range is defined, the date range picker should not consider a null range as valid
-    expect(emitSpy).not.toHaveBeenCalled();
+    expect(env.emitSpy).not.toHaveBeenCalled();
     expect(env.component.isDefaultRange).toBe(true);
   });
 
@@ -111,6 +116,7 @@ class TestEnvironment {
   readonly i18nStub: Partial<I18nService>;
   readonly fixture: ComponentFixture<DateRangePickerComponent>;
   readonly component: DateRangePickerComponent;
+  readonly emitSpy: jasmine.Spy<DateRangePickerComponent['dateRangeChange']['emit']>;
 
   constructor({
     startWithEmptyRange = false
@@ -141,6 +147,8 @@ class TestEnvironment {
     this.fixture = TestBed.createComponent(DateRangePickerComponent);
     this.component = this.fixture.componentInstance;
     this.component.startWithEmptyRange = startWithEmptyRange;
+    // Spy before the first change detection so that emissions from ngOnInit are recorded.
+    this.emitSpy = spyOn(this.component.dateRangeChange, 'emit').and.callThrough();
     this.fixture.detectChanges();
   }
 }

--- a/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/serval-administration/date-range-picker.component.ts
@@ -83,7 +83,7 @@ export class DateRangePickerComponent implements OnInit {
   /** Event emitted when the date range changes with a valid normalized range */
   @Output() dateRangeChange = new EventEmitter<NormalizedDateRange | undefined>();
 
-  /** Whether current range is equal to the initial default range. */
+  /** Whether the last emitted range is equal to the initial default range. */
   isDefaultRange: boolean = true;
 
   private defaultRange: NormalizedDateRange | undefined;


### PR DESCRIPTION
Test "should not emit undefined for a range if the default is defined"
starts listening for emits after the a non-null date range is emitted,
and it could be misleading to then assert that there was no emit.

This patch changes the test to start listening earlier, and assert
that there was a non-null emit, which will hopefully make it more
plain.

Follow-up to #4024.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/4080)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4080)
<!-- Reviewable:end -->
