### PR TITLE
SF-3855 Stop logged in pages reappearing via the Back button after logout

### DIFF
--- a/src/SIL.XForge.Scripture/Startup.cs
+++ b/src/SIL.XForge.Scripture/Startup.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HeaderParsing;
@@ -261,6 +262,8 @@ public class Startup
             }
         );
 
+        app.Use(PreventBackForwardCaching);
+
         if (SpaDevServerStartup == SpaDevServerStartup.None)
         {
             // Register header parsing for accept encoding
@@ -403,6 +406,38 @@ public class Startup
                 });
             }
         );
+    }
+
+    /// <summary>
+    /// Stops browsers from keeping pages of the Angular app in their back/forward cache, which would let the Back
+    /// button show a page from the logged in session after logging out.
+    /// </summary>
+    /// <remarks>
+    /// Firefox does not put pages served with <c>Cache-Control: no-store</c> in its back/forward cache. Chrome does,
+    /// except pages that used a WebSocket (which every page of the app does), and it evicts them when cookies change
+    /// (which logging out does). Safari ignores the header for its back/forward cache, so this does not help there.
+    /// The header is only set on the app's HTML page. Its scripts and other assets are versioned by file name, and
+    /// keep their existing cache headers.
+    /// </remarks>
+    internal Task PreventBackForwardCaching(HttpContext context, Func<Task> next)
+    {
+        if (IsSpaRoute(context))
+        {
+            context.Response.OnStarting(() =>
+            {
+                PreventBackForwardCaching(context.Response);
+                return Task.CompletedTask;
+            });
+        }
+        return next();
+    }
+
+    internal static void PreventBackForwardCaching(HttpResponse response)
+    {
+        if (response.ContentType?.StartsWith("text/html", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            response.Headers.CacheControl = "no-store";
+        }
     }
 
     /// <summary>Is the request something that should be handled by the Angular SPA, instead of by ASP.NET?</summary>

--- a/test/SIL.XForge.Scripture.Tests/StartupTests.cs
+++ b/test/SIL.XForge.Scripture.Tests/StartupTests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,6 +23,51 @@ public class StartupTests
         // SUT
         env.Startup.ConfigureServices(env.Services);
         Assert.That(env.Services, Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task PreventBackForwardCaching_SpaHtmlPage_NoStore()
+    {
+        var env = new TestEnvironment();
+        HttpContext context = TestEnvironment.CreateContextWithResponse("/projects");
+
+        // SUT
+        await env.Startup.PreventBackForwardCaching(context, () => Task.CompletedTask);
+
+        context.Response.ContentType = "text/html; charset=utf-8";
+        context.Response.Headers.CacheControl = "must-revalidate";
+        await TestEnvironment.StartResponse(context);
+        Assert.AreEqual("no-store", context.Response.Headers.CacheControl.ToString());
+    }
+
+    [Test]
+    public async Task PreventBackForwardCaching_SpaScript_CacheHeaderUnchanged()
+    {
+        var env = new TestEnvironment();
+        HttpContext context = TestEnvironment.CreateContextWithResponse("/main.js");
+
+        // SUT
+        await env.Startup.PreventBackForwardCaching(context, () => Task.CompletedTask);
+
+        context.Response.ContentType = "text/javascript";
+        context.Response.Headers.CacheControl = "must-revalidate";
+        await TestEnvironment.StartResponse(context);
+        Assert.AreEqual("must-revalidate", context.Response.Headers.CacheControl.ToString());
+    }
+
+    [Test]
+    public async Task PreventBackForwardCaching_NotSpaRoute_CacheHeaderUnchanged()
+    {
+        var env = new TestEnvironment();
+        HttpContext context = TestEnvironment.CreateContextWithResponse("/");
+
+        // SUT
+        await env.Startup.PreventBackForwardCaching(context, () => Task.CompletedTask);
+
+        context.Response.ContentType = "text/html; charset=utf-8";
+        context.Response.Headers.CacheControl = "must-revalidate";
+        await TestEnvironment.StartResponse(context);
+        Assert.AreEqual("must-revalidate", context.Response.Headers.CacheControl.ToString());
     }
 
     [Test]
@@ -271,5 +320,34 @@ public class StartupTests
         public HttpContext Context { get; } = Substitute.For<HttpContext>();
         public IServiceCollection Services { get; } = new ServiceCollection();
         public Startup Startup { get; }
+
+        /// <summary>Creates a GET request context whose response runs OnStarting callbacks in StartResponse.</summary>
+        public static HttpContext CreateContextWithResponse(string path)
+        {
+            var context = new DefaultHttpContext();
+            context.Features.Set<IHttpResponseFeature>(new StartingResponseFeature());
+            context.Request.Method = HttpMethods.Get;
+            context.Request.Path = new PathString(path);
+            return context;
+        }
+
+        public static Task StartResponse(HttpContext context) =>
+            ((StartingResponseFeature)context.Features.Get<IHttpResponseFeature>()!).StartAsync();
+
+        private class StartingResponseFeature : HttpResponseFeature
+        {
+            private readonly List<(Func<object, Task> Callback, object State)> _onStarting = [];
+
+            public override void OnStarting(Func<object, Task> callback, object state) =>
+                _onStarting.Add((callback, state));
+
+            public async Task StartAsync()
+            {
+                foreach ((Func<object, Task> callback, object state) in _onStarting)
+                {
+                    await callback(state);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug where you can log out, then click back and see the entire page you just logged out of.

The bug was caused by a "feature" in Chromium where the bfcache ("back forward cache") stores the state of the page so when the user clicks the back button navigation is instant. They don't make it trivial to opt out of, but if you set `Cache-Control: no-store` on the html file you're serving, and meet other criteria, it disables the cache.

I'm not sure if the problem was active in Firefox, but if it was this should fix it there I think. This fix is mostly targeted at Chromium, and I don't currently know of a fix for Safari or if there is one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4081)
<!-- Reviewable:end -->
