### PR TITLE
Fix chapter select cut off on the draft formatting page

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/shared/book-chapter-chooser/book-chapter-chooser.component.scss
@@ -5,15 +5,24 @@
   align-items: center;
 }
 
-// Unfortunately there doesn't appear to be a good way to style a mat-select
-// These styles were written by inspecting the elements using developer and then adding rules until it looked right
-#chapter-select,
 #book-select {
   @include dense-mat-select.dense-mat-select();
+}
 
-  ::ng-deep .mat-mdc-text-field-wrapper {
-    padding-left: 12px;
-    padding-right: 12px;
+#chapter-select {
+  @include dense-mat-select.dense-mat-select();
+  flex-shrink: 0;
+}
+
+// Unfortunately there doesn't appear to be a good way to style a mat-select
+// These styles were written by inspecting the elements using developer and then adding rules until it looked right
+::ng-deep {
+  #book-select,
+  #chapter-select {
+    .mat-mdc-text-field-wrapper {
+      padding-left: 12px;
+      padding-right: 12px;
+    }
   }
 }
 


### PR DESCRIPTION
This fixes a small issue where the chapter number is cut off on tablet sized screens.

Before
<img width="961" height="621" alt="draft-formatting-before" src="https://github.com/user-attachments/assets/b5985112-e1fd-41f2-ae36-8da2e248b65c" />

After
<img width="942" height="740" alt="Draft-formatting-after" src="https://github.com/user-attachments/assets/ebf05057-d20d-4857-9ebe-f4c833dff89f" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4090)
<!-- Reviewable:end -->
