### PR TITLE
Add gap between drafted books

### DIFF
--- a/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.scss
+++ b/src/SIL.XForge.Scripture/ClientApp/src/app/translate/draft-generation/draft-preview-books/draft-preview-books.component.scss
@@ -1,3 +1,9 @@
+:host {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 app-display-confidence ::ng-deep mat-icon {
   // it's not entirely clear why, but this is needed to vertically align the icon with the book name
   margin-bottom: -6px;


### PR DESCRIPTION
This adds the gap between books in a draft build. This was a regression from PR #4052 

Before
<img width="841" height="531" alt="Draft books before" src="https://github.com/user-attachments/assets/98a32a5e-8e7f-4a7a-9c58-20c668744fa1" />

After
<img width="1067" height="537" alt="Draft books after" src="https://github.com/user-attachments/assets/6bfaef78-22d4-44b1-a85c-39af50940da1" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/web-xforge/4099)
<!-- Reviewable:end -->
