### PR TITLE
Fix spurious screenshot diffs from draft-pending-updates component

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/draft-pending-updates/draft-pending-updates.component.stories.ts
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/new-draft/draft-pending-updates/draft-pending-updates.component.stories.ts
@@ -1,11 +1,11 @@
 import { Meta, StoryObj } from '@storybook/angular';
+import userEvent from '@testing-library/user-event';
 import { createTestProjectProfile } from 'realtime-server/lib/esm/scriptureforge/models/sf-project-test-data';
 import { Subject } from 'rxjs';
-import userEvent from '@testing-library/user-event';
 import { expect, waitFor, within } from 'storybook/test';
 import { anything, instance, mock, reset, when } from 'ts-mockito';
-import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { ErrorReportingService } from 'xforge-common/error-reporting.service';
+import { createTestFeatureFlag, FeatureFlagService } from 'xforge-common/feature-flags/feature-flag.service';
 import { OnlineStatusService } from 'xforge-common/online-status.service';
 import { SFProjectDoc } from '../../../../core/models/sf-project-doc';
 import { PermissionsService } from '../../../../core/permissions.service';
@@ -185,6 +185,10 @@ export const Loading: Story = {
 
 /** Start a sync, then let it finish successfully; the row shows "Up to date". */
 export const SyncSucceeded: Story = {
+  parameters: {
+    // Skip spurious/random diff on last few pixels in the text "Up to date"
+    screenshot: { maxDiffPixels: 4 }
+  },
   args: {
     projects: [{ projectId: 'p1', shortName: 'GRK', name: 'Greek NT', canSync: true, completeOnSyncWith: 'success' }]
   },


### PR DESCRIPTION
On quite a few recent occasions PRs have had a diff of this screenshot, with 4 pixels differing:

<img width="1115" height="143" alt="Screenshot from 2026-09-10 09-53-24" src="https://github.com/user-attachments/assets/6f9fbb94-6590-4d6d-89b1-07fdaf47e286" />

The diff tool shows exactly what is "changed":
<img width="239" height="106" alt="Screenshot from 2026-09-10 09-37-59" src="https://github.com/user-attachments/assets/73ca35c4-43e9-4dc3-a294-6615cd5a320a" />

This PR configures our diff tool to not consider the screenshot changed unless it has more than 4 pixels differing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4098)
<!-- Reviewable:end -->
