### PR TITLE
rts: add to activity log

### DIFF
--- a/doc/code-rules-ai.md
+++ b/doc/code-rules-ai.md
@@ -86,6 +86,7 @@ Follow all rules in [code-rules.md](code-rules.md) in addition to the below.
   8. public static and instance methods
   9. non-public static and instance methods
 - If an object literal is intended to match a specific type, enforce the type at the point the object literal is created by using one of these patterns: (1) assign it to a typed variable (`const x: SomeType = { ... }`); (2) apply `satisfies` (`const x = { ... } satisfies SomeType`); or (3) return it from a function or callback with an explicit return type (without first assigning it to an untyped variable). This helps flag extra properties that are no longer in the intended type.
+- TypeScript bypasses type checking when spreading excess properties onto an object. For example, with `interface Animal { name: string; legs?: number; }`, writing `const dog: Animal = { name: 'Fido', ...{ limbs: 4 } };` will give `dog` the `limbs` property. (And yet subsequently writing `dog.limbs` is a compile-time error.) Don't spread properties onto an object that aren't type-checked as valid properties for that type without good justification. Use `satisfies Partial<>` to type-check the spread. For example, `const dog: Animal = { name: 'Fido', ...({ limbs: 4 } satisfies Partial<Animal>) };` fails to compile and catches the mistake (`limbs` should be `legs`).
 
 ## Angular templates
 

--- a/src/RealtimeServer/common/activity-logger.spec.ts
+++ b/src/RealtimeServer/common/activity-logger.spec.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ActivityLogger } from './activity-logger';
+import { ActivityLogger, MAX_QUEUED_ENTRIES } from './activity-logger';
 
 let mockFsPromises: MockFsPromises;
 jest.mock('fs/promises', () => ({
@@ -63,6 +63,68 @@ describe('ActivityLogger', () => {
       expect(written.event).toBe('someEvent');
       expect(written.detail).toBe('abc');
       expect(typeof written.timestamp).toBe('string');
+    });
+  });
+
+  describe('dropped entries', () => {
+    it('records in the log itself that entries were dropped', async () => {
+      const env = new TestEnvironment({ SF_RTS_LOG_LEVEL: 'all' });
+      // Fill the queue past its limit while no write can complete, so that later entries are dropped.
+      for (let count = 0; count < TestEnvironment.maxQueuedEntries + 3; count++) {
+        env.logger.log('someEvent');
+      }
+      // SUT
+      await TestEnvironment.flushMicrotasks();
+      const written: any[] = mockFsPromises.appendFileCalls
+        .flatMap(data => data.split('\n'))
+        .filter(line => line.length > 0)
+        .map(line => JSON.parse(line));
+      const dropped: any = written.find(entry => entry.event === 'logEntriesDropped');
+      expect(dropped).toBeDefined();
+      expect(dropped.droppedCount).toBe(3);
+    });
+
+    it('still records that entries were dropped when the first write of the notice fails', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const env = new TestEnvironment({ SF_RTS_LOG_LEVEL: 'all' });
+        mockFsPromises.failWhen = data => data.includes('logEntriesDropped');
+        const cyclic: any = {};
+        cyclic.self = cyclic;
+        // Can't be stringified, so it is dropped.
+        env.logger.log('someEvent', { cyclic: cyclic });
+        env.logger.log('someOtherEvent');
+        await TestEnvironment.flushMicrotasks();
+        // Writing works again. The log must still say that an entry was lost.
+        mockFsPromises.failWhen = undefined;
+        // SUT
+        env.logger.log('anotherEvent');
+        await TestEnvironment.flushMicrotasks();
+        const written: any[] = mockFsPromises.appendFileCalls
+          .flatMap(data => data.split('\n'))
+          .filter(line => line.length > 0)
+          .map(line => JSON.parse(line));
+        const dropped: any = written.find(entry => entry.event === 'logEntriesDropped');
+        expect(dropped).toBeDefined();
+        expect(dropped.droppedCount).toBe(1);
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it('says nothing about dropped entries when the queue stayed within its limit', async () => {
+      const env = new TestEnvironment({ SF_RTS_LOG_LEVEL: 'all' });
+      for (let count = 0; count < TestEnvironment.maxQueuedEntries; count++) {
+        env.logger.log('someEvent');
+      }
+      // SUT
+      await TestEnvironment.flushMicrotasks();
+      const written: any[] = mockFsPromises.appendFileCalls
+        .flatMap(data => data.split('\n'))
+        .filter(line => line.length > 0)
+        .map(line => JSON.parse(line));
+      expect(written.length).toBe(TestEnvironment.maxQueuedEntries);
+      expect(written.find(entry => entry.event === 'logEntriesDropped')).toBeUndefined();
     });
   });
 
@@ -169,6 +231,8 @@ class MockFsPromises {
   public readonly mkdirCalls: string[] = [];
   public readonly appendFileCalls: string[] = [];
   public readonly appendFilePaths: string[] = [];
+  /** Fails appendFile for data that this returns true for, in place of a disk problem. */
+  public failWhen: ((data: string) => boolean) | undefined;
 
   mkdir(dirPath: string, _options?: unknown): Promise<void> {
     this.mkdirCalls.push(dirPath);
@@ -176,6 +240,9 @@ class MockFsPromises {
   }
 
   appendFile(filePath: string, data: string, _options?: unknown): Promise<void> {
+    if (this.failWhen?.(data) === true) {
+      return Promise.reject(new Error('Test-induced write failure'));
+    }
     this.appendFilePaths.push(filePath);
     this.appendFileCalls.push(data);
     return Promise.resolve();
@@ -209,6 +276,11 @@ class TestEnvironment {
     // Reset singleton between tests
     (ActivityLogger as any)._instance = undefined;
     this.logger = ActivityLogger.instance;
+  }
+
+  /** How many entries ActivityLogger queues before it starts dropping them. */
+  static get maxQueuedEntries(): number {
+    return MAX_QUEUED_ENTRIES;
   }
 
   static flushMicrotasks(): Promise<void> {

--- a/src/RealtimeServer/common/activity-logger.ts
+++ b/src/RealtimeServer/common/activity-logger.ts
@@ -20,7 +20,7 @@ const DEFAULT_LOG_LEVEL: RtsLogLevel = 'none';
 const DEFAULT_LOG_DIR_NAME = 'sf-rts-activity-log';
 const DEFAULT_LOG_FILE_NAME = 'realtimeserver-log.jsonl';
 // If disk writes can't keep up with log() calls past this limit, new entries are dropped.
-const MAX_QUEUED_ENTRIES = 10_000;
+export const MAX_QUEUED_ENTRIES = 10_000;
 
 /**
  * A single entry describing something the RealtimeServer did. Every entry shares a timestamp and an event name;
@@ -31,6 +31,8 @@ export interface ActivityLogEntry {
   event: string;
   /** Which RealtimeServer process wrote the entry. Processes and restarts share one log file. */
   pid: number;
+  /** Whatever else describes this particular event. What these are depends entirely on the event. */
+  [detail: string]: unknown;
 }
 
 /**
@@ -41,7 +43,8 @@ export class ActivityLogger {
   private static _instance: ActivityLogger | undefined;
   private readonly logLevel: RtsLogLevel;
   private readonly logPath: string;
-  private readonly pendingEntries: ActivityLogEntry[] = [];
+  /** Log entries waiting to be written. */
+  private readonly pendingLines: string[] = [];
   private isFlushing = false;
   private droppedEntryCount = 0;
   private directoryEnsured = false;
@@ -81,19 +84,26 @@ export class ActivityLogger {
    * Queues an entry to be written and, if a write isn't already in progress, starts one.
    */
   private enqueue(entry: ActivityLogEntry): void {
-    if (this.pendingEntries.length >= MAX_QUEUED_ENTRIES) {
+    let line: string;
+    try {
+      line = JSON.stringify(entry) + '\n';
+    } catch {
       this.droppedEntryCount++;
       return;
     }
-    this.pendingEntries.push(entry);
-    // If a flush is already running, it will pick up the pending entry.
+    if (this.pendingLines.length >= MAX_QUEUED_ENTRIES) {
+      this.droppedEntryCount++;
+    } else {
+      this.pendingLines.push(line);
+    }
+    // Started even when the line was dropped: writing may have been failing, and this is what tries it again.
     if (!this.isFlushing) {
       void this.flushQueue();
     }
   }
 
   /**
-   * Write pendingEntries to disk. May write more than once if more entries come in while running.
+   * Write pending log entries to disk. May write more than once if more entries come in while running.
    */
   private async flushQueue(): Promise<void> {
     this.isFlushing = true;
@@ -103,19 +113,12 @@ export class ActivityLogger {
         await mkdir(dirPath, { recursive: true });
         this.directoryEnsured = true;
       }
-      while (this.pendingEntries.length > 0) {
-        const batchSize: number = this.pendingEntries.length;
-        const lines: string = this.pendingEntries
-          .slice(0, batchSize)
-          .map(batchEntry => JSON.stringify(batchEntry) + '\n')
-          .join('');
-        await appendFile(this.logPath, lines, { flag: 'a' });
+      while (this.pendingLines.length > 0 || this.droppedEntryCount > 0) {
+        this.queueDroppedEntriesNotice();
+        const batchSize: number = this.pendingLines.length;
+        await appendFile(this.logPath, this.pendingLines.slice(0, batchSize).join(''), { flag: 'a' });
         // Only remove the batch after a successful write without throwing.
-        this.pendingEntries.splice(0, batchSize);
-      }
-      if (this.droppedEntryCount > 0) {
-        console.error(`ActivityLogger dropped ${this.droppedEntryCount} entries because its write queue was full.`);
-        this.droppedEntryCount = 0;
+        this.pendingLines.splice(0, batchSize);
       }
     } catch (error) {
       // Ignore rather than throw. Don't cause a problem to RealtimeServer.
@@ -123,6 +126,22 @@ export class ActivityLogger {
     } finally {
       this.isFlushing = false;
     }
+  }
+
+  /**
+   * If entries have been dropped, queue an entry saying so. It goes into the same queue as everything else so that a
+   * failed write is retried rather than losing the record that entries were lost.
+   */
+  private queueDroppedEntriesNotice(): void {
+    if (this.droppedEntryCount === 0) return;
+    const notice: ActivityLogEntry = {
+      timestamp: new Date().toISOString(),
+      event: 'logEntriesDropped',
+      pid: process.pid,
+      droppedCount: this.droppedEntryCount
+    };
+    this.pendingLines.push(JSON.stringify(notice) + '\n');
+    this.droppedEntryCount = 0;
   }
 
   private determineLogLevel(): RtsLogLevel {

--- a/src/RealtimeServer/common/realtime-server.spec.ts
+++ b/src/RealtimeServer/common/realtime-server.spec.ts
@@ -10,14 +10,22 @@ import { Migration } from './migration';
 import { Project } from './models/project';
 import { User, USERS_COLLECTION } from './models/user';
 import { createTestUser } from './models/user-test-data';
-import { RealtimeServer, submitMigrationOp } from './realtime-server';
-import { ConnectionInternal } from './resource-monitor';
+import { identifiersInClientRequest, RealtimeServer, submitMigrationOp } from './realtime-server';
+import { ConnectionInternal, ResourceMonitor, sizeof } from './resource-monitor';
 import { SchemaVersionRepository } from './schema-version-repository';
 import { ProjectService } from './services/project-service';
 import { UserService } from './services/user-service';
 import { Json0OpBuilder } from './utils/json0-op-builder';
-import { docFetch, docSubmitOp } from './utils/sharedb-utils';
-import { allowAll, clientConnect, createDoc, fetchDoc, submitJson0Op, submitOp } from './utils/test-utils';
+import { createFetchQuery, docFetch, docSubmitOp } from './utils/sharedb-utils';
+import {
+  allowAll,
+  clientConnect,
+  createDoc,
+  fetchDoc,
+  flushPromises,
+  submitJson0Op,
+  submitOp
+} from './utils/test-utils';
 
 const PROJECTS_COLLECTION = 'projects';
 
@@ -121,7 +129,7 @@ describe('RealtimeServer', () => {
     await env.createData();
     let session: ConnectSession;
     env.server.use('submit', (context, callback) => {
-      session = context.agent.connectSession as ConnectSession;
+      session = context.agent?.connectSession as ConnectSession;
       callback();
     });
 
@@ -135,9 +143,9 @@ describe('RealtimeServer', () => {
   it('gets correct project when new project added', async () => {
     const env = new TestEnvironment();
     await env.createData();
-    let session: ConnectSession;
+    let session: ConnectSession | undefined;
     env.server.use('submit', (context, callback) => {
-      session = context.agent.connectSession;
+      session = context.agent?.connectSession;
       callback();
     });
 
@@ -212,6 +220,17 @@ describe('RealtimeServer', () => {
         }
       ])
     ).rejects.toThrow('Invalid path for operation');
+  });
+
+  it('reports the path of an op it rejects, and not what the op was writing', async () => {
+    const env = new TestEnvironment();
+    await env.createData();
+    const userConn = clientConnect(env.server, 'user01');
+    const payload = 'a value from the user document';
+    // SUT
+    const submitting: Promise<void> = submitOp(userConn, USERS_COLLECTION, 'user01', [{ p: [0], oi: payload }]);
+    await expect(submitting).rejects.toThrow('Invalid path for operation');
+    await expect(submitting).rejects.not.toThrow(payload);
   });
 
   it('data validation allows valid boolean values', async () => {
@@ -696,6 +715,199 @@ describe('RealtimeServer', () => {
       const entry: LoggedActivity | undefined = logged.find(item => item.event === 'connectionEstablished');
       expect(entry!.details['interopHandle']).toBeUndefined();
     });
+
+    it('reports a doc request a client makes, naming the connection it came in on', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      const userConn = clientConnect(env.server, 'user01');
+      // SUT
+      await fetchDoc(userConn, USERS_COLLECTION, 'user01');
+      const request: LoggedActivity | undefined = logged.find(
+        item => item.event === 'clientRequest' && item.details['action'] === 'f'
+      );
+      const established: LoggedActivity | undefined = logged.find(item => item.event === 'connectionEstablished');
+      expect(request!.details['collection']).toBe(USERS_COLLECTION);
+      expect(request!.details['docId']).toBe('user01');
+      expect(request!.details['clientId']).toBe(established!.details['clientId']);
+    });
+
+    it('reports a query a client makes', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      const userConn = clientConnect(env.server, 'user01');
+      // SUT
+      await createFetchQuery(userConn, PROJECTS_COLLECTION, {});
+      const request: LoggedActivity | undefined = logged.find(
+        item => item.event === 'clientRequest' && item.details['action'] === 'qf'
+      );
+      expect(request!.details['collection']).toBe(PROJECTS_COLLECTION);
+      // The query itself is not reported, only that one was made, since a query can name arbitrary values.
+      expect(request!.details['query']).toBeUndefined();
+    });
+
+    it('names a request identifier according to what the request is', () => {
+      // SUT
+      expect(identifiersInClientRequest({ a: 'op', seq: 7 })).toEqual({ opSeq: 7 });
+      expect(identifiersInClientRequest({ a: 'qf', id: 'query1' })).toEqual({ queryId: 'query1' });
+      expect(identifiersInClientRequest({ a: 'hs', id: 'earlierId' })).toEqual({ srcClientId: 'earlierId' });
+      expect(identifiersInClientRequest({ a: 'hs', id: null })).toEqual({ srcClientId: undefined });
+      // A presence update has an id and a sequence number of its own, which mean neither of the above. Don't
+      // incorrectly report them as an op sequence or a query id.
+      expect(identifiersInClientRequest({ a: 'p', id: 'presence1', ch: 'texts:abc' })).toEqual({});
+      expect(identifiersInClientRequest({ a: 'ps', seq: 1, ch: 'texts:abc' })).toEqual({});
+      expect(identifiersInClientRequest({ a: 'pu', seq: 2, ch: 'texts:abc' })).toEqual({});
+    });
+
+    it('reports what a connection was holding when it goes away', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      const userConn = clientConnect(env.server, 'user01');
+      const doc: Doc = userConn.get(USERS_COLLECTION, 'user01');
+      await new Promise<void>((resolve, reject) => doc.subscribe(err => (err == null ? resolve() : reject(err))));
+      // SUT
+      userConn.close();
+      await flushPromises();
+      const entry: LoggedActivity | undefined = logged.find(item => item.event === 'agentDisconnected');
+      expect(entry!.details['subscribedDocsCount']).toBe(1);
+      expect(entry!.details['subscribedCollectionsCount']).toBe(1);
+      expect(entry!.details['subscribedQueriesCount']).toBe(0);
+      expect(entry!.details['subscribedPresencesCount']).toBe(0);
+    });
+
+    it('measures what a read returned, for reads the interop fetch tracking does not cover', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const reads: { collection: string; docsCount: number; docsBytes: number }[] = [];
+      jest
+        .spyOn(ResourceMonitor.instance, 'recordSnapshotRead')
+        .mockImplementation((_clientId, collection, _snapshotType, snapshots) => {
+          reads.push({
+            collection: collection,
+            docsCount: snapshots.length,
+            docsBytes: snapshots.reduce((sum: number, snapshot: { data?: unknown }) => sum + sizeof(snapshot.data), 0)
+          });
+        });
+      const userConn = clientConnect(env.server, 'user01');
+      // SUT
+      await fetchDoc(userConn, USERS_COLLECTION, 'user01');
+      const read = reads.find(entry => entry.collection === USERS_COLLECTION);
+      expect(read!.docsCount).toBe(1);
+      expect(read!.docsBytes).toBeGreaterThan(0);
+    });
+
+    it('measures the ops loaded from the database and sent to a client', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const loaded: { collection: string; docId: string; op: unknown }[] = [];
+      jest.spyOn(ResourceMonitor.instance, 'recordOpLoaded').mockImplementation((_clientId, collection, docId, op) => {
+        loaded.push({ collection: collection, docId: docId, op: op });
+      });
+      const watcher = clientConnect(env.server, 'user01');
+      const watched: Doc = watcher.get(PROJECTS_COLLECTION, 'project01');
+      await new Promise<void>((resolve, reject) => watched.subscribe(err => (err == null ? resolve() : reject(err))));
+      const editor = clientConnect(env.server, 'user01');
+      // SUT. The op is loaded and sent on to the connection watching the doc.
+      await submitOp(editor, PROJECTS_COLLECTION, 'project01', [{ p: ['userPermissions', 'abc123'], oi: 'admin' }]);
+      await flushPromises();
+      expect(loaded.length).toBeGreaterThan(0);
+      expect(loaded[0].collection).toBe(PROJECTS_COLLECTION);
+      // Which document the ops came from, so that a connection loading a great deal from one document can be told
+      // from one loading a little from many.
+      expect(loaded[0].docId).toBe('project01');
+      expect(loaded[0].op).toBeDefined();
+    });
+
+    it('reports the ops consumed to rebuild a document at an earlier version', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const userConn = clientConnect(env.server, 'user01');
+      await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [{ p: ['userPermissions', 'abc123'], oi: 'admin' }]);
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      // SUT
+      await new Promise<void>((resolve, reject) =>
+        userConn.fetchSnapshot(PROJECTS_COLLECTION, 'project01', 1, err => (err == null ? resolve() : reject(err)))
+      );
+      const rebuilds: LoggedActivity[] = logged.filter(item => item.event === 'snapshotRebuiltFromOps');
+      expect(rebuilds.length).toBe(1);
+      expect(rebuilds[0].details['docId']).toBe('project01');
+      expect(rebuilds[0].details['opsCount']).toBe(1);
+      expect(rebuilds[0].details['opsBytes']).toBeGreaterThan(0);
+    });
+
+    it('reports a subscribed query being re-polled, which the query middleware never sees', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const polled: { collection: string; pollType: string }[] = [];
+      jest
+        .spyOn(ResourceMonitor.instance, 'recordQueryPolled')
+        .mockImplementation((_clientId, collection, pollType) => {
+          polled.push({ collection: collection, pollType: pollType });
+        });
+      const watcher = clientConnect(env.server, 'user01');
+      await new Promise<void>((resolve, reject) =>
+        watcher.createSubscribeQuery(PROJECTS_COLLECTION, {}, {}, err => (err == null ? resolve() : reject(err)))
+      );
+      const editor = clientConnect(env.server, 'user01');
+      // SUT. Changing a document the query might match makes ShareDB poll the subscription again.
+      await submitOp(editor, PROJECTS_COLLECTION, 'project01', [{ p: ['userPermissions', 'abc123'], oi: 'admin' }]);
+      await flushPromises();
+      expect(polled.length).toBeGreaterThan(0);
+      expect(polled[0].collection).toBe(PROJECTS_COLLECTION);
+    });
+
+    it('measures a query being run against the database', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const queries: string[] = [];
+      jest.spyOn(ResourceMonitor.instance, 'recordQueryRun').mockImplementation((_clientId, collection) => {
+        queries.push(collection);
+      });
+      const userConn = clientConnect(env.server, 'user01');
+      // SUT
+      await createFetchQuery(userConn, PROJECTS_COLLECTION, {});
+      expect(queries).toContain(PROJECTS_COLLECTION);
+    });
+
+    it('reports a handshake', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      // SUT
+      clientConnect(env.server, 'user01');
+      // The handshake is sent over the stream rather than as part of connecting, so it has not arrived yet.
+      await flushPromises();
+      const handshakes: LoggedActivity[] = logged.filter(
+        item => item.event === 'clientRequest' && item.details['action'] === 'hs'
+      );
+      // A connection sends this more than once, so the count is not asserted, only that it is reported.
+      expect(handshakes.length).toBeGreaterThan(0);
+      // Absent because this connection is new and so has no earlier id it is asking to keep.
+      expect(handshakes[0].details['srcClientId']).toBeUndefined();
+    });
+
+    it('reports an op as received, as well as when it is submitted and committed', async () => {
+      const env = new TestEnvironment();
+      await env.createData();
+      const logged: LoggedActivity[] = env.captureActivityLog();
+      const userConn = clientConnect(env.server, 'user01');
+      // SUT
+      await submitOp(userConn, PROJECTS_COLLECTION, 'project01', [{ p: ['userPermissions', 'abc123'], oi: 'admin' }]);
+      const received: LoggedActivity | undefined = logged.find(
+        item => item.event === 'clientRequest' && item.details['action'] === 'op'
+      );
+      const submitted: LoggedActivity | undefined = logged.find(item => item.event === 'opSubmitted');
+      const committed: LoggedActivity | undefined = logged.find(item => item.event === 'opCommitted');
+      expect(received!.details['collection']).toBe(PROJECTS_COLLECTION);
+      expect(received!.details['docId']).toBe('project01');
+      // The three entries for one op are lined up by the connection and the op's sequence number.
+      expect(received!.details['clientId']).toBe(submitted!.details['clientId']);
+      expect(received!.details['opSeq']).toBe(submitted!.details['opSeq']);
+      expect(received!.details['clientId']).toBe(committed!.details['clientId']);
+      expect(received!.details['opSeq']).toBe(committed!.details['opSeq']);
+    });
   });
 });
 
@@ -817,6 +1029,7 @@ class TestEnvironment {
   /** Collect what is passed to ActivityLogger, rather than writing it to a log file. */
   captureActivityLog(): LoggedActivity[] {
     const logged: LoggedActivity[] = [];
+    jest.spyOn(ActivityLogger.instance, 'enabled', 'get').mockReturnValue(true);
     jest
       .spyOn(ActivityLogger.instance, 'log')
       .mockImplementation((event: string, details: Record<string, unknown> = {}) => {

--- a/src/RealtimeServer/common/realtime-server.ts
+++ b/src/RealtimeServer/common/realtime-server.ts
@@ -8,7 +8,7 @@ import { ActivityLogger } from './activity-logger';
 import { ConnectSession } from './connect-session';
 import { Project } from './models/project';
 import { SchemaProperties, ValidationSchema } from './models/validation-schema';
-import { AgentInternal, ResourceMonitor } from './resource-monitor';
+import { ResourceMonitor, sizeof } from './resource-monitor';
 import { SchemaVersionRepository } from './schema-version-repository';
 import { DocService } from './services/doc-service';
 import { createFetchQuery, docFetch } from './utils/sharedb-utils';
@@ -127,6 +127,34 @@ export function submitMigrationOp(version: number, doc: Doc, ops: Op[]): Promise
   });
 }
 
+/**
+ * Picks out the identifiers in a request received from a client over the ShareDB protocol.
+ *
+ * A request carries at most one id in `id` and one sequence number in `seq`, but what each means depends on the kind
+ * of request: an op's sequence number, a query's id, the id a reconnecting client is asking to keep, or a presence
+ * update's own id and sequence. Reporting them under a single name would mix those together, so each is named for the
+ * kind of request it came from. Presence contributes none, its ids identifying nothing outside the presence exchange.
+ */
+export function identifiersInClientRequest(request: Record<string, any>): {
+  opSeq?: number;
+  queryId?: string;
+  srcClientId?: string;
+} {
+  switch (request.a) {
+    case 'op':
+      return { opSeq: request.seq };
+    case 'qf':
+    case 'qs':
+    case 'qu':
+      return { queryId: request.id };
+    case 'hs':
+      // Absent when a client connects for the first time, having no earlier id to keep.
+      return { srcClientId: request.id ?? undefined };
+    default:
+      return {};
+  }
+}
+
 /* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
 // We merge these two declarations, as we want to extend two classes
 export interface RealtimeServer extends ShareDB, shareDBAccess.AccessControlBackend {}
@@ -169,6 +197,85 @@ export class RealtimeServer extends ShareDB {
         });
     });
 
+    // Measure what every read of documents returned. Including frontend client reads, a query's results, and the server's own connection's reads.
+    this.use('readSnapshots', (context, next) => {
+      if (context.agent == null) {
+        next();
+        return;
+      }
+      ResourceMonitor.instance.recordSnapshotRead(
+        context.agent.clientId,
+        context.collection,
+        context.snapshotType,
+        context.snapshots,
+        context.agent.connectSession?.userId,
+        context.agent.connectSession?.isServer
+      );
+      next();
+    });
+
+    // Measure the operations that pass through a connection.
+    this.use('op', (context, next) => {
+      if (context.agent == null) {
+        next();
+        return;
+      }
+      ResourceMonitor.instance.recordOpLoaded(
+        context.agent.clientId,
+        context.collection,
+        context.id,
+        context.op,
+        context.agent.connectSession?.userId,
+        context.agent.connectSession?.isServer
+      );
+      next();
+    });
+
+    // Count the queries a connection asks for. ShareDB triggers this when a query is fetched or subscribed to, and not
+    // for the re-polls a subscription then causes, which reach the database without passing through middleware.
+    this.use('query', (context, next) => {
+      if (context.agent == null) {
+        next();
+        return;
+      }
+      ResourceMonitor.instance.recordQueryRun(
+        context.agent.clientId,
+        context.collection,
+        context.agent.connectSession?.userId,
+        context.agent.connectSession?.isServer
+      );
+      next();
+    });
+
+    // Count the polls of subscribed queries. A subscription is polled again whenever a document that might match it
+    // changes, so one subscription on a busy collection can put an unbounded number of queries on the database. Those
+    // polls reach the database with no middleware running. But by watching the 'timing' event notices, we can see them
+    // happen.
+    this.on('timing', (action: string, durationMs: number, context: ShareDB.TimingContext) => {
+      if (action !== 'queryEmitter.poll' && action !== 'queryEmitter.pollDoc') {
+        return;
+      }
+      if (context.agent == null || context.collection == null) {
+        return;
+      }
+      ResourceMonitor.instance.recordQueryPolled(
+        context.agent.clientId,
+        context.collection,
+        action,
+        durationMs,
+        context.agent.connectSession?.userId,
+        context.agent.connectSession?.isServer
+      );
+    });
+
+    // Report what a client asks for.
+    this.use('receive', (context, next) => {
+      if (ActivityLogger.instance.enabled) {
+        RealtimeServer.logClientRequest(context);
+      }
+      next();
+    });
+
     // Configure op, snapshot, or milestone changes to be made just before the op is committed to the database
     this.use('commit', (context, callback) => {
       switch (context.collection) {
@@ -200,7 +307,7 @@ export class RealtimeServer extends ShareDB {
       ActivityLogger.instance.log('opCommitted', {
         collection: context.collection,
         docId: context.id,
-        clientId: (context.agent as unknown as AgentInternal).clientId,
+        clientId: context.agent?.clientId,
         srcClientId: context.op.src,
         opSeq: context.op.seq,
         version: context.snapshot?.v,
@@ -232,7 +339,7 @@ export class RealtimeServer extends ShareDB {
           docId: context.id,
           // Needed here as well as on opSubmitted: a failed op never reaches the opSubmitted entry below, so this
           // entry has nothing else to be attributed by.
-          clientId: (context.agent as unknown as AgentInternal).clientId,
+          clientId: context.agent?.clientId,
           srcClientId: context.op.src,
           opSeq: context.op.seq,
           errorMessage: message
@@ -247,7 +354,7 @@ export class RealtimeServer extends ShareDB {
         !this.dataValidationDisabled &&
         validationSchema != null &&
         context.op.op != null &&
-        !context.agent.connectSession.isServer
+        !context.agent?.connectSession?.isServer
       ) {
         let ops;
         if (Array.isArray(context.op.op)) {
@@ -399,7 +506,7 @@ export class RealtimeServer extends ShareDB {
                 return;
               }
             } else {
-              failValidation(`Invalid path for operation: ${JSON.stringify(op)}`);
+              failValidation(`Invalid path for operation: ${JSON.stringify(op.p)}`);
               return;
             }
           }
@@ -434,15 +541,15 @@ export class RealtimeServer extends ShareDB {
         // back to the agent's clientId and the two agree. But a browser that reconnects does supply one: it keeps the
         // id from its previous session as the source of its ops. From then on its ops carry a srcClientId that no
         // connectionEstablished entry ever reported, and reporting both is what still ties them to a connection.
-        clientId: (context.agent as unknown as AgentInternal).clientId,
+        clientId: context.agent?.clientId,
         // Together these identify the op, so that this entry can be matched up with the opCommitted or
         // opValidationFailed entry for the same op.
         srcClientId: context.op.src,
         opSeq: context.op.seq,
         // The version the op was submitted against. A commit of this op lands at the next version.
         version: context.op.v,
-        userId: (context.agent as unknown as AgentInternal).connectSession?.userId,
-        isServer: (context.agent as unknown as AgentInternal).connectSession?.isServer,
+        userId: context.agent?.connectSession?.userId,
+        isServer: context.agent?.connectSession?.isServer,
         opType: opType,
         opsCount: opsCount,
         migrationVersion: context.op.m.migration
@@ -536,16 +643,32 @@ export class RealtimeServer extends ShareDB {
     if (!this.dataValidationDisabled) {
       ResourceMonitor.instance.monitorAgent(agent, stream);
     }
-    stream.once('close', () => {
+    let disconnectReported = false;
+    const reportDisconnect = (): void => {
+      if (disconnectReported) {
+        return;
+      }
+      disconnectReported = true;
       // The stream can close before the 'connect' middleware finishes (e.g. the client disconnects mid-handshake,
       // or authentication fails), so connectSession may not be set yet.
-      const agentInfo: AgentInternal = agent as unknown as AgentInternal;
       ActivityLogger.instance.log('agentDisconnected', {
-        clientId: agentInfo.clientId,
-        userId: agentInfo.connectSession?.userId,
-        isServer: agentInfo.connectSession?.isServer
+        clientId: agent.clientId,
+        userId: agent.connectSession?.userId,
+        isServer: agent.connectSession?.isServer,
+        // What the connection was still holding as it went. These are counted rather than measured to be faster.
+        subscribedCollectionsCount: Object.keys(agent.subscribedDocs).length,
+        subscribedDocsCount: Object.values(agent.subscribedDocs).reduce(
+          (total: number, docs: Record<string, unknown>) => total + Object.keys(docs).length,
+          0
+        ),
+        subscribedQueriesCount: Object.keys(agent.subscribedQueries).length,
+        subscribedPresencesCount: Object.keys(agent.subscribedPresences).length
       });
-    });
+    };
+    // A stream signals that it is finished with 'end' (the readable side reached its end) and 'close' (the stream was
+    // destroyed), or with only one of them, and sometimes more than once.
+    stream.once('end', reportDisconnect);
+    stream.once('close', reportDisconnect);
     this.trigger('connect', agent, { stream, req }, err => {
       if (err) {
         return agent.close(err);
@@ -553,6 +676,28 @@ export class RealtimeServer extends ShareDB {
       agent._open();
     });
     return agent;
+  }
+
+  /**
+   * Override to measure, log, and pass on a request to rebuild a document at a past version or timestamp by replaying operations onto a milestone snapshot.
+   *
+   * Measured here as these ops do not pass through the 'op' middleware.
+   */
+  _buildSnapshotFromOps(
+    id: string,
+    startingSnapshot: ShareDB.Snapshot | undefined,
+    ops: ShareDB.Op[],
+    callback: (err: Error, snapshot: ShareDB.Snapshot) => void
+  ): void {
+    if (ActivityLogger.instance.enabled) {
+      ActivityLogger.instance.log('snapshotRebuiltFromOps', {
+        docId: id,
+        fromVersion: startingSnapshot?.v ?? 0,
+        opsCount: ops.length,
+        opsBytes: sizeof(ops)
+      });
+    }
+    super._buildSnapshotFromOps(id, startingSnapshot, ops, callback);
   }
 
   async getProject(projectId: string): Promise<Project | undefined> {
@@ -617,6 +762,35 @@ export class RealtimeServer extends ShareDB {
     }
   }
 
+  /**
+   * Reports one request received over the ShareDB protocol.
+   *
+   * Every connection speaks this protocol, not only frontend clients, so entries carry isServer to tell them apart. A dotnet process's connection uses interop methods which drive an ordinary client underneath, and will come through here.
+   *
+   * An op is reported here as well as by opSubmitted and opCommitted. This is the only one of the three made before the
+   * agent and ot.checkOp can turn the op away, so an op malformed enough to be rejected by either is reported here and
+   * nowhere else.
+   */
+  private static logClientRequest(context: ShareDB.middleware.ReceiveContext): void {
+    const request: Record<string, any> = context.data;
+    const action: string = request.a;
+    const agent: ShareDB.Agent | undefined = context.agent;
+    const bulkIds: unknown = request.b;
+    ActivityLogger.instance.log('clientRequest', {
+      // The ShareDB message type.
+      action: action,
+      clientId: agent?.clientId,
+      userId: agent?.connectSession?.userId,
+      isServer: agent?.connectSession?.isServer,
+      collection: request.c,
+      docId: request.d,
+      // A bulk request names several docs at once, as a map of doc id to version, or a list of doc ids.
+      docsCount: bulkIds == null ? undefined : Array.isArray(bulkIds) ? bulkIds.length : Object.keys(bulkIds).length,
+      ...identifiersInClientRequest(request),
+      presenceChannel: request.ch
+    });
+  }
+
   private async setConnectSession(context: ShareDB.middleware.ConnectContext): Promise<void> {
     let session: ConnectSession;
     if (context.req != null && context.req.user != null) {
@@ -635,11 +809,15 @@ export class RealtimeServer extends ShareDB {
       }
       session = { isServer: true, userId, roles: [] };
     }
-    context.agent.connectSession = session;
+    const agent: ShareDB.Agent | undefined = context.agent;
+    if (agent == null) {
+      throw new Error('Cannot establish a connection session without an agent.');
+    }
+    agent.connectSession = session;
     ActivityLogger.instance.log('connectionEstablished', {
       // The op source (agent.src) is not reported here: it is not set until the client's handshake message, which
       // arrives after this runs. See the opSubmitted entry, which reports both ids.
-      clientId: (context.agent as unknown as AgentInternal).clientId,
+      clientId: agent.clientId,
       interopHandle: context.req?.interopHandle,
       userId: session.userId,
       roles: session.roles,

--- a/src/RealtimeServer/common/resource-monitor.spec.ts
+++ b/src/RealtimeServer/common/resource-monitor.spec.ts
@@ -1,5 +1,19 @@
 import path from 'path';
+import ShareDB from 'sharedb';
+import { Duplex } from 'stream';
 import { ResourceMonitor } from './resource-monitor';
+
+/**
+ * Stands in for the stream beneath an agent, carrying only what a report reads from it. A web socket client has a `ws`
+ * with bytes queued in it; the in-process streams have no `ws` at all. Handlers are kept so that a test can fire the
+ * event itself, rather than needing a real stream to reach the end of its life.
+ */
+interface FakeStream {
+  writableLength: number;
+  once: (event: string, handler: () => void) => void;
+  handlers: Map<string, () => void>;
+  ws?: { bufferedAmount: number };
+}
 
 let mockFsPromises: MockFsPromises;
 jest.mock('fs/promises', () => ({
@@ -12,7 +26,7 @@ let mockHomedir: string = '';
 jest.mock('os', () => ({ ...jest.requireActual('os'), homedir: () => mockHomedir }));
 
 // TestEnvironment sets these directly on real process.env. Restore after each test.
-const ENV_VAR_NAMES = ['SF_RESOURCE_REPORTS_PATH', 'XDG_DATA_HOME'] as const;
+const ENV_VAR_NAMES = ['SF_RESOURCE_REPORTS_PATH', 'XDG_DATA_HOME', 'SF_SIGUSR2_ACTION'] as const;
 let originalEnvValues: Record<string, string | undefined>;
 
 beforeEach(() => {
@@ -34,10 +48,10 @@ afterEach(() => {
 describe('ResourceMonitor', () => {
   describe('getOutputDir', () => {
     function expectWriteCallsForBaseDir(expectedDir: string): void {
-      expect(mockFsPromises.writeFileCalls.length).toBeGreaterThan(0);
-      expect(mockFsPromises.writeFileCalls[0]).toContain(`${expectedDir}${path.sep}heap-info.csv`);
-      expect(mockFsPromises.writeFileCalls).toContain(`${expectedDir}${path.sep}heap-space-info.csv`);
-      for (const filePath of mockFsPromises.writeFileCalls) {
+      expect(mockFsPromises.writtenPaths.length).toBeGreaterThan(0);
+      expect(mockFsPromises.writtenPaths[0]).toContain(`${expectedDir}${path.sep}heap-info.csv`);
+      expect(mockFsPromises.writtenPaths).toContain(`${expectedDir}${path.sep}heap-space-info.csv`);
+      for (const filePath of mockFsPromises.writtenPaths) {
         expect(filePath).toContain(`${expectedDir}${path.sep}`);
       }
       expect(mockFsPromises.mkdirCalls.length).toBeGreaterThan(0);
@@ -108,25 +122,137 @@ describe('ResourceMonitor', () => {
       expectWriteCallsForBaseDir(expectedDir);
     });
   });
+
+  describe('recordOpLoaded', () => {
+    it('keeps the totals of one document apart from those of another', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', { p: ['a'], oi: 1 }, 'user01', false);
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', { p: ['b'], oi: 2 }, 'user01', false);
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project02', { p: ['c'], oi: 3 }, 'user01', false);
+      // SUT
+      await env.monitor.record();
+      const records: Record<string, any>[] = env.usageRecords('opsLoaded');
+      expect(records.length).toBe(2);
+      expect(records.find(record => record.docId === 'project01')!.opsCount).toBe(2);
+      expect(records.find(record => record.docId === 'project02')!.opsCount).toBe(1);
+    });
+
+    it('reports the largest single op, so that one huge op is not hidden in the total', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      const small: object = { p: ['userPermissions', 'user01'], oi: 'admin' };
+      const huge: object = {
+        p: ['userPermissions'],
+        oi: Object.fromEntries(Array.from({ length: 400 }, (_unused: unknown, index: number) => [index, index]))
+      };
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', small);
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', huge);
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', small);
+      // SUT
+      await env.monitor.record();
+      const record: Record<string, any> = env.usageRecords('opsLoaded')[0];
+      expect(record.opsCount).toBe(3);
+      expect(record.largestOpBytes).toBeGreaterThan(record.opsBytes / 2);
+      expect(record.largestOpBytes).toBeLessThan(record.opsBytes);
+    });
+
+    it('accumulates nothing when nothing can ask for a report', async () => {
+      const env: TestEnvironment = new TestEnvironment({ resourceMonitoringOn: false });
+      // SUT
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', { p: ['a'], oi: 1 });
+      env.monitor.recordSnapshotRead('client01', 'sf_projects', 'current', [{ data: { a: 1 } }]);
+      env.monitor.recordQueryRun('client01', 'sf_projects');
+      await env.monitor.record();
+      expect(env.usageRecords('opsLoaded').length).toBe(0);
+      expect(env.usageRecords('snapshotRead').length).toBe(0);
+      expect(env.usageRecords('queryRun').length).toBe(0);
+    });
+
+    it('starts the totals again after a report', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      env.monitor.recordOpLoaded('client01', 'sf_projects', 'project01', { p: ['a'], oi: 1 });
+      await env.monitor.record();
+      // SUT
+      await env.monitor.record();
+      expect(env.usageRecords('opsLoaded').length).toBe(1);
+    });
+  });
+
+  describe('reportOnAgent', () => {
+    it('reports the bytes a web socket has queued but not yet sent', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      const stream: FakeStream = TestEnvironment.fakeStream({ bufferedAmount: 4096 });
+      env.monitorFakeAgent(stream);
+      // SUT
+      await env.monitor.record();
+      const rows: Record<string, string>[] = env.csvRows('agent-info.csv');
+      expect(rows.length).toBe(1);
+      expect(rows[0].outboundBufferedBytes).toBe('4096');
+    });
+
+    it('reports no buffered bytes for a stream that is not a web socket', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      // The streams this server makes for itself and for the dotnet process have no web socket beneath them, so the
+      // count of messages waiting in the stream is all there is to report.
+      const stream: FakeStream = TestEnvironment.fakeStream({ writableLength: 7 });
+      env.monitorFakeAgent(stream);
+      // SUT
+      await env.monitor.record();
+      const rows: Record<string, string>[] = env.csvRows('agent-info.csv');
+      expect(rows[0].outboundBufferedBytes).toBe('');
+      expect(rows[0].outboundQueuedCount).toBe('7');
+    });
+
+    it('counts the documents an agent subscribed to, not the collections holding them', async () => {
+      const env: TestEnvironment = new TestEnvironment();
+      env.monitorFakeAgent(TestEnvironment.fakeStream(), {
+        texts: { 'project01:MRK:1:target': {}, 'project01:MRK:2:target': {} },
+        sf_projects: { project01: {} }
+      });
+      // SUT
+      await env.monitor.record();
+      const rows: Record<string, string>[] = env.csvRows('agent-info.csv');
+      expect(rows[0].subscribedDocsCount).toBe('3');
+    });
+  });
+
+  describe('monitorAgent', () => {
+    // An in-memory stream closed by the client emits only 'end'.
+    for (const event of ['end', 'close']) {
+      it(`stops monitoring an agent when its stream emits '${event}'`, async () => {
+        const env: TestEnvironment = new TestEnvironment();
+        const stream: FakeStream = TestEnvironment.fakeStream();
+        env.monitorFakeAgent(stream);
+        // SUT
+        stream.handlers.get(event)!();
+        await env.monitor.record();
+        expect(env.csvRows('agent-info.csv').length).toBe(0);
+      });
+    }
+  });
 });
 
 class MockFsPromises {
   public readonly mkdirCalls: string[] = [];
-  public readonly writeFileCalls: string[] = [];
-  public readonly appendFileCalls: string[] = [];
+  /** What was written, in the order it was written, so that a test can read back the report contents. */
+  public readonly writes: { path: string; data: string }[] = [];
+
+  /** The paths written to, in order. A file gets one entry per write or append made to it. */
+  public get writtenPaths(): string[] {
+    return this.writes.map(write => write.path);
+  }
 
   mkdir(p: string, _options?: unknown): Promise<void> {
     this.mkdirCalls.push(p);
     return Promise.resolve();
   }
 
-  writeFile(p: string, _data: unknown, _options?: unknown): Promise<void> {
-    this.writeFileCalls.push(p);
+  writeFile(p: string, data: unknown, _options?: unknown): Promise<void> {
+    this.writes.push({ path: p, data: String(data) });
     return Promise.resolve();
   }
 
-  appendFile(p: string, _data: unknown, _options?: unknown): Promise<void> {
-    this.appendFileCalls.push(p);
+  appendFile(p: string, data: unknown, _options?: unknown): Promise<void> {
+    this.writes.push({ path: p, data: String(data) });
     return Promise.resolve();
   }
 }
@@ -134,23 +260,93 @@ class MockFsPromises {
 class TestEnvironment {
   public readonly monitor: ResourceMonitor;
 
-  constructor(values: {
-    SF_RESOURCE_REPORTS_PATH: string | null;
-    XDG_DATA_HOME: string | null;
-    homedir: string | null;
-  }) {
-    if (values.SF_RESOURCE_REPORTS_PATH == null) delete process.env.SF_RESOURCE_REPORTS_PATH;
-    else process.env.SF_RESOURCE_REPORTS_PATH = values.SF_RESOURCE_REPORTS_PATH;
+  constructor({
+    SF_RESOURCE_REPORTS_PATH = null,
+    XDG_DATA_HOME = null,
+    homedir = null,
+    resourceMonitoringOn = true
+  }: {
+    SF_RESOURCE_REPORTS_PATH?: string | null;
+    XDG_DATA_HOME?: string | null;
+    homedir?: string | null;
+    resourceMonitoringOn?: boolean;
+  } = {}) {
+    if (SF_RESOURCE_REPORTS_PATH == null) delete process.env.SF_RESOURCE_REPORTS_PATH;
+    else process.env.SF_RESOURCE_REPORTS_PATH = SF_RESOURCE_REPORTS_PATH;
 
-    if (values.XDG_DATA_HOME == null) delete process.env.XDG_DATA_HOME;
-    else process.env.XDG_DATA_HOME = values.XDG_DATA_HOME;
+    if (XDG_DATA_HOME == null) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = XDG_DATA_HOME;
 
-    mockHomedir = values.homedir ?? '';
+    // What makes reports reachable, and so what turns the measuring on. See ResourceMonitor.enabled.
+    if (resourceMonitoringOn) process.env.SF_SIGUSR2_ACTION = 'resourceUsage';
+    else delete process.env.SF_SIGUSR2_ACTION;
+
+    mockHomedir = homedir ?? '';
 
     // Recreate mock
     mockFsPromises = new MockFsPromises();
     // Reset singleton between tests
     (ResourceMonitor as any)._instance = undefined;
     this.monitor = ResourceMonitor.instance;
+  }
+
+  /** A stream that records the handlers put on it, so that a test can fire an event itself. */
+  public static fakeStream({
+    writableLength = 0,
+    bufferedAmount = undefined
+  }: { writableLength?: number; bufferedAmount?: number } = {}): FakeStream {
+    const handlers = new Map<string, () => void>();
+    const stream: FakeStream = {
+      writableLength: writableLength,
+      handlers: handlers,
+      once: (event: string, handler: () => void) => {
+        handlers.set(event, handler);
+      }
+    };
+    if (bufferedAmount != null) {
+      stream.ws = { bufferedAmount: bufferedAmount };
+    }
+    return stream;
+  }
+
+  /** Monitors an agent that has only the fields a report reads, over the given stream. */
+  public monitorFakeAgent(stream: FakeStream, subscribedDocs: Record<string, Record<string, unknown>> = {}): void {
+    const agent = {
+      stream: stream,
+      src: null,
+      clientId: 'client01',
+      connectTime: 0,
+      subscribedDocs: subscribedDocs,
+      subscribedQueries: {},
+      subscribedPresences: {},
+      connectSession: undefined
+    };
+    this.monitor.monitorAgent(agent as unknown as ShareDB.Agent, stream as unknown as Duplex);
+  }
+
+  /** The non-empty lines written to the named report file, in the order they were written. */
+  private static linesWrittenTo(fileName: string): string[] {
+    return mockFsPromises.writes
+      .filter(write => write.path.endsWith(fileName))
+      .flatMap(write => write.data.split('\n'))
+      .filter(line => line.length > 0);
+  }
+
+  /** The lines of the given type that were written to resource-usage.jsonl. */
+  public usageRecords(type: string): Record<string, any>[] {
+    return TestEnvironment.linesWrittenTo('resource-usage.jsonl')
+      .map(line => JSON.parse(line))
+      .filter(record => record.type === type);
+  }
+
+  /** The rows of one of the CSV reports, keyed by column heading. */
+  public csvRows(fileName: string): Record<string, string>[] {
+    const lines: string[] = TestEnvironment.linesWrittenTo(fileName);
+    if (lines.length === 0) return [];
+    const headings: string[] = lines[0].split(',');
+    return lines.slice(1).map(line => {
+      const values: string[] = line.split(',');
+      return Object.fromEntries(headings.map((heading, index) => [heading, values[index]]));
+    });
   }
 }

--- a/src/RealtimeServer/common/resource-monitor.ts
+++ b/src/RealtimeServer/common/resource-monitor.ts
@@ -8,10 +8,9 @@ import { Duplex } from 'stream';
 import v8 from 'v8';
 import vm from 'vm';
 import { ActivityLogger } from './activity-logger';
-import { ConnectSession } from './connect-session';
 import { resolveLogPath } from './utils/utils';
 
-function sizeof(obj: unknown): number {
+export function sizeof(obj: unknown): number {
   if (obj == null) return 0;
   return jsonSizeOf(obj);
 }
@@ -67,16 +66,20 @@ export interface ConnectionCollectionInfo {
 }
 
 /**
- * Defines some fields on the ShareDB Agent type in agent.js, used for measuring purposes.
+ * Fields of a ShareDB Agent that only the measuring here reads.
  */
-export interface AgentInternal {
+export interface AgentInternal extends ShareDB.Agent {
+  /**
+   * The id the client asked to keep, from its handshake, and the source recorded on its ops. Null until a handshake
+   * supplies one, so a client connecting for the first time has none and its ops fall back to clientId.
+   */
   src: string | null;
-  clientId: string;
   connectTime: number;
-  subscribedDocs: Record<string, Record<string, unknown>>;
-  subscribedQueries: Record<string, { query: unknown | undefined; streams: unknown }>;
-  subscribedPresences: Record<string, unknown>;
-  connectSession: ConnectSession | undefined;
+  /**
+   * The stream the agent sends over. For a frontend client this is a WebSocketJSONStream, which has a `ws` beneath it;
+   * but for this server's own connections and for the dotnet process it is a plain in-process stream.
+   */
+  stream: Duplex & { ws?: { bufferedAmount?: number } };
 }
 
 /**
@@ -91,11 +94,30 @@ export interface AgentInfo {
   connectTime: number;
   connectSessionUserId: string | undefined;
   subscribedDocsCount: number;
-  subscribedDocsBytes: number;
+  /**
+   * Bytes of operations sitting unread in this agent's document subscription streams. An agent holds no document
+   * content, only a stream per subscribed document, and ShareDB pushes operations into those streams as they happen
+   * (OpStream in op-stream.js relies on the stream's own buffer). So this is memory held for a client that is not
+   * reading its subscriptions fast enough.
+   *
+   * outboundBufferedBytes below is the same concern one layer down, at the socket.
+   */
+  subscribedDocsOpsBytes: number;
   subscribedPresencesCount: number;
   subscribedPresencesBytes: number;
   subscribedQueriesCount: number;
   subscribedQueriesBytes: number;
+  /**
+   * Bytes written towards this agent's client that the operating system has not yet taken, so memory the server is
+   * still holding on the client's behalf. Only web socket clients have this; it is undefined for the in-process
+   * streams.
+   */
+  outboundBufferedBytes: number | undefined;
+  /**
+   * For in-process, this is messages queued in the agent's stream itself.
+   * For a web socket client, this stays at zero.
+   */
+  outboundQueuedCount: number;
 }
 
 /**
@@ -183,6 +205,139 @@ interface FetchOperationState {
   inFlightAtStart: number;
 }
 
+/**
+ * What one read of documents returned.
+ *
+ * FetchInfo covers only the bulk fetches that the dotnet process makes, since those are the only ones wrapped by
+ * beginFetchOperation. This covers every read of documents, whoever asked for it: a frontend client fetching or
+ * subscribing to a document, a query's results, and the reads made by this server's own connections. It is recorded
+ * from the 'readSnapshots' middleware, which every such read passes through.
+ */
+export interface SnapshotReadInfo {
+  type: 'snapshotRead';
+  reportBatchId: string;
+  triggerType: ReportTriggerType;
+  timestamp: string;
+  /** The connection that read. */
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  /** Whether the reads were of the current documents, or of an earlier version or time. */
+  snapshotType: string;
+  /** How many reads were made since the previous report. */
+  readsCount: number;
+  docsCount: number;
+  docsBytes: number;
+}
+
+/**
+ * What one connection caused to be loaded from one document as operations, since the last report.
+ */
+export interface OpsLoadedInfo {
+  type: 'opsLoaded';
+  reportBatchId: string;
+  triggerType: ReportTriggerType;
+  timestamp: string;
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  docId: string;
+  opsCount: number;
+  opsBytes: number;
+  largestOpBytes: number;
+}
+
+/**
+ * How often a connection asked for a query, by fetching one or subscribing to one, since the last report. The re-polls
+ * that a subscription then causes are not included; queryPolled counts those.
+ */
+export interface QueryRunInfo {
+  type: 'queryRun';
+  reportBatchId: string;
+  triggerType: ReportTriggerType;
+  timestamp: string;
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  runsCount: number;
+}
+
+/**
+ * How often a subscribed query was polled again, for one connection, since the last report.
+ *
+ * A subscription is re-polled whenever a document that might match it changes, so one subscription on a busy
+ * collection can put an unbounded number of queries on the database. Those polls reach the database directly, without
+ * passing through any middleware, so queryRun does not see them and this is the only count of them.
+ */
+export interface QueryPolledInfo {
+  type: 'queryPolled';
+  reportBatchId: string;
+  triggerType: ReportTriggerType;
+  timestamp: string;
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  /**
+   * 'queryEmitter.poll' for the whole query being run again, 'queryEmitter.pollDoc' for a single document being
+   * checked against it. The first is the expensive one.
+   */
+  pollType: string;
+  pollsCount: number;
+  /** How long those polls took in total, as measured by ShareDB. */
+  totalMs: number;
+}
+
+/** Running totals of the polls of one connection's subscribed queries on one collection since the last report. */
+interface QueryPolledTotals {
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  pollType: string;
+  pollsCount: number;
+  totalMs: number;
+}
+
+/** Running totals of the operations one connection has loaded from one document since the last report. */
+interface OpsLoadedTotals {
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  docId: string;
+  opsCount: number;
+  opsBytes: number;
+  largestOpBytes: number;
+}
+
+/** Running totals of the queries run for one connection on one collection since the last report. */
+interface QueryRunTotals {
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  runsCount: number;
+}
+
+/** Running totals of what one connection has read in an area since the last report. */
+interface SnapshotReadTotals {
+  clientId: string;
+  userId: string | undefined;
+  isServer: boolean | undefined;
+  collection: string;
+  snapshotType: string;
+  readsCount: number;
+  docsCount: number;
+  docsBytes: number;
+}
+
+/**
+ * One bulk fetch made by the dotnet process: who asked for it, how long it took, and how much else was in flight.
+ */
 export interface FetchInfo {
   timestamp: string;
   operationId: string;
@@ -192,7 +347,6 @@ export interface FetchInfo {
   collection: string;
   requestedIdsCount: number;
   returnedDocsCount: number;
-  returnedDocsBytes: number;
   durationMs: number;
   inFlightAtStart: number;
   inFlightAtEnd: number;
@@ -211,6 +365,14 @@ export class ResourceMonitor {
   private readonly connections: Set<Connection> = new Set<Connection>();
   private readonly connectionStates = new Map<Connection, ConnectionMonitorState>();
   private readonly activeFetches = new Map<string, FetchOperationState>();
+  /** What each connection has read since the last report, keyed by connection, collection and snapshot type. */
+  private readonly snapshotReads = new Map<string, SnapshotReadTotals>();
+  /** Ops loaded for each connection since the last report, keyed by connection, collection and document. */
+  private readonly opsLoaded = new Map<string, OpsLoadedTotals>();
+  /** Queries run for each connection since the last report, keyed by connection and collection. */
+  private readonly queriesRun = new Map<string, QueryRunTotals>();
+  /** Polls of subscribed queries since the last report, keyed by connection, collection and poll type. */
+  private readonly queriesPolled = new Map<string, QueryPolledTotals>();
   private inFlightFetchCount = 0;
   private pubSub: PubSub | undefined;
   private readonly heapInfoPath: string;
@@ -220,10 +382,30 @@ export class ResourceMonitor {
   private readonly agentInfoPath: string;
   private readonly pubSubInfoPath: string;
   private readonly fetchInfoPath: string;
+  private readonly resourceUsagePath: string;
+  private periodicRecordingStarted = false;
+  /**
+   * Whether the application is listening for resource usage report requests via signaling.
+   */
+  private readonly reportsCanBeSignalledFor: boolean;
 
   /** Singleton. */
   public static get instance(): ResourceMonitor {
     return (ResourceMonitor._instance ??= new ResourceMonitor());
+  }
+
+  /**
+   * Whether to accumulate what connections are causing, between reports.
+   *
+   * True when a report can actually be asked for: either periodic recording has been started, or SIGUSR2 has been set
+   * up to produce one. Accumulating otherwise costs a walk of every operation and every document read, on every
+   * connection, to fill maps that nothing will ever empty or read.
+   *
+   * This does not gate the reports themselves. The rest of a report is sampled when it is taken, so it costs nothing
+   * in between and is always available.
+   */
+  public get enabled(): boolean {
+    return this.periodicRecordingStarted || this.reportsCanBeSignalledFor;
   }
 
   private constructor() {
@@ -235,12 +417,15 @@ export class ResourceMonitor {
     this.agentInfoPath = path.join(baseOutputPath, 'agent-info.csv');
     this.pubSubInfoPath = path.join(baseOutputPath, 'pubsub-info.csv');
     this.fetchInfoPath = path.join(baseOutputPath, 'fetch-info.csv');
+    this.resourceUsagePath = path.join(baseOutputPath, 'resource-usage.jsonl');
     const minutes: number = 30;
     this.intervalMs = minutes * 60 * 1000;
+    this.reportsCanBeSignalledFor = process.env['SF_SIGUSR2_ACTION'] === 'resourceUsage';
   }
 
   /** Begin periodic recording. */
   public start(): void {
+    this.periodicRecordingStarted = true;
     setInterval(() => void this.record('periodic'), this.intervalMs);
     void this.record('periodic');
   }
@@ -252,8 +437,9 @@ export class ResourceMonitor {
    * complete list. Only index.ts for connections made for dotnet ('interop'), and
    * RealtimeServer's constructor for defaultConnection ('default'), make connections that are included here. Connections made elsewhere, such as those
    * QuestionService and NoteThreadService make while cleaning up references, are absent from those files entirely.
+   * The defaultConnection is registered only when data validation is enabled, so it is absent during a migration run.
    *
-   * agent-info.csv does cover every connection, because monitorAgent below is called from RealtimeServer.listen, which
+   * agent-info.csv does cover every connection (at the moment in time), because monitorAgent below is called from RealtimeServer.listen, which
    * every connection goes through. So agent-info.csv is the file to use when asking "what connections existed"; the
    * connection files answer "what were the interop and default connections holding". See rts-diagnostics.md.
    */
@@ -284,7 +470,7 @@ export class ResourceMonitor {
   public monitorAgent(agent: ShareDB.Agent, stream: Duplex): void {
     if (this.agents.has(agent)) return;
     this.agents.add(agent);
-    // When the agent's stream closes, stop monitoring the agent.
+    stream.once('end', () => this.agents.delete(agent));
     stream.once('close', () => this.agents.delete(agent));
   }
 
@@ -321,6 +507,113 @@ export class ResourceMonitor {
     return operationId;
   }
 
+  /**
+   * Records what a read of documents returned. Called from the 'readSnapshots' middleware, which every read passes
+   * through, so this covers the reads that beginFetchOperation does not: those made by frontend clients, those made by
+   * this server's own connections, and the results of queries.
+   *
+   * The totals are kept in memory and written out with the next report, rather than a row being written per read.
+   */
+  public recordSnapshotRead(
+    clientId: string,
+    collection: string,
+    snapshotType: string,
+    snapshots: { data?: unknown }[],
+    userId?: string,
+    isServer?: boolean
+  ): void {
+    if (!this.enabled) return;
+    const key = `${clientId}|${collection}|${snapshotType}`;
+    let totals: SnapshotReadTotals | undefined = this.snapshotReads.get(key);
+    if (totals == null) {
+      totals = { clientId, userId, isServer, collection, snapshotType, readsCount: 0, docsCount: 0, docsBytes: 0 };
+      this.snapshotReads.set(key, totals);
+    }
+    totals.readsCount += 1;
+    totals.docsCount += snapshots.length;
+    totals.docsBytes += snapshots.reduce((sum: number, snapshot: { data?: unknown }) => sum + sizeof(snapshot.data), 0);
+  }
+
+  /**
+   * Records one operation that passed through a connection, whether it was read from the database, broadcast from
+   * pubsub, or written by that connection itself. Called from the 'op' middleware, which ShareDB runs once per
+   * operation, so this only counts and measures and leaves writing to the next report.
+   *
+   * Totals are kept per document rather than per collection, so that a connection loading a great deal from one
+   * document can be told from one loading a little from many.
+   *
+   * Possible improvement: when an op is broadcast, ShareDB calls this once per subscribed connection, handing over a
+   * shallow copy of the op each time (Agent.prototype._onOp in agent.js), so the payload is the same object on every
+   * such call. sizeof walks it once per subscriber to arrive at the same number each time. A WeakMap keyed on the
+   * payload would make that one walk and N-1 lookups. Check first whether a projection ever rewrites the payload in
+   * place, which would leave such a memo stale.
+   */
+  public recordOpLoaded(
+    clientId: string,
+    collection: string,
+    docId: string,
+    op: unknown,
+    userId?: string,
+    isServer?: boolean
+  ): void {
+    if (!this.enabled) return;
+    const key = `${clientId}|${collection}|${docId}`;
+    let totals: OpsLoadedTotals | undefined = this.opsLoaded.get(key);
+    if (totals == null) {
+      totals = { clientId, userId, isServer, collection, docId, opsCount: 0, opsBytes: 0, largestOpBytes: 0 };
+      this.opsLoaded.set(key, totals);
+    }
+    const opBytes: number = sizeof(op);
+    totals.opsCount += 1;
+    totals.opsBytes += opBytes;
+    totals.largestOpBytes = Math.max(totals.largestOpBytes, opBytes);
+  }
+
+  /**
+   * Records one query being asked for by a connection. Called from the 'query' middleware, which ShareDB triggers when
+   * a query is fetched or subscribed to.
+   *
+   * This is not a count of database work. A subscribed query is re-polled whenever a document that might match it
+   * changes, and those re-polls go straight to the database without passing through any middleware, so none of them
+   * are counted here. Subscribing on a reconnect goes the other way: the middleware runs even though no query is put
+   * to the database. See queryPolled for the re-polls.
+   */
+  public recordQueryRun(clientId: string, collection: string, userId?: string, isServer?: boolean): void {
+    if (!this.enabled) return;
+    const key = `${clientId}|${collection}`;
+    let totals: QueryRunTotals | undefined = this.queriesRun.get(key);
+    if (totals == null) {
+      totals = { clientId, userId, isServer, collection, runsCount: 0 };
+      this.queriesRun.set(key, totals);
+    }
+    totals.runsCount += 1;
+  }
+
+  /**
+   * Records one poll of a subscribed query. Driven by ShareDB's 'timing' event, which is the only notice given of
+   * these, since they reach the database without any middleware running.
+   *
+   * The connection is the one that subscribed, not whoever made the change that caused the poll.
+   */
+  public recordQueryPolled(
+    clientId: string,
+    collection: string,
+    pollType: string,
+    durationMs: number,
+    userId?: string,
+    isServer?: boolean
+  ): void {
+    if (!this.enabled) return;
+    const key = `${clientId}|${collection}|${pollType}`;
+    let totals: QueryPolledTotals | undefined = this.queriesPolled.get(key);
+    if (totals == null) {
+      totals = { clientId, userId, isServer, collection, pollType, pollsCount: 0, totalMs: 0 };
+      this.queriesPolled.set(key, totals);
+    }
+    totals.pollsCount += 1;
+    totals.totalMs += durationMs;
+  }
+
   public async endFetchOperation(
     operationId: string,
     results: Array<{ data: unknown }> | undefined,
@@ -332,7 +625,6 @@ export class ResourceMonitor {
     this.inFlightFetchCount = Math.max(0, this.inFlightFetchCount - 1);
 
     const returnedDocsCount = results?.length ?? 0;
-    const returnedDocsBytes = results?.reduce((sum, result) => sum + sizeof(result.data), 0) ?? 0;
     const data: FetchInfo = {
       timestamp: new Date().toISOString(),
       operationId,
@@ -342,7 +634,6 @@ export class ResourceMonitor {
       collection: state.collection,
       requestedIdsCount: state.requestedIdsCount,
       returnedDocsCount,
-      returnedDocsBytes,
       durationMs: Date.now() - state.startedAt,
       inFlightAtStart: state.inFlightAtStart,
       inFlightAtEnd: this.inFlightFetchCount,
@@ -359,6 +650,7 @@ export class ResourceMonitor {
     await this.recordConnectionDiagnostics(reportBatchId, triggerType);
     await this.recordAgentDiagnostics(reportBatchId, triggerType);
     await this.recordPubSubDiagnostics(reportBatchId, triggerType);
+    await this.recordUsageDiagnostics(reportBatchId, triggerType);
     ActivityLogger.instance.log('resourceReportGenerated', {
       reportBatchId: reportBatchId,
       triggerType: triggerType
@@ -392,6 +684,79 @@ export class ResourceMonitor {
     if (this.pubSub === undefined) return;
     const report = this.reportOnPubSub(this.pubSub, new Date().toISOString(), reportBatchId, triggerType);
     await this.saveToCsv(this.pubSubInfoPath, [report]);
+  }
+
+  /**
+   * Writes out what each connection caused since the previous report - documents read, operations loaded, queries run
+   * - and starts the totals again. A connection that did none of a thing contributes no line for it.
+   */
+  private async recordUsageDiagnostics(reportBatchId: string, triggerType: ReportTriggerType): Promise<void> {
+    const timestamp: string = new Date().toISOString();
+    const report: SnapshotReadInfo[] = [...this.snapshotReads.values()].map(
+      (totals: SnapshotReadTotals): SnapshotReadInfo => ({
+        type: 'snapshotRead',
+        reportBatchId: reportBatchId,
+        triggerType: triggerType,
+        timestamp: timestamp,
+        clientId: totals.clientId,
+        userId: totals.userId,
+        isServer: totals.isServer,
+        collection: totals.collection,
+        snapshotType: totals.snapshotType,
+        readsCount: totals.readsCount,
+        docsCount: totals.docsCount,
+        docsBytes: totals.docsBytes
+      })
+    );
+    this.snapshotReads.clear();
+
+    const opsLoaded: OpsLoadedInfo[] = [...this.opsLoaded.values()].map((totals: OpsLoadedTotals): OpsLoadedInfo => ({
+      type: 'opsLoaded',
+      reportBatchId: reportBatchId,
+      triggerType: triggerType,
+      timestamp: timestamp,
+      clientId: totals.clientId,
+      userId: totals.userId,
+      isServer: totals.isServer,
+      collection: totals.collection,
+      docId: totals.docId,
+      opsCount: totals.opsCount,
+      opsBytes: totals.opsBytes,
+      largestOpBytes: totals.largestOpBytes
+    }));
+    this.opsLoaded.clear();
+
+    const queriesRun: QueryRunInfo[] = [...this.queriesRun.values()].map((totals: QueryRunTotals): QueryRunInfo => ({
+      type: 'queryRun',
+      reportBatchId: reportBatchId,
+      triggerType: triggerType,
+      timestamp: timestamp,
+      clientId: totals.clientId,
+      userId: totals.userId,
+      isServer: totals.isServer,
+      collection: totals.collection,
+      runsCount: totals.runsCount
+    }));
+    this.queriesRun.clear();
+
+    const queriesPolled: QueryPolledInfo[] = [...this.queriesPolled.values()].map(
+      (totals: QueryPolledTotals): QueryPolledInfo => ({
+        type: 'queryPolled',
+        reportBatchId: reportBatchId,
+        triggerType: triggerType,
+        timestamp: timestamp,
+        clientId: totals.clientId,
+        userId: totals.userId,
+        isServer: totals.isServer,
+        collection: totals.collection,
+        pollType: totals.pollType,
+        pollsCount: totals.pollsCount,
+        totalMs: totals.totalMs
+      })
+    );
+    this.queriesPolled.clear();
+
+    await this.saveToJsonl(this.resourceUsagePath, [...report, ...opsLoaded, ...queriesRun, ...queriesPolled]);
   }
 
   private reportOnConnection(
@@ -471,12 +836,17 @@ export class ResourceMonitor {
       clientId: ag.clientId,
       connectTime: ag.connectTime,
       connectSessionUserId: ag.connectSession?.userId,
-      subscribedDocsCount: Object.keys(ag.subscribedDocs).length,
-      subscribedDocsBytes: sizeof(ag.subscribedDocs),
+      subscribedDocsCount: Object.values(ag.subscribedDocs).reduce(
+        (total: number, docs: Record<string, unknown>) => total + Object.keys(docs).length,
+        0
+      ),
+      subscribedDocsOpsBytes: sizeof(ag.subscribedDocs),
       subscribedPresencesCount: Object.keys(ag.subscribedPresences).length,
       subscribedPresencesBytes: sizeof(ag.subscribedPresences),
       subscribedQueriesCount: Object.keys(ag.subscribedQueries).length,
-      subscribedQueriesBytes
+      subscribedQueriesBytes,
+      outboundBufferedBytes: ag.stream?.ws?.bufferedAmount,
+      outboundQueuedCount: ag.stream?.writableLength ?? 0
     };
     return agentInfo;
   }
@@ -541,6 +911,20 @@ export class ResourceMonitor {
       physicalSpaceSizeBytes: space.physical_space_size
     }));
     await this.saveToCsv(this.heapSpaceInfoPath, data);
+  }
+
+  /**
+   * Appends one JSON object per line.
+   */
+  private async saveToJsonl<T extends object>(filePath: string, data: T[]): Promise<void> {
+    if (data.length === 0) return;
+    try {
+      await mkdir(path.dirname(filePath), { recursive: true });
+      const lines: string = data.map((item: T) => JSON.stringify(item)).join('\n');
+      await appendFile(filePath, lines + '\n', { flag: 'a' });
+    } catch (error) {
+      console.error(`Ignoring error writing to ${filePath}:`, error);
+    }
   }
 
   /** Write data to a CSV file. If needed, create header row from the data's objects' keys. */

--- a/src/RealtimeServer/common/rts-diagnostics.md
+++ b/src/RealtimeServer/common/rts-diagnostics.md
@@ -9,10 +9,22 @@ resource reports say **what it was holding while doing it**.
 
 ## Where the files are
 
-| Output           | Written by            | Default location                                              | Override                               |
-| ---------------- | --------------------- | ------------------------------------------------------------- | -------------------------------------- |
-| Activity log     | `activity-logger.ts`  | `$XDG_DATA_HOME/sf-rts-activity-log/realtimeserver-log.jsonl` | `SF_RTS_LOG_PATH` (full file path)     |
-| Resource reports | `resource-monitor.ts` | `$XDG_DATA_HOME/sf-resource-reports/*.csv`                    | `SF_RESOURCE_REPORTS_PATH` (directory) |
+| Output           | Written by                                       | Default location                                                        | Override                               |
+| ---------------- | ------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------- |
+| Activity log     | `activity-logger.ts`                             | `$XDG_DATA_HOME/sf-rts-activity-log/realtimeserver-log.jsonl`           | `SF_RTS_LOG_PATH` (full file path)     |
+| Resource reports | `resource-monitor.ts`                            | `$XDG_DATA_HOME/sf-resource-reports/`                                   | `SF_RESOURCE_REPORTS_PATH` (directory) |
+| Event export     | `mongodb/EventMetrics/EventsInPeriod.mongodb.js` | `events_<start>_<end>.jsonl` in whatever directory mongosh was run from | `DATE_START`, `DATE_END`               |
+
+The first two are written by the RealtimeServer as it runs. The third is not: it is exported from MongoDB afterwards.
+
+Content in `resource-usage.jsonl` includes:
+
+| `type`         | One line per                                    | Carries                                                                                  |
+| -------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `snapshotRead` | report batch, connection, collection            | What that connection read since the previous report, with bytes.                         |
+| `opsLoaded`    | report batch, connection, collection, **doc**   | `opsCount`, `opsBytes` and `largestOpBytes` for that one document.                       |
+| `queryRun`     | report batch, connection, collection            | `runsCount` - how often a connection fetched or subscribed to a query. Not the re-polls. |
+| `queryPolled`  | report batch, connection, collection, poll type | `pollsCount` and `totalMs` for the re-polls a subscription caused.                       |
 
 Resource reports are written one row per subject to
 each batch-scoped file, sharing a `reportBatchId`.
@@ -24,25 +36,96 @@ Events, grouped by what they describe:
 - **Server**: `serverStarted`, `serverStopped`.
 - **Connections**: `webSocketConnected`, `webSocketRejected`, `connectionEstablished`, `connectionRejected`,
   `agentDisconnected`.
+- **Client requests**: `clientRequest`, one per message a client sends over the ShareDB protocol. This is how a
+  frontend client's asking is recorded, the interop entries covering only the dotnet process. Its `action` is
+  ShareDB's own two-letter code, from `sharedb/lib/message-actions.js`:
+
+  | Code               | Meaning                            | Code                     | Meaning                                   |
+  | ------------------ | ---------------------------------- | ------------------------ | ----------------------------------------- |
+  | `hs`               | handshake                          | `op`                     | submit an operation                       |
+  | `f` / `s` / `u`    | fetch / subscribe / unsubscribe    | `nf`                     | fetch a snapshot by version               |
+  | `bf` / `bs` / `bu` | the same three, in bulk            | `nt`                     | fetch a snapshot by time                  |
+  | `qf` / `qs` / `qu` | query fetch / subscribe / unsub    | `pp`                     | ping                                      |
+  | `q`                | query update sent back to a client | `p` / `ps` / `pu` / `pr` | presence, subscribe, unsubscribe, request |
+
+  Both `nf` and `nt` lead to the expensive rebuild that `snapshotRebuiltFromOps` reports on, but they come from
+  different places, and which one appears says who asked:
+  - `nt` is only ever the dotnet process. The interop connection is itself a ShareDB client sending messages over a
+    stream, so asking for a snapshot by timestamp produces an `nt` as a side effect.
+  - `nf` is the browser, from `previousSnapshot()` in `sharedb-realtime-remote-store.ts`, which asks for the version
+    before the current one. Nothing else records it, so here the `clientRequest` line is the only evidence.
+
+  Expect more `nt` entries than `interopFetchSnapshotByTimestamp` entries. The dotnet process can ask for several
+  documents at once, and that method, `fetchSnapshotsByTimestamp`, logs only an `interopCall`; its documents produce
+  an `nt` each and no detail entry. So a `snapshotRebuiltFromOps` with no `interopFetchSnapshotByTimestamp` beside it
+  is either the browser or one of those bulk requests, and the `clientRequest` at the same moment says which: `nf` for
+  the browser, `nt` for dotnet.
+
 - **Ops**: `opSubmitted`, `opCommitted`, `opValidationFailed`.
+- **History**: `snapshotRebuiltFromOps`, when a document is asked for at a past version or timestamp and has to be
+  replayed from operations.
 - **Dotnet interop**: `interopConnect`, `interopDisconnect`, `interopCall`, and one per method -
   `interopCreateDoc`, `interopFetchDoc`, `interopFetchDocs`, `interopFetchSnapshotByTimestamp`, `interopGetOps`,
   `interopSubmitOp`, `interopDeleteDoc`, `interopReplaceDoc`.
 - **Migrations**: `migrationCollectionStarted`, `migrationCollectionCompleted`.
 - **Diagnostics**: `resourceReportGenerated`, `resourceUsageRequested`, `heapSnapshotStarted`, `heapSnapshotCompleted`,
   `cpuProfileStarted`, `cpuProfileCompleted`.
+- **The log itself**: `logEntriesDropped`, when entries had to be discarded rather than written. See below.
 
 ## Resource reports
 
-| File                             | One row per                                    | Notes                                                                  |
-| -------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
-| `heap-info.csv`                  | report batch                                   | Process-wide rss, heapTotal, heapUsed, external, arrayBuffers.         |
-| `heap-space-info.csv`            | report batch, V8 space                         |                                                                        |
-| `connection-info.csv`            | report batch, **monitored** connection         | Not every connection - see below.                                      |
-| `connection-collection-info.csv` | report batch, monitored connection, collection | Has `docsBytes` and `largestDocId`.                                    |
-| `agent-info.csv`                 | report batch, agent                            | **Every** connection. Has `subscribedDocsBytes`.                       |
-| `pubsub-info.csv`                | report batch                                   | Stream and subscription counts and bytes.                              |
-| `fetch-info.csv`                 | **fetch operation**                            | Not batch-scoped, and has no `reportBatchId`. Has `returnedDocsBytes`. |
+| File                             | One row per                                    | Notes                                                                           |
+| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| `heap-info.csv`                  | report batch                                   | Process-wide rss, heapTotal, heapUsed, external, arrayBuffers.                  |
+| `heap-space-info.csv`            | report batch, V8 space                         |                                                                                 |
+| `connection-info.csv`            | report batch, **monitored** connection         | Not every connection - see below.                                               |
+| `connection-collection-info.csv` | report batch, monitored connection, collection | Has `docsBytes` and `largestDocId`.                                             |
+| `agent-info.csv`                 | report batch, agent                            | **Every** connection. Has `subscribedDocsOpsBytes` and `outboundBufferedBytes`. |
+| `pubsub-info.csv`                | report batch                                   | Stream and subscription counts and bytes.                                       |
+| `fetch-info.csv`                 | **fetch operation**                            | Not batch-scoped, and has no `reportBatchId`. Timing, not bytes.                |
+| `resource-usage.jsonl`           | varies by record `type`                        | See above.                                                                      |
+
+## The event export (`events_*.jsonl`)
+
+Exported from MongoDB by `mongodb/EventMetrics/EventsInPeriod.mongodb.js`.
+
+The lines are in time order, so the file reads as one sequence. They come from three different collections and
+each line names its `source`. What follows is what a reader has to know to join them.
+
+| `source`            | One line per              | Time         | User      | Project      |
+| ------------------- | ------------------------- | ------------ | --------- | ------------ |
+| `event_metrics`     | backend API call          | `timeStamp`  | `userId`  | `projectId`  |
+| `translate_metrics` | editing session's metrics | `timestamp`  | `userRef` | `projectRef` |
+| `sync_metrics`      | one **attempt** at a sync | `dateQueued` | `userRef` | `projectRef` |
+
+**The field names differ by source, including the capital S in `timeStamp`.** Normalise time, user and project into
+one shape before joining anything, or a query will silently match only one of the three sources.
+
+`event_metrics` lines also carry `eventType` (such as `SyncAsync`, `UpdateSettingsAsync`, `DeleteProjectAsync`),
+`scope` (`Sync`, `Settings`, `Drafting`) and `failed`. `sync_metrics` lines also carry `dateStarted`, `dateFinished`,
+`status` and `changeCount`.
+
+### Joining the events to the RealtimeServer
+
+There is no connection id or `clientId` in the export, so the joins are on user, on project, and on time.
+
+```
+  event userId / userRef  -> activity log userId
+                          -> docId of a `users` or `user_profiles` doc
+                          -> the part after the colon in an `sf_project_user_configs` docId
+
+  event projectId / projectRef -> docId of an `sf_projects` or `sf_projects_profile` doc
+                               -> the part BEFORE THE FIRST COLON of a docId in
+                                  `texts`, `text_documents`, `questions`, `note_threads`,
+                                  `biblical_terms`, `sf_project_user_configs`
+```
+
+That prefix rule is how most RealtimeServer activity gets attributed to a project, since only a minority of documents
+are the project document itself. It holds for perhaps every composite docId in the logs, so `docId.split(':')[0]` is a sound way to ask which project an entry concerned.
+
+Since `opsLoaded` in `resource-usage.jsonl` now carries `docId`, this same prefix connects a heap reading to the
+project whose documents were being loaded, which is the join that answers "which project was the server busy with when
+it grew".
 
 ## The join keys
 
@@ -61,6 +144,10 @@ Events, grouped by what they describe:
   resourceReportGenerated.reportBatchId -> reportBatchId column in every batch-scoped CSV
   fetch-info.csv connectionId  -> connectionEstablished.clientId
   opSubmitted (srcClientId, opSeq) -> opCommitted / opValidationFailed (srcClientId, opSeq)
+  snapshotRebuiltFromOps (pid, docId) -> interopFetchSnapshotByTimestamp (pid, docId)
+
+  events_*.jsonl userId / userRef       -> activity log userId
+  events_*.jsonl projectId / projectRef -> docId, or docId up to the first colon
 ```
 
 `handle` and `callId` are only unique within a process. They are counters that restart at 0 when the
@@ -71,11 +158,14 @@ and need no such qualification.
 To determine who asked for a fetch and what it cost:
 
 1. Start at an `interopFetchDocs` entry. Take its `operationId`, `handle` and `pid`.
-2. Look up that `operationId` in `fetch-info.csv` for `returnedDocsBytes`, `durationMs`, and how many other fetches
-   overlapped it (`inFlightAtStart`, `inFlightAtEnd`).
+2. Look up that `operationId` in `fetch-info.csv` for `durationMs` and how many other fetches overlapped it
+   (`inFlightAtStart`, `inFlightAtEnd`).
 3. Find the `connectionEstablished` from the same `pid` whose `interopHandle` matches, for the `clientId` and `userId`
    behind the request.
-4. Compare against the heap around that moment, as described next.
+4. Look that `clientId` up in the `snapshotRead` lines of `resource-usage.jsonl` for `docsBytes` and `docsCount`. Those are totals for everything
+   the connection read between two reports rather than for the single fetch, so narrow by `collection` and pick the
+   report batch covering the moment the fetch happened.
+5. Compare against the heap around that moment, as described next.
 
 ### Relating activity to memory readings
 
@@ -98,6 +188,12 @@ part of a sample - it is an event with its own start and end, which is what `ope
 
 ## Additional notes
 
+- **A `logEntriesDropped` entry means the log has a hole in it.** Entries are queued and written in batches, and once
+  the queue holds 10,000 new ones are discarded rather than made to wait, so a burst of activity or a slow disk loses
+  entries instead of holding the server up. An entry that cannot be serialized to JSON is discarded the same way. The
+  notice says how many went missing, in `droppedCount`, but not which ones or what they were about. So for the
+  surrounding period, counts taken from the log are lower bounds, and an entry missing from a pair - an `opSubmitted`
+  with no `opCommitted` beside it - may be a dropped entry rather than a failed op.
 - **`srcClientId` is not always `clientId`.** ShareDB gives each agent a `clientId` at creation, but `agent.src` stays
   null until the client's handshake supplies an id - after the `connect` middleware has run, which is why
   `connectionEstablished` cannot report it. A first-time client supplies no id, so its ops fall back to `clientId` and
@@ -113,14 +209,25 @@ part of a sample - it is an event with its own start and end, which is what `ope
   `agent-info.csv` covering every _kind_ of connection does not mean it covers every connection. Take the list of
   connections from the activity log's `connectionEstablished` entries, and treat the reports as telling you about the
   subset that happened to be caught.
+- **The `resource-usage.jsonl` totals are only accumulated when a report can be asked for.** `snapshotRead`,
+  `opsLoaded`, `queryRun` and `queryPolled` are counted up between reports, and that counting is switched off unless
+  `SF_SIGUSR2_ACTION` is set to `resourceUsage`, or periodic recording has been started. Accumulating otherwise would
+  cost a walk of every document read and every operation on every connection, to fill maps that nothing would read.
+  The rest of a report is unaffected: the heap figures and the per-agent and per-connection rows are sampled at the
+  moment the report is taken, so they cost nothing in between and are always available. So a report with no
+  `opsLoaded` lines is not evidence that no operations were loaded - establish whether the counting was on at all
+  before reading anything into their absence.
 - **`interopDisconnect` and `agentDisconnected` do not mean the same thing.** `interopDisconnect` says the dotnet
   process released its handle, which stops the connection being monitored. `agentDisconnected` says the stream itself
   closed, which is when the connection's memory can actually be released. The two counts are worth comparing: far more
   `interopDisconnect` than `agentDisconnected` entries means connections are being let go of without being closed, and
   because releasing the handle also stops the monitoring, those connections then hold memory that no report will
   attribute to them.
-- **Agents are not monitored during migrations.** `RealtimeServer.listen` only calls `monitorAgent` when data
-  validation is enabled, which it is not during a migration run.
+- **A migration run produces almost no resource reports.** Everything the monitor needs is registered only when data
+  validation is enabled, which it is not during a migration. `RealtimeServer.listen` does not call `monitorAgent`, so
+  `agent-info.csv` is empty; `defaultConnection` is not registered, so `connection-info.csv` has no `default` row; and
+  the pubsub is never handed over, so `pubsub-info.csv` gets no row at all. The activity log still covers the
+  migration, through `migrationCollectionStarted` and `migrationCollectionCompleted`.
 - **`interopCall` is roughly a third of the log.** Each one is the generic timing and status record for a call whose
   details are on a separate entry with the same `callId`. `applyOp`, `isServerRunning`, `start`, `stop` and
   `fetchSnapshotsByTimestamp` log only the `interopCall`, so a `callId` appearing once rather than twice is expected,
@@ -129,9 +236,73 @@ part of a sample - it is an event with its own start and end, which is what `ope
   `SetPingServiceSchedule` in `RealtimeService.cs`). A regular once-a-minute heartbeat of these in the log is normal;
   a gap in them, or a slow one, is worth attention, because the dotnet side restarts the RealtimeServer when the check
   returns false.
-- **The activity log records no byte sizes.** They are on the resource reports. Measuring a
-  payload is expensive. Sizes live in `fetch-info.csv`
-  (`returnedDocsBytes`), `agent-info.csv` (`subscribedDocsBytes`) and `connection-collection-info.csv` (`docsBytes`).
+- **The activity log records no byte sizes.** They are on the resource reports. Measuring a payload means walking it,
+  which is expensive. Sizes live in the `snapshotRead` lines of `resource-usage.jsonl` (`docsBytes`, for what was
+  read), `agent-info.csv`
+  (`subscribedDocsOpsBytes`, for what is queued to an agent) and `connection-collection-info.csv` (`docsBytes`).
+- **An agent holds no document content.** It holds a stream per subscribed document, and ShareDB pushes operations
+  into those streams as they happen, so `subscribedDocsOpsBytes` is operations waiting to be read by a client that is
+  not keeping up - a couple of hundred bytes when the streams are empty, and unbounded when they are not. For what
+  documents cost, use `snapshotRead` (what was read) or `connection-collection-info.csv` (what a monitored connection
+  holds). `outboundBufferedBytes` is the same concern one layer down, at the socket.
+- **`subscribedDocsCount` counts documents, and it used to count collections.** In `agent-info.csv` and on
+  `agentDisconnected` it is the number of subscribed documents, summed across collections. A report directory survives
+  restarts and upgrades, so an older `agent-info.csv` can hold rows where the same column held the number of
+  collections instead, which is a much smaller number for the same connection. On `agentDisconnected` the two are
+  reported separately, as `subscribedDocsCount` and `subscribedCollectionsCount`.
+- **Every read is measured once, in the `snapshotRead` lines of `resource-usage.jsonl`.** They are written from the
+  'readSnapshots' middleware,
+  which every read passes through, so it covers frontend clients, this server's own connections and the dotnet
+  process alike. `fetch-info.csv` deliberately does not also report bytes, so that a fetch is not walked twice.
 - **A connection with no `interopHandle`** is either `defaultConnection`, a frontend client, or one of the doc
   services' connections. `isServer` and `userId` narrow it down; `agent-info.csv` `src` being set indicates a client
   that reconnected.
+- **`userId` is an empty string, not absent, when there is no user.** Server connections made without a user on whose
+  behalf to act report `""`.
+- **`queryRun` counts asking, not database work.** A connection fetching or subscribing to a query is counted. The
+  re-polls that a subscription then causes are not: they go from ShareDB's QueryEmitter straight to the database
+  without passing through middleware. Subscribing on a reconnect is counted even though no query is put to the
+  database. So a low `runsCount` on a busy collection does not mean the database was left alone. `queryPolled` is
+  where the re-polls are counted, from ShareDB's 'timing' event. Its `pollType` separates the whole query being run
+  again (`queryEmitter.poll`) from a single document being checked against it (`queryEmitter.pollDoc`); the first is
+  the expensive one, and its `clientId` is whoever subscribed, not whoever made the change that set it off.
+- **A huge operation is found through `opsLoaded`, not through the activity log.** `opCommitted` says an op was
+  written but not how big it was. The `opsLoaded` lines of `resource-usage.jsonl` say how much each connection was
+  sent from each document, so an op rewriting a whole `sf_projects` permissions map shows there, against the connection
+  that wrote it as well as against the ones it was sent to. Read `largestOpBytes` alongside `opsBytes`: the two being
+  close means one enormous op, and them being far apart means a long catch-up of ordinary ones. Both cost memory, but
+  they call for different explanations.
+- **`opsLoaded` counts every op that passed through a connection, not just ops read from the database.** ShareDB
+  sanitizes an op on three paths and the 'op' middleware runs as part of each: the catch-up sent to a client that
+  subscribes at an old version (a database read), the live broadcast to everyone else subscribed (from pubsub), and a
+  client's own op returning in its submit acknowledgement (no read at all). So a browser's `opsBytes` on `texts`
+  includes what that browser typed. A high figure means a connection saw a lot of op traffic, which costs memory either
+  way, but it is not evidence the database was read.
+- **`snapshotRebuiltFromOps` is the one op loading that `opsLoaded` does not see.** Asking for a document at a past
+  version or timestamp makes ShareDB replay operations onto a milestone snapshot, and it loads them straight from the
+  database, deliberately skipping the 'op' middleware. The rebuilt document is measured, by `snapshotRead`, but that
+  says nothing about how many operations went into it. So join `snapshotRebuiltFromOps` to the
+  `interopFetchSnapshotByTimestamp` with the same `pid` and `docId` to see what a history request actually cost.
+- **A `sync_metrics` line is a span, not a moment.** The file is sorted by `dateQueued`, which can be well before
+  `dateStarted`, and the work happened between `dateStarted` and `dateFinished`. Use that pair as the window. An
+  attempt whose `status` is `Queued` or `Cancelled` may have neither.
+- **A retried sync appears as several lines sharing one `id`,** told apart by `attempt`, numbered from 1 and all
+  carrying the original `dateQueued`. So `id` is not unique in this file; `(id, attempt)` is. Exporting the same
+  period twice can also give different results.
+- **`changeCount` does not predict how much the RealtimeServer did.** It sums the counters from every section of the
+  sync, including the `paratext*` ones describing changes sent the other way, which never become ops here. Read it as
+  "how big was this sync", not as "how much did this cost the RealtimeServer"; for the latter, count the activity in
+  the window.
+- **`event_metrics.id` and `sync_metrics.id` are different documents and do not join,** even for the same sync.
+  Link a `SyncAsync` event to its sync by project, user and time instead.
+- **`opCommitted` carries neither `isServer` nor `userId`, though `opSubmitted` carries both.** So a committed op does
+  not say on its own whether it came from a sync or from someone typing in a browser. Join it back to its
+  `opSubmitted` on `(srcClientId, opSeq)` to find that out. The same is true of `docId`: both carry it, but only
+  `opSubmitted` says who was responsible.
+- **`opValidationFailed.errorMessage` names the path within the document, not the value.** A rejected op is reported
+  by its JSON path (`op.p`).
+- **`outboundBufferedBytes` is memory held for a client that is not keeping up.** It is what has been written towards
+  a web socket and not yet taken by the operating system. Nothing in ShareDB waits for a client to catch up before
+  sending it more, so a slow client subscribed to a busy document makes this grow without limit. Only web socket
+  clients have it; for the in-process streams it is empty and `outboundQueuedCount` is the figure to read instead.
+  `pubsub-info.csv` `streamsBytes` is the same concern seen from the other end.

--- a/src/RealtimeServer/common/services/project-data-service.ts
+++ b/src/RealtimeServer/common/services/project-data-service.ts
@@ -314,7 +314,10 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
   }
 
   private async handleApply(context: ShareDB.middleware.SubmitContext): Promise<void> {
-    const connectSession = context.agent.connectSession as ConnectSession;
+    const connectSession: ConnectSession | undefined = context.agent?.connectSession;
+    if (connectSession == null) {
+      throw new Error('Op reached has no associated connection session.');
+    }
     if (context.op.del != null) {
       const domain = this.getUpdatedDomain([], context.snapshot!.data);
       if (domain != null) {
@@ -324,7 +327,10 @@ export abstract class ProjectDataService<T extends ProjectData> extends JsonDocS
   }
 
   private async handleAfterSubmit(context: ShareDB.middleware.SubmitContext): Promise<void> {
-    const connectSession = context.agent.connectSession as ConnectSession;
+    const connectSession: ConnectSession | undefined = context.agent?.connectSession;
+    if (connectSession == null) {
+      throw new Error('Op reached has no associated connection session.');
+    }
     if (context.op.create != null) {
       const domain = this.getUpdatedDomain([], context.op.create.data);
       if (domain != null) {

--- a/src/RealtimeServer/package.json
+++ b/src/RealtimeServer/package.json
@@ -65,7 +65,7 @@
     "jest-expect-message": "^1.1.3",
     "jest-junit": "^17.0.0",
     "jest-teamcity-reporter": "^0.9.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.9.6",
     "sharedb-mingo-memory": "^4.1.0",
     "ts-jest": "^29.4.11",
     "ts-mockito": "^2.6.1",

--- a/src/RealtimeServer/pnpm-lock.yaml
+++ b/src/RealtimeServer/pnpm-lock.yaml
@@ -122,7 +122,7 @@ importers:
         version: 60.8.3(eslint@9.39.2)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.6.2)
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.0)
@@ -136,8 +136,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0
       prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
+        specifier: ^3.9.6
+        version: 3.9.6
       sharedb-mingo-memory:
         specifier: ^4.1.0
         version: 4.1.0(sharedb@5.2.2)
@@ -2498,8 +2498,8 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -5133,10 +5133,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.9.6):
     dependencies:
       eslint: 9.39.2
-      prettier: 3.6.2
+      prettier: 3.9.6
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -6377,7 +6377,7 @@ snapshots:
     dependencies:
       fast-diff: 1.2.0
 
-  prettier@3.6.2: {}
+  prettier@3.9.6: {}
 
   pretty-format@29.7.0:
     dependencies:

--- a/src/RealtimeServer/scriptureforge/realtime-server.ts
+++ b/src/RealtimeServer/scriptureforge/realtime-server.ts
@@ -1,4 +1,5 @@
 import ShareDB from 'sharedb';
+import { ConnectSession } from '../common/connect-session';
 import { Operation } from '../common/models/project-rights';
 import { RealtimeServer } from '../common/realtime-server';
 import { SchemaVersionRepository } from '../common/schema-version-repository';
@@ -56,11 +57,17 @@ export default class SFRealtimeServer extends RealtimeServer {
     );
     this.use('query', (context: ShareDB.middleware.QueryContext, next: (err?: any) => void): void => {
       if (context.collection === NOTE_THREAD_COLLECTION) {
-        if (context.agent.connectSession.isServer) {
+        const connectSession: ConnectSession | undefined = context.agent?.connectSession;
+        if (connectSession == null) {
+          // How to process the query cannot be decided without knowing who is asking.
+          next(new Error('A query for note threads arrived without a connection session.'));
+          return;
+        }
+        if (connectSession.isServer) {
           next();
           return;
         }
-        const userId: string = context.agent.connectSession.userId;
+        const userId: string = connectSession.userId;
         this.getProject(context.query.projectRef)
           .then(p => {
             if (

--- a/src/RealtimeServer/typings/sharedb/AGENTS.md
+++ b/src/RealtimeServer/typings/sharedb/AGENTS.md
@@ -1,0 +1,14 @@
+# Declaring types for third-party code
+
+A declaration in `typings/` should describe what the library does, not the minimum that
+makes our code compile.
+
+- Read the library's implementation and its call sites before writing the
+  declaration. Say what you found.
+- Use the named types already in those typings. Do not invent a structural type
+  like `{ v: number }` for something that already has a name.
+- Follow the conventions of the neighbouring declarations.
+- Do not write `any`, mark a parameter optional, or add a union member unless you
+  found the line that produces that case. "It might be null" is not a reason.
+- Where the answer is a convention the library does not enforce, say so in a
+  comment rather than widening the type.

--- a/src/RealtimeServer/typings/sharedb/index.d.ts
+++ b/src/RealtimeServer/typings/sharedb/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+import { ConnectSession } from '../../common/connect-session';
 import { Connection, Query } from './lib/client';
 import * as common from './lib/common';
 
@@ -46,6 +47,28 @@ declare class ShareDB {
   addProjection(name: string, collection: string, fields: ShareDB.ProjectionFields): void;
   listen(stream: any, req?: any): void;
   close(callback?: (err?: Error) => any): void;
+  /**
+   * Reports how long a piece of work took. `action` names it: eg 'queryEmitter.poll'.
+   *
+   * Monitoring the 'timing' event can give us additional insight into the activity of ShareDB that might otherwise be
+   * hidden, such as when a subscription is being re-polled (those polls reach the database directly and no middleware
+   * runs for them).
+   */
+  on(event: 'timing', listener: (action: string, durationMs: number, context: ShareDB.TimingContext) => void): this;
+  /**
+   * Rebuilds a document by replaying operations onto a milestone snapshot. ShareDB calls this when a document is asked
+   * for at a past version or timestamp rather than at its current version. Declared here so that it can be overridden;
+   * it is not part of ShareDB's public API.
+   *
+   * startingSnapshot comes from the MilestoneDB, and is undefined when there is no milestone to start from. That is a
+   * convention every implementation follows rather than something ShareDB enforces.
+   */
+  _buildSnapshotFromOps(
+    id: string,
+    startingSnapshot: common.Snapshot | undefined,
+    ops: common.Op[],
+    callback: (err: Error, snapshot: common.Snapshot) => void
+  ): void;
   /**
    * Registers a server middleware function.
    *
@@ -120,10 +143,34 @@ declare namespace ShareDB {
 
   class MemoryDB extends DB {}
 
+  /**
+   * The third value a 'timing' event carries, being whichever object was doing the work: a QueryEmitter for the
+   * queryEmitter.* actions (which pass their own `this`), a request object for the others.
+   *
+   * Both name the collection, and both carry the agent when one asked for the work. A poll set off by another client's
+   * change carries the agent that subscribed, not the one that caused the change.
+   */
+  interface TimingContext {
+    collection?: string;
+    agent?: Agent;
+  }
+
   class Agent {
     constructor(backend: ShareDB, stream: any);
 
-    protected clientId: string;
+    /** Identifies this connection. ShareDB gives every agent one when it is created. */
+    clientId: string;
+    /** Map of collection -> document id -> stream. */
+    subscribedDocs: Record<string, Record<string, unknown>>;
+    /** Map of query id -> emitter. */
+    subscribedQueries: Record<string, { query: unknown | undefined; streams: unknown }>;
+    /** Map of channel -> stream. */
+    subscribedPresences: Record<string, unknown>;
+    /**
+     * This property is not a ShareDB property. This application attaches it in RealtimeServer.setConnectSession, once a
+     * connection's claims are known, and so it is absent on an agent whose connect middleware has not finished.
+     */
+    connectSession?: ConnectSession;
 
     close(err: any): void;
     _open(): void;
@@ -220,7 +267,8 @@ declare namespace ShareDB {
 
     interface BaseContext {
       action?: keyof ActionContextMap;
-      agent?: any;
+      // AI gave a lot of push-back on agent being optional. This may benefit from further investigation.
+      agent?: Agent;
       backend?: ShareDB;
     }
 

--- a/src/RealtimeServer/typings/sharedb/lib/client.d.ts
+++ b/src/RealtimeServer/typings/sharedb/lib/client.d.ts
@@ -22,6 +22,7 @@ export {
 export class Connection extends EventEmitter {
   state: 'connecting' | 'connected' | 'disconnected' | 'closed' | 'stopped';
   constructor(ws: WebSocket | WS);
+  close(): void;
   get(collectionName: string, documentID: string): Doc;
   createFetchQuery(
     collectionName: string,


### PR DESCRIPTION
- Adds more middleware hooks.
- Remove use of AgentInternal from realtime-server.ts. Add
declarations to Agent as needed. This had fallout such as accounting
for `agent` possibly being null by type when checking things like
`context.agent?.clientId`.
- Changed some error messaging from saying the op, to just the op
path. This information flows into the activity logs.
- Some Byte size measuring is now being done in realtime usage of the
server, not just upon intermittent SIGUSR2 request.
- Clarified typing for agent.connectSession resulted in some null
guards + throw being added.
- ResourceMonitor now cares if it's "enabled", because if so it will
build up some information over time to flush out on request.
- ResourceMonitor logs some additional information to a new file,
`resource-usage.jsonl`, alongside existing .csv files.
- The change to resource-monitor.ts subscribedDocsCount is a fix from
incorrect behaviour.
- An AGENTS.md file was placed alongside our sharedb typings to give
specific instructions to AI on how to treat these.
- sharedb typings received various enhancements. Including declaring
our custom property, `connectSession`.

<!-- Devin-placeholder:start -->
---
[**Open in Devin Review**](https://app.devin.ai/review/sillsdev/web-xforge/pull/4093)
<!-- Devin-placeholder:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4093)
<!-- Reviewable:end -->
